### PR TITLE
Add node_modules specifically as docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3.2"
 volumes:
   dbdata:
+  node_modules:
+
 services:
   db:
     image: postgres:11.1-alpine
@@ -17,6 +19,7 @@ services:
       - "3000:3000"
     volumes:
       - .:/app
+      - "node_modules:/app/node_modules"
     depends_on:
       - "db"
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails db:setup && bundle exec rails server -p 3000 -b '0.0.0.0'"


### PR DESCRIPTION
With a fresh checkout, you'd have to manually `yarn` before `docker-compose up`, as the `node_modules` interacts badly with mounting the whole app as a volume.

I don't fully understand this bad interaction, but this _seems_ to fix it...