### PR TITLE
Add makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: docker-down
+docker-down:
+	docker-compose down
+
+.PHONY: docker-build
+docker-build:
+	docker-compose build
+
+.PHONY: shell
+shell: docker-down docker-build
+	docker-compose run --rm web bash
+
+.PHONY: test
+test: docker-down docker-build
+	docker-compose run --rm web bundle exec rspec
+
+.PHONY: serve
+serve: docker-down docker-build
+	docker-compose up -d web


### PR DESCRIPTION
I'm too lazy to keep typing `docker-compose` in the right order.

Taking inspiration from the [Made Tech standards](https://github.com/madetech/rfcs/blob/master/rfc-012-makefile-standards.md) ... and because it's handy to have.