### PR TITLE
Tell the GOV.UK Design System how to load assets

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,1 +1,7 @@
-@import "govuk-frontend/all";
+$govuk-images-path: '/assets/';
+$govuk-fonts-path: '/assets/';
+$govuk-font-url-function: 'font-url';
+$govuk-image-url-function: 'image-url';
+$govuk-global-styles: true;
+
+@import 'govuk-frontend/all';


### PR DESCRIPTION
The GOV.UK Design System needs to know where to load assets and what SASS functions to use to render them, otherwise GOV.UK assets do not work. This PR addresses that and fixes #26 