### PR TITLE
Change phase banner to 'prototype'

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,9 +76,9 @@
 
   <div class="govuk-width-container">
     <div class="govuk-phase-banner">
-      <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag ">alpha</strong>
+      <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag ">prototype</strong>
         <span class="govuk-phase-banner__text">
-          This is a new service – your <%= link_to 'feedback', '#', class: 'govuk-link' %> will help us to improve it.
+          This is a prototype of a new service. Some parts of this prototype do not work yet.
         </span>
       </p>
     </div>


### PR DESCRIPTION
I think this is more appropriate, based on the guidance on GOV.UK. I wouldn't want someone to find this and think it's a real service.

New:
![image](https://user-images.githubusercontent.com/429326/54429434-7341f380-4718-11e9-8fa9-c03d6aa1a6fe.png)

Current:
![image](https://user-images.githubusercontent.com/429326/54429448-7f2db580-4718-11e9-870b-d310a462580b.png)
