### PR TITLE
Add endpoint for viewing one application

### DIFF
--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -1,6 +1,22 @@
 class Api::ApplicationsController < ActionController::API
   def index
-    fake_applications = File.read('lib/data/fake_applications.json')
-    render json: fake_applications
+    render json: applications
+  end
+
+  def show
+    if matching_application.present?
+      render json: matching_application
+    else
+      head :not_found
+    end
+  end
+
+private
+  def matching_application
+    applications.find{|app| app['id'] == params[:id]}
+  end
+
+  def applications
+    JSON.parse(File.read('lib/data/fake_applications.json'))
   end
 end

--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -12,8 +12,9 @@ class Api::ApplicationsController < ActionController::API
   end
 
 private
+
   def matching_application
-    applications.find{|app| app['id'] == params[:id]}
+    applications.find { |app| app['id'] == params[:id] }
   end
 
   def applications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
-    resources :applications, only: [:index]
+    resources :applications, only: [:index, :show]
   end
 
   match '/404', to: 'errors#not_found', via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
-    resources :applications, only: [:index, :show]
+    resources :applications, only: %i[index show]
   end
 
   match '/404', to: 'errors#not_found', via: :all

--- a/lib/data/fake_applications.json
+++ b/lib/data/fake_applications.json
@@ -1,10 +1,10 @@
 [
   {
     "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-    "first_name": "string",
-    "surname": "string",
+    "first_name": "Christopher",
+    "surname": "Kemp",
     "date_of_birth": "2019-03-11",
-    "email": "user@example.com",
+    "email": "christopherkemp@university.edu",
     "phone_number": "string",
     "nationality": "string",
     "disability": "string",
@@ -57,11 +57,11 @@
     }
   },
   {
-    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-    "first_name": "string",
-    "surname": "string",
+    "id": "74d1ed54-444d-4a9b-823f-9029fd1aacfc",
+    "first_name": "Alexander",
+    "surname": "Barry",
     "date_of_birth": "2019-03-11",
-    "email": "user@example.com",
+    "email": "alexander.barry@university.edu",
     "phone_number": "string",
     "nationality": "string",
     "disability": "string",
@@ -114,11 +114,11 @@
     }
   },
   {
-    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-    "first_name": "string",
-    "surname": "string",
+    "id": "7531944b-f134-4da4-ba85-a6f990055843",
+    "first_name": "Amy",
+    "surname": "McCarthy",
     "date_of_birth": "2019-03-11",
-    "email": "user@example.com",
+    "email": "amy.mccarthy@mail.com",
     "phone_number": "string",
     "nationality": "string",
     "disability": "string",

--- a/spec/requests/api/viewing_one_application_spec.rb
+++ b/spec/requests/api/viewing_one_application_spec.rb
@@ -14,10 +14,10 @@ describe 'GET one application' do
     end
 
     it 'responds with the right application' do
-      expect(json_response).to include({
+      expect(json_response).to include(
         'id' => id,
         'first_name' => "Christopher"
-      })
+      )
     end
   end
 
@@ -29,10 +29,10 @@ describe 'GET one application' do
     end
 
     it 'responds with the right application' do
-      expect(json_response).to include({
+      expect(json_response).to include(
         'id' => id,
         'first_name' => "Alexander"
-      })
+      )
     end
   end
 
@@ -44,10 +44,10 @@ describe 'GET one application' do
     end
 
     it 'responds with the right application' do
-      expect(json_response).to include({
+      expect(json_response).to include(
         'id' => id,
         'first_name' => "Amy"
-      })
+      )
     end
   end
 

--- a/spec/requests/api/viewing_one_application_spec.rb
+++ b/spec/requests/api/viewing_one_application_spec.rb
@@ -1,0 +1,65 @@
+describe 'GET one application' do
+  let(:json_response) { JSON.parse(response.body) }
+
+  before do
+    headers = { "ACCEPT" => "application/json" }
+    get "/api/applications/#{id}", headers: headers
+  end
+
+  context 'with an id matching the first application' do
+    let(:id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+
+    it 'responds with a success code' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'responds with the right application' do
+      expect(json_response).to include({
+        'id' => id,
+        'first_name' => "Christopher"
+      })
+    end
+  end
+
+  context 'with an id matching the second application' do
+    let(:id) { "74d1ed54-444d-4a9b-823f-9029fd1aacfc" }
+
+    it 'responds with a success code' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'responds with the right application' do
+      expect(json_response).to include({
+        'id' => id,
+        'first_name' => "Alexander"
+      })
+    end
+  end
+
+  context 'with an id matching the third application' do
+    let(:id) { "7531944b-f134-4da4-ba85-a6f990055843" }
+
+    it 'responds with a success code' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'responds with the right application' do
+      expect(json_response).to include({
+        'id' => id,
+        'first_name' => "Amy"
+      })
+    end
+  end
+
+  context 'with an id not matching any application' do
+    let(:id) { "nonsense-code" }
+
+    it 'responds with not found' do
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'returns no application data' do
+      expect(response.body).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
This PR causes the single application endpoint to act as if it's backed by the actual resources, even though it's just a flat file doing the work.

I don't like referencing the IDs directly in the tests, but I feel like I'd have to architect this excessively to prevent it.