### PR TITLE
Add basic make offer endpoint

### DIFF
--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -11,6 +11,14 @@ class Api::ApplicationsController < ActionController::API
     end
   end
 
+  def make_offer
+    if matching_application.present?
+      render json: matching_application
+    else
+      head :not_found
+    end
+  end
+
 private
 
   def matching_application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,9 @@ Rails.application.routes.draw do
   end
 
   namespace :api do
-    resources :applications, only: %i[index show]
+    resources :applications, only: %i[index show] do
+      member { patch :make_offer }
+    end
   end
 
   match '/404', to: 'errors#not_found', via: :all

--- a/spec/requests/api/making_an_offer_spec.rb
+++ b/spec/requests/api/making_an_offer_spec.rb
@@ -1,0 +1,37 @@
+describe 'making an offer' do
+  before do
+    headers = { "ACCEPT" => "application/json" }
+    patch "/api/applications/#{id}/make_offer", headers: headers
+  end
+
+  context 'with an id not matching any application' do
+    let(:id) { "nonsense-code" }
+
+    it 'responds with JSON' do
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it 'responds with a not found code' do
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'with an id matching an application' do
+    let(:id) { '3fa85f64-5717-4562-b3fc-2c963f66afa6' }
+
+    it 'responds with JSON' do
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it 'responds ok' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the relevant application' do
+      expect(JSON.parse(response.body)).to include(
+        'id' => id,
+        'first_name' => "Christopher"
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR allows clients to make an offer to a candidate, against a particular application.

Notably this implementation does not include:
- storing or logging that clients have made an offer
- acting differently if the application has already been responded to
- a good description of the result in the response
- any concept of ownership for these resources (and thus the corresponding failure case of "you don't own this")