### PR TITLE
Add basic reject endpoint

### DIFF
--- a/app/controllers/api/applications_controller.rb
+++ b/app/controllers/api/applications_controller.rb
@@ -19,6 +19,14 @@ class Api::ApplicationsController < ActionController::API
     end
   end
 
+  def reject
+    if matching_application.present?
+      render json: matching_application
+    else
+      head :not_found
+    end
+  end
+
 private
 
   def matching_application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,10 @@ Rails.application.routes.draw do
 
   namespace :api do
     resources :applications, only: %i[index show] do
-      member { patch :make_offer }
+      member do
+        patch :make_offer
+        patch :reject
+      end
     end
   end
 

--- a/spec/requests/api/rejecting_an_offer_spec.rb
+++ b/spec/requests/api/rejecting_an_offer_spec.rb
@@ -1,0 +1,37 @@
+describe 'rejecting an offer' do
+  before do
+    headers = { "ACCEPT" => "application/json" }
+    patch "/api/applications/#{id}/reject", headers: headers
+  end
+
+  context 'with an id not matching any application' do
+    let(:id) { "nonsense-code" }
+
+    it 'responds with JSON' do
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it 'responds with a not found code' do
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  context 'with an id matching an application' do
+    let(:id) { '3fa85f64-5717-4562-b3fc-2c963f66afa6' }
+
+    it 'responds with JSON' do
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it 'responds ok' do
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns the relevant application' do
+      expect(JSON.parse(response.body)).to include(
+        'id' => id,
+        'first_name' => "Christopher"
+      )
+    end
+  end
+end


### PR DESCRIPTION
THIS IS DRAFT BECAUSE: it's branched off #47 (and has that as its base), so that needs to go first.

This implementation has the same gaps as #47 around good responses and storing information.

As I look at this I realise these two endpoints aren't very RESTful - they don't describe well which resources are being modified on the server side. More importantly, that means they aren't very _helpful_ - they don't have particularly useful information in the response.