### PR TITLE
Add lint rake task (rubocop w/govuk-lint rules)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,10 @@ AllCops:
     - 'bin/update'
     - 'db/schema.rb'
 
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: single_quotes
+
 Metrics/BlockLength:
   # Disable block length restriction for files that use a DSL around blocks.
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,14 @@
+inherit_gem:
+  govuk-lint: configs/rubocop/all.yml
+
+AllCops:
+  Exclude:
+    - 'bin/rails'
+    - 'bin/rake'
+    - 'bin/setup'
+    - 'bin/update'
+    - 'db/schema.rb'
+
 Metrics/BlockLength:
   # Disable block length restriction for files that use a DSL around blocks.
   Exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: c
 services:
   - docker
 script:
-- make test
+- make lint && make test

--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ group :test do
   gem 'simplecov', require: false
 
   # Add Junit formatter for rspec
-  gem "rspec_junit_formatter"
+  gem 'rspec_junit_formatter'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ docker-down:
 docker-build:
 	docker-compose build
 
+.PHONY: lint
+lint: docker-down docker-build
+	docker-compose run --rm web bundle exec rubocop app config db lib spec Gemfile
+
 .PHONY: shell
 shell: docker-down docker-build db-setup
 	docker-compose run --rm web bash

--- a/app/controllers/api/v2/offers_controller.rb
+++ b/app/controllers/api/v2/offers_controller.rb
@@ -7,7 +7,7 @@ class Api::V2::OffersController < ActionController::API
     end
   end
 
-  private
+private
 
   def matching_application
     applications.find { |app| app['id'] == params[:application_id] }

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,13 +1,13 @@
 module DeviseHelper
   def devise_error_messages!
-    return "" unless devise_error_messages?
+    return '' unless devise_error_messages?
 
     messages = resource.errors.map do |field, message|
       content_tag(:li, "#{field} #{message}".humanize)
     end
     messages = messages.join
 
-    sentence = I18n.t("errors.messages.not_saved",
+    sentence = I18n.t('errors.messages.not_saved',
                       count: resource.errors.count,
                       resource: resource.class.model_name.human.downcase)
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,16 +1,16 @@
 require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "active_storage/engine"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
-require "action_cable/engine"
-require "sprockets/railtie"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'active_storage/engine'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_view/railtie'
+require 'action_cable/engine'
+require 'sprockets/railtie'
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,7 +83,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -9,10 +9,10 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # Add GOVUK image asset path
-Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "assets", "images")
+Rails.application.config.assets.paths << Rails.root.join('node_modules', 'govuk-frontend', 'assets', 'images')
 
 # Add GOVUK font asset path
-Rails.application.config.assets.paths << Rails.root.join("node_modules", "govuk-frontend", "assets", "fonts")
+Rails.application.config.assets.paths << Rails.root.join('node_modules', 'govuk-frontend', 'assets', 'fonts')
 
 Rails.application.config.assets.precompile += %w[
   favicon.ico

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,16 +4,16 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch('RAILS_ENV') { 'development' }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/db/migrate/20190124135027_devise_create_admin_users.rb
+++ b/db/migrate/20190124135027_devise_create_admin_users.rb
@@ -4,8 +4,8 @@ class DeviseCreateAdminUsers < ActiveRecord::Migration[5.2]
   def change
     create_table :admin_users, id: :uuid do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20190125155013_add_devise_to_candidates.rb
+++ b/db/migrate/20190125155013_add_devise_to_candidates.rb
@@ -4,8 +4,8 @@ class AddDeviseToCandidates < ActiveRecord::Migration[5.2]
   def self.up
     change_table :candidates do |t|
       ## Database authenticatable
-      t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :email,              null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
 
       ## Recoverable
       t.string   :reset_password_token

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -38,7 +38,7 @@ unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gem
       task :statsetup do
         require 'rails/code_statistics'
         ::STATS_DIRECTORIES << %w(Cucumber\ features features) if File.exist?('features')
-        ::CodeStatistics::TEST_TYPES << "Cucumber features" if File.exist?('features')
+        ::CodeStatistics::TEST_TYPES << 'Cucumber features' if File.exist?('features')
       end
 
       task :annotations_setup do

--- a/spec/controllers/admin/candidates_controller_spec.rb
+++ b/spec/controllers/admin/candidates_controller_spec.rb
@@ -1,40 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe Admin::CandidatesController, type: :controller do
-  context "when signed in" do
+  context 'when signed in' do
     let(:user) { Admin::User.create(email: 'example@example.com', password: 'testing123', password_confirmation: 'testing123') }
 
     before { sign_in user }
 
-    describe "GET #index" do
-      it "returns http success" do
+    describe 'GET #index' do
+      it 'returns http success' do
         get :index
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET #show" do
+    describe 'GET #show' do
       let(:candidate) { create(:candidate) }
 
-      it "returns http success" do
+      it 'returns http success' do
         get :show, params: { id: candidate }
         expect(response).to have_http_status(:success)
       end
     end
   end
 
-  context "when not signed in" do
-    describe "GET #index" do
-      it "redirects to admin sign in page" do
+  context 'when not signed in' do
+    describe 'GET #index' do
+      it 'redirects to admin sign in page' do
         get :index
         expect(response).to redirect_to(new_admin_user_session_path)
       end
     end
 
-    describe "GET #show" do
+    describe 'GET #show' do
       let(:candidate) { create(:candidate) }
 
-      it "redirects to admin sign in page" do
+      it 'redirects to admin sign in page' do
         get :show, params: { id: candidate }
         expect(response).to redirect_to(new_admin_user_session_path)
       end

--- a/spec/controllers/admin/home_controller_spec.rb
+++ b/spec/controllers/admin/home_controller_spec.rb
@@ -1,20 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe Admin::HomeController, type: :controller do
-  describe "GET #index" do
-    context "when signed in" do
+  describe 'GET #index' do
+    context 'when signed in' do
       let(:user) { Admin::User.create(email: 'example@example.com', password: 'testing123', password_confirmation: 'testing123') }
 
       before { sign_in user }
 
-      it "returns http success" do
+      it 'returns http success' do
         get :index
         expect(response).to have_http_status(:success)
       end
     end
 
-    context "when not signed in" do
-      it "should redirect to sign in page" do
+    context 'when not signed in' do
+      it 'should redirect to sign in page' do
         get :index
         expect(response).to redirect_to(new_admin_user_session_path)
       end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,38 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe HomeController, type: :controller do
-  describe "GET #landing" do
-    context "when not signed in" do
-      it "returns http success" do
+  describe 'GET #landing' do
+    context 'when not signed in' do
+      it 'returns http success' do
         get :landing
         expect(response).to have_http_status(:success)
       end
     end
 
-    context "when signed in" do
+    context 'when signed in' do
       let(:candidate) { create(:candidate) }
       before { sign_in candidate }
 
-      it "redirects to index / authenticated root" do
+      it 'redirects to index / authenticated root' do
         get :landing
         expect(response).to redirect_to(authenticated_root_path)
       end
     end
   end
 
-  describe "GET #index" do
-    context "when signed in" do
+  describe 'GET #index' do
+    context 'when signed in' do
       let(:candidate) { create(:candidate) }
       before { sign_in candidate }
 
-      it "returns http success" do
+      it 'returns http success' do
         get :index
         expect(response).to have_http_status(:success)
       end
     end
 
-    context "when not signed in" do
-      it "redirects to landing page / unauthenticated root" do
+    context 'when not signed in' do
+      it 'redirects to landing page / unauthenticated root' do
         get :index
         expect(response).to redirect_to(unauthenticated_root_path)
       end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,49 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe ProfileController, type: :controller do
-  context "when signed in" do
+  context 'when signed in' do
     let(:candidate) { create(:candidate, first_name: 'John', surname: 'Smith') }
     before { sign_in candidate }
 
-    describe "GET #show" do
-      it "returns http success" do
+    describe 'GET #show' do
+      it 'returns http success' do
         get :show
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET #edit" do
-      it "returns http success" do
+    describe 'GET #edit' do
+      it 'returns http success' do
         get :edit
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "PATCH/PUT #update" do
-      it "updates candidate" do
+    describe 'PATCH/PUT #update' do
+      it 'updates candidate' do
         put :update, params: { candidate: { first_name: 'Bob', surname: 'Jones' } }
         expect(candidate.reload.full_name).to eq('Bob Jones')
       end
     end
   end
 
-  context "when not signed in" do
-    describe "GET #show" do
-      it "redirects to sign in page" do
+  context 'when not signed in' do
+    describe 'GET #show' do
+      it 'redirects to sign in page' do
         get :show
         expect(response).to redirect_to(new_candidate_session_path)
       end
     end
 
-    describe "GET #edit" do
-      it "redirects to sign in page" do
+    describe 'GET #edit' do
+      it 'redirects to sign in page' do
         get :edit
         expect(response).to redirect_to(new_candidate_session_path)
       end
     end
 
-    describe "PATCH/PUT #update" do
-      it "redirects to sign in page" do
+    describe 'PATCH/PUT #update' do
+      it 'redirects to sign in page' do
         put :update
         expect(response).to redirect_to(new_candidate_session_path)
       end

--- a/spec/factories/candidate.rb
+++ b/spec/factories/candidate.rb
@@ -1,12 +1,12 @@
 FactoryBot.define do
   factory :candidate do
-    title { "Mr" }
-    first_name { "John" }
-    surname  { "Doe" }
+    title { 'Mr' }
+    first_name { 'John' }
+    surname  { 'Doe' }
     gender { Candidate.genders['male'] }
     date_of_birth { 20.years.ago.to_date }
-    email { "johndoe@example.com" }
-    password { "testing123" }
-    password_confirmation { "testing123" }
+    email { 'johndoe@example.com' }
+    password { 'testing123' }
+    password_confirmation { 'testing123' }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,7 +7,7 @@ SimpleCov.start 'rails'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/requests/api/v1/making_an_offer_spec.rb
+++ b/spec/requests/api/v1/making_an_offer_spec.rb
@@ -1,14 +1,14 @@
 describe 'making an offer' do
   before do
-    headers = { "ACCEPT" => "application/json" }
+    headers = { 'ACCEPT' => 'application/json' }
     patch "/api/applications/#{id}/make_offer", headers: headers
   end
 
   context 'with an id not matching any application' do
-    let(:id) { "nonsense-code" }
+    let(:id) { 'nonsense-code' }
 
     it 'responds with JSON' do
-      expect(response.content_type).to eq("application/json")
+      expect(response.content_type).to eq('application/json')
     end
 
     it 'responds with a not found code' do
@@ -20,7 +20,7 @@ describe 'making an offer' do
     let(:id) { '3fa85f64-5717-4562-b3fc-2c963f66afa6' }
 
     it 'responds with JSON' do
-      expect(response.content_type).to eq("application/json")
+      expect(response.content_type).to eq('application/json')
     end
 
     it 'responds ok' do
@@ -30,7 +30,7 @@ describe 'making an offer' do
     it 'returns the relevant application' do
       expect(JSON.parse(response.body)).to include(
         'id' => id,
-        'first_name' => "Boris"
+        'first_name' => 'Boris'
       )
     end
   end

--- a/spec/requests/api/v1/rejecting_an_offer_spec.rb
+++ b/spec/requests/api/v1/rejecting_an_offer_spec.rb
@@ -1,14 +1,14 @@
 describe 'rejecting an offer' do
   before do
-    headers = { "ACCEPT" => "application/json" }
+    headers = { 'ACCEPT' => 'application/json' }
     patch "/api/applications/#{id}/reject", headers: headers
   end
 
   context 'with an id not matching any application' do
-    let(:id) { "nonsense-code" }
+    let(:id) { 'nonsense-code' }
 
     it 'responds with JSON' do
-      expect(response.content_type).to eq("application/json")
+      expect(response.content_type).to eq('application/json')
     end
 
     it 'responds with a not found code' do
@@ -20,7 +20,7 @@ describe 'rejecting an offer' do
     let(:id) { '3fa85f64-5717-4562-b3fc-2c963f66afa6' }
 
     it 'responds with JSON' do
-      expect(response.content_type).to eq("application/json")
+      expect(response.content_type).to eq('application/json')
     end
 
     it 'responds ok' do
@@ -30,7 +30,7 @@ describe 'rejecting an offer' do
     it 'returns the relevant application' do
       expect(JSON.parse(response.body)).to include(
         'id' => id,
-        'first_name' => "Boris"
+        'first_name' => 'Boris'
       )
     end
   end

--- a/spec/requests/api/v1/viewing_all_applications_spec.rb
+++ b/spec/requests/api/v1/viewing_all_applications_spec.rb
@@ -2,12 +2,12 @@ describe 'GET applications' do
   let(:json_response) { JSON.parse(response.body) }
 
   before do
-    headers = { "ACCEPT" => "application/json" }
+    headers = { 'ACCEPT' => 'application/json' }
     get '/api/applications', headers: headers
   end
 
   it 'responds with JSON' do
-    expect(response.content_type).to eq("application/json")
+    expect(response.content_type).to eq('application/json')
   end
 
   it 'responds with a success code' do

--- a/spec/requests/api/v1/viewing_one_application_spec.rb
+++ b/spec/requests/api/v1/viewing_one_application_spec.rb
@@ -2,12 +2,12 @@ describe 'GET one application' do
   let(:json_response) { JSON.parse(response.body) }
 
   before do
-    headers = { "ACCEPT" => "application/json" }
+    headers = { 'ACCEPT' => 'application/json' }
     get "/api/applications/#{id}", headers: headers
   end
 
   context 'with an id matching the first application' do
-    let(:id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+    let(:id) { '3fa85f64-5717-4562-b3fc-2c963f66afa6' }
 
     it 'responds with a success code' do
       expect(response).to have_http_status(:ok)
@@ -16,13 +16,13 @@ describe 'GET one application' do
     it 'responds with the right application' do
       expect(json_response).to include(
         'id' => id,
-        'first_name' => "Boris"
+        'first_name' => 'Boris'
       )
     end
   end
 
   context 'with an id matching the second application' do
-    let(:id) { "74d1ed54-444d-4a9b-823f-9029fd1aacfc" }
+    let(:id) { '74d1ed54-444d-4a9b-823f-9029fd1aacfc' }
 
     it 'responds with a success code' do
       expect(response).to have_http_status(:ok)
@@ -31,13 +31,13 @@ describe 'GET one application' do
     it 'responds with the right application' do
       expect(json_response).to include(
         'id' => id,
-        'first_name' => "Priti"
+        'first_name' => 'Priti'
       )
     end
   end
 
   context 'with an id matching the third application' do
-    let(:id) { "7531944b-f134-4da4-ba85-a6f990055843" }
+    let(:id) { '7531944b-f134-4da4-ba85-a6f990055843' }
 
     it 'responds with a success code' do
       expect(response).to have_http_status(:ok)
@@ -46,13 +46,13 @@ describe 'GET one application' do
     it 'responds with the right application' do
       expect(json_response).to include(
         'id' => id,
-        'first_name' => "Francis"
+        'first_name' => 'Francis'
       )
     end
   end
 
   context 'with an id not matching any application' do
-    let(:id) { "nonsense-code" }
+    let(:id) { 'nonsense-code' }
 
     it 'responds with not found' do
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v2/viewing_all_applications_spec.rb
+++ b/spec/requests/api/v2/viewing_all_applications_spec.rb
@@ -2,12 +2,12 @@ describe 'GET applications' do
   let(:json_response) { JSON.parse(response.body) }
 
   before do
-    headers = { "ACCEPT" => "application/json" }
+    headers = { 'ACCEPT' => 'application/json' }
     get '/api/v2/applications', headers: headers
   end
 
   it 'responds with JSON' do
-    expect(response.content_type).to eq("application/json")
+    expect(response.content_type).to eq('application/json')
   end
 
   it 'responds with a success code' do

--- a/spec/requests/api/v2/viewing_offers_for_one_application_spec.rb
+++ b/spec/requests/api/v2/viewing_offers_for_one_application_spec.rb
@@ -2,12 +2,12 @@ describe 'GET offers against one application' do
   let(:json_response) { JSON.parse(response.body) }
 
   before do
-    headers = { "ACCEPT" => "application/json" }
+    headers = { 'ACCEPT' => 'application/json' }
     get "/api/v2/applications/#{id}/offers", headers: headers
   end
 
   context 'with an id matching the first application' do
-    let(:id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+    let(:id) { '3fa85f64-5717-4562-b3fc-2c963f66afa6' }
 
     it 'responds with a success code' do
       expect(response).to have_http_status(:ok)
@@ -19,7 +19,7 @@ describe 'GET offers against one application' do
   end
 
   context 'with an id matching the second application' do
-    let(:id) { "74d1ed54-444d-4a9b-823f-9029fd1aacfc" }
+    let(:id) { '74d1ed54-444d-4a9b-823f-9029fd1aacfc' }
 
     it 'responds with one offer' do
       expect(json_response['offers'].count).to eq 1
@@ -55,7 +55,7 @@ describe 'GET offers against one application' do
   end
 
   context 'with an id matching the third application' do
-    let(:id) { "7531944b-f134-4da4-ba85-a6f990055843" }
+    let(:id) { '7531944b-f134-4da4-ba85-a6f990055843' }
 
     it 'responds with one offer' do
       expect(json_response['offers'].count).to eq 1
@@ -77,7 +77,7 @@ describe 'GET offers against one application' do
   end
 
   context 'with an id not matching any application' do
-    let(:id) { "nonsense-code" }
+    let(:id) { 'nonsense-code' }
 
     it 'responds with not found' do
       expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v2/viewing_one_application_spec.rb
+++ b/spec/requests/api/v2/viewing_one_application_spec.rb
@@ -2,12 +2,12 @@ describe 'GET one application' do
   let(:json_response) { JSON.parse(response.body) }
 
   before do
-    headers = { "ACCEPT" => "application/json" }
+    headers = { 'ACCEPT' => 'application/json' }
     get "/api/v2/applications/#{id}", headers: headers
   end
 
   context 'with an id matching the first application' do
-    let(:id) { "3fa85f64-5717-4562-b3fc-2c963f66afa6" }
+    let(:id) { '3fa85f64-5717-4562-b3fc-2c963f66afa6' }
 
     it 'responds with a success code' do
       expect(response).to have_http_status(:ok)
@@ -16,7 +16,7 @@ describe 'GET one application' do
     it 'responds with the right application' do
       expect(json_response).to include(
         'id' => id,
-        'first_name' => "Boris"
+        'first_name' => 'Boris'
       )
     end
 
@@ -30,7 +30,7 @@ describe 'GET one application' do
   end
 
   context 'with an id matching the second application' do
-    let(:id) { "74d1ed54-444d-4a9b-823f-9029fd1aacfc" }
+    let(:id) { '74d1ed54-444d-4a9b-823f-9029fd1aacfc' }
 
     it 'responds with a success code' do
       expect(response).to have_http_status(:ok)
@@ -39,7 +39,7 @@ describe 'GET one application' do
     it 'responds with the right application' do
       expect(json_response).to include(
         'id' => id,
-        'first_name' => "Priti"
+        'first_name' => 'Priti'
       )
     end
 
@@ -49,7 +49,7 @@ describe 'GET one application' do
   end
 
   context 'with an id matching the third application' do
-    let(:id) { "7531944b-f134-4da4-ba85-a6f990055843" }
+    let(:id) { '7531944b-f134-4da4-ba85-a6f990055843' }
 
     it 'responds with a success code' do
       expect(response).to have_http_status(:ok)
@@ -58,7 +58,7 @@ describe 'GET one application' do
     it 'responds with the right application' do
       expect(json_response).to include(
         'id' => id,
-        'first_name' => "Francis"
+        'first_name' => 'Francis'
       )
     end
 
@@ -68,7 +68,7 @@ describe 'GET one application' do
   end
 
   context 'with an id not matching any application' do
-    let(:id) { "nonsense-code" }
+    let(:id) { 'nonsense-code' }
 
     it 'responds with not found' do
       expect(response).to have_http_status(:not_found)


### PR DESCRIPTION
It looks like [govuk-lint is being changed to be a rubocop rule set instead of a separate gem](https://github.com/alphagov/govuk-rfcs/pull/100), in the fullness of time. This PR uses rubocop directly, as it'll work fine right now, and be easy to switch in the future.

(Heavily 'inspired' by https://github.com/DFE-Digital/manage-courses-backend/pull/222 and https://github.com/alphagov/govwifi-admin/pull/680) 