### PR TITLE
Show a check answers page once the personal details form is complete

### DIFF
--- a/app/controllers/check_your_answers_controller.rb
+++ b/app/controllers/check_your_answers_controller.rb
@@ -1,0 +1,5 @@
+class CheckYourAnswersController < ApplicationController
+  def show
+    @personal_details = PersonalDetails.last
+  end
+end

--- a/app/controllers/personal_details_controller.rb
+++ b/app/controllers/personal_details_controller.rb
@@ -6,6 +6,8 @@ class PersonalDetailsController < ApplicationController
   def create
     @personal_details = PersonalDetails.new(personal_details_params)
     @personal_details.save
+
+    redirect_to check_your_answers_path
   end
 
 private

--- a/app/controllers/personal_details_controller.rb
+++ b/app/controllers/personal_details_controller.rb
@@ -1,11 +1,22 @@
 class PersonalDetailsController < ApplicationController
   def new
-    @personal_details = PersonalDetails.new
+    @personal_details = if params[:reviewing]
+                          PersonalDetails.last
+                        else
+                          PersonalDetails.new
+                        end
   end
 
   def create
     @personal_details = PersonalDetails.new(personal_details_params)
     @personal_details.save
+
+    redirect_to check_your_answers_path
+  end
+
+  def update
+    @personal_details = PersonalDetails.last
+    @personal_details.update(personal_details_params)
 
     redirect_to check_your_answers_path
   end

--- a/app/views/check_your_answers/show.html.erb
+++ b/app/views/check_your_answers/show.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl"><%= t('application_form.check_your_answers') %></h1>
+
+    <h2 class="govuk-heading-m"><%= t('application_form.personal_details_section.heading') %></h2>
+
+    <dl class="govuk-summary-list govuk-!-font-size-16 govuk-summary-list--no-border">
+      <%= render partial: 'shared/description_list_item', locals: { field: :title, value: @personal_details.title } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :first_name, value: @personal_details.first_name } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :last_name, value: @personal_details.last_name } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :preferred_name, value: @personal_details.preferred_name } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :date_of_birth, value: @personal_details.date_of_birth.to_s(:govuk_human_readable) } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :nationality, value: @personal_details.nationality } %>
+    </dl>
+
+    <%= link_to tt_application_path, role: 'button', class: 'govuk-button' do %>
+      <%= t('application_form.submit') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_description_list_item.html.erb
+++ b/app/views/shared/_description_list_item.html.erb
@@ -5,4 +5,9 @@
   <dd class="govuk-summary-list__value">
     <%= value %>
   </dd>
+  <dd class="govuk-summary-list__actions">
+    <%= link_to personal_details_path(reviewing: true), class: 'govuk-link', id: "change-#{field}" do %>
+        Change<span class="govuk-visually-hidden"> <%= field %></span>
+    <% end %>
+  </dd>
 </div>

--- a/app/views/tt_applications/show.html.erb
+++ b/app/views/tt_applications/show.html.erb
@@ -1,20 +1,5 @@
 <div class="govuk-panel govuk-panel--confirmation">
   <h1 class="govuk-panel__title">
-    <%= t('application_form.application_complete') %>
+    <%= t('application_form.application_submitted') %>
   </h1>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l"><%= t('application_form.personal_details_section.heading') %></h1>
-
-    <dl class="govuk-summary-list govuk-!-font-size-16 govuk-summary-list--no-border">
-      <%= render partial: 'shared/description_list_item', locals: { field: :title, value: @personal_details.title } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :first_name, value: @personal_details.first_name } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :last_name, value: @personal_details.last_name } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :preferred_name, value: @personal_details.preferred_name } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :date_of_birth, value: @personal_details.date_of_birth.to_s(:govuk_human_readable) } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :nationality, value: @personal_details.nationality } %>
-    </dl>
-  </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -2,9 +2,9 @@ en:
   application_form:
     begin_button: Start now
     save_and_continue: Save and continue
-    review_answers: Review your answers
     submit: Submit your application
-    application_complete: Application complete
+    application_submitted: Application submitted
+    check_your_answers: Check your answers before submitting your application
     personal_details_section:
       heading: Personal details
       title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   get 'personal_details', to: 'personal_details#new'
   post 'personal_details', to: 'personal_details#create'
+  patch 'personal_details', to: 'personal_details#update'
 
   get 'check_your_answers', to: 'check_your_answers#show'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   get 'personal_details', to: 'personal_details#new'
   post 'personal_details', to: 'personal_details#create'
 
+  get 'check_your_answers', to: 'check_your_answers#show'
+
   get 'application', to: 'tt_applications#show', as: :tt_application
 end

--- a/spec/system/candidate_fills_in_personal_details_spec.rb
+++ b/spec/system/candidate_fills_in_personal_details_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe 'A candidate filling in their personal details' do
 
     click_on t('application_form.save_and_continue')
 
+    expect(page).to have_content t('application_form.check_your_answers')
     expect(page).to have_content t('application_form.personal_details_section.heading')
-    expect(page).to have_content t('application_form.review_answers')
 
     within '.govuk-summary-list' do
       expect_description_list_item(
@@ -41,10 +41,6 @@ RSpec.describe 'A candidate filling in their personal details' do
       expect_description_list_item(
         t('application_form.personal_details_section.preferred_name.label'),
         'Dr Doe'
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.date_of_birth.label'),
-        '13 March 1997'
       )
       expect_description_list_item(
         t('application_form.personal_details_section.nationality.label'),
@@ -54,30 +50,7 @@ RSpec.describe 'A candidate filling in their personal details' do
 
     click_on t('application_form.submit')
 
-    expect(page).to have_content t('application_form.application_complete')
-
-    within '.govuk-summary-list' do
-      expect_description_list_item(
-        t('application_form.personal_details_section.title.label'),
-        'Dr'
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.first_name.label'),
-        'John'
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.last_name.label'),
-        'Doe'
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.preferred_name.label'),
-        'Dr Doe'
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.nationality.label'),
-        'British'
-      )
-    end
+    expect(page).to have_content t('application_form.application_submitted')
   end
 
   # search for a <dt> with an expected name adjacent to a <dd> with an expected value

--- a/spec/system/candidate_fills_in_personal_details_spec.rb
+++ b/spec/system/candidate_fills_in_personal_details_spec.rb
@@ -51,6 +51,34 @@ RSpec.describe 'A candidate filling in their personal details' do
     expect(page).to have_content t('application_form.application_submitted')
   end
 
+  it 'can edit the Personal details section via the Check your answers page' do
+    visit '/'
+    click_on t('application_form.begin_button')
+
+    # When I fill in the personal details form and submit it
+    fill_in_personal_details(VALID_PERSONAL_DETAILS.merge(first_name: 'Zuleika'))
+    click_on t('application_form.save_and_continue')
+
+    # And I click the relevant "Change" button on the Check your answers page
+    find('#change-first_name').click
+
+    # Then I expect to see the details I entered earlier
+    expect(page).to have_field('First name', with: 'Zuleika')
+
+    # And when I submit the form with a changed first name
+    fill_in t('application_form.personal_details_section.first_name.label'), with: 'Daphne'
+    click_on t('application_form.save_and_continue')
+
+    # Then I expect to see the Check your answers page again, with the new name in place
+    expect(page).to have_content t('application_form.check_your_answers')
+
+    # And I expect to see my new first name
+    expect_description_list_item(
+      t('application_form.personal_details_section.first_name.label'),
+      'Daphne'
+    )
+  end
+
   def fill_in_personal_details(details)
     fill_in t('application_form.personal_details_section.title.label'), with: details[:title]
     fill_in t('application_form.personal_details_section.first_name.label'), with: details[:first_name]

--- a/spec/system/candidate_fills_in_personal_details_spec.rb
+++ b/spec/system/candidate_fills_in_personal_details_spec.rb
@@ -1,24 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe 'A candidate filling in their personal details' do
+  VALID_PERSONAL_DETAILS = {
+    first_name: 'John',
+    last_name: 'Doe',
+    title: 'Dr',
+    preferred_name: 'Dr Doe',
+    nationality: 'British',
+    date_of_birth: Date.new(1997, 3, 13)
+  }.freeze
+
   it 'can enter details into the form, and see them on the finished application' do
     visit '/'
     click_on t('application_form.begin_button')
 
     expect(page).to have_content t('application_form.personal_details_section.heading')
 
-    fill_in t('application_form.personal_details_section.title.label'), with: 'Dr'
-    fill_in t('application_form.personal_details_section.first_name.label'), with: 'John'
-    fill_in t('application_form.personal_details_section.preferred_name.label'), with: 'Dr Doe'
-    fill_in t('application_form.personal_details_section.last_name.label'), with: 'Doe'
-
-    within '.govuk-date-input' do
-      fill_in 'Day', with: 13
-      fill_in 'Month', with: 3
-      fill_in 'Year', with: 1997
-    end
-
-    fill_in t('application_form.personal_details_section.nationality.label'), with: 'British'
+    fill_in_personal_details(VALID_PERSONAL_DETAILS)
 
     click_on t('application_form.save_and_continue')
 
@@ -28,29 +26,44 @@ RSpec.describe 'A candidate filling in their personal details' do
     within '.govuk-summary-list' do
       expect_description_list_item(
         t('application_form.personal_details_section.title.label'),
-        'Dr'
+        VALID_PERSONAL_DETAILS[:title]
       )
       expect_description_list_item(
         t('application_form.personal_details_section.first_name.label'),
-        'John'
+        VALID_PERSONAL_DETAILS[:first_name]
       )
       expect_description_list_item(
         t('application_form.personal_details_section.last_name.label'),
-        'Doe'
+        VALID_PERSONAL_DETAILS[:last_name]
       )
       expect_description_list_item(
         t('application_form.personal_details_section.preferred_name.label'),
-        'Dr Doe'
+        VALID_PERSONAL_DETAILS[:preferred_name]
       )
       expect_description_list_item(
         t('application_form.personal_details_section.nationality.label'),
-        'British'
+        VALID_PERSONAL_DETAILS[:nationality]
       )
     end
 
     click_on t('application_form.submit')
 
     expect(page).to have_content t('application_form.application_submitted')
+  end
+
+  def fill_in_personal_details(details)
+    fill_in t('application_form.personal_details_section.title.label'), with: details[:title]
+    fill_in t('application_form.personal_details_section.first_name.label'), with: details[:first_name]
+    fill_in t('application_form.personal_details_section.preferred_name.label'), with: details[:preferred_name]
+    fill_in t('application_form.personal_details_section.last_name.label'), with: details[:last_name]
+
+    within '.govuk-date-input' do
+      fill_in 'Day', with: details[:date_of_birth].day
+      fill_in 'Month', with: details[:date_of_birth].month
+      fill_in 'Year', with: details[:date_of_birth].year
+    end
+
+    fill_in t('application_form.personal_details_section.nationality.label'), with: details[:nationality]
   end
 
   # search for a <dt> with an expected name adjacent to a <dd> with an expected value

--- a/spec/system/candidate_fills_in_personal_details_spec.rb
+++ b/spec/system/candidate_fills_in_personal_details_spec.rb
@@ -24,26 +24,12 @@ RSpec.describe 'A candidate filling in their personal details' do
     expect(page).to have_content t('application_form.personal_details_section.heading')
 
     within '.govuk-summary-list' do
-      expect_description_list_item(
-        t('application_form.personal_details_section.title.label'),
-        VALID_PERSONAL_DETAILS[:title]
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.first_name.label'),
-        VALID_PERSONAL_DETAILS[:first_name]
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.last_name.label'),
-        VALID_PERSONAL_DETAILS[:last_name]
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.preferred_name.label'),
-        VALID_PERSONAL_DETAILS[:preferred_name]
-      )
-      expect_description_list_item(
-        t('application_form.personal_details_section.nationality.label'),
-        VALID_PERSONAL_DETAILS[:nationality]
-      )
+      expect_summary_to_include('first_name', 'John')
+      expect_summary_to_include('last_name', 'Doe')
+      expect_summary_to_include('title', 'Dr')
+      expect_summary_to_include('preferred_name', 'Dr Doe')
+      expect_summary_to_include('nationality', 'British')
+      expect_summary_to_include('date_of_birth', '13 March 1997')
     end
 
     click_on t('application_form.submit')
@@ -71,12 +57,7 @@ RSpec.describe 'A candidate filling in their personal details' do
 
     # Then I expect to see the Check your answers page again, with the new name in place
     expect(page).to have_content t('application_form.check_your_answers')
-
-    # And I expect to see my new first name
-    expect_description_list_item(
-      t('application_form.personal_details_section.first_name.label'),
-      'Daphne'
-    )
+    expect_summary_to_include('first_name', 'Daphne')
   end
 
   def fill_in_personal_details(details)
@@ -95,7 +76,8 @@ RSpec.describe 'A candidate filling in their personal details' do
   end
 
   # search for a <dt> with an expected name adjacent to a <dd> with an expected value
-  def expect_description_list_item(key, value)
-    expect(find('dt', text: key).find('+dd')).to have_content(value)
+  def expect_summary_to_include(key, value)
+    field_label = t("#{key}.label", scope: 'application_form.personal_details_section')
+    expect(find('dt', text: field_label).find('+dd')).to have_content(value)
   end
 end


### PR DESCRIPTION
This PR tidies up the existing form flow. New sequence:

```
                   +-----------------+
                   |Start application|
                   +--------+--------+
                            |
                            v
                   +--------+-------+
      +----------->+Complete details|
      |            +--------+-------+
Click "change" on field     |
      |                     v
      |          +----------+---------+
      +----------+ Review application |
                 +----------+---------+
                            |
                            |
                            v
                 +----------+---------+
                 | Submit application |
                 +--------------------+
```

A couple of minor decisions along the way:

- use a separate controller for checking answers for now, on the basis that it will be easier to smush this into a more generic controller than it would be to pull it out
- use a URL param to let `PersonalDetailsController` know whether to create a new record or update "the" 😏 existing record