### PR TITLE
Focus error summary

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,3 +1,3 @@
-require.context('../../../node_modules/govuk-frontend/assets');
+require.context('govuk-frontend/assets');
 
 import '../styles/application.scss';

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,3 +1,5 @@
 require.context('govuk-frontend/assets');
+import { initAll as govUKFrontendInitAll } from 'govuk-frontend';
 
 import '../styles/application.scss';
+govUKFrontendInitAll();

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -1,9 +1,9 @@
 @function frontend-font-url($filename) {
-  @return url("~fonts/" + $filename);
+  @return url("~assets/fonts/" + $filename);
 }
 
 @function frontend-image-url($filename) {
-  @return url("~images/" + $filename);
+  @return url("~assets/images/" + $filename);
 }
 
 $govuk-font-url-function: frontend-font-url;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,6 @@
 
     <meta property="og:image" content="<%= asset_pack_path('media/images/govuk-opengraph-image.png') %>">
 
-    <%= javascript_pack_tag 'application' %>
     <%= stylesheet_pack_tag 'application' %>
   </head>
 
@@ -80,5 +79,7 @@
         </div>
       </div>
     </footer>
+
+    <%= javascript_pack_tag 'application' %>
   </body>
 </html>

--- a/app/views/shared/_form_errors_summary.html.erb
+++ b/app/views/shared/_form_errors_summary.html.erb
@@ -1,5 +1,5 @@
 <% if errors.any? %>
-  <div class="govuk-error-summary" id="error-summary">
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
     <h2 class="govuk-error-summary__title">There is a problem</h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['node_modules/govuk-frontend/assets']
+  resolved_paths: ['node_modules/govuk-frontend']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
Adding the JS from `govuk-frontend` achieves the behaviour we want, ie "move keyboard focus to the error summary" per https://design-system.service.gov.uk/components/error-summary/