### PR TITLE
Fix link on date error message

### DIFF
--- a/app/views/personal_details/new.html.erb
+++ b/app/views/personal_details/new.html.erb
@@ -14,9 +14,12 @@
         <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details_section.first_name.label')} %>
         <%= f.govuk_text_field :preferred_name, label: { text: t('application_form.personal_details_section.preferred_name.label')} %>
         <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details_section.last_name.label')} %>
-        <%= f.govuk_date_field :date_of_birth %>
+        <div id='personal_details_date_of_birth'>
+          <%= f.govuk_date_field :date_of_birth %>
+        </div>
         <%= f.govuk_text_field :nationality, label: { text: t('application_form.personal_details_section.nationality.label')} %>
         <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
-    <% end %>
+      </fieldset>
+  <% end %>
   </div>
 </div>

--- a/app/views/personal_details/new.html.erb
+++ b/app/views/personal_details/new.html.erb
@@ -3,23 +3,21 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @personal_details, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: personal_details_path do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('application_form.personal_details_section.heading') %>
-          </h1>
-        </legend>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+          <%= t('application_form.personal_details_section.heading') %>
+        </h1>
+      </legend>
 
-        <%= f.govuk_text_field :title, label: { text: t('application_form.personal_details_section.title.label')}, width: 10 %>
-        <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details_section.first_name.label')} %>
-        <%= f.govuk_text_field :preferred_name, label: { text: t('application_form.personal_details_section.preferred_name.label')} %>
-        <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details_section.last_name.label')} %>
-        <div id='personal_details_date_of_birth'>
-          <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' } %>
-        </div>
-        <%= f.govuk_text_field :nationality, label: { text: t('application_form.personal_details_section.nationality.label')} %>
-        <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
-      </fieldset>
+      <%= f.govuk_text_field :title, label: { text: t('application_form.personal_details_section.title.label')}, width: 10 %>
+      <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details_section.first_name.label')} %>
+      <%= f.govuk_text_field :preferred_name, label: { text: t('application_form.personal_details_section.preferred_name.label')} %>
+      <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details_section.last_name.label')} %>
+      <div id='personal_details_date_of_birth'>
+        <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' } %>
+      </div>
+      <%= f.govuk_text_field :nationality, label: { text: t('application_form.personal_details_section.nationality.label')} %>
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
   <% end %>
   </div>
 </div>

--- a/app/views/personal_details/new.html.erb
+++ b/app/views/personal_details/new.html.erb
@@ -15,7 +15,7 @@
         <%= f.govuk_text_field :preferred_name, label: { text: t('application_form.personal_details_section.preferred_name.label')} %>
         <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details_section.last_name.label')} %>
         <div id='personal_details_date_of_birth'>
-          <%= f.govuk_date_field :date_of_birth %>
+          <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' } %>
         </div>
         <%= f.govuk_text_field :nationality, label: { text: t('application_form.personal_details_section.nationality.label')} %>
         <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>


### PR DESCRIPTION
This PR
- fixes the anchor relevant to "Enter your date of birth " in the page '/personal_details'
- add legend 'Date of birth'

Note: This PR fixes only the anchor redirection, in other words, it takes you to the date field,
but it does not focus the cursor into that field.

That fix should be done in the gem `govuk_design_system_formbuilder`. 
I spoke with @petenorth about this, and he opened an issue: https://github.com/DFE-Digital/govuk_design_system_formbuilder/issues/9 (thanks Peter!)

Trello: https://trello.com/c/ncVIy5Ty/577-provide-useful-feedback-when-an-incorrect-date-of-birth-is-provided