### PR TITLE
Check Javascript (in addition to Ruby) w/dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,10 @@
+version: 1
+
+update_configs:
+  - package_manager: "ruby:bundler"
+    directory: "/"
+    update_schedule: "live"
+
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "live"


### PR DESCRIPTION
This is a DRAFT because: I want to see if there's a way to test this config on a branch rather than having to push it to master.
___

The UI in github is missing multiple language configuration - this config should mean the repo has both js and ruby dependancies checked and updated.