### PR TITLE
Add Contact details form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ gem 'erb_lint', require: false
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'pry'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
-    bindex (0.7.0)
+    bindex (0.8.1)
     builder (3.2.3)
     capybara (3.26.0)
       addressable
@@ -66,6 +66,7 @@ GEM
       xpath (~> 3.2)
     childprocess (1.0.1)
       rake (< 13.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -114,6 +115,9 @@ GEM
     parser (2.6.3.0)
       ast (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     public_suffix (3.1.1)
     puma (4.0.1)
       nio4r (~> 2.0)
@@ -152,7 +156,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     regexp_parser (1.5.1)
-    rspec-core (3.8.1)
+    rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -176,7 +180,7 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.2.0)
+    rubocop-rails (2.2.1)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     rubocop-rspec (1.33.0)
@@ -239,6 +243,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1.4)
+  pry
   puma (~> 4.0)
   rails (~> 5.2.2, >= 5.2.2.1)
   rspec-rails

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -1,0 +1,27 @@
+class ContactDetailsController < ApplicationController
+  def new
+    @personal_details = PersonalDetails.last
+  end
+
+  def update
+    @personal_details = PersonalDetails.last
+
+    if @personal_details.update(contact_details_params)
+      redirect_to check_your_answers_path
+    else
+      render :new
+    end
+  end
+
+  def create
+    PersonalDetails.last.update(contact_details_params)
+
+    redirect_to check_your_answers_path
+  end
+
+private
+
+  def contact_details_params
+    params.require(:personal_details).permit(:phone_number, :email_address, :address)
+  end
+end

--- a/app/controllers/personal_details_controller.rb
+++ b/app/controllers/personal_details_controller.rb
@@ -11,7 +11,7 @@ class PersonalDetailsController < ApplicationController
     @personal_details = PersonalDetails.new(personal_details_params)
 
     if @personal_details.save
-      redirect_to check_your_answers_path
+      redirect_to contact_details_path
     else
       render :new
     end

--- a/app/models/personal_details.rb
+++ b/app/models/personal_details.rb
@@ -1,7 +1,11 @@
 class PersonalDetails < ApplicationRecord
+  # Personal Details
   validates :title, presence: true
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :date_of_birth, presence: true
   validates :nationality, presence: true
+
+  # Contact Details
+  validates :phone_number, :email_address, :address, presence: true, on: :update
 end

--- a/app/views/check_your_answers/show.html.erb
+++ b/app/views/check_your_answers/show.html.erb
@@ -6,12 +6,20 @@
     <h2 class="govuk-heading-m"><%= t('application_form.personal_details_section.heading') %></h2>
 
     <dl class="govuk-summary-list govuk-!-font-size-16 govuk-summary-list--no-border">
-      <%= render partial: 'shared/description_list_item', locals: { field: :title, value: @personal_details.title } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :first_name, value: @personal_details.first_name } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :last_name, value: @personal_details.last_name } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :preferred_name, value: @personal_details.preferred_name } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :date_of_birth, value: @personal_details.date_of_birth.to_s(:govuk_human_readable) } %>
-      <%= render partial: 'shared/description_list_item', locals: { field: :nationality, value: @personal_details.nationality } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :title, section: :personal, value: @personal_details.title } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :first_name, section: :personal, value: @personal_details.first_name } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :last_name, section: :personal, value: @personal_details.last_name } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :preferred_name, section: :personal, value: @personal_details.preferred_name } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :date_of_birth, section: :personal, value: @personal_details.date_of_birth.to_s(:govuk_human_readable) } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :nationality, section: :personal, value: @personal_details.nationality } %>
+    </dl>
+
+    <h2 class="govuk-heading-m"><%= t('application_form.contact_details_section.heading') %></h2>
+
+    <dl class="govuk-summary-list govuk-!-font-size-16 govuk-summary-list--no-border">
+      <%= render partial: 'shared/description_list_item', locals: { field: :phone_number, section: :contact, value: @personal_details.phone_number } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :email_address, section: :contact, value: @personal_details.email_address } %>
+      <%= render partial: 'shared/description_list_item', locals: { field: :address, section: :contact, value: @personal_details.address } %>
     </dl>
 
     <%= link_to tt_application_path, role: 'button', class: 'govuk-button' do %>

--- a/app/views/contact_details/new.html.erb
+++ b/app/views/contact_details/new.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @personal_details, builder: GOVUKDesignSystemFormBuilder::FormBuilder, url: contact_details_path do |f| %>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+          Contact Details
+        </h1>
+      </legend>
+
+      <%= f.govuk_text_field :phone_number, label: { text: t('application_form.contact_details_section.phone_number.label')}, width: 10 %>
+      <%= f.govuk_text_field :email_address, label: { text: t('application_form.contact_details_section.email_address.label')}, width: 10 %>
+      <%= f.govuk_text_field :address, label: { text: t('application_form.contact_details_section.address.label')}, width: 10 %>
+
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
+  <% end %>
+  </div>
+</div>

--- a/app/views/shared/_description_list_item.html.erb
+++ b/app/views/shared/_description_list_item.html.erb
@@ -1,12 +1,12 @@
 <div class="govuk-summary-list__row">
   <dt class="govuk-summary-list__key">
-  <%= t("application_form.personal_details_section.#{field}.label") %>
+    <%= t("application_form.#{section}_details_section.#{field}.label") %>
   </dt>
   <dd class="govuk-summary-list__value">
     <%= value %>
   </dd>
   <dd class="govuk-summary-list__actions">
-    <%= link_to personal_details_path(reviewing: true), class: 'govuk-link', id: "change-#{field}" do %>
+    <%= link_to "#{section}_details?reviewing=true", class: 'govuk-link', id: "change-#{field}" do %>
         Change<span class="govuk-visually-hidden"> <%= field %></span>
     <% end %>
   </dd>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -21,3 +21,12 @@ en:
         hint_text: For example, 12 11 1997
       nationality:
         label: What is your nationality?
+    contact_details_section:
+      heading:
+        Contact details
+      phone_number:
+        label: Phone number
+      email_address:
+        label: Email address
+      address:
+        label: Address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   post 'personal_details', to: 'personal_details#create'
   patch 'personal_details', to: 'personal_details#update'
 
+  get 'contact_details', to: 'contact_details#new'
+  post 'contact_details', to: 'contact_details#create'
+  patch 'contact_details', to: 'contact_details#update'
+
   get 'check_your_answers', to: 'check_your_answers#show'
 
   get 'application', to: 'tt_applications#show', as: :tt_application

--- a/db/migrate/20190718152003_add_phone_number_to_personal_details.rb
+++ b/db/migrate/20190718152003_add_phone_number_to_personal_details.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToPersonalDetails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :personal_details, :phone_number, :string
+  end
+end

--- a/db/migrate/20190721130643_add_email_address_to_personal_details.rb
+++ b/db/migrate/20190721130643_add_email_address_to_personal_details.rb
@@ -1,0 +1,5 @@
+class AddEmailAddressToPersonalDetails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :personal_details, :email_address, :string
+  end
+end

--- a/db/migrate/20190721140642_add_address_to_personal_details.rb
+++ b/db/migrate/20190721140642_add_address_to_personal_details.rb
@@ -1,0 +1,5 @@
+class AddAddressToPersonalDetails < ActiveRecord::Migration[5.2]
+  def change
+    add_column :personal_details, :address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_03_150225) do
+ActiveRecord::Schema.define(version: 2019_07_21_140642) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -25,6 +25,9 @@ ActiveRecord::Schema.define(version: 2019_07_03_150225) do
     t.string "nationality"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "phone_number"
+    t.string "email_address"
+    t.string "address"
   end
 
 end

--- a/spec/models/personal_details_spec.rb
+++ b/spec/models/personal_details_spec.rb
@@ -6,4 +6,8 @@ describe PersonalDetails, type: :model do
   it { is_expected.to validate_presence_of :last_name }
   it { is_expected.to validate_presence_of :date_of_birth }
   it { is_expected.to validate_presence_of :nationality }
+
+  it { is_expected.to validate_presence_of(:phone_number).on(:update) }
+  it { is_expected.to validate_presence_of(:email_address).on(:update) }
+  it { is_expected.to validate_presence_of(:address).on(:update) }
 end

--- a/spec/system/candidate_completing_an_application_spec.rb
+++ b/spec/system/candidate_completing_an_application_spec.rb
@@ -11,6 +11,8 @@ describe 'A candidate completing an application for teacher training' do
       fill_in_personal_details
 
       click_on t('application_form.save_and_continue')
+
+      visit '/check_your_answers'
       click_on t('application_form.submit')
     end
 

--- a/spec/system/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_entering_contact_details_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'A candidate entering contact details' do
+  include TestHelpers::PersonalDetails
+
+  context 'when details are correct' do
+    before do
+      visit '/'
+      click_on t('application_form.begin_button')
+
+      fill_in_personal_details
+      click_on t('application_form.save_and_continue')
+
+      fill_in_contact_details
+      click_on t('application_form.save_and_continue')
+    end
+
+    describe 'check_your_answers page' do
+      it 'contains phone number' do
+        expect(page).to have_content('Phone number')
+        expect(page).to have_content('Email address')
+        expect(page).to have_content('Address')
+      end
+    end
+
+    context 'and wishes to amend their details' do
+      it 'can go back and edit them' do
+        visit '/check_your_answers'
+
+        find('#change-phone_number').click
+        expect(page).to have_field('Phone number', with: '1234567890')
+      end
+    end
+  end
+
+private
+
+  def fill_in_contact_details
+    details = {
+      phone_number: '1234567890',
+      email_address: 'john.doe@example.com',
+      address: 'Westminster, London SW1P 1QW'
+    }
+
+    fill_in t('application_form.contact_details_section.phone_number.label'), with: details[:phone_number]
+    fill_in t('application_form.contact_details_section.email_address.label'), with: details[:email_address]
+    fill_in t('application_form.contact_details_section.address.label'), with: details[:address]
+  end
+end

--- a/spec/system/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_entering_personal_details_spec.rb
@@ -14,11 +14,15 @@ describe 'A candidate entering personal details' do
     end
 
     it 'sees a summary of those details' do
+      visit '/check_your_answers'
+
       expect(page).to have_content('First name John')
     end
 
     context 'and wishes to amend their details' do
       it 'can go back and edit them' do
+        visit '/check_your_answers'
+
         find('#change-first_name').click
         expect(page).to have_field('First name', with: 'John')
       end


### PR DESCRIPTION
This PR add the Contact details form

Implementation details: the new Contact Details form uses the `PersonalDetails` model (we might want to refactor it, and chose a better name for `PersonalDetails`)

Trello: https://trello.com/c/EXZ7oesH/602-create-the-contact-details-section-of-the-candidate-facing-service