### PR TITLE
Remove nationality from PersonalDetails

### DIFF
--- a/app/controllers/personal_details_controller.rb
+++ b/app/controllers/personal_details_controller.rb
@@ -34,7 +34,6 @@ private
                                              :first_name,
                                              :last_name,
                                              :preferred_name,
-                                             :date_of_birth,
-                                             :nationality)
+                                             :date_of_birth)
   end
 end

--- a/app/models/personal_details.rb
+++ b/app/models/personal_details.rb
@@ -4,7 +4,6 @@ class PersonalDetails < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :date_of_birth, presence: true
-  validates :nationality, presence: true
 
   # Contact Details
   validates :phone_number, :email_address, :address, presence: true, on: :update

--- a/app/views/check_your_answers/show.html.erb
+++ b/app/views/check_your_answers/show.html.erb
@@ -4,7 +4,7 @@
     <h1 class="govuk-heading-xl"><%= t('application_form.check_your_answers') %></h1>
 
     <%= render 'shared/section_summary',
-      fields: [:first_name, :last_name, :preferred_name, :date_of_birth, :nationality],
+      fields: [:first_name, :last_name, :preferred_name, :date_of_birth],
       section_name: :personal_details,
       record: @personal_details %>
 

--- a/app/views/personal_details/new.html.erb
+++ b/app/views/personal_details/new.html.erb
@@ -16,7 +16,6 @@
       <div id='personal_details_date_of_birth'>
         <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' } %>
       </div>
-      <%= f.govuk_text_field :nationality, label: { text: t('application_form.personal_details_section.nationality.label')} %>
       <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
   <% end %>
   </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -19,8 +19,6 @@ en:
       date_of_birth:
         label: Date of birth
         hint_text: For example, 12 11 1997
-      nationality:
-        label: What is your nationality?
     contact_details_section:
       heading:
         Contact details

--- a/db/migrate/20190723153756_remove_nationality_from_personal_details.rb
+++ b/db/migrate/20190723153756_remove_nationality_from_personal_details.rb
@@ -1,0 +1,5 @@
+class RemoveNationalityFromPersonalDetails < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :personal_details, :nationality, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_23_150542) do
+ActiveRecord::Schema.define(version: 2019_07_23_153756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,7 +22,6 @@ ActiveRecord::Schema.define(version: 2019_07_23_150542) do
     t.string "last_name"
     t.string "preferred_name"
     t.date "date_of_birth"
-    t.string "nationality"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "phone_number"

--- a/spec/models/personal_details_spec.rb
+++ b/spec/models/personal_details_spec.rb
@@ -5,7 +5,6 @@ describe PersonalDetails, type: :model do
   it { is_expected.to validate_presence_of :first_name }
   it { is_expected.to validate_presence_of :last_name }
   it { is_expected.to validate_presence_of :date_of_birth }
-  it { is_expected.to validate_presence_of :nationality }
 
   it { is_expected.to validate_presence_of(:phone_number).on(:update) }
   it { is_expected.to validate_presence_of(:email_address).on(:update) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,5 +58,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
+  config.example_status_persistence_file_path = "tmp/rspec-failures"
+
   config.include AbstractController::Translation
 end

--- a/spec/support/test_helpers/personal_details.rb
+++ b/spec/support/test_helpers/personal_details.rb
@@ -6,7 +6,6 @@ module TestHelpers
         last_name: 'Doe',
         title: 'Dr',
         preferred_name: 'Dr Doe',
-        nationality: 'British',
         date_of_birth: Date.new(1997, 3, 13)
       }
 
@@ -20,8 +19,6 @@ module TestHelpers
         fill_in 'Month', with: details[:date_of_birth].month
         fill_in 'Year', with: details[:date_of_birth].year
       end
-
-      fill_in t('application_form.personal_details_section.nationality.label'), with: details[:nationality]
     end
   end
 end


### PR DESCRIPTION
We don't yet understand how this information will be collected via the form, so we're going to leave it out for now and descope non-British candidates.
