### PR TITLE
Spruce up Contact Details form

### DIFF
--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -18,9 +18,13 @@ class ContactDetailsController < ApplicationController
   end
 
   def create
-    @contact_details = ContactDetails.create(contact_details_params)
+    @contact_details = ContactDetails.new(contact_details_params)
 
-    redirect_to check_your_answers_path
+    if @contact_details.save
+      redirect_to check_your_answers_path
+    else
+      render :new
+    end
   end
 
 private

--- a/app/views/contact_details/_form.html.erb
+++ b/app/views/contact_details/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render "shared/form_errors_summary", errors: @contact_details.errors %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @contact_details, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: action do |f| %>

--- a/app/views/contact_details/_form.html.erb
+++ b/app/views/contact_details/_form.html.erb
@@ -7,9 +7,9 @@
         </h1>
       </legend>
 
-      <%= f.govuk_text_field :phone_number, label: { text: t('application_form.contact_details_section.phone_number.label')}, width: 10 %>
-      <%= f.govuk_text_field :email_address, label: { text: t('application_form.contact_details_section.email_address.label')}, width: 10 %>
-      <%= f.govuk_text_field :address, label: { text: t('application_form.contact_details_section.address.label')}, width: 10 %>
+      <%= f.govuk_text_field :phone_number, label: { text: t('application_form.contact_details_section.phone_number.label')}, width: 10, type: :tel %>
+      <%= f.govuk_text_field :email_address, label: { text: t('application_form.contact_details_section.email_address.label')}, type: :email %>
+      <%= f.govuk_text_area :address, label: { text: t('application_form.contact_details_section.address.label')} %>
 
       <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
   <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -27,4 +27,4 @@ en:
       email_address:
         label: Email address
       address:
-        label: Address
+        label: Postal address

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,3 +47,11 @@ en:
               blank: 'Enter your date of birth'
             nationality:
               blank: 'Enter your nationality'
+        contact_details:
+          attributes:
+            phone_number:
+              blank: 'Enter your phone number'
+            email_address:
+              blank: 'Enter your email address'
+            address:
+              blank: 'Enter your postal address'

--- a/spec/system/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_entering_contact_details_spec.rb
@@ -29,6 +29,23 @@ describe 'A candidate entering contact details' do
     end
   end
 
+  xcontext 'who leaves out a required field' do
+    before do
+      # can cut this out shortly
+      visit '/personal_details'
+      fill_in_personal_details
+      click_on t('application_form.save_and_continue')
+
+      visit '/contact_details'
+      click_on t('application_form.save_and_continue')
+    end
+
+    it 'sees an error summary', js: true do
+      expect(page).to have_content('There is a problem')
+      expect(page).to have_content('Enter your phone number')
+    end
+  end
+
 private
 
   def fill_in_contact_details

--- a/spec/system/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_entering_contact_details_spec.rb
@@ -15,7 +15,7 @@ describe 'A candidate entering contact details' do
       it 'contains phone number' do
         expect(page).to have_content('Phone number')
         expect(page).to have_content('Email address')
-        expect(page).to have_content('Address')
+        expect(page).to have_content('Postal address')
       end
     end
 
@@ -29,18 +29,13 @@ describe 'A candidate entering contact details' do
     end
   end
 
-  xcontext 'who leaves out a required field' do
+  context 'who leaves out a required field' do
     before do
-      # can cut this out shortly
-      visit '/personal_details'
-      fill_in_personal_details
-      click_on t('application_form.save_and_continue')
-
-      visit '/contact_details'
+      visit '/contact_details/new'
       click_on t('application_form.save_and_continue')
     end
 
-    it 'sees an error summary', js: true do
+    it 'sees an error summary' do
       expect(page).to have_content('There is a problem')
       expect(page).to have_content('Enter your phone number')
     end


### PR DESCRIPTION
Spotted a few things I think we can make better here, mostly based on the [Design System guidance](https://design-system.service.gov.uk/). Better errors, more appropriate field shapes, more helpful labels.

____

Old:

![image](https://user-images.githubusercontent.com/429326/61788750-c9335000-ae0a-11e9-9d9c-a48ab771c9f9.png)

New:

![image](https://user-images.githubusercontent.com/429326/61788691-a6a13700-ae0a-11e9-90dd-b1371083b98f.png)

____

This PR is a DRAFT because: I'll need to rebase it on the contact details model changes we're making shortly.