### PR TITLE
Field summary fixes

### DIFF
--- a/app/views/personal_details/_form.html.erb
+++ b/app/views/personal_details/_form.html.erb
@@ -14,7 +14,7 @@
       <%= f.govuk_text_field :preferred_name, label: { text: t('application_form.personal_details_section.preferred_name.label')} %>
       <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details_section.last_name.label')} %>
       <div id='personal_details_date_of_birth'>
-        <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' } %>
+        <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' }, hint_text: 'For example, 31 3 1980' %>
       </div>
       <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
   <% end %>

--- a/app/views/shared/_section_summary.html.erb
+++ b/app/views/shared/_section_summary.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m"><%= t("application_form.#{section_name}_section.heading") %></h2>
 
 <% if record.present? %>
-  <dl class="govuk-summary-list govuk-!-font-size-16 govuk-summary-list--no-border">
+  <dl class="govuk-summary-list govuk-!-font-size-16">
     <% fields.each do |field| %>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">


### PR DESCRIPTION
This PR does two things (as separate commits):

* Adds the hint text to date of birth field:

<img width="271" alt="Screenshot" src="https://user-images.githubusercontent.com/813383/61802757-f0007f00-ae28-11e9-9ae3-6a98c58ea503.png">

* Shows borders on summary list (I think the prototype briefly omitted these, but they are back):

<img width="667" alt="Screenshot" src="https://user-images.githubusercontent.com/813383/61802777-f7278d00-ae28-11e9-908e-91049f0f5977.png">