### PR TITLE
Silence puma during spec runs

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -9,3 +9,5 @@ RSpec.configure do |config|
     driven_by(:selenium_chrome_headless)
   end
 end
+
+Capybara.server = :puma, { Silent: true }


### PR DESCRIPTION
Before, in the middle of a spec run involving Capybara, you would see
this amongst the reporting:

Capybara starting Puma...
* Version 4.0.1 , codename: 4 Fast 4 Furious
* Min threads: 0, max threads: 4
* Listening on tcp://127.0.0.1:51491

This message is now not displayed