### PR TITLE
Pin govuk_design_system_formbuilder to 0.7.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'webpacker'
 gem 'rubocop'
 gem 'rubocop-rspec'
 gem 'govuk-lint'
-gem 'govuk_design_system_formbuilder'
+gem 'govuk_design_system_formbuilder', '0.7.9'
 gem 'erb_lint', require: false
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,7 +240,7 @@ DEPENDENCIES
   capybara (>= 3.24)
   erb_lint
   govuk-lint
-  govuk_design_system_formbuilder
+  govuk_design_system_formbuilder (= 0.7.9)
   listen (>= 3.0.5, < 3.2)
   pg (~> 1.1.4)
   pry


### PR DESCRIPTION
0.7.10 naughtily (because this is a point release) changes the id
attributes on error fields, which broke our error summary. Pin it back
until we fix that, either by fixing our summary or using the gem's
summary, if it's now working in respect of linking to fields with errors