### PR TITLE
Update our automated end to end test to include adding a degree and contact details

### DIFF
--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -21,7 +21,7 @@ class ContactDetailsController < ApplicationController
     @contact_details = ContactDetails.new(contact_details_params)
 
     if @contact_details.save
-      redirect_to check_your_answers_path
+      redirect_to new_degree_path
     else
       render :new
     end

--- a/spec/helpers/form_error_summary_helper_spec.rb
+++ b/spec/helpers/form_error_summary_helper_spec.rb
@@ -2,8 +2,11 @@ require 'rails_helper'
 
 describe FormErrorSummaryHelper do
   describe '#field_anchor_link' do
-    context 'given a field_name' do
-      let(:naming_mock) { double(param_key: 'example_model') }
+    context 'given a model_name and field' do
+      let(:naming_mock) do
+        instance_double(ActiveModel::Name, param_key: 'example_model')
+      end
+
 
       it 'returns the correct anchor link for that model & field' do
         result = helper.field_anchor_link(

--- a/spec/support/test_helpers/contact_details.rb
+++ b/spec/support/test_helpers/contact_details.rb
@@ -1,0 +1,15 @@
+module TestHelpers
+  module ContactDetails
+    def fill_in_contact_details
+      details = {
+        phone_number: '1234567890',
+        email_address: 'john.doe@example.com',
+        address: 'Westminster, London SW1P 1QW'
+      }
+
+      fill_in t('application_form.contact_details_section.phone_number.label'), with: details[:phone_number]
+      fill_in t('application_form.contact_details_section.email_address.label'), with: details[:email_address]
+      fill_in t('application_form.contact_details_section.address.label'), with: details[:address]
+    end
+  end
+end

--- a/spec/support/test_helpers/degree_details_helper.rb
+++ b/spec/support/test_helpers/degree_details_helper.rb
@@ -17,4 +17,3 @@ module TestHelpers
     end
   end
 end
-

--- a/spec/support/test_helpers/degree_details_helper.rb
+++ b/spec/support/test_helpers/degree_details_helper.rb
@@ -1,0 +1,20 @@
+module TestHelpers
+  module DegreeDetails
+    def fill_in_degree_details
+      details = {
+        type: 'BA',
+        subject: 'Philosophy',
+        institution: 'University of London',
+        class: 'first',
+        year: 2000
+      }
+
+      fill_in t('application_form.degree_details_section.type.label'), with: details[:type]
+      fill_in t('application_form.degree_details_section.subject.label'), with: details[:subject]
+      fill_in t('application_form.degree_details_section.institution.label'), with: details[:institution]
+      fill_in t('application_form.degree_details_section.class.label'), with: details[:class]
+      fill_in t('application_form.degree_details_section.year.label'), with: details[:year]
+    end
+  end
+end
+

--- a/spec/system/candidate_completing_an_application_spec.rb
+++ b/spec/system/candidate_completing_an_application_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe 'A candidate completing an application for teacher training' do
   include TestHelpers::PersonalDetails
+  include TestHelpers::ContactDetails
+  include TestHelpers::DegreeDetails
 
   context 'who submits a valid application' do
     before do
@@ -9,7 +11,12 @@ describe 'A candidate completing an application for teacher training' do
       click_on t('application_form.begin_button')
 
       fill_in_personal_details
+      click_on t('application_form.save_and_continue')
 
+      fill_in_contact_details
+      click_on t('application_form.save_and_continue')
+
+      fill_in_degree_details
       click_on t('application_form.save_and_continue')
 
       visit '/check_your_answers'

--- a/spec/system/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_entering_contact_details_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'A candidate entering contact details' do
-  include TestHelpers::PersonalDetails
+  include TestHelpers::ContactDetails
 
   context 'when details are correct' do
     before do
@@ -11,12 +11,10 @@ describe 'A candidate entering contact details' do
       click_on t('application_form.save_and_continue')
     end
 
-    describe 'check_your_answers page' do
-      it 'contains phone number' do
-        expect(page).to have_content('Phone number')
-        expect(page).to have_content('Email address')
-        expect(page).to have_content('Postal address')
-      end
+    it 'sees a summary of those details' do
+      visit '/check_your_answers'
+
+      expect(page).to have_content('Phone number 1234567890')
     end
 
     context 'and wishes to amend their details' do
@@ -40,19 +38,5 @@ describe 'A candidate entering contact details' do
       click_on 'Enter your phone number'
       expect(page).to have_selector('#contact_details_phone_number:focus')
     end
-  end
-
-private
-
-  def fill_in_contact_details
-    details = {
-      phone_number: '1234567890',
-      email_address: 'john.doe@example.com',
-      address: 'Westminster, London SW1P 1QW'
-    }
-
-    fill_in t('application_form.contact_details_section.phone_number.label'), with: details[:phone_number]
-    fill_in t('application_form.contact_details_section.email_address.label'), with: details[:email_address]
-    fill_in t('application_form.contact_details_section.address.label'), with: details[:address]
   end
 end

--- a/spec/system/candidate_entering_degree_spec.rb
+++ b/spec/system/candidate_entering_degree_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'A candidate adding a Degree' do
+  include TestHelpers::DegreeDetails
+
   context 'who successfully enters their details' do
     before do
       visit '/degrees/new'
@@ -26,7 +28,7 @@ describe 'A candidate adding a Degree' do
 
   context 'who leaves out a required field' do
     before do
-      visit '/contact_details/new'
+      visit '/degrees/new'
     end
 
     it 'sees an error summary' do
@@ -34,23 +36,5 @@ describe 'A candidate adding a Degree' do
 
       expect(page).to have_content('There is a problem')
     end
-  end
-
-private
-
-  def fill_in_degree_details
-    details = {
-      type: 'BA',
-      subject: 'Philosophy',
-      institution: 'University of London',
-      class: 'first',
-      year: 2000
-    }
-
-    fill_in t('application_form.degree_details_section.type.label'), with: details[:type]
-    fill_in t('application_form.degree_details_section.subject.label'), with: details[:subject]
-    fill_in t('application_form.degree_details_section.institution.label'), with: details[:institution]
-    fill_in t('application_form.degree_details_section.class.label'), with: details[:class]
-    fill_in t('application_form.degree_details_section.year.label'), with: details[:year]
   end
 end


### PR DESCRIPTION
This PR addresses a couple of things that slipped through the cracks when we added contact details (#103) and degrees (#114). It

- adds these pages to the end to end spec
- fixes a minor bug in the code and a bit of copy-pasta in the specs

The second commit addresses a Rubocop violation from #112 — feeling the lack of CI here! It probably needs the eye of @kjdchapman.