### PR TITLE
Remove browser-level validation error messages

### DIFF
--- a/app/views/contact_details/_form.html.erb
+++ b/app/views/contact_details/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-two-thirds'>
-    <%= form_with model: @contact_details, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: action do |f| %>
+    <%= form_with model: @contact_details, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: action, html: { novalidate: true } do |f| %>
       <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
         <h1 class='govuk-fieldset__heading'>
           Contact Details

--- a/app/views/degrees/_form.html.erb
+++ b/app/views/degrees/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-two-thirds'>
-    <%= form_with model: @degree, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: :edit do |f| %>
+    <%= form_with model: @degree, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: :edit, html: { novalidate: true } do |f| %>
       <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
         <h1 class='govuk-fieldset__heading'>
           <span class='govuk-caption-xl'>Academic qualifications</span>

--- a/app/views/personal_details/_form.html.erb
+++ b/app/views/personal_details/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-two-thirds'>
-    <%= form_with model: @personal_details, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: action do |f| %>
+    <%= form_with model: @personal_details, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: action, html: { novalidate: true } do |f| %>
       <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
         <h1 class='govuk-fieldset__heading'>
           <%= t('application_form.personal_details_section.heading') %>


### PR DESCRIPTION
This PR adds `novalidate` HTML attribute (see [form novalidate attribute](https://www.w3schools.com/tags/att_form_novalidate.asp)) to all the forms to prevent browser-level error messages from showing.

Trello: https://trello.com/c/VlZP9ifk/657-dont-show-browser-level-validation-error-messages