### PR TITLE
See details of the failure if specs or linting fail on CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
+       touch rspec-results.xml
        $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rake spec SPEC_OPTS="--format RspecJunitFormatter --out ./rspec-results.xml"'
       displayName: 'Execute tests'
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,9 @@ stages:
 
     - script: |
        touch rspec-results.xml
+      displayName: 'Prepare test output file'
+
+    - script: |
        $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rake spec SPEC_OPTS="--format RspecJunitFormatter --out ./rspec-results.xml"'
       displayName: 'Execute tests'
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,8 @@ stages:
   displayName: 'Build, Test & Release'
   jobs:
   - job: build_and_test_docker_image
+    workspace:
+      clean: all
     displayName: 'Build & Test Docker Image'
     pool:
       vmImage: 'Ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
+       ls -ll
        touch rspec-results.xml
       displayName: 'Prepare test output file'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,6 @@ stages:
   displayName: 'Build, Test & Release'
   jobs:
   - job: build_and_test_docker_image
-    workspace:
-      clean: all
     displayName: 'Build & Test Docker Image'
     pool:
       vmImage: 'Ubuntu-16.04'
@@ -60,12 +58,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-       ls -ll
-       touch rspec-results.xml
-      displayName: 'Prepare test output file'
-
-    - script: |
-       $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rake spec SPEC_OPTS="--format RspecJunitFormatter --out ./rspec-results.xml"'
+       $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rake spec SPEC_OPTS="--format RspecJunitFormatter"' > rspec-results.xml
       displayName: 'Execute tests'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-       $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rake spec SPEC_OPTS="--format RspecJunitFormatter"' > rspec-results.xml
+       $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rspec --format RspecJunitFormatter' > rspec-results.xml
       displayName: 'Execute tests'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
       - "3000:3000"
     depends_on:
       - db
-    volumes:
-      - ./rspec-results.xml:/app/rspec-results.xml
     environment:
       - DB_HOSTNAME=db
       - DB_USERNAME=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       - "3000:3000"
     depends_on:
       - db
+    volumes:
+      - ./rspec-results.xml:/app/rspec-results.xml
     environment:
       - DB_HOSTNAME=db
       - DB_USERNAME=postgres

--- a/spec/helpers/form_error_summary_helper_spec.rb
+++ b/spec/helpers/form_error_summary_helper_spec.rb
@@ -7,7 +7,6 @@ describe FormErrorSummaryHelper do
         instance_double(ActiveModel::Name, param_key: 'example_model')
       end
 
-
       it 'returns the correct anchor link for that model & field' do
         result = helper.field_anchor_link(
           model_name: naming_mock,

--- a/spec/system/candidate_completing_an_application_spec.rb
+++ b/spec/system/candidate_completing_an_application_spec.rb
@@ -24,7 +24,7 @@ describe 'A candidate completing an application for teacher training' do
     end
 
     it 'can see that the application has been successfully submitted' do
-      expect(page).to have_content t('application_form.application_submitted')
+      expect(page).to have_content 'bananas'
     end
   end
 end


### PR DESCRIPTION
This was originally confirming that failing tests really did cause CI checks to fail.

Now that's confirmed, I've noticed there's no _details_ of those failures visible in the pipeline reporting. 

The intent of this PR is now to change the pipeline so those failures are correctly visible. It's draft whilst I sort it out.