### PR TITLE
Update to govuk-frontend v3

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,4 +1,4 @@
-require.context('govuk-frontend/assets');
+require.context('govuk-frontend/govuk/assets');
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend';
 
 import '../styles/application.scss';

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -9,4 +9,4 @@
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
-@import "~govuk-frontend/all";
+@import "~govuk-frontend/govuk/all";

--- a/app/views/check_your_answers/show.html.erb
+++ b/app/views/check_your_answers/show.html.erb
@@ -15,7 +15,7 @@
 
     <%= render 'academic_qualifications', degrees: @application[:degrees] %>
 
-    <%= link_to tt_application_path, role: 'button', class: 'govuk-button' do %>
+    <%= link_to tt_application_path, role: 'button', class: 'govuk-button', 'data-module': 'govuk-button' do %>
       <%= t('application_form.submit') %>
     <% end %>
   </div>

--- a/app/views/contact_details/_form.html.erb
+++ b/app/views/contact_details/_form.html.erb
@@ -13,7 +13,7 @@
       <%= f.govuk_text_field :email_address, label: { text: t('application_form.contact_details_section.email_address.label')}, type: :email %>
       <%= f.govuk_text_area :address, label: { text: t('application_form.contact_details_section.address.label')} %>
 
-      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
-  <% end %>
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/degrees/_form.html.erb
+++ b/app/views/degrees/_form.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_text_field :class_of_degree, label: { text: t('application_form.degree_details_section.class.label')}, width: 20 %>
       <%= f.govuk_text_field :year, label: { text: t('application_form.degree_details_section.year.label')}, width: 20 %>
 
-      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button' %>
     <% end %>
   </div>
 </div>

--- a/app/views/personal_details/_form.html.erb
+++ b/app/views/personal_details/_form.html.erb
@@ -16,7 +16,7 @@
       <div id='personal_details_date_of_birth'>
         <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' }, hint_text: 'For example, 31 3 1980' %>
       </div>
-      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button' %>
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button' %>
   <% end %>
   </div>
 </div>

--- a/app/views/start_page/show.html.erb
+++ b/app/views/start_page/show.html.erb
@@ -12,8 +12,11 @@
       <li>tailor your application to suit different providers</li>
     </ul>
 
-    <%= link_to new_personal_details_path, role: 'button', class: 'govuk-button govuk-button--start' do %>
+    <%= link_to new_personal_details_path, role: 'button', class: 'govuk-button govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
     <% end %>
   </div>
 </div>

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,8 +10,7 @@ default: &default
   webpack_compile_output: false
 
   # Additional paths webpack should lookup modules
-  # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ['node_modules/govuk-frontend']
+  resolved_paths: ['node_modules/govuk-frontend/govuk']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
-    "govuk-frontend": "^2.13.0"
+    "govuk-frontend": "^3.0.0"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2963,10 +2963,10 @@ globule@^1.0.0:
     lodash "~4.17.10"
     minimatch "~3.0.2"
 
-govuk-frontend@^2.13.0:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-2.13.0.tgz#0273f7c92070abd6450c73a006ebb3ddc793463a"
-  integrity sha512-6XDtTt5plSrPQvPgLFN4LCtb9ULuqoXCgkHy5c7XE/70/sVm47RPbLR11tYGPcmV8cOApBhW0wL8y8ryspHfpw==
+govuk-frontend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.0.0.tgz#27e4751592c0587ec925c637dcd1a2582429afe4"
+  integrity sha512-GCrEeaQZEnsthNtfmOUFlgsieNjHOeoamSWMdD4Gdq0RPxCA9uzfrT2i3jVnlBORekKjOL0C8eFZQBSNnjtz2A==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.0"


### PR DESCRIPTION
This PR updates the govuk-frontend version from 2.13.0 to 3.0.0
 - updates webpacker to use the new govuk frontend assets
- updated form buttons to use `govuk-button` data-module
- update form start button to use new arrow svg

Trello: https://trello.com/c/FqO59hF7/649-update-to-govuk-frontend-v3