### PR TITLE
Add data-prevent-double-click to submit buttons

### DIFF
--- a/app/views/contact_details/_form.html.erb
+++ b/app/views/contact_details/_form.html.erb
@@ -13,7 +13,7 @@
       <%= f.govuk_text_field :email_address, label: { text: t('application_form.contact_details_section.email_address.label')}, type: :email %>
       <%= f.govuk_text_area :address, label: { text: t('application_form.contact_details_section.address.label')} %>
 
-      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button' %>
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>
   </div>
 </div>

--- a/app/views/degrees/_form.html.erb
+++ b/app/views/degrees/_form.html.erb
@@ -16,7 +16,7 @@
       <%= f.govuk_text_field :class_of_degree, label: { text: t('application_form.degree_details_section.class.label')}, width: 20 %>
       <%= f.govuk_text_field :year, label: { text: t('application_form.degree_details_section.year.label')}, width: 20 %>
 
-      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button' %>
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>
   </div>
 </div>

--- a/app/views/personal_details/_form.html.erb
+++ b/app/views/personal_details/_form.html.erb
@@ -16,7 +16,8 @@
       <div id='personal_details_date_of_birth'>
         <%= f.govuk_date_field :date_of_birth, legend: { text: 'Date of birth', tag: 'span', size: 's' }, hint_text: 'For example, 31 3 1980' %>
       </div>
-      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button' %>
-  <% end %>
+
+      <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context
While updating to version 3 of `govuk-frontend` we found that forms could be double submitted which would add excess data to the database. The GOV.UK frontend has the ability to handle this (see https://design-system.service.gov.uk/components/button/#stop-users-from-accidentally-sending-information-more-than-once).

### Changes proposed in this pull request

`'data-prevent-double-click': true` has been added to the Personal Details, Contact Details and Degrees forms.

### Guidance to review

You can check this by using the Developer tools and changing the network speed to "Slow 3G" and attempting to double submit with and without the `data-prevent-double-click` present.

### Link to Trello card

[691 - Prevent double-click form submission](https://trello.com/c/9GB7aXwJ/691-prevent-double-click-form-submission)