### PR TITLE
Added deployment pipeline

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -1,4 +1,5 @@
 parameters:
+  debug: false
   subscriptionPrefix:
   subscriptionName:
   resourceEnvironmentName:
@@ -9,6 +10,9 @@ parameters:
   databasePassword:
   dockerhubUsername:
   securityKeyBase:
+  containerStartTimeLimit: '600'
+  warmupPingPath: '/personal_details/new'
+  warmupPingStatus: '200'
   railsEnv: 'production'
   securityAlertEmail: 'apprenticeshipsdevops@education.gov.uk'
   
@@ -21,6 +25,7 @@ jobs:
     variables:
       resourceGroupName: '${{parameters.subscriptionPrefix}}${{parameters.resourceEnvironmentName}}-${{parameters.serviceName}}'
       appServiceName: '${{parameters.subscriptionPrefix}}${{parameters.resourceEnvironmentName}}-${{parameters.serviceName}}-as'
+      system.debug: ${{parameters.debug}}
 
     pool:
       name: Hosted VS2017
@@ -38,6 +43,7 @@ jobs:
 
     - task: AzureResourceGroupDeployment@2
       displayName: 'Azure Deployment:Create Or Update Resource Group action on $(resourceGroupName)'
+      condition: succeeded()
       inputs:
         azureSubscription: '${{parameters.subscriptionName}}'
         resourceGroupName: '$(resourceGroupName)'
@@ -52,14 +58,19 @@ jobs:
           -databaseUsername "${{parameters.databaseUsername}}" 
           -databasePassword "${{parameters.databasePassword}}" 
           -securityAlertEmail "${{parameters.securityAlertEmail}}" 
-          -secretKeyBase "${{parameters.secretKeyBase}}"'
+          -secretKeyBase "${{parameters.secretKeyBase}}"
+          -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
+          -warmupPingPath "${{parameters.warmupPingPath}}"
+          -warmupPingStatus "${{parameters.warmupPingStatus}}"'
         deploymentOutputs: DeploymentOutput
 
     - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1
       displayName: 'Parse ARM Deployment Outputs into variables'
+      condition: succeeded()
 
     - task: AzureAppServiceManage@0
       displayName: 'Start Azure App Service: $(appServiceName)'
+      condition: succeeded()
       inputs:
         azureSubscription: '${{parameters.subscriptionName}}'
         Action: 'Start Azure App Service'
@@ -68,6 +79,99 @@ jobs:
         ResourceGroupName: '$(resourceGroupName)'
         Slot: staging
 
+    - task: AzurePowerShell@3
+      displayName: 'Azure PowerShell Script - Web App Warmup: $(appServiceName)'
+      condition: succeeded()
+      inputs:
+        azureSubscription: '${{parameters.subscriptionName}}'
+        ScriptType: InlineScript
+        azurePowerShellVersion: LatestVersion
+        Inline: |
+          Param(
+            [string] $appservicename = "$(appServiceName)",
+            [string] $path = "${{parameters.warmupPingPath}}",
+            [int]$timeoutInMinutes = 5,
+            [int]$sleepDelaySeconds = 10
+          )
+          
+          $result = @() 
+          $restartCount = 1
+
+          #Get current date and time for timeout properties
+          $startTime = (get-date).ToString()
+          
+          #Timer starts now
+          write-output "Elapsed:00:00:00"
+          $continue = $true
+
+          $uri = ("{0}-staging.azurewebsites.net{1}" -f $appservicename, $path)
+          
+          While ( $continue )
+          {
+            $webrequest = try { 
+            
+              $request = $null 
+              ## Request the URI, and measure how long the response took. 
+              $result1 = Measure-Command { $request = Invoke-WebRequest -Uri "https://$uri" -MaximumRedirection 0 -ErrorAction Ignore } 
+              write-output **Time took to invoke web request: $result1.TotalMilliseconds **
+              $request
+            }  
+            catch { 
+              $request = $_.Exception.Response 
+              $time = -1 
+            }   
+          
+            $result = [PSCustomObject] @{ 
+              Time = Get-Date; 
+              Uri = $uri; 
+              StatusCode = [int] $request.StatusCode; 
+              StatusDescription = $request.StatusDescription; 
+              ResponseLength = $request.RawContentLength; 
+              TimeTaken =  $time.TotalMilliseconds;
+              WebRequest = $webrequest 
+            }
+                  
+            $sleeprequired = $false
+            $outputstatuscode=$result.StatusCode
+            $outputuri=($result.uri).ToString()
+            $outputwebrequest= $result.WebRequest.headers.location
+            if ($result.StatusCode -eq 200 ) {
+              Write-output "$outputuri is up and running. Status code = $outputstatuscode"
+            }
+            elseif($result.StatusCode -eq 302) {
+              Write-Output "$outputuri is up and running. Redirection is in place. Status code = $outputstatuscode "
+              Write-Output "$outputuri is redirected to $outputwebrequest "
+            }
+            else { 
+              Write-Output "$outputuri site is currently down or unreachable"
+              $sleeprequired = $true
+              # Remove comment to display extra info # write-output $result | fl
+              #reseting previous result
+              $result = @() 
+            }
+          
+            $currenttime = (get-date).ToString()
+            $elapsedTime = new-timespan $startTime $currenttime
+            write-output "Elapsed:$($elapsedTime.ToString("hh\:mm\:ss"))"  
+          
+            #Handle event
+            if ( $elapsedTime.Minutes -ge $timeoutInMinutes ) {
+              if ( $restartCount -gt 0 ) {
+                write-output "Restarting web app in staging slot..."
+                Restart-AzureRmWebAppSlot -ResourceGroupName $(resourceGroupName) -Name $(appServiceName) -Slot "staging"
+                $startTime = (get-date).ToString()
+                $restartCount--
+              } else {
+                exit(1)
+              }
+            } elseif ( $sleeprequired -eq $false) { 
+              exit(0)
+            } else {
+              write-output ("Sleeping for {0}s..." -f $sleepDelaySeconds)
+              Start-Sleep $sleepDelaySeconds
+            }
+          }
+
     - task: AzureAppServiceManage@0
       displayName: 'Swap Slots: $(appServiceName)'
       inputs:
@@ -75,6 +179,7 @@ jobs:
         WebAppName: '$(appServiceName)'
         ResourceGroupName: '$(resourceGroupName)'
         SourceSlot: staging
+      condition: succeeded()
 
     - task: AzureAppServiceManage@0
       displayName: 'Stop Azure App Service: $(appServiceName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,3 +112,66 @@ stages:
       inputs:
         testRunner: JUnit
         testResultsFiles: 'rspec-results.xml'
+
+
+- stage: deploy_dev
+  displayName: 'Deploy - Development'
+  dependsOn: build_test_release
+  condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  jobs:
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      debug: $(debug)
+      subscriptionPrefix: 's106'
+      subscriptionName: 'Apply (106) - Dev'
+      resourceEnvironmentName: 'd01'
+      serviceName: 'apply'
+      containerImageReference: '$(imageName):$(build.buildNumber)'
+      databaseName: 'apply'
+      databaseUsername: 'applyadm512'
+      databasePassword: '$(databasePassword)'
+      dockerhubUsername: '$(dockerHubUsername)'
+      securityKeyBase: '$(secretKeyBase)'
+      railsEnv: 'development'
+
+      
+- stage: deploy_test
+  displayName: 'Deploy - Test'
+  dependsOn: build_test_release
+  condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  jobs:
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      debug: $(debug)
+      subscriptionPrefix: 's106'
+      subscriptionName: 'Apply (106) - Test'
+      resourceEnvironmentName: 't01'
+      serviceName: 'apply'
+      containerImageReference: '$(imageName):$(build.buildNumber)'
+      databaseName: 'apply'
+      databaseUsername: 'applyadm512'
+      databasePassword: '$(databasePassword)'
+      dockerhubUsername: '$(dockerHubUsername)'
+      securityKeyBase: '$(secretKeyBase)'
+      railsEnv: 'development'
+
+      
+# - stage: deploy_production
+#   displayName: 'Deploy - Production'
+#   dependsOn: build_test_release
+#   condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+#   jobs:
+#   - template: azure-pipelines-deploy-template.yml
+#     parameters:
+#       debug: $(debug)
+#       subscriptionPrefix: 's106'
+#       subscriptionName: 'Apply (106) - Production'
+#       resourceEnvironmentName: 'p01'
+#       serviceName: 'apply'
+#       containerImageReference: '$(imageName):$(build.buildNumber)'
+#       databaseName: 'apply'
+#       databaseUsername: 'applyadm512'
+#       databasePassword: '$(databasePassword)'
+#       dockerhubUsername: '$(dockerHubUsername)'
+#       securityKeyBase: '$(secretKeyBase)'
+#       railsEnv: 'development'

--- a/azure/template.json
+++ b/azure/template.json
@@ -63,6 +63,24 @@
                 "description": "Secret key base for rails"
             }
         },
+        "containerStartTimeLimit": {
+            "type": "string",
+            "metadata": {
+                "description": "Time limit in seconds, up to 1800s, that the appService will wait for the container to start."
+            }
+        },
+        "warmupPingPath": {
+            "type": "string",
+            "metadata": {
+                "description": "The path to ping during webapp warmup process, prior to slot swap."
+            }
+        },
+        "warmupPingStatus": {
+            "type": "string",
+            "metadata": {
+                "description": "The permitted status codes to indicate a successful app warmup."
+            }
+        },
         "railsServeStaticFiles": {
             "type": "string",
             "defaultValue": "true",
@@ -111,6 +129,12 @@
                 "parameters": {
                     "appServicePlanName": {
                         "value": "[variables('appServicePlanName')]"
+                    },
+                    "appServicePlanTier": {
+                        "value": "Standard"
+                    },
+                    "appServicePlanSize": {
+                        "value": "2"
                     }
                 }
             }
@@ -169,6 +193,18 @@
                                 "value": "[parameters('secretKeyBase')]"
                             },
                             {
+                                "name": "WEBSITES_CONTAINER_START_TIME_LIMIT",
+                                "value": "[parameters('containerStartTimeLimit')]"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
+                                "value": "[parameters('warmupPingPath')]"
+                            },
+                            {
+                                "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",
+                                "value": "[parameters('warmupPingStatus')]"
+                            },
+                            {
                                 "name": "RAILS_SERVE_STATIC_FILES",
                                 "value": "[parameters('railsServeStaticFiles')]"
                             }
@@ -178,6 +214,35 @@
             },
             "dependsOn": [
                 "app-service-plan"
+            ]
+        },
+        {
+            "name": "app-service-logs",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2017-05-10",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'app-service-logs.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appServiceName": {
+                        "value": "[variables('appServiceName')]"
+                    },
+                    "httpLoggingEnabled": {
+                        "value": true
+                    },
+                    "detailedErrorLoggingEnabled": {
+                        "value": true
+                    },
+                    "applicationLogsFileSystem": {
+                        "value": "Verbose"
+                    }
+                }
+            },
+            "dependsOn": [
+                "app-service"
             ]
         },
         {


### PR DESCRIPTION
This PR introduces the deployment components of the CI/CD pipeline, with the following things of note.
- Deployments for production environment are completed disabled (commented out) at present due to cost implications of using this environment unnecessarily. This will only be turned on when actually required.
- Deployments into dev and test environments will only occur on the master branch, however builds will continue to be triggered from all branches, as is currently the case.
- Approvals are not yet implemented. This is pending the release of this feature by Microsoft.
- Web App Plan has been sized as a "Standard Medium" because CIP doesn't allow the use of the premium tier at present, which would be preferable and cheaper. This can be trivially changed later once resolved by the CIP team.
- An inline script is used between the app start and slot swap stages to properly detect that the app is running and if after a five minute time out it isn't up is will restart the app prior to initiating the swap. A proper fix for this will be sought longer term.