### PR TITLE
Change URL paths to use dashes instead of underscores

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,13 @@
 Rails.application.routes.draw do
   root to: 'start_page#show'
 
-  resources :personal_details, only: %i[new create edit update]
+  resources :personal_details, only: %i[new create edit update], path: 'personal-details'
 
-  resources :contact_details, only: %i[new create edit update]
+  resources :contact_details, only: %i[new create edit update], path: 'contact-details'
 
   resources :degrees, only: %i[new create edit update]
 
-  get 'check_your_answers', to: 'check_your_answers#show'
+  get 'check-your-answers', to: 'check_your_answers#show'
 
   get 'application', to: 'tt_applications#show', as: :tt_application
 end

--- a/spec/system/candidate_completing_an_application_spec.rb
+++ b/spec/system/candidate_completing_an_application_spec.rb
@@ -19,7 +19,7 @@ describe 'A candidate completing an application for teacher training' do
       fill_in_degree_details
       click_on t('application_form.save_and_continue')
 
-      visit '/check_your_answers'
+      visit '/check-your-answers'
       click_on t('application_form.submit')
     end
 

--- a/spec/system/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_entering_contact_details_spec.rb
@@ -5,21 +5,21 @@ describe 'A candidate entering contact details' do
 
   context 'when details are correct' do
     before do
-      visit '/contact_details/new'
+      visit '/contact-details/new'
 
       fill_in_contact_details
       click_on t('application_form.save_and_continue')
     end
 
     it 'sees a summary of those details' do
-      visit '/check_your_answers'
+      visit '/check-your-answers'
 
       expect(page).to have_content('Phone number 1234567890')
     end
 
     context 'and wishes to amend their details' do
       it 'can go back and edit them' do
-        visit '/check_your_answers'
+        visit '/check-your-answers'
 
         find('#change-phone_number').click
         expect(page).to have_field('Phone number', with: '1234567890')
@@ -29,7 +29,7 @@ describe 'A candidate entering contact details' do
 
   context 'who leaves out a required field' do
     before do
-      visit '/contact_details/new'
+      visit '/contact-details/new'
       click_on t('application_form.save_and_continue')
     end
 

--- a/spec/system/candidate_entering_degree_spec.rb
+++ b/spec/system/candidate_entering_degree_spec.rb
@@ -18,7 +18,7 @@ describe 'A candidate adding a Degree' do
 
     context 'and wishes to amend their details' do
       it 'can go back and edit them' do
-        visit '/check_your_answers'
+        visit '/check-your-answers'
 
         find('#change-degree').click
         expect(page).to have_field('Type of degree', with: 'BA')

--- a/spec/system/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_entering_personal_details_spec.rb
@@ -14,14 +14,14 @@ describe 'A candidate entering personal details' do
     end
 
     it 'sees a summary of those details' do
-      visit '/check_your_answers'
+      visit '/check-your-answers'
 
       expect(page).to have_content('First name John')
     end
 
     context 'and wishes to amend their details' do
       it 'can go back and edit them' do
-        visit '/check_your_answers'
+        visit '/check-your-answers'
 
         find('#change-first_name').click
         expect(page).to have_field('First name', with: 'John')


### PR DESCRIPTION
### Context

We currently use underscores to separate words in our URLs. However, the use of underscores do not follow the [GOV.UK standards on URLs](https://www.gov.uk/guidance/content-design/url-standards-for-gov-uk).

### Changes proposed in this pull request

Change all the URL paths to use dashes instead of underscores by adding a `path` argument to the `personal_details` and `contact_details` resources and updating the `check_your_answers` path to `check-your-answers`.

As a result of these changes, our system tests have been updated.

### Guidance to review

Check that all routes have been correctly updated by running `rails routes`.

### Link to Trello card

[708 - Change URL paths to use dashes instead of underscores](https://trello.com/c/VJV4JhQu/708-change-url-paths-to-use-dashes-instead-of-underscores)