### PR TITLE
Show details of failing specs in CI checks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-       $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rake spec SPEC_OPTS="--format RspecJunitFormatter --out ./rspec-results.xml"'
+       $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rspec --format RspecJunitFormatter' > rspec-results.xml
       displayName: 'Execute tests'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)


### PR DESCRIPTION
This PR makes it so rspec results are written to the host machine, rather than the docker container, in our CI pipeline.

Prior to this change, this command caused the rspec-results.xml file to be written to the docker container, which then can't be accessed outside of that container.

A later pipeline step tries to read this file from the host machine, but fails to parse any output because it's missing.

Specs in action:

![image](https://user-images.githubusercontent.com/429326/62533887-a7d95780-b83f-11e9-8a2d-b4552ca07392.png)