### PR TITLE
Override file for Azure specific elements of docker compose

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ stages:
 
     variables:
       # Support multiple docker-compose files to allow travis and az pipelines to co exist: https://docs.docker.com/compose/extends/#multiple-compose-files
-      dockerOverride: 'docker-compose -f docker-compose.yml'
+      dockerOverride: 'docker-compose -f docker-compose.yml -f docker-compose.azure.yml'
       system.debug: $(debug)
 
     steps:

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -1,0 +1,4 @@
+version: '3.6'
+services:
+  web:
+    image: ${dockerHubUsername}/${dockerHubImageName}:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - dbdata:/var/lib/postgresql/data
   web:
     build: .
-    image: ${dockerHubUsername}/${dockerHubImageName}:latest
     working_dir: /app
     ports:
       - "3000:3000"


### PR DESCRIPTION
### Context

To facilitate use of common docker file for both local and azure deployments.

### Changes proposed in this pull request

Azure specific components of docker-compose.yml moved into a new overrides files called docker-compose.azure.yml. This file is then called in the azure pipeline, along with the normal docker-compose file.

### Guidance to review

Tested a build in Azure and local docker compose build to validate that the build succeeds in both types of environment.

### Link to Trello card

[697 - Use Docker in local development to match production environment](https://trello.com/c/qo5UkCSw/697-use-docker-in-local-development-to-match-production-environment)
