### PR TITLE
Add title to pages using page_title helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,11 @@
 module ApplicationHelper
+  def page_title(page)
+    page_title_translation_key = "page_titles.#{page}"
+
+    if I18n.exists?(page_title_translation_key)
+      "#{t(page_title_translation_key)} - #{t('page_titles.application')}"
+    else
+      t('page_titles.application')
+    end
+  end
 end

--- a/app/views/check_your_answers/show.html.erb
+++ b/app/views/check_your_answers/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, page_title(:check_your_answers) %>
+
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-two-thirds'>
 

--- a/app/views/contact_details/edit.html.erb
+++ b/app/views/contact_details/edit.html.erb
@@ -1,1 +1,3 @@
+<% content_for :title, page_title(:edit_contact_details) %>
+
 <%= render 'form', action: :edit %>

--- a/app/views/contact_details/new.html.erb
+++ b/app/views/contact_details/new.html.erb
@@ -1,1 +1,3 @@
+<% content_for :title, page_title(:contact_details) %>
+
 <%= render 'form', action: :new %>

--- a/app/views/degrees/edit.erb
+++ b/app/views/degrees/edit.erb
@@ -1,1 +1,3 @@
+<% content_for :title, page_title(:edit_degrees) %>
+
 <%= render 'form', action: :edit %>

--- a/app/views/degrees/new.erb
+++ b/app/views/degrees/new.erb
@@ -1,1 +1,3 @@
+<% content_for :title, page_title(:degrees) %>
+
 <%= render 'form', action: :new %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title>Apply for postgraduate teacher training - GOV.UK</title>
+    <title><%= yield(:title) %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/personal_details/edit.html.erb
+++ b/app/views/personal_details/edit.html.erb
@@ -1,1 +1,3 @@
+<% content_for :title, page_title(:edit_personal_details) %>
+
 <%= render 'form', action: :edit %>

--- a/app/views/personal_details/new.html.erb
+++ b/app/views/personal_details/new.html.erb
@@ -1,1 +1,3 @@
+<% content_for :title, page_title(:personal_details) %>
+
 <%= render 'form', action: :new %>

--- a/app/views/start_page/show.html.erb
+++ b/app/views/start_page/show.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, t('page_titles.application') %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,15 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  page_titles:
+    application: 'Apply for postgraduate teacher training - GOV.UK'
+    personal_details: 'Personal details'
+    edit_personal_details: 'Edit personal details'
+    contact_details: 'Contact details'
+    edit_contact_details: 'Edit contact details'
+    degrees: 'Add degree'
+    edit_degrees: 'Edit degree'
+    check_your_answers: 'Check your answers before submitting your application'
   activerecord:
     errors:
       models:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe ApplicationHelper do
+  describe '#page_title' do
+    context 'given a page is not defined in the translation file' do
+      it 'returns the application title' do
+        page_title = helper.page_title(:meow)
+
+        expect(page_title).to eq(t('page_titles.application'))
+      end
+    end
+
+    context 'given a page is defined in the translation file' do
+      it 'returns the page name with the application title' do
+        page_title = helper.page_title(:personal_details)
+
+        expect(page_title).to eq("#{t('page_titles.personal_details')} - #{t('page_titles.application')}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently all pages have the same HTML title: "Apply for postgraduate teacher training - GOV.UK". This should be dynamic and depend on individual pages.

### Changes proposed in this pull request

A `page_title` helper is used to create the title using what is defined in `config/locales/en.yml` and in each view it is called to set `:title`.

### Guidance to review

It would be good to get feedback on the way this has been done and particularly the tests.

### Link to Trello card

[712 - Set correct page titles for all the pages](https://trello.com/c/Nlc67KGJ/712-set-correct-page-titles-for-all-the-pages)
