### PR TITLE
Changed warmup ping path to resolve failing deployments

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -11,7 +11,7 @@ parameters:
   dockerhubUsername:
   securityKeyBase:
   containerStartTimeLimit: '600'
-  warmupPingPath: '/personal_details/new'
+  warmupPingPath: '/personal-details/new'
   warmupPingStatus: '200'
   railsEnv: 'production'
   securityAlertEmail: 'apprenticeshipsdevops@education.gov.uk'


### PR DESCRIPTION
### Context

At some point prior to PR134 being merged yesterday another PR resulted in a change of path for the first page of the form which is being used for the warmup task in the deployment stages of the CI/CD pipeline. Consequently the deployments will all now fail because the expected page is no longer valid.

### Changes proposed in this pull request

Modified the warmup path variable in the azure-pipelines-deploy-template.yml file.

### Guidance to review

Testing has already been completed (see: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=16388&view=results). 
To reproduce this testing you would have to temporarily comment out line 120 of the azure-pipelines-deploy-template.yml file because the deployment stages will only run on the master branch otherwise.

### Link to Trello card

N/A - Bug-fix
