### PR TITLE
Convert to deployment jobs and introduce environments

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -2,6 +2,7 @@ parameters:
   debug: false
   subscriptionPrefix:
   subscriptionName:
+  environment:
   resourceEnvironmentName:
   serviceName:
   containerImageReference:
@@ -17,8 +18,9 @@ parameters:
   securityAlertEmail: 'apprenticeshipsdevops@education.gov.uk'
   
 jobs:
-  - job: deploy_${{parameters.resourceEnvironmentName}}
+  - deployment: deploy_${{parameters.resourceEnvironmentName}}
     displayName: 'Deploy App to ${{parameters.subscriptionName}} Subscription'
+    environment: '${{parameters.serviceName}}-${{parameters.environment}}'
     #Your build pipeline references an undefined variable named ‘dockerHubUsername’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab. See https://go.microsoft.com/fwlink/?linkid=865972
     #Your build pipeline references a secret variable named ‘databasePassword’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it secret. See https://go.microsoft.com/fwlink/?linkid=865972
     #Your build pipeline references a secret variable named ‘secretKeyBase’. Create or edit the build pipeline for this YAML file, define the variable on the Variables tab, and then select the option to make it secret. See https://go.microsoft.com/fwlink/?linkid=865972
@@ -33,161 +35,158 @@ jobs:
       #- 'PowerShell'
       #- 'AzurepPS'
 
-    steps:
-    - task: DownloadBuildArtifacts@0
-      inputs:
-        buildType: 'current'
-        downloadType: 'single'
-        artifactName: 'arm_template'
-        downloadPath: '$(System.DefaultWorkingDirectory)' 
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - task: AzureResourceGroupDeployment@2
+            displayName: 'Azure Deployment:Create Or Update Resource Group action on $(resourceGroupName)'
+            condition: succeeded()
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              resourceGroupName: '$(resourceGroupName)'
+              location: 'West Europe'
+              csmFile: '$(Pipeline.Workspace)\arm_template\template.json'
+              overrideParameters: '-resourceEnvironmentName "${{parameters.resourceEnvironmentName}}" 
+                -serviceName "${{parameters.serviceName}}" 
+                -dockerHubUsername "${{parameters.dockerHubUsername}}" 
+                -containerImageReference "${{parameters.containerImageReference}}" 
+                -railsEnv "${{parameters.railsEnv}}" 
+                -databaseName "${{parameters.databaseName}}" 
+                -databaseUsername "${{parameters.databaseUsername}}" 
+                -databasePassword "${{parameters.databasePassword}}" 
+                -securityAlertEmail "${{parameters.securityAlertEmail}}" 
+                -secretKeyBase "${{parameters.secretKeyBase}}"
+                -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
+                -warmupPingPath "${{parameters.warmupPingPath}}"
+                -warmupPingStatus "${{parameters.warmupPingStatus}}"'
+              deploymentOutputs: DeploymentOutput
 
-    - task: AzureResourceGroupDeployment@2
-      displayName: 'Azure Deployment:Create Or Update Resource Group action on $(resourceGroupName)'
-      condition: succeeded()
-      inputs:
-        azureSubscription: '${{parameters.subscriptionName}}'
-        resourceGroupName: '$(resourceGroupName)'
-        location: 'West Europe'
-        csmFile: '$(System.DefaultWorkingDirectory)/arm_template/azure/template.json'
-        overrideParameters: '-resourceEnvironmentName "${{parameters.resourceEnvironmentName}}" 
-          -serviceName "${{parameters.serviceName}}" 
-          -dockerHubUsername "${{parameters.dockerHubUsername}}" 
-          -containerImageReference "${{parameters.containerImageReference}}" 
-          -railsEnv "${{parameters.railsEnv}}" 
-          -databaseName "${{parameters.databaseName}}" 
-          -databaseUsername "${{parameters.databaseUsername}}" 
-          -databasePassword "${{parameters.databasePassword}}" 
-          -securityAlertEmail "${{parameters.securityAlertEmail}}" 
-          -secretKeyBase "${{parameters.secretKeyBase}}"
-          -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
-          -warmupPingPath "${{parameters.warmupPingPath}}"
-          -warmupPingStatus "${{parameters.warmupPingStatus}}"'
-        deploymentOutputs: DeploymentOutput
+          - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1
+            displayName: 'Parse ARM Deployment Outputs into variables'
+            condition: succeeded()
 
-    - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1
-      displayName: 'Parse ARM Deployment Outputs into variables'
-      condition: succeeded()
+          - task: AzureAppServiceManage@0
+            displayName: 'Start Azure App Service: $(appServiceName)'
+            condition: succeeded()
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              Action: 'Start Azure App Service'
+              WebAppName: '$(appServiceName)'
+              SpecifySlotOrASE: true
+              ResourceGroupName: '$(resourceGroupName)'
+              Slot: staging
 
-    - task: AzureAppServiceManage@0
-      displayName: 'Start Azure App Service: $(appServiceName)'
-      condition: succeeded()
-      inputs:
-        azureSubscription: '${{parameters.subscriptionName}}'
-        Action: 'Start Azure App Service'
-        WebAppName: '$(appServiceName)'
-        SpecifySlotOrASE: true
-        ResourceGroupName: '$(resourceGroupName)'
-        Slot: staging
+          - task: AzurePowerShell@3
+            displayName: 'Azure PowerShell Script - Web App Warmup: $(appServiceName)'
+            condition: succeeded()
+            timeoutInMinutes: 15
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              ScriptType: InlineScript
+              azurePowerShellVersion: LatestVersion
+              Inline: |
+                Param(
+                  [string] $appservicename = "$(appServiceName)",
+                  [string] $path = "${{parameters.warmupPingPath}}",
+                  [int]$timeoutInMinutes = 5,
+                  [int]$sleepDelaySeconds = 10
+                )
+                
+                $result = @() 
+                $restartCount = 1
 
-    - task: AzurePowerShell@3
-      displayName: 'Azure PowerShell Script - Web App Warmup: $(appServiceName)'
-      condition: succeeded()
-      inputs:
-        azureSubscription: '${{parameters.subscriptionName}}'
-        ScriptType: InlineScript
-        azurePowerShellVersion: LatestVersion
-        Inline: |
-          Param(
-            [string] $appservicename = "$(appServiceName)",
-            [string] $path = "${{parameters.warmupPingPath}}",
-            [int]$timeoutInMinutes = 5,
-            [int]$sleepDelaySeconds = 10
-          )
-          
-          $result = @() 
-          $restartCount = 1
-
-          #Get current date and time for timeout properties
-          $startTime = (get-date).ToString()
-          
-          #Timer starts now
-          write-output "Elapsed:00:00:00"
-          $continue = $true
-
-          $uri = ("{0}-staging.azurewebsites.net{1}" -f $appservicename, $path)
-          
-          While ( $continue )
-          {
-            $webrequest = try { 
-            
-              $request = $null 
-              ## Request the URI, and measure how long the response took. 
-              $result1 = Measure-Command { $request = Invoke-WebRequest -Uri "https://$uri" -MaximumRedirection 0 -ErrorAction Ignore } 
-              write-output **Time took to invoke web request: $result1.TotalMilliseconds **
-              $request
-            }  
-            catch { 
-              $request = $_.Exception.Response 
-              $time = -1 
-            }   
-          
-            $result = [PSCustomObject] @{ 
-              Time = Get-Date; 
-              Uri = $uri; 
-              StatusCode = [int] $request.StatusCode; 
-              StatusDescription = $request.StatusDescription; 
-              ResponseLength = $request.RawContentLength; 
-              TimeTaken =  $time.TotalMilliseconds;
-              WebRequest = $webrequest 
-            }
-                  
-            $sleeprequired = $false
-            $outputstatuscode=$result.StatusCode
-            $outputuri=($result.uri).ToString()
-            $outputwebrequest= $result.WebRequest.headers.location
-            if ($result.StatusCode -eq 200 ) {
-              Write-output "$outputuri is up and running. Status code = $outputstatuscode"
-            }
-            elseif($result.StatusCode -eq 302) {
-              Write-Output "$outputuri is up and running. Redirection is in place. Status code = $outputstatuscode "
-              Write-Output "$outputuri is redirected to $outputwebrequest "
-            }
-            else { 
-              Write-Output "$outputuri site is currently down or unreachable"
-              $sleeprequired = $true
-              # Remove comment to display extra info # write-output $result | fl
-              #reseting previous result
-              $result = @() 
-            }
-          
-            $currenttime = (get-date).ToString()
-            $elapsedTime = new-timespan $startTime $currenttime
-            write-output "Elapsed:$($elapsedTime.ToString("hh\:mm\:ss"))"  
-          
-            #Handle event
-            if ( $elapsedTime.Minutes -ge $timeoutInMinutes ) {
-              if ( $restartCount -gt 0 ) {
-                write-output "Restarting web app in staging slot..."
-                Restart-AzureRmWebAppSlot -ResourceGroupName $(resourceGroupName) -Name $(appServiceName) -Slot "staging"
+                #Get current date and time for timeout properties
                 $startTime = (get-date).ToString()
-                $restartCount--
-              } else {
-                exit(1)
-              }
-            } elseif ( $sleeprequired -eq $false) { 
-              exit(0)
-            } else {
-              write-output ("Sleeping for {0}s..." -f $sleepDelaySeconds)
-              Start-Sleep $sleepDelaySeconds
-            }
-          }
+                
+                #Timer starts now
+                write-output "Elapsed:00:00:00"
+                $continue = $true
 
-    - task: AzureAppServiceManage@0
-      displayName: 'Swap Slots: $(appServiceName)'
-      inputs:
-        azureSubscription: '${{parameters.subscriptionName}}'
-        WebAppName: '$(appServiceName)'
-        ResourceGroupName: '$(resourceGroupName)'
-        SourceSlot: staging
-      condition: succeeded()
+                $uri = ("{0}-staging.azurewebsites.net{1}" -f $appservicename, $path)
+                
+                While ( $continue )
+                {
+                  $webrequest = try { 
+                  
+                    $request = $null 
+                    ## Request the URI, and measure how long the response took. 
+                    $result1 = Measure-Command { $request = Invoke-WebRequest -Uri "https://$uri" -MaximumRedirection 0 -ErrorAction Ignore } 
+                    write-output **Time took to invoke web request: $result1.TotalMilliseconds **
+                    $request
+                  }  
+                  catch { 
+                    $request = $_.Exception.Response 
+                    $time = -1 
+                  }   
+                
+                  $result = [PSCustomObject] @{ 
+                    Time = Get-Date; 
+                    Uri = $uri; 
+                    StatusCode = [int] $request.StatusCode; 
+                    StatusDescription = $request.StatusDescription; 
+                    ResponseLength = $request.RawContentLength; 
+                    TimeTaken =  $time.TotalMilliseconds;
+                    WebRequest = $webrequest 
+                  }
+                        
+                  $sleeprequired = $false
+                  $outputstatuscode=$result.StatusCode
+                  $outputuri=($result.uri).ToString()
+                  $outputwebrequest= $result.WebRequest.headers.location
+                  if ($result.StatusCode -eq 200 ) {
+                    Write-output "$outputuri is up and running. Status code = $outputstatuscode"
+                  }
+                  elseif($result.StatusCode -eq 302) {
+                    Write-Output "$outputuri is up and running. Redirection is in place. Status code = $outputstatuscode "
+                    Write-Output "$outputuri is redirected to $outputwebrequest "
+                  }
+                  else { 
+                    Write-Output "$outputuri site is currently down or unreachable"
+                    $sleeprequired = $true
+                    # Remove comment to display extra info # write-output $result | fl
+                    #reseting previous result
+                    $result = @() 
+                  }
+                
+                  $currenttime = (get-date).ToString()
+                  $elapsedTime = new-timespan $startTime $currenttime
+                  write-output "Elapsed:$($elapsedTime.ToString("hh\:mm\:ss"))"  
+                
+                  #Handle event
+                  if ( $elapsedTime.Minutes -ge $timeoutInMinutes ) {
+                    if ( $restartCount -gt 0 ) {
+                      write-output "Restarting web app in staging slot..."
+                      Restart-AzureRmWebAppSlot -ResourceGroupName $(resourceGroupName) -Name $(appServiceName) -Slot "staging"
+                      $startTime = (get-date).ToString()
+                      $restartCount--
+                    } else {
+                      exit(1)
+                    }
+                  } elseif ( $sleeprequired -eq $false) { 
+                    exit(0)
+                  } else {
+                    write-output ("Sleeping for {0}s..." -f $sleepDelaySeconds)
+                    Start-Sleep $sleepDelaySeconds
+                  }
+                }
 
-    - task: AzureAppServiceManage@0
-      displayName: 'Stop Azure App Service: $(appServiceName)'
-      inputs:
-        azureSubscription: '${{parameters.subscriptionName}}'
-        Action: 'Stop Azure App Service'
-        WebAppName: '$(appServiceName)'
-        SpecifySlotOrASE: true
-        ResourceGroupName: '$(resourceGroupName)'
-        Slot: staging
-      condition: succeeded()
+          - task: AzureAppServiceManage@0
+            displayName: 'Swap Slots: $(appServiceName)'
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              WebAppName: '$(appServiceName)'
+              ResourceGroupName: '$(resourceGroupName)'
+              SourceSlot: staging
+            condition: succeeded()
+
+          - task: AzureAppServiceManage@0
+            displayName: 'Stop Azure App Service: $(appServiceName)'
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              Action: 'Stop Azure App Service'
+              WebAppName: '$(appServiceName)'
+              SpecifySlotOrASE: true
+              ResourceGroupName: '$(resourceGroupName)'
+              Slot: staging
+            condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,22 +92,14 @@ stages:
         command: Push an image
         imageName: "$(docker_path):latest"
 
-    - task: CopyFiles@2
-      displayName: 'Copy Files to: $(build.artifactstagingdirectory)'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Pipeline Artifacts'
       inputs:
-        Contents: |
-          azure/**
-        TargetFolder: '$(build.artifactstagingdirectory)'
-        OverWrite: true
-
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact'
-      inputs:
-        PathtoPublish: '$(build.artifactstagingdirectory)'
-        ArtifactName: 'arm_template'
-        publishLocation: 'Container'
+        path: '$(System.DefaultWorkingDirectory)/azure/'
+        artifactName: 'arm_template'
 
     - task: PublishTestResults@2
+      displayName: 'Publish Test Results'
       condition: succeededOrFailed()
       inputs:
         testRunner: JUnit
@@ -124,6 +116,7 @@ stages:
       debug: $(debug)
       subscriptionPrefix: 's106'
       subscriptionName: 'Apply (106) - Dev'
+      environment: 'development'
       resourceEnvironmentName: 'd01'
       serviceName: 'apply'
       containerImageReference: '$(imageName):$(build.buildNumber)'
@@ -145,6 +138,7 @@ stages:
       debug: $(debug)
       subscriptionPrefix: 's106'
       subscriptionName: 'Apply (106) - Test'
+      environment: 'test'
       resourceEnvironmentName: 't01'
       serviceName: 'apply'
       containerImageReference: '$(imageName):$(build.buildNumber)'
@@ -166,6 +160,7 @@ stages:
 #       debug: $(debug)
 #       subscriptionPrefix: 's106'
 #       subscriptionName: 'Apply (106) - Production'
+#       environment: 'production'
 #       resourceEnvironmentName: 'p01'
 #       serviceName: 'apply'
 #       containerImageReference: '$(imageName):$(build.buildNumber)'


### PR DESCRIPTION
### Context

Why are you making this change? What might surprise someone about it?
This change switches out the traditional pipeline job that deploys the infrastructure for a dedicated pipeline "deployment job" which targets a pipeline environment. 
Targeting environments with deployment jobs will allow the future addition of manual approval gates without the need to make code changes when we want to implement that feature.

### Changes proposed in this pull request

No UI changes. Other changes summarised below:

1. Changed build pipeline job to "deployment job" type instead
2. Added environment targets to deployment jobs
3. Change publish task in build stage from PublishBuildArtifact to newer PublishPipelineArtifact type
4. Removed DownloadBuildArtifact task entirely because this function is performed automatically by the new Deployment Job type.
5. Added timeout to inline warmup script task.

### Guidance to review

Testing has already be completed successfully. To repeat the test off the master branch you would need to comment out lines 112 or 134 in the azure-pipelines.yml file.

### Link to Trello card

N/A
