### PR TITLE
Fix the Add/Edit action on degree page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,10 @@ module ApplicationHelper
       t('page_titles.application')
     end
   end
+
+  def page_heading(action, resource)
+    actions = { new: 'Add', edit: 'Edit' }
+
+    "#{actions.fetch(action)} #{resource}"
+  end
 end

--- a/app/views/degrees/_form.html.erb
+++ b/app/views/degrees/_form.html.erb
@@ -2,11 +2,11 @@
 
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-two-thirds'>
-    <%= form_with model: @degree, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: :edit, html: { novalidate: true } do |f| %>
+    <%= form_with model: @degree, builder: GOVUKDesignSystemFormBuilder::FormBuilder, action: action, html: { novalidate: true } do |f| %>
       <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
         <h1 class='govuk-fieldset__heading'>
           <span class='govuk-caption-xl'>Academic qualifications</span>
-          Add degree
+          <%= page_heading(action, 'degree') %>
         </h1>
       </legend>
 

--- a/app/views/qualifications/_form.html.erb
+++ b/app/views/qualifications/_form.html.erb
@@ -6,7 +6,7 @@
       <legend class='govuk-fieldset__legend govuk-fieldset__legend--xl'>
         <h1 class='govuk-fieldset__heading'>
           <span class='govuk-caption-xl'>Other qualifications</span>
-          Add qualification
+          <%= page_heading(action, 'qualification') %>
         </h1>
       </legend>
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,4 +18,26 @@ describe ApplicationHelper do
       end
     end
   end
+
+  describe '#page_heading' do
+    context 'when action is supported' do
+      let(:action) { :new }
+
+      it 'returns the correct heading' do
+        heading = helper.page_heading(:edit, 'degree')
+
+        expect(heading).to eq 'Edit degree'
+      end
+    end
+
+    context 'when action is NOT supported' do
+      let(:action) { :non_existent_action }
+
+      it 'raised Action not supported error' do
+        expect {
+          helper.page_heading(:action, 'degree')
+        }.to raise_error(KeyError)
+      end
+    end
+  end
 end

--- a/spec/system/candidate_entering_degree_spec.rb
+++ b/spec/system/candidate_entering_degree_spec.rb
@@ -23,6 +23,8 @@ describe 'A candidate adding a Degree' do
         visit '/check-your-answers'
 
         find('#change-degree').click
+
+        expect(page).to have_content('Edit degree')
         expect(page).to have_field('Type of degree', with: 'BA')
       end
     end

--- a/spec/system/candidate_entering_qualification_spec.rb
+++ b/spec/system/candidate_entering_qualification_spec.rb
@@ -22,7 +22,7 @@ describe 'A candidate adding a qualification' do
       visit '/check-your-answers'
 
       find('#change-qualification').click
-      expect(page).to have_content('Add qualification')
+      expect(page).to have_content('Edit qualification')
 
       expect(page).to have_field('Type of qualification', with: 'GCSE')
     end


### PR DESCRIPTION
### Context
There are pages to add and others to edit degree (and other resources). Now, all the edit pages show 'Add degree', instead of 'Edit degree'

The reason is that we are using a shared form for Add and Edit pages

### Why are you making this change? What might surprise someone about it?
to fix it (read context)

### Link to Trello card

https://trello.com/c/ErOM1md4/733-edit-pages-show-add-in-various-pages
