### PR TITLE
723 change local setup for better devving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,25 @@
+.PHONY: help
+help: ## Show this help
+	@grep -E '^[a-zA-Z\.\-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 .PHONY: build
-build:
+build: ## Create a new image
 	docker-compose build
 
 .PHONY: setup
-setup: build
+setup: build ## Set up a clean database for running the app or the specs in docker
 	docker-compose down -v
 	docker-compose run --rm web bundle exec rake db:setup
 
 .PHONY: test
-test:
+test: ## Run the linters and specs
 	docker-compose run --rm web /bin/sh -c "bundle exec rake"
 
 .PHONY: shell
-shell:
+shell: ## Open a shell on the app container
 	docker-compose run --rm web ash
 
 .PHONY: serve
-serve:
+serve: ## Run the service
 	docker-compose up --build
 	

--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,15 @@ shell: ## Open a shell on the app container
 serve: ## Run the service
 	docker-compose up --build
 	
+.PHONY: ci.lint-ruby
+ci.lint-ruby: ## Run Rubocop with results formatted for CI
+	docker-compose run --rm web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+
+.PHONY: ci.lint-erb
+ci.lint-erb: ## Run the ERB linter
+	docker-compose run --rm web /bin/sh -c "bundle exec rake lint_erb"
+
+.PHONY: ci.test
+ci.test: ## Run the tests with results formatted for CI
+	docker-compose run --rm web /bin/sh -c 'bundle exec rspec --format RspecJunitFormatter' > rspec-results.xml
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: build
+build:
+	docker-compose build
+
+.PHONY: setup
+setup: build
+	docker-compose down -v
+	docker-compose run --rm web bundle exec rake db:setup
+
+.PHONY: test
+test:
+	docker-compose run --rm web /bin/sh -c "bundle exec rake"
+
+.PHONY: shell
+shell:
+	docker-compose run --rm web ash
+
+.PHONY: serve
+serve:
+	docker-compose up --build
+	

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,21 +20,20 @@ stages:
       vmImage: 'Ubuntu-16.04'
 
     variables:
-      # Support multiple docker-compose files to allow travis and az pipelines to co exist: https://docs.docker.com/compose/extends/#multiple-compose-files
-      dockerOverride: 'docker-compose -f docker-compose.yml -f docker-compose.azure.yml'
       system.debug: $(debug)
 
     steps:
     - script: |
         GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
         docker_path=$(dockerHubUsername)/$(imageName)
+        echo '##vso[task.setvariable variable=compose_file]docker-compose.yml:docker-compose.azure.yml'
         echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
         echo "##vso[task.setvariable variable=docker_path;]$docker_path"
       displayName: 'Set version number'
 
     - script: |
-        $DOCKER_OVERRIDE build
-        $DOCKER_OVERRIDE run web /bin/sh -c "bundle exec rails db:setup"
+        docker-compose build
+        docker-compose run web /bin/sh -c "bundle exec rails db:setup"
       displayName: 'Build & setup'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)
@@ -42,7 +41,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-        $DOCKER_OVERRIDE run web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+        docker-compose run web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
       displayName: 'Rubocop'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)
@@ -50,7 +49,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-        $DOCKER_OVERRIDE run web /bin/sh -c "bundle exec rake lint_erb"
+        docker-compose run web /bin/sh -c "bundle exec rake lint_erb"
       displayName: 'ERB lint'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)
@@ -58,7 +57,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-       $DOCKER_OVERRIDE run web /bin/sh -c 'bundle exec rspec --format RspecJunitFormatter' > rspec-results.xml
+       docker-compose run web /bin/sh -c 'bundle exec rspec --format RspecJunitFormatter' > rspec-results.xml
       displayName: 'Execute tests'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,8 +32,7 @@ stages:
       displayName: 'Set version number'
 
     - script: |
-        docker-compose build
-        docker-compose run web /bin/sh -c "bundle exec rails db:setup"
+        make setup
       displayName: 'Build & setup'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)
@@ -41,7 +40,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-        docker-compose run web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+        make ci.lint-ruby
       displayName: 'Rubocop'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)
@@ -49,7 +48,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-        docker-compose run web /bin/sh -c "bundle exec rake lint_erb"
+        make ci.lint-erb
       displayName: 'ERB lint'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)
@@ -57,7 +56,7 @@ stages:
         dockerHubImageName: $(imageName)
 
     - script: |
-       docker-compose run web /bin/sh -c 'bundle exec rspec --format RspecJunitFormatter' > rspec-results.xml
+        make ci.test
       displayName: 'Execute tests'
       env:
         DOCKER_OVERRIDE: $(dockerOverride)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,16 @@
-# SQLite version 3.x
-#   gem install sqlite3
-#
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
-#
 default: &default
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
-  host: <%= ENV['DB_HOSTNAME'] || 'localhost' %>
-  port: <%= ENV['DB_PORT'] || '5432' %>
+  host: <%= ENV['DB_HOSTNAME'] %>
+  port: <%= ENV['DB_PORT'] %>
+  database: <%= ENV['DB_DATABASE'] %>
 
 development:
   <<: *default
-  database: <%= ENV['DB_DATABASE'] || 'bat_apply_dev' %>
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: <%= ENV['DB_DATABASE'] || 'bat_apply_test' %>
+  database: 'bat_apply_test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,9 @@
 version: '3.6'
-volumes:
-  dbdata:
 services:
   db:
     image: postgres:9.6-alpine
-    volumes:
-      - dbdata:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=developmentpassword
   web:
     build: .
     working_dir: /app
@@ -16,3 +14,6 @@ services:
     environment:
       - DB_HOSTNAME=db
       - DB_USERNAME=postgres
+      - DB_PASSWORD=developmentpassword
+      - DB_DATABASE=bat_apply_dev
+      - DB_PORT=5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.6'
 services:
   db:
     image: postgres:9.6-alpine
+    volumes:
+      - db_data:/var/lib/postgresql/data
     environment:
       - POSTGRES_PASSWORD=developmentpassword
   web:
@@ -17,3 +19,5 @@ services:
       - DB_PASSWORD=developmentpassword
       - DB_DATABASE=bat_apply_dev
       - DB_PORT=5432
+volumes:
+  db_data:


### PR DESCRIPTION
### Context

We are currently using docker in our CI/CD pipeline, but we have not leveraged docker and docker-compose to help during local development. This PR hopes to address this.

### Changes proposed in this pull request

This PR proposes the addition of a Makefile to the project that contains a number of helpful commands for local development including: 
- `make test` : builds a fresh docker container to run the test suite.
- `make shell` : builds a fresh docker container and starts an interactive shell within the container.
- `make serve` builds a fresh docker container that serves the rails application to localhost for development.

This PR also edits the current `database.yml` config file to remove database defaults that should be passed in via environment variables. 
This change requires anyone running the application to have to specify env variables for: 
`DB_HOSTNAME`
`DB_PORT`
`DB_DATABASE`

Unless using the `Makefile` or `docker-compose` commands.

### Guidance to review

 - Please review the Makefile addition. 
 - Review the changes to the `database.yml` file.
 - Review the changes to the `docker-compose.yml` file.



### Link to Trello card

[723 - Change local setup so devs can easily build test and deploy the service](https://trello.com/c/8dfnU6LH/723-change-local-setup-so-devs-can-easily-build-test-and-deploy-the-service)
