### PR TITLE
Remove redundant gem install from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN apk add --update build-base postgresql-dev git tzdata nodejs yarn && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 
-RUN gem install rails -v '5.2.2'
 RUN gem install bundler:2.0.2
 
 ENV APP_HOME /app


### PR DESCRIPTION
Remove an unnecessary `gem install` from the `Dockerfile`.

### Guidance to review

Confirm that `rails` is indeed a dependency of our app and is listed in the `Gemfile`

### Link to Trello card

Towards https://trello.com/c/0hVMdQg2/767-revise-dockerfile-to-speed-up-builds-5
