### PR TITLE
Mount . inside the web container under docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,10 @@ build: ## Create a new image
 	docker-compose build
 
 .PHONY: setup
-setup: build ## Set up a clean database for running the app or the specs in docker
+setup: build ## Set up a clean database and node_modules folder for running the app or the specs in docker
 	docker-compose down -v
 	docker-compose run --rm web bundle exec rake db:setup
+	docker-compose run --rm web yarn install
 
 .PHONY: test
 test: ## Run the linters and specs

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,11 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Do not buffer STDOUT in Ruby. This behaviour interacts weirdly with the docker-compose
+  # log output and causes logs only to be printed when an exception occurs or the process
+  # exits.
+  $stdout.sync = true
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
   web:
     build: .
     working_dir: /app
+    volumes:
+      - .:/app
     ports:
       - "3000:3000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     working_dir: /app
     volumes:
       - .:/app
+      - node_modules:/app/node_modules
     ports:
       - "3000:3000"
     depends_on:
@@ -23,3 +24,4 @@ services:
       - DB_PORT=5432
 volumes:
   db_data:
+  node_modules:


### PR DESCRIPTION
### Context

When the app is running under docker, it's necessary to rebuild it to see your changes reflected.

### Changes proposed in this pull request

Mount the host's working directory under /app inside the container when running under docker-compose, which effectively means that the container uses the code from the host.

### Guidance to review

Run the app using `make serve`. Make some changes and see them reflected. Also, make sure this doesn't break CI.

### Link to Trello card

https://trello.com/c/0hVMdQg2/767-revise-dockerfile-to-speed-up-builds-5
