### PR TITLE
Added GOV UK Notify API key to pipeline

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -59,7 +59,8 @@ jobs:
                 -secretKeyBase "${{parameters.secretKeyBase}}"
                 -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
                 -warmupPingPath "${{parameters.warmupPingPath}}"
-                -warmupPingStatus "${{parameters.warmupPingStatus}}"'
+                -warmupPingStatus "${{parameters.warmupPingStatus}}"
+                -govukNotifyAPIKey "$(govukNotifyAPIKey)"'
               deploymentOutputs: DeploymentOutput
 
           - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,8 +7,11 @@ trigger:
 pr: none
 
 variables:
-  imageName: 'apply-for-postgraduate-teacher-training'
-  debug: true
+- group: Docker Shared variables
+- name: imageName
+  value: 'apply-for-postgraduate-teacher-training'
+- name: debug
+  value: true
 
 stages:
 - stage: build_test_release
@@ -20,7 +23,8 @@ stages:
       vmImage: 'Ubuntu-16.04'
 
     variables:
-      system.debug: $(debug)
+    - name: system.debug 
+      value: $(debug)
 
     steps:
     - script: |
@@ -35,33 +39,33 @@ stages:
         make setup
       displayName: 'Build & setup'
       env:
-        DOCKER_OVERRIDE: $(dockerOverride)
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
+        GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
 
     - script: |
         make ci.lint-ruby
       displayName: 'Rubocop'
       env:
-        DOCKER_OVERRIDE: $(dockerOverride)
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
+        GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
 
     - script: |
         make ci.lint-erb
       displayName: 'ERB lint'
       env:
-        DOCKER_OVERRIDE: $(dockerOverride)
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
+        GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
 
     - script: |
         make ci.test
       displayName: 'Execute tests'
       env:
-        DOCKER_OVERRIDE: $(dockerOverride)
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
+        GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
@@ -108,6 +112,8 @@ stages:
   displayName: 'Deploy - Development'
   dependsOn: build_test_release
   condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  variables:
+  - group: APPLY - Development Secrets
   jobs:
   - template: azure-pipelines-deploy-template.yml
     parameters:
@@ -130,6 +136,8 @@ stages:
   displayName: 'Deploy - Test'
   dependsOn: build_test_release
   condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  variables:
+  - group: APPLY - Production Secrets
   jobs:
   - template: azure-pipelines-deploy-template.yml
     parameters:
@@ -152,6 +160,8 @@ stages:
 #   displayName: 'Deploy - Production'
 #   dependsOn: build_test_release
 #   condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+#   variables:
+#   - group: APPLY - Production Secrets
 #   jobs:
 #   - template: azure-pipelines-deploy-template.yml
 #     parameters:

--- a/azure/template.json
+++ b/azure/template.json
@@ -81,6 +81,12 @@
                 "description": "The permitted status codes to indicate a successful app warmup."
             }
         },
+        "govukNotifyAPIKey": {
+            "type": "string",
+            "metadata": {
+                "description": "GOV UK Notify service API key."
+            }
+        },
         "railsServeStaticFiles": {
             "type": "string",
             "defaultValue": "true",
@@ -207,6 +213,10 @@
                             {
                                 "name": "RAILS_SERVE_STATIC_FILES",
                                 "value": "[parameters('railsServeStaticFiles')]"
+                            },
+                            {
+                                "name": "GOVUK_NOTIFY_API_KEY",
+                                "value": "[parameters('govukNotifyAPIKey')]"
                             }
                         ]
                     }


### PR DESCRIPTION
### Context

GOV UK Notify service requires the use of a secret API key to interact with the service. This change puts in place the necessary changes to the DevOps pipeline to present the API key to the necessary stages of the pipeline.

### Changes proposed in this pull request

1. Created variable groups in Azure DevOps to contain the API key securely on a per environment.
2. Added the variable group to the pipeline file
3. Referenced the new "govukNotifyAPIKey" in the docker build stage and Azure App Service deployment template
4. Removed redundant "DOCKER_OVERRIDE" variable from the pipeline.

### Guidance to review

Tested that build completes, but requires another dependant change to full test that notify functionality works.

### Link to Trello card

[768 - Configure production environment to use GOV.UK Notify](https://trello.com/c/f2fFMEw4/768-configure-production-environment-to-use-govuk-notify)
