### PR TITLE
Remove date of birth from personal details

### DIFF
--- a/app/controllers/personal_details_controller.rb
+++ b/app/controllers/personal_details_controller.rb
@@ -33,7 +33,6 @@ private
     params.require(:personal_details).permit(:title,
                                              :first_name,
                                              :last_name,
-                                             :preferred_name,
-                                             :date_of_birth)
+                                             :preferred_name)
   end
 end

--- a/app/models/personal_details.rb
+++ b/app/models/personal_details.rb
@@ -1,5 +1,4 @@
 class PersonalDetails < ApplicationRecord
-  DATE_OF_BIRTH_LIMIT = 1900
   MAX_LENGTHS = {
     first_name: 50,
     last_name: 50,
@@ -7,17 +6,7 @@ class PersonalDetails < ApplicationRecord
     title: 4,
   }.freeze
 
-  validates :first_name, :last_name, :title, :date_of_birth, presence: true
+  validates :first_name, :last_name, :title, presence: true
 
   MAX_LENGTHS.each { |field, max| validates field, length: { maximum: max } }
-
-  validate :date_of_birth, :date_is_not_too_old
-
-private
-
-  def date_is_not_too_old
-    if date_of_birth.present? && date_of_birth.year < DATE_OF_BIRTH_LIMIT
-      errors.add(:date_of_birth, :too_old, year: DATE_OF_BIRTH_LIMIT)
-    end
-  end
 end

--- a/app/views/check_your_answers/show.html.erb
+++ b/app/views/check_your_answers/show.html.erb
@@ -6,7 +6,7 @@
     <h1 class='govuk-heading-xl'><%= t('application_form.check_your_answers') %></h1>
 
     <%= render 'shared/section_summary',
-      fields: [:first_name, :last_name, :preferred_name, :date_of_birth],
+      fields: [:first_name, :last_name, :preferred_name],
       section_name: :personal_details,
       record: @application[:personal_details] %>
 

--- a/app/views/personal_details/_form.html.erb
+++ b/app/views/personal_details/_form.html.erb
@@ -12,10 +12,6 @@
       <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details_section.first_name.label')} %>
       <%= f.govuk_text_field :preferred_name, label: { text: t('application_form.personal_details_section.preferred_name.label')} %>
       <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details_section.last_name.label')} %>
-      <div id='personal_details_date_of_birth'>
-        <%= f.govuk_date_field :date_of_birth, legend: { text: t('application_form.personal_details_section.date_of_birth.label'), tag: 'span', size: 's' },
-                               hint_text: t('application_form.personal_details_section.date_of_birth.hint_text') %>
-      </div>
 
       <%= f.submit t('application_form.save_and_continue'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -16,9 +16,6 @@ en:
         label: Last name
       preferred_name:
         label: Name you prefer to be addressed by
-      date_of_birth:
-        label: Date of birth
-        hint_text: For example, 31 3 1980
     contact_details_section:
       heading: Contact details
       phone_number:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,9 +55,6 @@ en:
             preferred_name:
               blank: 'Enter your preferred name'
               too_long: 'Preferred name must be %{count} characters or less'
-            date_of_birth:
-              blank: 'Enter your date of birth'
-              too_old: 'Date of birth must be after %{year}'
             nationality:
               blank: 'Enter your nationality'
         contact_details:

--- a/db/migrate/20190820141805_remove_date_of_birth_from_personal_details.rb
+++ b/db/migrate/20190820141805_remove_date_of_birth_from_personal_details.rb
@@ -1,0 +1,5 @@
+class RemoveDateOfBirthFromPersonalDetails < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :personal_details, :date_of_birth, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_30_095213) do
+ActiveRecord::Schema.define(version: 2019_08_20_141805) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -39,7 +39,6 @@ ActiveRecord::Schema.define(version: 2019_07_30_095213) do
     t.string "first_name"
     t.string "last_name"
     t.string "preferred_name"
-    t.date "date_of_birth"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/models/personal_details_spec.rb
+++ b/spec/models/personal_details_spec.rb
@@ -6,35 +6,8 @@ describe PersonalDetails, type: :model do
 
   it { is_expected.to validate_presence_of :first_name }
   it { is_expected.to validate_presence_of :last_name }
-  it { is_expected.to validate_presence_of :date_of_birth }
 
   it { is_expected.to validate_length_of(:first_name).is_at_most(50) }
   it { is_expected.to validate_length_of(:last_name).is_at_most(50) }
   it { is_expected.to validate_length_of(:preferred_name).is_at_most(50) }
-
-  describe 'date of birth' do
-    let(:personal_details) { described_class.new(date_of_birth: date_of_birth) }
-
-    context 'when date is before year 1900' do
-      let(:date_of_birth) { '31-12-1899' }
-
-      it 'provides a too_old validation error' do
-        personal_details.save
-
-        date_of_birth_error = personal_details.errors.details[:date_of_birth].first[:error]
-
-        expect(date_of_birth_error).to be :too_old
-      end
-    end
-
-    context 'when date is after year 1900' do
-      let(:date_of_birth) { '1-1-1900' }
-
-      it 'does NOT provide a too_old validation error' do
-        personal_details.save
-
-        expect(personal_details.errors.details[:date_of_birth]).to be_empty
-      end
-    end
-  end
 end

--- a/spec/support/test_helpers/personal_details.rb
+++ b/spec/support/test_helpers/personal_details.rb
@@ -5,20 +5,13 @@ module TestHelpers
         first_name: 'John',
         last_name: 'Doe',
         title: 'Dr',
-        preferred_name: 'Dr Doe',
-        date_of_birth: Date.new(1997, 3, 13)
+        preferred_name: 'Dr Doe'
       }
 
       fill_in t('application_form.personal_details_section.title.label'), with: details[:title]
       fill_in t('application_form.personal_details_section.first_name.label'), with: details[:first_name]
       fill_in t('application_form.personal_details_section.preferred_name.label'), with: details[:preferred_name]
       fill_in t('application_form.personal_details_section.last_name.label'), with: details[:last_name]
-
-      within '.govuk-date-input' do
-        fill_in 'Day', with: details[:date_of_birth].day
-        fill_in 'Month', with: details[:date_of_birth].month
-        fill_in 'Year', with: details[:date_of_birth].year
-      end
     end
   end
 end


### PR DESCRIPTION
### Context

Originally this had the aim to fix an `argument out of range` error caused by the date of birth field. However, because we no longer plan to store the date of birth of a candidate, the field has been removed completely.

### Changes proposed in this pull request

Remove all traces of `date_of_birth` e.g. the column in the Personal Details table, the views.

#### Before

![image](https://user-images.githubusercontent.com/42817036/63358377-d76d8100-c362-11e9-8c4e-40435b472b71.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/63358264-aab96980-c362-11e9-9a6b-98ceb6c63e7e.png)

### Guidance to review

Check that all traces of `date_of_birth` have been removed.

### Link to Trello card

[704 - Fix error on entering invalid data into Date of Birth field](https://trello.com/c/KM1ILWdL/704-fix-error-on-entering-invalid-data-into-date-of-birth-field)