### PR TITLE
Fix error messages on personal details, contact details and degrees

### DIFF
--- a/app/models/contact_details.rb
+++ b/app/models/contact_details.rb
@@ -1,11 +1,11 @@
 class ContactDetails < ApplicationRecord
   MAX_LENGTHS = {
-    address: 250,
+    phone_number: 35,
     email_address: 250,
-    phone_number: 35
+    address: 250
   }.freeze
 
-  validates :address, :email_address, :phone_number, presence: true
+  validates :phone_number, :email_address, :address, presence: true
 
   MAX_LENGTHS.each { |field, max| validates field, length: { maximum: max } }
 end

--- a/app/models/degree.rb
+++ b/app/models/degree.rb
@@ -1,9 +1,9 @@
 class Degree < ApplicationRecord
   MAX_LENGTHS = {
-    class_of_degree: 20,
-    institution: 100,
+    type_of_degree: 20,
     subject: 100,
-    type_of_degree: 20
+    institution: 100,
+    class_of_degree: 20
   }.freeze
 
   validates :type_of_degree, :subject, :institution, :class_of_degree, :year, presence: true

--- a/app/models/personal_details.rb
+++ b/app/models/personal_details.rb
@@ -1,12 +1,12 @@
 class PersonalDetails < ApplicationRecord
   MAX_LENGTHS = {
-    first_name: 50,
-    last_name: 50,
-    preferred_name: 50,
     title: 4,
+    first_name: 50,
+    preferred_name: 50,
+    last_name: 50
   }.freeze
 
-  validates :first_name, :last_name, :title, presence: true
+  validates :title, :first_name, :last_name, presence: true
 
   MAX_LENGTHS.each { |field, max| validates field, length: { maximum: max } }
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
           attributes:
             title:
               blank: 'Enter your title'
+              too_long: 'Title must be %{count} characters or less'
             first_name:
               blank: 'Enter your first name'
               too_long: 'First name must be %{count} characters or less'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,29 +46,29 @@ en:
           attributes:
             title:
               blank: 'Enter your title'
-              too_long: 'Title must be %{count} characters or less'
+              too_long: 'Title must be %{count} characters or fewer'
             first_name:
               blank: 'Enter your first name'
-              too_long: 'First name must be %{count} characters or less'
+              too_long: 'First name must be %{count} characters or fewer'
             last_name:
               blank: 'Enter your last name'
-              too_long: 'Last name must be %{count} characters or less'
+              too_long: 'Last name must be %{count} characters or fewer'
             preferred_name:
               blank: 'Enter your preferred name'
-              too_long: 'Preferred name must be %{count} characters or less'
+              too_long: 'Preferred name must be %{count} characters or fewer'
             nationality:
               blank: 'Enter your nationality'
         contact_details:
           attributes:
             phone_number:
               blank: 'Enter your phone number'
-              too_long: 'Phone number must be %{count} characters or less'
+              too_long: 'Phone number must be %{count} characters or fewer'
             email_address:
               blank: 'Enter your email address'
-              too_long: 'Email address must be %{count} characters or less'
+              too_long: 'Email address must be %{count} characters or fewer'
             address:
               blank: 'Enter your postal address'
-              too_long: 'Address must be %{count} characters or less'
+              too_long: 'Address must be %{count} characters or fewer'
         degree:
           attributes:
             type_of_degree:


### PR DESCRIPTION
### Context

Paul has raised this as an issue for the mismatch of order of the error messages and fields on Personal Details and Contact Details pages - see #141. Those on the Degree page were also updated as they did not match.

The maximum length error message for Title in Personal Details does not follow GOV.UK standards - see #158.

### Changes proposed in this pull request

Reorder the validations in the models: `PersonalDetails`, `ContactDetails` and `Degrees` to match the corresponding fields on the forms.

#### Before Example

![image](https://user-images.githubusercontent.com/42817036/63420944-a3946900-c3ff-11e9-8353-2cbb317ee520.png)

#### After Example

![image](https://user-images.githubusercontent.com/42817036/63421034-c7f04580-c3ff-11e9-91ab-09edfc471757.png)

Add locale for a `Title` maximum length error message.

#### Before

![image](https://user-images.githubusercontent.com/42817036/63421165-0ab21d80-c400-11e9-9336-c20a5eaa1e5a.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/63421365-61b7f280-c400-11e9-8be1-dd20f2541986.png)

### Guidance to review

Check the order of the error messages match the order of the form fields.

### Link to Trello card

[811 - Fix error messages on Personal Details and Contact details](https://trello.com/c/PPZHLUxK/811-fix-error-messages-on-personal-details-and-contact-details)
