### PR TITLE
Added default provider email variable.

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -60,7 +60,8 @@ jobs:
                 -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
                 -warmupPingPath "${{parameters.warmupPingPath}}"
                 -warmupPingStatus "${{parameters.warmupPingStatus}}"
-                -govukNotifyAPIKey "$(govukNotifyAPIKey)"'
+                -govukNotifyAPIKey "$(govukNotifyAPIKey)"
+                -defaultProviderEmail "$(defaultProviderEmail)"'
               deploymentOutputs: DeploymentOutput
 
           - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,8 @@ variables:
 - group: Docker Shared variables
 - name: imageName
   value: 'apply-for-postgraduate-teacher-training'
+- name: defaultProviderEmail
+  value: 'email@example.com'
 - name: debug
   value: true
 
@@ -43,6 +45,7 @@ stages:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
+        DEFAULT_PROVIDER_EMAIL: $(defaultProviderEmail)
 
     - script: |
         make ci.lint-ruby
@@ -51,6 +54,7 @@ stages:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
+        DEFAULT_PROVIDER_EMAIL: $(defaultProviderEmail)
 
     - script: |
         make ci.lint-erb
@@ -59,6 +63,7 @@ stages:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
+        DEFAULT_PROVIDER_EMAIL: $(defaultProviderEmail)
 
     - script: |
         make ci.test
@@ -67,6 +72,7 @@ stages:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
+        DEFAULT_PROVIDER_EMAIL: $(defaultProviderEmail)
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
@@ -163,6 +169,8 @@ stages:
 #   condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
 #   variables:
 #   - group: APPLY - Production Secrets
+#   - name: govukNotifyDefaultProviderEmail
+#     value: 'email@example.com'
 #   jobs:
 #   - template: azure-pipelines-deploy-template.yml
 #     parameters:

--- a/azure/template.json
+++ b/azure/template.json
@@ -87,6 +87,12 @@
                 "description": "GOV UK Notify service API key."
             }
         },
+        "defaultProviderEmail": {
+            "type": "string",
+            "metadata": {
+                "description": "Notify service Default provider email address."
+            }
+        },
         "railsServeStaticFiles": {
             "type": "string",
             "defaultValue": "true",
@@ -217,6 +223,10 @@
                             {
                                 "name": "GOVUK_NOTIFY_API_KEY",
                                 "value": "[parameters('govukNotifyAPIKey')]"
+                            },
+                            {
+                                "name": "DEFAULT_PROVIDER_EMAIL",
+                                "value": "[parameters('defaultProviderEmail')]"
                             }
                         ]
                     }

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -4,4 +4,4 @@ services:
     image: ${dockerHubUsername}/${dockerHubImageName}:latest
     environment:
       - GOVUK_NOTIFY_API_KEY=${GOVUK_NOTIFY_API_KEY}
-      - DEFAULT_PROVIDER_EMAIL=test@email.com
+      - DEFAULT_PROVIDER_EMAIL=${DEFAULT_PROVIDER_EMAIL}


### PR DESCRIPTION
### Context

Adding an environment variable to set the default provider email.

### Changes proposed in this pull request

Added variable to pipeline to reference the provider email address which is then passed into the build and deployment environments as an environment variable.

### Guidance to review

At the moment a common environment variable is used for both development and test environments, wit the value overridden for the production environment, when enabled. If more granularity is required this can be added.

### Link to Trello card

[726 - Applications are emailed to providers via GOV.UK Notify (8)](https://trello.com/c/fF02S0br/726-applications-are-emailed-to-providers-via-govuk-notify-8)
