### PR TITLE
Implement sign up using magic links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,4 +39,5 @@ end
 group :development, :test do
   gem 'rspec-rails'
   gem 'dotenv-rails'
+  gem 'factory_bot_rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'rubocop-rspec'
 gem 'govuk-lint'
 gem 'erb_lint', require: false
 
+gem 'devise'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,11 @@ GEM
       rubocop (~> 0.51)
       smart_properties
     erubi (1.8.0)
+    factory_bot (5.0.2)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.0.2)
+      factory_bot (~> 5.0.2)
+      railties (>= 4.2.0)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -268,6 +273,7 @@ DEPENDENCIES
   devise
   dotenv-rails
   erb_lint
+  factory_bot_rails
   govuk-lint
   govuk_design_system_formbuilder (= 0.9.2)
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
+    bcrypt (3.1.13)
     better_html (1.0.14)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -73,6 +74,12 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    devise (4.6.2)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0, < 6.0)
+      responders
+      warden (~> 1.2.3)
     diff-lcs (1.3)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
@@ -125,6 +132,7 @@ GEM
       mini_portile2 (~> 2.4.0)
     notifications-ruby-client (3.1.0)
       jwt (>= 1.5, < 3)
+    orm_adapter (0.5.0)
     parallel (1.17.0)
     parser (2.6.3.0)
       ast (~> 2.4.0)
@@ -170,6 +178,9 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     regexp_parser (1.6.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
@@ -230,6 +241,8 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
+    warden (1.2.8)
+      rack (>= 2.0.6)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -252,6 +265,7 @@ DEPENDENCIES
   capybara (>= 3.24)
   capybara-email
   climate_control
+  devise
   dotenv-rails
   erb_lint
   govuk-lint

--- a/app/controllers/check_your_answers_controller.rb
+++ b/app/controllers/check_your_answers_controller.rb
@@ -1,4 +1,6 @@
 class CheckYourAnswersController < ApplicationController
+  before_action :authenticate_candidate!
+
   def show
     @application = {
       personal_details: PersonalDetails.last,

--- a/app/controllers/contact_details_controller.rb
+++ b/app/controllers/contact_details_controller.rb
@@ -1,4 +1,6 @@
 class ContactDetailsController < ApplicationController
+  before_action :authenticate_candidate!
+
   def new
     @contact_details = ContactDetails.new
   end

--- a/app/controllers/degrees_controller.rb
+++ b/app/controllers/degrees_controller.rb
@@ -1,4 +1,6 @@
 class DegreesController < ApplicationController
+  before_action :authenticate_candidate!
+
   def new
     @degree = Degree.new
   end

--- a/app/controllers/magic_link/sign_up_controller.rb
+++ b/app/controllers/magic_link/sign_up_controller.rb
@@ -1,0 +1,24 @@
+class MagicLink::SignUpController < ApplicationController
+  def new
+    @candidate = Candidate.new
+  end
+
+  def create
+    @candidate = Candidate.new(candidate_params)
+
+    if @candidate.save
+      MagicLinkSignUp.call(candidate: @candidate)
+      render :show
+    else
+      render :new
+    end
+  end
+
+  def show; end
+
+private
+
+  def candidate_params
+    params.require(:candidate).permit(:email_address)
+  end
+end

--- a/app/controllers/personal_details_controller.rb
+++ b/app/controllers/personal_details_controller.rb
@@ -1,4 +1,6 @@
 class PersonalDetailsController < ApplicationController
+  before_action :authenticate_candidate!
+
   def new
     @personal_details = PersonalDetails.new
   end

--- a/app/controllers/qualifications_controller.rb
+++ b/app/controllers/qualifications_controller.rb
@@ -1,4 +1,6 @@
 class QualificationsController < ApplicationController
+  before_action :authenticate_candidate!
+
   def new
     @qualification = Qualification.new
   end

--- a/app/controllers/tt_application_submissions_controller.rb
+++ b/app/controllers/tt_application_submissions_controller.rb
@@ -1,6 +1,8 @@
 require 'notifications/client'
 
 class TTApplicationSubmissionsController < ApplicationController
+  before_action :authenticate_candidate!
+
   def create
     contact_details = ContactDetails.last
     TTApplicationMailer.send_application(to: ENV.fetch('DEFAULT_PROVIDER_EMAIL'), candidate_email: contact_details.email_address).deliver!

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,3 @@
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+class ApplicationMailer < Mail::Notify::Mailer
+  GENERIC_NOTIFY_TEMPLATE = '2744ea53-34f1-431f-8173-8388fadd826a'.freeze
 end

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -1,0 +1,9 @@
+class AuthenticationMailer < ApplicationMailer
+  def sign_up_email(to:, token:)
+    @magic_link = "#{new_personal_details_url}?token=#{token}"
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: to,
+              subject: t('authentication.sign_up.email.subject'))
+  end
+end

--- a/app/mailers/tt_application_mailer.rb
+++ b/app/mailers/tt_application_mailer.rb
@@ -1,6 +1,4 @@
-class TTApplicationMailer < Mail::Notify::Mailer
-  GENERIC_NOTIFY_TEMPLATE = '2744ea53-34f1-431f-8173-8388fadd826a'.freeze
-
+class TTApplicationMailer < ApplicationMailer
   def send_application(to:, candidate_email:)
     @candidate_email = candidate_email
 

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -1,0 +1,7 @@
+class Candidate < ApplicationRecord
+  # No Devise modules are enabled
+  # Custom Warden strategy is used instead see app/warden/magic_link_token.rb
+  devise
+
+  validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
+end

--- a/app/services/find_candidate_by_token.rb
+++ b/app/services/find_candidate_by_token.rb
@@ -1,0 +1,8 @@
+require_relative 'lib/magic_link_token'
+
+class FindCandidateByToken
+  def self.call(raw_token:)
+    token = MagicLinkToken.from_raw(raw_token)
+    Candidate.find_by(magic_link_token: token)
+  end
+end

--- a/app/services/lib/magic_link_token.rb
+++ b/app/services/lib/magic_link_token.rb
@@ -1,0 +1,11 @@
+class MagicLinkToken
+  attr_reader :encrypted, :raw
+
+  def initialize
+    @raw, @encrypted = Devise.token_generator.generate(Candidate, :magic_link_token)
+  end
+
+  def self.from_raw(token)
+    Devise.token_generator.digest(Candidate, :magic_link_token, token)
+  end
+end

--- a/app/services/magic_link_sign_up.rb
+++ b/app/services/magic_link_sign_up.rb
@@ -1,0 +1,9 @@
+require_relative 'lib/magic_link_token'
+
+class MagicLinkSignUp
+  def self.call(candidate:)
+    magic_link_token = MagicLinkToken.new
+    AuthenticationMailer.sign_up_email(to: candidate.email_address, token: magic_link_token.raw).deliver!
+    candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
+  end
+end

--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -1,0 +1,5 @@
+# <%= t('authentication.sign_up.email.heading') %>
+
+<%= t('authentication.sign_up.email.body') %>
+
+<%= @magic_link %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,7 @@
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
             Apply for postgraduate teacher training
           </a>
+          <p><%= current_candidate.email_address unless current_candidate.nil? %></p>
         </div>
       </div>
     </header>

--- a/app/views/magic_link/sign_up/new.html.erb
+++ b/app/views/magic_link/sign_up/new.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, t('authentication.sign_up.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('authentication.sign_up.heading') %>
+    </h1>
+
+    <p class="govuk-body-l">Please give us your email address so that you can save and return to your application.</p>
+
+    <%= form_with model: @candidate, url: sign_up_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label')}, hint_text: t('authentication.sign_up.email_address.hint_label'), type: :email %>
+
+      <%= f.submit t('authentication.sign_up.button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/magic_link/sign_up/show.html.erb
+++ b/app/views/magic_link/sign_up/show.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, t('authentication.check_your_email') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('authentication.check_your_email') %>
+    </h1>
+    <p class="govuk-body-l">
+      We’ve sent you an email. Click on the link to confirm your address and return to this service.
+    </p>
+  </div>
+</div>

--- a/app/views/start_page/show.html.erb
+++ b/app/views/start_page/show.html.erb
@@ -14,7 +14,7 @@
       <li>tailor your application to suit different providers</li>
     </ul>
 
-    <%= link_to new_personal_details_path, role: 'button', class: 'govuk-button govuk-button--start', 'data-module': 'govuk-button' do %>
+    <%= link_to new_sign_up_path, role: 'button', class: 'govuk-button govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/warden/magic_link_strategy.rb
+++ b/app/warden/magic_link_strategy.rb
@@ -1,0 +1,15 @@
+class MagicLinkStrategy < Warden::Strategies::Base
+  def valid?
+    params[:token].present?
+  end
+
+  def authenticate!
+    candidate = FindCandidateByToken.call(raw_token: params[:token])
+
+    if candidate
+      success!(candidate)
+    else
+      fail!
+    end
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,8 @@ Rails.application.configure do
     api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
   }
 
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+
   # Do not buffer STDOUT in Ruby. This behaviour interacts weirdly with the docker-compose
   # log output and causes logs only to be printed when an exception occurs or the process
   # exits.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
   config.action_mailer.default_options = {
     from: 'mail@example.com'
   }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -265,10 +265,9 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.default_strategies(scope: :candidate).unshift :magic_link_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,299 @@
+# frozen_string_literal: true
+
+# Use this hook to configure devise mailer, warden hooks and so forth.
+# Many of these configuration options can be set straight in your model.
+Devise.setup do |config|
+  # The secret key used by Devise. Devise uses this key to generate
+  # random tokens. Changing this key will render invalid all existing
+  # confirmation, reset password and unlock tokens in the database.
+  # Devise will use the `secret_key_base` as its `secret_key`
+  # by default. You can change it below and use your own secret key.
+  # config.secret_key = '48c6be901d674f735e06ca4266eeff2f2809b96c19d1d77e4a0283866d150604377c2bbf6bbcce12799abdcd02481e8847e4383a44df30b4d4374749c89d2e97'
+
+  # ==> Controller configuration
+  # Configure the parent class to the devise controllers.
+  # config.parent_controller = 'DeviseController'
+
+  # ==> Mailer Configuration
+  # Configure the e-mail address which will be shown in Devise::Mailer,
+  # note that it will be overwritten if you use your own mailer class
+  # with default "from" parameter.
+  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+
+  # Configure the class responsible to send e-mails.
+  # config.mailer = 'Devise::Mailer'
+
+  # Configure the parent class responsible to send e-mails.
+  # config.parent_mailer = 'ActionMailer::Base'
+
+  # ==> ORM configuration
+  # Load and configure the ORM. Supports :active_record (default) and
+  # :mongoid (bson_ext recommended) by default. Other ORMs may be
+  # available as additional gems.
+  require 'devise/orm/active_record'
+
+  # ==> Configuration for any authentication mechanism
+  # Configure which keys are used when authenticating a user. The default is
+  # just :email. You can configure it to use [:username, :subdomain], so for
+  # authenticating a user, both parameters are required. Remember that those
+  # parameters are used only when authenticating and not when retrieving from
+  # session. If you need permissions, you should implement that in a before filter.
+  # You can also supply a hash where the value is a boolean determining whether
+  # or not authentication should be aborted when the value is not present.
+  # config.authentication_keys = [:email]
+
+  # Configure parameters from the request object used for authentication. Each entry
+  # given should be a request method and it will automatically be passed to the
+  # find_for_authentication method and considered in your model lookup. For instance,
+  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
+  # The same considerations mentioned for authentication_keys also apply to request_keys.
+  # config.request_keys = []
+
+  # Configure which authentication keys should be case-insensitive.
+  # These keys will be downcased upon creating or modifying a user and when used
+  # to authenticate or find a user. Default is :email.
+  config.case_insensitive_keys = [:email]
+
+  # Configure which authentication keys should have whitespace stripped.
+  # These keys will have whitespace before and after removed upon creating or
+  # modifying a user and when used to authenticate or find a user. Default is :email.
+  config.strip_whitespace_keys = [:email]
+
+  # Tell if authentication through request.params is enabled. True by default.
+  # It can be set to an array that will enable params authentication only for the
+  # given strategies, for example, `config.params_authenticatable = [:database]` will
+  # enable it only for database (email + password) authentication.
+  # config.params_authenticatable = true
+
+  # Tell if authentication through HTTP Auth is enabled. False by default.
+  # It can be set to an array that will enable http authentication only for the
+  # given strategies, for example, `config.http_authenticatable = [:database]` will
+  # enable it only for database authentication. The supported strategies are:
+  # :database      = Support basic authentication with authentication key + password
+  # config.http_authenticatable = false
+
+  # If 401 status code should be returned for AJAX requests. True by default.
+  # config.http_authenticatable_on_xhr = true
+
+  # The realm used in Http Basic Authentication. 'Application' by default.
+  # config.http_authentication_realm = 'Application'
+
+  # It will change confirmation, password recovery and other workflows
+  # to behave the same regardless if the e-mail provided was right or wrong.
+  # Does not affect registerable.
+  # config.paranoid = true
+
+  # By default Devise will store the user in session. You can skip storage for
+  # particular strategies by setting this option.
+  # Notice that if you are skipping storage for all authentication paths, you
+  # may want to disable generating routes to Devise's sessions controller by
+  # passing skip: :sessions to `devise_for` in your config/routes.rb
+  config.skip_session_storage = [:http_auth]
+
+  # By default, Devise cleans up the CSRF token on authentication to
+  # avoid CSRF token fixation attacks. This means that, when using AJAX
+  # requests for sign in and sign up, you need to get a new CSRF token
+  # from the server. You can disable this option at your own risk.
+  # config.clean_up_csrf_token_on_authentication = true
+
+  # When false, Devise will not attempt to reload routes on eager load.
+  # This can reduce the time taken to boot the app but if your application
+  # requires the Devise mappings to be loaded during boot time the application
+  # won't boot properly.
+  # config.reload_routes = true
+
+  # ==> Configuration for :database_authenticatable
+  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
+  # using other algorithms, it sets how many times you want the password to be hashed.
+  #
+  # Limiting the stretches to just one in testing will increase the performance of
+  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
+  # a value less than 10 in other environments. Note that, for bcrypt (the default
+  # algorithm), the cost increases exponentially with the number of stretches (e.g.
+  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
+  config.stretches = Rails.env.test? ? 1 : 11
+
+  # Set up a pepper to generate the hashed password.
+  # config.pepper = 'afa143728ebb524a67548e54e3298efec37547fbd057eb094c12414fdfb89839695411ab4bf47b93b76d1c4e07d8360a783ca6e16d9fda0c8cd29a79c41f36ca'
+
+  # Send a notification to the original email when the user's email is changed.
+  # config.send_email_changed_notification = false
+
+  # Send a notification email when the user's password is changed.
+  # config.send_password_change_notification = false
+
+  # ==> Configuration for :confirmable
+  # A period that the user is allowed to access the website even without
+  # confirming their account. For instance, if set to 2.days, the user will be
+  # able to access the website for two days without confirming their account,
+  # access will be blocked just in the third day.
+  # You can also set it to nil, which will allow the user to access the website
+  # without confirming their account.
+  # Default is 0.days, meaning the user cannot access the website without
+  # confirming their account.
+  # config.allow_unconfirmed_access_for = 2.days
+
+  # A period that the user is allowed to confirm their account before their
+  # token becomes invalid. For example, if set to 3.days, the user can confirm
+  # their account within 3 days after the mail was sent, but on the fourth day
+  # their account can't be confirmed with the token any more.
+  # Default is nil, meaning there is no restriction on how long a user can take
+  # before confirming their account.
+  # config.confirm_within = 3.days
+
+  # If true, requires any email changes to be confirmed (exactly the same way as
+  # initial account confirmation) to be applied. Requires additional unconfirmed_email
+  # db field (see migrations). Until confirmed, new email is stored in
+  # unconfirmed_email column, and copied to email column on successful confirmation.
+  config.reconfirmable = true
+
+  # Defines which key will be used when confirming an account
+  # config.confirmation_keys = [:email]
+
+  # ==> Configuration for :rememberable
+  # The time the user will be remembered without asking for credentials again.
+  # config.remember_for = 2.weeks
+
+  # Invalidates all the remember me tokens when the user signs out.
+  config.expire_all_remember_me_on_sign_out = true
+
+  # If true, extends the user's remember period when remembered via cookie.
+  # config.extend_remember_period = false
+
+  # Options to be passed to the created cookie. For instance, you can set
+  # secure: true in order to force SSL only cookies.
+  # config.rememberable_options = {}
+
+  # ==> Configuration for :validatable
+  # Range for password length.
+  config.password_length = 6..128
+
+  # Email regex used to validate email formats. It simply asserts that
+  # one (and only one) @ exists in the given string. This is mainly
+  # to give user feedback and not to assert the e-mail validity.
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+
+  # ==> Configuration for :timeoutable
+  # The time you want to timeout the user session without activity. After this
+  # time the user will be asked for credentials again. Default is 30 minutes.
+  # config.timeout_in = 30.minutes
+
+  # ==> Configuration for :lockable
+  # Defines which strategy will be used to lock an account.
+  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
+  # :none            = No lock strategy. You should handle locking by yourself.
+  # config.lock_strategy = :failed_attempts
+
+  # Defines which key will be used when locking and unlocking an account
+  # config.unlock_keys = [:email]
+
+  # Defines which strategy will be used to unlock an account.
+  # :email = Sends an unlock link to the user email
+  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
+  # :both  = Enables both strategies
+  # :none  = No unlock strategy. You should handle unlocking by yourself.
+  # config.unlock_strategy = :both
+
+  # Number of authentication tries before locking an account if lock_strategy
+  # is failed attempts.
+  # config.maximum_attempts = 20
+
+  # Time interval to unlock the account if :time is enabled as unlock_strategy.
+  # config.unlock_in = 1.hour
+
+  # Warn on the last attempt before the account is locked.
+  # config.last_attempt_warning = true
+
+  # ==> Configuration for :recoverable
+  #
+  # Defines which key will be used when recovering the password for an account
+  # config.reset_password_keys = [:email]
+
+  # Time interval you can reset your password with a reset password key.
+  # Don't put a too small interval or your users won't have the time to
+  # change their passwords.
+  config.reset_password_within = 6.hours
+
+  # When set to false, does not sign a user in automatically after their password is
+  # reset. Defaults to true, so a user is signed in automatically after a reset.
+  # config.sign_in_after_reset_password = true
+
+  # ==> Configuration for :encryptable
+  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
+  # You can use :sha1, :sha512 or algorithms from others authentication tools as
+  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
+  # for default behavior) and :restful_authentication_sha1 (then you should set
+  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
+  #
+  # Require the `devise-encryptable` gem when using anything other than bcrypt
+  # config.encryptor = :sha512
+
+  # ==> Scopes configuration
+  # Turn scoped views on. Before rendering "sessions/new", it will first check for
+  # "users/sessions/new". It's turned off by default because it's slower if you
+  # are using only default views.
+  # config.scoped_views = false
+
+  # Configure the default scope given to Warden. By default it's the first
+  # devise role declared in your routes (usually :user).
+  # config.default_scope = :user
+
+  # Set this configuration to false if you want /users/sign_out to sign out
+  # only the current scope. By default, Devise signs out all scopes.
+  # config.sign_out_all_scopes = true
+
+  # ==> Navigation configuration
+  # Lists the formats that should be treated as navigational. Formats like
+  # :html, should redirect to the sign in page when the user does not have
+  # access, but formats like :xml or :json, should return 401.
+  #
+  # If you have any extra navigational formats, like :iphone or :mobile, you
+  # should add them to the navigational formats lists.
+  #
+  # The "*/*" below is required to match Internet Explorer requests.
+  # config.navigational_formats = ['*/*', :html]
+
+  # The default HTTP method used to sign out a resource. Default is :delete.
+  config.sign_out_via = :delete
+
+  # ==> OmniAuth
+  # Add a new OmniAuth provider. Check the wiki for more information on setting
+  # up on your models and hooks.
+  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  # ==> Warden configuration
+  # If you want to use other strategies, that are not supported by Devise, or
+  # change the failure app, you can configure them inside the config.warden block.
+  #
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
+
+  # ==> Mountable engine configurations
+  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
+  # is mountable, there are some extra configurations to be taken into account.
+  # The following options are available, assuming the engine is mounted as:
+  #
+  #     mount MyEngine, at: '/my_engine'
+  #
+  # The router that invoked `devise_for`, in the example above, would be:
+  # config.router_name = :my_engine
+  #
+  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
+  # so you need to do it manually. For the users scope, it would be:
+  # config.omniauth_path_prefix = '/my_engine/users/auth'
+
+  # ==> Turbolinks configuration
+  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
+  #
+  # ActiveSupport.on_load(:devise_failure_app) do
+  #   include Turbolinks::Controller
+  # end
+
+  # ==> Configuration for :registerable
+
+  # When set to false, does not sign a user in automatically after their password is
+  # changed. Defaults to true, so a user is signed in automatically after changing a password.
+  # config.sign_in_after_change_password = true
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,298 +1,29 @@
 # frozen_string_literal: true
 
-# Use this hook to configure devise mailer, warden hooks and so forth.
-# Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
-  # The secret key used by Devise. Devise uses this key to generate
-  # random tokens. Changing this key will render invalid all existing
-  # confirmation, reset password and unlock tokens in the database.
-  # Devise will use the `secret_key_base` as its `secret_key`
-  # by default. You can change it below and use your own secret key.
-  # config.secret_key = '48c6be901d674f735e06ca4266eeff2f2809b96c19d1d77e4a0283866d150604377c2bbf6bbcce12799abdcd02481e8847e4383a44df30b4d4374749c89d2e97'
-
-  # ==> Controller configuration
-  # Configure the parent class to the devise controllers.
-  # config.parent_controller = 'DeviseController'
-
-  # ==> Mailer Configuration
-  # Configure the e-mail address which will be shown in Devise::Mailer,
-  # note that it will be overwritten if you use your own mailer class
-  # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
-
-  # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
-
-  # Configure the parent class responsible to send e-mails.
-  # config.parent_mailer = 'ActionMailer::Base'
-
-  # ==> ORM configuration
-  # Load and configure the ORM. Supports :active_record (default) and
-  # :mongoid (bson_ext recommended) by default. Other ORMs may be
-  # available as additional gems.
   require 'devise/orm/active_record'
 
-  # ==> Configuration for any authentication mechanism
-  # Configure which keys are used when authenticating a user. The default is
-  # just :email. You can configure it to use [:username, :subdomain], so for
-  # authenticating a user, both parameters are required. Remember that those
-  # parameters are used only when authenticating and not when retrieving from
-  # session. If you need permissions, you should implement that in a before filter.
-  # You can also supply a hash where the value is a boolean determining whether
-  # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
-
-  # Configure parameters from the request object used for authentication. Each entry
-  # given should be a request method and it will automatically be passed to the
-  # find_for_authentication method and considered in your model lookup. For instance,
-  # if you set :request_keys to [:subdomain], :subdomain will be used on authentication.
-  # The same considerations mentioned for authentication_keys also apply to request_keys.
-  # config.request_keys = []
-
-  # Configure which authentication keys should be case-insensitive.
-  # These keys will be downcased upon creating or modifying a user and when used
-  # to authenticate or find a user. Default is :email.
   config.case_insensitive_keys = [:email]
 
-  # Configure which authentication keys should have whitespace stripped.
-  # These keys will have whitespace before and after removed upon creating or
-  # modifying a user and when used to authenticate or find a user. Default is :email.
   config.strip_whitespace_keys = [:email]
 
-  # Tell if authentication through request.params is enabled. True by default.
-  # It can be set to an array that will enable params authentication only for the
-  # given strategies, for example, `config.params_authenticatable = [:database]` will
-  # enable it only for database (email + password) authentication.
-  # config.params_authenticatable = true
-
-  # Tell if authentication through HTTP Auth is enabled. False by default.
-  # It can be set to an array that will enable http authentication only for the
-  # given strategies, for example, `config.http_authenticatable = [:database]` will
-  # enable it only for database authentication. The supported strategies are:
-  # :database      = Support basic authentication with authentication key + password
-  # config.http_authenticatable = false
-
-  # If 401 status code should be returned for AJAX requests. True by default.
-  # config.http_authenticatable_on_xhr = true
-
-  # The realm used in Http Basic Authentication. 'Application' by default.
-  # config.http_authentication_realm = 'Application'
-
-  # It will change confirmation, password recovery and other workflows
-  # to behave the same regardless if the e-mail provided was right or wrong.
-  # Does not affect registerable.
-  # config.paranoid = true
-
-  # By default Devise will store the user in session. You can skip storage for
-  # particular strategies by setting this option.
-  # Notice that if you are skipping storage for all authentication paths, you
-  # may want to disable generating routes to Devise's sessions controller by
-  # passing skip: :sessions to `devise_for` in your config/routes.rb
   config.skip_session_storage = [:http_auth]
 
-  # By default, Devise cleans up the CSRF token on authentication to
-  # avoid CSRF token fixation attacks. This means that, when using AJAX
-  # requests for sign in and sign up, you need to get a new CSRF token
-  # from the server. You can disable this option at your own risk.
-  # config.clean_up_csrf_token_on_authentication = true
-
-  # When false, Devise will not attempt to reload routes on eager load.
-  # This can reduce the time taken to boot the app but if your application
-  # requires the Devise mappings to be loaded during boot time the application
-  # won't boot properly.
-  # config.reload_routes = true
-
-  # ==> Configuration for :database_authenticatable
-  # For bcrypt, this is the cost for hashing the password and defaults to 11. If
-  # using other algorithms, it sets how many times you want the password to be hashed.
-  #
-  # Limiting the stretches to just one in testing will increase the performance of
-  # your test suite dramatically. However, it is STRONGLY RECOMMENDED to not use
-  # a value less than 10 in other environments. Note that, for bcrypt (the default
-  # algorithm), the cost increases exponentially with the number of stretches (e.g.
-  # a value of 20 is already extremely slow: approx. 60 seconds for 1 calculation).
   config.stretches = Rails.env.test? ? 1 : 11
 
-  # Set up a pepper to generate the hashed password.
-  # config.pepper = 'afa143728ebb524a67548e54e3298efec37547fbd057eb094c12414fdfb89839695411ab4bf47b93b76d1c4e07d8360a783ca6e16d9fda0c8cd29a79c41f36ca'
-
-  # Send a notification to the original email when the user's email is changed.
-  # config.send_email_changed_notification = false
-
-  # Send a notification email when the user's password is changed.
-  # config.send_password_change_notification = false
-
-  # ==> Configuration for :confirmable
-  # A period that the user is allowed to access the website even without
-  # confirming their account. For instance, if set to 2.days, the user will be
-  # able to access the website for two days without confirming their account,
-  # access will be blocked just in the third day.
-  # You can also set it to nil, which will allow the user to access the website
-  # without confirming their account.
-  # Default is 0.days, meaning the user cannot access the website without
-  # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
-
-  # A period that the user is allowed to confirm their account before their
-  # token becomes invalid. For example, if set to 3.days, the user can confirm
-  # their account within 3 days after the mail was sent, but on the fourth day
-  # their account can't be confirmed with the token any more.
-  # Default is nil, meaning there is no restriction on how long a user can take
-  # before confirming their account.
-  # config.confirm_within = 3.days
-
-  # If true, requires any email changes to be confirmed (exactly the same way as
-  # initial account confirmation) to be applied. Requires additional unconfirmed_email
-  # db field (see migrations). Until confirmed, new email is stored in
-  # unconfirmed_email column, and copied to email column on successful confirmation.
   config.reconfirmable = true
 
-  # Defines which key will be used when confirming an account
-  # config.confirmation_keys = [:email]
-
-  # ==> Configuration for :rememberable
-  # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
-
-  # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
-  # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
-
-  # Options to be passed to the created cookie. For instance, you can set
-  # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
-
-  # ==> Configuration for :validatable
-  # Range for password length.
   config.password_length = 6..128
 
-  # Email regex used to validate email formats. It simply asserts that
-  # one (and only one) @ exists in the given string. This is mainly
-  # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
-  # ==> Configuration for :timeoutable
-  # The time you want to timeout the user session without activity. After this
-  # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
-
-  # ==> Configuration for :lockable
-  # Defines which strategy will be used to lock an account.
-  # :failed_attempts = Locks an account after a number of failed attempts to sign in.
-  # :none            = No lock strategy. You should handle locking by yourself.
-  # config.lock_strategy = :failed_attempts
-
-  # Defines which key will be used when locking and unlocking an account
-  # config.unlock_keys = [:email]
-
-  # Defines which strategy will be used to unlock an account.
-  # :email = Sends an unlock link to the user email
-  # :time  = Re-enables login after a certain amount of time (see :unlock_in below)
-  # :both  = Enables both strategies
-  # :none  = No unlock strategy. You should handle unlocking by yourself.
-  # config.unlock_strategy = :both
-
-  # Number of authentication tries before locking an account if lock_strategy
-  # is failed attempts.
-  # config.maximum_attempts = 20
-
-  # Time interval to unlock the account if :time is enabled as unlock_strategy.
-  # config.unlock_in = 1.hour
-
-  # Warn on the last attempt before the account is locked.
-  # config.last_attempt_warning = true
-
-  # ==> Configuration for :recoverable
-  #
-  # Defines which key will be used when recovering the password for an account
-  # config.reset_password_keys = [:email]
-
-  # Time interval you can reset your password with a reset password key.
-  # Don't put a too small interval or your users won't have the time to
-  # change their passwords.
   config.reset_password_within = 6.hours
 
-  # When set to false, does not sign a user in automatically after their password is
-  # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
-
-  # ==> Configuration for :encryptable
-  # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
-  # You can use :sha1, :sha512 or algorithms from others authentication tools as
-  # :clearance_sha1, :authlogic_sha512 (then you should set stretches above to 20
-  # for default behavior) and :restful_authentication_sha1 (then you should set
-  # stretches to 10, and copy REST_AUTH_SITE_KEY to pepper).
-  #
-  # Require the `devise-encryptable` gem when using anything other than bcrypt
-  # config.encryptor = :sha512
-
-  # ==> Scopes configuration
-  # Turn scoped views on. Before rendering "sessions/new", it will first check for
-  # "users/sessions/new". It's turned off by default because it's slower if you
-  # are using only default views.
-  # config.scoped_views = false
-
-  # Configure the default scope given to Warden. By default it's the first
-  # devise role declared in your routes (usually :user).
-  # config.default_scope = :user
-
-  # Set this configuration to false if you want /users/sign_out to sign out
-  # only the current scope. By default, Devise signs out all scopes.
-  # config.sign_out_all_scopes = true
-
-  # ==> Navigation configuration
-  # Lists the formats that should be treated as navigational. Formats like
-  # :html, should redirect to the sign in page when the user does not have
-  # access, but formats like :xml or :json, should return 401.
-  #
-  # If you have any extra navigational formats, like :iphone or :mobile, you
-  # should add them to the navigational formats lists.
-  #
-  # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html]
-
-  # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete
 
-  # ==> OmniAuth
-  # Add a new OmniAuth provider. Check the wiki for more information on setting
-  # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-
-  # ==> Warden configuration
-  # If you want to use other strategies, that are not supported by Devise, or
-  # change the failure app, you can configure them inside the config.warden block.
-  #
   config.warden do |manager|
     manager.default_strategies(scope: :candidate).unshift :magic_link_strategy
   end
-
-  # ==> Mountable engine configurations
-  # When using Devise inside an engine, let's call it `MyEngine`, and this engine
-  # is mountable, there are some extra configurations to be taken into account.
-  # The following options are available, assuming the engine is mounted as:
-  #
-  #     mount MyEngine, at: '/my_engine'
-  #
-  # The router that invoked `devise_for`, in the example above, would be:
-  # config.router_name = :my_engine
-  #
-  # When using OmniAuth, Devise cannot automatically set OmniAuth path,
-  # so you need to do it manually. For the users scope, it would be:
-  # config.omniauth_path_prefix = '/my_engine/users/auth'
-
-  # ==> Turbolinks configuration
-  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
-  #
-  # ActiveSupport.on_load(:devise_failure_app) do
-  #   include Turbolinks::Controller
-  # end
-
-  # ==> Configuration for :registerable
-
-  # When set to false, does not sign a user in automatically after their password is
-  # changed. Defaults to true, so a user is signed in automatically after changing a password.
-  # config.sign_in_after_change_password = true
 end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -1,0 +1,1 @@
+Warden::Strategies.add(:magic_link_strategy, MagicLinkStrategy)

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -4,3 +4,7 @@ en:
       button: Continue
       email_address:
         label: Email address
+      email:
+        subject: Please confirm your email address
+        heading: Please confirm your email address
+        body: Click the link below to sign in to the Apply for postgraduate teacher training service.

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -1,0 +1,6 @@
+en:
+  authentication:
+    sign_up:
+      button: Continue
+      email_address:
+        label: Email address

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -1,10 +1,13 @@
 en:
   authentication:
     sign_up:
+      heading:  Before you begin
       button: Continue
       email_address:
         label: Email address
+        hint_label: Don’t use a work or university email address you might lose access to
       email:
         subject: Please confirm your email address
         heading: Please confirm your email address
         body: Click the link below to sign in to the Apply for postgraduate teacher training service.
+    check_your_email: Check your email

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,65 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,12 @@ en:
   activerecord:
     errors:
       models:
+        candidate:
+          attributes:
+            email_address:
+              blank: 'Enter your email address'
+              taken: 'Email address is already in use'
+              too_long: 'Email address must be %{count} characters or fewer'
         personal_details:
           attributes:
             title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   resources :degrees, only: %i[new create edit update]
   resources :qualifications, only: %i[new create edit update]
 
+  get 'sign-up', to: 'magic_link/sign_up#new', as: :new_sign_up
+  post 'sign-up', to: 'magic_link/sign_up#create', as: :sign_up
+
   get 'check-your-answers', to: 'check_your_answers#show'
   get 'application', to: 'tt_applications#show', as: :tt_application
   post 'application/submit', to: 'tt_application_submissions#create', as: :tt_application_submission

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,9 @@
 Rails.application.routes.draw do
+  # No Devise modules are enabled
+  # Custom Warden strategy is used instead see app/warden/magic_link_token.rb
+  # Custom views are used, see app/views/magic_link/sign_up/
+  devise_for :candidates, skip: :all
+
   root to: 'start_page#show'
 
   resources :personal_details, only: %i[new create edit update], path: 'personal-details'

--- a/db/migrate/20190827141654_create_candidates.rb
+++ b/db/migrate/20190827141654_create_candidates.rb
@@ -1,0 +1,11 @@
+class CreateCandidates < ActiveRecord::Migration[5.2]
+  def change
+    create_table :candidates do |t|
+      t.string :email_address, null: false, unique: true
+
+      t.timestamps
+    end
+
+    add_index :candidates, :email_address, unique: true
+  end
+end

--- a/db/migrate/20190827155122_add_magic_link_token_to_candidate.rb
+++ b/db/migrate/20190827155122_add_magic_link_token_to_candidate.rb
@@ -1,0 +1,8 @@
+class AddMagicLinkTokenToCandidate < ActiveRecord::Migration[5.2]
+  def change
+    add_column :candidates, :magic_link_token, :string, unique: true
+    add_column :candidates, :magic_link_token_sent_at, :datetime
+
+    add_index :candidates, :magic_link_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_20_141805) do
+ActiveRecord::Schema.define(version: 2019_08_27_141654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "candidates", force: :cascade do |t|
+    t.string "email_address", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
+  end
 
   create_table "contact_details", force: :cascade do |t|
     t.string "phone_number"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_27_141654) do
+ActiveRecord::Schema.define(version: 2019_08_27_155122) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,7 +20,10 @@ ActiveRecord::Schema.define(version: 2019_08_27_141654) do
     t.string "email_address", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "magic_link_token"
+    t.datetime "magic_link_token_sent_at"
     t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
+    t.index ["magic_link_token"], name: "index_candidates_on_magic_link_token", unique: true
   end
 
   create_table "contact_details", force: :cascade do |t|

--- a/spec/controllers/check_your_answers_controller_spec.rb
+++ b/spec/controllers/check_your_answers_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe CheckYourAnswersController, type: :controller do
+  context 'when a candidate is not signed in' do
+    it 'can redirect a candidate' do
+      get 'show'
+
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/controllers/contact_details_controller_spec.rb
+++ b/spec/controllers/contact_details_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe ContactDetailsController, type: :controller do
+  context 'when a candidate is not signed in' do
+    it 'can redirect a candidate' do
+      get 'new'
+
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/controllers/degrees_controller_spec.rb
+++ b/spec/controllers/degrees_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe DegreesController, type: :controller do
+  context 'when a candidate is not signed in' do
+    it 'can redirect a candidate' do
+      get 'new'
+
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/controllers/personal_details_controller_spec.rb
+++ b/spec/controllers/personal_details_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe PersonalDetailsController, type: :controller do
+  context 'when a candidate is not signed in' do
+    it 'can redirect a candidate' do
+      get 'new'
+
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/controllers/qualifications_controller_spec.rb
+++ b/spec/controllers/qualifications_controller_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe QualificationsController, type: :controller do
+  context 'when a candidate is not signed in' do
+    it 'can redirect a candidate' do
+      get 'new'
+
+      expect(response).to have_http_status(:redirect)
+    end
+  end
+end

--- a/spec/factories/candidate.rb
+++ b/spec/factories/candidate.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :candidate do
+    email_address { 'test@example.com' }
+  end
+end

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe AuthenticationMailer, type: :mailer do
+  subject(:mailer) { described_class }
+
+  describe '.sign_up_email' do
+    let(:token) { 'blub' }
+    let(:mail) { mailer.sign_up_email(to: 'test@example.com', token: token) }
+
+    before { mail.deliver! }
+
+    it 'sends an email with the correct subject' do
+      expect(mail.subject).to include(t('authentication.sign_up.email.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(mail.body.encoded).to include(t('authentication.sign_up.email.heading'))
+    end
+
+    it 'sends an email with the correct body' do
+      expect(mail.body.encoded).to include(t('authentication.sign_up.email.body'))
+    end
+
+    it 'sends an email with a magic link' do
+      expect(mail.body.encoded).to include("http://localhost:3000/personal-details/new?token=#{token}")
+    end
+  end
+end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Candidate, type: :model do
+  subject { FactoryBot.create(:candidate) }
+
+  it { is_expected.to validate_presence_of :email_address }
+  it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
+  it { is_expected.to validate_uniqueness_of :email_address }
+end

--- a/spec/support/test_helpers/sign_up.rb
+++ b/spec/support/test_helpers/sign_up.rb
@@ -1,0 +1,8 @@
+module TestHelpers
+  module SignUp
+    def fill_in_sign_up
+      fill_in t('authentication.sign_up.email_address.label'), with: 'april@pawnee.com'
+      click_on t('authentication.sign_up.button')
+    end
+  end
+end

--- a/spec/support/warden.rb
+++ b/spec/support/warden.rb
@@ -1,0 +1,4 @@
+RSpec.configure do |config|
+  config.include Warden::Test::Helpers
+  config.include Devise::Test::ControllerHelpers, type: :controller
+end

--- a/spec/system/candidate_completing_an_application_spec.rb
+++ b/spec/system/candidate_completing_an_application_spec.rb
@@ -11,6 +11,12 @@ describe 'A candidate completing an application for teacher training' do
       visit '/'
       click_on t('application_form.begin_button')
 
+      fill_in t('authentication.sign_up.email_address.label'), with: 'april@pawnee.com'
+      click_on t('authentication.sign_up.button')
+
+      open_email('april@pawnee.com')
+      current_email.find_css('a').first.click
+
       fill_in_personal_details
       click_on t('application_form.save_and_continue')
 

--- a/spec/system/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_entering_contact_details_spec.rb
@@ -5,6 +5,9 @@ describe 'A candidate entering contact details' do
 
   context 'when details are correct' do
     before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
       visit '/contact-details/new'
 
       fill_in_contact_details
@@ -31,6 +34,9 @@ describe 'A candidate entering contact details' do
 
   context 'who leaves out a required field' do
     before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
       visit '/contact-details/new'
       click_on t('application_form.save_and_continue')
     end

--- a/spec/system/candidate_entering_degree_spec.rb
+++ b/spec/system/candidate_entering_degree_spec.rb
@@ -5,6 +5,9 @@ describe 'A candidate adding a Degree' do
 
   context 'who successfully enters their details' do
     before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
       visit '/degrees/new'
 
       fill_in_degree_details
@@ -32,6 +35,9 @@ describe 'A candidate adding a Degree' do
 
   context 'who leaves out a required field' do
     before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
       visit '/degrees/new'
     end
 
@@ -43,6 +49,11 @@ describe 'A candidate adding a Degree' do
   end
 
   context 'who wants to add another degree' do
+    before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+    end
+
     it 'navigates to the page Add degree' do
       visit '/check-your-answers'
 

--- a/spec/system/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_entering_personal_details_spec.rb
@@ -5,8 +5,10 @@ describe 'A candidate entering personal details' do
 
   context 'who successfully enters their details' do
     before do
-      visit '/'
-      click_on t('application_form.begin_button')
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
+      visit '/personal-details/new'
 
       fill_in_personal_details
 
@@ -31,8 +33,11 @@ describe 'A candidate entering personal details' do
 
   context 'who leaves out a required field' do
     before do
-      visit '/'
-      click_on t('application_form.begin_button')
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
+      visit '/personal-details/new'
+
       click_on t('application_form.save_and_continue')
     end
 

--- a/spec/system/candidate_entering_qualification_spec.rb
+++ b/spec/system/candidate_entering_qualification_spec.rb
@@ -5,6 +5,9 @@ describe 'A candidate adding a qualification' do
 
   context 'who successfully enters their details' do
     before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
       visit '/qualifications/new'
 
       fill_in_qualification_details
@@ -30,6 +33,9 @@ describe 'A candidate adding a qualification' do
 
   context 'who leaves out a required field' do
     before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+
       visit '/qualifications/new'
     end
 
@@ -41,6 +47,11 @@ describe 'A candidate adding a qualification' do
   end
 
   context 'who wants to add another qualification' do
+    before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate, scope: :candidate)
+    end
+
     it 'navigates to the "Add qualification" page' do
       visit '/check-your-answers'
 

--- a/spec/system/candidate_signing_up_spec.rb
+++ b/spec/system/candidate_signing_up_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe 'A candidate signing up' do
+  include TestHelpers::SignUp
+
+  context 'who successfully signs up' do
+    before do
+      visit '/'
+      click_on t('application_form.begin_button')
+      fill_in_sign_up
+    end
+
+    it 'sees the check your email page' do
+      expect(page).to have_content t('authentication.check_your_email')
+    end
+
+    it 'receives an email with a valid magic link' do
+      open_email('april@pawnee.com')
+      current_email.find_css('a').first.click
+
+      expect(page).to have_content 'april@pawnee.com'
+    end
+  end
+
+  context 'who tries to sign up twice' do
+    it 'sees the form error summary' do
+      visit '/sign-up'
+      fill_in_sign_up
+      visit '/sign-up'
+      fill_in_sign_up
+
+      expect(page).to have_content 'There is a problem'
+    end
+  end
+
+  context 'who clicks a link with an invalid token' do
+    it 'sees the start page' do
+      visit '/personal-details/new?token=meow'
+
+      expect(page.current_url).to eq(root_url)
+    end
+  end
+end


### PR DESCRIPTION
### Context

User research conducted by the team found that sign in using an email and password was confusing for candidates and therefore recommend to use magic links as a more lightweight and faster solution.

### Changes proposed in this pull request

- Add and use Devise to implement sign up via magic links.
- Create a mailer to send magic link emails for sign up.
- Create Candidate Model to store candidate email and magic link details.
- Add FactoryBot Gem to allow candidate sign in during tests. 

### Guidance to review

- Run test suite to ensure end to end specs pass.
- Serve locally and sign up, check notify for email and follow magic link. 

### Link to Trello card

[822 - Magic link sign up](https://trello.com/c/RvAsj6AL/822-magic-link-sign-up)
