### PR TITLE
Update GOV.UK Notify template ID

### DIFF
--- a/app/mailers/tt_application_mailer.rb
+++ b/app/mailers/tt_application_mailer.rb
@@ -1,5 +1,5 @@
 class TTApplicationMailer < Mail::Notify::Mailer
-  GENERIC_NOTIFY_TEMPLATE = 'b357c7b4-7e7d-4f59-a97d-301758a13eb6'.freeze
+  GENERIC_NOTIFY_TEMPLATE = '2744ea53-34f1-431f-8173-8388fadd826a'.freeze
 
   def send_application(to:, candidate_email:)
     @candidate_email = candidate_email


### PR DESCRIPTION
### Context

When implementing the mailer for sending the sign up email, we discovered that template we were using was overwritten. Therefore, we had to create a new template on GOV.UK Notify.

### Changes proposed in this pull request

Update the `GENERIC_NOTIFY_TEMPLATE` constant to the new template.

### Guidance to review

For now we've decided to keep the template ID in the mailer but we plan to have this as a environment variable in the near future.

Check the template ID matches the one on Notify.
