### PR TITLE
Changed warmup ping path variable

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -12,7 +12,7 @@ parameters:
   dockerhubUsername:
   securityKeyBase:
   containerStartTimeLimit: '600'
-  warmupPingPath: '/personal-details/new'
+  warmupPingPath: '/sign-up'
   warmupPingStatus: '200'
   railsEnv: 'production'
   securityAlertEmail: 'apprenticeshipsdevops@education.gov.uk'


### PR DESCRIPTION
### Context

The introduction of magic links in an earlier PR resulted in the application failing to start because it was looking for a warmup path that no longer exists. This path has now been changed to a page that does exist.

### Changes proposed in this pull request

Simply changed the warmup ping path from "/personal-details/new" to "/sign-up".

### Guidance to review

This is a simple single line change.

### Link to Trello card

N/A
