### PR TITLE
Update states to reflect unconditional offers

### DIFF
--- a/features/offer_conditions.feature
+++ b/features/offer_conditions.feature
@@ -21,7 +21,7 @@ Feature: Managing conditions on offers
 
   Scenario Outline: adding conditions - who can do it and when
     Providers can add conditions to an application as part of making the offer,
-    or when the application has the 'offer made' status. Both the accredited body
+    or when the application has the 'conditional offer' status. Both the accredited body
     and the non-accredited body can add conditions.
 
     When an application has been made to a course X123
@@ -32,9 +32,10 @@ Feature: Managing conditions on offers
       | Provider code | Application status   | Can add conditions? | Notes                           |
       | 10M           | application complete | N                   | Application in the wrong status |
       | U80           | meeting conditions   | N                   | Application in the wrong status |
-      | S13           | offer made           | N                   | Wrong provider                  |
-      | U80           | offer made           | Y                   |                                 |
-      | 10M           | offer made           | Y                   |                                 |
+      | U80           | unconditional offer  | N                   | Application in the wrong status |
+      | S13           | conditional offer    | N                   | Wrong provider                  |
+      | U80           | conditional offer    | Y                   |                                 |
+      | 10M           | conditional offer    | Y                   |                                 |
 
   Scenario Outline: amending conditions - who can do it and when
     Once a provider makes a conditional offer, they can amend these conditions,
@@ -48,15 +49,16 @@ Feature: Managing conditions on offers
       | provider code | Application status   | Can amend conditions? | Notes                           |
       | 10M           | application complete | N                     | Application in the wrong status |
       | U80           | meeting conditions   | N                     | Application in the wrong status |
-      | S13           | offer made           | N                     | Wrong provider                  |
-      | U80           | offer made           | Y                     |                                 |
-      | 10M           | offer made           | Y                     |                                 |
+      | U80           | unconditional offer  | N                     | Application in the wrong status |
+      | S13           | conditional offer    | N                     | Wrong provider                  |
+      | U80           | conditional offer    | Y                     |                                 |
+      | 10M           | conditional offer    | Y                     |                                 |
 
   Scenario: amending condition changes the offer's expiry time
     The expiry time on the offer is reset when conditions are successfully amended.
 
     Given an application has been made to a course X123
-    And the application in "offer made" state
+    And the application in "conditional offer" state
     And the expiry time on the offer is "12 June 2019 12:00:00 PM"
     When the provider with code "U80" amends a condition at 8:00 AM on 13 June 2019
     And the new expiry time on the offer is "<expected DBD time>"

--- a/features/provider_rejections.feature
+++ b/features/provider_rejections.feature
@@ -10,7 +10,8 @@ Feature: rejections by the provider
       | original state       | actor    | action  | new state | possible reason                  |
       | references pending   | provider | reject  | rejected  | failed the sift                  |
       | application complete | provider | reject  | rejected  | failed the sift/failed interview |
-      | offer made           | provider | reject  | rejected  | course is full                   |
+      | conditional offer    | provider | reject  | rejected  | course is full                   |
+      | unconditional offer  | provider | reject  | rejected  | course is full                   |
       | meeting conditions   | provider | reject  | rejected  | if conditions not met in time    |
 
   Scenario: A provider cannot reject applications when the candidate is recruited

--- a/features/provider_rejections.feature
+++ b/features/provider_rejections.feature
@@ -12,4 +12,7 @@ Feature: rejections by the provider
       | application complete | provider | reject  | rejected  | failed the sift/failed interview |
       | offer made           | provider | reject  | rejected  | course is full                   |
       | meeting conditions   | provider | reject  | rejected  | if conditions not met in time    |
-      | recruited            | provider | reject  | recruited | not possible                     |
+
+  Scenario: A provider cannot reject applications when the candidate is recruited
+    Given an application in "recruited" state
+    When a provider cannot reject

--- a/features/step_definitions/applications.rb
+++ b/features/step_definitions/applications.rb
@@ -6,11 +6,12 @@ Given(/(an|the) application in "(.*)" state/) do |_, orginal_application_state|
   end
 end
 
-When(/^a (\w+) ([\w\s]+)$/) do |actor, action|
+When(/^a (\w+) (cannot)?([\w\s]+)$/) do |actor, nil_or_cannot, action|
   event_name = action.gsub(' ', '_').to_sym
-  begin
+  if nil_or_cannot == 'cannot'
+    expect { @application.aasm.fire!(event_name, actor) }.to raise_error(Exception)
+  else
     @application.aasm.fire!(event_name, actor)
-  rescue AASM::InvalidTransition # rubocop:disable Lint/HandleExceptions
   end
 end
 

--- a/features/step_definitions/applications.rb
+++ b/features/step_definitions/applications.rb
@@ -39,7 +39,7 @@ end
 Then('a provider with code {string} is able to add conditions: {string}') do |provider_code, can_add_conditions|
   if can_add_conditions == 'Y'
     @application.add_conditions('provider', provider_code)
-    expect(@application.state).to eq('offer_made')
+    expect(@application.state).to eq('conditional_offer')
   else
     expect {
       @application.add_conditions('provider', provider_code)

--- a/features/successful_application_states.feature
+++ b/features/successful_application_states.feature
@@ -43,7 +43,7 @@ Feature: successful application states
       | original state        | actor     | action                   | new state                |
       | unsubmitted           | candidate | submit                   | references pending       |
       | references pending    | referee   | submit reference         | application complete     |
-      | application complete  | provider  | make unconditional offer | conditional offer        |
+      | application complete  | provider  | make conditional offer   | conditional offer        |
       | application complete  | provider  | make unconditional offer | unconditional offer      |
       | conditional offer     | candidate | accept offer             | meeting conditions       |
       | meeting conditions    | provider  | confirm conditions met   | recruited                |

--- a/features/successful_application_states.feature
+++ b/features/successful_application_states.feature
@@ -40,10 +40,12 @@ Feature: successful application states
     Then the new application state is "<new state>"
 
     Examples:
-      | original state       | actor     | action                 | new state            |
-      | unsubmitted          | candidate | submit                 | references pending   |
-      | references pending   | referee   | submit reference       | application complete |
-      | application complete | provider  | set conditions         | offer made           |
-      | offer made           | candidate | accept offer           | meeting conditions   |
-      | meeting conditions   | provider  | confirm conditions met | recruited            |
-      | recruited            | provider  | confirm onboarding     | enrolled             |
+      | original state        | actor     | action                   | new state                |
+      | unsubmitted           | candidate | submit                   | references pending       |
+      | references pending    | referee   | submit reference         | application complete     |
+      | application complete  | provider  | make unconditional offer | conditional offer        |
+      | application complete  | provider  | make unconditional offer | unconditional offer      |
+      | conditional offer     | candidate | accept offer             | meeting conditions       |
+      | meeting conditions    | provider  | confirm conditions met   | recruited                |
+      | unconditional offer   | candidate | accept offer             | recruited                |
+      | recruited             | provider  | confirm onboarding       | enrolled                 |

--- a/features/successful_application_states.feature
+++ b/features/successful_application_states.feature
@@ -8,11 +8,15 @@ Feature: successful application states
   one reference has been submitted, the application goes into 'application complete'
   status.
 
-  Offer made & meeting conditions
-  ===============================
-  A provider makes an offer to the candidate (be it conditional and unconditional).
-  The candidate then has to accept the offer, which sets the application status
-  to 'meeting conditions'.
+  Conditional offers & meeting conditions
+  =======================================
+  A provider makes a conditional offer to the candidate. The candidate then has
+  to accept the offer, which sets the application status to 'meeting conditions'.
+
+  Unconditional offers
+  ====================
+  A provider makes an unconditional offer to the candidate. Once the candidate
+  accepts this offer, the application is then goes into 'recruited' status.
 
   Recruited
   =========


### PR DESCRIPTION

# Context

Unconditional offers are currently not taken into account in the `successful_application_states.feature` file

### Changes proposed in this pull request

Update `successful_application_states.feature` to reflect the states for unconditional offers

### Guidance to review

Would like some feedback on if the states proposed make any sense from a business rules point of view.

### Link to Trello card

[897 - Unconditional offers states](897-unconditional-offer-states-in-cucumber-spec)
