### PR TITLE
Update the way we run the Ruby linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ serve: ## Run the service
 	
 .PHONY: ci.lint-ruby
 ci.lint-ruby: ## Run Rubocop with results formatted for CI
-	docker-compose run --rm web /bin/sh -c "bundle exec rubocop --format clang"
+	docker-compose run --rm web /bin/sh -c "bundle exec rubocop --format clang --parallel"
 
 .PHONY: ci.lint-erb
 ci.lint-erb: ## Run the ERB linter

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ serve: ## Run the service
 	
 .PHONY: ci.lint-ruby
 ci.lint-ruby: ## Run Rubocop with results formatted for CI
-	docker-compose run --rm web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+	docker-compose run --rm web /bin/sh -c "bundle exec rubocop --format clang"
 
 .PHONY: ci.lint-erb
 ci.lint-erb: ## Run the ERB linter

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -2,6 +2,6 @@ desc 'Lint ruby code'
 namespace :lint do
   task :ruby do
     puts 'Linting ruby...'
-    system 'bundle exec rubocop'
+    system 'bundle exec rubocop --parallel'
   end
 end


### PR DESCRIPTION
### Context

When running the tests locally (`make test`) we run the ruby linter in a slightly different way compared to CI. This might cause issues where things pass locally but not on CI.

### Changes proposed in this pull request

Make the tasks run the same rubocop command. As a bonus, add the `--parallel` flag to speed up linting.

### Guidance to review

Check the CI logs to see that the `ci.lint-ruby` task still works as expected.
