### PR TITLE
Remove unused selenium-webdriver dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ end
 group :test do
   gem 'capybara', '>= 3.24'
   gem 'shoulda-matchers', '~> 4.1'
-  gem 'selenium-webdriver', '~> 3.142'
   gem 'rspec_junit_formatter'
   gem 'capybara-email'
   gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,8 +68,6 @@ GEM
     capybara-email (3.0.1)
       capybara (>= 2.4, < 4.0)
       mail
-    childprocess (1.0.1)
-      rake (< 13.0)
     climate_control (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
@@ -219,7 +217,6 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -228,9 +225,6 @@ GEM
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
-      rubyzip (~> 1.2, >= 1.2.2)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
     smart_properties (1.15.0)
@@ -286,7 +280,6 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-rspec
-  selenium-webdriver (~> 3.142)
   shoulda-matchers (~> 4.1)
   web-console (>= 3.3.0)
   webpacker


### PR DESCRIPTION
### Context

This gem isn't used since we stopped running JS specs

### Guidance to review

Passing CI should give certainty everything's ok