### PR TITLE
Graph application statuses as an image

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'pry'
+  gem 'aasm-diagram'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,9 @@ GEM
   specs:
     aasm (5.0.5)
       concurrent-ruby (~> 1.0)
+    aasm-diagram (0.1.2)
+      aasm (~> 5.0, >= 4.12)
+      ruby-graphviz (~> 1.2)
     actioncable (5.2.3)
       actionpack (= 5.2.3)
       nio4r (~> 2.0)
@@ -237,6 +240,7 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.35.0)
       rubocop (>= 0.60.0)
+    ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
@@ -287,6 +291,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
+  aasm-diagram
   business_time
   capybara (>= 3.24)
   capybara-email

--- a/lib/tasks/create_application_status_graph.rake
+++ b/lib/tasks/create_application_status_graph.rake
@@ -1,0 +1,4 @@
+task create_application_status_graph: :environment do
+  application = CandidateApplication.new
+  AASMDiagram::Diagram.new(application.aasm, 'tmp/application.png')
+end


### PR DESCRIPTION
### Context

We're prototyping the application statuses using the AASM gem.

### Changes proposed in this pull request

Add a way to generate an image of the state machine graph, via a rake task.

@alexdesi I think you had this in mind a couple of weeks ago