### PR TITLE
Application workflow prototype – amending offers and authorisation refactoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,9 @@ gem 'aasm'
 gem 'business_time'
 gem 'holidays'
 
+# Authorisation
+gem 'pundit'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,8 @@ GEM
     public_suffix (3.1.1)
     puma (4.1.0)
       nio4r (~> 2.0)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.0.7)
     rack-proxy (0.6.5)
       rack
@@ -308,6 +310,7 @@ DEPENDENCIES
   pg (~> 1.1.4)
   pry
   puma (~> 4.1)
+  pundit
   rails (~> 5.2.2, >= 5.2.2.1)
   rspec-rails
   rspec_junit_formatter

--- a/app/models/candidate_application.rb
+++ b/app/models/candidate_application.rb
@@ -51,7 +51,11 @@ class CandidateApplication < ApplicationRecord
       transitions from: %i[references_pending application_complete conditional_offer unconditional_offer meeting_conditions], to: :rejected
     end
 
-    event :add_conditions, if: %i[done_by_provider? can_add_conditions?] do
+    event :add_conditions, if: %i[done_by_provider? can_update_conditions?] do
+      transitions from: :conditional_offer, to: :conditional_offer
+    end
+
+    event :amend_conditions, if: %i[done_by_provider? can_update_conditions?] do
       transitions from: :conditional_offer, to: :conditional_offer
     end
   end
@@ -94,7 +98,7 @@ class CandidateApplication < ApplicationRecord
     end
   end
 
-  def can_add_conditions?(_, provider_code)
+  def can_update_conditions?(_, provider_code)
     provider_code.in?([self.course.provider.code, self.course.accredited_body.code])
   end
 end

--- a/app/models/candidate_application.rb
+++ b/app/models/candidate_application.rb
@@ -8,6 +8,8 @@ class CandidateApplication < ApplicationRecord
 
   # rubocop:disable Metrics/BlockLength
   aasm column: 'state' do
+    before_all_events :authorize
+
     state :unsubmitted, initial: true
     state :references_pending, before_enter: %i[record_submission_time assign_rejected_by_default_at]
     state :application_complete
@@ -19,58 +21,50 @@ class CandidateApplication < ApplicationRecord
     state :rejected
 
     event :submit do
-      transitions from: :unsubmitted, to: :references_pending, if: :done_by_candidate?
+      transitions from: :unsubmitted, to: :references_pending
     end
 
     event :submit_reference do
-      transitions from: :references_pending, to: :application_complete, if: :done_by_referee?
+      transitions from: :references_pending, to: :application_complete
     end
 
     event :make_conditional_offer do
-      transitions from: :application_complete, to: :conditional_offer, if: :done_by_provider?
+      transitions from: :application_complete, to: :conditional_offer
     end
 
     event :make_unconditional_offer do
-      transitions from: :application_complete, to: :unconditional_offer, if: :done_by_provider?
+      transitions from: :application_complete, to: :unconditional_offer
     end
 
     event :accept_offer do
-      transitions from: :conditional_offer, to: :meeting_conditions, if: :done_by_candidate?
-      transitions from: :unconditional_offer, to: :recruited, if: :done_by_candidate?
+      transitions from: :conditional_offer, to: :meeting_conditions
+      transitions from: :unconditional_offer, to: :recruited
     end
 
     event :confirm_conditions_met do
-      transitions from: :meeting_conditions, to: :recruited, if: :done_by_provider?
+      transitions from: :meeting_conditions, to: :recruited
     end
 
     event :confirm_onboarding do
-      transitions from: :recruited, to: :enrolled, if: :done_by_provider?
+      transitions from: :recruited, to: :enrolled
     end
 
-    event :reject, if: :done_by_provider? do
+    event :reject do
       transitions from: %i[references_pending application_complete conditional_offer unconditional_offer meeting_conditions], to: :rejected
     end
 
-    event :add_conditions, if: %i[done_by_provider? can_update_conditions?] do
+    event :add_conditions, if: :can_update_conditions? do
       transitions from: :conditional_offer, to: :conditional_offer
     end
 
-    event :amend_conditions, if: %i[done_by_provider? can_update_conditions?] do
+    event :amend_conditions, if: :can_update_conditions? do
       transitions from: :conditional_offer, to: :conditional_offer
     end
   end
   # rubocop:enable Metrics/BlockLength
 
-  def done_by_referee?(actor)
-    actor == 'referee'
-  end
-
-  def done_by_provider?(actor)
-    actor == 'provider'
-  end
-
-  def done_by_candidate?(actor)
-    actor == 'candidate'
+  def authorize(user, *args)
+    Pundit.authorize(user, self, "#{aasm.current_event.to_s.gsub("!", "")}?".to_sym)
   end
 
   def actions_for(actor)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -4,4 +4,8 @@ class Course < ApplicationRecord
 
   has_many :courses_training_locations
   has_many :training_locations, through: :courses_training_locations
+
+  def provider_or_accredited_body?(provider_code)
+    provider_code.in?([provider.code, accredited_body.code])
+  end
 end

--- a/app/policies/candidate_application_policy.rb
+++ b/app/policies/candidate_application_policy.rb
@@ -13,7 +13,7 @@ class CandidateApplicationPolicy
   end
 
   def done_by_provider?
-    @user == 'provider'
+    @user.start_with?('provider')
   end
 
   alias_method :submit?, :done_by_candidate?
@@ -26,6 +26,12 @@ class CandidateApplicationPolicy
   alias_method :confirm_conditions_met?, :done_by_provider?
   alias_method :confirm_onboarding?, :done_by_provider?
   alias_method :reject?, :done_by_provider?
-  alias_method :add_conditions?, :done_by_provider?
-  alias_method :amend_conditions?, :done_by_provider?
+
+  def update_conditions?
+    provider_code = @user.scan(/provider \((.*)\)/).flatten.last
+    done_by_provider? && @candidate_application.course.provider_or_accredited_body?(provider_code)
+  end
+
+  alias_method :add_conditions?, :update_conditions?
+  alias_method :amend_conditions?, :update_conditions?
 end

--- a/app/policies/candidate_application_policy.rb
+++ b/app/policies/candidate_application_policy.rb
@@ -1,0 +1,31 @@
+class CandidateApplicationPolicy
+  def initialize(user, candidate_application)
+    @user = user
+    @candidate_application = candidate_application
+  end
+
+  def done_by_candidate?
+    @user == 'candidate'
+  end
+
+  def done_by_referee?
+    @user == 'referee'
+  end
+
+  def done_by_provider?
+    @user == 'provider'
+  end
+
+  alias_method :submit?, :done_by_candidate?
+  alias_method :accept_offer?, :done_by_candidate?
+
+  alias_method :submit_reference?, :done_by_referee?
+
+  alias_method :make_conditional_offer?, :done_by_provider?
+  alias_method :make_unconditional_offer?, :done_by_provider?
+  alias_method :confirm_conditions_met?, :done_by_provider?
+  alias_method :confirm_onboarding?, :done_by_provider?
+  alias_method :reject?, :done_by_provider?
+  alias_method :add_conditions?, :done_by_provider?
+  alias_method :amend_conditions?, :done_by_provider?
+end

--- a/features/step_definitions/applications.rb
+++ b/features/step_definitions/applications.rb
@@ -36,13 +36,14 @@ When('the automatic process for rejecting applications is run at {string}') do |
   end
 end
 
-Then('a provider with code {string} is able to add conditions: {string}') do |provider_code, can_add_conditions|
-  if can_add_conditions == 'Y'
-    @application.add_conditions('provider', provider_code)
+Then(/a provider with code "(.*)" is able to (add conditions|amend conditions): "(.*)"/) do |provider_code, event_string, yes_or_no|
+  event = event_string.gsub(" ", "_").to_sym
+  if yes_or_no == 'Y'
+    @application.aasm.fire!(event, 'provider', provider_code)
     expect(@application.state).to eq('conditional_offer')
   else
     expect {
-      @application.add_conditions('provider', provider_code)
+      @application.aasm.fire!(event, 'provider', provider_code)
     }.to raise_error(AASM::InvalidTransition)
   end
 end

--- a/features/step_definitions/applications.rb
+++ b/features/step_definitions/applications.rb
@@ -7,7 +7,7 @@ Given(/(an|the) application in "(.*)" state/) do |_, orginal_application_state|
 end
 
 When(/^a (\w+) (cannot)?([\w\s]+)$/) do |actor, nil_or_cannot, action|
-  command_name = (action.gsub(' ', '_') + "!").to_sym
+  command_name = (action.gsub(' ', '_') + '!').to_sym
   if nil_or_cannot == 'cannot'
     expect { @application.send(command_name, actor) }.to raise_error(Exception)
   else
@@ -37,13 +37,13 @@ When('the automatic process for rejecting applications is run at {string}') do |
 end
 
 Then(/a provider with code "(.*)" is able to (add conditions|amend conditions): "(.*)"/) do |provider_code, event_string, yes_or_no|
-  command_name = (event_string.gsub(" ", "_") + "!").to_sym
+  command_name = (event_string.gsub(' ', '_') + '!').to_sym
   if yes_or_no == 'Y'
-    @application.send(command_name, 'provider', provider_code)
+    @application.send(command_name, "provider (#{provider_code})", provider_code)
     expect(@application.state).to eq('conditional_offer')
   else
     expect {
-      @application.send(command_name, 'provider', provider_code)
+      @application.send(command_name, "provider (#{provider_code})", provider_code)
     }.to raise_error(AASM::InvalidTransition)
   end
 end

--- a/features/step_definitions/applications.rb
+++ b/features/step_definitions/applications.rb
@@ -7,11 +7,11 @@ Given(/(an|the) application in "(.*)" state/) do |_, orginal_application_state|
 end
 
 When(/^a (\w+) (cannot)?([\w\s]+)$/) do |actor, nil_or_cannot, action|
-  event_name = action.gsub(' ', '_').to_sym
+  command_name = (action.gsub(' ', '_') + "!").to_sym
   if nil_or_cannot == 'cannot'
-    expect { @application.aasm.fire!(event_name, actor) }.to raise_error(Exception)
+    expect { @application.send(command_name, actor) }.to raise_error(Exception)
   else
-    @application.aasm.fire!(event_name, actor)
+    @application.send(command_name, actor)
   end
 end
 
@@ -37,13 +37,13 @@ When('the automatic process for rejecting applications is run at {string}') do |
 end
 
 Then(/a provider with code "(.*)" is able to (add conditions|amend conditions): "(.*)"/) do |provider_code, event_string, yes_or_no|
-  event = event_string.gsub(" ", "_").to_sym
+  command_name = (event_string.gsub(" ", "_") + "!").to_sym
   if yes_or_no == 'Y'
-    @application.aasm.fire!(event, 'provider', provider_code)
+    @application.send(command_name, 'provider', provider_code)
     expect(@application.state).to eq('conditional_offer')
   else
     expect {
-      @application.aasm.fire!(event, 'provider', provider_code)
+      @application.send(command_name, 'provider', provider_code)
     }.to raise_error(AASM::InvalidTransition)
   end
 end


### PR DESCRIPTION
### Context

The spec for amending conditions on an offer hasn't been implemented yet.

### Changes proposed in this pull request

- implement the spec for amending conditions
- introduce the [Pundit gem](https://github.com/varvet/pundit) for expressing authorisation.

### Guidance to review

Pulling out authorisation into Pundit policies simplifies the logic in the `CandidateApplication` class. It may be fairly early to introduce an explicit thing for authorisation but

- many of the policy rules concern who can do what/when
- there's more authorisation complexity to come
