### PR TITLE
Prevent service from being indexed in Google

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <meta name="robots" content="noindex, nofollow">
+
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 


### PR DESCRIPTION
We currently allow this service (the dev/test versions) to be indexed in Google. We don't want this to happen to avoid confusing users, but we don't want the eventual live service to appear in search results anyway - their journey should [start on GOV.UK](https://www.gov.uk/service-manual/technology/get-a-domain-name#ensure-users-start-their-journey-on-govuk).