### PR TITLE
Fix the 'declining offers' spec so it passes again

### DIFF
--- a/features/declining_offers.feature
+++ b/features/declining_offers.feature
@@ -6,7 +6,7 @@ Feature: Declining offers
 
   Scenario Outline: A candidate can decline an application with an offer
     Given an application in "<original state>" state
-    When a <actor> <action>
+    When the <actor> takes action "<action>"
     Then the new application state is "<new state>"
 
     Examples:


### PR DESCRIPTION
### Context

The 'declining offers' spec was inadvertently merged using outdated step syntax.

### Changes proposed in this pull request

Realign the step syntax so the feature passes.

