### PR TITLE
Application workflow prototype: candidate applications should have course choices, not courses

### DIFF
--- a/app/models/candidate_application.rb
+++ b/app/models/candidate_application.rb
@@ -1,7 +1,7 @@
 class CandidateApplication < ApplicationRecord
   include AASM
 
-  belongs_to :course, optional: true
+  belongs_to :course_choice, optional: true
 
   scope :with_rbd_times_in_the_past, -> { where('rejected_by_default_at < ?', Time.now) }
   scope :pre_offer, -> { where(state: %i[unsubmitted references_pending application_complete]) }
@@ -98,5 +98,9 @@ class CandidateApplication < ApplicationRecord
     self.with_rbd_times_in_the_past.pre_offer.each do |application|
       application.reject!('provider')
     end
+  end
+
+  def course
+    course_choice&.course
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,8 +2,8 @@ class Course < ApplicationRecord
   belongs_to :provider
   belongs_to :accredited_body, class_name: 'Provider', foreign_key: :accredited_body_provider_id
 
-  has_many :courses_training_locations
-  has_many :training_locations, through: :courses_training_locations
+  has_many :course_choices
+  has_many :training_locations, through: :course_choices
 
   def provider_or_accredited_body?(provider_code)
     provider_code.in?([provider.code, accredited_body.code])

--- a/app/models/course_choice.rb
+++ b/app/models/course_choice.rb
@@ -1,0 +1,16 @@
+class CourseChoice < ActiveRecord::Base
+  belongs_to :training_location
+  belongs_to :course
+
+  def self.find_matching(provider_code, course_code, training_location_code)
+    provider = Provider.find_by!(code: provider_code)
+    find_by!(
+      course: provider.courses.find_by!(course_code: course_code),
+      training_location: provider.training_locations.find_by!(code: training_location_code)
+    )
+  end
+
+  def same_choice_as?(other)
+    self.course == other.course
+  end
+end

--- a/app/models/courses_training_location.rb
+++ b/app/models/courses_training_location.rb
@@ -1,4 +1,0 @@
-class CoursesTrainingLocation < ActiveRecord::Base
-  belongs_to :training_location
-  belongs_to :course
-end

--- a/db/migrate/20190922162019_add_id_to_courses_training_locations.rb
+++ b/db/migrate/20190922162019_add_id_to_courses_training_locations.rb
@@ -1,0 +1,5 @@
+class AddIdToCoursesTrainingLocations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :courses_training_locations, :id, :primary_key
+  end
+end

--- a/db/migrate/20190922164558_rename_courses_training_locations_to_course_choices.rb
+++ b/db/migrate/20190922164558_rename_courses_training_locations_to_course_choices.rb
@@ -1,0 +1,5 @@
+class RenameCoursesTrainingLocationsToCourseChoices < ActiveRecord::Migration[5.2]
+  def change
+    rename_table :courses_training_locations, :course_choices
+  end
+end

--- a/db/migrate/20190922164923_rename_course_id_to_course_choice_id_on_candidate_applications.rb
+++ b/db/migrate/20190922164923_rename_course_id_to_course_choice_id_on_candidate_applications.rb
@@ -1,0 +1,5 @@
+class RenameCourseIdToCourseChoiceIdOnCandidateApplications < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :candidate_applications, :course_id, :course_choice_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_20_152810) do
+ActiveRecord::Schema.define(version: 2019_09_22_164923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2019_09_20_152810) do
     t.string "state"
     t.datetime "submitted_at"
     t.datetime "rejected_by_default_at"
-    t.integer "course_id"
+    t.integer "course_choice_id"
   end
 
   create_table "candidates", force: :cascade do |t|
@@ -43,17 +43,17 @@ ActiveRecord::Schema.define(version: 2019_09_20_152810) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "course_choices", force: :cascade do |t|
+    t.bigint "course_id", null: false
+    t.bigint "training_location_id", null: false
+  end
+
   create_table "courses", force: :cascade do |t|
     t.string "course_code"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "provider_id"
     t.integer "accredited_body_provider_id"
-  end
-
-  create_table "courses_training_locations", id: false, force: :cascade do |t|
-    t.bigint "course_id", null: false
-    t.bigint "training_location_id", null: false
   end
 
   create_table "degrees", force: :cascade do |t|

--- a/features/step_definitions/applications.rb
+++ b/features/step_definitions/applications.rb
@@ -14,10 +14,14 @@ Given('the following application exists:') do |table|
 
     if row['choice'].present?
       provider_code, course_code = row['choice'].split('/')
-      attributes[:course] = Provider
-                              .find_by!(code: provider_code)
-                              .courses
-                              .find_by!(course_code: course_code)
+      course = Provider
+                 .find_by!(code: provider_code)
+                 .courses
+                 .find_by!(course_code: course_code)
+      attributes[:course_choice] = CourseChoice.new(
+        course: course,
+        training_location: course.training_locations.sample
+      )
     end
 
     @application = CandidateApplication.create!(attributes)

--- a/features/step_definitions/courses.rb
+++ b/features/step_definitions/courses.rb
@@ -40,9 +40,20 @@ When(/an application has been made to course (.*)\/(.*)/) do |provider_code, cou
              .courses
              .find_by!(course_code: course_code)
 
-  @application = CandidateApplication.create!(course: course)
+  course_choice = CourseChoice.new(course: course, training_location: course.training_locations.sample)
+
+  @application = CandidateApplication.create!(course_choice: course_choice)
 end
 
-Then(/(.*) and (.*) are treated as the same choice: (.*)/) do |_course_a, _course_b, _yes_or_no|
-  pending
+Then(/(.*) and (.*) are treated as the same choice: (.*)/) do |choice_a_string, choice_b_string, yes_or_no|
+  choice_a_key = choice_a_string.scan(/(.*)\/(.*) \(location: (.*)\)/)[0]
+  choice_b_key = choice_b_string.scan(/(.*)\/(.*) \(location: (.*)\)/)[0]
+  choice_a = CourseChoice.find_matching(*choice_a_key)
+  choice_b = CourseChoice.find_matching(*choice_b_key)
+
+  if yes_or_no == 'Y'
+    expect(choice_a).to be_same_choice_as(choice_b)
+  else
+    expect(choice_a).to_not be_same_choice_as(choice_b)
+  end
 end


### PR DESCRIPTION
- A course choice also includes a training location. The training
location isn't always relevant in the feature files, so the step
definitions will pick out a random one when it's not been specified.
- Rename CoursesTrainingLocation => CourseChoice
- Additionally, implement the comparison to allow the course choices
feature to pass.
