### PR TITLE
[825] Expire tokens after time has passed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :test do
   gem 'capybara-email'
   gem 'climate_control'
   gem 'launchy'
+  gem 'timecop'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :test do
   gem 'rspec_junit_formatter'
   gem 'capybara-email'
   gem 'climate_control'
+  gem 'launchy'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,6 +267,7 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -315,6 +316,7 @@ DEPENDENCIES
   rubocop-rspec
   selenium-webdriver
   shoulda-matchers (~> 4.1)
+  timecop
   web-console (>= 3.3.0)
   webpacker
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     jwt (2.2.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -299,6 +301,7 @@ DEPENDENCIES
   factory_bot_rails
   govuk-lint
   govuk_design_system_formbuilder (= 0.9.4)
+  launchy
   listen (>= 3.0.5, < 3.2)
   mail-notify
   pg (~> 1.1.4)

--- a/app/warden/magic_link_strategy.rb
+++ b/app/warden/magic_link_strategy.rb
@@ -1,4 +1,6 @@
 class MagicLinkStrategy < Warden::Strategies::Base
+  MAX_TOKEN_DURATION = 1.hour
+
   def valid?
     params[:token].present?
   end
@@ -6,10 +8,16 @@ class MagicLinkStrategy < Warden::Strategies::Base
   def authenticate!
     candidate = FindCandidateByToken.call(raw_token: params[:token])
 
-    if candidate
+    if candidate.present? && token_not_expired?(candidate)
       success!(candidate)
     else
       fail!
     end
+  end
+
+private
+
+  def token_not_expired?(candidate)
+    Time.now < (candidate.magic_link_token_sent_at + MAX_TOKEN_DURATION)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,6 +29,9 @@ rescue ActiveRecord::PendingMigrationError => e
   puts e.to_s.strip
   exit 1
 end
+
+Timecop.safe_mode = true
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/system/candidate_interface/candidate_signing_up_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_up_spec.rb
@@ -14,11 +14,25 @@ describe 'A candidate signing up' do
       expect(page).to have_content t('authentication.check_your_email')
     end
 
-    it 'receives an email with a valid magic link' do
-      open_email('april@pawnee.com')
-      current_email.find_css('a').first.click
+    context 'receives an email with a valid magic link' do
+      let(:sign_in_link) { current_email.find_css('a').first }
 
-      expect(page).to have_content 'april@pawnee.com'
+      before do
+        open_email('april@pawnee.com')
+      end
+
+      it 'does sign the user in' do
+        sign_in_link.click
+        expect(page).to have_content 'april@pawnee.com'
+      end
+
+      it 'does not sign the user in when the token expiration time has passed' do
+        Timecop.travel(Time.now + 1.hour + 1.second) do
+          sign_in_link.click
+
+          expect(page).not_to have_content 'april@pawnee.com'
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

Sign in tokens which are emailed to users can currently be used indefinitely. This is a security issue.

Paired on this with: @alexdesi 

### Changes proposed in this pull request

- Add timecop gem to allow manipulating `Time` within specs
- Add launchy to allow debugging tests using `save_and_open_page`
- Do not allow users to sign in with a token that is older than 1 hour

### Guidance to review

Check if the expiration logic makes sense and is easy to follow.

### Link to Trello card

[825 - Expire magic link tokens](https://trello.com/c/gWThpj9i/825-expire-magic-link-tokens)