### PR TITLE
Make binding.pry work everywhere without require

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'devise'
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'pry'
   gem 'rails-erd'
 end
 
@@ -43,4 +42,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'dotenv-rails'
   gem 'factory_bot_rails'
+  gem 'pry'
+  gem 'pry-byebug'
+  gem 'pry-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       smart_properties
     bindex (0.8.1)
     builder (3.2.3)
+    byebug (11.0.1)
     capybara (3.29.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -161,6 +162,11 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (4.2.0)
       nio4r (~> 2.0)
@@ -307,6 +313,8 @@ DEPENDENCIES
   mail-notify
   pg (~> 1.1.4)
   pry
+  pry-byebug
+  pry-rails
   puma (~> 4.2)
   rails (~> 6.0)
   rails-erd


### PR DESCRIPTION
Move `pry` to the shared `:development, :test` group so that we can use it to debug both the application and the tests.

Add `pry-byebug` for stack navigation.

Add `pry-rails` which initializes it so we don't need to `require` every time.