### PR TITLE
Allow candidates to sign out

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -46,7 +46,8 @@
             <%= t('layout.service_name') %>
           </a>
           <% if candidate_signed_in? %>
-            <p class="govuk-body"><%= current_candidate.email_address %></p>
+            <p class="govuk-header__body"><%= current_candidate.email_address %></p>
+            <%= link_to 'Sign out', candidate_interface_sign_out_path, class: 'govuk-header__link' %>
           <% end %>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   # Custom views are used, see app/views/magic_link/sign_up/
   devise_for :candidates, skip: :all
 
+  devise_scope :candidate do
+    get '/candidate/sign-out', to: 'devise/sessions#destroy', as: :candidate_interface_sign_out
+  end
+
   root to: redirect('/candidate')
 
   namespace :candidate_interface, path: '/candidate' do

--- a/spec/system/candidate_interface/candidate_signing_out_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_out_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+describe 'A candidate signing out' do
+  context 'when a candidate is signed in' do
+    before do
+      candidate = FactoryBot.create(:candidate)
+      login_as(candidate)
+
+      visit candidate_interface_welcome_path
+    end
+
+    it 'can see a sign out button' do
+      expect(page).to have_selector :link_or_button, 'Sign out'
+    end
+
+    context 'when the sign out button is clicked' do
+      it 'sends the candidate to the start page' do
+        click_link 'Sign out'
+
+        expect(page).to have_current_path(candidate_interface_start_path)
+      end
+
+      it 'can only access start page' do
+        click_link 'Sign out'
+
+        visit candidate_interface_welcome_path
+
+        expect(page).to have_current_path(candidate_interface_start_path)
+      end
+    end
+  end
+
+  context 'when a candidate is not signed in' do
+    it 'does not display a sign out button' do
+      visit candidate_interface_start_path
+
+      expect(page).not_to have_selector :link_or_button, 'Sign out'
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently if a candidate signs in, they have no way to sign out of their account.

### Changes proposed in this pull request

This PR adds:

- a candidate_signing_out_spec
- a sign out route that maps to Devise's sessions#destroy
- a sign out link in the header

#### Before

![image](https://user-images.githubusercontent.com/42817036/65694625-1384b780-e06e-11e9-90f7-44e99c0b3585.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/65694589-02d44180-e06e-11e9-8899-f1fedd486262.png)

### Guidance to review

- Try out the user flow for signing up and signing out.

### Link to Trello card

[827 - Allow candidates to sign out](https://trello.com/c/aU4sPu08/827-allow-candidates-to-sign-out)
