### PR TITLE
Add the pages used for sign in.

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  class SignInController < CandidateInterfaceController
+    def new
+      @candidate = Candidate.new
+    end
+
+    def create
+      render :show
+    end
+  end
+end

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, t('authentication.sign_in.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">Sign in</h1>
+
+    <p class="govuk-body-l">Enter the email address you used to register with, and we will send you a link to sign in.</p>
+
+    <%= form_with model: @candidate, url: candidate_interface_sign_in_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm'}, type: :email %>
+
+      <%= f.submit t('authentication.sign_up.button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/sign_in/show.html.erb
+++ b/app/views/candidate_interface/sign_in/show.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, t('authentication.check_your_email') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('authentication.check_your_email') %>
+    </h1>
+    <p class="govuk-body-l">
+      We’ve sent you an email. Click on the link to confirm your address and return to this service.
+    </p>
+  </div>
+</div>

--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -5,42 +5,35 @@
     <h1 class="govuk-heading-xl">
       Apply for postgraduate teacher training
     </h1>
-
     <p class="govuk-body">
       Apply for teacher training is a new GOV.UK service being trialled with a small number of training providers.
     </p>
-
-    <h2 class="govuk-heading-m">
-      What you’ll need
-    </h2>
-
+    <div class="govuk-inset-text">
+      Learn more about teacher training in <a href="https://www.discoverteaching.wales/routes-into-teaching/">Wales</a>, <a href="https://teachinscotland.scot/">Scotland</a> and <a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a>
+    </div>
+    <h2 class="govuk-heading-m">What you’ll need</h2>
     <p class="govuk-body">
       To be eligible for teacher training, you need these qualifications (or their non-UK equivalents):
     </p>
-
     <ul class="govuk-list govuk-list--bullet">
       <li>a degree</li>
       <li>grade 4 (C) or above in English and maths GCSEs</li>
       <li>grade 4 (C) or above in GCSE science if you want to teach primary</li>
     </ul>
-
     <p class="govuk-body">
       Before you start a teacher training course you’ll also need to confirm you have the health and physical capacity to start training.
     </p>
-
-    <h2 class="govuk-heading-m">
-      If you don’t have a degree
-    </h2>
+    <h2 class="govuk-heading-m">If you don’t have a degree</h2>
     <p class="govuk-body">
       You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status.
-      <a class="govuk-link" href="https://getintoteaching.education.gov.uk/eligibility-for-teacher-training">Learn more</a>.
+      <a href="https://getintoteaching.education.gov.uk/eligibility-for-teacher-training">Learn more</a>.
     </p>
-
     <%= link_to candidate_interface_sign_up_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
       </svg>
     <% end %>
+    <p class="govuk-body">If you have teacher training applications in progress, please <%= link_to 'sign in', candidate_interface_sign_in_path %></p>
   </div>
 </div>

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -11,3 +11,7 @@ en:
         heading: Please confirm your email address
         body: Click the link below to sign in to the Apply for postgraduate teacher training service.
     check_your_email: Check your email
+    sign_in:
+      heading: Sign in
+      email_address:
+        label: Email address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
     get '/welcome', to: 'welcome#show'
     get '/sign-up', to: 'sign_up#new', as: :sign_up
     post '/sign-up', to: 'sign_up#create'
+
+    get '/sign-in', to: 'sign_in#new', as: :sign_in
+    post '/sign-in', to: 'sign_in#create'
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/spec/system/candidate_interface/candidate_signing_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_in_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe 'A candidate signing in' do
+  before do
+    visit '/'
+    click_on 'sign in'
+
+    fill_in t('authentication.sign_in.email_address.label'), with: 'new_candidate@example.com'
+  end
+
+  it 'sees the the sign in page' do
+    expect(page).to have_content 'Enter the email address you used to register with'
+  end
+
+  context 'who successfully signs in' do
+    it 'sees the "Check your email" page' do
+      fill_in t('authentication.sign_in.email_address.label'), with: 'new_candidate@example.com'
+      click_on t('authentication.sign_up.button')
+
+      expect(page).to have_content 'Check your email'
+    end
+  end
+end


### PR DESCRIPTION
### Context
We need to build the sign-in workflow, which makes use of the magic link.

### Changes proposed in this pull request

This adds the pages, that will be used in the sign-in workflow.


### Link to Trello card

https://trello.com/c/0wmsvsgX/64-implement-sign-in-using-magic-links
