### PR TITLE
Update test descriptions in sign out spec

### DIFF
--- a/spec/system/candidate_interface/candidate_signing_out_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_out_spec.rb
@@ -9,12 +9,12 @@ describe 'A candidate signing out' do
       visit candidate_interface_welcome_path
     end
 
-    it 'can see a sign out button' do
+    it 'displays a sign out button' do
       expect(page).to have_selector :link_or_button, 'Sign out'
     end
 
-    context 'when the sign out button is clicked' do
-      it 'sends the candidate to the start page' do
+    describe 'click the sign out button' do
+      it 'displays the start page' do
         click_link 'Sign out'
 
         expect(page).to have_current_path(candidate_interface_start_path)


### PR DESCRIPTION
### Context

To address comments made in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/216.

### Changes proposed in this pull request

This PR updates test descriptions in `candidate_signing_out_spec`.

### Guidance to review

@alexdesi 

### Link to Trello card

[827 - Allow candidates to sign out](https://trello.com/c/aU4sPu08/827-allow-candidates-to-sign-out)
