### PR TITLE
Add timeout to candidate sessions

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -1,7 +1,7 @@
 class Candidate < ApplicationRecord
-  # No Devise modules are enabled
+  # Only Devise's :timeoutable module is enabled to handle session expiry
   # Custom Warden strategy is used instead see app/warden/magic_link_token.rb
-  devise
+  devise :timeoutable
   validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
 
   has_many :application_forms

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -23,6 +23,8 @@ Devise.setup do |config|
 
   config.sign_out_via = :delete
 
+  config.timeout_in = 7.days
+
   config.warden do |manager|
     manager.default_strategies(scope: :candidate).unshift :magic_link_strategy
   end

--- a/spec/system/candidate_interface/candidate_expire_session_spec.rb
+++ b/spec/system/candidate_interface/candidate_expire_session_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'Candidate session expires' do
+  it 'expires the current candidate session' do
+    candidate = FactoryBot.create(:candidate)
+    login_as(candidate)
+
+    visit candidate_interface_welcome_path
+    Timecop.travel(Time.now + 7.days + 1.second) do
+      visit candidate_interface_welcome_path
+
+      expect(page).to have_current_path(candidate_interface_start_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context

Candidate sessions need to be expired after a given amount of time.

### Changes proposed in this pull request

- Add spec to test that candidate sessions are expired after an amount of time.
- Add devise `timeoutable` module to the Candidate model.
- Set timeout after 30 minutes in devise initialiser.

### Guidance to review
- Would like to know how long a candidate session should last?
- Could we move this spec into the `sign in` spec file?
- Run test

### Link to Trello card

[67 - Expire candidate sessions](https://trello.com/c/1QZRUrF0/67-expire-candidate-sessions)
