### PR TITLE
Update header for when a candidate is signed in

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,10 +45,16 @@
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
             <%= t('layout.service_name') %>
           </a>
-          <% if candidate_signed_in? %>
-            <p class="govuk-header__body"><%= current_candidate.email_address %></p>
-            <%= link_to 'Sign out', candidate_interface_sign_out_path, class: 'govuk-header__link' %>
-          <% end %>
+          <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+            <% if candidate_signed_in? %>
+              <li class="govuk-header__navigation-item">
+                <b><%= current_candidate.email_address %></b>
+              </li>
+              <li class="govuk-header__navigation-item">
+                <%= link_to 'Sign out', candidate_interface_sign_out_path, class: 'govuk-header__link' %>
+              </li>
+            <% end %>
+          </ul>
         </div>
       </div>
     </header>


### PR DESCRIPTION
### Context

Currently, our header looks like the below:

![image](https://user-images.githubusercontent.com/42817036/65758536-27cdc080-e111-11e9-995c-1482b516e4ee.png)

But the prototype looks like this:

![image](https://user-images.githubusercontent.com/42817036/65758590-3caa5400-e111-11e9-96fd-af22ce7b807f.png)

### Changes proposed in this pull request

This PR makes the header when a candidate is signed in more aligned with the prototype. So instead of the email and sign out button below each other, they are side by side.

![image](https://user-images.githubusercontent.com/42817036/65758720-74190080-e111-11e9-9683-d8a05a525601.png)

### Guidance to review

Does it look alright?

### Link to Trello card

A quick add-on for: [827 - Allow candidates to sign out](https://trello.com/c/aU4sPu08/827-allow-candidates-to-sign-out)