### PR TITLE
Fix deployment

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -12,9 +12,11 @@ parameters:
   dockerhubUsername:
   railsSecretKeyBase:
   containerStartTimeLimit: '600'
-  warmupPingPath: '/sign-up'
+  warmupPingPath: 'candidate/sign-up'
   warmupPingStatus: '200'
   railsEnv: 'production'
+  domain:
+  staging_domain:
   securityAlertEmail: 'apprenticeshipsdevops@education.gov.uk'
   
 jobs:
@@ -61,7 +63,8 @@ jobs:
                 -warmupPingPath "${{parameters.warmupPingPath}}"
                 -warmupPingStatus "${{parameters.warmupPingStatus}}"
                 -govukNotifyAPIKey "$(govukNotifyAPIKey)"
-                -defaultProviderEmail "$(defaultProviderEmail)"'
+                -domain "${{parameters.domain}}"
+                -staging_domain "${{parameters.staging_domain}}"'
               deploymentOutputs: DeploymentOutput
 
           - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,7 @@ stages:
         RAILS_ENV: test
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
+        STAGING_DOMAIN: $(domain)
 
     - script: make ci.lint-ruby
       displayName: 'Rubocop'
@@ -56,6 +57,7 @@ stages:
         RAILS_ENV: test
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
+        STAGING_DOMAIN: $(domain)
 
     - script: make ci.lint-erb
       displayName: 'ERB lint'
@@ -65,6 +67,7 @@ stages:
         RAILS_ENV: test
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
+        STAGING_DOMAIN: $(domain)
 
     - script: |
         make ci.test
@@ -77,6 +80,7 @@ stages:
         RAILS_ENV: test
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
+        STAGING_DOMAIN: $(domain)
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
@@ -140,12 +144,15 @@ stages:
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
       domain: '$(domain)'
+      staging_domain: '$(staging_domain)'
 
 
 - stage: deploy_test
   displayName: 'Deploy - Test'
   dependsOn: build_test_release
   condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  variables:
+  - group: APPLY - Development Secrets
   jobs:
   - template: azure-pipelines-deploy-template.yml
     parameters:
@@ -163,6 +170,7 @@ stages:
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
       domain: '$(domain)'
+      staging_domain: '$(staging_domain)'
 
 
 # - stage: deploy_production
@@ -186,4 +194,6 @@ stages:
 #       databasePassword: '$(databasePassword)'
 #       dockerhubUsername: '$(dockerHubUsername)'
 #       railsSecretKeyBase: '$(railsSecretKeyBase)'
-#       railsEnv: 'development'
+#       railsEnv: 'production'
+#       domain: '$(domain)'
+#       staging_domain: '$(staging_domain)'

--- a/azure/template.json
+++ b/azure/template.json
@@ -87,10 +87,16 @@
                 "description": "GOV UK Notify service API key."
             }
         },
-        "defaultProviderEmail": {
+        "domain": {
             "type": "string",
             "metadata": {
-                "description": "Notify service Default provider email address."
+                "description": "Site domain name for use in GOV UK Notify and Rails security features."
+            }
+        },
+        "staging_domain": {
+            "type": "string",
+            "metadata": {
+                "description": "Site domain name for use in GOV UK Notify and Rails security features. Used during swap slots only."
             }
         },
         "railsServeStaticFiles": {
@@ -227,6 +233,14 @@
                             {
                                 "name": "GOVUK_NOTIFY_API_KEY",
                                 "value": "[parameters('govukNotifyAPIKey')]"
+                            },
+                            {
+                                "name": "DOMAIN",
+                                "value": "[parameters('domain')]"
+                            },
+                            {
+                                "name": "STAGING_DOMAIN",
+                                "value": "[parameters('staging_domain')]"
                             }
                         ]
                     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -111,4 +111,5 @@ Rails.application.configure do
 
   # Whitelist the production domain for HostAuthorization
   config.hosts << ENV.fetch('DOMAIN')
+  config.hosts << ENV.fetch('STAGING_DOMAIN') # Domain used in Azure pipelines for deploying to the second slot
 end

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -7,3 +7,4 @@ services:
       - GOVUK_NOTIFY_API_KEY
       - SECRET_KEY_BASE=${railsSecretKeyBase}
       - DOMAIN=${domain}
+      - STAGING_DOMAIN=${staging_domain}


### PR DESCRIPTION
### Context

Rails 6 has broken the release pipeline due to the new domain whitelisting feature.

When we deploy, our blue/green pipeline spins up a copy of the application under a different domain. Rails 6 doesn't like this, unless we specifically tell it to.

### Changes proposed in this pull request

Pulls in a `STAGING_DOMAIN` environment variable in the domain whitelist and populates it in the pipeline.

### Guidance to review

We should do a release based on this branch; if it works, then it's good!

This is built by @tpinney and I'm just helping with the PR and rebasing it as well.