### PR TITLE
83 - Add Google Tag Manager to the app

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,14 @@
     <meta property="og:image" content="<%= asset_pack_path('media/images/govuk-opengraph-image.png') %>">
 
     <%= stylesheet_pack_tag 'application' %>
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112932657-3"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'UA-112932657-3', { 'anonymize_ip': true });
+    </script>
   </head>
 
   <body class="govuk-template__body">


### PR DESCRIPTION
### Context

This will allow us to track and improve the service.

### Link to Trello card

[83 - Add Google Analytics to the app](https://trello.com/c/Jvwh3BvK)