### PR TITLE
Fix header height when signed out

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,16 +45,16 @@
           <a href="/" class="govuk-header__link govuk-header__link--service-name">
             <%= t('layout.service_name') %>
           </a>
-          <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-            <% if candidate_signed_in? %>
+          <% if candidate_signed_in? %>
+            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item">
                 <b><%= current_candidate.email_address %></b>
               </li>
               <li class="govuk-header__navigation-item">
                 <%= link_to 'Sign out', candidate_interface_sign_out_path, class: 'govuk-header__link' %>
               </li>
-            <% end %>
-          </ul>
+            </ul>
+          <% end %>
         </div>
       </div>
     </header>


### PR DESCRIPTION
When signed out, the header displays an empty `<ul>` which has an assigned `margin` that makes the header look slightly bigger than it should.