### PR TITLE
Align our rubocop with govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,10 +12,6 @@ AllCops:
     - 'config/puma.rb'
     - 'config/environments/*'
 
-Style/StringLiterals:
-  Enabled: true
-  EnforcedStyle: single_quotes
-
 Bundler/OrderedGems:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,49 +1,49 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.3'
+ruby "2.6.3"
 
-gem 'rails', '~> 6.0'
-gem 'puma', '~> 4.2'
-gem 'pg', '~> 1.1.4'
+gem "rails", "~> 6.0"
+gem "puma", "~> 4.2"
+gem "pg", "~> 1.1.4"
 
-gem 'webpacker'
-gem 'govuk_design_system_formbuilder', '0.9.4'
+gem "webpacker"
+gem "govuk_design_system_formbuilder", "0.9.4"
 
 # GovUK Notify
-gem 'mail-notify'
+gem "mail-notify"
 
 # Linting
-gem 'rubocop'
-gem 'rubocop-rspec'
-gem 'govuk-lint'
-gem 'erb_lint', require: false
+gem "rubocop"
+gem "rubocop-rspec"
+gem "govuk-lint"
+gem "erb_lint", require: false
 
-gem 'devise'
+gem "devise"
 
 group :development do
-  gem 'web-console', '>= 3.3.0'
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'rails-erd'
+  gem "web-console", ">= 3.3.0"
+  gem "listen", ">= 3.0.5", "< 3.2"
+  gem "rails-erd"
 end
 
 group :test do
-  gem 'selenium-webdriver'
-  gem 'capybara', '>= 3.24'
-  gem 'shoulda-matchers', '~> 4.1'
-  gem 'rspec_junit_formatter'
-  gem 'capybara-email'
-  gem 'climate_control'
-  gem 'launchy'
-  gem 'timecop'
-  gem 'guard-rspec'
+  gem "selenium-webdriver"
+  gem "capybara", ">= 3.24"
+  gem "shoulda-matchers", "~> 4.1"
+  gem "rspec_junit_formatter"
+  gem "capybara-email"
+  gem "climate_control"
+  gem "launchy"
+  gem "timecop"
+  gem "guard-rspec"
 end
 
 group :development, :test do
-  gem 'rspec-rails'
-  gem 'dotenv-rails'
-  gem 'factory_bot_rails'
-  gem 'pry'
-  gem 'pry-byebug'
-  gem 'pry-rails'
+  gem "rspec-rails"
+  gem "dotenv-rails"
+  gem "factory_bot_rails"
+  gem "pry"
+  gem "pry-byebug"
+  gem "pry-rails"
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
-guard :rspec, cmd: 'bundle exec rspec --format documentation' do
-  require 'guard/rspec/dsl'
+guard :rspec, cmd: "bundle exec rspec --format documentation" do
+  require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 
   # RSpec files

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,16 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks
 
-task lint_ruby: ['lint:ruby']
+task lint_ruby: ["lint:ruby"]
 
 task(:default).clear
 
 task default: %i[lint_erb lint_ruby spec]
 
-Rake::Task['db:migrate'].enhance do
-  sh 'bundle exec erd'
+Rake::Task["db:migrate"].enhance do
+  sh "bundle exec erd"
 end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
   class CandidateInterfaceController < ActionController::Base
-    layout 'application'
+    layout "application"
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -1,5 +1,5 @@
 module ProviderInterface
   class ProviderInterfaceController < ActionController::Base
-    layout 'application'
+    layout "application"
   end
 end

--- a/app/controllers/vendor_api/ping_controller.rb
+++ b/app/controllers/vendor_api/ping_controller.rb
@@ -1,7 +1,7 @@
 module VendorApi
   class PingController < VendorApiController
     def ping
-      render json: { data: 'pong' }
+      render json: { data: "pong" }
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     if I18n.exists?(page_title_translation_key)
       "#{t(page_title_translation_key)} - #{t('page_titles.application')}"
     else
-      t('page_titles.application')
+      t("page_titles.application")
     end
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,3 @@
 class ApplicationMailer < Mail::Notify::Mailer
-  GENERIC_NOTIFY_TEMPLATE = '2744ea53-34f1-431f-8173-8388fadd826a'.freeze
+  GENERIC_NOTIFY_TEMPLATE = "2744ea53-34f1-431f-8173-8388fadd826a".freeze
 end

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -4,6 +4,6 @@ class AuthenticationMailer < ApplicationMailer
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: to,
-              subject: t('authentication.sign_up.email.subject'))
+              subject: t("authentication.sign_up.email.subject"))
   end
 end

--- a/app/services/find_candidate_by_token.rb
+++ b/app/services/find_candidate_by_token.rb
@@ -1,4 +1,4 @@
-require_relative 'lib/magic_link_token'
+require_relative "lib/magic_link_token"
 
 class FindCandidateByToken
   def self.call(raw_token:)

--- a/app/services/magic_link_sign_up.rb
+++ b/app/services/magic_link_sign_up.rb
@@ -1,4 +1,4 @@
-require_relative 'lib/magic_link_token'
+require_relative "lib/magic_link_token"
 
 class MagicLinkSignUp
   def self.call(candidate:)

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,5 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,3 @@
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
+require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,5 @@
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,12 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,1 @@
-Date::DATE_FORMATS[:default] = '%-d %B %Y'
+Date::DATE_FORMATS[:default] = "%-d %B %Y"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Devise.setup do |config|
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   config.case_insensitive_keys = [:email]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,26 +5,26 @@ Rails.application.routes.draw do
   devise_for :candidates, skip: :all
 
   devise_scope :candidate do
-    get '/candidate/sign-out', to: 'devise/sessions#destroy', as: :candidate_interface_sign_out
+    get "/candidate/sign-out", to: "devise/sessions#destroy", as: :candidate_interface_sign_out
   end
 
-  root to: redirect('/candidate')
+  root to: redirect("/candidate")
 
-  namespace :candidate_interface, path: '/candidate' do
-    get '/' => 'start_page#show', as: :start
-    get '/welcome', to: 'welcome#show'
-    get '/sign-up', to: 'sign_up#new', as: :sign_up
-    post '/sign-up', to: 'sign_up#create'
+  namespace :candidate_interface, path: "/candidate" do
+    get "/" => "start_page#show", as: :start
+    get "/welcome", to: "welcome#show"
+    get "/sign-up", to: "sign_up#new", as: :sign_up
+    post "/sign-up", to: "sign_up#create"
 
-    get '/sign-in', to: 'sign_in#new', as: :sign_in
-    post '/sign-in', to: 'sign_in#create'
+    get "/sign-in", to: "sign_in#new", as: :sign_in
+    post "/sign-in", to: "sign_in#create"
   end
 
-  namespace :vendor_api, path: 'api/v1' do
-    get '/ping', to: 'ping#ping'
+  namespace :vendor_api, path: "api/v1" do
+    get "/ping", to: "ping#ping"
   end
 
-  namespace :provider, path: '/provider' do
-    get '/' => 'home#index'
+  namespace :provider, path: "/provider" do
+    get "/" => "home#index"
   end
 end

--- a/db/migrate/20190702143141_enable_pgcrypto.rb
+++ b/db/migrate/20190702143141_enable_pgcrypto.rb
@@ -1,5 +1,5 @@
 class EnablePgcrypto < ActiveRecord::Migration[5.2]
   def change
-    enable_extension 'pgcrypto' unless extension_enabled?('pgcrypto')
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
   end
 end

--- a/lib/tasks/govuk_lint.rake
+++ b/lib/tasks/govuk_lint.rake
@@ -1,7 +1,7 @@
-desc 'Lint ruby code'
+desc "Lint ruby code"
 namespace :lint do
   task :ruby do
-    puts 'Linting ruby...'
-    system 'bundle exec rubocop --parallel'
+    puts "Linting ruby..."
+    system "bundle exec rubocop --parallel"
   end
 end

--- a/lib/tasks/lint_erb.rake
+++ b/lib/tasks/lint_erb.rake
@@ -1,4 +1,4 @@
-desc 'Lint all *.erb* files in app/views using erblint'
+desc "Lint all *.erb* files in app/views using erblint"
 task :lint_erb do
-  sh('erblint app/views')
+  sh("erblint app/views")
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,17 +1,17 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe ApplicationHelper do
-  describe '#page_title' do
-    context 'given a page is not defined in the translation file' do
-      it 'returns the application title' do
+  describe "#page_title" do
+    context "given a page is not defined in the translation file" do
+      it "returns the application title" do
         page_title = helper.page_title(:meow)
 
-        expect(page_title).to eq(t('page_titles.application'))
+        expect(page_title).to eq(t("page_titles.application"))
       end
     end
 
-    context 'given a page is defined in the translation file' do
-      it 'returns the page name with the application title' do
+    context "given a page is defined in the translation file" do
+      it "returns the page name with the application title" do
         page_title = helper.page_title(:welcome)
 
         expect(page_title).to eq("#{t('page_titles.welcome')} - #{t('page_titles.application')}")

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -1,27 +1,27 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe AuthenticationMailer, type: :mailer do
   subject(:mailer) { described_class }
 
-  describe '.sign_up_email' do
-    let(:token) { 'blub' }
-    let(:mail) { mailer.sign_up_email(to: 'test@example.com', token: token) }
+  describe ".sign_up_email" do
+    let(:token) { "blub" }
+    let(:mail) { mailer.sign_up_email(to: "test@example.com", token: token) }
 
     before { mail.deliver! }
 
-    it 'sends an email with the correct subject' do
-      expect(mail.subject).to include(t('authentication.sign_up.email.subject'))
+    it "sends an email with the correct subject" do
+      expect(mail.subject).to include(t("authentication.sign_up.email.subject"))
     end
 
-    it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include(t('authentication.sign_up.email.heading'))
+    it "sends an email with the correct heading" do
+      expect(mail.body.encoded).to include(t("authentication.sign_up.email.heading"))
     end
 
-    it 'sends an email with the correct body' do
-      expect(mail.body.encoded).to include(t('authentication.sign_up.email.body'))
+    it "sends an email with the correct body" do
+      expect(mail.body.encoded).to include(t("authentication.sign_up.email.body"))
     end
 
-    it 'sends an email with a magic link' do
+    it "sends an email with a magic link" do
       expect(mail.body.encoded).to include("http://localhost:3000/candidate/welcome/?token=#{token}")
     end
   end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Candidate, type: :model do
   subject { FactoryBot.create(:candidate) }
@@ -7,8 +7,8 @@ RSpec.describe Candidate, type: :model do
   it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
   it { is_expected.to validate_uniqueness_of :email_address }
 
-  describe '#delete' do
-    it 'deletes all dependent records through cascading deletes in the database' do
+  describe "#delete" do
+    it "deletes all dependent records through cascading deletes in the database" do
       candidate = FactoryBot.create(:candidate)
       application_form = FactoryBot.create(:application_form, candidate: candidate)
       application_choice = FactoryBot.create(:application_choice, application_form: application_form)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'rspec/rails'
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -19,7 +19,7 @@ require 'rspec/rails'
 # of increasing the boot-up time by auto-requiring all files in the support
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
-Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -61,7 +61,7 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  config.example_status_persistence_file_path = 'tmp/rspec-failures'
+  config.example_status_persistence_file_path = "tmp/rspec-failures"
 
   config.include AbstractController::Translation
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,4 +1,4 @@
-require 'capybara/rails'
+require "capybara/rails"
 
 RSpec.configure do |config|
   config.before(:each, type: :system) do

--- a/spec/support/capybara_email.rb
+++ b/spec/support/capybara_email.rb
@@ -1,1 +1,1 @@
-require 'capybara/email/rspec'
+require "capybara/email/rspec"

--- a/spec/support/test_helpers/sign_up.rb
+++ b/spec/support/test_helpers/sign_up.rb
@@ -1,8 +1,8 @@
 module TestHelpers
   module SignUp
     def fill_in_sign_up
-      fill_in t('authentication.sign_up.email_address.label'), with: 'april@pawnee.com'
-      click_on t('authentication.sign_up.button')
+      fill_in t("authentication.sign_up.email_address.label"), with: "april@pawnee.com"
+      click_on t("authentication.sign_up.button")
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_expire_session_spec.rb
+++ b/spec/system/candidate_interface/candidate_expire_session_spec.rb
@@ -1,7 +1,7 @@
-require 'rails_helper'
+require "rails_helper"
 
-describe 'Candidate session expires' do
-  it 'expires the current candidate session' do
+describe "Candidate session expires" do
+  it "expires the current candidate session" do
     candidate = FactoryBot.create(:candidate)
     login_as(candidate)
 

--- a/spec/system/candidate_interface/candidate_signing_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_in_spec.rb
@@ -1,23 +1,23 @@
-require 'rails_helper'
+require "rails_helper"
 
-describe 'A candidate signing in' do
+describe "A candidate signing in" do
   before do
-    visit '/'
-    click_on 'sign in'
+    visit "/"
+    click_on "sign in"
 
-    fill_in t('authentication.sign_in.email_address.label'), with: 'new_candidate@example.com'
+    fill_in t("authentication.sign_in.email_address.label"), with: "new_candidate@example.com"
   end
 
-  it 'sees the the sign in page' do
-    expect(page).to have_content 'Enter the email address you used to register with'
+  it "sees the the sign in page" do
+    expect(page).to have_content "Enter the email address you used to register with"
   end
 
-  context 'who successfully signs in' do
+  context "who successfully signs in" do
     it 'sees the "Check your email" page' do
-      fill_in t('authentication.sign_in.email_address.label'), with: 'new_candidate@example.com'
-      click_on t('authentication.sign_up.button')
+      fill_in t("authentication.sign_in.email_address.label"), with: "new_candidate@example.com"
+      click_on t("authentication.sign_up.button")
 
-      expect(page).to have_content 'Check your email'
+      expect(page).to have_content "Check your email"
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_signing_out_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_out_spec.rb
@@ -1,7 +1,7 @@
-require 'rails_helper'
+require "rails_helper"
 
-describe 'A candidate signing out' do
-  context 'when a candidate is signed in' do
+describe "A candidate signing out" do
+  context "when a candidate is signed in" do
     before do
       candidate = FactoryBot.create(:candidate)
       login_as(candidate)
@@ -9,19 +9,19 @@ describe 'A candidate signing out' do
       visit candidate_interface_welcome_path
     end
 
-    it 'displays a sign out button' do
-      expect(page).to have_selector :link_or_button, 'Sign out'
+    it "displays a sign out button" do
+      expect(page).to have_selector :link_or_button, "Sign out"
     end
 
-    describe 'click the sign out button' do
-      it 'displays the start page' do
-        click_link 'Sign out'
+    describe "click the sign out button" do
+      it "displays the start page" do
+        click_link "Sign out"
 
         expect(page).to have_current_path(candidate_interface_start_path)
       end
 
-      it 'can only access start page' do
-        click_link 'Sign out'
+      it "can only access start page" do
+        click_link "Sign out"
 
         visit candidate_interface_welcome_path
 
@@ -30,11 +30,11 @@ describe 'A candidate signing out' do
     end
   end
 
-  context 'when a candidate is not signed in' do
-    it 'does not display a sign out button' do
+  context "when a candidate is not signed in" do
+    it "does not display a sign out button" do
       visit candidate_interface_start_path
 
-      expect(page).not_to have_selector :link_or_button, 'Sign out'
+      expect(page).not_to have_selector :link_or_button, "Sign out"
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_signing_up_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_up_spec.rb
@@ -1,55 +1,55 @@
-require 'rails_helper'
+require "rails_helper"
 
-describe 'A candidate signing up' do
+describe "A candidate signing up" do
   include TestHelpers::SignUp
 
-  context 'who successfully signs up' do
+  context "who successfully signs up" do
     before do
-      visit '/'
-      click_on t('application_form.begin_button')
+      visit "/"
+      click_on t("application_form.begin_button")
       fill_in_sign_up
     end
 
-    it 'sees the check your email page' do
-      expect(page).to have_content t('authentication.check_your_email')
+    it "sees the check your email page" do
+      expect(page).to have_content t("authentication.check_your_email")
     end
 
-    context 'receives an email with a valid magic link' do
-      let(:sign_in_link) { current_email.find_css('a').first }
+    context "receives an email with a valid magic link" do
+      let(:sign_in_link) { current_email.find_css("a").first }
 
       before do
-        open_email('april@pawnee.com')
+        open_email("april@pawnee.com")
       end
 
-      it 'does sign the user in' do
+      it "does sign the user in" do
         sign_in_link.click
-        expect(page).to have_content 'april@pawnee.com'
+        expect(page).to have_content "april@pawnee.com"
       end
 
-      it 'does not sign the user in when the token expiration time has passed' do
+      it "does not sign the user in when the token expiration time has passed" do
         Timecop.travel(Time.now + 1.hour + 1.second) do
           sign_in_link.click
 
-          expect(page).not_to have_content 'april@pawnee.com'
+          expect(page).not_to have_content "april@pawnee.com"
         end
       end
     end
   end
 
-  context 'who tries to sign up twice' do
-    it 'sees the form error summary' do
+  context "who tries to sign up twice" do
+    it "sees the form error summary" do
       visit candidate_interface_sign_up_path
       fill_in_sign_up
       visit candidate_interface_sign_up_path
       fill_in_sign_up
 
-      expect(page).to have_content 'There is a problem'
+      expect(page).to have_content "There is a problem"
     end
   end
 
-  context 'who clicks a link with an invalid token' do
-    it 'sees the start page' do
-      visit candidate_interface_welcome_path(token: 'meow')
+  context "who clicks a link with an invalid token" do
+    it "sees the start page" do
+      visit candidate_interface_welcome_path(token: "meow")
 
       expect(page.current_url).to eq(candidate_interface_start_url)
     end


### PR DESCRIPTION
### Context

The newest version of `govuk-lint` specifies a different default that is sensible, so we should comply with it.

### Changes proposed in this pull request

Removed the rule in `rubocop.yml` and ran `bundle exec rubocop -a`.

### Guidance to review

Part of the reason for this is that I'm secretly planning to add [rufo](https://github.com/ruby-formatter/rufo).