### PR TITLE
Add rufo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,14 @@ AllCops:
     - 'config/puma.rb'
     - 'config/environments/*'
 
+Style/StringLiteralsInInterpolation:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Layout/AccessModifierIndentation:
+  Enabled: true
+  EnforcedStyle: indent
+
 Bundler/OrderedGems:
   Enabled: false
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem "web-console", ">= 3.3.0"
   gem "listen", ">= 3.0.5", "< 3.2"
   gem "rails-erd"
+  gem "rufo"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.4)
+    rufo (0.7.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -348,6 +349,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop
   rubocop-rspec
+  rufo
   selenium-webdriver
   shoulda-matchers (~> 4.1)
   timecop

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -17,7 +17,7 @@ module CandidateInterface
 
     def show; end
 
-  private
+    private
 
     def candidate_params
       params.require(:candidate).permit(:email_address)

--- a/app/controllers/candidate_interface/welcome_controller.rb
+++ b/app/controllers/candidate_interface/welcome_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class WelcomeController < CandidateInterfaceController
     before_action :authenticate_candidate!
+
     def show; end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@ module ApplicationHelper
     page_title_translation_key = "page_titles.#{page}"
 
     if I18n.exists?(page_title_translation_key)
-      "#{t(page_title_translation_key)} - #{t('page_titles.application')}"
+      "#{t(page_title_translation_key)} - #{t("page_titles.application")}"
     else
       t("page_titles.application")
     end

--- a/app/warden/magic_link_strategy.rb
+++ b/app/warden/magic_link_strategy.rb
@@ -15,7 +15,7 @@ class MagicLinkStrategy < Warden::Strategies::Base
     end
   end
 
-private
+  private
 
   def token_not_expired?(candidate)
     Time.now < (candidate.magic_link_token_sent_at + MAX_TOKEN_DURATION)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,4 @@
-require_relative 'boot'
+require_relative "boot"
 
 require "rails"
 # Pick the frameworks you want:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,13 +14,13 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
@@ -33,10 +33,10 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
-    api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
+    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
   }
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Do not buffer STDOUT in Ruby. This behaviour interacts weirdly with the docker-compose
   # log output and causes logs only to be printed when an exception occurs or the process

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
@@ -20,7 +20,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
@@ -43,7 +43,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
@@ -55,10 +55,10 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
-    api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
+    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
   }
   config.action_mailer.default_url_options = {
-    host: ENV.fetch('DOMAIN')
+    host: ENV.fetch("DOMAIN"),
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -80,9 +80,9 @@ Rails.application.configure do
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
   end
 
   # Do not dump schema after migrations.
@@ -110,6 +110,6 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Whitelist the production domain for HostAuthorization
-  config.hosts << ENV.fetch('DOMAIN')
-  config.hosts << ENV.fetch('STAGING_DOMAIN') # Domain used in Azure pipelines for deploying to the second slot
+  config.hosts << ENV.fetch("DOMAIN")
+  config.hosts << ENV.fetch("STAGING_DOMAIN") # Domain used in Azure pipelines for deploying to the second slot
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,11 +16,11 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
@@ -37,9 +37,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_options = {
-    from: 'mail@example.com'
+    from: "mail@example.com",
   }
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -10,7 +10,7 @@ threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch("PORT") { 3000 }
+port ENV.fetch("PORT") { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -14,7 +14,7 @@ describe ApplicationHelper do
       it "returns the page name with the application title" do
         page_title = helper.page_title(:welcome)
 
-        expect(page_title).to eq("#{t('page_titles.welcome')} - #{t('page_titles.application')}")
+        expect(page_title).to eq("#{t("page_titles.welcome")} - #{t("page_titles.application")}")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,8 +56,8 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
 =begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing


### PR DESCRIPTION
### Context

[From the docs](https://github.com/ruby-formatter/rufo):

> Rufo is as an opinionated ruby formatter, intended to be used via the command line as a text-editor plugin, to autoformat files on save or on demand.

> Unlike the best known Ruby formatter RuboCop, Rufo offers little in the way of configuration. Like other language formatters such as gofmt, prettier, and autopep8, we strive to find a "one true format" for Ruby code, and make sure your code adheres to it, with zero config where possible.

There's a few reasons I am proposing `rufo`.

- It's 5x+ faster (will only become more important as the app grows):

```bash
$ time bundle exec rubocop
Inspecting 79 files
...............................................................................

79 files inspected, no offenses detected
        1.81 real         1.45 user         0.32 sys

$ time bundle exec bundle exec rufo app config db lib spec
        0.35 real         0.28 user         0.06 sys
```

- It eliminates bikeshedding over style by not being configurable
- It can fix more code, such as this example (Rubocop thinks it's fine):

```ruby
  enum foo: {
        a: "1",
      b: "2",
    c: "3",
  d: "4",
e: "5",
  }
```

The Rufo defaults are almost identical to our Rubocop config, so we can have them coexisting for a while.

### Changes proposed in this pull request

Add rufo and update the `.rubocop.yml` to keep Rubocop happy, then run `bundle exec rufo app config db lib spec`.

### Guidance to review

This doesn't actually add a task to run it on precommit or such, but it allows developers to start using [editor plugins](https://github.com/ruby-formatter/rufo#editor-support) to enable it.

Apart from the way `private` is indented and the double quotes inside interpolation, everything stays the same for everyone else.

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/231 is a prerequisite to this.