### PR TITLE
6 - Create landing page for Find traffic

### DIFF
--- a/app/controllers/candidate_interface/apply_controller.rb
+++ b/app/controllers/candidate_interface/apply_controller.rb
@@ -1,0 +1,8 @@
+module CandidateInterface
+  class ApplyController < CandidateInterfaceController
+    def show
+      @provider_code = params.fetch(:providerCode)
+      @course_code = params.fetch(:courseCode)
+    end
+  end
+end

--- a/app/views/candidate_interface/apply/show.html.erb
+++ b/app/views/candidate_interface/apply/show.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title, t('page_titles.application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('apply.heading') %>
+    </h1>
+    <p class="govuk-body">
+      You must apply for this course on UCAS. You’ll need to register with UCAS
+      before you can apply. Visit Get into Teaching for
+      <a class="govuk-link" target="_blank" href="https://getintoteaching.education.gov.uk">
+        guidance on applying for teacher training</a>.
+    </p>
+
+    <p class="govuk-body">
+      When you’ll apply you’ll need these codes for the Choices section of your
+      application form:
+    </p>
+
+    <div class="govuk-inset-text">
+      <ul class="govuk-list">
+        <li class="govuk-!-margin-bottom-2">
+          Training provider code:
+          <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">
+            <%= @provider_code %>
+          </span>
+        </li>
+        <li>
+          Training programme code:
+          <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">
+            <%= @course_code %>
+          </span>
+        </li>
+      </ul>
+    </div>
+
+    <a href="https://2019.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">
+      <%= t('apply.apply_button') %>
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    </a>
+  </div>
+</div>

--- a/config/locales/apply.yml
+++ b/config/locales/apply.yml
@@ -1,0 +1,4 @@
+en:
+  apply:
+    heading: Apply for this course
+    apply_button: Apply through UCAS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
 
     get '/sign-in', to: 'sign_in#new', as: :sign_in
     post '/sign-in', to: 'sign_in#create'
+
+    get '/apply', to: 'apply#show'
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/spec/system/candidate_interface/candidate_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe 'A candidate applying from Find' do
+  let(:provider_code) { '1AB' }
+  let(:course_code) { '2ABC' }
+
+  before do
+    visit candidate_interface_apply_path providerCode: provider_code, courseCode: course_code
+  end
+
+  it 'sees the apply page' do
+    expect(page).to have_content t('apply.heading')
+  end
+
+  it 'sees their provider code' do
+    expect(page).to have_content provider_code
+  end
+
+  it 'sees their course code' do
+    expect(page).to have_content course_code
+  end
+
+  it 'can apply through UCAS' do
+    expect(page).to have_content t('apply.apply_button')
+  end
+end


### PR DESCRIPTION
### Context

When Find will start sending traffic over to us, this is the landing page that users will see.

This will be updated to pull in data from the Find API instead of simply displaying the query string parameters (which can be defaced quite easily)

This is the initial page content without the Find API integration.

### Changes proposed in this pull request

Write specs, route, template, controller.

### Guidance to review

![Screenshot 2019-09-30 at 11 55 59](https://user-images.githubusercontent.com/1650875/65873097-12a79a80-e37a-11e9-9a52-f7a0202cc00f.png)

### Link to Trello card

[6 - Create landing page for Find traffic](https://trello.com/c/wvZYWAvT)
