### PR TITLE
Add vendor staging environment to pipeline

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -12,7 +12,7 @@ parameters:
   dockerhubUsername:
   railsSecretKeyBase:
   containerStartTimeLimit: '600'
-  warmupPingPath: 'candidate/sign-up'
+  warmupPingPath: '/candidate/sign-up'
   warmupPingStatus: '200'
   railsEnv: 'production'
   domain:
@@ -67,9 +67,27 @@ jobs:
                 -staging_domain "${{parameters.staging_domain}}"'
               deploymentOutputs: DeploymentOutput
 
+
           - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1
             displayName: 'Parse ARM Deployment Outputs into variables'
             condition: succeeded()
+
+
+          - task: AzurePowerShell@3
+            displayName: 'Azure PowerShell Script - Tag resource group: $(resourceGroupName)'
+            condition: succeeded()
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              ScriptType: InlineScript
+              azurePowerShellVersion: LatestVersion
+              Inline: |
+                Param(
+                  [string] $resourceGroupName = "$(resourceGroupName)",
+                  [string] $environment = "${{parameters.environment}}"
+                )
+
+                Set-AzureRmResourceGroup -Name $resourceGroupName -Tag @{ Environment= "$environment" }
+
 
           - task: AzureAppServiceManage@0
             displayName: 'Start Azure App Service: $(appServiceName)'
@@ -81,6 +99,7 @@ jobs:
               SpecifySlotOrASE: true
               ResourceGroupName: '$(resourceGroupName)'
               Slot: staging
+
 
           - task: AzurePowerShell@3
             displayName: 'Azure PowerShell Script - Web App Warmup: $(appServiceName)'
@@ -117,7 +136,7 @@ jobs:
                     $request = $null 
                     ## Request the URI, and measure how long the response took. 
                     $result1 = Measure-Command { $request = Invoke-WebRequest -Uri "https://$uri" -MaximumRedirection 0 -ErrorAction Ignore } 
-                    write-output **Time took to invoke web request: $result1.TotalMilliseconds **
+                    write-output **Time taken to invoke web request: $result1.TotalMilliseconds **
                     $request
                   }  
                   catch { 
@@ -176,6 +195,7 @@ jobs:
                   }
                 }
 
+
           - task: AzureAppServiceManage@0
             displayName: 'Swap Slots: $(appServiceName)'
             inputs:
@@ -184,6 +204,7 @@ jobs:
               ResourceGroupName: '$(resourceGroupName)'
               SourceSlot: staging
             condition: succeeded()
+
 
           - task: AzureAppServiceManage@0
             displayName: 'Stop Azure App Service: $(appServiceName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,6 +173,32 @@ stages:
       staging_domain: '$(staging_domain)'
 
 
+- stage: deploy_vendor_staging
+  displayName: 'Deploy - Vendor Staging'
+  dependsOn: build_test_release
+  condition: and(succeeded('build_test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  variables:
+  - group: APPLY - ENV - Vendor Staging
+  jobs:
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      debug: $(debug)
+      subscriptionPrefix: 's106'
+      subscriptionName: 'Apply (106) - Test'
+      environment: 'vendor-staging'
+      resourceEnvironmentName: 't02'
+      serviceName: 'apply'
+      containerImageReference: '$(imageName):$(build.buildNumber)'
+      databaseName: 'apply'
+      databaseUsername: 'applyadm512'
+      databasePassword: '$(databasePassword)'
+      dockerhubUsername: '$(dockerHubUsername)'
+      railsSecretKeyBase: '$(railsSecretKeyBase)'
+      railsEnv: 'production'
+      domain: '$(domain)'
+      staging_domain: '$(staging_domain)'
+
+
 # - stage: deploy_production
 #   displayName: 'Deploy - Production'
 #   dependsOn: build_test_release


### PR DESCRIPTION
### Context

A dedicated vendor staging environment is required to enable vendors to test their API integration against.

### Changes proposed in this pull request

1. Create a vendor staging deployment in the test subscription
2. Corrected a typo in the warm-up ping path that was adding an unnecessary delay in the deployment pipeline
3. Added and environment tag to the resource groups in Azure to make it easier to identify the deployments in Azure because the CIP naming convention isn't ideal for this.

### Guidance to review

Only azure pipeline files have been changed with the most significant change being the addition of a new block to add a vendor staging stage to the pipeline.

### Link to Trello card

[1007 - Sandbox Environment for Vendor Integrations](https://trello.com/c/B4VKqUO1/1007-sandbox-environment-for-vendor-integrations)