### PR TITLE
6 - Pull in courses data from Find

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 GOVUK_NOTIFY_API_KEY=
+FIND_BASE_URL=https://bat-qa-mcbe-as.azurewebsites.net/api/v3/

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,1 @@
+FIND_BASE_URL=http://find-test/api/v3/

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'erb_lint', require: false
 gem 'devise'
 
 gem 'json-schema'
+gem 'json_api_client'
 
 gem 'sentry-raven'
 
@@ -40,6 +41,7 @@ group :test do
   gem 'launchy'
   gem 'timecop'
   gem 'guard-rspec'
+  gem 'webmock'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
     climate_control (0.2.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -115,6 +117,8 @@ GEM
       railties (>= 4.2.0)
     faraday (0.16.2)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.13.1)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.11.1)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -142,12 +146,20 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hashdiff (1.0.0)
     html_tokenizer (0.0.7)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
     json-schema (2.8.1)
       addressable (>= 2.4)
+    json_api_client (1.16.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      addressable (~> 2.2)
+      faraday (~> 0.15, >= 0.15.2)
+      faraday_middleware (~> 0.9)
+      rack (>= 0.2)
     jwt (2.2.1)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -281,6 +293,7 @@ GEM
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.3.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -318,6 +331,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.7.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.0.7)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -344,6 +361,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (= 0.9.5)
   guard-rspec
   json-schema
+  json_api_client
   launchy
   listen (>= 3.0.5, < 3.2)
   mail-notify
@@ -362,6 +380,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.1)
   timecop
   web-console (>= 3.3.0)
+  webmock
   webpacker
 
 RUBY VERSION

--- a/app/controllers/candidate_interface/apply_controller.rb
+++ b/app/controllers/candidate_interface/apply_controller.rb
@@ -1,8 +1,20 @@
 module CandidateInterface
   class ApplyController < CandidateInterfaceController
+    rescue_from ActionController::ParameterMissing, with: :render_not_found
+
     def show
-      @provider_code = params.fetch(:providerCode)
-      @course_code = params.fetch(:courseCode)
+      provider_code = params.fetch(:providerCode)
+      course_code = params.fetch(:courseCode)
+
+      @course = FindAPI::Course.fetch(provider_code, course_code)
+
+      render_not_found if @course.nil?
+    end
+
+  private
+
+    def render_not_found
+      render :not_found, status: :not_found
     end
   end
 end

--- a/app/controllers/candidate_interface/applying_controller.rb
+++ b/app/controllers/candidate_interface/applying_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class ApplyController < CandidateInterfaceController
+  class ApplyingController < CandidateInterfaceController
     rescue_from ActionController::ParameterMissing, with: :render_not_found
 
     def show

--- a/app/controllers/candidate_interface/applying_controller.rb
+++ b/app/controllers/candidate_interface/applying_controller.rb
@@ -6,9 +6,13 @@ module CandidateInterface
       provider_code = params.fetch(:providerCode)
       course_code = params.fetch(:courseCode)
 
-      @course = FindAPI::Course.fetch(provider_code, course_code)
+      course = FindAPI::Course.fetch(provider_code, course_code)
 
-      render_not_found if @course.nil?
+      if course.nil?
+        render_not_found
+      else
+        @course = CoursePresenter.new course
+      end
     end
 
   private

--- a/app/models/find_api/course.rb
+++ b/app/models/find_api/course.rb
@@ -15,7 +15,7 @@ module FindAPI
         .first
     rescue JsonApiClient::Errors::NotFound
       nil
-    rescue JsonApiClient::Errors::ServerError
+    rescue JsonApiClient::Errors::ServerError, JsonApiClient::Errors::ConnectionError
       new provider_code: provider_code, course_code: course_code
     end
   end

--- a/app/models/find_api/course.rb
+++ b/app/models/find_api/course.rb
@@ -1,6 +1,7 @@
 module FindAPI
   class Course < JsonApiClient::Resource
-    self.site = 'https://bat-qa-mcbe-as.azurewebsites.net/api/v3/'
+    RECRUITMENT_CYCLE_YEAR = ENV.fetch('RECRUITMENT_CYCLE_YEAR') { 2020 }
+    self.site = ENV.fetch('FIND_BASE_URL')
 
     belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
     belongs_to :provider, param: :provider_code
@@ -8,7 +9,7 @@ module FindAPI
     property :name, type: :string
 
     def self.fetch(provider_code, course_code)
-      where(recruitment_cycle_year: '2020')
+      where(recruitment_cycle_year: RECRUITMENT_CYCLE_YEAR)
         .where(provider_code: provider_code)
         .find(course_code)
         .first

--- a/app/models/find_api/course.rb
+++ b/app/models/find_api/course.rb
@@ -1,0 +1,21 @@
+module FindAPI
+  class Course < JsonApiClient::Resource
+    self.site = 'https://bat-qa-mcbe-as.azurewebsites.net/api/v3/'
+
+    belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
+    belongs_to :provider, param: :provider_code
+
+    property :name, type: :string
+
+    def self.fetch(provider_code, course_code)
+      where(recruitment_cycle_year: '2020')
+        .where(provider_code: provider_code)
+        .find(course_code)
+        .first
+    rescue JsonApiClient::Errors::NotFound
+      nil
+    rescue JsonApiClient::Errors::ServerError
+      new provider_code: provider_code, course_code: course_code
+    end
+  end
+end

--- a/app/presenters/candidate_interface/course_presenter.rb
+++ b/app/presenters/candidate_interface/course_presenter.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  class CoursePresenter
+    def initialize(course = nil)
+      @course = course
+    end
+
+    def provider_code
+      @course.provider_code
+    end
+
+    def course_code
+      @course.course_code
+    end
+
+    def name
+      @course.name
+    end
+
+    def name_and_code
+      "#{name} (#{course_code})"
+    end
+  end
+end

--- a/app/views/candidate_interface/apply/not_found.html.erb
+++ b/app/views/candidate_interface/apply/not_found.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, t('page_titles.application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('layout.service_name') %>
+    </h1>
+
+    <p class="govuk-body">
+      We couldn’t find the course you’re looking for – there may be a problem with the training provider and/or course code(s).
+    </p>
+
+    <p class="govuk-body">
+      Go back to <a href="https://find-postgraduate-teacher-training.education.gov.uk">Find postgraduate teacher training</a> and try selecting your course again, or choose a different course.
+    </p>
+
+    <a href="https://find-postgraduate-teacher-training.education.gov.uk" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">
+      <%= t('apply.find_button') %>
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    </a>
+  </div>
+</div>

--- a/app/views/candidate_interface/apply/show.html.erb
+++ b/app/views/candidate_interface/apply/show.html.erb
@@ -3,6 +3,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
+      <% if @course.name.present? %>
+        <span class="govuk-caption-xl"><%= @course.name %> (<%= @course.course_code %>)</span>
+      <% end %>
       <%= t('apply.heading') %>
     </h1>
     <p class="govuk-body">
@@ -22,13 +25,13 @@
         <li class="govuk-!-margin-bottom-2">
           Training provider code:
           <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">
-            <%= @provider_code %>
+            <%= @course.provider_code %>
           </span>
         </li>
         <li>
           Training programme code:
           <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold">
-            <%= @course_code %>
+            <%= @course.course_code %>
           </span>
         </li>
       </ul>

--- a/app/views/candidate_interface/applying/not_found.html.erb
+++ b/app/views/candidate_interface/applying/not_found.html.erb
@@ -11,7 +11,7 @@
     </p>
 
     <p class="govuk-body">
-      Go back to <a href="https://find-postgraduate-teacher-training.education.gov.uk">Find postgraduate teacher training</a> and try selecting your course again, or choose a different course.
+      Go back to <%= govuk_link_to 'Find postgraduate teacher training', 'https://find-postgraduate-teacher-training.education.gov.uk' %> and try selecting your course again, or choose a different course.
     </p>
 
     <a href="https://find-postgraduate-teacher-training.education.gov.uk" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">

--- a/app/views/candidate_interface/applying/not_found.html.erb
+++ b/app/views/candidate_interface/applying/not_found.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <a href="https://find-postgraduate-teacher-training.education.gov.uk" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">
-      <%= t('apply.find_button') %>
+      <%= t('applying.find_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
       </svg>

--- a/app/views/candidate_interface/applying/show.html.erb
+++ b/app/views/candidate_interface/applying/show.html.erb
@@ -37,7 +37,7 @@
       </ul>
     </div>
 
-    <a href="https://2019.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">
+    <a href="#not-implemented" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">
       <%= t('applying.apply_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/views/candidate_interface/applying/show.html.erb
+++ b/app/views/candidate_interface/applying/show.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <% if @course.name.present? %>
-        <span class="govuk-caption-xl"><%= @course.name %> (<%= @course.course_code %>)</span>
+        <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
       <% end %>
       <%= t('applying.heading') %>
     </h1>

--- a/app/views/candidate_interface/applying/show.html.erb
+++ b/app/views/candidate_interface/applying/show.html.erb
@@ -6,7 +6,7 @@
       <% if @course.name.present? %>
         <span class="govuk-caption-xl"><%= @course.name %> (<%= @course.course_code %>)</span>
       <% end %>
-      <%= t('apply.heading') %>
+      <%= t('applying.heading') %>
     </h1>
     <p class="govuk-body">
       You must apply for this course on UCAS. You’ll need to register with UCAS
@@ -38,7 +38,7 @@
     </div>
 
     <a href="https://2019.teachertraining.apply.ucas.com/apply/student/login.do" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">
-      <%= t('apply.apply_button') %>
+      <%= t('applying.apply_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
       </svg>

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -19,6 +19,7 @@ parameters:
   staging_domain:
   securityAlertEmail: 'apprenticeshipsdevops@education.gov.uk'
   sentryDSN:
+  findBaseUrl:
 
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
@@ -66,7 +67,8 @@ jobs:
                 -govukNotifyAPIKey "$(govukNotifyAPIKey)"
                 -domain "${{parameters.domain}}"
                 -staging_domain "${{parameters.staging_domain}}"
-                -sentryDSN "${{parameters.sentryDSN}}"'
+                -sentryDSN "${{parameters.sentryDSN}}"
+                -findBaseUrl "${{parameters.findBaseUrl}}"'
               deploymentOutputs: DeploymentOutput
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        FIND_BASE_URL: $(findBaseUrl)
 
     - script: make ci.lint-ruby
       displayName: 'Rubocop'
@@ -58,6 +59,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        FIND_BASE_URL: $(findBaseUrl)
 
     - script: make ci.lint-erb
       displayName: 'ERB lint'
@@ -68,6 +70,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        FIND_BASE_URL: $(findBaseUrl)
 
     - script: |
         make ci.test
@@ -81,6 +84,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        FIND_BASE_URL: $(findBaseUrl)
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
@@ -146,6 +150,7 @@ stages:
       domain: '$(domain)'
       staging_domain: '$(staging_domain)'
       sentryDSN: '$(sentryDSN)'
+      findBaseUrl: '$(findBaseUrl)'
 
 
 - stage: deploy_test
@@ -173,6 +178,7 @@ stages:
       domain: '$(domain)'
       staging_domain: '$(staging_domain)'
       sentryDSN: '$(sentryDSN)'
+      findBaseUrl: '$(findBaseUrl)'
 
 - stage: deploy_vendor_staging
   displayName: 'Deploy - Vendor Staging'
@@ -225,4 +231,4 @@ stages:
 #       domain: '$(domain)'
 #       staging_domain: '$(staging_domain)'
 #       sentryDSN: '$(sentryDSN)'
-
+#       findBaseUrl: '$(findBaseUrl)'

--- a/azure/template.json
+++ b/azure/template.json
@@ -111,6 +111,12 @@
             "metadata": {
                 "description": "Sentry client key."
             }
+        },
+        "findBaseUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "The base URL to manage-courses-backend, Find's backend."
+            }
         }
     },
     "variables": {
@@ -251,6 +257,10 @@
                             {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
+                            },
+                            {
+                                "name": "FIND_BASE_URL",
+                                "value": "[parameters('findBaseUrl')]"
                             }
                         ]
                     }

--- a/config/locales/apply.yml
+++ b/config/locales/apply.yml
@@ -2,3 +2,5 @@ en:
   apply:
     heading: Apply for this course
     apply_button: Apply through UCAS
+    find_button: Find postgraduate teacher training
+    heading_not_found: We couldn’t find the course you’re looking for

--- a/config/locales/applying.yml
+++ b/config/locales/applying.yml
@@ -1,5 +1,5 @@
 en:
-  apply:
+  applying:
     heading: Apply for this course
     apply_button: Apply through UCAS
     find_button: Find postgraduate teacher training

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
     get '/sign-in', to: 'sign_in#new', as: :sign_in
     post '/sign-in', to: 'sign_in#create'
 
-    get '/apply', to: 'apply#show'
+    get '/apply', to: 'applying#show'
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/spec/presenters/candidate_interface/course_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/course_presenter_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe CandidateInterface::CoursePresenter do
+  let(:provider_code) { '2AT' }
+  let(:course_code) { '1234' }
+  let(:name) { 'Biology' }
+  let(:find_course) {
+    FindAPI::Course.new(
+      provider_code: provider_code, course_code: course_code, name: name,
+    )
+  }
+  let(:course) { described_class.new find_course }
+
+  describe '#name_and_code' do
+    it 'returns name and code' do
+      expect(course.name_and_code).to eq("#{name} (#{course_code})")
+    end
+  end
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,1 @@
+require 'webmock/rspec'

--- a/spec/system/candidate_interface/candidate_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_spec.rb
@@ -3,24 +3,109 @@ require 'rails_helper'
 describe 'A candidate applying from Find' do
   let(:provider_code) { '1AB' }
   let(:course_code) { '2ABC' }
+  let(:course_name) { 'Biology' }
 
-  before do
-    visit candidate_interface_apply_path providerCode: provider_code, courseCode: course_code
+  shared_examples 'displays basic course information' do
+    it 'sees the apply page' do
+      expect(page).to have_content t('apply.heading')
+    end
+
+    it 'sees their provider code' do
+      expect(page).to have_content provider_code
+    end
+
+    it 'sees their course code' do
+      expect(page).to have_content course_code
+    end
+
+    it 'can apply through UCAS' do
+      expect(page).to have_content t('apply.apply_button')
+    end
   end
 
-  it 'sees the apply page' do
-    expect(page).to have_content t('apply.heading')
+  context 'when Find is available' do
+    before do
+      stub_find_is_up
+    end
+
+    context 'when a valid request is made' do
+      before do
+        visit candidate_interface_apply_path providerCode: provider_code, courseCode: course_code
+      end
+
+      include_examples 'displays basic course information'
+
+      it 'sees additional course information' do
+        expect(page).to have_content "#{course_name} (#{course_code})"
+      end
+    end
+
+    context 'when an invalid request is made' do
+      before do
+        visit candidate_interface_apply_path providerCode: 'BAD', courseCode: 'CODE'
+      end
+
+      it 'sees an error page' do
+        expect(page).to have_content t('apply.heading_not_found')
+      end
+    end
+
+    context "when query parameters are missing" do
+      before do
+        visit candidate_interface_apply_path
+      end
+
+      it 'sees an error page' do
+        expect(page).to have_content t('applying.heading_not_found')
+      end
+    end
   end
 
-  it 'sees their provider code' do
-    expect(page).to have_content provider_code
+  context 'when Find is unavailable' do
+    before do
+      stub_find_is_down
+      visit candidate_interface_apply_path providerCode: provider_code, courseCode: course_code
+    end
+
+    include_examples 'displays basic course information'
+
+    it 'does not see additional course information' do
+      expect(page).not_to have_content "#{course_name} (#{course_code})"
+    end
   end
 
-  it 'sees their course code' do
-    expect(page).to have_content course_code
+  def stub_api_find_course(provider_code, course_code)
+    stub_request(:get, 'https://bat-qa-mcbe-as.azurewebsites.net/api/v3' \
+      '/recruitment_cycles/2020' \
+      "/providers/#{provider_code}" \
+      "/courses/#{course_code}")
   end
 
-  it 'can apply through UCAS' do
-    expect(page).to have_content t('apply.apply_button')
+  def stub_find_is_up
+    stub_api_find_course(provider_code, course_code)
+    .to_return(
+      status: 200,
+      headers: { 'Content-Type': 'application/vnd.api+json' },
+      body: {
+        'data' => {
+          'id' => '1',
+          'type' => 'courses',
+          'attributes' => {
+            'course_code' => course_code,
+            'name' => course_name,
+            'provider_code' => provider_code,
+          },
+        },
+        'jsonapi' => { 'version' => '1.0' },
+      }.to_json,
+    )
+
+    stub_api_find_course('BAD', 'CODE')
+      .to_return(status: 404)
+  end
+
+  def stub_find_is_down
+    stub_api_find_course(provider_code, course_code)
+      .to_return(status: 503)
   end
 end

--- a/spec/system/candidate_interface/candidate_applying_spec.rb
+++ b/spec/system/candidate_interface/candidate_applying_spec.rb
@@ -7,7 +7,7 @@ describe 'A candidate applying from Find' do
 
   shared_examples 'displays basic course information' do
     it 'sees the apply page' do
-      expect(page).to have_content t('apply.heading')
+      expect(page).to have_content t('applying.heading')
     end
 
     it 'sees their provider code' do
@@ -19,7 +19,7 @@ describe 'A candidate applying from Find' do
     end
 
     it 'can apply through UCAS' do
-      expect(page).to have_content t('apply.apply_button')
+      expect(page).to have_content t('applying.apply_button')
     end
   end
 
@@ -46,7 +46,7 @@ describe 'A candidate applying from Find' do
       end
 
       it 'sees an error page' do
-        expect(page).to have_content t('apply.heading_not_found')
+        expect(page).to have_content t('applying.heading_not_found')
       end
     end
 


### PR DESCRIPTION
### Context

First attempt at pulling in data from Find. ⬇️ 

### Changes proposed in this pull request

The main work here is implementing a pattern for querying the Find API in a way where we
use them if available, but can gracefully fallback to a simpler page should their service return a `50X` status code.

When Find returns a 404 (indicating the course information in the URL is invalid), we now display a `not_found` page with some fresh content.

Additionally:

- Add `json_api_client` and `webmock` as dependencies
- Rename `apply_controller` and its ilk to `applying` as that feels better cc @duncanjbrown 
- Handle the case where there are are no query string params
- Add environment variables for `FIND_BASE_URL` to the pipeline, and also allow `RECRUITMENT_CYCLE_YEAR` to be passed in (eventually, one year away)

### Guidance to review

What do you think of `FindAPI::Course.fetch`?

The proposed `/api/v3/` Find API does not yet exist, but it's reasonable to assume it'll follow this shape.

In the future, we may consider using some form of cached data instead of always querying Find as we do here. This can be done as a follow-up.

A few other things I might do:

- [ ] ~Create factories for the json api response data?~ Not sure if worth
- [x] Use `govuk_link_to` where relevant after #242 is merged
- [ ] Investigate at least one alternative to `json_api_client`

### Link to Trello card

[6 - Create landing page for Find traffic](https://trello.com/c/wvZYWAvT/6-create-landing-page-for-find-traffic)
