### PR TITLE
Add Sentry for production logging debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'devise'
 
 gem 'json-schema'
 
+gem 'sentry-raven'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     factory_bot_rails (5.1.0)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    faraday (0.16.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -168,7 +170,8 @@ GEM
     mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.12.2)
+    minitest (5.12.0)
+    multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.2)
     nokogiri (1.10.4)
@@ -289,6 +292,8 @@ GEM
     selenium-webdriver (3.142.4)
       childprocess (>= 0.5, < 3.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    sentry-raven (2.11.3)
+      faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
@@ -354,6 +359,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   selenium-webdriver
+  sentry-raven
   shoulda-matchers (~> 4.1)
   timecop
   web-console (>= 3.3.0)

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -18,7 +18,8 @@ parameters:
   domain:
   staging_domain:
   securityAlertEmail: 'apprenticeshipsdevops@education.gov.uk'
-  
+  sentryDSN:
+
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
     displayName: 'Deploy App to ${{parameters.subscriptionName}} Subscription'
@@ -49,22 +50,23 @@ jobs:
               resourceGroupName: '$(resourceGroupName)'
               location: 'West Europe'
               csmFile: '$(Pipeline.Workspace)\arm_template\template.json'
-              overrideParameters: '-resourceEnvironmentName "${{parameters.resourceEnvironmentName}}" 
-                -serviceName "${{parameters.serviceName}}" 
-                -dockerHubUsername "${{parameters.dockerHubUsername}}" 
-                -containerImageReference "${{parameters.containerImageReference}}" 
-                -railsEnv "${{parameters.railsEnv}}" 
-                -databaseName "${{parameters.databaseName}}" 
-                -databaseUsername "${{parameters.databaseUsername}}" 
-                -databasePassword "${{parameters.databasePassword}}" 
-                -securityAlertEmail "${{parameters.securityAlertEmail}}" 
+              overrideParameters: '-resourceEnvironmentName "${{parameters.resourceEnvironmentName}}"
+                -serviceName "${{parameters.serviceName}}"
+                -dockerHubUsername "${{parameters.dockerHubUsername}}"
+                -containerImageReference "${{parameters.containerImageReference}}"
+                -railsEnv "${{parameters.railsEnv}}"
+                -databaseName "${{parameters.databaseName}}"
+                -databaseUsername "${{parameters.databaseUsername}}"
+                -databasePassword "${{parameters.databasePassword}}"
+                -securityAlertEmail "${{parameters.securityAlertEmail}}"
                 -secretKeyBase "${{parameters.railsSecretKeyBase}}"
                 -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
                 -warmupPingPath "${{parameters.warmupPingPath}}"
                 -warmupPingStatus "${{parameters.warmupPingStatus}}"
                 -govukNotifyAPIKey "$(govukNotifyAPIKey)"
                 -domain "${{parameters.domain}}"
-                -staging_domain "${{parameters.staging_domain}}"'
+                -staging_domain "${{parameters.staging_domain}}"
+                -sentryDSN "${{parameters.sentryDSN}}"'
               deploymentOutputs: DeploymentOutput
 
 
@@ -116,44 +118,44 @@ jobs:
                   [int]$timeoutInMinutes = 5,
                   [int]$sleepDelaySeconds = 10
                 )
-                
-                $result = @() 
+
+                $result = @()
                 $restartCount = 1
 
                 #Get current date and time for timeout properties
                 $startTime = (get-date).ToString()
-                
+
                 #Timer starts now
                 write-output "Elapsed:00:00:00"
                 $continue = $true
 
                 $uri = ("{0}-staging.azurewebsites.net{1}" -f $appservicename, $path)
-                
+
                 While ( $continue )
                 {
-                  $webrequest = try { 
-                  
-                    $request = $null 
-                    ## Request the URI, and measure how long the response took. 
-                    $result1 = Measure-Command { $request = Invoke-WebRequest -Uri "https://$uri" -MaximumRedirection 0 -ErrorAction Ignore } 
+                  $webrequest = try {
+
+                    $request = $null
+                    ## Request the URI, and measure how long the response took.
+                    $result1 = Measure-Command { $request = Invoke-WebRequest -Uri "https://$uri" -MaximumRedirection 0 -ErrorAction Ignore }
                     write-output **Time taken to invoke web request: $result1.TotalMilliseconds **
                     $request
-                  }  
-                  catch { 
-                    $request = $_.Exception.Response 
-                    $time = -1 
-                  }   
-                
-                  $result = [PSCustomObject] @{ 
-                    Time = Get-Date; 
-                    Uri = $uri; 
-                    StatusCode = [int] $request.StatusCode; 
-                    StatusDescription = $request.StatusDescription; 
-                    ResponseLength = $request.RawContentLength; 
-                    TimeTaken =  $time.TotalMilliseconds;
-                    WebRequest = $webrequest 
                   }
-                        
+                  catch {
+                    $request = $_.Exception.Response
+                    $time = -1
+                  }
+
+                  $result = [PSCustomObject] @{
+                    Time = Get-Date;
+                    Uri = $uri;
+                    StatusCode = [int] $request.StatusCode;
+                    StatusDescription = $request.StatusDescription;
+                    ResponseLength = $request.RawContentLength;
+                    TimeTaken =  $time.TotalMilliseconds;
+                    WebRequest = $webrequest
+                  }
+
                   $sleeprequired = $false
                   $outputstatuscode=$result.StatusCode
                   $outputuri=($result.uri).ToString()
@@ -165,18 +167,18 @@ jobs:
                     Write-Output "$outputuri is up and running. Redirection is in place. Status code = $outputstatuscode "
                     Write-Output "$outputuri is redirected to $outputwebrequest "
                   }
-                  else { 
+                  else {
                     Write-Output "$outputuri site is currently down or unreachable"
                     $sleeprequired = $true
                     # Remove comment to display extra info # write-output $result | fl
                     #reseting previous result
-                    $result = @() 
+                    $result = @()
                   }
-                
+
                   $currenttime = (get-date).ToString()
                   $elapsedTime = new-timespan $startTime $currenttime
-                  write-output "Elapsed:$($elapsedTime.ToString("hh\:mm\:ss"))"  
-                
+                  write-output "Elapsed:$($elapsedTime.ToString("hh\:mm\:ss"))"
+
                   #Handle event
                   if ( $elapsedTime.Minutes -ge $timeoutInMinutes ) {
                     if ( $restartCount -gt 0 ) {
@@ -187,7 +189,7 @@ jobs:
                     } else {
                       exit(1)
                     }
-                  } elseif ( $sleeprequired -eq $false) { 
+                  } elseif ( $sleeprequired -eq $false) {
                     exit(0)
                   } else {
                     write-output ("Sleeping for {0}s..." -f $sleepDelaySeconds)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        SENTRY_DSN: $(sentryDSN)
 
     - script: make ci.lint-ruby
       displayName: 'Rubocop'
@@ -58,6 +59,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        SENTRY_DSN: $(sentryDSN)
 
     - script: make ci.lint-erb
       displayName: 'ERB lint'
@@ -68,6 +70,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        SENTRY_DSN: $(sentryDSN)
 
     - script: |
         make ci.test
@@ -81,6 +84,7 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
+        SENTRY_DSN: $(sentryDSN)
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
@@ -145,6 +149,7 @@ stages:
       railsEnv: 'production'
       domain: '$(domain)'
       staging_domain: '$(staging_domain)'
+      sentryDSN: '$(sentryDSN)'
 
 
 - stage: deploy_test
@@ -171,7 +176,7 @@ stages:
       railsEnv: 'production'
       domain: '$(domain)'
       staging_domain: '$(staging_domain)'
-
+      sentryDSN: '$(sentryDSN)'
 
 - stage: deploy_vendor_staging
   displayName: 'Deploy - Vendor Staging'
@@ -223,3 +228,5 @@ stages:
 #       railsEnv: 'production'
 #       domain: '$(domain)'
 #       staging_domain: '$(staging_domain)'
+#       sentryDSN: '$(sentryDSN)'
+

--- a/azure/template.json
+++ b/azure/template.json
@@ -105,6 +105,12 @@
             "metadata": {
                 "description": "Serve static files."
             }
+        },
+        "sentryDSN": {
+            "type": "string",
+            "metadata": {
+                "description": "Sentry client key."
+            }
         }
     },
     "variables": {
@@ -241,6 +247,10 @@
                             {
                                 "name": "STAGING_DOMAIN",
                                 "value": "[parameters('staging_domain')]"
+                            },
+                            {
+                                "name": "SENTRY_DSN",
+                                "value": "[parameters('sentryDSN')]"
                             }
                         ]
                     }

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -8,3 +8,4 @@ services:
       - SECRET_KEY_BASE=${railsSecretKeyBase}
       - DOMAIN=${domain}
       - STAGING_DOMAIN=${staging_domain}
+      - SENTRY_DSN


### PR DESCRIPTION
### Context

We have no visibility and we get no notifications when stuff goes wrong on our deployed applications.

Sentry can provide real-time Slack notifications when errors occur, and it will log the context of a request as well as the full error message.

### Changes proposed in this pull request

This PR adds:

- Raven the Ruby client for Sentry to the Gemfile
- configuration in the Rails production environment
- a `SENTRY_DSN` environment variable

### Guidance to review

Has the environment variable been unnecessarily added anywhere?

Also, apologies my editor has done some deletion of whitespaces so would recommend viewing diff to hide whitespace changes (Theo taught me dis).

### Link to Trello card

[82 - Add Sentry for production logging debugging](82-add-sentry-for-production-logging-debugging)
