### PR TITLE
Add email validation for sign-up

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -4,5 +4,7 @@ class Candidate < ApplicationRecord
   devise :timeoutable
   validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
 
+  validates :email_address, format: { with: /@/ }
+
   has_many :application_forms
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,3 +45,4 @@ en:
               blank: Enter your email address
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer
+              invalid: Enter an email address in the correct format, like name@example.com

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -3,9 +3,14 @@ require 'rails_helper'
 RSpec.describe Candidate, type: :model do
   subject { FactoryBot.create(:candidate) }
 
-  it { is_expected.to validate_presence_of :email_address }
-  it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
-  it { is_expected.to validate_uniqueness_of :email_address }
+  describe 'a valid candidate' do
+    it { is_expected.to validate_presence_of :email_address }
+    it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
+    it { is_expected.to validate_uniqueness_of :email_address }
+
+    it { is_expected.to allow_value('candidate@example.com').for(:email_address) }
+    it { is_expected.not_to allow_value('candidate.com').for(:email_address) }
+  end
 
   describe '#delete' do
     it 'deletes all dependent records through cascading deletes in the database' do


### PR DESCRIPTION
### Context
We need the candidate to enter a valid email.

### Changes proposed in this pull request

Add simple validation that checks the presence of the `@` in the email.

### Guidance to review
note: the message is set in the `:invalid` key in the internationalization YAML file, it is automatically recognized by rails as the error message for invalid format.

### Link to Trello card
66-implement-sign-up-using-magic-links

