### PR TITLE
Fix styling for links using a view helper

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,0 +1,11 @@
+module ViewHelper
+  def govuk_link_to(body, url, html_options = {})
+    if html_options[:class]
+      html_options[:class].prepend('govuk-link ')
+    else
+      html_options[:class] = 'govuk-link'
+    end
+
+    link_to(body, url, html_options)
+  end
+end

--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -9,7 +9,7 @@
       Apply for teacher training is a new GOV.UK service being trialled with a small number of training providers.
     </p>
     <div class="govuk-inset-text">
-      Learn more about teacher training in <a href="https://www.discoverteaching.wales/routes-into-teaching/">Wales</a>, <a href="https://teachinscotland.scot/">Scotland</a> and <a href="https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland">Northern Ireland</a>
+      Learn more about teacher training in <%= govuk_link_to('Wales', 'https://www.discoverteaching.wales/routes-into-teaching/', target: :_blank) %>, <%= govuk_link_to('Scotland', 'https://teachinscotland.scot/', target: :_blank) %> and <%= govuk_link_to('Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland', target: :_blank) %>
     </div>
     <h2 class="govuk-heading-m">What you’ll need</h2>
     <p class="govuk-body">
@@ -26,7 +26,7 @@
     <h2 class="govuk-heading-m">If you don’t have a degree</h2>
     <p class="govuk-body">
       You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status.
-      <a href="https://getintoteaching.education.gov.uk/eligibility-for-teacher-training">Learn more</a>.
+      <%= govuk_link_to('Learn more', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
     </p>
     <%= link_to candidate_interface_sign_up_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
@@ -34,6 +34,6 @@
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
       </svg>
     <% end %>
-    <p class="govuk-body">If you have teacher training applications in progress, please <%= link_to 'sign in', candidate_interface_sign_in_path %></p>
+    <p class="govuk-body">If you have teacher training applications in progress, please <%= govuk_link_to 'sign in', candidate_interface_sign_in_path %></p>
   </div>
 </div>

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'View helpers', type: :helper do
+  describe '#govuk_link_to' do
+    it 'returns an anchor tag with the govuk-link class' do
+      anchor_tag = helper.govuk_link_to('Woof', 'https://localhost:0103/dog/woof')
+
+      expect(anchor_tag).to eq('<a class="govuk-link" href="https://localhost:0103/dog/woof">Woof</a>')
+    end
+
+    it 'returns an anchor tag with the govuk-link class and target="_blank"' do
+      anchor_tag = helper.govuk_link_to('Meow', 'https://localhost:0103/cat/meow', target: :_blank)
+
+      expect(anchor_tag).to eq('<a target="_blank" class="govuk-link" href="https://localhost:0103/cat/meow">Meow</a>')
+    end
+
+    it 'returns an anchor tag with additional HTML options' do
+      anchor_tag = helper.govuk_link_to('Baaa', 'https://localhost:0103/sheep/baaa', class: 'govuk-link--no-visited-state', target: :_blank)
+
+      expect(anchor_tag).to eq('<a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://localhost:0103/sheep/baaa">Baaa</a>')
+    end
+  end
+end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'View helpers', type: :helper do
+RSpec.describe ViewHelper, type: :helper do
   describe '#govuk_link_to' do
     it 'returns an anchor tag with the govuk-link class' do
       anchor_tag = helper.govuk_link_to('Woof', 'https://localhost:0103/dog/woof')


### PR DESCRIPTION
### Context

There are links on the start page that are not using the `govuk-link` class and don't match the styling of the application.

### Changes proposed in this pull request

This PR adds `ViewHelper#govuk_link_to` that creates links using the `govuk-link` CSS class.

#### Before

![image](https://user-images.githubusercontent.com/42817036/65959307-88c70280-e449-11e9-9451-bc93ebdb8bb1.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/65959275-7a78e680-e449-11e9-8ce5-5211a3ebfd06.png)

### Guidance to review

Have I missed any links that need to use the `govuk-link` class?

### Link to Trello card

[79 - Fix styling for links](https://trello.com/c/3TUn6spl/79-fix-styling-for-links)
