### PR TITLE
Use acceptance-like rspec style for system tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,8 @@ Naming/UncommunicativeMethodParamName:
   AllowedNames:
     - e
     - to
+
+Capybara/FeatureMethods:
+  EnabledMethods:
+    - feature
+    - scenario

--- a/spec/system/candidate_interface/candidate_applying_spec.rb
+++ b/spec/system/candidate_interface/candidate_applying_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# TODO: This test needs to be rewritten to use the new acceptance-test style
+# specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
 describe 'A candidate applying from Find' do
   let(:provider_code) { '1AB' }
   let(:course_code) { '2ABC' }

--- a/spec/system/candidate_interface/candidate_expire_session_spec.rb
+++ b/spec/system/candidate_interface/candidate_expire_session_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# TODO: This test needs to be rewritten to use the new acceptance-test style
+# specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
 describe 'Candidate session expires' do
   it 'expires the current candidate session' do
     candidate = FactoryBot.create(:candidate)

--- a/spec/system/candidate_interface/candidate_signing_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_in_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# TODO: This test needs to be rewritten to use the new acceptance-test style
+# specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
 describe 'A candidate signing in' do
   include TestHelpers::SignUp
 

--- a/spec/system/candidate_interface/candidate_signing_out_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_out_spec.rb
@@ -1,40 +1,28 @@
 require 'rails_helper'
 
-describe 'A candidate signing out' do
-  context 'when a candidate is signed in' do
-    before do
-      candidate = FactoryBot.create(:candidate)
-      login_as(candidate)
-
-      visit candidate_interface_welcome_path
-    end
-
-    it 'displays a sign out button' do
-      expect(page).to have_selector :link_or_button, 'Sign out'
-    end
-
-    describe 'click the sign out button' do
-      it 'displays the start page' do
-        click_link 'Sign out'
-
-        expect(page).to have_current_path(candidate_interface_start_path)
-      end
-
-      it 'can only access start page' do
-        click_link 'Sign out'
-
-        visit candidate_interface_welcome_path
-
-        expect(page).to have_current_path(candidate_interface_start_path)
-      end
-    end
+RSpec.feature 'Signing out' do
+  scenario 'Logged in candidate signs out' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+    when_i_click_the_sign_out_button
+    then_i_should_be_signed_out
   end
 
-  context 'when a candidate is not signed in' do
-    it 'does not display a sign out button' do
-      visit candidate_interface_start_path
+  def given_i_am_signed_in
+    candidate = FactoryBot.create(:candidate)
+    login_as(candidate)
+  end
 
-      expect(page).not_to have_selector :link_or_button, 'Sign out'
-    end
+  def and_i_visit_the_site
+    visit candidate_interface_welcome_path
+  end
+
+  def when_i_click_the_sign_out_button
+    click_link 'Sign out'
+  end
+
+  def then_i_should_be_signed_out
+    expect(page).not_to have_selector :link_or_button, 'Sign out'
+    expect(page).to have_current_path(candidate_interface_start_path)
   end
 end

--- a/spec/system/candidate_interface/candidate_signing_up_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_up_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# TODO: This test needs to be rewritten to use the new acceptance-test style
+# specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
 describe 'A candidate signing up' do
   include TestHelpers::SignUp
 


### PR DESCRIPTION
### Context

We currently use a RSpec style for system tests where we use `before` blocks and multiple `it` blocks for assertions. After talking to @duncanjbrown, it seems that we have a preference for the style that was first described by FutureLearn in this blog post:

https://about.futurelearn.com/blog/how-we-write-readable-feature-tests-with-rspec

MadeTech also has a blog post about it:

https://www.madetech.com/blog/feature-testing-with-rspec

The upsides of this pattern are:

- We're being super clear about what we're expecting and why
- It's both readable by reading the `scenario` block, and the individual methods
- It's pure ruby, no cucumber needed

It has been used a lot on GOV.UK, for example in this application:

https://github.com/alphagov/content-publisher/tree/master/spec/features

### Changes proposed in this pull request

This changes a single test as an example. If we agree that this is something to adopt, we can rewite the other tests.

### Guidance to review

Check out the rewritten spec:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/system-tests/spec/system/candidate_interface/candidate_signing_out_spec.rb

