### PR TITLE
Let govuk-lint handle our rubocop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'govuk_design_system_formbuilder', '0.9.5'
 gem 'mail-notify'
 
 # Linting
-gem 'rubocop'
 gem 'rubocop-rspec'
 gem 'govuk-lint'
 gem 'erb_lint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
     rspec-support (3.8.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.75.0)
+    rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
@@ -356,7 +356,6 @@ DEPENDENCIES
   rails-erd
   rspec-rails
   rspec_junit_formatter
-  rubocop
   rubocop-rspec
   selenium-webdriver
   sentry-raven


### PR DESCRIPTION
### Context

We upgraded to Rubocop 0.75.0 (#239) which caused a lot of warnings from the `govuk-lint` gem. This gem can handle our rubocop dependency for us, so let us not declare a rival `rubocop` in our `Gemfile`.