### PR TITLE
Add sign in for candidates who use the sign up form to sign in

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -5,9 +5,12 @@ module CandidateInterface
     end
 
     def create
-      @candidate = Candidate.new(candidate_params)
+      @candidate = Candidate.find_or_initialize_by(candidate_params)
 
-      if @candidate.save
+      if @candidate.persisted?
+        MagicLinkSignIn.call(candidate: @candidate)
+        render 'candidate_interface/sign_in/show'
+      elsif @candidate.save
         MagicLinkSignUp.call(candidate: @candidate)
         render :show
       else

--- a/spec/system/candidate_interface/candidate_signing_up_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_up_spec.rb
@@ -16,6 +16,12 @@ describe 'A candidate signing up' do
       expect(page).to have_content t('authentication.check_your_email')
     end
 
+    it 'receives the sign up email' do
+      open_email('april@pawnee.com')
+
+      expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
+    end
+
     context 'receives an email with a valid magic link' do
       let(:sign_in_link) { current_email.find_css('a').first }
 

--- a/spec/system/candidate_interface/candidate_signing_up_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_up_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'A candidate signing up' do
   include TestHelpers::SignUp
 
-  context 'who successfully signs up' do
+  context 'who does not have an account' do
     before do
       visit '/'
       click_on t('application_form.begin_button')
@@ -38,14 +38,33 @@ describe 'A candidate signing up' do
     end
   end
 
-  context 'who tries to sign up twice' do
-    it 'sees the form error summary' do
+  context 'who already has an account' do
+    before do
       visit candidate_interface_sign_up_path
       fill_in_sign_up
-      visit candidate_interface_sign_up_path
-      fill_in_sign_up
+      open_email('april@pawnee.com')
+      current_email.find_css('a').first.click
+      click_link 'Sign out'
 
-      expect(page).to have_content 'There is a problem'
+      visit candidate_interface_sign_up_path
+      fill_in_sign_up
+    end
+
+    it 'receives the sign in email' do
+      open_email('april@pawnee.com')
+
+      expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+    end
+
+    it 'sees the check your email page' do
+      expect(page).to have_content t('authentication.check_your_email')
+    end
+
+    it 'does sign the user in' do
+      open_email('april@pawnee.com')
+      current_email.find_css('a').first.click
+
+      expect(page).to have_content 'april@pawnee.com'
     end
   end
 


### PR DESCRIPTION
### Context

We currently tell users who use an existing mail in the sign up form that the "Email address is already in use." We should instead just sign them in.

Paul L has provided a table describing the logic: https://docs.google.com/spreadsheets/d/16wv92fkfYCwY5KHcJe3YpufXEYQG8EgCjSkjcyOwhIY/edit#gid=0 

### Changes proposed in this pull request

This PR adds the ability to allow a candidate who already has created an account to use the sign up form to sign in.

It also adds a spec to ensure that the correct email is sent when signing up. From https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/248/commits/76e5e38626867e6b7f61d12e8b4384211521599d:

>More specifically this is a regression test to ensure that the incorrect magic link
service is not used as it's the service that handles sending the email. E.g. if the
MagicLinkSignIn service was used after a candidate is created, tests at its current
state would have still passed but the incorrect email would have been received.

### Guidance to review

Are the specs clear? Would recommend going through the flow to ensure it's what we expect.

### Link to Trello card

[77 - Sign in users who use the sign up form](https://trello.com/c/8yYJ2e9z/77-sign-in-users-who-use-the-sign-up-form)
