### PR TITLE
Remove SENTRY_DSN environment variable from scripts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,6 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
-        SENTRY_DSN: $(sentryDSN)
 
     - script: make ci.lint-ruby
       displayName: 'Rubocop'
@@ -59,7 +58,6 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
-        SENTRY_DSN: $(sentryDSN)
 
     - script: make ci.lint-erb
       displayName: 'ERB lint'
@@ -70,7 +68,6 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
-        SENTRY_DSN: $(sentryDSN)
 
     - script: |
         make ci.test
@@ -84,7 +81,6 @@ stages:
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         DOMAIN: $(domain)
         STAGING_DOMAIN: $(domain)
-        SENTRY_DSN: $(sentryDSN)
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)


### PR DESCRIPTION
### Context

Sentry was triggered when a draft PR was made, this was not expected.

### Changes proposed in this pull request

This PR removes `SENTRY_DSN` environment variable from scripts as Sentry isn't required for these scripts and cause Sentry being triggered when PRs are made.

### Guidance to review

Does it make sense?

### Link to Trello card

N/A
