### PR TITLE
Add endpoint to generate test data

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -1,0 +1,8 @@
+module VendorApi
+  class TestDataController < VendorApiController
+    def regenerate
+      GenerateTestData.new.generate([params[:count].to_i, 100].min)
+      render json: { data: { message: 'OK, regenerated the test data' } }
+    end
+  end
+end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -1,4 +1,11 @@
 module VendorApi
   class VendorApiController < ActionController::API
+    before_action :set_cors_headers
+
+  private
+
+    def set_cors_headers
+      headers['Access-Control-Allow-Origin'] = '*'
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
   namespace :vendor_api, path: 'api/v1' do
     get '/applications' => 'applications#index'
     get '/applications/:application_id' => 'applications#show'
+
+    post '/test-data/regenerate' => 'test_data#regenerate'
+
     get '/ping', to: 'ping#ping'
   end
 

--- a/config/vendor-api-0.4.0.yml
+++ b/config/vendor-api-0.4.0.yml
@@ -189,8 +189,33 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+  "/test-data/regenerate":
+    post:
+      tags:
+        - Testing
+      summary: Regenerate test data
+      description: Deletes all applications and generates 100 new applications
+      parameters:
+        - name: count
+          description: How many items to generate (max 100)
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          $ref: "#/components/responses/OK"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
 components:
   responses:
+    OK:
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OkResponse"
+
     NotFound:
       description: Not found
       content:
@@ -725,6 +750,19 @@ components:
           example:
             - error: ParameterMissing
               message: "param is missing or the value is empty: parameter_name"
+    OkResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: object
+          required:
+            - message
+          properties:
+            message:
+              type: string
+              example: "OK"
 
   parameters:
     application_id:

--- a/config/vendor-api-0.4.0.yml
+++ b/config/vendor-api-0.4.0.yml
@@ -6,6 +6,15 @@ info:
     name: DfE
     email: becomingateacher@digital.education.gov.uk
   description: API for DfE's Apply for postgraduate teacher training service
+servers:
+  - description: Local development environment
+    url: http://localhost:3000/api/v1
+  - description: DfE development environment
+    url: https://s106d01-apply-as.azurewebsites.net/api/v1
+  - description: DfE test environment
+    url: https://s106t01-apply-as.azurewebsites.net/api/v1
+  - description: Vendor sandbox
+    url: https://s106t02-apply-as.azurewebsites.net/api/v1
 paths:
   /applications:
     get:

--- a/config/vendor-api-0.4.0.yml
+++ b/config/vendor-api-0.4.0.yml
@@ -684,16 +684,6 @@ components:
           example:
             - error: NotFound
               message: Unable to find Application(s)
-    NotFoundResponse:
-      type: object
-      properties:
-        errors:
-          type: array
-          items:
-            $ref: "#/components/schemas/Error"
-          example:
-            - error: NotFound
-              message: Unable to find Application(s)
     UnauthorizedResponse:
       type: object
       properties:

--- a/config/vendor-api-0.4.0.yml
+++ b/config/vendor-api-0.4.0.yml
@@ -18,6 +18,8 @@ servers:
 paths:
   /applications:
     get:
+      tags:
+        - Application management
       summary: Get many applications
       description: Applications are returned in the order they were changed or created.
       parameters:
@@ -47,6 +49,8 @@ paths:
           $ref: "#/components/responses/ParameterMissing"
   "/applications/{application_id}":
     get:
+      tags:
+        - Application management
       summary: Get a single application
       parameters:
         - $ref: "#/components/parameters/application_id"
@@ -63,6 +67,8 @@ paths:
           $ref: "#/components/responses/NotFound"
   "/applications/{application_id}/offer":
     post:
+      tags:
+        - Application management
       summary: Make an offer
       description: Make an unconditional or conditional offer
       parameters:
@@ -94,6 +100,8 @@ paths:
           $ref: "#/components/responses/NotFound"
   "/applications/{application_id}/confirm-enrolment":
     post:
+      tags:
+        - Application management
       summary: Confirm enrolment
       description: Confirm that the candidate has enrolled
       parameters:
@@ -119,6 +127,8 @@ paths:
           $ref: "#/components/responses/NotFound"
   "/applications/{application_id}/confirm-conditions-met":
     post:
+      tags:
+        - Application management
       summary: Confirm offer conditions
       description: Confirm that the candidate has met all the conditions set out in the offer
       parameters:
@@ -144,6 +154,8 @@ paths:
           $ref: "#/components/responses/NotFound"
   "/applications/{application_id}/reject":
     post:
+      tags:
+        - Application management
       summary: Reject application
       description: Reject the candidate's application with a reason
       parameters:

--- a/spec/requests/vendor_api/post_test_data_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1/test-data/regenerate', type: :request do
+  include VendorApiSpecHelpers
+
+  it 'generates test data' do
+    post '/api/v1/test-data/regenerate?count=3'
+
+    expect(Candidate.count).to be(3)
+    expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
+  end
+end


### PR DESCRIPTION
### Context

We can now create test data (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/253). This adds an endpoint to the provider API to do the same. This allows for easier testing of production environments.

### Changes proposed in this pull request

<img width="659" alt="Screenshot 2019-10-02 at 12 27 38" src="https://user-images.githubusercontent.com/233676/66040705-0fdeae00-e510-11e9-9ab9-8e3428fd96ec.png">

Testing it ✨ works ✨ 

<img width="658" alt="Screenshot 2019-10-02 at 12 27 47" src="https://user-images.githubusercontent.com/233676/66040706-0fdeae00-e510-11e9-8530-f9757fb9d9ac.png">

### Guidance to review

Read the code, try it out in the Swagger editor (only against localhost and from http://editor.swagger.io/)

### Link to Trello card

https://trello.com/c/w5aoXbeK/1041-create-rake-task-to-create-a-bunch-of-test-data
