### PR TITLE
1036 api endpoint to make an offer

### DIFF
--- a/app/controllers/vendor_api/offers_controller.rb
+++ b/app/controllers/vendor_api/offers_controller.rb
@@ -1,0 +1,22 @@
+module VendorApi
+  class OffersController < VendorApiController
+    rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
+
+    def create
+      application_choice = ApplicationChoice.find(params[:application_id])
+
+      make_an_offer = MakeAnOffer.new(application_choice: application_choice, offer_conditions: params[:data]).call
+      if make_an_offer.successful?
+        render json: { data: SingleApplicationPresenter.new(make_an_offer.application_choice).as_json }
+      else
+        raise NotImplementedError
+      end
+    end
+
+  private
+
+    def application_not_found(_e)
+      render json: { errors: [{ error: 'NotFound', message: "Could not find an application with ID #{params[:application_id]}" }] }, status: 404
+    end
+  end
+end

--- a/app/controllers/vendor_api/offers_controller.rb
+++ b/app/controllers/vendor_api/offers_controller.rb
@@ -8,8 +8,6 @@ module VendorApi
       make_an_offer = MakeAnOffer.new(application_choice: application_choice, offer_conditions: params[:data]).call
       if make_an_offer.successful?
         render json: { data: SingleApplicationPresenter.new(make_an_offer.application_choice).as_json }
-      else
-        raise NotImplementedError
       end
     end
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -4,5 +4,6 @@ class ApplicationChoice < ApplicationRecord
   enum status: {
     application_complete: 'application_complete',
     conditional_offer: 'conditional_offer',
+    unconditional_offer: 'unconditional_offer',
   }
 end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -1,0 +1,15 @@
+class MakeAnOffer
+  Response = Struct.new(:successful?, :application_choice)
+
+  def initialize(application_choice:, offer_conditions:)
+    @application_choice = application_choice
+    @offer_conditions = offer_conditions
+  end
+
+  def call
+    @application_choice.status = @offer_conditions.present? ? :conditional_offer : :unconditional_offer
+    @application_choice.offer = @offer_conditions.present? ? @offer_conditions : { 'conditions' => [] }
+    @application_choice.save
+    Response.new(true, @application_choice)
+  end
+end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -7,8 +7,14 @@ class MakeAnOffer
   end
 
   def call
-    @application_choice.status = @offer_conditions.present? ? :conditional_offer : :unconditional_offer
-    @application_choice.offer = @offer_conditions.present? ? @offer_conditions : { 'conditions' => [] }
+    if @offer_conditions.present?
+      @application_choice.status = :conditional_offer
+      @application_choice.offer = @offer_conditions
+    else
+      @application_choice.status = :unconditional_offer
+      @application_choice.offer = { 'conditions' => [] }
+    end
+
     @application_choice.save
     Response.new(true, @application_choice)
   end

--- a/app/services/vendor_api/single_application_presenter.rb
+++ b/app/services/vendor_api/single_application_presenter.rb
@@ -41,7 +41,7 @@ module VendorApi
           qualifications: [],
           references: [],
           work_experiences: [],
-          offer: nil,
+          offer: application_choice.offer,
           rejection: nil,
           withdrawal: nil,
           hesa_itt_data: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   namespace :vendor_api, path: 'api/v1' do
     get '/applications' => 'applications#index'
     get '/applications/:application_id' => 'applications#show'
+    post '/applications/:application_id/offer' => 'offers#create'
 
     post '/test-data/regenerate' => 'test_data#regenerate'
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
 
   factory :application_choice do
     application_form
+    status { :application_complete }
   end
 end

--- a/spec/requests/vendor_api/make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/make_an_offer_spec.rb
@@ -62,8 +62,10 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:id/offer', type: :reques
                       },
                     }
 
-    post '/api/v1/applications/123/offer', params: request_body
+    post '/api/v1/applications/non-existent-id/offer', params: request_body
 
+    expect(response).to have_http_status(404)
     expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+    expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
   end
 end

--- a/spec/requests/vendor_api/make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/make_an_offer_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /api/v1/applications/:id/offer', type: :request do
   include VendorApiSpecHelpers
 
-  context 'when a conditional offer is make successfully' do
-    let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
-    let(:request_body) do
-      {
+  describe 'making a conditional offer' do
+    it 'returns the updated application' do
+      application_choice = create(:application_choice, provider_ucas_code: 'ABC')
+      request_body = {
         "data": {
           "conditions": [
             'Completion of subject knowledge enhancement',
@@ -14,15 +14,10 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:id/offer', type: :reques
           ],
         },
       }
-    end
 
-    before { post "/api/v1/applications/#{application_choice.id}/offer", params: request_body }
+      post "/api/v1/applications/#{application_choice.id}/offer", params: request_body
 
-    it 'returns a response that is valid according to the OpenAPI schema' do
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
-    end
-
-    it 'returns an application with a conditional offer' do
       expect(parsed_response['data']['attributes']['status']).to eq('conditional_offer')
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [
@@ -33,22 +28,18 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:id/offer', type: :reques
     end
   end
 
-  context 'when an unconditional offer is make successfully' do
-    let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
-    let(:request_body) { {} }
+  describe 'making an unconditional offer' do
+    it 'returns the updated application' do
+      application_choice = create(:application_choice, provider_ucas_code: 'ABC')
+      request_body = {}
 
+      post "/api/v1/applications/#{application_choice.id}/offer", params: request_body
 
-    before { post "/api/v1/applications/#{application_choice.id}/offer", params: request_body }
-
-    it 'returns a response that is valid according to the OpenAPI schema' do
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
-    end
-
-    it 'returns an application with an unconditional offer' do
       expect(parsed_response['data']['attributes']['status']).to eq('unconditional_offer')
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [],
-       )
+      )
     end
   end
 

--- a/spec/requests/vendor_api/make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/make_an_offer_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /api/v1/applications/:id/offer', type: :request do
   include VendorApiSpecHelpers
 
-  context 'successfully made a conditional offer' do
+  context 'when a conditional offer is make successfully' do
     let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
     let(:request_body) do
       {
@@ -33,11 +33,10 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:id/offer', type: :reques
     end
   end
 
-  context 'successfully made an unconditional offer' do
+  context 'when an unconditional offer is make successfully' do
     let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
-    let(:request_body) do
-      {}
-    end
+    let(:request_body) { {} }
+
 
     before { post "/api/v1/applications/#{application_choice.id}/offer", params: request_body }
 

--- a/spec/requests/vendor_api/make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/make_an_offer_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /api/v1/applications/:id/offer', type: :request do
+  include VendorApiSpecHelpers
+
+  context 'successfully made a conditional offer' do
+    let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
+    let(:request_body) do
+      {
+        "data": {
+          "conditions": [
+            'Completion of subject knowledge enhancement',
+            'Completion of professional skills test',
+          ],
+        },
+      }
+    end
+
+    before { post "/api/v1/applications/#{application_choice.id}/offer", params: request_body }
+
+    it 'returns a response that is valid according to the OpenAPI schema' do
+      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
+    end
+
+    it 'returns an application with a conditional offer' do
+      expect(parsed_response['data']['attributes']['status']).to eq('conditional_offer')
+      expect(parsed_response['data']['attributes']['offer']).to eq(
+        'conditions' => [
+          'Completion of subject knowledge enhancement',
+          'Completion of professional skills test',
+        ],
+      )
+    end
+  end
+
+  context 'successfully made an unconditional offer' do
+    let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
+    let(:request_body) do
+      {}
+    end
+
+    before { post "/api/v1/applications/#{application_choice.id}/offer", params: request_body }
+
+    it 'returns a response that is valid according to the OpenAPI schema' do
+      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
+    end
+
+    it 'returns an application with an unconditional offer' do
+      expect(parsed_response['data']['attributes']['status']).to eq('unconditional_offer')
+      expect(parsed_response['data']['attributes']['offer']).to eq(
+        'conditions' => [],
+       )
+    end
+  end
+
+  it 'returns a not found error if the application can\'t be found' do
+    request_body = {
+                      "data": {
+                        "conditions": [
+                                  'Completion of subject knowledge enhancement',
+                                  'Completion of professional skills test',
+                        ],
+                      },
+                    }
+
+    post '/api/v1/applications/123/offer', params: request_body
+
+    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+  end
+end

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe MakeAnOffer do
   context 'when a conditional offer is make successfully' do
     let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
+    let(:make_an_offer) { MakeAnOffer.new(application_choice: application_choice, offer_conditions: conditions) }
     let(:conditions) do
       {
         "conditions": [
@@ -11,7 +12,6 @@ describe MakeAnOffer do
         ],
       }
     end
-    let(:make_an_offer) { MakeAnOffer.new(application_choice: application_choice, offer_conditions: conditions) }
 
     it 'returns a success' do
       response = make_an_offer.call

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe MakeAnOffer do
+  context 'when a conditional offer is make successfully' do
+    let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
+    let(:conditions) do
+      {
+        "conditions": [
+          'Completion of subject knowledge enhancement',
+          'Completion of professional skills test',
+        ],
+      }
+    end
+    let(:make_an_offer) { MakeAnOffer.new(application_choice: application_choice, offer_conditions: conditions) }
+
+    it 'returns a success' do
+      response = make_an_offer.call
+
+      expect(response.successful?).to be true
+    end
+
+    it 'returns the updated application choice' do
+      response = make_an_offer.call
+
+      expect(response.application_choice.status).to eq('conditional_offer')
+      expect(response.application_choice.offer).to eq(
+        'conditions' => [
+          'Completion of subject knowledge enhancement',
+          'Completion of professional skills test',
+        ],
+      )
+    end
+  end
+
+
+  context 'when an unconditional offer is make successfully' do
+    let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
+    let(:make_an_offer) { MakeAnOffer.new(application_choice: application_choice, offer_conditions: nil) }
+
+    it 'returns a success' do
+      response = make_an_offer.call
+
+      expect(response.successful?).to be true
+    end
+
+    it 'returns the updated application choice' do
+      response = make_an_offer.call
+
+      expect(response.application_choice.status).to eq('unconditional_offer')
+      expect(response.application_choice.offer).to eq(
+        'conditions' => [],
+      )
+    end
+  end
+end

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe MakeAnOffer do
   context 'when a conditional offer is make successfully' do
     let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
-    let(:make_an_offer) { MakeAnOffer.new(application_choice: application_choice, offer_conditions: conditions) }
+    let(:response) { MakeAnOffer.new(application_choice: application_choice, offer_conditions: conditions).call }
     let(:conditions) do
       {
         "conditions": [
@@ -14,14 +14,10 @@ describe MakeAnOffer do
     end
 
     it 'returns a success' do
-      response = make_an_offer.call
-
       expect(response.successful?).to be true
     end
 
     it 'returns the updated application choice' do
-      response = make_an_offer.call
-
       expect(response.application_choice.status).to eq('conditional_offer')
       expect(response.application_choice.offer).to eq(
         'conditions' => [


### PR DESCRIPTION
### Context

We need an api endpoint for making an offer on an application. 

### Changes proposed in this pull request

- Add `/applications/:application_id/offer` route and `OffersController`
- Add `MakeAnOffer` service to handle the making of the offer
- Update application_choice presenter to handle offers
- Update status enum to include conditional and unconditional offers
- Add specs to test the api response.

### Guidance to review

Run specs

### Link to Trello card

[1036 - Api Endpoint for making an offer](https://trello.com/c/ed4OxspE/1036-api-endpoint-to-make-an-offer)
