### PR TITLE
1039 api endpoint to confirm enrolment

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -26,9 +26,5 @@ module VendorApi
     def parameter_missing(e)
       render json: { errors: [{ error: 'ParameterMissing', message: e }] }, status: 422
     end
-
-    def application_not_found(_e)
-      render json: { errors: [{ error: 'NotFound', message: "Could not find an application with ID #{params[:application_id]}" }] }, status: 404
-    end
   end
 end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -4,12 +4,9 @@ module VendorApi
     rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
 
     def index
-      application_choices = ApplicationChoice.where(
-        provider_ucas_code: params.fetch(:provider),
-      )
-      .joins(:application_form)
-      .where(
-        'application_forms.updated_at > ?', params.fetch(:since).to_datetime
+      application_choices = get_application_choices_for_provider_since(
+        provider: params.fetch(:provider),
+        since: params.fetch(:since),
       )
 
       render json: { data: MultipleApplicationsPresenter.new(application_choices).as_json }
@@ -22,6 +19,13 @@ module VendorApi
     end
 
   private
+
+    def get_application_choices_for_provider_since(provider:, since:)
+      ApplicationChoice
+        .where(provider_ucas_code: provider)
+        .joins(:application_form)
+        .where('application_forms.updated_at > ?', since.to_datetime)
+    end
 
     def parameter_missing(e)
       render json: { errors: [{ error: 'ParameterMissing', message: e }] }, status: 422

--- a/app/controllers/vendor_api/confirm_candidate_enrolment_controller.rb
+++ b/app/controllers/vendor_api/confirm_candidate_enrolment_controller.rb
@@ -1,0 +1,15 @@
+module VendorApi
+  class ConfirmCandidateEnrolmentController < VendorApiController
+    def confirm
+      application_choice = ApplicationChoice.find(params[:application_id])
+
+      result = ConfirmEnrolment.new(application_choice: application_choice).call
+
+      if(result.successful?)
+        render json: {
+          data: SingleApplicationPresenter.new(result.application_choice).as_json,
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/vendor_api/confirm_candidate_enrolment_controller.rb
+++ b/app/controllers/vendor_api/confirm_candidate_enrolment_controller.rb
@@ -1,11 +1,13 @@
 module VendorApi
   class ConfirmCandidateEnrolmentController < VendorApiController
+    rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
+
     def confirm
       application_choice = ApplicationChoice.find(params[:application_id])
 
       result = ConfirmEnrolment.new(application_choice: application_choice).call
 
-      if(result.successful?)
+      if result.successful?
         render json: {
           data: SingleApplicationPresenter.new(result.application_choice).as_json,
         }

--- a/app/controllers/vendor_api/offers_controller.rb
+++ b/app/controllers/vendor_api/offers_controller.rb
@@ -10,11 +10,5 @@ module VendorApi
         render json: { data: SingleApplicationPresenter.new(make_an_offer.application_choice).as_json }
       end
     end
-
-  private
-
-    def application_not_found(_e)
-      render json: { errors: [{ error: 'NotFound', message: "Could not find an application with ID #{params[:application_id]}" }] }, status: 404
-    end
   end
 end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -7,5 +7,11 @@ module VendorApi
     def set_cors_headers
       headers['Access-Control-Allow-Origin'] = '*'
     end
+
+    def application_not_found(_e)
+      render json: {
+        errors: [{ error: 'NotFound', message: "Could not find an application with ID #{params[:application_id]}" }],
+      }, status: 404
+    end
   end
 end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -1,9 +1,10 @@
-# Candidates can apply to multiple courses via a single Application Form.
 class ApplicationChoice < ApplicationRecord
   belongs_to :application_form, touch: true
+
   enum status: {
     application_complete: 'application_complete',
     conditional_offer: 'conditional_offer',
     unconditional_offer: 'unconditional_offer',
+    enrolled: 'enrolled',
   }
 end

--- a/app/services/confirm_enrolment.rb
+++ b/app/services/confirm_enrolment.rb
@@ -1,0 +1,13 @@
+class ConfirmEnrolment
+  Response = Struct.new(:successful?, :application_choice)
+
+  def initialize(application_choice:)
+    @application_choice = application_choice
+  end
+
+  def call
+    @application_choice.update_attribute(:status, :enrolled)
+
+    Response.new(true, @application_choice)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
     get '/applications/:application_id' => 'applications#show'
     post '/applications/:application_id/offer' => 'offers#create'
 
+    post 'applications/:application_id/confirm-enrolment' => 'confirm_candidate_enrolment#confirm'
+
     post '/test-data/regenerate' => 'test_data#regenerate'
 
     get '/ping', to: 'ping#ping'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
   end
 
   factory :application_choice do
+    provider_ucas_code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     application_form
     status { :application_complete }
   end

--- a/spec/requests/vendor_api/confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/confirm_enrolment_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolment', type: :request do
   include VendorApiSpecHelpers
 
-  context 'a valid request' do
+  context 'when the request is valid' do
     let!(:application_choice) { create(:application_choice) }
 
     before { post "/api/v1/applications/#{application_choice.id}/confirm-enrolment" }
@@ -18,6 +18,16 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
 
     it 'returns an application with the status "enrolled"' do
       expect(parsed_response['data']['attributes']['status']).to eq 'enrolled'
+    end
+  end
+
+  context 'when the application was not found' do
+    it 'returns not found error - 404' do
+      post '/api/v1/applications/non-existent-id/confirm-enrolment'
+
+      expect(response).to have_http_status(404)
+      expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+      expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
     end
   end
 end

--- a/spec/requests/vendor_api/confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/confirm_enrolment_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolment', type: :request do
+  include VendorApiSpecHelpers
+
+  context 'a valid request' do
+    let!(:application_choice) { create(:application_choice) }
+
+    before { post "/api/v1/applications/#{application_choice.id}/confirm-enrolment" }
+
+    it 'returns 200' do
+      expect(response).to have_http_status(200)
+    end
+
+    it 'returns a response that is valid according to JSON schema' do
+      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
+    end
+
+    it 'returns an application with the status "enrolled"' do
+      expect(parsed_response['data']['attributes']['status']).to eq 'enrolled'
+    end
+  end
+end

--- a/spec/requests/vendor_api/confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/confirm_enrolment_spec.rb
@@ -3,31 +3,23 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolment', type: :request do
   include VendorApiSpecHelpers
 
-  context 'when the request is valid' do
-    let!(:application_choice) { create(:application_choice) }
+  describe 'successfully confirming enrolment' do
+    it 'returns updated application' do
+      application_choice = create(:application_choice)
 
-    before { post "/api/v1/applications/#{application_choice.id}/confirm-enrolment" }
+      post "/api/v1/applications/#{application_choice.id}/confirm-enrolment"
 
-    it 'returns 200' do
       expect(response).to have_http_status(200)
-    end
-
-    it 'returns a response that is valid according to JSON schema' do
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
-    end
-
-    it 'returns an application with the status "enrolled"' do
       expect(parsed_response['data']['attributes']['status']).to eq 'enrolled'
     end
   end
 
-  context 'when the application was not found' do
-    it 'returns not found error - 404' do
-      post '/api/v1/applications/non-existent-id/confirm-enrolment'
+  it 'returns not found error when the application was not found' do
+    post '/api/v1/applications/non-existent-id/confirm-enrolment'
 
-      expect(response).to have_http_status(404)
-      expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
-      expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
-    end
+    expect(response).to have_http_status(404)
+    expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
+    expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
   end
 end

--- a/spec/services/confirm_enrolment_spec.rb
+++ b/spec/services/confirm_enrolment_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ConfirmEnrolment do
+  describe '#call' do
+    context 'when the update is valid' do
+      subject(:result) do
+        ConfirmEnrolment.new(
+          application_choice: create(:application_choice)
+        ).call
+      end
+
+      it 'reports that it was successful' do
+        expect(result.successful?).to be true
+      end
+
+      it 'returns the updated application_choice' do
+        expect(result.application_choice.status).to eq 'enrolled'
+      end
+    end
+  end
+end

--- a/spec/services/confirm_enrolment_spec.rb
+++ b/spec/services/confirm_enrolment_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ConfirmEnrolment do
     context 'when the update is valid' do
       subject(:result) do
         ConfirmEnrolment.new(
-          application_choice: create(:application_choice)
+          application_choice: create(:application_choice),
         ).call
       end
 


### PR DESCRIPTION
### Context

This PR implements the POST /applications/{application_id}/confirm-enrolment

### Changes proposed in this pull request
Adds a new service to implement the API,
this do not include metadata, which will be covered separately.

### Guidance to review
Start from `confirm_enrolment_spec`

### Link to Trello card
https://trello.com/c/duvhHr7C/1039-api-endpoint-to-confirm-enrolment
