### PR TITLE
Replace email regexp with the one used by Notify

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -4,7 +4,11 @@ class Candidate < ApplicationRecord
   devise :timeoutable
   validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
 
-  validates :email_address, format: { with: /@/ }
+  # Validate against the pattern that notify use, because a mismatch will lead
+  # to a 400.
+  # From https://github.com/alphagov/notifications-utils/blob/ace25bd04f5802a1ca41633b8308600abce517fc/notifications_utils/__init__.py#L10-L11
+  NOTIFY_EMAIL_REGEXP = %r{[a-zA-Z0-9.!#$%&'*+=?^_`{|}~\\-]+@([^.@][^@\\s]+)}.freeze
+  validates :email_address, format: { with: NOTIFY_EMAIL_REGEXP }
 
   has_many :application_forms
 end


### PR DESCRIPTION
### Context

We originally only checked for `/@/` because that's enough for most cases, but this passes validations on some emails that will then fail downstream when we send them to Notify. Notify will return a 400 which if uncaught will lead to our app responding with a 500. This would not be a possibility if we align our own validation with Notify's, which is what I've done here.

Example unhandled 400 on Sentry: https://sentry.io/organizations/dfe-bat/issues/1250735040/

### Changes proposed in this pull request

Replaces our simple regular expression with a more complex one. :face_with_head_bandage:

### Guidance to review

I had to parse Notify's code a bit to make it Ruby (and Rubocop) friendly, which could be tricky in the future if they dealign, but I think that's highly unlikely.