### PR TITLE
Make sign in and sign up email fields two-thirds wide

### DIFF
--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -11,7 +11,7 @@
     <%= form_with model: @candidate, url: candidate_interface_sign_in_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, type: :email %>
+      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, type: :email, width: 'two-thirds' %>
 
       <%= f.submit t('authentication.sign_up.button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -12,7 +12,7 @@
     <%= form_with model: @candidate, url: candidate_interface_sign_up_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint_text: t('authentication.sign_up.email_address.hint_label'), type: :email %>
+      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint_text: t('authentication.sign_up.email_address.hint_label'), type: :email, width: 'two-thirds' %>
 
       <%= f.submit t('authentication.sign_up.button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>


### PR DESCRIPTION
:smol:

### Before

![Screenshot 2019-10-04 at 17 51 40](https://user-images.githubusercontent.com/1650875/66225154-a3121200-e6cf-11e9-9f9f-a52f2641a146.png)

### After 

![Screenshot 2019-10-04 at 17 51 25](https://user-images.githubusercontent.com/1650875/66225153-a3121200-e6cf-11e9-8aed-f34cccf37fce.png)