### PR TITLE
Add provider & support UI

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,0 +1,31 @@
+module ProviderInterface
+  class ApplicationChoicesController < ProviderInterfaceController
+    def index
+      application_choices = ApplicationChoice
+        .includes(:application_form)
+        .where(provider_ucas_code: current_user.provider_ucas_code)
+
+      @application_choices = application_choices.map do |application_choice|
+        ApplicationChoicePresenter.new(application_choice)
+      end
+    end
+
+    def show
+      application_choice = ApplicationChoice
+        .includes(:application_form)
+        .where(provider_ucas_code: current_user.provider_ucas_code)
+        .find(params[:application_choice_id])
+
+      @application_choice = ApplicationChoicePresenter.new(application_choice)
+    end
+
+  private
+
+    # Stub out the current user and their organisation. Will be replaced
+    # by a proper ProviderUser when implementing Signin.
+    def current_user
+      fake_user_class = Struct.new(:provider_ucas_code)
+      fake_user_class.new('ABC')
+    end
+  end
+end

--- a/app/controllers/provider_interface/home_controller.rb
+++ b/app/controllers/provider_interface/home_controller.rb
@@ -1,5 +1,0 @@
-module ProviderInterface
-  class HomeController < ProviderInterfaceController
-    def index; end
-  end
-end

--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -1,0 +1,19 @@
+module SupportInterface
+  class ApplicationFormsController < SupportInterfaceController
+    def index
+      application_forms = ApplicationForm.includes(:application_choices)
+
+      @application_forms = application_forms.map do |application_choice|
+        ApplicationFormPresenter.new(application_choice)
+      end
+    end
+
+    def show
+      application_form = ApplicationForm
+        .includes(:application_choices)
+        .find(params[:application_form_id])
+
+      @application_form = ApplicationFormPresenter.new(application_form)
+    end
+  end
+end

--- a/app/services/provider_interface/application_choice_presenter.rb
+++ b/app/services/provider_interface/application_choice_presenter.rb
@@ -1,0 +1,31 @@
+module ProviderInterface
+  class ApplicationChoicePresenter
+    def initialize(application_choice)
+      @application_choice = application_choice
+    end
+
+    def full_name
+      "#{application_choice.application_form.first_name} #{application_choice.application_form.last_name}"
+    end
+
+    def course_name
+      "Course #{application_choice.course_ucas_code}"
+    end
+
+    def status_name
+      I18n.t!("application_choice.status_name.#{application_choice.status}")
+    end
+
+    def updated_at
+      application_choice.updated_at.to_s(:short)
+    end
+
+    def to_param
+      application_choice.id
+    end
+
+  private
+
+    attr_reader :application_choice
+  end
+end

--- a/app/services/support_interface/application_form_presenter.rb
+++ b/app/services/support_interface/application_form_presenter.rb
@@ -1,0 +1,23 @@
+module SupportInterface
+  class ApplicationFormPresenter
+    def initialize(application_form)
+      @application_form = application_form
+    end
+
+    def full_name
+      "#{application_form.first_name} #{application_form.last_name}"
+    end
+
+    def updated_at
+      application_form.updated_at
+    end
+
+    def to_param
+      application_form.id.to_s
+    end
+
+  private
+
+    attr_reader :application_form
+  end
+end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,0 +1,23 @@
+<h1 class='govuk-heading-xl'>Your applications</h1>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Name</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Course</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Last update</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @application_choices.each do |application_choice| %>
+    <tr class='govuk-table__row'>
+      <td class='govuk-table__cell'><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
+      <td class='govuk-table__cell'><%= application_choice.course_name %></td>
+      <td class='govuk-table__cell'><%= tag.strong application_choice.status_name, class: 'govuk-tag' %></td>
+      <td class='govuk-table__cell'><%= application_choice.updated_at %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class='govuk-heading-xl'><%= @application_choice.full_name %>'s application</h1>

--- a/app/views/provider_interface/home/index.html.erb
+++ b/app/views/provider_interface/home/index.html.erb
@@ -1,5 +1,0 @@
-<h1 class='govuk-heading-xl'>Welcome to the Provider UI</h1>
-
-<p class='govuk-body'>
-  This is where providers will be able to manage applications
-</p>

--- a/app/views/support_interface/application_forms/index.html.erb
+++ b/app/views/support_interface/application_forms/index.html.erb
@@ -1,0 +1,19 @@
+<h1 class='govuk-heading-xl'>Applications</h1>
+
+<table class='govuk-table'>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last update</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @application_forms.each do |application_form| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><%= govuk_link_to application_form.full_name, support_interface_application_form_path(application_form) %></td>
+      <td class="govuk-table__cell"><%= application_form.updated_at.to_s(:long) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class='govuk-heading-xl'><%= @application_form.full_name %>'s application</h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,3 +61,11 @@ en:
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer
               invalid: Enter an email address in the correct format, like name@example.com
+  application_choice:
+    status_name:
+      application_complete: 'Application completed'
+      conditional_offer: 'Conditional offer'
+      unconditional_offer: 'Unconditional offer'
+      recruited: 'Candidate recruited'
+      enrolled: 'Candidate  enrolled'
+      rejected: 'Candidate rejected'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,11 +47,17 @@ Rails.application.routes.draw do
   end
 
   namespace :provider_interface, path: '/provider' do
-    get '/' => 'home#index'
+    get '/' => redirect('/provider/applications')
+
+    get '/applications' => 'application_choices#index'
+    get '/applications/:application_choice_id' => 'application_choices#show', as: :application_choice
   end
 
   namespace :support_interface, path: '/support' do
-    get '/' => redirect('/support/tokens')
+    get '/' => redirect('/support/applications')
+
+    get '/applications' => 'application_forms#index'
+    get '/applications/:application_form_id' => 'application_forms#show', as: :application_form
 
     get '/tokens' => 'api_tokens#index', as: :api_tokens
     post '/tokens' => 'api_tokens#create'

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.feature 'See applications' do
+  scenario 'Provider visits application page' do
+    given_i_am_a_provider_user
+    and_my_organisation_has_applications
+    and_i_visit_the_provider_page
+    then_i_should_see_the_applications_from_my_organisation
+    but_not_the_applications_from_other_providers
+
+    when_i_click_on_an_application
+    then_i_should_be_on_the_application_view_page
+  end
+
+  def given_i_am_a_provider_user
+    # This is stubbed out for now in the controller.
+  end
+
+  def and_my_organisation_has_applications
+    create(:application_choice, provider_ucas_code: 'ABC', application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
+    create(:application_choice, provider_ucas_code: 'ABC', application_form: create(:application_form, first_name: 'Bob'))
+    create(:application_choice, provider_ucas_code: 'ANOTHER_ORG', application_form: create(:application_form, first_name: 'Charlie'))
+  end
+
+  def and_i_visit_the_provider_page
+    visit provider_interface_path
+  end
+
+  def then_i_should_see_the_applications_from_my_organisation
+    expect(page).to have_content 'Alice'
+    expect(page).to have_content 'Bob'
+  end
+
+  def but_not_the_applications_from_other_providers
+    expect(page).not_to have_content 'Charlie'
+  end
+
+  def when_i_click_on_an_application
+    click_on 'Alice'
+  end
+
+  def then_i_should_be_on_the_application_view_page
+    expect(page).to have_content "Alice Wunder's application"
+  end
+end

--- a/spec/system/support_interface/manage_applications_spec.rb
+++ b/spec/system/support_interface/manage_applications_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'See applications' do
+  scenario 'Provider visits application page' do
+    given_i_am_a_support_user
+    and_there_are_applications_in_the_system
+    and_i_visit_the_support_page
+    then_i_should_see_the_applications
+
+    when_i_click_on_an_application
+    then_i_should_be_on_the_application_view_page
+  end
+
+  def given_i_am_a_support_user
+    page.driver.browser.authorize('test', 'test')
+  end
+
+  def and_there_are_applications_in_the_system
+    create(:application_choice, provider_ucas_code: 'ABC', application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
+    create(:application_choice, provider_ucas_code: 'ABC', application_form: create(:application_form, first_name: 'Bob'))
+    create(:application_choice, provider_ucas_code: 'ANOTHER_ORG', application_form: create(:application_form, first_name: 'Charlie'))
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def then_i_should_see_the_applications
+    expect(page).to have_content 'Alice'
+    expect(page).to have_content 'Bob'
+    expect(page).to have_content 'Charlie'
+  end
+
+  def when_i_click_on_an_application
+    click_on 'Alice'
+  end
+
+  def then_i_should_be_on_the_application_view_page
+    expect(page).to have_content "Alice Wunder's application"
+  end
+end


### PR DESCRIPTION
### Context

This is the start of the interfaces for the providers (schools and other training providers) and support (people on the Apply team in DfE).

It doesn't do much yet, it only allows:

- Providers to see all their applications, and click through to an individual application
- Support staff to see all of the applications in the system

I'm raising this PR now, because: in the current sprint @chubberlisk and @tvararu will try to get the end-to-end candidate flow working. Having the provider and support interfaces ready will mean that we can "test" the entire system. I also would like to do a spike into using the decisions code that we built for the API in the provider interface.

### Guidance to review

<img width="1041" alt="Screenshot 2019-10-09 at 15 21 50" src="https://user-images.githubusercontent.com/233676/66490125-95320780-eaa8-11e9-8caf-ecbb4e96c5ac.png">
<img width="1041" alt="Screenshot 2019-10-09 at 15 21 52" src="https://user-images.githubusercontent.com/233676/66490126-95320780-eaa8-11e9-88d6-8f3be14f9d2d.png">
<img width="1041" alt="Screenshot 2019-10-09 at 15 22 00" src="https://user-images.githubusercontent.com/233676/66490128-95320780-eaa8-11e9-8b7e-dc1b584d321e.png">
<img width="1041" alt="Screenshot 2019-10-09 at 15 22 03" src="https://user-images.githubusercontent.com/233676/66490129-95320780-eaa8-11e9-82e0-27351c9d3ffa.png">

### Link to Trello card

https://trello.com/c/x4oJgpsK
