### PR TITLE
Correct provider= to provider_ucas_code= in GET /applications

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -5,7 +5,7 @@ module VendorApi
 
     def index
       application_choices = get_application_choices_for_provider_since(
-        provider: params.fetch(:provider),
+        provider: params.fetch(:provider_ucas_code),
         since: params.fetch(:since),
       )
 

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     create(:application_choice, provider_ucas_code: 'ABC')
     create(:application_choice, provider_ucas_code: 'DEF')
 
-    get "/api/v1/applications?provider=ABC&since=#{(Time.now - 1.days).iso8601}"
+    get "/api/v1/applications?provider_ucas_code=ABC&since=#{(Time.now - 1.days).iso8601}"
 
     expect(parsed_response['data'].size).to be(2)
   end
@@ -20,7 +20,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     create(:application_choice, provider_ucas_code: 'ABC')
 
-    get "/api/v1/applications?provider=ABC&since=#{(Time.now - 1.days).iso8601}"
+    get "/api/v1/applications?provider_ucas_code=ABC&since=#{(Time.now - 1.days).iso8601}"
 
     expect(parsed_response['data'].size).to be(1)
   end
@@ -29,13 +29,13 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     create(:application_choice, provider_ucas_code: 'ABC')
     create(:application_choice, provider_ucas_code: 'DEF')
 
-    get "/api/v1/applications?provider=ABC&since=#{(Time.now - 1.days).iso8601}"
+    get "/api/v1/applications?provider_ucas_code=ABC&since=#{(Time.now - 1.days).iso8601}"
 
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
   end
 
   it 'returns an error if the `since` parameter is missing' do
-    get '/api/v1/applications?provider=ABC'
+    get '/api/v1/applications?provider_ucas_code=ABC'
 
     expect(response).to have_http_status(422)
 
@@ -44,13 +44,13 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     expect(error_response['message']).to eql('param is missing or the value is empty: since')
   end
 
-  it 'returns an error if the `provider` parameter is missing' do
+  it 'returns an error if the `provider_ucas_code` parameter is missing' do
     get "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
 
     expect(response).to have_http_status(422)
 
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
 
-    expect(error_response['message']).to eql('param is missing or the value is empty: provider')
+    expect(error_response['message']).to eql('param is missing or the value is empty: provider_ucas_code')
   end
 end


### PR DESCRIPTION
This had diverged from the docs. It seems sensible to be more specific
at this early stage - if we do end up with our own concept of "provider"
then we can use the plain name for that

### Context

Swagger editor was broken and we had to change the param name every. time.
