### PR TITLE
Disable monkey patching in RSpec

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe ApplicationHelper do
+RSpec.describe ApplicationHelper do
   describe '#page_title' do
     context 'given a page is not defined in the translation file' do
       it 'returns the application title' do

--- a/spec/presenters/candidate_interface/course_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/course_presenter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe CandidateInterface::CoursePresenter do
+RSpec.describe CandidateInterface::CoursePresenter do
   let(:provider_code) { '2AT' }
   let(:course_code) { '1234' }
   let(:name) { 'Biology' }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,8 +61,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 
-  config.example_status_persistence_file_path = 'tmp/rspec-failures'
-
   config.include AbstractController::Translation
 
   config.include FactoryBot::Syntax::Methods

--- a/spec/requests/candidate_interface/errors_spec.rb
+++ b/spec/requests/candidate_interface/errors_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Candidate Interface - Errors', type: :request do
+RSpec.describe 'Candidate Interface - Errors', type: :request do
   describe 'Not found (404)' do
     context 'GET /404' do
       it 'returns the not found page' do

--- a/spec/requests/candidate_interface/get_application_spec.rb
+++ b/spec/requests/candidate_interface/get_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Candidate Interface - GET /candidate/application', type: :request do
+RSpec.describe 'Candidate Interface - GET /candidate/application', type: :request do
   before do
     candidate = FactoryBot.create(:candidate)
     login_as(candidate)

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe MakeAnOffer do
+RSpec.describe MakeAnOffer do
   context 'when a conditional offer is make successfully' do
     let(:application_choice) { create(:application_choice, provider_ucas_code: 'ABC') }
     let(:response) { MakeAnOffer.new(application_choice: application_choice, offer_conditions: conditions).call }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,9 +56,9 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -69,7 +69,7 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'tmp/rspec-failures'
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
@@ -85,12 +85,11 @@ RSpec.configure do |config|
     # Use the documentation formatter for detailed output,
     # unless a formatter has already been configured
     # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
+    config.default_formatter = 'doc'
   end
 
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   config.profile_examples = 10
-=end
 end

--- a/spec/system/candidate_interface/candidate_applying_spec.rb
+++ b/spec/system/candidate_interface/candidate_applying_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # TODO: This test needs to be rewritten to use the new acceptance-test style
 # specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
-describe 'A candidate applying from Find' do
+RSpec.describe 'A candidate applying from Find' do
   let(:provider_code) { '1AB' }
   let(:course_code) { '2ABC' }
   let(:course_name) { 'Biology' }

--- a/spec/system/candidate_interface/candidate_expire_session_spec.rb
+++ b/spec/system/candidate_interface/candidate_expire_session_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # TODO: This test needs to be rewritten to use the new acceptance-test style
 # specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
-describe 'Candidate session expires' do
+RSpec.describe 'Candidate session expires' do
   it 'expires the current candidate session' do
     candidate = FactoryBot.create(:candidate)
     login_as(candidate)

--- a/spec/system/candidate_interface/candidate_signing_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_in_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # TODO: This test needs to be rewritten to use the new acceptance-test style
 # specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
-describe 'A candidate signing in' do
+RSpec.describe 'A candidate signing in' do
   include TestHelpers::SignUp
 
   before do

--- a/spec/system/candidate_interface/candidate_signing_up_spec.rb
+++ b/spec/system/candidate_interface/candidate_signing_up_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # TODO: This test needs to be rewritten to use the new acceptance-test style
 # specs - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/246
-describe 'A candidate signing up' do
+RSpec.describe 'A candidate signing up' do
   include TestHelpers::SignUp
 
   context 'who does not have an account' do


### PR DESCRIPTION
This also enables some other features in spec_helper, like slow test profiling.