### PR TITLE
Set better default for FIND_BASE_URL

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+FIND_BASE_URL=https://api2.qa.publish-teacher-training-courses.service.gov.uk/api/v3/

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 GOVUK_NOTIFY_API_KEY=
-FIND_BASE_URL=https://bat-qa-mcbe-as.azurewebsites.net/api/v3/
+FIND_BASE_URL=https://api2.qa.publish-teacher-training-courses.service.gov.uk/api/v3/

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
 GOVUK_NOTIFY_API_KEY=
-FIND_BASE_URL=https://api2.qa.publish-teacher-training-courses.service.gov.uk/api/v3/


### PR DESCRIPTION
### Context

We don't set a default `FIND_BASE_URL` and the URL in `.env.example` is not the public one.

### Changes proposed in this pull request

This uses the public CNAME instead of the internal Azure one, which will make it more resilient to infrastructure changes in the Find team.

Also set up `.env.development` and `.env.production` to set defaults in both development and production mode.

### Guidance to review

Not much going on here, just some env vars.

### Link to Trello card

[115 - Implement public Courses endpoint on Find](https://trello.com/c/bQzgIERR)