### PR TITLE
Bump version of the API spec

### DIFF
--- a/config/vendor-api-0.5.0.yml
+++ b/config/vendor-api-0.5.0.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.4.0
+  version: 0.5.0
   title: Apply API
   contact:
     name: DfE

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -9,7 +9,7 @@ module VendorApiSpecHelpers
 
   RSpec::Matchers.define :be_valid_against_openapi_schema do |schema_name|
     match do |item|
-      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.4.0.yml"))
+      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.5.0.yml"))
 
       JSONSchemaValidator.new(
         spec.as_json_schema(schema_name),
@@ -18,7 +18,7 @@ module VendorApiSpecHelpers
     end
 
     failure_message do |item|
-      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.4.0.yml"))
+      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.5.0.yml"))
 
       JSONSchemaValidator.new(
         spec.as_json_schema(schema_name),


### PR DESCRIPTION
This so we don't confuse this version with the 0.4.0 spec that's currently in the docs.