### PR TITLE
Add js-enabled and govuk-skip-link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,6 +36,10 @@
   </head>
 
   <body class="govuk-template__body">
+    <script>
+      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+    </script>
+
     <header class="govuk-header " role="banner" data-module="header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,8 @@
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>
 
+    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+
     <header class="govuk-header " role="banner" data-module="header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">


### PR DESCRIPTION
### Context

`js-enabled` is used by `govuk-frontend` to determine whether to trigger certain behaviours, like hiding conditional radio content.

`govuk-skip-link` is necessary for accessibility reasons.

### Changes proposed in this pull request

Adds some small bits to the layout.

### Guidance to review

I'm pretty confident in this changeset as it's small and the bits are uncontroversial / widely used.