### PR TITLE
Add remaining fields to Personal Details edit page

### DIFF
--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -15,7 +15,7 @@ module CandidateInterface
     def personal_details_params
       params.require(:candidate_interface_personal_details_form).permit(
         :first_name, :last_name, :"date_of_birth(3i)", :"date_of_birth(2i)",
-        :"date_of_birth(1i)", :nationality, :english_main_language
+        :"date_of_birth(1i)", :english_main_language, nationalities: []
       )
         .transform_keys { |key| dob_field_to_attribute(key) }
     end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -2,18 +2,11 @@ module CandidateInterface
   class PersonalDetailsForm
     include ActiveModel::Model
 
-    attr_accessor :first_name, :last_name, :day, :month, :year, :nationality,
+    attr_accessor :first_name, :last_name, :day, :month, :year, :nationalities,
                   :english_main_language
 
     def name
       "#{first_name} #{last_name}"
-    end
-
-    def english_main_language_options
-      [
-        OpenStruct.new(id: 'yes', name: 'Yes'),
-        OpenStruct.new(id: 'no', name: 'No'),
-      ]
     end
   end
 end

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -19,9 +19,28 @@
 
         <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint_text: t('application_form.personal_details.date_of_birth.hint_text') %>
 
-        <%= f.govuk_text_field :nationality, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+        <%= f.govuk_text_field 'nationalities', label: { text: t('application_form.personal_details.nationality.label'), size: 'm' }, multiple: true %>
 
-        <%= f.govuk_collection_radio_buttons :english_main_language, @personal_details_form.english_main_language_options, :id, :name, legend: { text: t('application_form.personal_details.english_main_language.label') } %>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              Add another nationality
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <%= f.govuk_text_field 'nationalities', label: { text: t('application_form.personal_details.second_nationality.label') }, multiple: true %>
+          </div>
+        </details>
+
+        <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label') } do %>
+          <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' } do %>
+            <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
+          <% end %>
+
+          <%= f.govuk_radio_button :english_main_language, 'no', label: { text: 'No' } do %>
+            <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
+          <% end %>
+        <% end %>
 
         <%= f.govuk_submit 'Continue' %>
       <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -14,6 +14,10 @@ en:
         hint_text: For example, 31 3 1980
       nationality:
         label: Nationality
+      second_nationality:
+        label: Second nationality
       english_main_language:
         label: Is English your main language?
+        yes_label: If you are bilingual or very familiar with languages other than English, you can tell us about them here.
+        no_label: Please tell us about your English language qualifications (including grades or scores), and give details of other languages you are fluent in.
       complete_form_button: Continue

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -8,14 +8,4 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       expect(personal_details.name).to eq('Bruce Wayne')
     end
   end
-
-  describe '#english_main_language_options' do
-    it 'returns an array of OpenStructs with id and name' do
-      personal_details = CandidateInterface::PersonalDetailsForm.new
-
-      expect(personal_details.english_main_language_options).to all(be_an(OpenStruct))
-      expect(personal_details.english_main_language_options[0]).to have_attributes(id: 'yes', name: 'Yes')
-      expect(personal_details.english_main_language_options[1]).to have_attributes(id: 'no', name: 'No')
-    end
-  end
 end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -46,9 +46,14 @@ RSpec.feature 'Entering their personal details' do
     fill_in 'Month', with: '4'
     fill_in 'Year', with: '1937'
 
-    fill_in t('application_form.personal_details.nationality.label'), with: 'English'
+    fill_in t('application_form.personal_details.nationality.label'), with: 'British'
+    find('details').click
+    within('details') do
+      fill_in t('application_form.personal_details.second_nationality.label'), with: 'American'
+    end
 
     choose 'Yes'
+    fill_in t('application_form.personal_details.english_main_language.yes_label'), with: "I'm great at Galactic Basic so English is a piece of cake", match: :prefer_exact
 
     click_button t('application_form.personal_details.complete_form_button')
   end


### PR DESCRIPTION
### Context

This is a follow-up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/287, which introduced the model/controller/view, but didn't go so far as to implement every single field because then it would be quite long.

### Changes proposed in this pull request

- Adds second nationality field inside `details` element
- Adds conditionally revealed `english_language_details` and `other_language_details` text fields with word count

### Guidance to review

Nothing in particular :eyes:

### Link to Trello card

[122 - Allow users to fill in "Personal details" with validation](https://trello.com/c/LTQDGPQh/122-allow-users-to-fill-in-personal-details-with-validation)

### After screenshot

![Screenshot 2019-10-10 at 10 41 50](https://user-images.githubusercontent.com/1650875/66557904-97e53900-eb4a-11e9-8b83-5f66d7b22f5c.png)

The alignment of the conditional content has been fixed upstream and will reach us soon™ via Dependabot: https://github.com/DFE-Digital/govuk_design_system_formbuilder/pull/50