### PR TITLE
Present 10-character alphanumeric IDs for Applications served via the API

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -13,7 +13,16 @@ class ApplicationChoice < ApplicationRecord
 
 private
 
+  def generate_alphanumeric_id
+    SecureRandom.hex(5)
+  end
+
   def set_id
-    self.id = SecureRandom.hex(5)
+    alphanumeric_id = ''
+    loop do
+      alphanumeric_id = generate_alphanumeric_id
+      break unless ApplicationChoice.exists?(id: alphanumeric_id)
+    end
+    self.id = alphanumeric_id
   end
 end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -1,4 +1,5 @@
 class ApplicationChoice < ApplicationRecord
+  before_create :set_id
   belongs_to :application_form, touch: true
 
   enum status: {
@@ -9,4 +10,10 @@ class ApplicationChoice < ApplicationRecord
     enrolled: 'enrolled',
     rejected: 'rejected',
   }
+
+private
+
+  def set_id
+    self.id = SecureRandom.hex(5)
+  end
 end

--- a/app/services/vendor_api/single_application_presenter.rb
+++ b/app/services/vendor_api/single_application_presenter.rb
@@ -8,7 +8,7 @@ module VendorApi
 
     def as_json
       {
-        id: SecureRandom.hex[0..9],
+        id: application_choice.id,
         type: 'application',
         attributes: {
           status: application_choice.status || 'application_complete',

--- a/db/migrate/20191010134807_convert_application_choice_id_to_string.rb
+++ b/db/migrate/20191010134807_convert_application_choice_id_to_string.rb
@@ -1,0 +1,5 @@
+class ConvertApplicationChoiceIdToString < ActiveRecord::Migration[6.0]
+  def change
+    change_column :application_choices, :id, :string, limit: 10, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_160606) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
-  create_table "application_choices", force: :cascade do |t|
+  create_table "application_choices", id: :string, limit: 10, force: :cascade do |t|
     t.bigint "application_form_id", null: false
     t.text "personal_statement"
     t.string "provider_ucas_code"


### PR DESCRIPTION
### Context

Vendors have given feedback that they can handle up to 10 chars alphanumeric IDs for Applications.

### Changes proposed in this pull request

- Convert ApplicationChoice `id` to be a 10 char string. 
- Generate ApplicationChoice `id` within ApplicationChoice model via ActiveRecord callback.
- Edit `single_application_presenter` to use ApplicationChoice `id`

### Guidance to review

### Before 
![Screenshot 2019-10-11 at 10 51 05](https://user-images.githubusercontent.com/47318392/66642809-57062680-ec15-11e9-8d50-15a41ce4ca7b.png)

### After
![Screenshot 2019-10-11 at 10 52 21](https://user-images.githubusercontent.com/47318392/66642819-5d949e00-ec15-11e9-8140-cacc3285ecc5.png)

- Run Specs
- Read `20191010134807_convert_application_choice_id_to_string` migration and `db/schema` to ensure that they make sense.

### Link to Trello card

[1060 - Present 10 character alphanumeric ids for applications served via the api](https://trello.com/c/133wdp0s/1060-present-10-character-alphanumeric-ids-for-applications-served-via-the-api)
