### PR TITLE
Update the review page for filling in personal details to show more fields

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -25,6 +25,8 @@ guard :rspec, cmd: 'bundle exec rspec --format documentation' do
     ]
   end
 
+  watch(%r{^app/presenters/candidate_interface/(.+)\.rb}) { |m| "spec/presenters/candidate_interface/#{m[1]}_spec.rb" }
+
   # Rails config changes
   watch(rails.spec_helper)     { rspec.spec_dir }
   watch(rails.routes)          { "#{rspec.spec_dir}/routing" }

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
 
     def update
       @personal_details_form = PersonalDetailsForm.new(personal_details_params)
+      @personal_details_review = PersonalDetailsReviewPresenter.new(@personal_details_form)
 
       if @personal_details_form.valid?
         render :show

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -42,5 +42,9 @@ module CandidateInterface
     def date_of_birth_not_in_future
       errors.add(:date_of_birth, :future) if date_of_birth.present? && date_of_birth > Date.today
     end
+
+    def english_main_language?
+      english_main_language == 'yes'
+    end
   end
 end

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -1,0 +1,75 @@
+module CandidateInterface
+  class PersonalDetailsReviewPresenter
+    def initialize(form)
+      @form = form
+    end
+
+    def present
+      [
+        name_row,
+        date_of_birth_row,
+        nationality_row,
+        english_main_language_row,
+        language_details_row
+      ].compact
+    end
+
+  private
+
+    def name_row
+      {
+        key: I18n.t('application_form.personal_details.name.label'),
+        value: @form.name,
+        action: 'name',
+      }
+    end
+
+    def date_of_birth_row
+      {
+        key: I18n.t('application_form.personal_details.date_of_birth.label'),
+        value: @form.date_of_birth.strftime('%e %B %Y'),
+        action: 'date of birth',
+      }
+    end
+
+    def nationality_row
+      {
+        key: I18n.t('application_form.personal_details.nationality.label'),
+        value: [@form.first_nationality, @form.second_nationality].reject(&:blank?).to_sentence,
+        action: 'nationality',
+      }
+    end
+
+    def english_main_language_row
+      {
+        key: I18n.t('application_form.personal_details.english_main_language.label'),
+        value: @form.english_main_language.titleize,
+        action: 'if English is your main language',
+      }
+    end
+
+    def language_details_row
+      if @form.english_main_language?
+        english_main_language_details_row if @form.english_language_details.present?
+      else
+        other_language_details_row if @form.other_language_details.present?
+      end
+    end
+
+    def english_main_language_details_row
+      {
+        key: I18n.t('application_form.personal_details.english_main_language_details.label'),
+        value: @form.english_language_details,
+        action: 'other languages',
+      }
+    end
+
+    def other_language_details_row
+      {
+        key: I18n.t('application_form.personal_details.other_language_details.label'),
+        value: @form.other_language_details,
+        action: 'english languages qualifications',
+      }
+    end
+  end
+end

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -10,7 +10,7 @@ module CandidateInterface
         date_of_birth_row,
         nationality_row,
         english_main_language_row,
-        language_details_row
+        language_details_row,
       ].compact
     end
 
@@ -51,8 +51,8 @@ module CandidateInterface
     def language_details_row
       if @form.english_main_language?
         english_main_language_details_row if @form.english_language_details.present?
-      else
-        other_language_details_row if @form.other_language_details.present?
+      elsif @form.other_language_details.present?
+        other_language_details_row
       end
     end
 

--- a/app/views/candidate_interface/personal_details/show.html.erb
+++ b/app/views/candidate_interface/personal_details/show.html.erb
@@ -8,20 +8,22 @@
 <section class="app-summary-card govuk-!-margin-bottom-6">
   <div class="app-summary-card__body">
     <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Name
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @personal_details_form.name %>
-        </dd>
+      <% @personal_details_review.present.each do |row| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <%= row[:key] %>
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <%= row[:value] %>
+          </dd>
 
-        <dd class="govuk-summary-list__actions">
-          <%= link_to candidate_interface_personal_details_edit_path, class: 'govuk-link' do %>
-            Change<span class="govuk-visually-hidden"> name</span>
-          <% end %>
-        </dd>
-      </div>
+          <dd class="govuk-summary-list__actions">
+            <%= link_to candidate_interface_personal_details_edit_path, class: 'govuk-link' do %>
+              Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
     </dl>
   </div>
 </section>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -9,17 +9,29 @@ en:
       last_name:
         label: Last name
         hint_text: Or family name
+      name:
+        label: Name
+        change_action: name
       date_of_birth:
         label: Date of birth
         hint_text: For example, 31 3 1980
+        change_action: date of birth
       nationality:
         label: Nationality
+        change_action: nationality
       second_nationality:
         label: Second nationality
       english_main_language:
         label: Is English your main language?
         yes_label: If you are bilingual or very familiar with languages other than English, you can tell us about them here.
         no_label: Please tell us about your English language qualifications (including grades or scores), and give details of other languages you are fluent in.
+        change_action: if English is your main language
+      english_main_language_details:
+        label: Other languages spoken
+        change_action: other languages
+      other_language_details:
+        label: English language qualifications and other languages spoken
+        change_action: english languages qualifications
       complete_form_button: Continue
   activemodel:
     errors:

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
   describe '#name' do
-    it 'concatenates the first name and last name ' do
+    it 'concatenates the first name and last name' do
       personal_details = CandidateInterface::PersonalDetailsForm.new(first_name: 'Bruce', last_name: 'Wayne')
 
       expect(personal_details.name).to eq('Bruce Wayne')
@@ -74,6 +74,20 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
           ['Date of birth Enter a date of birth that is in the past, for example 13 1 1993'],
         )
       end
+    end
+  end
+
+  describe '#english_main_language?' do
+    it 'returns true if "yes"' do
+      personal_details = CandidateInterface::PersonalDetailsForm.new(english_main_language: 'yes')
+
+      expect(personal_details).to be_english_main_language
+    end
+
+    it 'returns false if "no"' do
+      personal_details = CandidateInterface::PersonalDetailsForm.new(english_main_language: 'no')
+
+      expect(personal_details).not_to be_english_main_language
     end
   end
 end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -1,0 +1,186 @@
+require 'rails_helper'
+
+FactoryBot.define do
+  factory :personal_details_form, class: CandidateInterface::PersonalDetailsForm do
+    date_of_birth = Faker::Date.birthday
+
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    day { date_of_birth.day }
+    month { date_of_birth.month }
+    year { date_of_birth.year }
+    first_nationality { Faker::Nation.nationality }
+    second_nationality { Faker::Nation.nationality }
+    english_main_language { %w[yes no].sample }
+    english_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+    other_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+  end
+end
+
+RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
+  describe '#present' do
+    it 'includes hashes for the name and date of birth' do
+      personal_details_form = FactoryBot.build(
+        :personal_details_form,
+        first_name: 'Max',
+        last_name: 'Caulfield',
+        day: 21,
+        month: 9,
+        year: 1995,
+      )
+
+      expect(present(personal_details_form)).to include(
+        row_for(:name, 'Max Caulfield'),
+        row_for(:date_of_birth, '21 September 1995'),
+      )
+    end
+
+    context 'when presenting nationality' do
+      it 'includes a hash for a single nationality' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          first_nationality: 'British',
+          second_nationality: nil,
+        )
+
+        expect(present(personal_details_form)).to include(
+          row_for(:nationality, 'British')
+        )
+      end
+
+      it 'includes a hash for dual nationalities' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          first_nationality: 'British',
+          second_nationality: 'Spanish',
+        )
+
+        expect(present(personal_details_form)).to include(
+          row_for(:nationality, 'British and Spanish')
+        )
+      end
+    end
+
+    context 'when presenting English as the main language' do
+      it 'includes a hash with "Yes"' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'yes',
+          english_language_details: '',
+          other_language_details: '',
+        )
+
+        expect(present(personal_details_form)).to include(
+          row_for(:english_main_language, 'Yes')
+        )
+      end
+
+      it 'excludes a hash for English language details if blank' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'yes',
+          english_language_details: '',
+          other_language_details: '',
+        )
+
+        expect(present(personal_details_form)).not_to include(
+          row_for(:english_main_language_details, '')
+        )
+      end
+
+      it 'excludes a hash for other language details if given' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'yes',
+          english_language_details: '',
+          other_language_details: 'Broken? Oh man, are you cereal?',
+        )
+
+        expect(present(personal_details_form)).not_to include(
+          row_for(:other_language_details, 'Broken? Oh man, are you cereal?')
+        )
+      end
+
+      it 'includes a hash for English language details if given' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'yes',
+          english_language_details: 'Mi nombre es Max.',
+          other_language_details: '',
+        )
+
+        expect(present(personal_details_form)).to include(
+          row_for(:english_main_language_details, 'Mi nombre es Max.')
+        )
+      end
+    end
+
+    context 'when presenting English not as the main language' do
+      it 'includes a hash with "No"' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'no',
+          english_language_details: '',
+          other_language_details: '',
+        )
+
+        expect(present(personal_details_form)).to include(
+          row_for(:english_main_language, 'No')
+        )
+      end
+
+      it 'excludes a hash for other language details if blank' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'no',
+          english_language_details: '',
+          other_language_details: '',
+        )
+
+        expect(present(personal_details_form)).not_to include(
+          row_for(:other_language_details, '')
+        )
+      end
+
+      it 'excludes a hash for English language details if given' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'no',
+          english_language_details: 'Mi nombre es Max.',
+          other_language_details: '',
+        )
+
+        expect(present(personal_details_form)).not_to include(
+          row_for(:english_main_language_details, 'Mi nombre es Max.')
+        )
+      end
+
+      it 'includes a hash for other language details if given' do
+        personal_details_form = FactoryBot.build(
+          :personal_details_form,
+          english_main_language: 'no',
+          english_language_details: '',
+          other_language_details: 'Broken? Oh man, are you cereal?',
+        )
+
+        expect(present(personal_details_form)).to include(
+          row_for(:other_language_details, 'Broken? Oh man, are you cereal?')
+        )
+      end
+    end
+  end
+
+  def present(form)
+    CandidateInterface::PersonalDetailsReviewPresenter
+      .new(form)
+      .present
+  end
+
+  def row_for(key, value)
+    {
+      key: t("application_form.personal_details.#{key.to_s}.label"),
+      value: value,
+      action: t("application_form.personal_details.#{key.to_s}.change_action"),
+    }
+  end
+end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).to include(
-          row_for(:nationality, 'British')
+          row_for(:nationality, 'British'),
         )
       end
 
@@ -56,7 +56,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).to include(
-          row_for(:nationality, 'British and Spanish')
+          row_for(:nationality, 'British and Spanish'),
         )
       end
     end
@@ -71,7 +71,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).to include(
-          row_for(:english_main_language, 'Yes')
+          row_for(:english_main_language, 'Yes'),
         )
       end
 
@@ -84,7 +84,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).not_to include(
-          row_for(:english_main_language_details, '')
+          row_for(:english_main_language_details, ''),
         )
       end
 
@@ -97,7 +97,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).not_to include(
-          row_for(:other_language_details, 'Broken? Oh man, are you cereal?')
+          row_for(:other_language_details, 'Broken? Oh man, are you cereal?'),
         )
       end
 
@@ -110,7 +110,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).to include(
-          row_for(:english_main_language_details, 'Mi nombre es Max.')
+          row_for(:english_main_language_details, 'Mi nombre es Max.'),
         )
       end
     end
@@ -125,7 +125,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).to include(
-          row_for(:english_main_language, 'No')
+          row_for(:english_main_language, 'No'),
         )
       end
 
@@ -138,7 +138,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).not_to include(
-          row_for(:other_language_details, '')
+          row_for(:other_language_details, ''),
         )
       end
 
@@ -151,7 +151,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).not_to include(
-          row_for(:english_main_language_details, 'Mi nombre es Max.')
+          row_for(:english_main_language_details, 'Mi nombre es Max.'),
         )
       end
 
@@ -164,7 +164,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(present(personal_details_form)).to include(
-          row_for(:other_language_details, 'Broken? Oh man, are you cereal?')
+          row_for(:other_language_details, 'Broken? Oh man, are you cereal?'),
         )
       end
     end
@@ -178,9 +178,9 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
 
   def row_for(key, value)
     {
-      key: t("application_form.personal_details.#{key.to_s}.label"),
+      key: t("application_form.personal_details.#{key}.label"),
       value: value,
-      action: t("application_form.personal_details.#{key.to_s}.change_action"),
+      action: t("application_form.personal_details.#{key}.change_action"),
     }
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -81,7 +81,18 @@ RSpec.feature 'Entering their personal details' do
   def then_i_can_check_my_answers
     expect(page).to have_content 'Name'
     expect(page).to have_content 'Lando Calrissian'
-    expect(page).to have_content 'Change'
+
+    expect(page).to have_content t('application_form.personal_details.date_of_birth.label')
+    expect(page).to have_content '6 April 1937'
+
+    expect(page).to have_content t('application_form.personal_details.nationality.label')
+    expect(page).to have_content 'British and American'
+
+    expect(page).to have_content t('application_form.personal_details.english_main_language.label')
+    expect(page).to have_content 'Yes'
+
+    expect(page).to have_content t('application_form.personal_details.english_main_language_details.label')
+    expect(page).to have_content "I'm great at Galactic Basic so English is a piece of cake"
   end
 
   def then_i_can_see_my_application


### PR DESCRIPTION
### Context

Currently after filling in your personal details and clicking `Continue`, you only can review your `Name`.

### Changes proposed in this pull request

- Add `PersonalDetailsReviewPresenter` to allow us to display the review page
- Update Guardfile
- Add `#english_main_language?` helper

### Guidance to review

As we build the other parts of the candidate form, some stuff like the presenter view and model may get refactored into separate concerns, because we'll need them quite a few more times.

The long `spec/system/candidate_interface/candidate_entering_personal_details_spec.rb` will be refactored in a separate PR.

### Screenshot 📸

![Screenshot 2019-10-14 at 11 41 38](https://user-images.githubusercontent.com/1650875/66745691-9fbd1a00-ee77-11e9-9d53-9fbc2df03df1.png)

### Link to Trello card

[122 - Allow users to fill in "Personal details" with validation](https://trello.com/c/LTQDGPQh/122-allow-users-to-fill-in-personal-details-with-validation)
