### PR TITLE
Add validations to the endpoints

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -5,7 +5,7 @@ module VendorApi
     def make_offer
       decision = MakeAnOffer.new(
         application_choice: application_choice,
-        offer_conditions: params[:data],
+        offer_conditions: params.dig(:data, :conditions),
       )
 
       respond_to_decision(decision)

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -22,7 +22,7 @@ module VendorApi
     def reject
       decision = RejectApplication.new(
         application_choice: application_choice,
-        rejection: params[:data],
+        rejection_reason: params.dig(:data, :reason),
       )
 
       respond_to_decision(decision)

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -9,7 +9,7 @@ class MakeAnOffer
   def save
     if @offer_conditions.present?
       ApplicationStateChange.new(@application_choice).make_conditional_offer!
-      @application_choice.offer = @offer_conditions
+      @application_choice.offer = { 'conditions' => @offer_conditions }
     else
       ApplicationStateChange.new(@application_choice).make_unconditional_offer!
       @application_choice.offer = { 'conditions' => [] }

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -1,12 +1,19 @@
 class MakeAnOffer
   include ActiveModel::Validations
 
+  MAX_CONDITIONS_COUNT = 20
+  MAX_CONDITION_LENGTH = 255
+
+  validate :validate_offer_conditions
+
   def initialize(application_choice:, offer_conditions:)
     @application_choice = application_choice
     @offer_conditions = offer_conditions
   end
 
   def save
+    return unless valid?
+
     if @offer_conditions.present?
       ApplicationStateChange.new(@application_choice).make_conditional_offer!
       @application_choice.offer = { 'conditions' => @offer_conditions }
@@ -19,5 +26,19 @@ class MakeAnOffer
   rescue Workflow::NoTransitionAllowed => e
     errors.add(:state, e.message)
     false
+  end
+
+private
+
+  def validate_offer_conditions
+    return if @offer_conditions.blank?
+
+    unless @offer_conditions.is_a?(Array)
+      errors.add(:offer_conditions, 'must be an array')
+      return
+    end
+
+    errors.add(:offer_conditions, "has over #{MAX_CONDITIONS_COUNT} elements") if @offer_conditions.count > MAX_CONDITIONS_COUNT
+    errors.add(:offer_conditions, "has a condition over #{MAX_CONDITION_LENGTH} chars in length") if @offer_conditions.any? { |c| c.length > MAX_CONDITION_LENGTH }
   end
 end

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -12,7 +12,6 @@ class RejectApplication
 
       @application_choice.update!(
         rejection_reason: @rejection[:reason],
-        rejected_at: @rejection[:timestamp],
       )
     end
   rescue Workflow::NoTransitionAllowed => e

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -1,17 +1,24 @@
 class RejectApplication
+  attr_reader :rejection_reason
+
   include ActiveModel::Validations
 
-  def initialize(application_choice:, rejection:)
+  validates_presence_of :rejection_reason
+  validates_length_of :rejection_reason, maximum: 255
+
+  def initialize(application_choice:, rejection_reason:)
     @application_choice = application_choice
-    @rejection = rejection
+    @rejection_reason = rejection_reason
   end
 
   def save
+    return unless valid?
+
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).reject_application!
 
       @application_choice.update!(
-        rejection_reason: @rejection[:reason],
+        rejection_reason: @rejection_reason,
       )
     end
   rescue Workflow::NoTransitionAllowed => e

--- a/app/services/vendor_api/single_application_presenter.rb
+++ b/app/services/vendor_api/single_application_presenter.rb
@@ -57,7 +57,7 @@ module VendorApi
       if application_choice.rejection_reason?
         {
           reason: application_choice.rejection_reason,
-          date: application_choice.rejected_at,
+          date: Time.now,
         }
       end
     end

--- a/db/migrate/20191010160606_remove_rejected_at_from_application_choice.rb
+++ b/db/migrate/20191010160606_remove_rejected_at_from_application_choice.rb
@@ -1,0 +1,5 @@
+class RemoveRejectedAtFromApplicationChoice < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :application_choices, :rejected_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_08_122541) do
+ActiveRecord::Schema.define(version: 2019_10_10_160606) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -26,7 +26,6 @@ ActiveRecord::Schema.define(version: 2019_10_08_122541) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "status"
     t.json "offer"
-    t.datetime "rejected_at"
     t.string "rejection_reason"
     t.index ["application_form_id"], name: "index_application_choices_on_application_form_id"
   end

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
   end
 
+  it 'returns an error when given invalid conditions' do
+    application_choice = create(:application_choice, status: 'application_complete')
+
+    post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+      data: {
+        conditions: 'DO NOT WANT',
+      },
+    }
+
+    expect(response).to have_http_status(422)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(error_response['message']).to eql 'Offer conditions must be an array'
+  end
+
   it 'returns a not found error if the application can\'t be found' do
     request_body = {
                       "data": {

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
       request_body = {
         "data": {
           "reason": 'Does not meet minimum GCSE requirements',
-          "timestamp": '2019-03-01T15:33:49.216Z',
         },
       }
 
@@ -20,10 +19,10 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
       expect(response).to have_http_status(200)
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
-      expect(parsed_response['data']['attributes']['rejection']).to eq(
+      expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including({
         'reason' => 'Does not meet minimum GCSE requirements',
-        'date' => '2019-03-01T15:33:49.216Z',
-      )
+        'date' => anything, # This is not implemented yet
+      })
     end
   end
 

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
       expect(response).to have_http_status(200)
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
-      expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including({
+      expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
         'reason' => 'Does not meet minimum GCSE requirements',
         'date' => anything, # This is not implemented yet
-      })
+      )
     end
   end
 
@@ -34,6 +34,21 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
   end
+
+  it 'returns an error when a proper reason is not provided' do
+    application_choice = create(:application_choice, status: 'application_complete')
+
+    post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: {
+      data: {
+        reason: '',
+      },
+    }
+
+    expect(response).to have_http_status(422)
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(error_response['message']).to eql "Rejection reason can't be blank"
+  end
+
 
   it 'returns not found error when the application was not found' do
     post_api_request '/api/v1/applications/non-existent-id/reject'

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe MakeAnOffer do
+  describe 'validation' do
+    it 'accepts nil conditions' do
+      decision = MakeAnOffer.new(
+        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        offer_conditions: nil,
+      )
+
+      expect(decision).to be_valid
+    end
+
+    it 'only accepts conditions as an array' do
+      decision = MakeAnOffer.new(
+        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        offer_conditions: 'SPLAT',
+      )
+
+      expect(decision).not_to be_valid
+    end
+
+    it 'limits the number of conditions to 20' do
+      decision = MakeAnOffer.new(
+        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        offer_conditions: Array.new(21) { 'a condition' },
+      )
+
+      expect(decision).not_to be_valid
+    end
+
+    it 'limits the length of conditions to 255 characters' do
+      decision = MakeAnOffer.new(
+        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        offer_conditions: ['a' * 256],
+      )
+
+      expect(decision).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
### Context

When a Vendor posts invalid data to our endpoints (as they will), we need to return suitable and useful errors.

### Changes proposed in this pull request

- [X] 0. Remove the `rejected_at` field from the `ApplicationChoice` model. This field is not in line with our plan of using the audit log to assign dates to events. At least, it's not clear that this is the implementation we want. As keeping this would involve adding more code to the service at this stage, I've taken it out.
- [X] 1. Add validations to the `MakeAnOffer` service and surface them via the API: max 20 conditions, and max 255 chars per condition. allow nil for unconditional offers.
- [X] 2. Add validations to the `Reject` service and surface them via the API: require rejection_reason and limit it to 255 chars

I was able to use built-in validations for rejection_reason but not for offer_conditions bc it's an array.

See commit messages for more details.

### Guidance to review

There are no validations in the `ApplicationChoice` model. How do we feel about that? Note that JSON fields require somewhat special treatment.

### Link to Trello card

https://trello.com/c/2wtVwvIj/1077-add-validations-to-the-endpoints