### PR TITLE
Add WordCountValidator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,6 @@ RSpec/DescribedClass:
 # of `expect().to change { Candidate.count }`, which doesn't seem better.
 RSpec/ExpectChange:
   Enabled: false
+
+RSpec/LeadingSubject:
+  Enabled: false

--- a/app/validators/word_count_validator.rb
+++ b/app/validators/word_count_validator.rb
@@ -1,0 +1,11 @@
+class WordCountValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    # This RegExp should match the implementation in govuk-frontend:
+    # https://github.com/alphagov/govuk-frontend/blob/aa30ee76a5f84e230a323bb92d341285a6da3a10/src/govuk/components/character-count/character-count.js#L82
+    if value.scan(/\S+/).size > options[:maximum]
+      record.errors[attribute] << (options[:message] || "Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
+    end
+  end
+end

--- a/spec/validators/word_count_validator_spec.rb
+++ b/spec/validators/word_count_validator_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe WordCountValidator do
+  maximum = 10
+
+  before do
+    stub_const('Validatable', Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :some_words
+      validates :some_words, word_count: { maximum: maximum }
+    end
+  end
+
+  let(:model) {
+    Validatable.new.tap { |model| model.some_words = some_words_field }
+  }
+
+  let(:expected_errors) { ['Reduce the word count for some words'] }
+
+  subject! {
+    model.valid?
+  }
+
+  context 'with max valid number of words' do
+    let(:some_words_field) { (%w[word] * maximum).join(' ') }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with no words' do
+    let(:some_words_field) { '' }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with nil words' do
+    let(:some_words_field) { nil }
+
+    it { is_expected.to be true }
+  end
+
+  context 'with invalid number of words' do
+    let(:some_words_field) { (%w[word] * maximum).join(' ') + ' popped' }
+
+    it { is_expected.to be false }
+
+    it 'adds an error' do
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+
+  context 'with newlines' do
+    let(:some_words_field) { (%w[word] * maximum).join("\n") + ' popped' }
+
+    it { is_expected.to be false }
+
+    it 'adds an error' do
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+
+  context 'with non-words such as markdown' do
+    let(:some_words_field) { (%w[word] * maximum).join(' ') + ' *' }
+
+    it { is_expected.to be false }
+
+    it 'adds an error' do
+      expect(model.errors[:some_words]).to match_array expected_errors
+    end
+  end
+end


### PR DESCRIPTION
### Context

The upcoming validations PR for the candidate personal details depends on this, and it can be reviewed on its own.

### Changes proposed in this pull request

Add the `WordCountValidator` class with a spec.

### Guidance to review

This is stolen verbatim from Find, with only ~1~ 2 changes: I renamed it to `word_count` from `words_count` as it sounds better, and linting fixes.

The RegExp being used is the same exact one as the frontend word counting component. This is intentional, as otherwise we can get a mismatch between the JS validation and the error message that users will see. This is also why this functionality isn't implemented using a third party dependency (and because using a library for this seems a bit much).

This isn't nested within a candidate interface namespace because it can potentially be used by other parts, like the Provider interface when they specify a reason for acceptance/rejection.