### PR TITLE
Add validations to PersonalDetailsForm

### DIFF
--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -7,7 +7,11 @@ module CandidateInterface
     def update
       @personal_details_form = PersonalDetailsForm.new(personal_details_params)
 
-      render :show
+      if @personal_details_form.valid?
+        render :show
+      else
+        render :edit
+      end
     end
 
   private

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -23,8 +23,6 @@ module CandidateInterface
     validates :english_language_details, :other_language_details,
               word_count: { maximum: 200 }
 
-    # TODO: Better validation content
-
     def name
       "#{first_name} #{last_name}"
     end
@@ -38,9 +36,9 @@ module CandidateInterface
     def date_of_birth_cannot_be_in_the_future
       raise 'Invalid date' if [year, month, day].any?(&:blank?)
 
-      errors.add(:date_of_birth, 'Enter a date of birth that is in the past, for example 13 1 1993') if date_of_birth > Date.today
+      errors.add(:date_of_birth, :future) if date_of_birth > Date.today
     rescue RuntimeError, NoMethodError
-      errors.add(:date_of_birth, 'Enter a date of birth in the correct format, for example 13 1 1993')
+      errors.add(:date_of_birth, :invalid)
     end
   end
 end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -8,6 +8,18 @@ module CandidateInterface
                   :english_main_language,
                   :english_language_details, :other_language_details
 
+    validates :first_name, :last_name, :english_main_language,
+              :first_nationality,
+              presence: true
+
+    validates :first_name, :last_name,
+              length: { maximum: 100 }
+
+    # TODO: DoB valid date validation
+    # TODO: Nationality matches existing nationalities array
+    # TODO: Word count validation for english_language_details, other_language_details
+    # TODO: Better validation content
+
     def name
       "#{first_name} #{last_name}"
     end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -28,9 +28,12 @@ module CandidateInterface
     end
 
     def date_of_birth
-      Date.new(*[year, month, day].map(&:to_i))
-    rescue ArgumentError, NoMethodError
-      nil
+      date_args = [year, month, day].map(&:to_i)
+      if Date.valid_date?(*date_args)
+        Date.new(*date_args)
+      else
+        nil
+      end
     end
 
     def date_of_birth_cannot_be_in_the_future

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -15,7 +15,8 @@ module CandidateInterface
     validates :first_name, :last_name,
               length: { maximum: 100 }
 
-    validate :date_of_birth_cannot_be_in_the_future
+    validate :date_of_birth_valid
+    validate :date_of_birth_not_in_future
 
     validates :first_nationality, :second_nationality,
               inclusion: { in: NATIONALITIES, allow_blank: true }
@@ -31,17 +32,15 @@ module CandidateInterface
       date_args = [year, month, day].map(&:to_i)
       if Date.valid_date?(*date_args)
         Date.new(*date_args)
-      else
-        nil
       end
     end
 
-    def date_of_birth_cannot_be_in_the_future
-      raise 'Invalid date' if [year, month, day].any?(&:blank?)
+    def date_of_birth_valid
+      errors.add(:date_of_birth, :invalid) if date_of_birth.nil?
+    end
 
-      errors.add(:date_of_birth, :future) if date_of_birth > Date.today
-    rescue RuntimeError, NoMethodError
-      errors.add(:date_of_birth, :invalid)
+    def date_of_birth_not_in_future
+      errors.add(:date_of_birth, :future) if date_of_birth.present? && date_of_birth > Date.today
     end
   end
 end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -20,7 +20,9 @@ module CandidateInterface
     validates :first_nationality, :second_nationality,
               inclusion: { in: NATIONALITIES, allow_blank: true }
 
-    # TODO: Word count validation for english_language_details, other_language_details
+    validates :english_language_details, :other_language_details,
+              word_count: { maximum: 200 }
+
     # TODO: Better validation content
 
     def name

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -15,13 +15,28 @@ module CandidateInterface
     validates :first_name, :last_name,
               length: { maximum: 100 }
 
-    # TODO: DoB valid date validation
+    validate :date_of_birth_cannot_be_in_the_future
+
     # TODO: Nationality matches existing nationalities array
     # TODO: Word count validation for english_language_details, other_language_details
     # TODO: Better validation content
 
     def name
       "#{first_name} #{last_name}"
+    end
+
+    def date_of_birth
+      Date.new(*[year, month, day].map(&:to_i))
+    rescue ArgumentError, NoMethodError
+      nil
+    end
+
+    def date_of_birth_cannot_be_in_the_future
+      raise 'Invalid date' if [year, month, day].any?(&:blank?)
+
+      errors.add(:date_of_birth, 'Enter a date of birth that is in the past, for example 13 1 1993') if date_of_birth > Date.today
+    rescue RuntimeError, NoMethodError
+      errors.add(:date_of_birth, 'Enter a date of birth in the correct format, for example 13 1 1993')
     end
   end
 end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -17,7 +17,9 @@ module CandidateInterface
 
     validate :date_of_birth_cannot_be_in_the_future
 
-    # TODO: Nationality matches existing nationalities array
+    validates :first_nationality, :second_nationality,
+              inclusion: { in: NATIONALITIES, allow_blank: true }
+
     # TODO: Word count validation for english_language_details, other_language_details
     # TODO: Better validation content
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -21,3 +21,24 @@ en:
         yes_label: If you are bilingual or very familiar with languages other than English, you can tell us about them here.
         no_label: Please tell us about your English language qualifications (including grades or scores), and give details of other languages you are fluent in.
       complete_form_button: Continue
+  activemodel:
+    errors:
+      models:
+        candidate_interface/personal_details_form:
+          attributes:
+            first_name:
+              blank: Enter your first name or given names
+              too_long: First name must be 100 characters or fewer
+            last_name:
+              blank: Enter your last name or family name
+              too_long: Last name must be 100 characters or fewer
+            first_nationality:
+              blank: Choose your nationality from the list
+              inclusion: Choose your nationality from the list
+            second_nationality:
+              inclusion: Choose your nationality from the list
+            english_main_language:
+              blank: Choose if English is your main language
+            date_of_birth:
+              invalid: Enter a date of birth in the correct format, for example 13 1 1993
+              future: Enter a date of birth that is in the past, for example 13 1 1993

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -9,6 +9,26 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
     end
   end
 
+  describe '#date_of_birth' do
+    it "returns nil for nil day/month/year" do
+      personal_details = CandidateInterface::PersonalDetailsForm.new(day: nil, month: nil, year: nil)
+
+      expect(personal_details.date_of_birth).to eq(nil)
+    end
+
+    it "returns nil for invalid day/month/year" do
+      personal_details = CandidateInterface::PersonalDetailsForm.new(day: 99, month: 99, year: 99)
+
+      expect(personal_details.date_of_birth).to eq(nil)
+    end
+
+    it "returns a date for a valid day/month/year" do
+      personal_details = CandidateInterface::PersonalDetailsForm.new(day: '2', month: '8', year: '802701')
+
+      expect(personal_details.date_of_birth).to eq(Date.new(802701, 8, 2))
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:first_name) }
     it { is_expected.to validate_presence_of(:last_name) }

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -9,13 +9,51 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
     end
   end
 
-  describe "validations" do
-    it { should validate_presence_of(:first_name) }
-    it { should validate_presence_of(:last_name) }
-    it { should validate_presence_of(:first_nationality) }
-    it { should validate_presence_of(:english_main_language) }
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:first_name) }
+    it { is_expected.to validate_presence_of(:last_name) }
+    it { is_expected.to validate_presence_of(:first_nationality) }
+    it { is_expected.to validate_presence_of(:english_main_language) }
 
-    it { should validate_length_of(:first_name).is_at_most(100) }
-    it { should validate_length_of(:last_name).is_at_most(100) }
+    it { is_expected.to validate_length_of(:first_name).is_at_most(100) }
+    it { is_expected.to validate_length_of(:last_name).is_at_most(100) }
+
+    it { is_expected.to validate_inclusion_of(:first_nationality).in_array(NATIONALITIES) }
+    it { is_expected.to validate_inclusion_of(:second_nationality).in_array(NATIONALITIES) }
+
+    okay_text = Faker::Lorem.sentence(word_count: 200)
+    long_text = Faker::Lorem.sentence(word_count: 201)
+
+    it { is_expected.to allow_value(okay_text).for(:english_language_details) }
+    it { is_expected.not_to allow_value(long_text).for(:english_language_details) }
+
+    it { is_expected.to allow_value(okay_text).for(:other_language_details) }
+    it { is_expected.not_to allow_value(long_text).for(:other_language_details) }
+
+    describe 'date of birth' do
+      it 'is invalid if not well-formed' do
+        personal_details = CandidateInterface::PersonalDetailsForm.new(
+          day: '99', month: '99', year: '99',
+        )
+
+        personal_details.validate
+
+        expect(personal_details.errors.full_messages_for(:date_of_birth)).to eq(
+          ['Date of birth Enter a date of birth in the correct format, for example 13 1 1993'],
+        )
+      end
+
+      it 'is invalid if the date is in the past' do
+        personal_details = CandidateInterface::PersonalDetailsForm.new(
+          day: '2', month: '8', year: '802701',
+        )
+
+        personal_details.validate
+
+        expect(personal_details.errors.full_messages_for(:date_of_birth)).to eq(
+          ['Date of birth Enter a date of birth that is in the past, for example 13 1 1993'],
+        )
+      end
+    end
   end
 end

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -10,19 +10,19 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
   end
 
   describe '#date_of_birth' do
-    it "returns nil for nil day/month/year" do
+    it 'returns nil for nil day/month/year' do
       personal_details = CandidateInterface::PersonalDetailsForm.new(day: nil, month: nil, year: nil)
 
       expect(personal_details.date_of_birth).to eq(nil)
     end
 
-    it "returns nil for invalid day/month/year" do
+    it 'returns nil for invalid day/month/year' do
       personal_details = CandidateInterface::PersonalDetailsForm.new(day: 99, month: 99, year: 99)
 
       expect(personal_details.date_of_birth).to eq(nil)
     end
 
-    it "returns a date for a valid day/month/year" do
+    it 'returns a date for a valid day/month/year' do
       personal_details = CandidateInterface::PersonalDetailsForm.new(day: '2', month: '8', year: '802701')
 
       expect(personal_details.date_of_birth).to eq(Date.new(802701, 8, 2))

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -8,4 +8,14 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       expect(personal_details.name).to eq('Bruce Wayne')
     end
   end
+
+  describe "validations" do
+    it { should validate_presence_of(:first_name) }
+    it { should validate_presence_of(:last_name) }
+    it { should validate_presence_of(:first_nationality) }
+    it { should validate_presence_of(:english_main_language) }
+
+    it { should validate_length_of(:first_name).is_at_most(100) }
+    it { should validate_length_of(:last_name).is_at_most(100) }
+  end
 end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -20,6 +20,12 @@ RSpec.feature 'Entering their personal details' do
     then_i_can_see_my_application
   end
 
+  scenario 'Candidate triggers validation errors' do
+    given_i_am_on_the_personal_details_page
+    when_i_submit_the_form
+    then_i_should_see_validation_errors
+  end
+
   def given_i_am_signed_in
     candidate = FactoryBot.create(:candidate)
     login_as(candidate)
@@ -55,6 +61,10 @@ RSpec.feature 'Entering their personal details' do
     choose 'Yes'
     fill_in t('application_form.personal_details.english_main_language.yes_label'), with: "I'm great at Galactic Basic so English is a piece of cake", match: :prefer_exact
 
+    when_i_submit_the_form
+  end
+
+  def when_i_submit_the_form
     click_button t('application_form.personal_details.complete_form_button')
   end
 
@@ -76,5 +86,13 @@ RSpec.feature 'Entering their personal details' do
 
   def then_i_can_see_my_application
     expect(page).to have_content t('page_titles.application_form')
+  end
+
+  def then_i_should_see_validation_errors
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/personal_details_form.attributes.first_name.blank')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/personal_details_form.attributes.last_name.blank')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/personal_details_form.attributes.date_of_birth.invalid')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/personal_details_form.attributes.first_nationality.blank')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/personal_details_form.attributes.english_main_language.blank')
   end
 end


### PR DESCRIPTION
### Context

We need to make sure that users don't submit invalid data when they add their personal details to an application form.

### Changes proposed in this pull request

- Add validations, with unit tests
- Add an end to end test for a basic case (will be split out once `PersonalDetailsForm` is finished)

### Guidance to review

I didn't opt to make `date_of_birth` its own separate `Validator` because I don't expect it to be reused, and also naming it and figuring out options to pass in (`{ future: true }` etc) were giving me "overengineering" vibes so I decided to just leave it as a simple class method.

The constant `raise`ing in the date of birth stuff is a bit `GOTO`y and maybe could be improved?

I've split out some PRs for some of the commits on this in order to make this smaller:

- [x] `WordCountValidator` https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/302
- [x] `NATIONALITIES` https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/305
- [x] Replacing `nationalities` with `first_nationality` and `second_nationality` https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/306

### After screenshot

![Screenshot 2019-10-11 at 12 22 47](https://user-images.githubusercontent.com/1650875/66668540-61dcad80-ec4d-11e9-8a51-db268bb736d3.png)

### Link to Trello card

[122 - Allow users to fill in "Personal details" with validation](https://trello.com/c/LTQDGPQh/122-allow-users-to-fill-in-personal-details-with-validation)