### PR TITLE
Replace `nationalities` array with first and second in PersonalDetailsForm

### DIFF
--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -14,8 +14,11 @@ module CandidateInterface
 
     def personal_details_params
       params.require(:candidate_interface_personal_details_form).permit(
-        :first_name, :last_name, :"date_of_birth(3i)", :"date_of_birth(2i)",
-        :"date_of_birth(1i)", :english_main_language, nationalities: []
+        :first_name, :last_name,
+        :"date_of_birth(3i)", :"date_of_birth(2i)", :"date_of_birth(1i)",
+        :first_nationality, :second_nationality,
+        :english_main_language,
+        :english_language_details, :other_language_details
       )
         .transform_keys { |key| dob_field_to_attribute(key) }
     end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -2,8 +2,11 @@ module CandidateInterface
   class PersonalDetailsForm
     include ActiveModel::Model
 
-    attr_accessor :first_name, :last_name, :day, :month, :year, :nationalities,
-                  :english_main_language
+    attr_accessor :first_name, :last_name,
+                  :day, :month, :year,
+                  :first_nationality, :second_nationality,
+                  :english_main_language,
+                  :english_language_details, :other_language_details
 
     def name
       "#{first_name} #{last_name}"

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -19,7 +19,7 @@
 
         <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint_text: t('application_form.personal_details.date_of_birth.hint_text') %>
 
-        <%= f.govuk_text_field 'nationalities', label: { text: t('application_form.personal_details.nationality.label'), size: 'm' }, multiple: true %>
+        <%= f.govuk_text_field :first_nationality, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
 
         <details class="govuk-details" data-module="govuk-details">
           <summary class="govuk-details__summary">
@@ -28,7 +28,7 @@
             </span>
           </summary>
           <div class="govuk-details__text">
-            <%= f.govuk_text_field 'nationalities', label: { text: t('application_form.personal_details.second_nationality.label') }, multiple: true %>
+            <%= f.govuk_text_field :second_nationality, label: { text: t('application_form.personal_details.second_nationality.label') } %>
           </div>
         </details>
 


### PR DESCRIPTION
### Context

Refactoring to make https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/304 easier to review.

### Changes proposed in this pull request

Replaces `nationalities` with `first_nationality` and `second_nationality`.

The array is a bit difficult to deal with, because it's not a `has_many` relationship, so built in form helpers get a bit confused in what they post to and also what values they should prepopulate individual fields with. Moreover, I don't know if we'll save it as an array data type in the end anyway.

Also adds some more missing accessors to `PersonalDetailsForm`.

### Guidance to review

This makes validations a lot more simple, and I don't think the obvious downside (we can't do 3 or more nationalities) will come back to haunt us too soon.

### Link to Trello card

[122 - Allow users to fill in "Personal details" with validation](https://trello.com/c/LTQDGPQh/122-allow-users-to-fill-in-personal-details-with-validation)