### PR TITLE
Edit OpenApi3 yml and specs to fix boolean bug

### DIFF
--- a/config/vendor-api-0.5.0.yml
+++ b/config/vendor-api-0.5.0.yml
@@ -348,15 +348,15 @@ components:
         offer:
           anyOf:
             - $ref: "#/components/schemas/Offer"
-          nullable: 'true'
+          nullable: true
         withdrawal:
           anyOf:
             - $ref: "#/components/schemas/Withdrawal"
-          nullable: 'true'
+          nullable: true
         rejection:
           anyOf:
             - $ref: "#/components/schemas/Rejection"
-          nullable: 'true'
+          nullable: true
         hesa_itt_data:
           $ref: "#/components/schemas/HESAITTData"
     Candidate:

--- a/spec/helpers/open_api3_specification_spec.rb
+++ b/spec/helpers/open_api3_specification_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OpenApi3Specification do
                     'anyOf' => [
                       { 'type' => 'string' },
                     ],
-                    'nullable' => 'true',
+                    'nullable' => true,
                   },
                 },
               },
@@ -74,7 +74,7 @@ RSpec.describe OpenApi3Specification do
                     'anyOf' => [
                       { 'type' => 'string' },
                     ],
-                    'nullable' => 'true',
+                    'nullable' => true,
                   },
                 },
               },

--- a/spec/support/vendor_api/open_api_3_specification.rb
+++ b/spec/support/vendor_api/open_api_3_specification.rb
@@ -40,6 +40,6 @@ private
   end
 
   def nullable_properties(props)
-    props.select { |_prop, value| value['nullable'] == 'true' }
+    props.select { |_prop, value| value['nullable'] == true }
   end
 end


### PR DESCRIPTION
### Context

@duncanjbrown mentioned a bug where nullable objects in the JSON Schema are represented by strings instead of booleans which is not OpenAPI3 compliant. 
This PR aims to fix this.

### Changes proposed in this pull request

- Update `OpenApi3 yml` file to change nullable fields from strings to booleans
- Update OpenApi specs the use the new boolean field.

### Guidance to review

- Run specs
- Check `OpenApi3 yml` with swagger editor to ensure it is now OpenApi3 compliant.

### Link to Trello card

[1043 - Tech docs updates following implementation of api](https://trello.com/c/l6RyfvYc/1043-tech-docs-updates-following-implementation-of-api)
