### PR TITLE
make git ignore any Mac Finder directory metadata files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-debug.log*
 
 # dotenv
 .env
+
+# Mac OS thumbnail DBs
+.DS_Store


### PR DESCRIPTION
### Context

If you open one of the directories in this repo in your Mac OS X Finder, it can create a [.DS_Store](https://en.wikipedia.org/wiki/.DS_Store) file, which stores metadata about the view options for that directory. These files then show up in git, and could be accidentally added. 

### Changes proposed in this pull request

This PR makes git ignore .DS_Store files, by adding them to .gitignore

### Guidance to review

Try creating a .DS_Store file, either through opening Finder, or from the cmd line with `touch .DS_Store`. 
Then `git status` - the .DS_Store file should not show up.

### Link to Trello card

(none, just noticed it when pulling the latest changes to my local repo)
