### PR TITLE
Complete personal details section

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -5,6 +5,7 @@ module CandidateInterface
     def show
       redirect_to candidate_interface_application_form_path if params[:token]
       @application_form = current_candidate.current_application
+      @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(@application_form)
     end
   end
 end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -4,8 +4,7 @@ module CandidateInterface
 
     def show
       redirect_to candidate_interface_application_form_path if params[:token]
-      @application_form = current_candidate.current_application
-      @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(@application_form)
+      @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_candidate.current_application)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -17,6 +17,13 @@ module CandidateInterface
       end
     end
 
+    def show
+      personal_details_form = PersonalDetailsForm.build_from_application(
+        current_candidate.current_application,
+      )
+      @personal_details_review = PersonalDetailsReviewPresenter.new(personal_details_form)
+    end
+
   private
 
     def personal_details_params

--- a/app/frontend/styles/_task-list.scss
+++ b/app/frontend/styles/_task-list.scss
@@ -31,6 +31,17 @@
   }
 }
 
+.app-task-list__task-completed {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
 @media print {
   .app-task-list__task-name::after {
     display: none;

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  class ApplicationFormPresenter
+    def initialize(application_form)
+      @application_form = application_form
+    end
+
+    def personal_details_completed?
+      CandidateInterface::PersonalDetailsForm.build_from_application(@application_form).valid?
+    end
+  end
+end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -4,6 +4,10 @@ module CandidateInterface
       @application_form = application_form
     end
 
+    def application_choices_added?
+      @application_form.application_choices.present?
+    end
+
     def personal_details_completed?
       CandidateInterface::PersonalDetailsForm.build_from_application(@application_form).valid?
     end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -9,7 +9,7 @@
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
       Courses
     </h2>
-    <% if @application_form.application_choices.empty? %>
+    <% unless @application_form_presenter.application_choices_added? %>
       <p class="govuk-body"><%= t('application_form.courses') %></p>
     <% end %>
     <%= govuk_button_link_to 'TODO: Add course', '#' %>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -19,7 +19,12 @@
     </h2>
     <ol class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
-        <%= govuk_link_to t('page_titles.personal_details'), candidate_interface_personal_details_edit_path, class: 'app-task-list__task-name' %>
+        <% if @application_form_presenter.personal_details_completed? %>
+          <%= govuk_link_to t('page_titles.personal_details'), candidate_interface_personal_details_show_path, class: 'app-task-list__task-name', 'aria-describedby': 'personal-details-completed' %>
+          <strong class="govuk-tag app-task-list__task-completed" id="personal-details-completed">Completed</strong>
+        <% else %>
+          <%= govuk_link_to t('page_titles.personal_details'), candidate_interface_personal_details_edit_path, class: 'app-task-list__task-name' %>
+        <% end %>
       </li>
       <li class="app-task-list__item">
         <%= govuk_link_to 'TODO: Contact details', '#', class: 'app-task-list__task-name' %>

--- a/app/views/candidate_interface/personal_details/show.html.erb
+++ b/app/views/candidate_interface/personal_details/show.html.erb
@@ -27,3 +27,5 @@
     </dl>
   </div>
 </section>
+
+<%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,7 @@ Rails.application.routes.draw do
       scope :personal_details, path: '/personal-details' do
         get '/' => 'personal_details#edit', as: :personal_details_edit
         post '/review' => 'personal_details#update', as: :personal_details_update
-        # get '/review' => 'personal_details#show', as: :personal_details_show
-        # post '/submit' => 'personal_details#create', as: :personal_details_create
+        get '/review' => 'personal_details#show', as: :personal_details_show
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
   end
 
   factory :application_choice do
-    application_form
+    association :application_form, factory: :completed_application_form
     status { ApplicationStateChange.valid_states.sample }
 
     provider_ucas_code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,9 +15,17 @@ FactoryBot.define do
       english_main_language { %w[yes no].sample }
       english_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
       other_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+
+      transient do
+        application_choices_count { 3 }
+      end
     end
 
-    factory :completed_application_form, traits: [:completed_application_form]
+    factory :completed_application_form, traits: [:completed_application_form] do
+      after(:build) do |application_form, evaluator|
+        create_list(:application_choice, evaluator.application_choices_count, application_form: application_form)
+      end
+    end
   end
 
   factory :application_choice do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,9 +6,18 @@ FactoryBot.define do
   factory :application_form do
     candidate
 
-    date_of_birth { Faker::Date.birthday }
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    trait :completed_application_form do
+      first_name { Faker::Name.first_name }
+      last_name { Faker::Name.last_name }
+      date_of_birth { Faker::Date.birthday }
+      first_nationality { NATIONALITIES.sample }
+      second_nationality { NATIONALITIES.sample }
+      english_main_language { %w[yes no].sample }
+      english_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+      other_language_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+    end
+
+    factory :completed_application_form, traits: [:completed_application_form]
   end
 
   factory :application_choice do

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       expect(presenter).not_to be_personal_details_completed
     end
   end
+
+  describe '#application_choices_added?' do
+    it 'returns true if application choices are added' do
+      application_form = FactoryBot.build(:completed_application_form)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_application_choices_added
+    end
+
+    it 'returns false if no application choices are added' do
+      application_form = FactoryBot.build(:application_form)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_application_choices_added
+    end
+  end
 end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplicationFormPresenter do
+  describe '#personal_details_completed?' do
+    it 'returns true if personal details section is completed' do
+      application_form = FactoryBot.build(:completed_application_form)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_personal_details_completed
+    end
+
+    it 'returns false if personal details section is incomplete' do
+      application_form = FactoryBot.build(:application_form)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_personal_details_completed
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -19,10 +19,10 @@ RSpec.feature 'Entering their personal details' do
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
-    # when_i_submit_my_details
-    # then_i_should_see_the_form
-    # and_that_the_section_is_completed
-    #
+    when_i_submit_my_details
+    then_i_should_see_the_form
+    and_that_the_section_is_completed
+
     # when_i_click_on_personal_details
     # then_i_can_check_my_revised_answers
   end
@@ -99,6 +99,6 @@ RSpec.feature 'Entering their personal details' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#personal-details-completed', 'Completed')
+    expect(page).to have_css('#personal-details-completed', text: 'Completed')
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -23,8 +23,8 @@ RSpec.feature 'Entering their personal details' do
     then_i_should_see_the_form
     and_that_the_section_is_completed
 
-    # when_i_click_on_personal_details
-    # then_i_can_check_my_revised_answers
+    when_i_click_on_personal_details
+    then_i_can_check_my_revised_answers
   end
 
   def given_i_am_signed_in


### PR DESCRIPTION
### Context

Currently, when a candidate has submitted their personal details they can't see from the 'Your application' page that it is completed.

### Changes proposed in this pull request

This PR allows the `Completed` label to the personal details section and correctly links to the review page when it is completed.

### Guidance to review

This is the second or third time that we've had to write up a bunch of `Faker` stuff to mock up an `application_form` in `spec/models/application_form_spec.rb`, but it's also likely the last time, since the feature is done... Worth making into a factory or nah? 🤔 

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/66841654-f141d380-ef61-11e9-8ae1-d15a269ddea2.png)

### Link to Trello card

[122 - Allow users to fill in "Personal details" with validation](https://trello.com/c/LTQDGPQh/122-allow-users-to-fill-in-personal-details-with-validation)
