### PR TITLE
Change nationalities text fields to be dropdowns

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -21,6 +21,12 @@ module ViewHelper
     link_to(body, url, role: 'button', class: html_options[:class], 'data-module': 'govuk-button', draggable: false)
   end
 
+  def select_nationality_options
+    [
+      OpenStruct.new(id: '', name: t('application_form.personal_details.nationality.default_option')),
+    ] + NATIONALITIES.map { |nationality| OpenStruct.new(id: nationality, name: nationality) }
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -19,8 +19,7 @@
 
         <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint_text: t('application_form.personal_details.date_of_birth.hint_text') %>
 
-        <%= f.govuk_text_field :first_nationality, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
-
+        <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
         <details class="govuk-details" data-module="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
@@ -28,7 +27,7 @@
             </span>
           </summary>
           <div class="govuk-details__text">
-            <%= f.govuk_text_field :second_nationality, label: { text: t('application_form.personal_details.second_nationality.label') } %>
+            <%= f.govuk_collection_select :second_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.second_nationality.label') } %>
           </div>
         </details>
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -19,6 +19,7 @@ en:
       nationality:
         label: Nationality
         change_action: nationality
+        default_option: Select a nationality
       second_nationality:
         label: Second nationality
       english_main_language:

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -68,4 +68,13 @@ RSpec.describe ViewHelper, type: :helper do
       expect(anchor_tag).to eq('<a role="button" class="govuk-button govuk-button--start" data-module="govuk-button" draggable="false" href="https://localhost:0103/chicken/cluck">Cluck</a>')
     end
   end
+
+  describe '#select_nationality_options' do
+    it 'returns a list of nationalities' do
+      random_nationality = NATIONALITIES.sample
+
+      expect(select_nationality_options).to include(OpenStruct.new(id: '', name: t('application_form.personal_details.nationality.default_option')))
+      expect(select_nationality_options).to include(OpenStruct.new(id: random_nationality, name: random_nationality))
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -56,10 +56,10 @@ RSpec.feature 'Entering their personal details' do
     fill_in 'Month', with: '4'
     fill_in 'Year', with: '1937'
 
-    fill_in t('nationality.label', scope: scope), with: 'British'
+    select('British', from: t('nationality.label', scope: scope))
     find('details').click
     within('details') do
-      fill_in t('second_nationality.label', scope: scope), with: 'American'
+      select('American', from: t('second_nationality.label', scope: scope))
     end
 
     choose 'Yes'


### PR DESCRIPTION
### Context

Currently we have a text field for a candidate to fill in their nationality / nationalities, when we should have autocomplete or a dropdown for when JavaScript is disabled.

### Changes proposed in this pull request

This PR replaces the text field for nationalities with a dropdown.

#### Before

![image](https://user-images.githubusercontent.com/42817036/66834581-cfdaea80-ef55-11e9-8f97-b92a9b09e90f.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/66834521-afab2b80-ef55-11e9-8658-39526ae99d0f.png)

![image](https://user-images.githubusercontent.com/42817036/66834855-5b547b80-ef56-11e9-8fc2-cc5e34ae44ff.png)

### Guidance to review

We'll follow up with a second PR for adding autocomplete.

### Link to Trello card

[149 - Allow users to specify their nationality using autocomplete or <select> (personal details)](https://trello.com/c/tesxXi4Q/149-allow-users-to-specify-their-nationality-using-autocomplete-personal-details)
