### PR TITLE
add simplecov gem to measure test coverage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,8 @@
 yarn-debug.log*
 .yarn-integrity
 
+# ignore code coverage reports
+coverage/*
+
 # dotenv
 .env

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :test do
   gem 'timecop'
   gem 'guard-rspec'
   gem 'webmock'
+  gem 'simplecov', require: false, group: :test
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    docile (1.3.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -153,6 +154,7 @@ GEM
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
+    json (2.2.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     json_api_client (1.16.1)
@@ -310,6 +312,11 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (4.1.2)
       activesupport (>= 4.2.0)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     smart_properties (1.15.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
@@ -382,6 +389,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-raven
   shoulda-matchers (~> 4.1)
+  simplecov
   timecop
   web-console (>= 3.3.0)
   webmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'simplecov'
+SimpleCov.start 'rails'
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
### Context

To give us confidence in our test suite, and help us make sure that our test suite is comprehensive and doesn't give us a false sense of security, we should report how much of our codebase is covered by tests.

### Changes proposed in this pull request

Add the simplecov gem, which measures code coverage and integrates cleanly with rspec.
It's a straightforward setup at the moment. Later we can configure it to do things like:

* fail the build if coverage drops below a certain percentage, or drops by a certain threshold percentage in one PR 
* provide a 'badge' on the readme reporting the coverage alongside the build status

... but the first step is just to report the percentage. 

### Guidance to review

Run the specs, and it will report coverage on the command line -
```bash
> bundle exec rspec
(...)
Finished in 17.34 seconds (files took 7.03 seconds to load)
165 examples, 0 failures

Randomized with seed 23692

Coverage report generated for RSpec to (...)/apply-for-postgraduate-teacher-training/coverage. 532 / 538 LOC (98.88%) covered.
``` 
...and also generate nice clickable HTML per-file breakdowns in the coverage/ directory:

```
open coverage/index.html
```
<img width="1121" alt="Screen Shot 2019-10-15 at 14 54 38" src="https://user-images.githubusercontent.com/134501/66838027-df5d3200-ef5b-11e9-8f1b-c563e0c29b92.png">


### Link to Trello card

(n/a)
