### PR TITLE
Create initial ADR for how we retrieve data from Find

### DIFF
--- a/adr/0006-retrieving-data-from-find.md
+++ b/adr/0006-retrieving-data-from-find.md
@@ -36,7 +36,7 @@ Keeping all information in the Find Service and contacting the `Find API` every 
 
 #### Cons
 
-- This can be slow if making many requests to the `Find API`. 
+- This can be slow if making many requests to the `Find API`. (Caching could be a solution to this.)
 - Apply Service is dependent on the Find Service to function. 
 
 

--- a/adr/0006-retrieving-data-from-find.md
+++ b/adr/0006-retrieving-data-from-find.md
@@ -16,7 +16,9 @@ In order to do this the Apply service needs to retrieve data for `Training Provi
 
 The main areas where the Apply Service needs data from the Find Service are: 
 -   The Apply Service Start Page.
+    - Users arrive with a course course code as a URL parameter and the corresponding course needs to be retrieved.
 -   The Add a course to Application Page.
+    - All current courses need to be retrieved to populate a autocomplete field.
 -   The Application requirements require the Course type (`Secondary` or `Primary`).
 -   The Provider UI needs to know information about the currently signed in Provider.
 - The Applications to a certain Provider's courses need to be scoped for the currently signed in Provider.

--- a/adr/0006-retrieving-data-from-find.md
+++ b/adr/0006-retrieving-data-from-find.md
@@ -25,31 +25,41 @@ The main areas where the Apply Service needs data from the Find Service are:
 
 From an initial discussion and planning session we have decided on two main methods from retrieving data from the Find Service:
 
-`Ask the Find API for all information.`
+
+### Ask the Find API for all information.
 
 Keeping all information in the Find Service and contacting the `Find API` every time the Apply Service needs information for `Provider`, `Course` and `Site`.
+#### Pros
 
 - This reduces the need to store information within the Apply Service.
 - The data from Find is always the latest up-to-date data.
+
+#### Cons
+
 - This can be slow if making many requests to the `Find API`. 
 - Apply Service is dependent on the Find Service to function. 
 
 
-`Create a local copy from Find data`
+### Create a local copy from Find data
 
-Create local models for `Provider`, `Course` and `Site`. Populating these models from information from the `Find API` which is called periodically.
+Create local models for `Provider`, `Course` and `Site`. Populate these models from information from the `Find API` which is called periodically.
+
+#### Pros
 
 - Apply Service is not dependent on the Find Service to function. 
-- Faster to lookup local copy that make API request.
+- Faster to lookup local copy than make API request.
 - We have more control of local models and only need to request and save data that the Apply Service requires.
 - Easier to test local models.
+
+
+#### Cons
+
 - Requires method to retrieve data from Find and create and update local models.
 - Local models can drift from information stored in find if not updated frequently.
 - Newly created courses on Find may not be created on the Apply Service until they are retrieved. 
 (Will need to check Find service often for new data.)
 - Data deleted from the Find service will need to be reflected in the Apply Service somehow. 
 (Possibly deleting and rebuilding Apply models from  Find Data Periodically).
-
 
 ## Decision
 

--- a/adr/0006-retrieving-data-from-find.md
+++ b/adr/0006-retrieving-data-from-find.md
@@ -1,0 +1,60 @@
+# 6. Retrieving Data from Find Service
+
+Date: 2019-10-15
+
+## Status
+
+Accepted
+
+## Context
+We are currently working towards meeting these two main user needs:
+-   Candidates want to apply to teacher training courses.
+-   Training providers want to view applicants who have applied to their courses.
+
+In order to do this the Apply service needs to retrieve data for `Training Providers`, 
+`Courses` and `Sites` from the Find service.
+
+The main areas where the Apply Service need data from the Find Service are: 
+-   The Apply Service Start Page.
+-   The Add a course to Application Page.
+-   The Application requirements require the Course type (`Secondary` or `Primary`).
+-   The Provider UI needs to know information about the currently signed in Provider.
+- The Applications to a certain Provider's courses need to be scoped for the currently signed in Provider.
+
+From an initial discussion and planning session we have decided on two main methods from retrieving data from the Find Service:
+
+`Ask the Find API for all information.`
+
+Keeping all information in the Find Service and contacting the `Find API` every time the Apply Service needs information for `Provider`, `Course` and `Site`.
+
+- This reduces the need to store information within the Apply Service.
+- The data from Find is always the latest up-to-date data.
+- This can be slow if making many requests to the `Find API`. 
+- Apply Service is dependent on the Find Service to function. 
+
+
+`Create a local copy from Find data`
+
+Create local models for `Provider`, `Course` and `Site`. Populating these models from information from the `Find API` which is called periodically.
+
+- Apply Service is not dependent on the Find Service to function. 
+- Faster to lookup local copy that make API request.
+- We have more control or local models and only need to request and save data that the Apply Service requires.
+- Easier to test local models.
+- Requires method to retrieve data from Find and create and update local models.
+- Local models can drift from information stored in find if not updated frequently.
+
+
+## Decision
+
+Create local copies of `Provider`, `Course` and `Site` that can be populated with data from the Find Service.
+
+
+## Consequences
+
+- Local models for `Provider`, `Course` and `Site` will need to be created.
+- `ApplicationChoice` needs to be linked to a unique `Course` in some way. 
+- A system for retrieving data from the Find API and creating or updating local models need to be created.
+
+
+

--- a/adr/0006-retrieving-data-from-find.md
+++ b/adr/0006-retrieving-data-from-find.md
@@ -45,6 +45,10 @@ Create local models for `Provider`, `Course` and `Site`. Populating these models
 - Easier to test local models.
 - Requires method to retrieve data from Find and create and update local models.
 - Local models can drift from information stored in find if not updated frequently.
+- Newly created courses on Find may not be created on the Apply Service until they are retrieved. 
+(Will need to check Find service often for new data.)
+- Data deleted from the Find service will need to be reflected in the Apply Service somehow. 
+(Possibly deleting and rebuilding Apply models from  Find Data Periodically).
 
 
 ## Decision

--- a/adr/0006-retrieving-data-from-find.md
+++ b/adr/0006-retrieving-data-from-find.md
@@ -53,7 +53,7 @@ Create local copies of `Provider`, `Course` and `Site` that can be populated wit
 ## Consequences
 
 - Local models for `Provider`, `Course` and `Site` will need to be created.
-- `ApplicationChoice` needs to be linked to a unique `Course` in some way. 
+- `ApplicationChoice` needs to be linked to a unique `Course`/`Site` combination in some way. 
 - A system for retrieving data from the Find API and creating or updating local models need to be created.
 
 

--- a/adr/0006-retrieving-data-from-find.md
+++ b/adr/0006-retrieving-data-from-find.md
@@ -14,7 +14,7 @@ We are currently working towards meeting these two main user needs:
 In order to do this the Apply service needs to retrieve data for `Training Providers`, 
 `Courses` and `Sites` from the Find service.
 
-The main areas where the Apply Service need data from the Find Service are: 
+The main areas where the Apply Service needs data from the Find Service are: 
 -   The Apply Service Start Page.
 -   The Add a course to Application Page.
 -   The Application requirements require the Course type (`Secondary` or `Primary`).
@@ -39,7 +39,7 @@ Create local models for `Provider`, `Course` and `Site`. Populating these models
 
 - Apply Service is not dependent on the Find Service to function. 
 - Faster to lookup local copy that make API request.
-- We have more control or local models and only need to request and save data that the Apply Service requires.
+- We have more control of local models and only need to request and save data that the Apply Service requires.
 - Easier to test local models.
 - Requires method to retrieve data from Find and create and update local models.
 - Local models can drift from information stored in find if not updated frequently.
@@ -54,7 +54,7 @@ Create local copies of `Provider`, `Course` and `Site` that can be populated wit
 
 - Local models for `Provider`, `Course` and `Site` will need to be created.
 - `ApplicationChoice` needs to be linked to a unique `Course`/`Site` combination in some way. 
-- A system for retrieving data from the Find API and creating or updating local models need to be created.
+- A system for retrieving data from the Find API and creating or updating local models needs to be created.
 
 
 


### PR DESCRIPTION
### Context

Currently there are many streams of work that require data from Providers, Courses and Sites which are currently only stored at the Find Service side.
- Connect API tokens to providers
- Allow candidates to apply to a course.
- Allow providers to view applications to their courses.

From discussions around how the Apply service will retrieve data from the Find service we have made some architectural decisions that need to be recorded as an ADR. 

### Changes proposed in this pull request

Add an ADR for decisions around how the Apply service will retrieve data from the Find service.

### Guidance to review

Read through `adr/0006-retrieving-data-from-find.md` and ensure it is accurate to the decided approach.

### Link to Trello card

[1099 - Model courses providers and populate with find data](https://trello.com/c/hmJQSExM/1099-model-courses-providers-and-populate-with-find-data)
