### PR TITLE
Add autocomplete for nationality fields

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,5 +1,25 @@
 require.context('govuk-frontend/govuk/assets');
 import { initAll as govUKFrontendInitAll } from 'govuk-frontend';
+import 'accessible-autocomplete/dist/accessible-autocomplete.min.css';
+import accessibleAutocomplete from 'accessible-autocomplete';
 
 import '../styles/application.scss';
 govUKFrontendInitAll();
+
+try {
+  const nationalitySelects = [
+    '#candidate-interface-personal-details-form-first-nationality-field',
+    '#candidate-interface-personal-details-form-second-nationality-field'
+  ].forEach(id => {
+    const nationalitySelect = document.querySelector(id);
+
+    // Replace "Select a nationality" with empty string
+    nationalitySelect.querySelector("[value='']").innerHTML = '';
+
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: nationalitySelect
+    })
+  })
+} catch(err) {
+  console.error('Could not enhance nationality select:', err)
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -12,3 +12,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "~govuk-frontend/govuk/all";
 @import "_task-list";
 @import "_summary-card";
+
+.autocomplete__wrapper, .autocomplete__input, .autocomplete__hint {
+  font-family: $govuk-font-family;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "^4.0.7",
+    "accessible-autocomplete": "^2.0.1",
     "govuk-frontend": "^3.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -922,6 +922,13 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+accessible-autocomplete@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.1.tgz#dbbe703d0b48cd37ec0fea97fe46f066528e8098"
+  integrity sha512-2Cq8uI+deZNGMS38MmzE+40yT1A2ZC+aRC80l4zazQeh9TrhTn7Ho1fZ0Den1F+WQBe8RNLZtufzGFrMVU8K8w==
+  dependencies:
+    preact "^8.3.1"
+
 acorn@^6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.2.1.tgz#3ed8422d6dec09e6121cc7a843ca86a330a86b51"
@@ -5466,6 +5473,11 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
+
+preact@^8.3.1:
+  version "8.5.2"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.2.tgz#2f532da485287c07369e08150cf4d23921a09789"
+  integrity sha512-37tlDJGq5IQKqGUbqPZ7qPtsTOWFyxe+ojAOFfzKo0dEPreenqrqgJuS83zGpeGAqD9h9L9Yr7QuxH2W4ZrKxg==
 
 prepend-http@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
### Context

We have a PR #316 for to change the nationality fields to be dropdowns but this is for when JavaScript is disabled. 

### Changes proposed in this pull request

This PR adds autocomplete for the nationality fields.

#### Screenshot

![image](https://user-images.githubusercontent.com/42817036/66840969-cd31c280-ef60-11e9-87f3-f24dd1637095.png)

### Guidance to review

We've branched off from #316 so we'll get that merged in first and rebase.

Worth trying it out to see how it works.

### Link to Trello card

[149 - Allow users to specify their nationality using autocomplete or <select> (personal details)](https://trello.com/c/tesxXi4Q/149-allow-users-to-specify-their-nationality-using-autocomplete-personal-details)
