### PR TITLE
Add name and date of birth to provider, vendor and support interfaces

### DIFF
--- a/app/services/provider_interface/application_choice_presenter.rb
+++ b/app/services/provider_interface/application_choice_presenter.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   class ApplicationChoicePresenter
     def initialize(application_choice)
       @application_choice = application_choice
+      @application_form = application_choice.application_form
     end
 
     def full_name
@@ -24,8 +25,12 @@ module ProviderInterface
       application_choice.id
     end
 
+    def date_of_birth
+      application_form.date_of_birth
+    end
+
   private
 
-    attr_reader :application_choice
+    attr_reader :application_choice, :application_form
   end
 end

--- a/app/services/support_interface/application_form_presenter.rb
+++ b/app/services/support_interface/application_form_presenter.rb
@@ -12,6 +12,10 @@ module SupportInterface
       application_form.updated_at
     end
 
+    def date_of_birth
+      application_form.date_of_birth
+    end
+
     def to_param
       application_form.id.to_s
     end

--- a/app/services/vendor_api/single_application_presenter.rb
+++ b/app/services/vendor_api/single_application_presenter.rb
@@ -1,9 +1,8 @@
 module VendorApi
   class SingleApplicationPresenter
-    attr_reader :application_choice
-
     def initialize(application_choice)
       @application_choice = application_choice
+      @application_form = application_choice.application_form
     end
 
     def as_json
@@ -16,9 +15,9 @@ module VendorApi
           submitted_at: Time.now,
           personal_statement: 'hello',
           candidate: {
-            first_name: '',
-            last_name: '',
-            date_of_birth: '2019-01-01',
+            first_name: application_form.first_name,
+            last_name: application_form.last_name,
+            date_of_birth: application_form.date_of_birth,
             nationality: %w[NL],
             uk_residency_status: '',
           },
@@ -61,5 +60,9 @@ module VendorApi
         }
       end
     end
+
+  private
+
+    attr_reader :application_choice, :application_form
   end
 end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -1,1 +1,21 @@
 <h1 class='govuk-heading-xl'><%= @application_choice.full_name %>'s application</h1>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @application_choice.full_name %>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @application_choice.date_of_birth %>
+    </dd>
+  </div>
+</dl>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,1 +1,21 @@
 <h1 class='govuk-heading-xl'><%= @application_form.full_name %>'s application</h1>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Name
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @application_form.full_name %>
+    </dd>
+  </div>
+
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Date of birth
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= @application_form.date_of_birth %>
+    </dd>
+  </div>
+</dl>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -5,11 +5,16 @@ FactoryBot.define do
 
   factory :application_form do
     candidate
+
+    date_of_birth { Faker::Date.birthday }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
   end
 
   factory :application_choice do
-    provider_ucas_code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     application_form
+
+    provider_ucas_code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     status { :application_complete }
   end
 end


### PR DESCRIPTION
### Context

In previous PRs we've added name and date of birth to the form that the candidate can fill in.

### Changes proposed in this pull request

This adds the name and data of birth to the Support UI, Provider UI, and Vendor API. 

### Guidance to review

Ignore the fact that this is slightly untested. I'd like to get this in before the Show & Tell tomorrow, and I'm unsure about the testing strategy we'd like to take for this - we'll come back to this!

### Link to Trello card

https://trello.com/c/LTQDGPQh/122-allow-users-to-fill-in-personal-details-with-validation
