### PR TITLE
Make english_main_language not default to false when it's nil

### DIFF
--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -30,13 +30,19 @@ module CandidateInterface
         last_name: application_form.last_name,
         first_nationality: application_form.first_nationality,
         second_nationality: application_form.second_nationality,
-        english_main_language: application_form.english_main_language ? 'yes' : 'no',
+        english_main_language: boolean_to_word(application_form.english_main_language),
         english_language_details: application_form.english_language_details,
         other_language_details: application_form.other_language_details,
         day: application_form.date_of_birth&.day,
         month: application_form.date_of_birth&.month,
         year: application_form.date_of_birth&.year,
       )
+    end
+
+    def self.boolean_to_word(boolean)
+      return nil if boolean.nil?
+
+      boolean ? 'yes' : 'no'
     end
 
     def save(application_form)

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
 
       expect(personal_details).to have_attributes(form_data)
     end
+
+    it "initialises english_main_language to nil when it's nil in the application form" do
+      application_form = ApplicationForm.new(english_main_language: nil)
+      personal_details = CandidateInterface::PersonalDetailsForm.build_from_application(
+        application_form,
+      )
+
+      expect(personal_details).to have_attributes(english_main_language: nil)
+    end
   end
 
   describe '#save' do


### PR DESCRIPTION
### Context

Fixes #326.

### Changes proposed in this pull request

- Update `build_from_application` conditional to respect `nil` as its own value

### Guidance to review

This is just the minimal amount of code that works; improvements welcome.

### Before (fresh candidate)

![Screenshot 2019-10-16 at 10 34 11](https://user-images.githubusercontent.com/1650875/66906990-82678780-f000-11e9-8cb6-5b6fb08983a5.png)

### After (fresh candidate)

![Screenshot 2019-10-16 at 10 34 32](https://user-images.githubusercontent.com/1650875/66907014-8eebe000-f000-11e9-8875-0a0a9f279950.png)
