### PR TITLE
Add unsubmitted application status to openapi.yml

### DIFF
--- a/config/vendor-api-0.5.0.yml
+++ b/config/vendor-api-0.5.0.yml
@@ -304,6 +304,7 @@ components:
           type: string
           description: The status of this application
           enum:
+            - unsubmitted
             - application_complete
             - conditional_offer
             - unconditional_offer


### PR DESCRIPTION
### Context

Currently the tests fail if the application is in an unsubmitted state. 

### Changes proposed in this pull request

Add `unsubmitted` to the openapi spec file.

### Guidance to review


### Link to Trello card

Fix