### PR TITLE
Render the 404 page in all formats

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
 class ErrorsController < ApplicationController
   def not_found
-    render status: :not_found
+    render 'not_found.html', status: :not_found
   end
 
   def internal_server_error

--- a/spec/requests/candidate_interface/errors_spec.rb
+++ b/spec/requests/candidate_interface/errors_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe 'Candidate Interface - Errors', type: :request do
         expect(response.header['Content-Type']).to include 'text/html'
         expect(response.body).to include(t('page_titles.not_found'))
       end
+
+      it 'returns the HTML not found page for other formats too' do
+        get '/404.css'
+
+        expect(response).to have_http_status(:not_found)
+        expect(response.header['Content-Type']).to include 'text/html'
+        expect(response.body).to include(t('page_titles.not_found'))
+      end
     end
 
     context 'GET non-existent page' do


### PR DESCRIPTION
### Context

Currently we render an 500 page instead of 404 when a CSS/JS file doesn't exist, because there isn't a CSS template for the 404 page.

### Changes proposed in this pull request

This commit forces the not found page to always respond with HTML, regardless of the request format.

### Link to Trello card

Fixes https://sentry.io/organizations/dfe-bat/issues/1277008811