### PR TITLE
Check that users are signed in on personal details forms

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class ApplicationFormController < CandidateInterfaceController
-    before_action :authenticate_candidate!
-
     def show
       redirect_to candidate_interface_application_form_path if params[:token]
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_candidate.current_application)

--- a/app/controllers/candidate_interface/application_review_controller.rb
+++ b/app/controllers/candidate_interface/application_review_controller.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class ApplicationReviewController < CandidateInterfaceController
-    before_action :authenticate_candidate!
-
     def show; end
   end
 end

--- a/app/controllers/candidate_interface/applying_controller.rb
+++ b/app/controllers/candidate_interface/applying_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class ApplyingController < CandidateInterfaceController
+    skip_before_action :authenticate_candidate!
+
     rescue_from ActionController::ParameterMissing, with: :render_not_found
 
     def show

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class CandidateInterfaceController < ActionController::Base
+    before_action :authenticate_candidate!
+
     layout 'application'
   end
 end

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
+    before_action :authenticate_candidate!
+
     def edit
       @personal_details_form = PersonalDetailsForm.build_from_application(
         current_candidate.current_application,

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -1,7 +1,5 @@
 module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
-    before_action :authenticate_candidate!
-
     def edit
       @personal_details_form = PersonalDetailsForm.build_from_application(
         current_candidate.current_application,

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class SignInController < CandidateInterfaceController
+    skip_before_action :authenticate_candidate!
+
     def new
       @candidate = Candidate.new
     end

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class SignUpController < CandidateInterfaceController
+    skip_before_action :authenticate_candidate!
+
     def new
       @candidate = Candidate.new
     end

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class StartPageController < CandidateInterfaceController
+    skip_before_action :authenticate_candidate!
+
     def show; end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.feature 'Entering their personal details' do
   scenario 'Candidate submits their personal details' do
+    given_i_am_not_signed_in
+    and_i_visit_the_personal_details_page
+    then_i_should_see_the_homepage
+
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -25,6 +29,16 @@ RSpec.feature 'Entering their personal details' do
 
     when_i_click_on_personal_details
     then_i_can_check_my_revised_answers
+  end
+
+  def given_i_am_not_signed_in; end
+
+  def and_i_visit_the_personal_details_page
+    visit candidate_interface_personal_details_edit_path
+  end
+
+  def then_i_should_see_the_homepage
+    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def given_i_am_signed_in


### PR DESCRIPTION
### Context

Without this, `current_candidate` is nil and breaks the site.

Example Sentry issue: https://sentry.io/organizations/dfe-bat/issues/1276702467/?project=1765973&query=is%3Aunresolved

### Changes proposed in this pull request

- Add the `before_action` and update the spec

### Guidance to review

This makes the spec even longer but I think it's okay?

Review commit by commit.

### Trello

https://trello.com/c/N5AQy6Tt