### PR TITLE
Default to "Apply for teacher training" on error pages

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,8 @@ module ApplicationHelper
       'Apply for teacher training'
     when 'support_interface'
       'Support'
+    else
+      'Apply for teacher training'
     end
   end
 
@@ -28,6 +30,8 @@ module ApplicationHelper
       candidate_interface_start_path
     when 'support_interface'
       support_interface_path
+    else
+      root_path
     end
   end
 


### PR DESCRIPTION
### Context

We currently show an empty title with a link in the header on error pages, because they're not part of a namespace. This adds a sensible default.

### Changes proposed in this pull request

Screenie:

![image](https://user-images.githubusercontent.com/233676/67015509-8d004a80-f0ee-11e9-8df5-b977053b30e4.png)

### Link to Trello card

https://trello.com/c/dz3zecq4
