### PR TITLE
Link to the application form if the user is signed in

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,7 +25,11 @@ module ApplicationHelper
     when 'provider_interface'
       provider_interface_path
     when 'candidate_interface'
-      candidate_interface_start_path
+      if candidate_signed_in?
+        candidate_interface_application_form_path
+      else
+        candidate_interface_start_path
+      end
     when 'support_interface'
       support_interface_path
     end

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -61,7 +61,10 @@ RSpec.feature 'Candidate account' do
   end
 
   def then_i_am_signed_in
-    expect(page).to have_content @email
+    within 'header' do
+      expect(page).to have_content @email
+      expect(page).to have_link(href: candidate_interface_application_form_path)
+    end
   end
 
   def when_i_click_the_sign_out_button


### PR DESCRIPTION
### Context

When a user is signed out, ‘Apply for teacher training’ link in the header should link to the landing page.

When a user is signed in, ‘Apply for teacher training’ link in the header should link to the ‘Your application’ page.

### Changes proposed in this pull request

See commits.

### Guidance to review

N/A

### Link to Trello card

https://trello.com/c/ShLbkPN5

