### PR TITLE
Fix saving both other languages spoken and English language qualifications

### DIFF
--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -53,9 +53,9 @@ module CandidateInterface
         last_name: last_name,
         first_nationality: first_nationality,
         second_nationality: second_nationality,
-        english_main_language: english_main_language == 'yes',
-        english_language_details: english_language_details,
-        other_language_details: other_language_details,
+        english_main_language: english_main_language?,
+        english_language_details: english_main_language? ? english_language_details : '',
+        other_language_details: english_main_language? ? '' : other_language_details,
         date_of_birth: date_of_birth,
       )
     end

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       date_of_birth: Faker::Date.birthday,
       first_nationality: NATIONALITY_DEMONYMS.sample,
       second_nationality: NATIONALITY_DEMONYMS.sample,
-      english_main_language: [true, false].sample,
+      english_main_language: true,
       english_language_details: Faker::Lorem.paragraph_by_chars(number: 200),
-      other_language_details: Faker::Lorem.paragraph_by_chars(number: 200),
+      other_language_details: '',
     }
   end
 
@@ -70,6 +70,28 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
 
       expect(personal_details.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
+    end
+
+    it 'saves the English language details only if English is the main language' do
+      application_form = FactoryBot.create(:application_form)
+      personal_details = CandidateInterface::PersonalDetailsForm.new(form_data)
+
+      personal_details.save(application_form)
+
+      expect(application_form.english_language_details).to eq(form_data[:english_language_details])
+      expect(application_form.other_language_details).to eq('')
+    end
+
+    it 'saves the other language details only if English is not the main language' do
+      application_form = FactoryBot.create(:application_form)
+      data[:english_main_language] = false
+      data[:other_language_details] = Faker::Lorem.paragraph_by_chars(number: 200)
+      personal_details = CandidateInterface::PersonalDetailsForm.new(form_data)
+
+      personal_details.save(application_form)
+
+      expect(application_form.other_language_details).to eq(form_data[:other_language_details])
+      expect(application_form.english_language_details).to eq('')
     end
   end
 


### PR DESCRIPTION
### Context

When product reviewing https://trello.com/c/LTQDGPQh/122-allow-users-to-fill-in-personal-details-with-validation Paul L questioned whether or not we _**only**_ save one corresponding additional text when the candidate says  if English is their main language. However, it turns out we save both... Which we shouldn't.

### Changes proposed in this pull request

This PR ensures we only save one or the other depending on whether the candidate's main language is English.

### Guidance to review

Does it make sense?

### Link to Trello card

[184 - Fix saving both other languages spoken and English language qualifications](https://trello.com/c/fI9Vh4S3/184-fix-saving-both-other-languages-spoken-and-english-language-qualifications)
