### PR TITLE
Nationality autocomplete improvements

### DIFF
--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -35,6 +35,7 @@ module CandidateInterface
         :english_language_details, :other_language_details
       )
         .transform_keys { |key| dob_field_to_attribute(key) }
+        .transform_keys(&:strip)
     end
 
     def dob_field_to_attribute(key)

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,25 +1,25 @@
-require.context('govuk-frontend/govuk/assets');
-import { initAll as govUKFrontendInitAll } from 'govuk-frontend';
-import 'accessible-autocomplete/dist/accessible-autocomplete.min.css';
-import accessibleAutocomplete from 'accessible-autocomplete';
+require.context("govuk-frontend/govuk/assets");
+import { initAll as govUKFrontendInitAll } from "govuk-frontend";
+import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
+import accessibleAutocomplete from "accessible-autocomplete";
 
-import '../styles/application.scss';
+import "../styles/application.scss";
 govUKFrontendInitAll();
 
 try {
   const nationalitySelects = [
-    '#candidate-interface-personal-details-form-first-nationality-field',
-    '#candidate-interface-personal-details-form-second-nationality-field'
+    "#candidate-interface-personal-details-form-first-nationality-field",
+    "#candidate-interface-personal-details-form-second-nationality-field"
   ].forEach(id => {
     const nationalitySelect = document.querySelector(id);
 
     // Replace "Select a nationality" with empty string
-    nationalitySelect.querySelector("[value='']").innerHTML = '';
+    nationalitySelect.querySelector("[value='']").innerHTML = "";
 
     accessibleAutocomplete.enhanceSelectElement({
       selectElement: nationalitySelect
-    })
-  })
-} catch(err) {
-  console.error('Could not enhance nationality select:', err)
+    });
+  });
+} catch (err) {
+  console.error("Could not enhance nationality select:", err);
 }

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,32 +1,9 @@
 require.context("govuk-frontend/govuk/assets");
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
-import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
-import accessibleAutocomplete from "accessible-autocomplete";
+import initNationalityAutocomplete from "./nationality-autocomplete";
 
+import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import "../styles/application.scss";
 govUKFrontendInitAll();
 
-try {
-  const nationalitySelects = [
-    "#candidate-interface-personal-details-form-first-nationality-field",
-    "#candidate-interface-personal-details-form-first-nationality-field-error",
-    "#candidate-interface-personal-details-form-second-nationality-field",
-    "#candidate-interface-personal-details-form-second-nationality-field-error"
-  ].forEach(id => {
-    const nationalitySelect = document.querySelector(id);
-
-    if (!nationalitySelect) return;
-
-    // Replace "Select a nationality" with empty string
-    nationalitySelect.querySelector("[value='']").innerHTML = "";
-
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: nationalitySelect,
-      name: nationalitySelect.name
-    });
-
-    nationalitySelect.name = "";
-  });
-} catch (err) {
-  console.error("Could not enhance nationality select:", err);
-}
+initNationalityAutocomplete();

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -21,8 +21,11 @@ try {
     nationalitySelect.querySelector("[value='']").innerHTML = "";
 
     accessibleAutocomplete.enhanceSelectElement({
-      selectElement: nationalitySelect
+      selectElement: nationalitySelect,
+      name: nationalitySelect.name
     });
+
+    nationalitySelect.name = "";
   });
 } catch (err) {
   console.error("Could not enhance nationality select:", err);

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -9,9 +9,13 @@ govUKFrontendInitAll();
 try {
   const nationalitySelects = [
     "#candidate-interface-personal-details-form-first-nationality-field",
-    "#candidate-interface-personal-details-form-second-nationality-field"
+    "#candidate-interface-personal-details-form-first-nationality-field-error",
+    "#candidate-interface-personal-details-form-second-nationality-field",
+    "#candidate-interface-personal-details-form-second-nationality-field-error"
   ].forEach(id => {
     const nationalitySelect = document.querySelector(id);
+
+    if (!nationalitySelect) return;
 
     // Replace "Select a nationality" with empty string
     nationalitySelect.querySelector("[value='']").innerHTML = "";

--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -1,0 +1,30 @@
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const initNationalityAutocomplete = () => {
+  try {
+    const nationalitySelects = [
+      "#candidate-interface-personal-details-form-first-nationality-field",
+      "#candidate-interface-personal-details-form-first-nationality-field-error",
+      "#candidate-interface-personal-details-form-second-nationality-field",
+      "#candidate-interface-personal-details-form-second-nationality-field-error"
+    ].forEach(id => {
+      const nationalitySelect = document.querySelector(id);
+
+      if (!nationalitySelect) return;
+
+      // Replace "Select a nationality" with empty string
+      nationalitySelect.querySelector("[value='']").innerHTML = "";
+
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: nationalitySelect,
+        name: nationalitySelect.name
+      });
+
+      nationalitySelect.name = "";
+    });
+  } catch (err) {
+    console.error("Could not enhance nationality select:", err);
+  }
+};
+
+export default initNationalityAutocomplete;


### PR DESCRIPTION
### Context

Squashing bugs.

### Changes proposed in this pull request

- Enhance nationality error fields
- Use autocomplete input for nationality submission
- Trim spaces when users submit personal details

### Guidance to review

Commits have some more context. We also don't have a way currently in place to test this, but will add Cypress smoke tests later which could handle this.

### Link to Trello card

[174 - Error appears when a user leaves space in the Nationality field](https://trello.com/c/GvRTeQ9m)