### PR TITLE
Update content for 404 page

### DIFF
--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -4,10 +4,15 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('page_titles.not_found') %></h1>
     <p class="govuk-body">
-      If you entered a web address please check it was correct.
+      If you entered a web address, check it is correct.
     </p>
     <p class="govuk-body">
-      <%= bat_contact_mail_to('Contact the Becoming a Teacher team') %> if you believe you are seeing this message in error.
+      If you pasted the web address, check you copied the entire address.
+    </p>
+    <p class="govuk-body">
+      If the web address is correct or you selected a link or button and you
+      need to speak to someone about this problem, contact the Becoming a Teacher team:
+      <%= bat_contact_mail_to %>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
### Context

Following https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/339#issuecomment-543196473, we've decided we need to update the content for our 404 page.

### Changes proposed in this pull request

This PR updates the content for our 404 page to match the screenshot given in the comment above.

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/67076965-1e6ecb80-f186-11e9-89af-8e65e8ce15ec.png)

### Guidance to review

Quick double check that the content is what we want it to be.

### Link to Trello card

[186 - Update content for 404 page](https://trello.com/c/Elj2AhuA/186-update-404-page-content)
