### PR TITLE
Add accessibility statement page

### DIFF
--- a/app/controllers/accessibility_controller.rb
+++ b/app/controllers/accessibility_controller.rb
@@ -1,0 +1,3 @@
+class AccessibilityController < ApplicationController
+  def show; end
+end

--- a/app/views/accessibility/show.html.erb
+++ b/app/views/accessibility/show.html.erb
@@ -4,59 +4,64 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('page_titles.accessibility') %></h1>
 
+    <h2 class="govuk-heading-m">
+      How accessible this website is
+    </h2>
     <p class="govuk-body">
-      Apply for teacher training is a pilot service run by the
+      Apply for teacher training is a new service being developed by the
       Department for Education. It allows people to apply to some teacher
-      training programmes in the UK.
+      training courses in England.
     </p>
     <p class="govuk-body">
-      This service is designed to be used by as many people as possible.
-      We have built this service in line with the <%= govuk_link_to 'accessible design principles used across GOV.UK', 'https://design-system.service.gov.uk/accessibility/', target: '_blank' %>.
+      The service is being trialled with a limited number of users.
     </p>
     <p class="govuk-body">
-      The service is being piloted with a limited number of users. We have tested
-      the prototype with users with accessibility needs, for instance, users who
-      require screen readers.
+      However, it is designed to be accessible for as many people as possible.
+      We have built it in line with the <%= govuk_link_to 'accessible design principles used across GOV.UK', 'https://design-system.service.gov.uk/accessibility/', target: '_blank' %>.
     </p>
     <p class="govuk-body">
-      We will carry out a full accessibility audit after or during the pilot.
+      During development we tested the prototype with users with accessibility
+      needs, for instance, users who require screen readers.
+    </p>
+    <p class="govuk-body">
+      We are planning to improve the accessibility of this service as we test
+      and develop it.
+    </p>
+
+    <h2 class="govuk-heading-m">
+      What to do if you cannot access parts of this website
+    </h2>
+    <p class="govuk-body">
+      If you need information on this website in a different format, for example
+      accessible PDF, large print, easy read, audio recording or braille, please
+      email us on <%= bat_contact_mail_to %>.
+    </p>
+    <p class="govuk-body">
+      We’ll consider your request and respond to you within 5 working days.
     </p>
     <p class="govuk-body">
       <%= govuk_link_to 'AbilityNet', 'https://mcmw.abilitynet.org.uk/', target: '_blank' %>
       has advice on making your device easier to use if you have a disability.
     </p>
 
-    <h2 class="govuk-heading-l">
-      What to do if you cannot access parts of this website
-    </h2>
-    <p class="govuk-body">
-      If you need information on this website in a different format like accessible
-      PDF, large print, easy read, audio recording or braille:
-    </p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>email <%= bat_contact_mail_to %></li>
-    </ul>
-    <p class="govuk-body">
-      We will get back to you within 5 working days.
-    </p>
-
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       Reporting accessibility problems with this website
     </h2>
     <p class="govuk-body">
-      We’re looking to improve the accessibility of this service. If you find any
-      problems or think we’re not meeting accessibility requirements, contact us:
-      <%= bat_contact_mail_to %>.
+      If you have any problems accessing the service or want to give us
+      feedback, please email us on <%= bat_contact_mail_to %>.
     </p>
 
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       Enforcement procedure
     </h2>
     <p class="govuk-body">
-      The Equality and Human Rights Commission (EHRC) is responsible for enforcing
-      the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
-      Accessibility Regulations 2018 (the ‘accessibility regulations’).
-      If you’re not happy with how we respond to your complaint,
+      The Equality and Human Rights Commission (EHRC) is responsible for
+      enforcing the Public Sector Bodies (Websites and Mobile Applications)
+      (No. 2) Accessibility Regulations 2018 (the ‘accessibility regulations’).
+    </p>
+    <p class="govuk-body">
+      If you’re not happy with how we respond to your complaint, please
       <%= govuk_link_to 'contact the quality Advisory and Support Service (EASS)', 'https://www.equalityadvisoryservice.com/', target: '_blank' %>.
     </p>
 
@@ -78,17 +83,19 @@
       Non accessible content
     </h2>
     <p class="govuk-body">
-      We will list any non accessible content as soon as possible. Please get in
-      touch with us if you come across any accessibility requirements:
-      <%= bat_contact_mail_to %>.
+      We will list any content that isn’t complaint with the Public Sector
+      Bodies (Websites and Mobile Applications) (No. 2) Accessibility
+      Regulations 2018 as soon as possible.
     </p>
 
     <h2 class="govuk-heading-l">
       What we’re doing to improve accessibility
     </h2>
     <p class="govuk-body">
-      We will carry out a full accessibility audit after or during the pilot of
+      We will carry out a full accessibility audit during or after the trial of
       this service.
     </p>
+
+    <p class="govuk-body">This statement was prepared on 21 October 2019.</p>
   </div>
 </div>

--- a/app/views/accessibility/show.html.erb
+++ b/app/views/accessibility/show.html.erb
@@ -4,9 +4,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('page_titles.accessibility') %></h1>
 
-    <h3 class="govuk-heading-m">
+    <h2 class="govuk-heading-m">
       How accessible this website is
-    </h3>
+    </h2>
     <p class="govuk-body">
       Apply for teacher training is a new service being developed by the
       Department for Education. It allows people to apply to some teacher
@@ -28,9 +28,9 @@
       and develop it.
     </p>
 
-    <h3 class="govuk-heading-m">
+    <h2 class="govuk-heading-m">
       What to do if you cannot access parts of this website
-    </h3>
+    </h2>
     <p class="govuk-body">
       If you need information on this website in a different format, for example
       accessible PDF, large print, easy read, audio recording or braille, please
@@ -44,17 +44,17 @@
       has advice on making your device easier to use if you have a disability.
     </p>
 
-    <h3 class="govuk-heading-m">
+    <h2 class="govuk-heading-m">
       Reporting accessibility problems with this website
-    </h3>
+    </h2>
     <p class="govuk-body">
       If you have any problems accessing the service or want to give us
       feedback, please email us on <%= bat_contact_mail_to %>.
     </p>
 
-    <h3 class="govuk-heading-m">
+    <h2 class="govuk-heading-m">
       Enforcement procedure
-    </h3>
+    </h2>
     <p class="govuk-body">
       The Equality and Human Rights Commission (EHRC) is responsible for
       enforcing the Public Sector Bodies (Websites and Mobile Applications)
@@ -65,7 +65,7 @@
       <%= govuk_link_to 'contact the quality Advisory and Support Service (EASS)', 'https://www.equalityadvisoryservice.com/', target: '_blank' %>.
     </p>
 
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       Technical information about this website’s accessibility
     </h2>
     <p class="govuk-body">
@@ -79,7 +79,7 @@
       AA standard, due to the non-compliances listed below.
     </p>
 
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       Non accessible content
     </h2>
     <p class="govuk-body">
@@ -88,7 +88,7 @@
       Regulations 2018 as soon as possible.
     </p>
 
-    <h2 class="govuk-heading-l">
+    <h2 class="govuk-heading-m">
       What we’re doing to improve accessibility
     </h2>
     <p class="govuk-body">

--- a/app/views/accessibility/show.html.erb
+++ b/app/views/accessibility/show.html.erb
@@ -4,9 +4,9 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('page_titles.accessibility') %></h1>
 
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
       How accessible this website is
-    </h2>
+    </h3>
     <p class="govuk-body">
       Apply for teacher training is a new service being developed by the
       Department for Education. It allows people to apply to some teacher
@@ -28,9 +28,9 @@
       and develop it.
     </p>
 
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
       What to do if you cannot access parts of this website
-    </h2>
+    </h3>
     <p class="govuk-body">
       If you need information on this website in a different format, for example
       accessible PDF, large print, easy read, audio recording or braille, please
@@ -44,17 +44,17 @@
       has advice on making your device easier to use if you have a disability.
     </p>
 
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
       Reporting accessibility problems with this website
-    </h2>
+    </h3>
     <p class="govuk-body">
       If you have any problems accessing the service or want to give us
       feedback, please email us on <%= bat_contact_mail_to %>.
     </p>
 
-    <h2 class="govuk-heading-m">
+    <h3 class="govuk-heading-m">
       Enforcement procedure
-    </h2>
+    </h3>
     <p class="govuk-body">
       The Equality and Human Rights Commission (EHRC) is responsible for
       enforcing the Public Sector Bodies (Websites and Mobile Applications)

--- a/app/views/accessibility/show.html.erb
+++ b/app/views/accessibility/show.html.erb
@@ -1,0 +1,94 @@
+<%= content_for :title, page_title(:accessibility) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('page_titles.accessibility') %></h1>
+
+    <p class="govuk-body">
+      Apply for teacher training is a pilot service run by the
+      Department for Education. It allows people to apply to some teacher
+      training programmes in the UK.
+    </p>
+    <p class="govuk-body">
+      This service is designed to be used by as many people as possible.
+      We have built this service in line with the <%= govuk_link_to 'accessible design principles used across GOV.UK', 'https://design-system.service.gov.uk/accessibility/', target: '_blank' %>.
+    </p>
+    <p class="govuk-body">
+      The service is being piloted with a limited number of users. We have tested
+      the prototype with users with accessibility needs, for instance, users who
+      require screen readers.
+    </p>
+    <p class="govuk-body">
+      We will carry out a full accessibility audit after or during the pilot.
+    </p>
+    <p class="govuk-body">
+      <%= govuk_link_to 'AbilityNet', 'https://mcmw.abilitynet.org.uk/', target: '_blank' %>
+      has advice on making your device easier to use if you have a disability.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      What to do if you cannot access parts of this website
+    </h2>
+    <p class="govuk-body">
+      If you need information on this website in a different format like accessible
+      PDF, large print, easy read, audio recording or braille:
+    </p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>email <%= bat_contact_mail_to %></li>
+    </ul>
+    <p class="govuk-body">
+      We will get back to you within 5 working days.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Reporting accessibility problems with this website
+    </h2>
+    <p class="govuk-body">
+      We’re looking to improve the accessibility of this service. If you find any
+      problems or think we’re not meeting accessibility requirements, contact us:
+      <%= bat_contact_mail_to %>.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Enforcement procedure
+    </h2>
+    <p class="govuk-body">
+      The Equality and Human Rights Commission (EHRC) is responsible for enforcing
+      the Public Sector Bodies (Websites and Mobile Applications) (No. 2)
+      Accessibility Regulations 2018 (the ‘accessibility regulations’).
+      If you’re not happy with how we respond to your complaint,
+      <%= govuk_link_to 'contact the quality Advisory and Support Service (EASS)', 'https://www.equalityadvisoryservice.com/', target: '_blank' %>.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Technical information about this website’s accessibility
+    </h2>
+    <p class="govuk-body">
+      The Department for Education is committed to making its website services
+      accessible, in accordance with the Public Sector Bodies (Websites and
+      Mobile Applications) (No. 2) Accessibility Regulations 2018.
+    </p>
+    <p class="govuk-body">
+      This website is partially compliant with the
+      <%= govuk_link_to 'Web Content Accessibility Guidelines version 2.1', 'https://www.w3.org/TR/WCAG21/', target: '_blank' %>
+      AA standard, due to the non-compliances listed below.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      Non accessible content
+    </h2>
+    <p class="govuk-body">
+      We will list any non accessible content as soon as possible. Please get in
+      touch with us if you come across any accessibility requirements:
+      <%= bat_contact_mail_to %>.
+    </p>
+
+    <h2 class="govuk-heading-l">
+      What we’re doing to improve accessibility
+    </h2>
+    <p class="govuk-body">
+      We will carry out a full accessibility audit after or during the pilot of
+      this service.
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,7 +92,11 @@
       <div class="govuk-width-container ">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
+            <ul class="govuk-footer__inline-list">
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to t('layout.accessibility'), accessibility_path, class: 'govuk-footer__link' %>
+              </li>
+            </ul>
             <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
               <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
             </svg>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,9 +39,12 @@ en:
     not_found: Page not found
     internal_server_error: Sorry, there is a problem with the service
     personal_details: Personal details
+    review_application: Review your application
+    accessibility: Accessibility statement for Apply for teacher training
   layout:
     service_name: Apply for teacher training
     phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.
+    accessibility: Accessibility
   activemodel:
     attributes:
       vendor_api/metadata:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
 
   root to: redirect('/candidate')
 
+  get '/accessibility', to: 'accessibility#show'
+
   namespace :candidate_interface, path: '/candidate' do
     get '/' => 'start_page#show', as: :start
     get '/sign-up', to: 'sign_up#new', as: :sign_up

--- a/spec/system/user_viewing_accessibility_statement_spec.rb
+++ b/spec/system/user_viewing_accessibility_statement_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing accessibility statement' do
+  scenario 'User views the accessibility statement' do
+    given_i_am_on_the_start_page
+    when_i_can_click_on_accessibility
+    then_i_can_see_the_accessibility_statement
+  end
+
+  def given_i_am_on_the_start_page
+    visit '/'
+  end
+
+  def when_i_can_click_on_accessibility
+    within('.govuk-footer') { click_link t('layout.accessibility') }
+  end
+
+  def then_i_can_see_the_accessibility_statement
+    expect(page).to have_content(t('page_titles.accessibility'))
+  end
+end


### PR DESCRIPTION
### Context

We need to have an accessibility statement to [meet the requirements of accessibility regulations](https://www.gov.uk/guidance/accessibility-requirements-for-public-sector-websites-and-apps).

### Changes proposed in this pull request

This PR adds an accessibility statement page with content that has 97% been lifted from the Google Doc that has been worked on by @EmmaFrith, @laurahermionetennant92 etc.

### Screenshots

![Screenshot 2019-10-18 at 11 53 31](https://user-images.githubusercontent.com/42817036/67089746-4e2acd00-f1a0-11e9-9dd4-a931d8d46258.png)

![image](https://user-images.githubusercontent.com/42817036/67089084-b37dbe80-f19e-11e9-88ba-2e1f2237b219.png)

### Guidance to review

#### Technical feedback

- I've placed the accessibility related files as a top-level thing as it didn't seem right to scope it within a single interface e.g. within `candidate_interface`, `provider_interface`, etc. Would you agree?

#### Content feedback

Would be good to get feedback from @EmmaFrith and @laurahermionetennant92.

- I added the smol changes I suggested in the Google Doc such as calling the service `Apply for teacher training` instead of `Apply for postgraduate training` as this is inline with the rest of the app. Let me know if this is okay.
- It wasn't clear to me what size headings to use for each section so currently each is a `h2`. Again, let me know if this wasn't what you were thinking!
- I noticed on [GOV.UK's accessibility statement](https://www.gov.uk/help/accessibility-statement) and [Find's accessibility statement](https://find-postgraduate-teacher-training.education.gov.uk/accessibility), they have stated when it has been last updated. Is this a thing we want to do as well?

### Link to Trello card

[98 - Accessibility statement (private beta)](https://trello.com/c/RKnQOsbQ/98-accessibility-statement-private-beta)
