### PR TITLE
Hide personal details SummaryCardComponent if incomplete

### DIFF
--- a/app/components/personal_details_review_component.html.erb
+++ b/app/components/personal_details_review_component.html.erb
@@ -1,0 +1,5 @@
+<% if @personal_details_form.valid? %>
+  <%= render(SummaryCardComponent, rows: rows) %>
+<% else %>
+  <p class="govuk-body">No personal details entered.</p>
+<% end %>

--- a/app/components/personal_details_review_component.rb
+++ b/app/components/personal_details_review_component.rb
@@ -1,0 +1,20 @@
+class PersonalDetailsReviewComponent < ActionView::Component::Base
+  validates :application_form, presence: true
+
+  def initialize(application_form:)
+    @application_form = application_form
+    @personal_details_form = CandidateInterface::PersonalDetailsForm.build_from_application(
+      application_form,
+    )
+  end
+
+  def rows
+    CandidateInterface::PersonalDetailsReviewPresenter
+      .new(@personal_details_form)
+      .present
+  end
+
+private
+
+  attr_reader :application_form
+end

--- a/app/components/personal_details_review_component.rb
+++ b/app/components/personal_details_review_component.rb
@@ -11,7 +11,7 @@ class PersonalDetailsReviewComponent < ActionView::Component::Base
   def rows
     CandidateInterface::PersonalDetailsReviewPresenter
       .new(@personal_details_form)
-      .present
+      .rows
   end
 
 private

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
     end
 
     def review
+      @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_candidate.current_application)
       personal_details_form = PersonalDetailsForm.build_from_application(
         current_candidate.current_application,
         )

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,11 +6,7 @@ module CandidateInterface
     end
 
     def review
-      @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_candidate.current_application)
-      personal_details_form = PersonalDetailsForm.build_from_application(
-        current_candidate.current_application,
-        )
-      @personal_details_review = PersonalDetailsReviewPresenter.new(personal_details_form)
+      @application_form = current_candidate.current_application
     end
 
     def submit_show

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -4,7 +4,7 @@ module CandidateInterface
       @form = form
     end
 
-    def present
+    def rows
       [
         name_row,
         date_of_birth_row,

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -11,11 +11,7 @@
 
 <h3 class="govuk-heading-m">Personal details</h3>
 
-<% if @application_form_presenter.personal_details_completed? %>
-  <%= render(SummaryCardComponent, rows: @personal_details_review.present) %>
-<% else %>
-  <p class="govuk-body">No contact details entered.</p>
-<% end %>
+<%= render(PersonalDetailsReviewComponent, application_form: @application_form) %>
 
 <h3 class="govuk-heading-m">Contact details</h3>
 

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -11,7 +11,11 @@
 
 <h3 class="govuk-heading-m">Personal details</h3>
 
-<%= render(SummaryCardComponent, rows: @personal_details_review.present) %>
+<% if @application_form_presenter.personal_details_completed? %>
+  <%= render(SummaryCardComponent, rows: @personal_details_review.present) %>
+<% else %>
+  <p class="govuk-body">No contact details entered.</p>
+<% end %>
 
 <h3 class="govuk-heading-m">Contact details</h3>
 

--- a/app/views/candidate_interface/personal_details/show.html.erb
+++ b/app/views/candidate_interface/personal_details/show.html.erb
@@ -5,6 +5,6 @@
   Personal details
 </h1>
 
-<%= render(SummaryCardComponent, rows: @personal_details_review.present) %>
+<%= render(SummaryCardComponent, rows: @personal_details_review.rows) %>
 
 <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/spec/components/personal_details_review_component_spec.rb
+++ b/spec/components/personal_details_review_component_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe PersonalDetailsReviewComponent do
+  it 'renders SummaryCardComponent with valid personal details' do
+    application_form = create(:application_form, :completed_application_form)
+    result = render_inline(PersonalDetailsReviewComponent, application_form: application_form)
+
+    expect(result.text).to include(application_form.first_name)
+  end
+
+  it 'renders fallback text with invalid personal details' do
+    application_form = create(:application_form)
+    result = render_inline(PersonalDetailsReviewComponent, application_form: application_form)
+
+    expect(result.text).to include('No personal details entered')
+  end
+end

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         year: 1995,
       )
 
-      expect(present(personal_details_form)).to include(
+      expect(rows(personal_details_form)).to include(
         row_for(:name, 'Max Caulfield'),
         row_for(:date_of_birth, '21 September 1995'),
       )
@@ -43,7 +43,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           second_nationality: nil,
         )
 
-        expect(present(personal_details_form)).to include(
+        expect(rows(personal_details_form)).to include(
           row_for(:nationality, 'British'),
         )
       end
@@ -55,7 +55,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           second_nationality: 'Spanish',
         )
 
-        expect(present(personal_details_form)).to include(
+        expect(rows(personal_details_form)).to include(
           row_for(:nationality, 'British and Spanish'),
         )
       end
@@ -70,7 +70,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(present(personal_details_form)).to include(
+        expect(rows(personal_details_form)).to include(
           row_for(:english_main_language, 'Yes'),
         )
       end
@@ -83,7 +83,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(present(personal_details_form)).not_to include(
+        expect(rows(personal_details_form)).not_to include(
           row_for(:english_main_language_details, ''),
         )
       end
@@ -96,7 +96,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: 'Broken? Oh man, are you cereal?',
         )
 
-        expect(present(personal_details_form)).not_to include(
+        expect(rows(personal_details_form)).not_to include(
           row_for(:other_language_details, 'Broken? Oh man, are you cereal?'),
         )
       end
@@ -109,7 +109,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(present(personal_details_form)).to include(
+        expect(rows(personal_details_form)).to include(
           row_for(:english_main_language_details, 'Mi nombre es Max.'),
         )
       end
@@ -124,7 +124,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(present(personal_details_form)).to include(
+        expect(rows(personal_details_form)).to include(
           row_for(:english_main_language, 'No'),
         )
       end
@@ -137,7 +137,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(present(personal_details_form)).not_to include(
+        expect(rows(personal_details_form)).not_to include(
           row_for(:other_language_details, ''),
         )
       end
@@ -150,7 +150,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: '',
         )
 
-        expect(present(personal_details_form)).not_to include(
+        expect(rows(personal_details_form)).not_to include(
           row_for(:english_main_language_details, 'Mi nombre es Max.'),
         )
       end
@@ -163,17 +163,17 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
           other_language_details: 'Broken? Oh man, are you cereal?',
         )
 
-        expect(present(personal_details_form)).to include(
+        expect(rows(personal_details_form)).to include(
           row_for(:other_language_details, 'Broken? Oh man, are you cereal?'),
         )
       end
     end
   end
 
-  def present(form)
+  def rows(form)
     CandidateInterface::PersonalDetailsReviewPresenter
       .new(form)
-      .present
+      .rows
   end
 
   def row_for(key, value)


### PR DESCRIPTION
### Context

Currently if users attempt to submit their application directly, it will result in a 500.

### Changes proposed in this pull request

Wrap the call to the component with a check that the personal details section is finished.

Create a component to DRY up the controller and encapsulate + test the logic.

### Guidance to review

Builds on https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/347, ignore first commits until then.

Missing a test, draft.

### Before

(\~envisage a screenshot of a Rails 500\~)

### After

![Screenshot 2019-10-21 at 16 38 32](https://user-images.githubusercontent.com/1650875/67220195-3ca42800-f421-11e9-8904-f9791586fe0e.png)

### Link to Trello card

[210 - Clicking "Check your answers before submitting" triggers a 500 error if you haven't filled in personal details](https://trello.com/c/0mq7gmkR)
