### PR TITLE
Add rake task for generating a provider for each vendor

### DIFF
--- a/lib/tasks/generate_vendor_providers.rake
+++ b/lib/tasks/generate_vendor_providers.rake
@@ -1,0 +1,16 @@
+desc 'Generate providers for vendor sandbox'
+task generate_vendor_providers: :environment do
+  providers = [
+      { name: 'Tribal Provider', code: 'TRIB' },
+      { name: 'Ellucian Provider', code: 'ELLU' },
+      { name: 'Oracle Provider', code: 'ORAC' },
+      { name: 'NASBITT Provider', code: 'NASB' },
+      { name: 'Unit 4 Provider', code: 'UNIT' },
+      { name: 'Capita Provider', code: 'CAPI' },
+      { name: 'Technology One Provider', code: 'TECH' },
+      { name: 'Gordon Associates Provider', code: 'GORD' },
+  ]
+  providers.each do |provider|
+    Provider.find_or_create_by(provider)
+  end
+end


### PR DESCRIPTION
### Context

Vendors need a test provider with a token to be able to use the Vendor API.

### Changes proposed in this pull request

Add a rake task to generate a provider for each Vendor that can be run in the CI pipeline for the Vendor sandbox environment.

### Guidance to review
- Run the rake task
- Check the rake task makes sense. 

### Link to Trello card

[1123 - Create Test Providers for each vendor](https://trello.com/c/3i7MUHoJ/1123-create-test-providers-for-each-vendor)
