### PR TITLE
Post JSON not x-www-url-form-urlencoded data in request specs

### DIFF
--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -34,7 +34,11 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
     it 'returns the updated application' do
       application_choice = create(:application_choice, status: 'application_complete', provider: currently_authenticated_provider)
 
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {}
+      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
+        "data": {
+          "conditions": [],
+        },
+      }
 
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
       expect(parsed_response['data']['attributes']['status']).to eq('unconditional_offer')

--- a/spec/support/vendor_api/shared_examples.rb
+++ b/spec/support/vendor_api/shared_examples.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action|
   it 'returns an error when Metadata is not provided' do
     application_choice = create(:application_choice)
 
-    post "/api/v1/applications/#{application_choice.id}/#{action}", auth_headers
+    post_api_request "/api/v1/applications/#{application_choice.id}/#{action}", params: { 'meta' => nil }
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
@@ -13,7 +13,7 @@ RSpec.shared_examples 'an endpoint that requires metadata' do |action|
 
     invalid_metadata = { invalid: :metadata }
 
-    post "/api/v1/applications/#{application_choice.id}/#{action}", auth_headers.merge(params: { meta: invalid_metadata })
+    post_api_request "/api/v1/applications/#{application_choice.id}/#{action}", params: { 'meta' => invalid_metadata }
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -9,16 +9,32 @@ module VendorApiSpecHelpers
   }.freeze
 
   def get_api_request(url, options = {})
-    get url, auth_headers.deep_merge(options)
+    get url, {
+      headers: {
+        'Authorization' => auth_header,
+      },
+    }.deep_merge(options)
   end
 
   def post_api_request(url, options = {})
-    post url, { params: { meta: VALID_METADATA } }.merge(auth_headers).deep_merge(options)
+    headers_and_params = {
+      params: {
+        meta: VALID_METADATA,
+      },
+      headers: {
+        'Authorization' => auth_header,
+        'Content-Type' => 'application/json',
+      },
+    }.deep_merge(options)
+
+    headers_and_params[:params] = headers_and_params[:params].to_json
+
+    post url, headers_and_params
   end
 
-  def auth_headers
+  def auth_header
     unhashed_token = VendorApiToken.create_with_random_token!(provider: currently_authenticated_provider)
-    { headers: { 'Authorization' => "Bearer #{unhashed_token}" } }
+    "Bearer #{unhashed_token}"
   end
 
   def currently_authenticated_provider


### PR DESCRIPTION
The default behaviour of a Rails request spec turns out to be that it
formencodes the incoming params, but for our API we want to accept JSON
data. Adding a Content-Type header (see below) causes the payloads not
to be correctly parsed, and blow up with schema errors like 'Cannot find
"data" key'. Explicitly transforming the Ruby hash we give params into a
string of valid JSON prevents the magical formencoding and the JSON
is delivered as-is.

The change was driven by the changed spec in this file. We wanted to
change the payload for an unconditional offer to be the same as
conditional, except the 'conditions' array would be empty. When Rails
formencoded the empty array it turned it into '[""]', which is not an
empty array, and resulted in a conditional offer being created with ""
as a condition.