### PR TITLE
Edit openapi-spec to outline that unconditional offers are requested using an empty array

### DIFF
--- a/config/vendor-api-0.5.0.yml
+++ b/config/vendor-api-0.5.0.yml
@@ -71,7 +71,7 @@ paths:
         description: |
           The conditions of the offer
 
-          Providing a request body with an array of conditions is equivalent to making a **conditional** offer. For an **unconditional** offer, provide an empty request body.
+          Providing a request body with an array of conditions is equivalent to making a **conditional** offer. For an **unconditional** offer, provide an empty array.
         content:
           application/json:
             schema:


### PR DESCRIPTION
Edit openapi-spec to inform vendors that an unconditional offer
is requested with an empty array rather than an empty request.

### Context

Fix bug in docs.
For unconditional offers we invite an empty post request. Which is incorrect.

This PR is to keep parity with the openapi-spec in the tech docs repo

### Changes proposed in this pull request
- Edit openapi-spec to change make an offer summary to outline that unconditional offers are requested with an empty conditions array.

### Guidance to review

Ensure the changes in this PR are the same as here https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/102

How could someone else check this work? Which parts do you want more feedback on?

### Link to Trello card

[1044 - Tech docs bug we invite empty request body when creating unconditional offer](https://trello.com/c/feyFGMsZ/1044-tech-docs-bug-we-invite-empty-request-body-when-creating-unconditional-offer-but-the-meta-key-is-still-required)
