### PR TITLE
Database Backups

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -9,6 +9,8 @@ parameters:
   databaseName:
   databaseUsername:
   databasePassword:
+  databaseStorageAutoGrow:
+  databaseBackupRetentionDays:
   dockerhubUsername:
   railsSecretKeyBase:
   containerStartTimeLimit: '600'
@@ -34,10 +36,7 @@ jobs:
       system.debug: ${{parameters.debug}}
 
     pool:
-      name: Hosted VS2017
-      #demands:
-      #- 'PowerShell'
-      #- 'AzurepPS'
+      vmImage: vs2017-win2016
 
     strategy:
       runOnce:
@@ -59,6 +58,8 @@ jobs:
                 -databaseName "${{parameters.databaseName}}"
                 -databaseUsername "${{parameters.databaseUsername}}"
                 -databasePassword "${{parameters.databasePassword}}"
+                -databaseStorageAutoGrow "${{parameters.databaseStorageAutoGrow}}"
+                -databaseBackupRetentionDays "${{parameters.databaseBackupRetentionDays}}"
                 -securityAlertEmail "${{parameters.securityAlertEmail}}"
                 -secretKeyBase "${{parameters.railsSecretKeyBase}}"
                 -containerStartTimeLimit "${{parameters.containerStartTimeLimit}}"
@@ -72,11 +73,6 @@ jobs:
                 -sentryDSN "${{parameters.sentryDSN}}"
                 -findBaseUrl "${{parameters.findBaseUrl}}"'
               deploymentOutputs: DeploymentOutput
-
-
-          - task: RasmusWatjen.ARMOutputParserExtension.ARMOutputConverter.ARMOutputParserExtension@1
-            displayName: 'Parse ARM Deployment Outputs into variables'
-            condition: succeeded()
 
 
           - task: AzurePowerShell@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -144,6 +144,8 @@ stages:
       databaseName: 'apply'
       databaseUsername: 'applyadm512'
       databasePassword: '$(databasePassword)'
+      databaseStorageAutoGrow: 'disabled'
+      databaseBackupRetentionDays: 7
       dockerhubUsername: '$(dockerHubUsername)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
@@ -172,6 +174,8 @@ stages:
       databaseName: 'apply'
       databaseUsername: 'applyadm512'
       databasePassword: '$(databasePassword)'
+      databaseStorageAutoGrow: 'disabled'
+      databaseBackupRetentionDays: 7
       dockerhubUsername: '$(dockerHubUsername)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
@@ -199,6 +203,8 @@ stages:
       databaseName: 'apply'
       databaseUsername: 'applyadm512'
       databasePassword: '$(databasePassword)'
+      databaseStorageAutoGrow: 'disabled'
+      databaseBackupRetentionDays: 7
       dockerhubUsername: '$(dockerHubUsername)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
@@ -225,6 +231,8 @@ stages:
 #       databaseName: 'apply'
 #       databaseUsername: 'applyadm512'
 #       databasePassword: '$(databasePassword)'
+#       databaseStorageAutoGrow: 'enabled'
+#       databaseBackupRetentionDays: 35
 #       dockerhubUsername: '$(dockerHubUsername)'
 #       railsSecretKeyBase: '$(railsSecretKeyBase)'
 #       railsEnv: 'production'

--- a/azure/template.json
+++ b/azure/template.json
@@ -51,6 +51,18 @@
                 "description": "The password used to connect to the database."
             }
         },
+        "databaseStorageAutoGrow": {
+            "type": "string",
+            "metadata": {
+                "description": "Used to enable or disable autogrow on the database storage."
+            }
+        },
+        "databaseBackupRetentionDays": {
+            "type": "int",
+            "metadata": {
+                "description": "Used to configure the number of days the database backups will be retained for."
+            }
+        },
         "securityAlertEmail": {
             "type": "string",
             "metadata": {
@@ -364,7 +376,13 @@
                     },
                     "storageAccountName": {
                         "value": "[variables('storageAccountName')]"
-                    }
+                    },
+		    "storageAutoGrow": {
+			"value": "[parameters('databaseStorageAutoGrow')]"
+	            },
+		    "backupRetentionDays": {
+			"value": "[parameters('databaseBackupRetentionDays')]"
+	            }
                 }
             },
             "dependsOn": [

--- a/azure/template.json
+++ b/azure/template.json
@@ -377,12 +377,12 @@
                     "storageAccountName": {
                         "value": "[variables('storageAccountName')]"
                     },
-		    "storageAutoGrow": {
-			"value": "[parameters('databaseStorageAutoGrow')]"
-	            },
-		    "backupRetentionDays": {
-			"value": "[parameters('databaseBackupRetentionDays')]"
-	            }
+                    "storageAutoGrow": {
+                        "value": "[parameters('databaseStorageAutoGrow')]"
+                    },
+                    "backupRetentionDays": {
+                        "value": "[parameters('databaseBackupRetentionDays')]"
+                    }
                 }
             },
             "dependsOn": [


### PR DESCRIPTION
### Context

At the present time the database backups are fixed at the default 35 days retention across all environments in which our app is deployed. This change implements revised retention period of 7 days on all environments except production, which is set at the default 35 days in addition to having auto-grow configured on the underlying storage.

This PR additionally addresses a recent issue with the deployment aspect of the pipeline.

### Changes proposed in this pull request

- Sets backup retention to 7 days in dev and test subscription deployments
- Sets backup retention to 35 days in production deployments
- Enables auto-grow on database storage in production deployments
- Configures deployment stage to use new agent pools following recent updates by MS.
- Remove deployment task that parses ARM deployment outputs that is no longer actually used and is currently the cause of failed deployment stages due to an unsupported dependency following a suspected update by MS.

### Guidance to review

Review of database resource configuration to verify database backup retention period.

### Link to Trello card

[1052 - Implement backups of database in azure](https://trello.com/c/sy6S2ThT/1052-implement-backups-of-database-in-azure)
