### PR TITLE
Update FurtherInformationForm to correctly save

### DIFF
--- a/app/models/candidate_interface/further_information_form.rb
+++ b/app/models/candidate_interface/further_information_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     attr_accessor :further_information, :further_information_details
 
     validates :further_information, presence: true
-    validates :further_information_details, presence: true, if: :further_information
+    validates :further_information_details, presence: true, if: :further_information?
 
     validates :further_information_details, word_count: { maximum: 300 }
 
@@ -13,9 +13,13 @@ module CandidateInterface
       return false unless valid?
 
       application_form.update(
-        further_information: further_information,
-        further_information_details: further_information_details,
+        further_information: further_information?,
+        further_information_details: further_information? ? further_information_details : '',
       )
+    end
+
+    def further_information?
+      further_information == 'true'
     end
   end
 end

--- a/spec/models/candidate_interface/further_information_form_spec.rb
+++ b/spec/models/candidate_interface/further_information_form_spec.rb
@@ -9,15 +9,36 @@ RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
     end
 
     it 'updates the provided ApplicationForm if valid' do
+      form_data = {
+        further_information: 'true',
+        further_information_details: 'Much wow.',
+      }
       data = {
         further_information: true,
         further_information_details: 'Much wow.',
       }
       application_form = FactoryBot.create(:application_form)
-      further_information = CandidateInterface::FurtherInformationForm.new(data)
+      further_information = CandidateInterface::FurtherInformationForm.new(form_data)
 
       expect(further_information.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(data)
+    end
+
+    it 'saves the further information details only if adding further information is true' do
+      form_data = {
+        further_information: 'false',
+        further_information_details: 'Much wow.',
+      }
+      data = {
+        further_information: false,
+        further_information_details: '',
+      }
+      application_form = FactoryBot.create(:application_form)
+      further_information = CandidateInterface::FurtherInformationForm.new(form_data)
+
+      further_information.save(application_form)
+
+      expect(application_form.further_information_details).to eq(data[:further_information_details])
     end
   end
 
@@ -25,7 +46,7 @@ RSpec.describe CandidateInterface::FurtherInformationForm, type: :model do
     it { is_expected.to validate_presence_of(:further_information) }
 
     it 'validates further information details if chosen to add further information' do
-      further_information = CandidateInterface::FurtherInformationForm.new(further_information: true)
+      further_information = CandidateInterface::FurtherInformationForm.new(further_information: 'true')
       error_message = t('activemodel.errors.models.candidate_interface/further_information_form.attributes.further_information_details.blank')
 
       further_information.validate


### PR DESCRIPTION
### Context

While product reviewing adding in further information near the end of submission, Theo found a bug which didn't allow a candidate to say "No". It turns out this is because the model was expecting booleans i.e `true` and not `"true"`.

Whilst fixing this I noticed that we also save `further_information_details` when it is `false`.

### Changes proposed in this pull request

This PR ensures that `further_information` is stored as a boolean and `further_information_details` is only stored when `further_information` is true.

### Guidance to review

Get the app running and try out:

1. Not selecting any radio buttons and submitting, you should get a "Choose if you would like to add anything else to your application"
2. Selecting "Yes" and without entering anything in the text area and submitting, you should get a "Enter further information" error
3. Try "No" or "Yes" and with text

### Link to Trello card

[208 - Allow users to provide additional information via a free text box (submitting an application)](https://trello.com/c/Kv5CFsrB/208-allow-users-to-provide-additional-information-via-a-free-text-box-submitting-an-application)
