### PR TITLE
Log sent emails in development

### DIFF
--- a/app/services/magic_link_sign_in.rb
+++ b/app/services/magic_link_sign_in.rb
@@ -1,7 +1,7 @@
 class MagicLinkSignIn
   def self.call(candidate:)
     magic_link_token = MagicLinkToken.new
-    AuthenticationMailer.sign_in_email(to: candidate.email_address, token: magic_link_token.raw).deliver!
+    AuthenticationMailer.sign_in_email(to: candidate.email_address, token: magic_link_token.raw).deliver_now
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
   end
 end

--- a/app/services/magic_link_sign_up.rb
+++ b/app/services/magic_link_sign_up.rb
@@ -1,7 +1,7 @@
 class MagicLinkSignUp
   def self.call(candidate:)
     magic_link_token = MagicLinkToken.new
-    AuthenticationMailer.sign_up_email(to: candidate.email_address, token: magic_link_token.raw).deliver!
+    AuthenticationMailer.sign_up_email(to: candidate.email_address, token: magic_link_token.raw).deliver_now
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -17,6 +17,6 @@ class SubmitApplication
     @application_form.update!(submitted_at: Time.now)
 
     CandidateMailer.submit_application_email(to: candidate_email,
-                                             application_ref: '1234567890').deliver!
+                                             application_ref: '1234567890').deliver_now
   end
 end

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     let(:token) { 'blub' }
     let(:mail) { mailer.sign_up_email(to: 'test@example.com', token: token) }
 
-    before { mail.deliver! }
+    before { mail.deliver_now }
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('authentication.sign_up.email.subject'))
@@ -26,7 +26,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     let(:token) { 'blub' }
     let(:mail) { mailer.sign_in_email(to: 'test@example.com', token: token) }
 
-    before { mail.deliver! }
+    before { mail.deliver_now }
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('authentication.sign_in.email.subject'))

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe 'Send submit application email' do
     let(:mail) { mailer.submit_application_email(to: 'test@example.com', application_ref: 'APPLICATION-REF') }
 
-    before { mail.deliver! }
+    before { mail.deliver_now }
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('submit_application_success.email.subject'))


### PR DESCRIPTION
### Context

This change makes the emails show up in the logs in development. This is super handy because we don't have to log in to GOV.UK Notify to inspect the contents.

Calling `deliver_now` is the standard way to send an email, while calling `deliver!` probably circumvents Rails features like logging and instrumentation. 

We're not entirely sure why the app previously used `deliver!`, this is possibly because [it's a method in mail-notify](https://github.com/dxw/mail-notify/blob/5674ee1fe6b3b260592bab695df55e4b327ed73d/lib/mail/notify/delivery_method.rb#L14-L18).

### Changes proposed in this pull request

Behold useful logs:

<img width="1551" alt="Screenshot 2019-10-23 at 14 20 00" src="https://user-images.githubusercontent.com/233676/67399841-b7498080-f5a4-11e9-8d43-ef95b3e1c012.png">

### Guidance to review

Nothing in particular.

### Link to Trello card

https://trello.com/c/4elQnzEj/1132-improve-infrastructure-for-sending-email