### PR TITLE
Add ability to enter address within contact details

### DIFF
--- a/app/components/contact_details_component.rb
+++ b/app/components/contact_details_component.rb
@@ -6,7 +6,7 @@ class ContactDetailsComponent < ActionView::Component::Base
   end
 
   def contact_details_form_rows
-    [phone_number_row]
+    [phone_number_row, address_row]
   end
 
 private
@@ -18,7 +18,28 @@ private
       key: t('application_form.contact_details.phone_number.label'),
       value: @contact_details_form.phone_number,
       action: t('application_form.contact_details.phone_number.change_action'),
-      change_path: Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_path,
+      change_path: Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_base_path,
     }
+  end
+
+  def address_row
+    {
+      key: t('application_form.contact_details.full_address.label'),
+      value: full_address,
+      action: t('application_form.contact_details.full_address.change_action'),
+      change_path: Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_path,
+    }
+  end
+
+  def full_address
+    [
+      @contact_details_form.address_line1,
+      @contact_details_form.address_line2,
+      @contact_details_form.address_line3,
+      @contact_details_form.address_line4,
+      @contact_details_form.postcode,
+    ]
+      .reject(&:blank?)
+      .join('<br>')
   end
 end

--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -7,7 +7,7 @@
             <%= row[:key] %>
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= row[:value] %>
+            <%= render inline: row[:value] %>
           </dd>
 
           <dd class="govuk-summary-list__actions">

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -1,0 +1,25 @@
+module CandidateInterface
+  class ContactDetails::AddressController < CandidateInterfaceController
+    def edit
+      @contact_details_form = ContactDetailsForm.new
+    end
+
+    def update
+      @contact_details_form = ContactDetailsForm.new(contact_details_params)
+
+      if @contact_details_form.save_address(current_candidate.current_application)
+        redirect_to candidate_interface_contact_details_review_path
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def contact_details_params
+      params.require(:candidate_interface_contact_details_form).permit(
+        :address_line1, :address_line2, :address_line3, :address_line4, :postcode
+      )
+    end
+  end
+end

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class ContactDetailsController < CandidateInterfaceController
+  class ContactDetails::BaseController < CandidateInterfaceController
     def edit
       @contact_details_form = ContactDetailsForm.new
     end
@@ -7,8 +7,8 @@ module CandidateInterface
     def update
       @contact_details_form = ContactDetailsForm.new(contact_details_params)
 
-      if @contact_details_form.save(current_candidate.current_application)
-        render :show
+      if @contact_details_form.save_base(current_candidate.current_application)
+        redirect_to candidate_interface_contact_details_edit_address_path
       else
         render :edit
       end

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class ContactDetails::ReviewController < CandidateInterfaceController
+    def show
+      @contact_details_form = ContactDetailsForm.build_from_application(
+        current_candidate.current_application,
+      )
+    end
+  end
+end

--- a/app/models/candidate_interface/contact_details_form.rb
+++ b/app/models/candidate_interface/contact_details_form.rb
@@ -2,14 +2,32 @@ module CandidateInterface
   class ContactDetailsForm
     include ActiveModel::Model
 
-    attr_accessor :phone_number
+    attr_accessor :phone_number, :address_line1, :address_line2, :address_line3,
+                  :address_line4, :postcode
 
     def self.build_from_application(application_form)
-      new(phone_number: application_form.phone_number)
+      new(
+        phone_number: application_form.phone_number,
+        address_line1: application_form.address_line1,
+        address_line2: application_form.address_line2,
+        address_line3: application_form.address_line3,
+        address_line4: application_form.address_line4,
+        postcode: application_form.postcode,
+      )
     end
 
-    def save(application_form)
+    def save_base(application_form)
       application_form.update(phone_number: phone_number)
+    end
+
+    def save_address(application_form)
+      application_form.update(
+        address_line1: address_line1,
+        address_line2: address_line2,
+        address_line3: address_line3,
+        address_line4: address_line4,
+        postcode: postcode,
+      )
     end
   end
 end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -27,7 +27,7 @@
         <% end %>
       </li>
       <li class="app-task-list__item">
-        <%= govuk_link_to t('page_titles.contact_details'), candidate_interface_contact_details_edit_path, class: 'app-task-list__task-name' %>
+        <%= govuk_link_to t('page_titles.contact_details'), candidate_interface_contact_details_edit_base_path, class: 'app-task-list__task-name' %>
       </li>
       <li class="app-task-list__item">
         <%= govuk_link_to 'TODO: Work history', '#', class: 'app-task-list__task-name' %>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -1,0 +1,29 @@
+<% content_for :title, page_title('contact_details') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_base_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+        <span class="govuk-caption-xl">
+          <%= t('page_titles.contact_details') %>
+        </span>
+        <h1 class="govuk-fieldset__heading">
+          <%= t('page_titles.address') %>
+        </h1>
+      </legend>
+
+      <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_text_field :address_line1, label: { text: t('application_form.contact_details.address_line1.label') } %>
+        <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true } %>
+        <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds' %>
+        <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds' %>
+        <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10 %>
+
+        <%= f.govuk_submit t('application_form.contact_details.complete_form_button') %>
+      <% end %>
+    </fieldset>
+  </div>
+</div>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -10,7 +10,7 @@
         </h1>
       </legend>
 
-      <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
         <%= f.govuk_error_summary %>
 
         <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20 %>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, page_title('contact_details') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_base_path) %>
 
 <h1 class="govuk-heading-xl">
   <%= t('page_titles.contact_details') %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -44,6 +44,9 @@ en:
         label: Phone number
         hint_text: For non-UK numbers, include the country code
         change_action: phone number
+      full_address:
+        label: Address
+        change_action: address
       address_line1:
         label: Building and street
       address_line2:
@@ -54,7 +57,7 @@ en:
         label: County
       postcode:
         label: Postal code
-      complete_form_button: Continue
+      complete_form_button: Save and continue
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     review_application: Review your application
     accessibility: Accessibility statement for Apply for teacher training
     contact_details: Contact details
+    address: What is your address?
   layout:
     service_name: Apply for teacher training
     phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,9 +36,10 @@ Rails.application.routes.draw do
       end
 
       scope '/contact-details' do
-        get '/' => 'contact_details#edit', as: :contact_details_edit
-        post '/review' => 'contact_details#update', as: :contact_details_update
-        get '/review' => 'contact_details#show', as: :contact_details_show
+        get '/' => 'contact_details/base#edit', as: :contact_details_edit_base
+        post '/' => 'contact_details/base#update', as: :contact_details_update_base
+
+        get '/review' => 'contact_details/review#show', as: :contact_details_review
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,9 @@ Rails.application.routes.draw do
         get '/' => 'contact_details/base#edit', as: :contact_details_edit_base
         post '/' => 'contact_details/base#update', as: :contact_details_update_base
 
+        get '/address' => 'contact_details/address#edit', as: :contact_details_edit_address
+        post '/address' => 'contact_details/address#update', as: :contact_details_update_address
+
         get '/review' => 'contact_details/review#show', as: :contact_details_review
       end
     end

--- a/spec/components/contact_details_component_spec.rb
+++ b/spec/components/contact_details_component_spec.rb
@@ -1,17 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe ContactDetailsComponent do
-  it 'renders component with correct structure' do
-    contact_details_form = instance_double(
+  let(:contact_details_form) do
+    instance_double(
       'CandidateInterface::ContactDetailsForm',
       phone_number: '07700 900 982',
+      address_line1: '42',
+      address_line2: 'Much Wow Street',
+      address_line3: 'London',
+      address_line4: 'England',
+      postcode: 'SW1P 3BT',
     )
+  end
 
+  it 'renders component with correct values for a phone number' do
     result = render_inline(ContactDetailsComponent, contact_details_form: contact_details_form)
 
     expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_details.phone_number.label'))
     expect(result.css('.govuk-summary-list__value').text).to include('07700 900 982')
-    expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_path)
+    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_base_path)
     expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_details.phone_number.change_action')}")
+  end
+
+  it 'renders component with correct values for an address' do
+    result = render_inline(ContactDetailsComponent, contact_details_form: contact_details_form)
+
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.contact_details.full_address.label'))
+    expect(result.css('.govuk-summary-list__value').to_html).to include('42<br>Much Wow Street<br>London<br>England<br>SW1P 3BT')
+    expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_path)
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.contact_details.full_address.change_action')}")
+  end
+
+  it 'renders the address fields that are not empty strings' do
+    contact_details_form = instance_double(
+      'CandidateInterface::ContactDetailsForm',
+      phone_number: '07700 900 982',
+      address_line1: '42 Much Wow Street',
+      address_line2: '',
+      address_line3: 'London',
+      address_line4: 'England',
+      postcode: 'SW1P 3BT',
+    )
+
+    result = render_inline(ContactDetailsComponent, contact_details_form: contact_details_form)
+
+    expect(result.css('.govuk-summary-list__value').to_html).to include('42 Much Wow Street<br>London<br>England<br>SW1P 3BT')
   end
 end

--- a/spec/models/candidate_interface/contact_details_form_spec.rb
+++ b/spec/models/candidate_interface/contact_details_form_spec.rb
@@ -1,36 +1,60 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
-  let(:data) do
-    {
-      phone_number: '07700 900 982',
-    }
-  end
-
   describe '.build_from_application' do
     it 'creates an object based on the provided ApplicationForm' do
+      data = {
+        phone_number: Faker::PhoneNumber.cell_phone,
+        address_line1: Faker::Address.street_name,
+        address_line2: Faker::Address.street_address,
+        address_line3: Faker::Address.city,
+        address_line4: Faker::Address.country,
+        postcode: Faker::Address.postcode,
+      }
       application_form = build_stubbed(:application_form, data)
-      contact_details = CandidateInterface::ContactDetailsForm.build_from_application(
-        application_form,
-      )
+      contact_details = CandidateInterface::ContactDetailsForm.build_from_application(application_form)
 
       expect(contact_details).to have_attributes(data)
     end
   end
 
-  describe '#save' do
+  describe '#save_base' do
     it 'returns false if not valid' do
       contact_details = CandidateInterface::ContactDetailsForm.new
 
-      expect(contact_details.save(ApplicationForm.new)).to eq(false)
+      expect(contact_details.save_base(ApplicationForm.new)).to eq(false)
     end
 
     it 'updates the provided ApplicationForm if valid' do
-      application_form = build(:application_form, data)
-      contact_details = CandidateInterface::ContactDetailsForm.new(data)
+      form_data = { phone_number: Faker::PhoneNumber.cell_phone }
+      application_form = build(:application_form)
+      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
 
-      expect(contact_details.save(application_form)).to eq(true)
-      expect(application_form).to have_attributes(data)
+      expect(contact_details.save_base(application_form)).to eq(true)
+      expect(application_form).to have_attributes(form_data)
+    end
+  end
+
+  describe '#save_address' do
+    it 'returns false if not valid' do
+      contact_details = CandidateInterface::ContactDetailsForm.new
+
+      expect(contact_details.save_address(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm with the address fields if valid' do
+      form_data = {
+        address_line1: Faker::Address.street_name,
+        address_line2: Faker::Address.street_address,
+        address_line3: Faker::Address.city,
+        address_line4: Faker::Address.country,
+        postcode: Faker::Address.postcode,
+      }
+      application_form = build(:application_form)
+      contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+
+      expect(contact_details.save_address(application_form)).to eq(true)
+      expect(application_form).to have_attributes(form_data)
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -18,8 +18,8 @@ RSpec.feature 'Entering their contact details' do
 
     when_i_fill_in_my_phone_number
     and_i_submit_the_form
-    # and_i_fill_in_my_address
-    # and_i_submit_the_form
+    and_i_fill_in_my_address
+    and_i_submit_the_form
     then_i_can_check_my_answers
 
     # when_i_submit_my_details
@@ -33,7 +33,7 @@ RSpec.feature 'Entering their contact details' do
   def given_i_am_not_signed_in; end
 
   def and_i_visit_the_contact_details_page
-    visit candidate_interface_contact_details_edit_path
+    visit candidate_interface_contact_details_edit_base_path
   end
 
   def then_i_should_see_the_homepage
@@ -67,5 +67,11 @@ RSpec.feature 'Entering their contact details' do
   def then_i_can_check_my_answers
     expect(page).to have_content t('application_form.contact_details.phone_number.label')
     expect(page).to have_content '07700 900 982'
+  end
+
+  def and_i_fill_in_my_address
+    fill_in t('application_form.contact_details.address_line1.label'), with: '42 Much Wow Street'
+    fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'
   end
 end


### PR DESCRIPTION
### Context

Currently, candidates are only able to enter phone number.

### Changes proposed in this pull request

This PR allows a candidate to enter their address and then review it at the end.

Additionally, there has been some refactoring to enable having multi-steps to enter contact details. Instead of a single controller `ContactDetailsController`, this PR adds a namespace `ContactDetails::` so that each step for contact details, there is a controller. This means we can avoid having a bloated single controller and each `ContactDetails` controller redirects to the another and handles only what it needs to for the step it's responsible for.

For example:

1. Enter phone number (and eventually email) => `ContactDetails::BaseController`
2. Enter address => `ContactDetails::AddressController`
3. Check your contact details => `ContactDetails::ReviewController`

Further, there are now two separate save methods for `ContactDetailsForm` to follow the spitting of controllers. E.g. `ContactDetails::AddressController` will call `ContactDetailsForm#save_address`.

![image](https://user-images.githubusercontent.com/42817036/67483700-44044500-f65e-11e9-8c3d-2b4999460234.png)

![image](https://user-images.githubusercontent.com/42817036/67483772-68f8b800-f65e-11e9-9393-bbd4d673e467.png)

### Guidance to review

- Get the app running, try adding in an address and see if it works. Currently, there is no validation, this will be added in a later PR.
- There are comments in the system tests to show where this is headed.

To make things easier to review, below is my plan of action. Let know if this makes sense and if it's missing anything.

- [x] Be able to add phone number and review it (#363) 
- [ ] Be able to add address and review it (this PR)
- [ ] Add validation for phone number
- [ ] Add validation for address
- [ ] Add completed label to contact details section and show contact details at application review
- [ ] Be able to change your contact details

### Link to Trello card

[191 - Providing contact details](https://trello.com/c/h2MIJjei/191-providing-contact-details)
