### PR TITLE
Declare basicAuthUsername in the Azure deployment template

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -66,6 +66,8 @@ jobs:
                 -warmupPingPath "${{parameters.warmupPingPath}}"
                 -warmupPingStatus "${{parameters.warmupPingStatus}}"
                 -govukNotifyAPIKey "$(govukNotifyAPIKey)"
+                -basicAuthUsername "$(basicAuthUsername)"
+                -basicAuthPassword "$(basicAuthPassword)"
                 -supportUsername "$(supportUsername)"
                 -supportPassword "$(supportPassword)"
                 -domain "${{parameters.domain}}"


### PR DESCRIPTION
Following #365, the build was failing with the message

```
[error] Deployment template validation failed: 'The value for the
template parameter 'basicAuthUsername' at line '1' and column '2139' is
not provided. Please see https://aka.ms/resource-manager-parameter-files
for usage details.'
```