### PR TITLE
Do not use shoulda for a long validate_inclusion_of spec

### DIFF
--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -124,8 +124,26 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
     it { is_expected.to validate_length_of(:first_name).is_at_most(100) }
     it { is_expected.to validate_length_of(:last_name).is_at_most(100) }
 
-    it { is_expected.to validate_inclusion_of(:first_nationality).in_array(NATIONALITY_DEMONYMS) }
-    it { is_expected.to validate_inclusion_of(:second_nationality).in_array(NATIONALITY_DEMONYMS) }
+    it 'validates nationalities against the NATIONALITY_DEMONYMS list' do
+      details_with_invalid_nationality = CandidateInterface::PersonalDetailsForm.new(
+        first_nationality: 'Tralfamadorian',
+        second_nationality: 'Czechoslovakian',
+      )
+
+      details_with_valid_nationality = CandidateInterface::PersonalDetailsForm.new(
+        first_nationality: NATIONALITY_DEMONYMS.sample,
+        second_nationality: NATIONALITY_DEMONYMS.sample,
+      )
+
+      details_with_valid_nationality.validate
+      details_with_invalid_nationality.validate
+
+      expect(details_with_valid_nationality.errors.keys).not_to include :first_nationality
+      expect(details_with_valid_nationality.errors.keys).not_to include :second_nationality
+
+      expect(details_with_invalid_nationality.errors.keys).to include :first_nationality
+      expect(details_with_invalid_nationality.errors.keys).to include :second_nationality
+    end
 
     okay_text = Faker::Lorem.sentence(word_count: 200)
     long_text = Faker::Lorem.sentence(word_count: 201)


### PR DESCRIPTION
The test description shoulda generates is an exhaustive list of
countries that fills half a screen twice during every test run: once
when the spec itself runs, and once at the bottom for the profiling
report. I think it was in the profiling report in the first place
because it checked every single entry in this long array.

This is core Rails functionality anyway. Replace the noisy shoulda spec
with a more direct handmade spec.

### Before

<img width="1677" alt="Screenshot 2019-10-24 at 14 28 18" src="https://user-images.githubusercontent.com/642279/67490066-9186af00-f66a-11e9-9fa2-d3f246bd26de.png">

### After

<img width="1680" alt="Screenshot 2019-10-24 at 14 28 25" src="https://user-images.githubusercontent.com/642279/67490079-951a3600-f66a-11e9-98b3-64aa57088f3b.png">
