### PR TITLE
Do not run the RSpec profiler on every run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :test do
   gem 'timecop'
   gem 'guard-rspec'
   gem 'webmock'
-  gem 'simplecov', require: false, group: :test
+  gem 'simplecov', require: false
 end
 
 group :development, :test do

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,16 @@ task :brakeman do
   Brakeman.run(app_path: '.', print_report: true)
 end
 
-task default: %i[lint_erb lint_ruby spec generate_state_diagram brakeman]
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec_with_profile) do |t|
+    t.rspec_opts = '--profile'
+  end
+rescue LoadError
+  nil
+end
+
+task default: %i[lint_erb lint_ruby spec_with_profile generate_state_diagram brakeman]
 
 Rake::Task['db:migrate'].enhance do
   sh 'bundle exec erd' if Rails.env.development?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,5 +93,5 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 end


### PR DESCRIPTION
### Context

The RSpec profiler means extra scrolling when reading test output on the CLI. It is useful, though.

### Changes proposed in this pull request

Keep the profiling information when we run `rake`. Don't show it when we run plain `rspec`.
