### PR TITLE
Add validation to contact details

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'faker'
 
 gem 'actionview-component'
 
+gem 'uk_postcode'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,6 +332,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    uk_postcode (2.1.5)
     unicode-display_width (1.6.0)
     warden (1.2.8)
       rack (>= 2.0.6)
@@ -395,6 +396,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.1)
   simplecov
   timecop
+  uk_postcode
   web-console (>= 3.3.0)
   webmock
   webpacker

--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -12,6 +12,6 @@
     </p>
     <p class="govuk-body">You can only resubmit each application once.</p>
 
-    <%= govuk_button_link_to "TODO: Edit your application", "#" %>
+    <%= govuk_button_link_to 'TODO: Edit your application', '#' %>
   </div>
 <% end %>

--- a/app/models/candidate_interface/contact_details_form.rb
+++ b/app/models/candidate_interface/contact_details_form.rb
@@ -5,12 +5,14 @@ module CandidateInterface
     attr_accessor :phone_number, :address_line1, :address_line2, :address_line3,
                   :address_line4, :postcode
 
-    validates :address_line1, :address_line3, :postcode, presence: true
+    validates :address_line1, :address_line3, :postcode, presence: true, on: :address
 
     validates :address_line1, :address_line2, :address_line3, :address_line4,
               length: { maximum: 50 }, on: :address
 
-    validates :postcode, postcode: true
+    validates :phone_number, phone_number: true, on: :base
+
+    validates :postcode, postcode: true, on: :address
 
     def self.build_from_application(application_form)
       new(
@@ -24,11 +26,13 @@ module CandidateInterface
     end
 
     def save_base(application_form)
+      return false unless valid?(:base)
+
       application_form.update(phone_number: phone_number)
     end
 
     def save_address(application_form)
-      return false unless valid?
+      return false unless valid?(:address)
 
       application_form.update(
         address_line1: address_line1,

--- a/app/models/candidate_interface/contact_details_form.rb
+++ b/app/models/candidate_interface/contact_details_form.rb
@@ -5,6 +5,13 @@ module CandidateInterface
     attr_accessor :phone_number, :address_line1, :address_line2, :address_line3,
                   :address_line4, :postcode
 
+    validates :address_line1, :address_line3, :postcode, presence: true
+
+    validates :address_line1, :address_line2, :address_line3, :address_line4,
+              length: { maximum: 50 }, on: :address
+
+    validates :postcode, postcode: true
+
     def self.build_from_application(application_form)
       new(
         phone_number: application_form.phone_number,
@@ -21,6 +28,8 @@ module CandidateInterface
     end
 
     def save_address(application_form)
+      return false unless valid?
+
       application_form.update(
         address_line1: address_line1,
         address_line2: address_line2,

--- a/app/validators/phone_number_validator.rb
+++ b/app/validators/phone_number_validator.rb
@@ -1,0 +1,13 @@
+class PhoneNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.blank? || is_invalid_phone_number_format?(value)
+      record.errors[attribute] << I18n.t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid')
+    end
+  end
+
+private
+
+  def is_invalid_phone_number_format?(value)
+    value.match?(/[^ext()+\. 0-9]/)
+  end
+end

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -1,0 +1,11 @@
+class PostcodeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    postcode = UKPostcode.parse(value)
+
+    unless postcode.full_valid?
+      record.errors[attribute] << I18n.t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.postcode.invalid')
+    end
+  end
+end

--- a/app/views/candidate_interface/application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/application_form/submit_show.html.erb
@@ -3,35 +3,35 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <h1 class="govuk-fieldset__heading">
-          <%= t('submit_application.heading') %>
-        </h1>
-      </legend>
+    <%= form_with model: @further_information_form, url: candidate_interface_application_submit_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
 
-      <p class="govuk-body">
-        I understand I will have to undergo an enhanced
-        <%= govuk_link_to t('submit_application.disclosure_link'), 'https://www.gov.uk/government/organisations/disclosure-and-barring-service' %>
-        as part of my application.
-      </p>
-      <div class="govuk-inset-text">
-        <p class="govuk-body">
-          As prospective teachers, all candidates must consent to an enhanced DBS
-          check. This will show up any past criminal convictions, both spent and
-          unspent. Some convictions, even if they are spent, will disbar you from
-          teaching.
-        </p>
-        However, not all past convictions prevent you from training to be a teacher.
-        Talk to your provider about their policy on criminal convictions.
-        <p></p>
-        <p class="govuk-body">
-          <%= govuk_link_to t('submit_application.conviction_link'), 'https://www.gov.uk/exoffenders-and-employment' %>.
-        </p>
-      </div>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('submit_application.heading') %>
+          </h1>
+        </legend>
 
-      <%= form_with model: @further_information_form, url: candidate_interface_application_submit_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :post do |f| %>
-        <%= f.govuk_error_summary %>
+        <p class="govuk-body">
+          I understand I will have to undergo an enhanced
+          <%= govuk_link_to t('submit_application.disclosure_link'), 'https://www.gov.uk/government/organisations/disclosure-and-barring-service' %>
+          as part of my application.
+        </p>
+        <div class="govuk-inset-text">
+          <p class="govuk-body">
+            As prospective teachers, all candidates must consent to an enhanced DBS
+            check. This will show up any past criminal convictions, both spent and
+            unspent. Some convictions, even if they are spent, will disbar you from
+            teaching.
+          </p>
+          However, not all past convictions prevent you from training to be a teacher.
+          Talk to your provider about their policy on criminal convictions.
+          <p></p>
+          <p class="govuk-body">
+            <%= govuk_link_to t('submit_application.conviction_link'), 'https://www.gov.uk/exoffenders-and-employment' %>.
+          </p>
+        </div>
 
         <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
           <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' } do %>
@@ -47,7 +47,7 @@
         </p>
 
         <%= f.govuk_submit t('submit_application.submit_button') %>
-      <% end %>
-    </fieldset>
+      </fieldset>
+    <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -22,7 +22,7 @@
         <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds' %>
         <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10 %>
 
-        <%= f.govuk_submit t('application_form.contact_details.complete_form_button') %>
+        <%= f.govuk_submit t('application_form.contact_details.address.button') %>
       <% end %>
     </fieldset>
   </div>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -3,18 +3,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <span class="govuk-caption-xl">
-          <%= t('page_titles.contact_details') %>
-        </span>
-        <h1 class="govuk-fieldset__heading">
-          <%= t('page_titles.address') %>
-        </h1>
-      </legend>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
 
-      <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-        <%= f.govuk_error_summary %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <span class="govuk-caption-xl">
+            <%= t('page_titles.contact_details') %>
+          </span>
+          <h1 class="govuk-fieldset__heading">
+            <%= t('page_titles.address') %>
+          </h1>
+        </legend>
 
         <%= f.govuk_text_field :address_line1, label: { text: t('application_form.contact_details.address_line1.label') } %>
         <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true } %>
@@ -23,7 +23,7 @@
         <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10 %>
 
         <%= f.govuk_submit t('application_form.contact_details.address.button') %>
-      <% end %>
-    </fieldset>
+      </fieldset>
+    <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -15,7 +15,7 @@
 
         <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20 %>
 
-        <%= f.govuk_submit t('application_form.contact_details.complete_form_button') %>
+        <%= f.govuk_submit t('application_form.contact_details.base.button') %>
       <% end %>
     </fieldset>
   </div>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -3,20 +3,20 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <h1 class="govuk-fieldset__heading">
-          <%= t('page_titles.contact_details') %>
-        </h1>
-      </legend>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
 
-      <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-        <%= f.govuk_error_summary %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('page_titles.contact_details') %>
+          </h1>
+        </legend>
 
         <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20 %>
 
         <%= f.govuk_submit t('application_form.contact_details.base.button') %>
-      <% end %>
-    </fieldset>
+      </fieldset>
+    <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -7,4 +7,4 @@
 
 <%= render(ContactDetailsComponent, contact_details_form: @contact_details_form) %>
 
-<%= govuk_button_link_to t('application_form.contact_details.complete_form_button'), candidate_interface_application_form_path %>
+<%= govuk_button_link_to t('application_form.contact_details.review.button'), candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -3,15 +3,15 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <fieldset class="govuk-fieldset">
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <h1 class="govuk-fieldset__heading">
-          <%= t('page_titles.personal_details') %>
-        </h1>
-      </legend>
+    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
 
-      <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-        <%= f.govuk_error_summary %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('page_titles.personal_details') %>
+          </h1>
+        </legend>
 
         <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.first_name.hint_text') %>
 
@@ -42,7 +42,7 @@
         <% end %>
 
         <%= f.govuk_submit 'Continue' %>
-      <% end %>
-    </fieldset>
+      </fieldset>
+    <% end %>
   </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -58,6 +58,12 @@ en:
       postcode:
         label: Postal code
       complete_form_button: Save and continue
+      base:
+        button: Save and continue
+      address:
+        button: Save and continue
+      review:
+        button: Continue
   activemodel:
     errors:
       models:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -95,6 +95,7 @@ en:
           attributes:
             phone_number:
               blank: Enter your phone number
+              invalid: Enter a phone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
             address_line1:
               blank: Enter your building and street
               too_long: Building and street must be %{count} characters or fewer

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -95,3 +95,16 @@ en:
           attributes:
             phone_number:
               blank: Enter your phone number
+            address_line1:
+              blank: Enter your building and street
+              too_long: Building and street must be %{count} characters or fewer
+            address_line2:
+              too_long: Building and street must be %{count} characters or fewer
+            address_line3:
+              blank: Enter your town or city
+              too_long: Town or city must be %{count} characters or fewer
+            address_line4:
+              too_long: County must be %{count} characters or fewer
+            postcode:
+              blank: Enter a postal code
+              invalid: Enter a real postal code (for example, BN1 1AA)

--- a/spec/models/candidate_interface/contact_details_form_spec.rb
+++ b/spec/models/candidate_interface/contact_details_form_spec.rb
@@ -57,4 +57,18 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
       expect(application_form).to have_attributes(form_data)
     end
   end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:address_line1) }
+    it { is_expected.to validate_presence_of(:address_line3) }
+    it { is_expected.to validate_presence_of(:postcode) }
+
+    it { is_expected.to validate_length_of(:address_line1).is_at_most(50).on(:address) }
+    it { is_expected.to validate_length_of(:address_line2).is_at_most(50).on(:address) }
+    it { is_expected.to validate_length_of(:address_line3).is_at_most(50).on(:address) }
+    it { is_expected.to validate_length_of(:address_line4).is_at_most(50).on(:address) }
+
+    it { is_expected.to allow_value('SW1P 3BT').for(:postcode) }
+    it { is_expected.not_to allow_value('MUCH WOW').for(:postcode) }
+  end
 end

--- a/spec/models/candidate_interface/contact_details_form_spec.rb
+++ b/spec/models/candidate_interface/contact_details_form_spec.rb
@@ -59,16 +59,19 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:address_line1) }
-    it { is_expected.to validate_presence_of(:address_line3) }
-    it { is_expected.to validate_presence_of(:postcode) }
+    it { is_expected.to validate_presence_of(:address_line1).on(:address) }
+    it { is_expected.to validate_presence_of(:address_line3).on(:address) }
+    it { is_expected.to validate_presence_of(:postcode).on(:address) }
 
     it { is_expected.to validate_length_of(:address_line1).is_at_most(50).on(:address) }
     it { is_expected.to validate_length_of(:address_line2).is_at_most(50).on(:address) }
     it { is_expected.to validate_length_of(:address_line3).is_at_most(50).on(:address) }
     it { is_expected.to validate_length_of(:address_line4).is_at_most(50).on(:address) }
 
-    it { is_expected.to allow_value('SW1P 3BT').for(:postcode) }
-    it { is_expected.not_to allow_value('MUCH WOW').for(:postcode) }
+    it { is_expected.to allow_value('SW1P 3BT').for(:postcode).on(:address) }
+    it { is_expected.not_to allow_value('MUCH WOW').for(:postcode).on(:address) }
+
+    it { is_expected.to allow_value('07700 900 982').for(:phone_number).on(:base) }
+    it { is_expected.not_to allow_value('07700 WUT WUT').for(:phone_number).on(:base) }
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -13,13 +13,13 @@ RSpec.feature 'Entering their contact details' do
 
     when_i_click_on_contact_details
     # and_i_incorrectly_fill_in_my_phone_number
-    # and_i_submit_the_form
+    # and_i_submit_my_phone_number
     # then_i_should_see_validation_errors
 
     when_i_fill_in_my_phone_number
-    and_i_submit_the_form
+    and_i_submit_my_phone_number
     and_i_fill_in_my_address
-    and_i_submit_the_form
+    and_i_submit_my_address
     then_i_can_check_my_answers
 
     # when_i_submit_my_details
@@ -56,22 +56,26 @@ RSpec.feature 'Entering their contact details' do
     fill_in t('application_form.contact_details.phone_number.label'), with: 'A phone number'
   end
 
-  def and_i_submit_the_form
-    click_button t('application_form.contact_details.complete_form_button')
-  end
-
   def when_i_fill_in_my_phone_number
     fill_in t('application_form.contact_details.phone_number.label'), with: '07700 900 982'
   end
 
-  def then_i_can_check_my_answers
-    expect(page).to have_content t('application_form.contact_details.phone_number.label')
-    expect(page).to have_content '07700 900 982'
+  def and_i_submit_my_phone_number
+    click_button t('application_form.contact_details.base.button')
   end
 
   def and_i_fill_in_my_address
     fill_in t('application_form.contact_details.address_line1.label'), with: '42 Much Wow Street'
     fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
     fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'
+  end
+
+  def and_i_submit_my_address
+    click_button t('application_form.contact_details.address.button')
+  end
+
+  def then_i_can_check_my_answers
+    expect(page).to have_content t('application_form.contact_details.phone_number.label')
+    expect(page).to have_content '07700 900 982'
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -14,11 +14,15 @@ RSpec.feature 'Entering their contact details' do
     when_i_click_on_contact_details
     # and_i_incorrectly_fill_in_my_phone_number
     # and_i_submit_my_phone_number
-    # then_i_should_see_validation_errors
+    # then_i_should_see_validation_errors_for_my_phone_number
 
     when_i_fill_in_my_phone_number
     and_i_submit_my_phone_number
-    and_i_fill_in_my_address
+    and_i_incorrectly_fill_in_my_address
+    and_i_submit_my_address
+    then_i_should_see_validation_errors_for_my_address
+
+    when_i_fill_in_my_address
     and_i_submit_my_address
     then_i_can_check_my_answers
 
@@ -64,7 +68,17 @@ RSpec.feature 'Entering their contact details' do
     click_button t('application_form.contact_details.base.button')
   end
 
-  def and_i_fill_in_my_address
+  def and_i_incorrectly_fill_in_my_address
+    fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
+    fill_in t('application_form.contact_details.postcode.label'), with: 'MUCH W0W'
+  end
+
+  def then_i_should_see_validation_errors_for_my_address
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.address_line1.blank')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.postcode.invalid')
+  end
+
+  def when_i_fill_in_my_address
     fill_in t('application_form.contact_details.address_line1.label'), with: '42 Much Wow Street'
     fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
     fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -12,9 +12,9 @@ RSpec.feature 'Entering their contact details' do
     and_i_visit_the_site
 
     when_i_click_on_contact_details
-    # and_i_incorrectly_fill_in_my_phone_number
-    # and_i_submit_my_phone_number
-    # then_i_should_see_validation_errors_for_my_phone_number
+    and_i_incorrectly_fill_in_my_phone_number
+    and_i_submit_my_phone_number
+    then_i_should_see_validation_errors_for_my_phone_number
 
     when_i_fill_in_my_phone_number
     and_i_submit_my_phone_number
@@ -57,15 +57,19 @@ RSpec.feature 'Entering their contact details' do
   end
 
   def and_i_incorrectly_fill_in_my_phone_number
-    fill_in t('application_form.contact_details.phone_number.label'), with: 'A phone number'
-  end
-
-  def when_i_fill_in_my_phone_number
-    fill_in t('application_form.contact_details.phone_number.label'), with: '07700 900 982'
+    fill_in t('application_form.contact_details.phone_number.label'), with: '07700 CAT DOG'
   end
 
   def and_i_submit_my_phone_number
     click_button t('application_form.contact_details.base.button')
+  end
+
+  def then_i_should_see_validation_errors_for_my_phone_number
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid')
+  end
+
+  def when_i_fill_in_my_phone_number
+    fill_in t('application_form.contact_details.phone_number.label'), with: '07700 900 982'
   end
 
   def and_i_incorrectly_fill_in_my_address

--- a/spec/validators/phone_number_validator_spec.rb
+++ b/spec/validators/phone_number_validator_spec.rb
@@ -1,0 +1,102 @@
+require 'rails_helper'
+
+RSpec.describe PhoneNumberValidator do
+  before do
+    stub_const('Validatable', Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :phone_number
+      validates :phone_number, phone_number: true
+    end
+  end
+
+  context 'when nil phone number' do
+    let(:model) { Validatable.new }
+
+    before do
+      model.phone_number = nil
+      model.validate(:no_context)
+    end
+
+    it 'returns invalid' do
+      expect(model).not_to be_valid
+    end
+
+    it 'returns the correct error message' do
+      expect(model.errors[:phone_number]).to include(t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid'))
+    end
+  end
+
+  context 'when empty phone number' do
+    let(:model) { Validatable.new }
+
+    before do
+      model.phone_number = ''
+      model.validate(:no_context)
+    end
+
+    it 'returns invalid' do
+      expect(model.valid?(:no_context)).to be false
+    end
+
+    it 'returns the correct error message' do
+      expect(model.errors[:phone_number]).to include(t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid'))
+    end
+  end
+
+  context 'when a phone number is in an invalid format' do
+    it 'returns invalid' do
+      model = Validatable.new
+      invalid_phone_numbers = [
+        '12 3 4 cat',
+        '12dog34',
+      ]
+
+      invalid_phone_numbers.each do |phone_number|
+        model.phone_number = phone_number
+
+        model.validate(:no_context)
+
+        expect(model).not_to be_valid
+      end
+    end
+  end
+
+  context 'when a valid phone number' do
+    it 'correctly validates valid phone numbers' do
+      model = Validatable.new
+      valid_phone_numbers = [
+        '+447123 123 123',
+        '+407123 123 123',
+        '+1 7123 123 123',
+        '+447123123123',
+        '07123123123',
+        '01234 123 123 ext123',
+        '01234 123 123 ext 123',
+        '01234 123 123 x123',
+        '(01234) 123123',
+        '(12345) 123123',
+        '(+44) (0)1234 123456',
+        '+44 (0) 123 4567 123',
+        '123 1234 1234 ext 123',
+        '12345 123456 ext 123',
+        '12345 123456 ext. 123',
+        '12345 123456 ext123',
+        '01234123456 ext 123',
+        '123 1234 1234 x123',
+        '12345 123456 x123',
+        '12345123456 x123',
+        '(1234) 123 1234',
+        '1234 123 1234 x123',
+        '1234 123 1234 ext 1234',
+        '1234 123 1234  ext 123',
+        '+44(0)123 12 12345',
+      ]
+
+      valid_phone_numbers.each do |number|
+        model.phone_number = number
+
+        expect(model).to be_valid
+      end
+    end
+  end
+end

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PostcodeValidator do
+  before do
+    stub_const('Validatable', Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :postcode
+      validates :postcode, postcode: true
+    end
+  end
+
+  context 'with a valid UK postcode' do
+    it 'does not add an error' do
+      model = Validatable.new
+
+      model.postcode = 'SE1 1TE'
+
+      expect(model).to be_valid
+      expect(model.errors[:postcode]).to be_blank
+    end
+  end
+
+  context 'with a valid UK postcode' do
+    it 'adds an error' do
+      model = Validatable.new
+
+      model.postcode = 'MUCH WOW'
+
+      expect(model).not_to be_valid
+      expect(model.errors[:postcode]).not_to be_blank
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently, candidates can enter whatever they want for all the fields for contact details.

### Changes proposed in this pull request

This PR adds:
-  a `PostcodeValidator` which is borrowed from [Find](https://github.com/DFE-Digital/manage-courses-backend/blob/5a5838f8644c10fb9d71fa1d5e7f338b648d479a/app/validators/postcode_validator.rb)
- a `PhoneNumberValidator` which is borrowed from [Find](https://github.com/DFE-Digital/manage-courses-backend/blob/5a5838f8644c10fb9d71fa1d5e7f338b648d479a/app/validators/phone_validator.rb) 
- validation for all address fields
- validation for phone number

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/67552605-48cf0480-f703-11e9-9c71-c6b04c6bbe64.png)

![image](https://user-images.githubusercontent.com/42817036/67506027-3e215a80-f684-11e9-8ff4-58433046cb1c.png)

![image](https://user-images.githubusercontent.com/42817036/67552693-7ae06680-f703-11e9-83cc-2f67193278af.png)

### Guidance to review

Get the app running and try putting invalid data.

- [x] Be able to add phone number and review it (#363) 
- [x] Be able to add address and review it (#375)
- [ ] Add validation for phone number (this PR)
- [ ] Add validation for address (this PR)
- [ ] Be able to change your contact details
- [ ] Add completed label to contact details section and show contact details at application review

### Link to Trello card

[191 - Providing contact details](https://trello.com/c/h2MIJjei/191-providing-contact-details)
