### PR TITLE
Add initial Work History page

### DIFF
--- a/app/controllers/candidate_interface/work_history_controller.rb
+++ b/app/controllers/candidate_interface/work_history_controller.rb
@@ -1,0 +1,24 @@
+module CandidateInterface
+  class WorkHistoryController < CandidateInterfaceController
+    def length
+      @work_details_form = WorkHistoryForm.new
+    end
+
+    def submit_length
+      @work_details_form = WorkHistoryForm.new(work_history_params)
+
+      @work_details_form.valid?
+      render :length
+    end
+
+  private
+
+    def work_history_params
+      return nil unless params.has_key?(:candidate_interface_work_history_form)
+
+      params.require(:candidate_interface_work_history_form).permit(
+        :work_history,
+      )
+    end
+  end
+end

--- a/app/models/candidate_interface/work_history_form.rb
+++ b/app/models/candidate_interface/work_history_form.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class WorkHistoryForm
+    include ActiveModel::Model
+
+    attr_accessor :work_history
+
+    validates :work_history, presence: true
+  end
+end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -30,7 +30,7 @@
         <%= govuk_link_to t('page_titles.contact_details'), candidate_interface_contact_details_edit_base_path, class: 'app-task-list__task-name' %>
       </li>
       <li class="app-task-list__item">
-        <%= govuk_link_to 'TODO: Work history', '#', class: 'app-task-list__task-name' %>
+        <%= govuk_link_to t('page_titles.work_history'), candidate_interface_work_history_length_path, class: 'app-task-list__task-name' %>
       </li>
       <li class="app-task-list__item">
         <%= govuk_link_to 'TODO: School experience and volunteering', '#', class: 'app-task-list__task-name' %>

--- a/app/views/candidate_interface/work_history/length.html.erb
+++ b/app/views/candidate_interface/work_history/length.html.erb
@@ -1,0 +1,61 @@
+<% content_for :title, page_title('work_history') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @work_details_form, url: candidate_interface_work_history_length_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.work_history') %>
+      </h1>
+
+      <p class="govuk-body">
+        Training providers need a complete picture of the last 5 years of your
+        work history, including time out of the workplace, to safeguard
+        children.
+      </p>
+
+      <p class="govuk-body">
+        Breaks in work history won’t impact your application if you have a
+        reasonable explanation for them (for example, parenting
+        responsibilities, redundancy, illness or personal reasons such as
+        study or travel).
+      </p>
+
+      <div class="govuk-!-margin-top-6">
+        <%= f.govuk_radio_buttons_fieldset :work_history, legend: { size: 'm', text: 'How long have you been working?', tag: 'h2' } do %>
+          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5') } do %>
+            <p class="govuk-body">
+              Give us as much of your work history as you can. For example, if
+              you are a recent graduate, tell us about your employment before,
+              during and since leaving university.
+            </p>
+          <% end %>
+
+          <%= f.govuk_radio_button :work_history, :more_than_5, label: { text: t('application_form.work_history.more_than_5') } do %>
+            <p class="govuk-body">
+              You can list your complete work history – or just the roles you
+              think are relevant – going back further than 5 years if you wish.
+            </p>
+          <% end %>
+
+          <%= f.govuk_radio_button :work_history, :more_than_5_with_breaks, label: { text: t('application_form.work_history.more_than_5_with_breaks') } do %>
+            <p class="govuk-body">
+              You’ll be able to give details once you’ve entered your employment
+              history. Please explain any break longer than a month.
+            </p>
+          <% end %>
+
+          <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing') } do %>
+            <p class="govuk-body">
+              You’ll be able to explain why you’ve been out of the workplace.
+            </p>
+          <% end %>
+        <% end %>
+
+        <%= f.govuk_submit 'Continue' %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -64,6 +64,11 @@ en:
         button: Save and continue
       review:
         button: Continue
+    work_history:
+      less_than_5: Less than 5 years
+      more_than_5: More than 5 years
+      more_than_5_with_breaks: More than 5 years, but with breaks
+      missing: I have not worked in the last 5 years
   activemodel:
     errors:
       models:
@@ -109,3 +114,7 @@ en:
             postcode:
               blank: Enter a postal code
               invalid: Enter a real postal code (for example, BN1 1AA)
+        candidate_interface/work_history_form:
+          attributes:
+            work_history:
+              blank: Choose how long you’ve been working for

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
     accessibility: Accessibility statement for Apply for teacher training
     contact_details: Contact details
     address: What is your address?
+    work_history: Work history
   layout:
     service_name: Apply for teacher training
     phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,11 @@ Rails.application.routes.draw do
 
         get '/review' => 'contact_details/review#show', as: :contact_details_review
       end
+
+      scope '/work-history' do
+        get '/length' => 'work_history#length', as: :work_history_length
+        post '/length' => 'work_history#submit_length'
+      end
     end
   end
 

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their work history' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their work history' do
+    given_i_am_not_signed_in
+    and_i_visit_the_work_history_page
+    then_i_should_see_the_homepage
+
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_work_history
+    then_i_should_see_a_list_of_work_lengths
+
+    when_i_choose_more_than_5_years
+    # then_i_should_see_the_job_form
+  end
+
+  def given_i_am_not_signed_in; end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_work_history_page
+    visit candidate_interface_work_history_length_path
+  end
+
+  def then_i_should_see_the_homepage
+    expect(page).to have_current_path(candidate_interface_start_path)
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_work_history
+    click_link t('page_titles.work_history')
+  end
+
+  def then_i_should_see_a_list_of_work_lengths
+    expect(page).to have_content(t('application_form.work_history.more_than_5'))
+  end
+
+  def when_i_choose_more_than_5_years
+    choose t('application_form.work_history.more_than_5')
+  end
+
+  def then_i_should_see_the_job_form
+    expect(page).to have_content('Add job')
+  end
+end


### PR DESCRIPTION
### Context

Allow candidates to specify how long their work history is.

Further additions to this flow to be added in future PRs.

### Changes proposed in this pull request

Add initial model, controller, and test.

### Guidance to review

Not much going on here, adding a job is a bigger task because it involves a proper active model association with its own separate resourceful CRUD interactions so that will be done separately.

### Screenshots

![Screenshot 2019-10-24 at 17 28 41](https://user-images.githubusercontent.com/1650875/67505997-2d70e480-f684-11e9-91cc-e122e4a3c72e.png)
![Screenshot 2019-10-24 at 17 29 27](https://user-images.githubusercontent.com/1650875/67506000-2d70e480-f684-11e9-8f73-44db483badc0.png)


### Link to Trello card

[192 - Adding work history](https://trello.com/c/G8slDphi/192-adding-work-history)