### PR TITLE
Fix current_application to create new application_choice

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -13,15 +13,16 @@ class Candidate < ApplicationRecord
   has_many :application_forms
 
   def current_application
-    choice = ApplicationChoice.first_or_create do |ac|
+    application_form = application_forms.first_or_create!
+
+    # TODO: this is a temporary thing until candidates can choose their course
+    application_form.application_choices.first_or_create! do |ac|
       provider = Provider.find_or_create_by(code: 'ABC') { |p| p.name = 'Example provider' }
       course = Course.find_or_create_by(name: 'English Primary', code: '123', provider: provider, level: 'primary')
       site = Site.find_or_create_by(code: 'A', name: 'Example School', provider: provider)
       ac.course_option = CourseOption.find_or_create_by(course: course, site: site, vacancy_status: 'B')
     end
 
-    ApplicationForm.find_or_create_by(candidate: self) do |form|
-      form.application_choices = [choice]
-    end
+    application_form
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -27,17 +27,29 @@ RSpec.describe Candidate, type: :model do
   end
 
   describe '#current_application' do
-    it 'returns an existing application' do
+    it 'returns an existing application_form' do
       candidate = create(:candidate)
       application_form = create(:application_form, candidate: candidate)
 
       expect(candidate.current_application).to eq(application_form)
     end
 
-    it 'creates an application if there are none' do
+    it 'creates an application_form if there are none' do
       candidate = create(:candidate)
 
       expect { candidate.current_application }.to change { candidate.application_forms.count }.from(0).to(1)
+    end
+
+    describe 'with an existing application_form' do
+      let!(:other_application_form) { create(:completed_application_form) }
+
+      it 'creates a new application_choice for the current application' do
+        candidate = create(:candidate)
+
+        expect(other_application_form.application_choices.map(&:id)).not_to include(
+          candidate.current_application.application_choices.first.id,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

The current implementation calls `ApplicationChoice.first_or_create`
which can unintentionally "hijack" unrelated `application_choice`s.

More context in this comment: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/323/files#r339052811

### Changes proposed in this pull request

Add a test and then patch the implementation.

### Guidance to review

This should still go away ASAP when we have proper course choices implemented.