### PR TITLE
Add Sentry configuration for current Azure environment

### DIFF
--- a/app/lib/azure_environment.rb
+++ b/app/lib/azure_environment.rb
@@ -1,0 +1,9 @@
+module AzureEnvironment
+  def self.authorised_hosts
+    ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
+  end
+
+  def self.hostname
+    ENV.fetch('CUSTOM_HOST_NAME', authorised_hosts.first)
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,8 +1,4 @@
 Rails.application.configure do
-  def authorised_hosts
-    ENV.fetch("AUTHORISED_HOSTS").split(",").map(&:strip)
-  end
-
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
@@ -62,7 +58,7 @@ Rails.application.configure do
     api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
   }
   config.action_mailer.default_url_options = {
-    host: ENV.fetch("CUSTOM_HOST_NAME", authorised_hosts.first)
+    host: AzureEnvironment.hostname
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -114,7 +110,7 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Whitelist the production domains for HostAuthorization
-  ENV.fetch("AUTHORISED_HOSTS").split(",").each do |domain|
-      config.hosts << domain
+  AzureEnvironment.authorised_hosts.each do |host|
+    config.hosts << host
   end
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,3 @@
+Raven.tags_context(
+  azure_host: AzureEnvironment.hostname,
+)


### PR DESCRIPTION
### Context

This adds an `azure_environment` context tag to Sentry, which will help us debug which environment an error has occurred on.