### PR TITLE
Fix XSS in the summary card component

### DIFF
--- a/app/components/contact_details_review_component.rb
+++ b/app/components/contact_details_review_component.rb
@@ -28,7 +28,7 @@ private
   def address_row
     {
       key: t('application_form.contact_details.full_address.label'),
-      value: full_address,
+      DANGEROUS_html_value: full_address,
       action: t('application_form.contact_details.full_address.change_action'),
       change_path: Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_path,
     }
@@ -42,6 +42,7 @@ private
       @contact_details_form.address_line4,
       @contact_details_form.postcode,
     ]
+      .map { |line| sanitize(line, tags: []) }
       .reject(&:blank?)
       .join('<br>')
   end

--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -7,7 +7,11 @@
             <%= row[:key] %>
           </dt>
           <dd class="govuk-summary-list__value">
-            <%= render inline: row[:value] %>
+            <% if row[:DANGEROUS_html_value].nil? %>
+              <%= row[:value] %>
+            <% else %>
+              <%= render inline: row[:DANGEROUS_html_value] %>
+            <% end %>
           </dd>
 
           <dd class="govuk-summary-list__actions">

--- a/spec/components/contact_details_review_component_spec.rb
+++ b/spec/components/contact_details_review_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ContactDetailsReviewComponent do
     application_form = build(
       :application_form,
       phone_number: '07700 900 982',
-      address_line1: '42 Much Wow Street',
+      address_line1: '42 <script>Much</script> Wow Street',
       address_line2: '',
       address_line3: 'London',
       address_line4: 'England',

--- a/spec/components/summary_card_component_spec.rb
+++ b/spec/components/summary_card_component_spec.rb
@@ -15,4 +15,16 @@ RSpec.describe SummaryCardComponent do
     expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/some/url')
     expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
   end
+
+  it "renders dangerous HTML content when passed in" do
+    rows = [
+      key: 'Address:',
+      DANGEROUS_html_value: 'Whoa Drive,<br>Wewvile<br>London',
+      action: 'Name',
+      change_path: '/some/url',
+    ]
+    result = render_inline(SummaryCardComponent, rows: rows)
+
+    expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive,<br>Wewvile<br>London')
+  end
 end

--- a/spec/components/summary_card_component_spec.rb
+++ b/spec/components/summary_card_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SummaryCardComponent do
     expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
   end
 
-  it "renders dangerous HTML content when passed in" do
+  it 'renders dangerous HTML content when passed in' do
     rows = [
       key: 'Address:',
       DANGEROUS_html_value: 'Whoa Drive,<br>Wewvile<br>London',


### PR DESCRIPTION
### Context

This component uses `render inline:` in order to display address details on multiple lines. We need to sanitize the output in order to prevent users from injecting HTML content themselves.

### Changes proposed in this pull request

Change the component so you need to specify `DANGEROUS_html_value` if you want to use `render inline:`, and then call `sanitize` at the point where we map to `<br>`.

### Guidance to review

Does this seem sensible?

### Trello card

[263 - [Security] Fix XSS vulnerability when candidate supplies their name](https://trello.com/c/O20hngGP/263-security-fix-xss-vulnerability-when-candidate-supplies-their-name)