### PR TITLE
Allow users to submit work experience entries

### DIFF
--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -1,0 +1,3 @@
+<% @application_form.application_work_experiences.each do |work| %>
+  <%= render(SummaryCardComponent, rows: work_experience_rows(work)) %>
+<% end %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -25,7 +25,7 @@ private
         .map { |field| sanitize(field, tags: []) }
         .join('<br>'),
       action: 'job',
-      change_path: '#'
+      change_path: '#',
     }
   end
 
@@ -34,7 +34,7 @@ private
       key: 'Type',
       value: work.commitment.dasherize.humanize,
       action: 'type',
-      change_path: '#'
+      change_path: '#',
     }
   end
 
@@ -43,7 +43,7 @@ private
       key: 'Description',
       value: work.details,
       action: 'description',
-      change_path: '#'
+      change_path: '#',
     }
   end
 end

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -1,0 +1,49 @@
+class WorkHistoryReviewComponent < ActionView::Component::Base
+  validates :application_form, presence: true
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def work_experience_rows(work)
+    [
+      job_row(work),
+      type_row(work),
+      description_row(work),
+    ]
+      .compact
+  end
+
+private
+
+  attr_reader :application_form
+
+  def job_row(work)
+    {
+      key: 'Job',
+      DANGEROUS_html_value: [work.role, work.organisation]
+        .map { |field| sanitize(field, tags: []) }
+        .join('<br>'),
+      action: 'job',
+      change_path: '#'
+    }
+  end
+
+  def type_row(work)
+    {
+      key: 'Type',
+      value: work.commitment.dasherize.humanize,
+      action: 'type',
+      change_path: '#'
+    }
+  end
+
+  def description_row(work)
+    {
+      key: 'Description',
+      value: work.details,
+      action: 'description',
+      change_path: '#'
+    }
+  end
+end

--- a/app/controllers/candidate_interface/work_history_controller.rb
+++ b/app/controllers/candidate_interface/work_history_controller.rb
@@ -7,8 +7,29 @@ module CandidateInterface
     def submit_length
       @work_details_form = WorkHistoryForm.new(work_history_params)
 
-      @work_details_form.valid?
-      render :length
+      if @work_details_form.valid?
+        redirect_to candidate_interface_work_history_new_path
+      else
+        render :length
+      end
+    end
+
+    def new
+      @work_experience_form = WorkExperienceForm.new
+    end
+
+    def create
+      @work_experience_form = WorkExperienceForm.new(work_experience_params)
+
+      if @work_experience_form.save(current_candidate.current_application)
+        redirect_to candidate_interface_work_history_show_path
+      else
+        render :new
+      end
+    end
+
+    def show
+      @application_form = current_candidate.current_application
     end
 
   private
@@ -19,6 +40,14 @@ module CandidateInterface
       params.require(:candidate_interface_work_history_form).permit(
         :work_history,
       )
+    end
+
+    def work_experience_params
+      params.require(:candidate_interface_work_experience_form)
+        .permit(
+          :role, :organisation, :details, :working_with_children, :commitment,
+          :start_date_month, :start_date_year, :end_date_month, :end_date_year
+        )
     end
   end
 end

--- a/app/models/application_work_experience.rb
+++ b/app/models/application_work_experience.rb
@@ -1,3 +1,10 @@
 class ApplicationWorkExperience < ApplicationExperience
   belongs_to :application_form
+
+  validates :commitment, presence: true
+
+  enum commitment: {
+    full_time: 'Full-time',
+    part_time: 'Part-time',
+  }
 end

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -1,0 +1,29 @@
+module CandidateInterface
+  class WorkExperienceForm
+    include ActiveModel::Model
+
+    attr_accessor :role, :organisation, :details, :working_with_children,
+                  :commitment, :start_date_month, :start_date_year,
+                  :end_date_month, :end_date_year
+
+    validates :role, :organisation, :details, :working_with_children,
+              :commitment, :start_date_month, :start_date_year,
+              presence: true
+
+    validates :working_with_children, inclusion: { in: %w(true false) }
+
+    def save(application_form)
+      return false unless valid?
+
+      application_form.application_work_experiences.create!(
+        role: role,
+        organisation: organisation,
+        details: details,
+        commitment: commitment,
+        working_with_children: ActiveModel::Type::Boolean.new.cast(working_with_children),
+        start_date: Date.new(start_date_year.to_i, start_date_month.to_i),
+        end_date: Date.new(end_date_year.to_i, end_date_month.to_i),
+      )
+    end
+  end
+end

--- a/app/views/candidate_interface/work_history/new.html.erb
+++ b/app/views/candidate_interface/work_history/new.html.erb
@@ -1,0 +1,104 @@
+<% content_for :title, page_title('add_job') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @work_experience_form, url: candidate_interface_work_history_create_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <fieldset class="govuk-fieldset">
+        <%= f.govuk_error_summary %>
+
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= t('page_titles.work_history') %></span>
+            <%= t('page_titles.add_job') %>
+          </h1>
+        </legend>
+
+        <p class="govuk-body">
+          Please include all your paid work in school (for example as a teaching
+          assistant) in this section.
+        </p>
+
+        <p class="govuk-body">
+          Don’t include voluntary or unpaid experience – we’ll ask you about this in
+          ‘Volunteering with children and young people’.
+        </p>
+
+        <%= f.govuk_text_field :role, label: { text: t('application_form.work_history.role.label'), size: 'm' } %>
+
+        <%= f.govuk_text_field :organisation, label: { text: t('application_form.work_history.organisation.label'), size: 'm' } %>
+
+        <%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: 'Was this job full-time or part-time?', tag: 'span' } do %>
+          <%= f.govuk_radio_button :commitment, 'full_time', label: { text: 'Full-time' } %>
+
+          <%= f.govuk_radio_button :commitment, 'part_time', label: { text: 'Part-time' } %>
+        <% end %>
+
+        <div class="govuk-form-group" data-qa="start-date">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="start-date-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              Start date
+            </legend>
+
+            <span id="start-date-hint" class="govuk-hint">
+              For example, 5 2018
+            </span>
+
+            <div class="govuk-date-input">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <%= f.label :start_date_month, 'Month', class: 'govuk-label govuk-date-input__label' %>
+                  <%= f.text_field :start_date_month, type: 'number', pattern: '[0-9]*', class: 'govuk-input govuk-date-input__input govuk-input--width-2' %>
+                </div>
+              </div>
+
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <%= f.label :start_date_year, 'Year', class: 'govuk-label govuk-date-input__label' %>
+                  <%= f.text_field :start_date_year, type: 'number', pattern: '[0-9]*', class: 'govuk-input govuk-date-input__input govuk-input--width-4' %>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <div class="govuk-form-group" data-qa="end-date">
+          <fieldset class="govuk-fieldset" role="group" aria-describedby="end-date-hint">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+              End date (leave blank if this is your current role)
+            </legend>
+
+            <span id="end-date-hint" class="govuk-hint">
+              For example, 5 2019
+            </span>
+
+            <div class="govuk-date-input">
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <%= f.label :end_date_month, 'Month', class: 'govuk-label govuk-date-input__label' %>
+                  <%= f.text_field :end_date_month, type: 'number', pattern: '[0-9]*', class: 'govuk-input govuk-date-input__input govuk-input--width-2' %>
+                </div>
+              </div>
+
+              <div class="govuk-date-input__item">
+                <div class="govuk-form-group">
+                  <%= f.label :end_date_year, 'Year', class: 'govuk-label govuk-date-input__label' %>
+                  <%= f.text_field :end_date_year, type: 'number', pattern: '[0-9]*', class: 'govuk-input govuk-date-input__input govuk-input--width-4' %>
+                </div>
+              </div>
+            </div>
+          </fieldset>
+        </div>
+
+        <%= f.govuk_text_area :details, label: { text: t('application_form.work_history.details.label'), size: 'm' }, hint_text: 'Give a brief overview of your role and explain how you developed transferable skills like communication, creativity and organisation', max_words: 150 %>
+
+        <%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: 'Did this job involve working in a school or with children?', tag: 'span' }, inline: true do %>
+          <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' } %>
+          <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
+        <% end %>
+
+        <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/work_history/show.html.erb
+++ b/app/views/candidate_interface/work_history/show.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, page_title('work_history') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<h1 class="govuk-heading-xl">
+  Work history
+</h1>
+
+<%= render(WorkHistoryReviewComponent, application_form: @application_form) %>
+
+<%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -69,6 +69,13 @@ en:
       more_than_5: More than 5 years
       more_than_5_with_breaks: More than 5 years, but with breaks
       missing: I have not worked in the last 5 years
+      role:
+        label: Job title
+      organisation:
+        label: Name of employer
+      details:
+        label: Skills and experience relevant to teaching you gained in this role
+      complete_form_button: Save and continue
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,7 @@ en:
     contact_details: Contact details
     address: What is your address?
     work_history: Work history
+    add_job: Add job
   layout:
     service_name: Apply for teacher training
     phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,11 @@ Rails.application.routes.draw do
       scope '/work-history' do
         get '/length' => 'work_history#length', as: :work_history_length
         post '/length' => 'work_history#submit_length'
+
+        get '/new' => 'work_history#new', as: :work_history_new
+        post '/create' => 'work_history#create', as: :work_history_create
+
+        get '/review' => 'work_history#show', as: :work_history_show
       end
     end
   end

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe WorkHistoryReviewComponent do
+  it 'renders component with correct structure' do
+    application_form = build(:completed_application_form)
+
+    result = render_inline(WorkHistoryReviewComponent, application_form: application_form)
+
+    application_form.application_work_experiences.each do |work|
+      expect(result.text).to include(work.role)
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -15,7 +15,10 @@ RSpec.feature 'Entering their work history' do
     then_i_should_see_a_list_of_work_lengths
 
     when_i_choose_more_than_5_years
-    # then_i_should_see_the_job_form
+    then_i_should_see_the_job_form
+
+    when_i_fill_in_the_job_form
+    then_i_should_see_my_completed_job
   end
 
   def given_i_am_not_signed_in; end
@@ -46,9 +49,38 @@ RSpec.feature 'Entering their work history' do
 
   def when_i_choose_more_than_5_years
     choose t('application_form.work_history.more_than_5')
+    click_button 'Continue'
   end
 
   def then_i_should_see_the_job_form
-    expect(page).to have_content('Add job')
+    expect(page).to have_content(t('page_titles.add_job'))
+  end
+
+  def when_i_fill_in_the_job_form
+    scope = 'application_form.work_history'
+    fill_in t('role.label', scope: scope), with: 'Chief Terraforming Officer'
+    fill_in t('organisation.label', scope: scope), with: 'Weyland-Yutani'
+
+    choose 'Full-time'
+
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '5'
+      fill_in 'Year', with: '2119'
+    end
+
+    within('[data-qa="end-date"]') do
+      fill_in 'Month', with: '1'
+      fill_in 'Year', with: '2129'
+    end
+
+    fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
+
+    choose 'No'
+
+    click_button t('complete_form_button', scope: scope)
+  end
+
+  def then_i_should_see_my_completed_job
+    expect(page).to have_content('Chief Terraforming Officer')
   end
 end


### PR DESCRIPTION
### Context

Candidates need to be able to submit work experience.

### Changes proposed in this pull request

CODE

### Guidance to review

Review commit by commit is probably easier, plus I have quite a bit more lined up as follow-up.

Next PRs:

- Add content for validations
- Fix error highlight for `start_date` and `end_date` fields
- Edit job entries
- Delete job entries
- Show working with children and dates
- Add new job entry
- Mark section as completed
- Change links
- Allow free text submission when no work history
- Allow free text submission for gaps

### Screenshots

![Screenshot 2019-10-29 at 09 54 52](https://user-images.githubusercontent.com/1650875/67756969-df1c6680-fa32-11e9-9471-984155f72ebf.png)
![Screenshot 2019-10-29 at 09 57 31](https://user-images.githubusercontent.com/1650875/67756971-df1c6680-fa32-11e9-84dd-12e3e80fa6b6.png)


### Link to Trello card

[192 - Adding work history](https://trello.com/b/aRIgjf0y/candidate-team-board)