### PR TITLE
Fix time dependent spec for ApplicationCompleteContentComponent

### DIFF
--- a/spec/components/application_complete_content_component_spec.rb
+++ b/spec/components/application_complete_content_component_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe ApplicationCompleteContentComponent do
   let(:submitted_at) { Date.new(2019, 10, 22) }
 
+  around do |example|
+    Timecop.freeze(submitted_at) do
+      example.run
+    end
+  end
+
   def render_result
     application_form = create(:application_form, submitted_at: submitted_at)
     render_inline(ApplicationCompleteContentComponent, application_form: application_form)


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/spec/components/application_complete_content_component_spec.rb#L19 started failing today because there was an assumption that today's date was before 29th October 2019. 

### Changes proposed in this pull request

Have added a `Timecop.freeze` to 22nd October 2019 so that all tests have a fixed 'default' today except those that explicitly set it with `Timecop.travel`.

### Guidance to review

Is there a better way to set the default today's date?

### Link to Trello card

There is no card for this quickfix.
