### PR TITLE
Add generate vendor providers button to support interface

### DIFF
--- a/app/controllers/support_interface/manage_vendors_controller.rb
+++ b/app/controllers/support_interface/manage_vendors_controller.rb
@@ -6,7 +6,7 @@ module SupportInterface
 
     def create
       GenerateVendorProviders.call
-      redirect_back(fallback_location: root_path)
+      redirect_to action: 'index'
     end
   end
 end

--- a/app/controllers/support_interface/manage_vendors_controller.rb
+++ b/app/controllers/support_interface/manage_vendors_controller.rb
@@ -1,0 +1,12 @@
+module SupportInterface
+  class ManageVendorsController < SupportInterfaceController
+    def index
+      @providers = Provider.all
+    end
+
+    def create
+      GenerateVendorProviders.call
+      redirect_back(fallback_location: root_path)
+    end
+  end
+end

--- a/app/services/generate_vendor_providers.rb
+++ b/app/services/generate_vendor_providers.rb
@@ -1,0 +1,18 @@
+class GenerateVendorProviders
+  def self.call
+    providers = [
+      { name: 'Tribal Provider', code: 'TRIB' },
+      { name: 'Ellucian Provider', code: 'ELLU' },
+      { name: 'Oracle Provider', code: 'ORAC' },
+      { name: 'NASBITT Provider', code: 'NASB' },
+      { name: 'Unit 4 Provider', code: 'UNIT' },
+      { name: 'Capita Provider', code: 'CAPI' },
+      { name: 'Technology One Provider', code: 'TECH' },
+      { name: 'Gordon Associates Provider', code: 'GORD' },
+    ]
+
+    providers.each do |provider|
+      Provider.find_or_create_by(provider)
+    end
+  end
+end

--- a/app/views/support_interface/manage_vendors/index.html.erb
+++ b/app/views/support_interface/manage_vendors/index.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, 'Manage vendors' %>
+<h1 class='govuk-heading-xl'>Manage vendors</h1>
+
+
+<%= form_tag support_interface_vendors_path, method: :post do %>
+  <%= submit_tag('Generate Vendor Providers', class: 'govuk-button govuk-button--secondary')%>
+<% end %>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Vendor Account</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Created at</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @providers.each do |provider| %>
+    <tr class='govuk-table__row'>
+      <td class='govuk-table__cell'><%= provider.name %></td>
+      <td class='govuk-table__cell'><%= provider.created_at.to_s(:lonProvg) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/manage_vendors/index.html.erb
+++ b/app/views/support_interface/manage_vendors/index.html.erb
@@ -1,9 +1,8 @@
 <% content_for :title, 'Manage vendors' %>
 <h1 class='govuk-heading-xl'>Manage vendors</h1>
 
-
 <%= form_tag support_interface_vendors_path, method: :post do %>
-  <%= submit_tag('Generate Vendor Providers', class: 'govuk-button govuk-button--secondary')%>
+  <%= submit_tag('Generate Vendor Providers', class: 'govuk-button govuk-button--secondary') %>
 <% end %>
 
 <table class='govuk-table'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,9 @@ Rails.application.routes.draw do
 
     get '/tokens' => 'api_tokens#index', as: :api_tokens
     post '/tokens' => 'api_tokens#create'
+
+    get '/vendors' => 'manage_vendors#index'
+    post '/vendors' => 'manage_vendors#create'
   end
 
   get '/check', to: 'healthcheck#show'


### PR DESCRIPTION
### Context

For Vendors to be able to have a token to use the API they need a vendor_provider account. 
To generate these a rake file was created, but is unable to be used in the deployment pipeline.
To solve this we have decided to add a button to generate vendor_provider accounts in the support interface.

### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/47318392/67767765-15fd7700-fa49-11e9-9c8c-1323ea152576.png)

Add manage_vendor page to the support interface that has a button to generate vendor providers.

### Guidance to review

Check the support pages and generate some vendor_provider accounts using the button on
`support/vendors` page.

### Link to Trello card

[1123 - Button to create test providers for each vendor](https://trello.com/c/3i7MUHoJ/1123-button-to-create-test-providers-for-each-vendor)
