### PR TITLE
Bring API spec into line with tech docs

### DIFF
--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.5.0
+  version: 0.8.0
   title: Apply API
   contact:
     name: DfE
@@ -10,11 +10,9 @@ servers:
   - description: Local development environment
     url: http://localhost:3000/api/v1
   - description: DfE development environment
-    url: https://s106d01-apply-as.azurewebsites.net/api/v1
-  - description: DfE test environment
-    url: https://s106t01-apply-as.azurewebsites.net/api/v1
+    url: https://qa.apply-for-teacher-training.education.gov.uk/api/v1
   - description: Vendor sandbox
-    url: https://s106t02-apply-as.azurewebsites.net/api/v1
+    url: https://sandbox.apply-for-teacher-training.education.gov.uk/api/v1
 paths:
   /applications:
     get:
@@ -59,6 +57,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
   "/applications/{application_id}/offer":
     post:
       tags:
@@ -92,6 +92,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
   "/applications/{application_id}/confirm-enrolment":
     post:
       tags:
@@ -148,6 +150,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
   "/applications/{application_id}/reject":
     post:
       tags:
@@ -185,6 +189,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "404":
           $ref: "#/components/responses/NotFound"
+        "422":
+          $ref: "#/components/responses/UnprocessableEntity"
   "/test-data/regenerate":
     post:
       tags:
@@ -704,7 +710,8 @@ components:
           example: true
         commitment:
           nullable: true
-          type: enum
+          type: string
+          enum:
             - full_time
             - part_time
     HESAITTData:

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApplicationStateChange do
     end
 
     it 'has corresponding entries in the OpenAPI spec' do
-      valid_states_in_openapi = YAML.load_file('config/vendor-api-0.5.0.yml')['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
+      valid_states_in_openapi = YAML.load_file('config/vendor-api-0.8.0.yml')['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
       expect(ApplicationStateChange.valid_states)
         .to match_array(valid_states_in_openapi.map(&:to_sym))

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -61,7 +61,7 @@ module VendorApiSpecHelpers
 
   RSpec::Matchers.define :be_valid_against_openapi_schema do |schema_name|
     match do |item|
-      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.5.0.yml"))
+      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.8.0.yml"))
 
       JSONSchemaValidator.new(
         spec.as_json_schema(schema_name),
@@ -70,7 +70,7 @@ module VendorApiSpecHelpers
     end
 
     failure_message do |item|
-      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.5.0.yml"))
+      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.8.0.yml"))
 
       JSONSchemaValidator.new(
         spec.as_json_schema(schema_name),


### PR DESCRIPTION
See also https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/104

Pick up some changes we missed in the downstream docs (the `422` schema), fix a bug (`enum` for `string`) found by the OpenAPI linter, and bump the API version to ~`0.9.0`~ `0.8.0`.

https://trello.com/c/gRCLMBqY/1129-update-the-tech-docs-to-latest-version