### PR TITLE
Add dummy Reference data to API

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -72,7 +72,7 @@ module VendorApi
                 grade: 'B',
                 award_year: '2004',
                 equivalency_details: nil,
-                institution_details: 'Harris Westminster Sixth Form	',
+                institution_details: 'Harris Westminster Sixth Form',
               },
             ],
           },

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -76,7 +76,48 @@ module VendorApi
               },
             ],
           },
-          references: [],
+          references: [
+            {
+              name: 'John Smith',
+              email: 'johnsmith@example.com',
+              phone_number: '07999 111111',
+              relationship: 'BA Geography course director at Imperial College. I tutored the candidate for one academic year.',
+              confirms_safe_to_work_with_children: true,
+              reference: <<~HEREDOC,
+                Fantastic personality. Great with people. Strong communicator .  Excellent character. Passionate about teaching . Great potential.  A charismatic talented able young person who is far better than her official degree result. An exceptional person.
+
+                Passion for their subject	7 / 10
+                Knowledge about their subject	10 / 10
+                General academic performance	9 / 10
+                Ability to meet deadlines and organise their time	7 / 10
+                Ability to think critically	10 / 10
+                Ability to work collaboratively	Don’t know
+                Mental and emotional resilience	8 / 10
+                Literacy	9 / 10
+                Numeracy	7 / 10
+              HEREDOC
+            },
+            {
+              name: 'Jane Brown',
+              email: 'janebrown@example.com',
+              phone_number: '07111 999999',
+              relationship: 'Headmistress at Harris Westminster Sixth Form',
+              confirms_safe_to_work_with_children: true,
+              reference: <<~HEREDOC,
+                An ideal teacher. Brisk and lively communicator. Intelligent and self-aware. Good with children. Led education outreach workshops.
+
+                Passion for their subject	7 / 10
+                Knowledge about their subject	10 / 10
+                General academic performance	9 / 10
+                Ability to meet deadlines and organise their time	7 / 10
+                Ability to think critically	10 / 10
+                Ability to work collaboratively	Don’t know
+                Mental and emotional resilience	8 / 10
+                Literacy	9 / 10
+                Numeracy	7 / 10
+              HEREDOC
+            },
+          ],
           work_experience: {
             jobs: work_experience_jobs,
             volunteering: work_experience_volunteering,

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -592,43 +592,38 @@ components:
       type: object
       additionalProperties: false
       required:
-        - reference_type
-        - email
-        - relationship
-        - content
         - name
-        - reason_for_character_reference
+        - email
+        - phone_number
+        - relationship
+        - confirms_safe_to_work_with_children
+        - reference
       properties:
-        reference_type:
-          type: string
-          description: The type of the reference
-          maxLength: 255
-          enum:
-            - academic
-            - professional
-            - school_senior_leadership
-            - character
-          example: school_senior_leadership
-        reason_for_character_reference:
-          type: string
-          description: "If this is a character reference, this field will contain the reason the candidate gave for not providing one of the other types"
-          maxLength: 255
-        email:
-          type: string
-          description: The referee’s email
-          maxLength: 100
-          example: julia@example.com
         name:
           type: string
           description: The referee’s name
           maxLength: 255
           example: Julia Wild
+        email:
+          type: string
+          description: The referee’s email
+          maxLength: 100
+          example: julia@example.com
+        phone_number:
+          type: string
+          description: The referee’s phone number
+          maxLength: 100
+          example: '07890 123456'
         relationship:
           type: string
           description: The referee’s relationship to the candidate
           maxLength: 255
           example: Julia was my mentor at Cheadle Hulme High
-        content:
+        confirms_safe_to_work_with_children:
+          type: boolean
+          description: Does the referee confirm the candidate is safe to work with children
+          example: true
+        reference:
           type: string
           description: "Optional. The reference content provided by the referee, once it is available"
           example: Boris is committed to the profession of teaching...

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -313,7 +313,7 @@ components:
             - recruited
             - enrolled
             - rejected
-          example: conditional_offer
+          example: application_complete
         submitted_at:
           type: string
           format: date-time

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -97,7 +97,48 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
               },
             ],
           },
-          references: [],
+          references: [
+            {
+              name: 'John Smith',
+              email: 'johnsmith@example.com',
+              phone_number: '07999 111111',
+              relationship: 'BA Geography course director at Imperial College. I tutored the candidate for one academic year.',
+              confirms_safe_to_work_with_children: true,
+              reference: <<~HEREDOC,
+                Fantastic personality. Great with people. Strong communicator .  Excellent character. Passionate about teaching . Great potential.  A charismatic talented able young person who is far better than her official degree result. An exceptional person.
+
+                Passion for their subject	7 / 10
+                Knowledge about their subject	10 / 10
+                General academic performance	9 / 10
+                Ability to meet deadlines and organise their time	7 / 10
+                Ability to think critically	10 / 10
+                Ability to work collaboratively	Don’t know
+                Mental and emotional resilience	8 / 10
+                Literacy	9 / 10
+                Numeracy	7 / 10
+              HEREDOC
+            },
+            {
+              name: 'Jane Brown',
+              email: 'janebrown@example.com',
+              phone_number: '07111 999999',
+              relationship: 'Headmistress at Harris Westminster Sixth Form',
+              confirms_safe_to_work_with_children: true,
+              reference: <<~HEREDOC,
+                An ideal teacher. Brisk and lively communicator. Intelligent and self-aware. Good with children. Led education outreach workshops.
+
+                Passion for their subject	7 / 10
+                Knowledge about their subject	10 / 10
+                General academic performance	9 / 10
+                Ability to meet deadlines and organise their time	7 / 10
+                Ability to think critically	10 / 10
+                Ability to work collaboratively	Don’t know
+                Mental and emotional resilience	8 / 10
+                Literacy	9 / 10
+                Numeracy	7 / 10
+              HEREDOC
+            },
+          ],
           rejection: nil,
           status: application_choice.status,
           submitted_at: application_choice.application_form.submitted_at,

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
                 grade: 'B',
                 award_year: '2004',
                 equivalency_details: nil,
-                institution_details: 'Harris Westminster Sixth Form	',
+                institution_details: 'Harris Westminster Sixth Form',
               },
             ],
           },


### PR DESCRIPTION
### Context

Following #400, test data will only be in the `application_complete` stage. IRL applications in this state must have references attached.

So that applications are more realistic and vendors can give us feedback on this feature, this PR hardcodes references into the API response (we're nowhere near implementing them properly yet)

### Changes proposed in this pull request

Add references. Update OpenAPI spec. Fix a typo.

### Guidance to review

Does the data look sensible. Any missing fields? My guide was "First Referee" on https://manage-applications-beta.herokuapp.com/application/202

### Link to Trello card

https://trello.com/c/s5Zvje3I/1168-add-dummy-reference-data-to-the-api-response
