### PR TITLE
Enabled production environment SSL

### DIFF
--- a/app/lib/azure_environment.rb
+++ b/app/lib/azure_environment.rb
@@ -4,6 +4,6 @@ module AzureEnvironment
   end
 
   def self.hostname
-    ENV.fetch('CUSTOM_HOST_NAME', authorised_hosts.first)
+    ENV.fetch('CUSTOM_HOSTNAME', authorised_hosts.first)
   end
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,6 +268,7 @@ stages:
       containerImageReference: '$(imageName):$(build.buildNumber)'
       keyVaultName: 's106p01-shared-kv-01'
       keyVaultResourceGroup: 's106p01-shared-rg'
+      customHostName: '$(govukHostname)'
       databaseName: 'apply'
       databaseUsername: 'applyadm512'
       databasePassword: '$(databasePassword)'

--- a/azure/template.json
+++ b/azure/template.json
@@ -347,6 +347,10 @@
                                 "value": "[variables('rubyAuthHosts')]"
                             },
                             {
+                                "name": "CUSTOM_HOSTNAME",
+                                "value": "[parameters('customHostName')]"
+                            },
+                            {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
                             },


### PR DESCRIPTION
### Context

This change enables SSL custom hostname for the production environment in Azure and also corrects a potential issue with the CUSTOM_HOSTNAME environment variable.

### Changes proposed in this pull request

- Added govukHostname variable to production deployment stage of pipeline.
- Renamed CUSTOM_HOST_NAME environment variable to CUSTOM_HOSTNAME and correctly populated it in the ARM template.

### Guidance to review

New domain is accessible at https://www.apply-for-teacher-training.education.gov.uk

### Link to Trello card

[1137 Set up apply education domain](https://trello.com/c/9Fd3wxUt/1137-set-up-apply-education-domain)
