### PR TITLE
Remove direct rubocop dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'mail-notify'
 gem 'redcarpet'
 
 # Linting
-gem 'rubocop', '< 0.76.0'
 gem 'rubocop-rspec'
 gem 'govuk-lint'
 gem 'erb_lint', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,7 +392,6 @@ DEPENDENCIES
   redcarpet
   rspec-rails
   rspec_junit_formatter
-  rubocop (< 0.76.0)
   rubocop-rspec
   selenium-webdriver
   sentry-raven


### PR DESCRIPTION
This is provided as a transistive dep by govuk-lint. Dependabot will try
to upgrade it if it's a direct dep, which sometimes breaks govuk-lint.
Remove the direct dep and lean on the transitive.

Supersedes #395