### PR TITLE
Only load Sentry in production

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,3 +1,5 @@
-Raven.tags_context(
-  azure_host: AzureEnvironment.hostname,
-)
+if Rails.env.production?
+  Raven.tags_context(
+    azure_host: AzureEnvironment.hostname,
+  )
+end


### PR DESCRIPTION
#240 introduced a dev-time dependency on an ENV var only present in production. This restricts the dependency to prod only.