### PR TITLE
Add rest of the fields for adding an undergraduate degree with validations

### DIFF
--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -15,7 +15,8 @@ module CandidateInterface
 
     def degrees_params
       params.require(:candidate_interface_degrees_form).permit(
-        :qualification_type, :subject, :institution_name
+        :qualification_type, :subject, :institution_name, :grade, :other_grade,
+        :predicted_grade, :award_year
       )
     end
   end

--- a/app/models/candidate_interface/degrees_form.rb
+++ b/app/models/candidate_interface/degrees_form.rb
@@ -2,11 +2,18 @@ module CandidateInterface
   class DegreesForm
     include ActiveModel::Model
 
-    attr_accessor :qualification_type, :subject, :institution_name
+    attr_accessor :qualification_type, :subject, :institution_name, :grade,
+                  :other_grade, :predicted_grade, :award_year
 
-    validates :qualification_type, :subject, :institution_name, presence: true
+    validates :qualification_type, :subject, :institution_name, :grade, presence: true
+    validates :other_grade, presence: true, if: :other_grade?
+    validates :predicted_grade, presence: true, if: :predicted_grade?
+    validates :award_year, presence: true
 
     validates :qualification_type, :subject, :institution_name, length: { maximum: 255 }
+    validates :other_grade, :predicted_grade, length: { maximum: 255 }
+
+    validate :award_year_is_date, if: :award_year
 
     def save_base(application_form)
       return false unless valid?
@@ -16,9 +23,26 @@ module CandidateInterface
         qualification_type: qualification_type,
         subject: subject,
         institution_name: institution_name,
+        grade: grade,
+        award_year: award_year,
       )
 
       true
+    end
+
+  private
+
+    def other_grade?
+      grade == 'other'
+    end
+
+    def predicted_grade?
+      grade == 'predicted'
+    end
+
+    def award_year_is_date
+      valid_award_year = award_year.match(/^[1-9]\d{3}$/)
+      errors.add(:award_year, :invalid) unless valid_award_year
     end
   end
 end

--- a/app/views/candidate_interface/degrees/base/new.html.erb
+++ b/app/views/candidate_interface/degrees/base/new.html.erb
@@ -25,6 +25,20 @@
         <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.degree.qualification_type.label'), size: 'm' }, hint_text: t('application_form.degree.qualification_type.hint_text.new') %>
         <%= f.govuk_text_field :subject, label: { text: t('application_form.degree.subject.label'), size: 'm' } %>
         <%= f.govuk_text_field :institution_name, label: { text: t('application_form.degree.institution_name.label'), size: 'm' } %>
+        <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.degree.grade.label'), tag: 'span' } do %>
+          <%= f.govuk_radio_button :grade, 'first', label: { text: t('application_form.degree.grade.first.label') } %>
+          <%= f.govuk_radio_button :grade, 'upper_second', label: { text: t('application_form.degree.grade.upper_second.label') } %>
+          <%= f.govuk_radio_button :grade, 'lower_second', label: { text: t('application_form.degree.grade.lower_second.label') } %>
+          <%= f.govuk_radio_button :grade, 'third', label: { text: t('application_form.degree.grade.third.label') } %>
+          <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
+            <%= f.govuk_text_field :other_grade, label: { text: t('application_form.degree.grade.other.conditional.label') }, width: 10 %>
+          <% end %>
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_button :grade, 'predicted', label: { text: t('application_form.degree.grade.predicted.label') } do %>
+            <%= f.govuk_text_field :predicted_grade, label: { text: t('application_form.degree.grade.predicted.conditional.label') }, hint_text: t('application_form.degree.grade.predicted.conditional.hint_text'), width: 10 %>
+          <% end %>
+        <% end %>
+        <%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label'), size: 'm' }, hint_text: t('application_form.degree.award_year.hint_text'), width: 4 %>
 
         <%= f.govuk_submit t('application_form.degree.base.button') %>
       </fieldset>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -85,6 +85,28 @@ en:
         label: Subject of degree
       institution_name:
         label: Institution where you studied
+      grade:
+        label: What class is your degree?
+        first:
+          label: First
+        upper_second:
+          label: Upper second (2:1)
+        lower_second:
+          label: Lower second (2:2)
+        third:
+          label: Third
+        other:
+          label: Other
+          conditional:
+            label: Enter your degree grade
+        predicted:
+          label: I am still studying for my degree
+          conditional:
+            label: Please give details of your predicted grade.
+            hint_text: Predicted grades must be validated by an academic referee in the ‘References' section.
+      award_year:
+        label: Graduation year
+        hint_text: You must have successfully graduated by the time you start your course.
       base:
         button: Save and continue
   activemodel:
@@ -147,6 +169,15 @@ en:
             institution_name:
               blank: Enter the institution where you studied
               too_long: The institution where you studied must be %{count} characters or fewer
+            grade:
+              blank: Enter the class of your degree
+            other_grade:
+              blank: Enter your degree grade
+            predicted_grade:
+              blank: Enter your predicted grade
+            award_year:
+              blank: Enter your graduation year
+              invalid: Enter a real graduation year
         candidate_interface/work_experience_form:
           attributes:
             role:

--- a/spec/models/candidate_interface/degrees_form_spec.rb
+++ b/spec/models/candidate_interface/degrees_form_spec.rb
@@ -5,10 +5,62 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
     it { is_expected.to validate_presence_of(:qualification_type) }
     it { is_expected.to validate_presence_of(:subject) }
     it { is_expected.to validate_presence_of(:institution_name) }
+    it { is_expected.to validate_presence_of(:grade) }
+    it { is_expected.to validate_presence_of(:award_year) }
+
+    it "validates presence of `other_grade` if chosen grade is 'other'" do
+      degrees_form = CandidateInterface::DegreesForm.new(grade: 'other')
+      error_message = t('activemodel.errors.models.candidate_interface/degrees_form.attributes.other_grade.blank')
+
+      degrees_form.validate
+
+      expect(degrees_form.errors.full_messages_for(:other_grade)).to eq(
+        ["Other grade #{error_message}"],
+      )
+    end
+
+    it "validates presence of `predicted_grade` if chosen grade is 'predicted'" do
+      degrees_form = CandidateInterface::DegreesForm.new(grade: 'predicted')
+      error_message = t('activemodel.errors.models.candidate_interface/degrees_form.attributes.predicted_grade.blank')
+
+      degrees_form.validate
+
+      expect(degrees_form.errors.full_messages_for(:predicted_grade)).to eq(
+        ["Predicted grade #{error_message}"],
+      )
+    end
 
     it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
     it { is_expected.to validate_length_of(:subject).is_at_most(255) }
     it { is_expected.to validate_length_of(:institution_name).is_at_most(255) }
+    it { is_expected.to validate_length_of(:other_grade).is_at_most(255) }
+    it { is_expected.to validate_length_of(:predicted_grade).is_at_most(255) }
+
+    describe 'award year' do
+      ['a year', '200'].each do |invalid_date|
+        it "is invalid if the award year is '#{invalid_date}'" do
+          degrees_form = CandidateInterface::DegreesForm.new(award_year: invalid_date)
+          error_message = t('activemodel.errors.models.candidate_interface/degrees_form.attributes.award_year.invalid')
+
+          degrees_form.validate
+
+          expect(degrees_form.errors.full_messages_for(:award_year)).to eq(
+            ["Award year #{error_message}"],
+          )
+        end
+      end
+
+      it 'is valid if the award year is 4 digits' do
+        degrees_form = CandidateInterface::DegreesForm.new(award_year: '2009')
+        error_message = t('activemodel.errors.models.candidate_interface/degrees_form.attributes.award_year.invalid')
+
+        degrees_form.validate
+
+        expect(degrees_form.errors.full_messages_for(:award_year)).not_to eq(
+          ["Award year #{error_message}"],
+        )
+      end
+    end
   end
 
   describe '#save_base' do
@@ -23,6 +75,8 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
         qualification_type: 'BA',
         subject: 'maths',
         institution_name: 'University of Much Wow',
+        grade: 'first',
+        award_year: '2008',
       }
       application_form = create(:application_form)
       degree = CandidateInterface::DegreesForm.new(form_data)


### PR DESCRIPTION
### Context

We have decided to reduce the complexity of the degrees form in the prototype by placing moving degree class and graduation year onto the same page. This makes it significantly easier to test and develop than a multistep form.

### Changes proposed in this pull request

This PR adds all the fields to the form to add an undergraduate degree with validations. It's not currently possible to save yet.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/67869049-c4c2b580-fb24-11e9-8aef-3d66da38b5fe.png)
![image](https://user-images.githubusercontent.com/42817036/67869079-d2783b00-fb24-11e9-92b7-159362710b5f.png)
![image](https://user-images.githubusercontent.com/42817036/67869416-4dd9ec80-fb25-11e9-95c8-05086d21e79f.png)
![image](https://user-images.githubusercontent.com/42817036/67869471-634f1680-fb25-11e9-9df2-86317a724b3e.png)


### Guidance to review

Try submitting stuff and ensure validations show as appropriate!

`:other_grade` and `:predicted_grade` has been added to `DegreesForm` to enable the conditional radio button and text fields and will be appropriately used when saving in the application form.

### Link to Trello card

[194 - Adding degree information](https://trello.com/c/ADqlESXx/194-adding-degree-information)
