### PR TITLE
Add ability to review degrees

### DIFF
--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -1,0 +1,9 @@
+<% @degrees_form.each do |degree_form| %>
+  <%= render(SummaryCardComponent, rows: degree_form_rows(degree_form)) do %>
+    <header class="app-summary-card__header">
+      <h3 class="app-summary-card__title">
+        <%= formatted_degree_title(degree_form.qualification_type, degree_form.subject) %>
+      </h3>
+    </header>
+  <% end %>
+<% end %>

--- a/app/components/degrees_review_component.rb
+++ b/app/components/degrees_review_component.rb
@@ -1,0 +1,68 @@
+class DegreesReviewComponent < ActionView::Component::Base
+  validates :application_form, presence: true
+
+  def initialize(application_form:)
+    @application_form = application_form
+    @degrees_form = CandidateInterface::DegreesForm.build_from_application(
+      @application_form,
+    )
+  end
+
+  def degree_form_rows(degree_form)
+    [
+      qualification_row(degree_form),
+      award_year_row(degree_form),
+      grade_row(degree_form),
+    ]
+  end
+
+  def formatted_degree_title(qualification_type, subject)
+    "#{qualification_type} #{subject}"
+  end
+
+private
+
+  attr_reader :application_form
+
+  def qualification_row(degree_form)
+    {
+      key: t('application_form.degree.qualification.label'),
+      DANGEROUS_html_value: formatted_qualification(degree_form.qualification_type, degree_form.subject, degree_form.institution_name),
+      action: t('application_form.degree.qualification.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def award_year_row(degree_form)
+    {
+      key: t('application_form.degree.award_year.review_label'),
+      value: degree_form.award_year,
+      action: t('application_form.degree.award_year.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def grade_row(degree_form)
+    {
+      key: t('application_form.degree.grade.review_label'),
+      value: formatted_grade(degree_form.grade, degree_form.predicted_grade),
+      action: t('application_form.degree.grade.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def formatted_qualification(qualification_type, subject, institution_name)
+    [formatted_degree_title(qualification_type, subject), institution_name]
+      .map { |line| sanitize(line, tags: []) }
+      .join('<br>')
+  end
+
+  def formatted_grade(grade, predicted_grade)
+    case grade
+    when 'first', 'upper_second', 'lower_second', 'third'
+      t("application_form.degree.grade.#{grade}.label")
+    else
+      predicted_grade ? "#{grade} (Predicted)" : grade
+    end
+  end
+end

--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -1,5 +1,9 @@
 module CandidateInterface
   class Degrees::BaseController < CandidateInterfaceController
+    def index
+      @application_form = current_candidate.current_application
+    end
+
     def new
       @degree = DegreesForm.new
     end
@@ -8,7 +12,11 @@ module CandidateInterface
       @degree = DegreesForm.new(degrees_params)
       application_form = current_candidate.current_application
 
-      render :new unless @degree.save_base(application_form)
+      if @degree.save_base(application_form)
+        redirect_to candidate_interface_degrees_path
+      else
+        render :new
+      end
     end
 
   private

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,6 +1,8 @@
 class ApplicationQualification < ApplicationRecord
   belongs_to :application_form
 
+  scope :degrees, -> { where level: 'degree' }
+
   enum level: {
     degree: 'degree',
     gcse: 'gcse',

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -6,10 +6,4 @@ class ApplicationQualification < ApplicationRecord
     gcse: 'gcse',
     other: 'other',
   }
-
-  enum subject: {
-    maths: 'maths',
-    english: 'english',
-    science: 'science',
-  }
 end

--- a/app/models/candidate_interface/degrees_form.rb
+++ b/app/models/candidate_interface/degrees_form.rb
@@ -22,6 +22,7 @@ module CandidateInterface
           subject: degree.subject,
           institution_name: degree.institution_name,
           grade: degree.grade,
+          predicted_grade: degree.predicted_grade,
           award_year: degree.award_year,
         )
       end
@@ -35,7 +36,8 @@ module CandidateInterface
         qualification_type: qualification_type,
         subject: subject,
         institution_name: institution_name,
-        grade: grade,
+        grade: determine_grade,
+        predicted_grade: predicted_grade? ? true : false,
         award_year: award_year,
       )
 
@@ -55,6 +57,17 @@ module CandidateInterface
     def award_year_is_date
       valid_award_year = award_year.match(/^[1-9]\d{3}$/)
       errors.add(:award_year, :invalid) unless valid_award_year
+    end
+
+    def determine_grade
+      case grade
+      when 'other'
+        other_grade
+      when 'predicted'
+        predicted_grade
+      else
+        grade
+      end
     end
   end
 end

--- a/app/models/candidate_interface/degrees_form.rb
+++ b/app/models/candidate_interface/degrees_form.rb
@@ -10,7 +10,7 @@ module CandidateInterface
     validates :predicted_grade, presence: true, if: :predicted_grade?
     validates :award_year, presence: true
 
-    validates :qualification_type, :subject, :institution_name, length: { maximum: 255 }
+    validates :qualification_type, :subject, :institution_name, :grade, length: { maximum: 255 }
     validates :other_grade, :predicted_grade, length: { maximum: 255 }
 
     validate :award_year_is_date, if: :award_year

--- a/app/models/candidate_interface/degrees_form.rb
+++ b/app/models/candidate_interface/degrees_form.rb
@@ -15,6 +15,18 @@ module CandidateInterface
 
     validate :award_year_is_date, if: :award_year
 
+    def self.build_from_application(application_form)
+      application_form.application_qualifications.degrees.map do |degree|
+        new(
+          qualification_type: degree.qualification_type,
+          subject: degree.subject,
+          institution_name: degree.institution_name,
+          grade: degree.grade,
+          award_year: degree.award_year,
+        )
+      end
+    end
+
     def save_base(application_form)
       return false unless valid?
 

--- a/app/views/candidate_interface/degrees/base/index.html.erb
+++ b/app/views/candidate_interface/degrees/base/index.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, page_title(:degree) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.degree') %>
+</h1>
+
+<%= render(DegreesReviewComponent, application_form: @application_form) %>
+
+<%= govuk_button_link_to t('application_form.degree.review.button'), candidate_interface_application_form_path %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -78,6 +78,9 @@ en:
       complete_form_button: Save and continue
       working_with_children: This role involved working with children
     degree:
+      qualification:
+        label: Qualification
+        change_action: qualification
       qualification_type:
         label: Type of degree
         hint_text:
@@ -88,6 +91,8 @@ en:
         label: Institution where you studied
       grade:
         label: What class is your degree?
+        review_label: Grade
+        change_action: grade
         first:
           label: First
         upper_second:
@@ -108,8 +113,12 @@ en:
       award_year:
         label: Graduation year
         hint_text: You must have successfully graduated by the time you start your course.
+        review_label: Year awarded
+        change_action: year
       base:
         button: Save and continue
+      review:
+        button: Continue
   activemodel:
     errors:
       models:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -172,10 +172,13 @@ en:
               too_long: The institution where you studied must be %{count} characters or fewer
             grade:
               blank: Enter the class of your degree
+              too_long: The class of your degree must be %{count} characters or fewer
             other_grade:
               blank: Enter your degree grade
+              too_long: Your degree grade must be %{count} characters or fewer
             predicted_grade:
               blank: Enter your predicted grade
+              too_long: Your predicted grade must be %{count} characters or fewer
             award_year:
               blank: Enter your graduation year
               invalid: Enter a real graduation year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,9 +60,11 @@ Rails.application.routes.draw do
         get '/review' => 'work_history#show', as: :work_history_show
       end
 
-      scope '/degree' do
+      scope '/degrees' do
         get '/' => 'degrees/base#new', as: :degrees_new_base
         post '/' => 'degrees/base#create', as: :degrees_create_base
+
+        get '/review' => 'degrees/base#index', as: :degrees
       end
     end
   end

--- a/spec/components/degrees_review_component_spec.rb
+++ b/spec/components/degrees_review_component_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe DegreesReviewComponent do
+  let(:application_form) do
+    create(:application_form) do |form|
+      form.application_qualifications.create(
+        level: 'degree',
+        qualification_type: 'BA',
+        subject: 'Woof',
+        institution_name: 'University of Doge',
+        grade: 'first',
+        predicted_grade: false,
+        award_year: '2008',
+      )
+      form.application_qualifications.create(
+        level: 'degree',
+        qualification_type: 'BA',
+        subject: 'Meow',
+        institution_name: 'University of Cate',
+        grade: '2:1',
+        predicted_grade: true,
+        award_year: '2010',
+      )
+    end
+  end
+
+  it 'renders component with correct values for a qualification' do
+    result = render_inline(DegreesReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('BA Woof')
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.qualification.label'))
+    expect(result.css('.govuk-summary-list__value').to_html).to include('BA Woof<br>University of Doge')
+    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include('#')
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.degree.qualification.change_action')}")
+  end
+
+  it 'renders component with correct values for an award year' do
+    result = render_inline(DegreesReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('BA Woof')
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.award_year.review_label'))
+    expect(result.css('.govuk-summary-list__value').text).to include('2008')
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.degree.award_year.change_action')}")
+  end
+
+  it 'renders component with correct values for a grade' do
+    result = render_inline(DegreesReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('BA Woof')
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.grade.review_label'))
+    expect(result.css('.govuk-summary-list__value').text).to include('First')
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.degree.grade.change_action')}")
+  end
+
+  it 'renders component with correct values for a predicted grade' do
+    result = render_inline(DegreesReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('BA Meow')
+    expect(result.css('.govuk-summary-list__value').text).to include('2:1 (Predicted)')
+  end
+
+  it 'renders component with correct values for multiple degrees' do
+    result = render_inline(DegreesReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('BA Woof')
+    expect(result.css('.app-summary-card__title').text).to include('BA Meow')
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
         application_choices_count { 3 }
         work_experiences_count { 1 }
         volunteering_experiences_count { 1 }
+        qualifications_count { 4 }
       end
     end
 
@@ -39,6 +40,7 @@ FactoryBot.define do
         create_list(:application_choice, evaluator.application_choices_count, application_form: application_form)
         create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)
         create_list(:application_volunteering_experience, evaluator.volunteering_experiences_count, application_form: application_form)
+        create_list(:application_qualification, evaluator.qualifications_count, application_form: application_form)
       end
     end
   end
@@ -55,6 +57,20 @@ FactoryBot.define do
 
   factory :application_volunteering_experience, parent: :application_experience, class: 'ApplicationVolunteeringExperience'
   factory :application_work_experience, parent: :application_experience, class: 'ApplicationWorkExperience'
+
+  factory :application_qualification do
+    level { %w[degree gcse other].sample }
+    qualification_type { %w[BA Masters A-Level GCSE].sample }
+    subject { Faker::Educator.subject }
+
+    grade { %w[first upper_second A B].sample }
+    predicted_grade { %w[true false].sample }
+    award_year { Faker::Date.between(from: 60.years.ago, to: 3.years.from_now).year }
+    institution_name { Faker::Educator.university }
+    institution_country { Faker::Address.country_code }
+    awarding_body { Faker::Educator.university }
+    equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+  end
 
   factory :site do
     provider

--- a/spec/models/candidate_interface/degrees_form_spec.rb
+++ b/spec/models/candidate_interface/degrees_form_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
     it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
     it { is_expected.to validate_length_of(:subject).is_at_most(255) }
     it { is_expected.to validate_length_of(:institution_name).is_at_most(255) }
+    it { is_expected.to validate_length_of(:grade).is_at_most(255) }
     it { is_expected.to validate_length_of(:other_grade).is_at_most(255) }
     it { is_expected.to validate_length_of(:predicted_grade).is_at_most(255) }
 

--- a/spec/models/candidate_interface/degrees_form_spec.rb
+++ b/spec/models/candidate_interface/degrees_form_spec.rb
@@ -64,6 +64,81 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
     end
   end
 
+  describe '.build_from_application' do
+    it 'creates an array of objects based on the provided ApplicationForm' do
+      application_form = create(:application_form) do |form|
+        form.application_qualifications.create(
+          level: 'degree',
+          qualification_type: 'BA',
+          subject: 'Woof',
+          institution_name: 'University of Doge',
+          grade: 'first',
+          award_year: '2008',
+        )
+        form.application_qualifications.create(
+          level: 'degree',
+          qualification_type: 'BA',
+          subject: 'Meow',
+          institution_name: 'University of Cate',
+          grade: 'upper_second',
+          award_year: '2010',
+        )
+      end
+
+      degrees = CandidateInterface::DegreesForm.build_from_application(application_form)
+
+      expect(degrees).to match_array([
+        have_attributes(
+          qualification_type: 'BA',
+          subject: 'Woof',
+          institution_name: 'University of Doge',
+          grade: 'first',
+          award_year: '2008',
+        ),
+        have_attributes(
+          qualification_type: 'BA',
+          subject: 'Meow',
+          institution_name: 'University of Cate',
+          grade: 'upper_second',
+          award_year: '2010',
+        ),
+      ])
+    end
+
+    it 'only includes degrees and not other qualifications' do
+      application_form = create(:application_form) do |form|
+        form.application_qualifications.create(
+          level: 'degree',
+          qualification_type: 'BA',
+          subject: 'Ssss',
+          institution_name: 'University of Snek',
+          grade: 'third',
+          award_year: '2010',
+        )
+        form.application_qualifications.create(
+          level: 'gcse',
+          qualification_type: 'GCSE',
+          subject: 'Hoot',
+          institution_name: 'School of Owls',
+          grade: 'A',
+          award_year: '2005',
+        )
+      end
+
+      degrees = CandidateInterface::DegreesForm.build_from_application(application_form)
+
+      expect(degrees).to match_array([
+        have_attributes(
+          qualification_type: 'BA',
+          subject: 'Ssss',
+          institution_name: 'University of Snek',
+          grade: 'third',
+          award_year: '2010',
+        ),
+      ])
+    end
+  end
+
   describe '#save_base' do
     it 'returns false if not valid' do
       degree = CandidateInterface::DegreesForm.new
@@ -74,7 +149,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
     it 'updates the provided ApplicationForm if valid' do
       form_data = {
         qualification_type: 'BA',
-        subject: 'maths',
+        subject: 'Doge',
         institution_name: 'University of Much Wow',
         grade: 'first',
         award_year: '2008',

--- a/spec/models/candidate_interface/degrees_form_spec.rb
+++ b/spec/models/candidate_interface/degrees_form_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
           subject: 'Woof',
           institution_name: 'University of Doge',
           grade: 'first',
+          predicted_grade: false,
           award_year: '2008',
         )
         form.application_qualifications.create(
@@ -81,6 +82,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
           subject: 'Meow',
           institution_name: 'University of Cate',
           grade: 'upper_second',
+          predicted_grade: true,
           award_year: '2010',
         )
       end
@@ -140,6 +142,16 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
   end
 
   describe '#save_base' do
+    let(:form_data) do
+      {
+        qualification_type: 'BA',
+        subject: 'Doge',
+        institution_name: 'University of Much Wow',
+        grade: 'first',
+        award_year: '2008',
+      }
+    end
+
     it 'returns false if not valid' do
       degree = CandidateInterface::DegreesForm.new
 
@@ -147,19 +159,34 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
     end
 
     it 'updates the provided ApplicationForm if valid' do
-      form_data = {
-        qualification_type: 'BA',
-        subject: 'Doge',
-        institution_name: 'University of Much Wow',
-        grade: 'first',
-        award_year: '2008',
-      }
       application_form = create(:application_form)
       degree = CandidateInterface::DegreesForm.new(form_data)
 
       expect(degree.save_base(application_form)).to eq(true)
       expect(application_form.application_qualifications.degree.first)
         .to have_attributes(form_data)
+    end
+
+    it 'updates grade for the provided ApplicationForm if other grade is given' do
+      form_data[:grade] = 'other'
+      form_data[:other_grade] = 'Distinction'
+      application_form = create(:application_form)
+      degree = CandidateInterface::DegreesForm.new(form_data)
+
+      expect(degree.save_base(application_form)).to eq(true)
+      expect(application_form.application_qualifications.degree.first)
+        .to have_attributes(grade: 'Distinction')
+    end
+
+    it 'updates grade and predicted grade for the provided ApplicationForm if predicted grade is given' do
+      form_data[:grade] = 'predicted'
+      form_data[:predicted_grade] = 'First'
+      application_form = create(:application_form)
+      degree = CandidateInterface::DegreesForm.new(form_data)
+
+      expect(degree.save_base(application_form)).to eq(true)
+      expect(application_form.application_qualifications.degree.first)
+        .to have_attributes(grade: 'First', predicted_grade: true)
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_completed_ug_degree_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_completed_ug_degree_spec.rb
@@ -17,6 +17,10 @@ RSpec.feature 'Entering their degrees' do
     when_i_fill_in_some_of_my_undergraduate_degree_but_omit_some_required_details
     and_i_submit_the_undergraduate_degree_form
     then_i_should_see_validation_errors_for_my_undergraduate_degree
+
+    when_i_fill_in_my_undergraduate_degree
+    and_i_submit_the_undergraduate_degree_form
+    then_i_can_check_my_answers
   end
 
   def given_i_am_not_signed_in; end
@@ -56,5 +60,20 @@ RSpec.feature 'Entering their degrees' do
 
   def then_i_should_see_validation_errors_for_my_undergraduate_degree
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/degrees_form.attributes.institution_name.blank')
+  end
+
+  def when_i_fill_in_my_undergraduate_degree
+    fill_in t('application_form.degree.qualification_type.label'), with: 'BA'
+    fill_in t('application_form.degree.subject.label'), with: 'Doge'
+    fill_in t('application_form.degree.institution_name.label'), with: 'University of Much Wow'
+
+    choose t('application_form.degree.grade.first.label')
+
+    fill_in t('application_form.degree.award_year.label'), with: '2009'
+  end
+
+  def then_i_can_check_my_answers
+    expect(page).to have_content t('application_form.degree.qualification.label')
+    expect(page).to have_content 'BA Doge'
   end
 end


### PR DESCRIPTION
### Context

Currently when a candidate submits a degree nothing happens unless they are validations errors.

### Changes proposed in this pull request

This PR adds the ability for a candidate to review their degrees.

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/67951720-f6e71c80-fbe3-11e9-9575-01b37b2acf8a.png)

### Guidance to review

@alexdesi thing to note: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/b1f770d8e61a15f391f3bf8ce4db5ff1ce9ecf80.

Try adding different grades using the Other or Predicted option and ensure that the review component correctly outputs.

### Link to Trello card

[194 - Adding degree information](https://trello.com/c/ADqlESXx/194-adding-degree-information)
