### PR TITLE
Fixed pipeline results publishing feature.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ stages:
     - script: |
         make ci.test
         test_result=$?
-        if [ "$test_result" == "0" ]; then true; else cat rspec-results.xml; false; fi
+        if [ "$test_result" == "0" ]; then true; else cat results/rspec-results.xml; false; fi
       displayName: 'Execute tests'
       env:
         dockerHubUsername: $(dockerHubUsername)
@@ -130,7 +130,7 @@ stages:
       condition: succeededOrFailed()
       inputs:
         testRunner: JUnit
-        testResultsFiles: 'rspec-results.xml'
+        testResultsFiles: 'results/*.xml'
 
 
 - stage: deploy_qa


### PR DESCRIPTION
### Context

A PR merged in a couple of weeks ago to reduce the size of the docker image had the unintended side effect of breaking the test results publishing feature within the Azure DevOps GUI. This PR restores this feature.

### Changes proposed in this pull request

- Test commands in the Makefile changed to save the results files locally within the docker container.
- Created a custom function in the Makefile to copy these result files from the container to the local storage on the Azure agent for publishing later.
- Includes publishing the cucumber test results too.

### Guidance to review

The "Tests" tab has been restored by this fix in the Azure pipeline results view. This can be verified by checking pipeline runs on the "pipeline-results-publishing" branch.

e.g. https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=28121&view=ms.vss-test-web.build-test-results-tab

### Link to Trello card

[1170 BUG: Fix test result publishing in pipeline](https://trello.com/c/S75MiIOP/1170-bug-fix-test-result-publishing-in-pipeline)

### Env vars

- [N/A] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
