### PR TITLE
Fix date dependent spec

### DIFF
--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -96,7 +96,7 @@ RSpec.feature 'Candidate submit the application' do
   end
 
   def then_i_can_see_my_submitted_application
-    this_day = Time.now.strftime('%e %B %Y')
+    this_day = Time.now.strftime('%-e %B %Y')
     expect(page).to have_content "You submitted your application on #{this_day}"
   end
 end


### PR DESCRIPTION


### Context

This PR fixes a build failure today. The spec in question failed when today's date is a single digit due to padding introduced by`strftime` in the test

### Changes proposed in this pull request

Remove the padding from the value in the spec so that it matches the actual output.

### Guidance to review



### Link to Trello card

No trello card

### Env vars

None
