### PR TITLE
Update reject_application in vendor-api-0.8.0 file to use rejection schema

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -143,7 +143,6 @@ module VendorApi
       if application_choice.rejection_reason?
         {
           reason: application_choice.rejection_reason,
-          date: Time.now,
         }
       end
     end

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -628,18 +628,12 @@ components:
       additionalProperties: false
       required:
         - reason
-        - date
       properties:
         reason:
           type: string
           description: The reason for rejection
           maxLength: 255
           example: Does not meet minimum GCSE requirements
-        date:
-          type: string
-          format: date-time
-          description: The date on which the rejection was issued
-          example: "2019-09-18T15:33:49.216Z"
     Withdrawal:
       type: object
       additionalProperties: false

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -168,11 +168,7 @@ paths:
               type: object
               properties:
                 data:
-                  type: object
-                  properties:
-                    reason:
-                      type: string
-                      example: Does not meet minimum GCSE requirements
+                  $ref: '#/components/schemas/Rejection'
                 meta:
                   $ref: '#/components/schemas/TimestampAndAttribution'
       responses:

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
       expect(parsed_response['data']['attributes']['status']).to eq 'rejected'
       expect(parsed_response['data']['attributes']['rejection']).to match a_hash_including(
         'reason' => 'Does not meet minimum GCSE requirements',
-        'date' => anything, # This is not implemented yet
       )
     end
   end


### PR DESCRIPTION
### Context

Currently the reject application request body in the open-api spec file does not use the rejection schema. 

### Changes proposed in this pull request

Update the open-api spec to make the reject application endpoint use the rejection schema. 
This is linked to the tech-docs PR here: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/108

### Guidance to review

Check the open-api spec to ensure the correct information is being displayed for rejecting applications.

