### PR TITLE
Add ability to delete a degree

### DIFF
--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -2,7 +2,7 @@
   <%= render(SummaryCardComponent, rows: degree_form_rows(degree_form)) do %>
     <header class="app-summary-card__header">
       <h3 class="app-summary-card__title">
-        <%= formatted_degree_title(degree_form.qualification_type, degree_form.subject) %>
+        <%= degree_form.title %>
       </h3>
       <div class="app-summary-card__actions">
         <%= link_to t('application_form.degree.delete'), candidate_interface_degrees_destroy_path(degree_form.id), class: 'govuk-link' %>

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -5,7 +5,7 @@
         <%= degree_form.title %>
       </h3>
       <div class="app-summary-card__actions">
-        <%= link_to t('application_form.degree.delete'), candidate_interface_degrees_destroy_path(degree_form.id), class: 'govuk-link' %>
+        <%= link_to t('application_form.degree.delete'), candidate_interface_confirm_degrees_destroy_path(degree_form.id), class: 'govuk-link' %>
       </div>
     </header>
   <% end %>

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -4,6 +4,9 @@
       <h3 class="app-summary-card__title">
         <%= formatted_degree_title(degree_form.qualification_type, degree_form.subject) %>
       </h3>
+      <div class="app-summary-card__actions">
+        <%= link_to t('application_form.degree.delete'), candidate_interface_degrees_destroy_path(degree_form.id), class: 'govuk-link' %>
+      </div>
     </header>
   <% end %>
 <% end %>

--- a/app/components/degrees_review_component.rb
+++ b/app/components/degrees_review_component.rb
@@ -16,10 +16,6 @@ class DegreesReviewComponent < ActionView::Component::Base
     ]
   end
 
-  def formatted_degree_title(qualification_type, subject)
-    "#{qualification_type} #{subject}"
-  end
-
 private
 
   attr_reader :application_form
@@ -27,7 +23,7 @@ private
   def qualification_row(degree_form)
     {
       key: t('application_form.degree.qualification.label'),
-      DANGEROUS_html_value: formatted_qualification(degree_form.qualification_type, degree_form.subject, degree_form.institution_name),
+      DANGEROUS_html_value: formatted_qualification(degree_form),
       action: t('application_form.degree.qualification.change_action'),
       change_path: '#',
     }
@@ -51,8 +47,8 @@ private
     }
   end
 
-  def formatted_qualification(qualification_type, subject, institution_name)
-    [formatted_degree_title(qualification_type, subject), institution_name]
+  def formatted_qualification(degree_form)
+    [degree_form.title, degree_form.institution_name]
       .map { |line| sanitize(line, tags: []) }
       .join('<br>')
   end

--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  class Degrees::DestroyController < CandidateInterfaceController
+    def confirm_destroy
+      application_form = current_candidate.current_application
+      @degree = DegreesForm.find_by_application(application_form, degrees_params[:id])
+    end
+
+    def destroy
+      current_candidate.current_application
+        .application_qualifications
+        .find(degrees_params[:id])
+        .destroy!
+
+      redirect_to candidate_interface_degrees_review_path
+    end
+
+  private
+
+    def degrees_params
+      params.permit(:id)
+    end
+  end
+end

--- a/app/models/candidate_interface/degrees_form.rb
+++ b/app/models/candidate_interface/degrees_form.rb
@@ -2,6 +2,8 @@ module CandidateInterface
   class DegreesForm
     include ActiveModel::Model
 
+    CLASSES = %w[first upper_second lower_second third].freeze
+
     attr_accessor :id, :qualification_type, :subject, :institution_name, :grade,
                   :other_grade, :predicted_grade, :award_year
 
@@ -50,7 +52,7 @@ module CandidateInterface
 
       def determine_application_grade(grade, predicted_grade)
         case grade
-        when 'first', 'upper_second', 'lower_second', 'third'
+        when CLASSES
           grade
         else
           if predicted_grade

--- a/app/models/candidate_interface/degrees_form.rb
+++ b/app/models/candidate_interface/degrees_form.rb
@@ -45,6 +45,10 @@ module CandidateInterface
       true
     end
 
+    def title
+      "#{qualification_type} #{subject}"
+    end
+
   private
 
     def other_grade?

--- a/app/models/candidate_interface/degrees_form.rb
+++ b/app/models/candidate_interface/degrees_form.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class DegreesForm
     include ActiveModel::Model
 
-    attr_accessor :qualification_type, :subject, :institution_name, :grade,
+    attr_accessor :id, :qualification_type, :subject, :institution_name, :grade,
                   :other_grade, :predicted_grade, :award_year
 
     validates :qualification_type, :subject, :institution_name, :grade, presence: true
@@ -18,6 +18,7 @@ module CandidateInterface
     def self.build_from_application(application_form)
       application_form.application_qualifications.degrees.map do |degree|
         new(
+          id: degree.id,
           qualification_type: degree.qualification_type,
           subject: degree.subject,
           institution_name: degree.institution_name,

--- a/app/views/candidate_interface/degrees/base/_form.html.erb
+++ b/app/views/candidate_interface/degrees/base/_form.html.erb
@@ -1,18 +1,22 @@
 <%= f.govuk_text_field :subject, label: { text: t('application_form.degree.subject.label'), size: 'm' } %>
 <%= f.govuk_text_field :institution_name, label: { text: t('application_form.degree.institution_name.label'), size: 'm' } %>
 <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.degree.grade.label'), tag: 'span' } do %>
-  <%= f.govuk_radio_button :grade, 'first', label: { text: t('application_form.degree.grade.first.label') } %>
-  <%= f.govuk_radio_button :grade, 'upper_second', label: { text: t('application_form.degree.grade.upper_second.label') } %>
-  <%= f.govuk_radio_button :grade, 'lower_second', label: { text: t('application_form.degree.grade.lower_second.label') } %>
-  <%= f.govuk_radio_button :grade, 'third', label: { text: t('application_form.degree.grade.third.label') } %>
+
+  <% CandidateInterface::DegreesForm::CLASSES.each do |degree_class| %>
+    <%= f.govuk_radio_button :grade, degree_class, label: { text: t("application_form.degree.grade.#{degree_class}.label") } %>
+  <% end %>
+
   <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>
     <%= f.govuk_text_field :other_grade, label: { text: t('application_form.degree.grade.other.conditional.label') }, width: 10 %>
   <% end %>
+
   <%= f.govuk_radio_divider %>
+
   <%= f.govuk_radio_button :grade, 'predicted', label: { text: t('application_form.degree.grade.predicted.label') } do %>
     <%= f.govuk_text_field :predicted_grade, label: { text: t('application_form.degree.grade.predicted.conditional.label') }, hint_text: t('application_form.degree.grade.predicted.conditional.hint_text'), width: 10 %>
   <% end %>
 <% end %>
+
 <%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label'), size: 'm' }, hint_text: t('application_form.degree.award_year.hint_text'), width: 4 %>
 
 <%= f.govuk_submit t('application_form.degree.base.button') %>

--- a/app/views/candidate_interface/degrees/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/degrees/destroy/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, page_title('destroy_degree') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @degree, url: candidate_interface_degrees_destroy_path(@degree.id), method: :delete do |f| %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @degree.title %></span>
+            <%= t('page_titles.destroy_degree') %>
+          </h1>
+        </legend>
+
+        <%= f.submit t('application_form.degree.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to 'Cancel', candidate_interface_degrees_review_path %>
+        </p>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/degrees/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/degrees/destroy/confirm_destroy.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @degree, url: candidate_interface_degrees_destroy_path(@degree.id), method: :delete do |f| %>
+    <%= form_with model: @degree, url: candidate_interface_confirm_degrees_destroy_path(@degree.id), method: :delete do |f| %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
           <h1 class="govuk-fieldset__heading">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -131,6 +131,8 @@ en:
         button: Continue
       another:
         button: Add another degree
+      delete: Delete degree
+      confirm_delete: Yes I’m sure - delete this degree
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
     edit_job: Add job
     add_another_degree: Add another degree
     out_of_work: Tell us why you’ve been out of the workplace
+    destroy_degree: Are you sure you want to delete this degree?
   layout:
     service_name: Apply for teacher training
     phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
         get '/review' => 'degrees/review#show', as: :degrees_review
         patch '/review' => 'degrees/review#complete', as: :degrees_complete
 
-        get '/delete/:id' => 'degrees/destroy#confirm_destroy', as: :degrees_destroy
+        get '/delete/:id' => 'degrees/destroy#confirm_destroy', as: :confirm_degrees_destroy
         delete '/delete/:id' => 'degrees/destroy#destroy'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,9 @@ Rails.application.routes.draw do
 
         get '/review' => 'degrees/review#show', as: :degrees_review
         patch '/review' => 'degrees/review#complete', as: :degrees_complete
+
+        get '/delete/:id' => 'degrees/destroy#confirm_destroy', as: :degrees_destroy
+        delete '/delete/:id' => 'degrees/destroy#destroy'
       end
     end
   end

--- a/spec/components/degrees_review_component_spec.rb
+++ b/spec/components/degrees_review_component_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe DegreesReviewComponent do
 
     expect(result.css('.app-summary-card__actions').text).to include(t('application_form.degree.delete'))
     expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
-      Rails.application.routes.url_helpers.candidate_interface_degrees_destroy_path(2),
+      Rails.application.routes.url_helpers.candidate_interface_confirm_degrees_destroy_path(2),
     )
   end
 end

--- a/spec/components/degrees_review_component_spec.rb
+++ b/spec/components/degrees_review_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe DegreesReviewComponent do
   let(:application_form) do
     create(:application_form) do |form|
       form.application_qualifications.create(
+        id: 1,
         level: 'degree',
         qualification_type: 'BA',
         subject: 'Woof',
@@ -13,6 +14,7 @@ RSpec.describe DegreesReviewComponent do
         award_year: '2008',
       )
       form.application_qualifications.create(
+        id: 2,
         level: 'degree',
         qualification_type: 'BA',
         subject: 'Meow',
@@ -64,5 +66,14 @@ RSpec.describe DegreesReviewComponent do
 
     expect(result.css('.app-summary-card__title').text).to include('BA Woof')
     expect(result.css('.app-summary-card__title').text).to include('BA Meow')
+  end
+
+  it 'renders component along with a delete link for each degree' do
+    result = render_inline(DegreesReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__actions').text).to include(t('application_form.degree.delete'))
+    expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
+      Rails.application.routes.url_helpers.candidate_interface_degrees_destroy_path(2),
+    )
   end
 end

--- a/spec/models/candidate_interface/degrees_form_spec.rb
+++ b/spec/models/candidate_interface/degrees_form_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
     it 'creates an array of objects based on the provided ApplicationForm' do
       application_form = create(:application_form) do |form|
         form.application_qualifications.create(
+          id: 1,
           level: 'degree',
           qualification_type: 'BA',
           subject: 'Woof',
@@ -77,6 +78,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
           award_year: '2008',
         )
         form.application_qualifications.create(
+          id: 2,
           level: 'degree',
           qualification_type: 'BA',
           subject: 'Meow',
@@ -91,6 +93,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
 
       expect(degrees).to match_array([
         have_attributes(
+          id: 1,
           qualification_type: 'BA',
           subject: 'Woof',
           institution_name: 'University of Doge',
@@ -98,6 +101,7 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
           award_year: '2008',
         ),
         have_attributes(
+          id: 2,
           qualification_type: 'BA',
           subject: 'Meow',
           institution_name: 'University of Cate',

--- a/spec/models/candidate_interface/degrees_form_spec.rb
+++ b/spec/models/candidate_interface/degrees_form_spec.rb
@@ -193,4 +193,12 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
         .to have_attributes(grade: 'First', predicted_grade: true)
     end
   end
+
+  describe '#title' do
+    it 'concatenates the qualification type and subject' do
+      degree = CandidateInterface::DegreesForm.new(qualification_type: 'BA', subject: 'Doge')
+
+      expect(degree.title).to eq('BA Doge')
+    end
+  end
 end

--- a/spec/models/candidate_interface/degrees_form_spec.rb
+++ b/spec/models/candidate_interface/degrees_form_spec.rb
@@ -145,6 +145,58 @@ RSpec.describe CandidateInterface::DegreesForm, type: :model do
     end
   end
 
+  describe '.find_by_application' do
+    it 'returns a new DegreesForm object using the id' do
+      application_form = create(:application_form) do |form|
+        form.application_qualifications.create(
+          id: 1,
+          level: 'degree',
+          qualification_type: 'BA',
+          subject: 'Woof',
+        )
+        form.application_qualifications.create(
+          id: 2,
+          level: 'degree',
+          qualification_type: 'BA',
+          subject: 'Meow',
+        )
+      end
+
+      degree = CandidateInterface::DegreesForm.find_by_application(application_form, 2)
+
+      expect(degree).to have_attributes(qualification_type: 'BA', subject: 'Meow')
+    end
+
+    it 'returns grade and other grade if grade is not known' do
+      application_form = create(:application_form) do |form|
+        form.application_qualifications.create(
+          id: 1,
+          level: 'degree',
+          grade: 'Distinction',
+        )
+      end
+
+      degree = CandidateInterface::DegreesForm.find_by_application(application_form, 1)
+
+      expect(degree).to have_attributes(grade: 'other', other_grade: 'Distinction')
+    end
+
+    it 'returns grade and predicted if predicted grade is true' do
+      application_form = create(:application_form) do |form|
+        form.application_qualifications.create(
+          id: 1,
+          level: 'degree',
+          grade: 'First',
+          predicted_grade: true,
+        )
+      end
+
+      degree = CandidateInterface::DegreesForm.find_by_application(application_form, 1)
+
+      expect(degree).to have_attributes(grade: 'predicted', predicted_grade: 'First')
+    end
+  end
+
   describe '#save_base' do
     let(:form_data) do
       {

--- a/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
@@ -34,6 +34,10 @@ RSpec.feature 'Entering their degrees' do
     and_i_submit_the_add_another_degree_form
     then_i_can_check_my_additional_degree
 
+    when_i_click_on_delete_degree
+    and_i_confirm_that_i_want_to_delete_my_additional_degree
+    then_i_can_only_see_my_undergraduate_degree
+
     when_i_mark_this_section_as_completed
     and_i_click_on_continue
     then_i_should_see_the_form
@@ -132,6 +136,19 @@ RSpec.feature 'Entering their degrees' do
     expect(page).to have_content 'Masters Cate'
   end
 
+  def when_i_click_on_delete_degree
+    click_link(t('application_form.degree.delete'), match: :first)
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_additional_degree
+    click_button t('application_form.degree.confirm_delete')
+  end
+
+  def then_i_can_only_see_my_undergraduate_degree
+    then_i_can_check_my_undergraduate_degree
+    expect(page).not_to have_content 'Masters Cate'
+  end
+
   def when_i_mark_this_section_as_completed
     check t('application_form.degree.review.completed_checkbox')
   end
@@ -150,6 +167,5 @@ RSpec.feature 'Entering their degrees' do
 
   def then_i_can_check_my_answers
     then_i_can_check_my_undergraduate_degree
-    then_i_can_check_my_additional_degree
   end
 end


### PR DESCRIPTION
### Context

Candidates should be able to delete a degree, currently we don't allow this.

### Changes proposed in this pull request

This PR adds the ability to delete a degree with some small refactors.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68115400-3bc6c800-fef0-11e9-83ee-e326e3133067.png)

![image](https://user-images.githubusercontent.com/42817036/68115441-500ac500-fef0-11e9-88ca-9c08aa224d93.png)

![image](https://user-images.githubusercontent.com/42817036/68115467-5dc04a80-fef0-11e9-8512-c64c7c83e8e6.png)


### Guidance to review

Would recommend going through each commit and trying it out.

### Link to Trello card

[194 - Adding degree information](https://trello.com/c/ADqlESXx/194-adding-degree-information)
