### PR TITLE
Scope application_choice by viewable states

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -2,9 +2,9 @@ module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     def index
       application_choices = ApplicationChoice
-        .includes(:application_form)
-        .order(updated_at: :desc)
         .for_provider(current_user.provider.code)
+        .visible_to_provider
+        .order(updated_at: :desc)
 
       @application_choices = application_choices.map do |application_choice|
         ApplicationChoicePresenter.new(application_choice)
@@ -13,8 +13,8 @@ module ProviderInterface
 
     def show
       application_choice = ApplicationChoice
-        .includes(:application_form)
         .for_provider(current_user.provider.code)
+        .visible_to_provider
         .find(params[:application_choice_id])
 
       @application_choice = ApplicationChoicePresenter.new(application_choice)

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,9 +1,7 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     def index
-      application_choices = ApplicationChoice
-        .for_provider(current_user.provider.code)
-        .visible_to_provider
+      application_choices = GetApplicationChoicesForProvider.call(provider: current_user.provider)
         .order(updated_at: :desc)
 
       @application_choices = application_choices.map do |application_choice|
@@ -12,9 +10,7 @@ module ProviderInterface
     end
 
     def show
-      application_choice = ApplicationChoice
-        .for_provider(current_user.provider.code)
-        .visible_to_provider
+      application_choice = GetApplicationChoicesForProvider.call(provider: current_user.provider)
         .find(params[:application_choice_id])
 
       @application_choice = ApplicationChoicePresenter.new(application_choice)

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -9,7 +9,10 @@ module VendorApi
     end
 
     def show
-      application_choice = current_provider.visible_applications.find(params[:application_id])
+      application_choice = ApplicationChoice
+      .for_provider(current_provider.code)
+      .visible_to_provider
+      .find(params[:application_id])
 
       render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
     end
@@ -17,10 +20,10 @@ module VendorApi
   private
 
     def get_application_choices_for_provider_since(since:)
-      current_provider
-        .visible_applications
-        .joins(:application_form)
-        .where('application_forms.updated_at > ?', since.to_datetime)
+      ApplicationChoice
+        .for_provider(current_provider.code)
+        .visible_to_provider
+        .where('application_choices.updated_at > ?', since.to_datetime)
     end
   end
 end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -9,10 +9,8 @@ module VendorApi
     end
 
     def show
-      application_choice = ApplicationChoice
-      .for_provider(current_provider.code)
-      .visible_to_provider
-      .find(params[:application_id])
+      application_choice = GetApplicationChoicesForProvider.call(provider: current_provider)
+        .find(params[:application_id])
 
       render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
     end
@@ -20,9 +18,7 @@ module VendorApi
   private
 
     def get_application_choices_for_provider_since(since:)
-      ApplicationChoice
-        .for_provider(current_provider.code)
-        .visible_to_provider
+      GetApplicationChoicesForProvider.call(provider: current_provider)
         .where('application_choices.updated_at > ?', since.to_datetime)
     end
   end

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -39,7 +39,10 @@ module VendorApi
   private
 
     def application_choice
-      @application_choice ||= current_provider.visible_applications.find(params[:application_id])
+      @application_choice ||= ApplicationChoice
+        .for_provider(current_provider.code)
+        .visible_to_provider
+        .find(params[:application_id])
     end
 
     def respond_to_decision(decision)

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -39,9 +39,7 @@ module VendorApi
   private
 
     def application_choice
-      @application_choice ||= ApplicationChoice
-        .for_provider(current_provider.code)
-        .visible_to_provider
+      @application_choice ||= GetApplicationChoicesForProvider.call(provider: current_provider)
         .find(params[:application_id])
     end
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -9,9 +9,16 @@ class ApplicationChoice < ApplicationRecord
 
   audited associated_with: :application_form
 
+  viewable_states = %i[application_complete conditional_offer unconditional_offer meeting_conditions recruited enrolled rejected]
+
   scope :for_provider, ->(provider_code) {
     includes(:course, :provider).where(providers: { code: provider_code })
   }
+
+  scope :viewable, -> {
+    where(status: viewable_states)
+  }
+
 
   enum status: {
     unsubmitted: 'unsubmitted',

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -9,10 +9,12 @@ class ApplicationChoice < ApplicationRecord
 
   audited associated_with: :application_form
 
-  viewable_states = %i[application_complete conditional_offer unconditional_offer meeting_conditions recruited enrolled rejected]
+  non_viewable_states = %i[unsubmitted awaiting_references]
+  viewable_states = ApplicationStateChange.valid_states - non_viewable_states
 
   scope :for_provider, ->(provider_code) {
-    includes(:course, :provider).where(providers: { code: provider_code })
+    includes(:course, :provider)
+    .where(providers: { code: provider_code })
   }
 
   scope :viewable, -> {

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -9,16 +9,9 @@ class ApplicationChoice < ApplicationRecord
 
   audited associated_with: :application_form
 
-  states_not_visible_to_provider = %i[unsubmitted awaiting_references]
-  states_visible_to_provider = ApplicationStateChange.valid_states - states_not_visible_to_provider
-
   scope :for_provider, ->(provider_code) {
     includes(:course, :provider)
     .where(providers: { code: provider_code })
-  }
-
-  scope :visible_to_provider, -> {
-    where(status: states_visible_to_provider)
   }
 
   enum status: {

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -9,11 +9,6 @@ class ApplicationChoice < ApplicationRecord
 
   audited associated_with: :application_form
 
-  scope :for_provider, ->(provider_code) {
-    includes(:course, :provider)
-    .where(providers: { code: provider_code })
-  }
-
   enum status: {
     unsubmitted: 'unsubmitted',
     awaiting_references: 'awaiting_references',

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -9,18 +9,17 @@ class ApplicationChoice < ApplicationRecord
 
   audited associated_with: :application_form
 
-  non_viewable_states = %i[unsubmitted awaiting_references]
-  viewable_states = ApplicationStateChange.valid_states - non_viewable_states
+  states_not_visible_to_provider = %i[unsubmitted awaiting_references]
+  states_visible_to_provider = ApplicationStateChange.valid_states - states_not_visible_to_provider
 
   scope :for_provider, ->(provider_code) {
     includes(:course, :provider)
     .where(providers: { code: provider_code })
   }
 
-  scope :viewable, -> {
-    where(status: viewable_states)
+  scope :visible_to_provider, -> {
+    where(status: states_visible_to_provider)
   }
-
 
   enum status: {
     unsubmitted: 'unsubmitted',

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -2,9 +2,4 @@ class Provider < ApplicationRecord
   has_many :courses
   has_many :course_options, through: :courses
   has_many :application_choices, through: :course_options
-
-  def visible_applications
-    # TODO: include `.where('status != ?', 'unsubmitted')` here
-    application_choices.viewable
-  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,6 @@ class Provider < ApplicationRecord
 
   def visible_applications
     # TODO: include `.where('status != ?', 'unsubmitted')` here
-    application_choices
+    application_choices.viewable
   end
 end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -1,7 +1,9 @@
 class GetApplicationChoicesForProvider
   def self.call(provider:)
+    states_not_visible_to_provider = %i[unsubmitted awaiting_references]
+
     ApplicationChoice
     .for_provider(provider.code)
-    .visible_to_provider
+    .where('status NOT IN (?)', states_not_visible_to_provider)
   end
 end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -3,7 +3,8 @@ class GetApplicationChoicesForProvider
     states_not_visible_to_provider = %i[unsubmitted awaiting_references application_complete]
 
     ApplicationChoice
-    .for_provider(provider.code)
+    .includes(:course, :provider)
+    .where(providers: { code: provider.code })
     .where('status NOT IN (?)', states_not_visible_to_provider)
   end
 end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -1,0 +1,7 @@
+class GetApplicationChoicesForProvider
+  def self.call(provider:)
+    ApplicationChoice
+    .for_provider(provider.code)
+    .visible_to_provider
+  end
+end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -1,10 +1,10 @@
 class GetApplicationChoicesForProvider
-  def self.call(provider:)
-    states_not_visible_to_provider = %i[unsubmitted awaiting_references application_complete]
+  STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete].freeze
 
+  def self.call(provider:)
     ApplicationChoice
     .includes(:course, :provider)
     .where(providers: { code: provider.code })
-    .where('status NOT IN (?)', states_not_visible_to_provider)
+    .where('status NOT IN (?)', STATES_NOT_VISIBLE_TO_PROVIDER)
   end
 end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -1,6 +1,6 @@
 class GetApplicationChoicesForProvider
   def self.call(provider:)
-    states_not_visible_to_provider = %i[unsubmitted awaiting_references]
+    states_not_visible_to_provider = %i[unsubmitted awaiting_references application_complete]
 
     ApplicationChoice
     .for_provider(provider.code)

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       :application_choice,
       2,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: 'awaiting_provider_decision',
     )
 
     alternate_provider = create(:provider, code: 'DIFFERENT')
@@ -18,6 +19,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       :application_choice,
       1,
       course_option: course_option_for_provider(provider: alternate_provider),
+      status: 'awaiting_provider_decision',
     )
 
     get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
@@ -26,10 +28,14 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
   it 'returns applications filtered with `since`' do
     Timecop.travel(Time.now - 2.days) do
-      create_application_choice_for_currently_authenticated_provider
+      create_application_choice_for_currently_authenticated_provider(
+        status: 'awaiting_provider_decision',
+      )
     end
 
-    create_application_choice_for_currently_authenticated_provider
+    create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
 
     get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
 
@@ -37,7 +43,9 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
   end
 
   it 'returns a response that is valid according to the OpenAPI schema' do
-    create_application_choice_for_currently_authenticated_provider
+    create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
 
     get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
 
@@ -59,7 +67,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       :application_choice,
       2,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
-      status: :application_complete,
+      status: :awaiting_provider_decision,
     )
 
     create_list(

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -53,4 +53,24 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
     expect(error_response['message']).to eql('param is missing or the value is empty: since')
   end
+
+  it 'returns applications that are in a viewable state' do
+    create_list(
+      :application_choice,
+      2,
+      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: :application_complete,
+    )
+
+    create_list(
+      :application_choice,
+      3,
+      course_option: course_option_for_provider(provider: currently_authenticated_provider),
+      status: :unsubmitted,
+    )
+
+    get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
+
+    expect(parsed_response['data'].size).to be(2)
+  end
 end

--- a/spec/requests/vendor_api/get_single_application_spec.rb
+++ b/spec/requests/vendor_api/get_single_application_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe 'Vendor API - GET /api/v1/applications/:application_id', type: :r
   include CourseOptionHelpers
 
   it 'returns a response that is valid according to the OpenAPI schema' do
-    application_choice = create_application_choice_for_currently_authenticated_provider
+    application_choice = create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
 
     get_api_request "/api/v1/applications/#{application_choice.id}"
 

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -38,7 +38,9 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
   end
 
   it 'returns an error when a proper reason is not provided' do
-    application_choice = create_application_choice_for_currently_authenticated_provider(status: 'application_complete')
+    application_choice = create_application_choice_for_currently_authenticated_provider(
+      status: 'awaiting_provider_decision',
+    )
 
     post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: {
       data: {

--- a/spec/services/get_application_choices_for_provider_spec.rb
+++ b/spec/services/get_application_choices_for_provider_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe GetApplicationChoicesForProvider do
+  include CourseOptionHelpers
+
+  it 'returns the application for the given provider' do
+    current_provider = create(:provider, code: 'BAT')
+
+    create_list(
+      :application_choice,
+      2,
+      course_option: course_option_for_provider(provider: current_provider),
+      status: 'awaiting_provider_decision',
+    )
+
+    alternate_provider = create(:provider, code: 'DIFFERENT')
+
+    create_list(
+      :application_choice,
+      4,
+      course_option: course_option_for_provider(provider: alternate_provider),
+      status: 'awaiting_provider_decision',
+    )
+
+    returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
+    expect(returned_applications.size).to be(2)
+  end
+
+  it 'returns applications that are in a state visible to providers' do
+    current_provider = create(:provider, code: 'BAT')
+
+    create_list(
+      :application_choice,
+      3,
+      course_option: course_option_for_provider(provider: current_provider),
+      status: 'awaiting_provider_decision',
+    )
+
+    create_list(
+      :application_choice,
+      4,
+      course_option: course_option_for_provider(provider: current_provider),
+      status: 'unsubmitted',
+    )
+
+    create_list(
+      :application_choice,
+      2,
+      course_option: course_option_for_provider(provider: current_provider),
+      status: 'awaiting_references',
+    )
+
+    returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
+    expect(returned_applications.size).to be(3)
+  end
+
+
+  it 'contians the correct states to filter by' do
+    valid_states = ApplicationStateChange.valid_states
+    expect(valid_states).to include(*GetApplicationChoicesForProvider::STATES_NOT_VISIBLE_TO_PROVIDER)
+  end
+end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -22,9 +22,9 @@ RSpec.feature 'See applications' do
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
 
-    create(:application_choice, course_option: course_option, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
-    create(:application_choice, course_option: course_option, application_form: create(:application_form, first_name: 'Bob'))
-    create(:application_choice, course_option: other_course_option, application_form: create(:application_form, first_name: 'Charlie'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Bob'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option, application_form: create(:application_form, first_name: 'Charlie'))
   end
 
   def and_i_visit_the_provider_page


### PR DESCRIPTION
### Context

Providers should only be able to see applications that are in a viewable state. 

These states include:
- awaiting_provider_decision 
- offer
- pending_conditions
- recruited
- enrolled
- rejected
- declined
- withdrawn

### Changes proposed in this pull request

Add service that returns `application_choices` for a given provider.
`GetApplicationChoiceForProvider`
This service scopes by application state.

### Guidance to review

Run specs and ensure the correct states are being scoped.

### Link to Trello card

[1213 - Revealing viewable applications to provider](https://trello.com/c/pQZUP7vi/1213-api-revealing-viewable-applications-to-providers)

### Env vars

No Env Vars