### PR TITLE
Update work experience validations

### DIFF
--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -24,9 +24,9 @@ module CandidateInterface
       work_experience = current_candidate.current_application
         .application_work_experiences
         .find(work_experience_params[:id])
-      work_experience_form = WorkExperienceForm.new(work_experience_form_params)
+      @work_experience_form = WorkExperienceForm.new(work_experience_form_params)
 
-      if work_experience_form.update(work_experience)
+      if @work_experience_form.update(work_experience)
         redirect_to candidate_interface_work_history_show_path
       else
         render :edit

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -78,17 +78,17 @@ module CandidateInterface
 
   private
 
+    def valid_date_or_nil(year, month)
+      date_args = [year, month, 1].map(&:to_i)
+      Date.new(*date_args) if year.present? && Date.valid_date?(*date_args)
+    end
+
     def end_date_blank?
       end_date_year.blank? && end_date_month.blank?
     end
 
     def end_date_valid
       errors.add(:end_date, :invalid) unless end_date
-    end
-
-    def valid_date_or_nil(year, month)
-      date_args = [year, month, 1].map(&:to_i)
-      Date.new(*date_args) if year.present? && Date.valid_date?(*date_args)
     end
 
     def start_date_valid

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -34,9 +34,9 @@ module CandidateInterface
         start_date_day: work_experience.start_date.day,
         start_date_month: work_experience.start_date.month,
         start_date_year: work_experience.start_date.year,
-        end_date_day: work_experience.end_date.day,
-        end_date_month: work_experience.end_date.month,
-        end_date_year: work_experience.end_date.year,
+        end_date_day: work_experience.end_date&.day || '',
+        end_date_month: work_experience.end_date&.month || '',
+        end_date_year: work_experience.end_date&.year || '',
       )
     end
 

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -14,7 +14,9 @@ module CandidateInterface
     validates :working_with_children, inclusion: { in: %w(true false) }
 
     validate :start_date_valid
-    validate :start_date_after_end_date
+    validate :end_date_valid, if: :end_date_given?
+    validate :end_date_year_before_current_year, if: :end_date_valid?
+    validate :start_date_after_end_date, if: :start_date_and_end_date_valid?
 
     validates :role, :organisation,
               length: { maximum: 60 }
@@ -80,12 +82,34 @@ module CandidateInterface
       end
     end
 
+  private
+
     def start_date_valid
-      errors.add(:start_date, :invalid) if start_date.nil?
+      errors.add(:start_date, :invalid) unless start_date
+    end
+
+    def end_date_valid
+      errors.add(:end_date, :invalid) if end_date.nil?
     end
 
     def start_date_after_end_date
-      errors.add(:start_date, :before) if end_date.present? && start_date > end_date
+      errors.add(:start_date, :before) if start_date > end_date
+    end
+
+    def end_date_year_before_current_year
+      errors.add(:end_date, :year_after) if end_date.year > Date.today.year
+    end
+
+    def start_date_and_end_date_valid?
+      end_date_given? && !errors.include?(:start_date) && !errors.include?(:end_date)
+    end
+
+    def end_date_valid?
+      end_date_given? && !errors.include?(:end_date)
+    end
+
+    def end_date_given?
+      end_date_year.present? && end_date_month.present?
     end
   end
 end

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -69,20 +69,19 @@ module CandidateInterface
     end
 
     def start_date
-      date_args = [start_date_year, start_date_month, 1].map(&:to_i)
-      if Date.valid_date?(*date_args)
-        Date.new(*date_args)
-      end
+      valid_date_or_nil(start_date_year, start_date_month)
     end
 
     def end_date
-      date_args = [end_date_year, end_date_month, 1].map(&:to_i)
-      if Date.valid_date?(*date_args)
-        Date.new(*date_args)
-      end
+      valid_date_or_nil(end_date_year, end_date_month)
     end
 
   private
+
+    def valid_date_or_nil(year, month)
+      date_args = [year, month, 1].map(&:to_i)
+      Date.new(*date_args) if Date.valid_date?(*date_args)
+    end
 
     def start_date_valid
       errors.add(:start_date, :invalid) unless start_date

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -16,7 +16,7 @@ module CandidateInterface
     validate :start_date_valid
     validate :end_date_valid, if: :end_date_given?
     validate :end_date_year_before_current_year, if: :end_date_valid?
-    validate :start_date_after_end_date, if: :start_date_and_end_date_valid?
+    validate :start_date_before_end_date, if: :start_date_and_end_date_valid?
 
     validates :role, :organisation,
               length: { maximum: 60 }
@@ -92,8 +92,8 @@ module CandidateInterface
       errors.add(:end_date, :invalid) if end_date.nil?
     end
 
-    def start_date_after_end_date
-      errors.add(:start_date, :before) if start_date > end_date
+    def start_date_before_end_date
+      errors.add(:start_date, :before) unless start_date < end_date
     end
 
     def end_date_year_before_current_year

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -95,12 +95,6 @@ module CandidateInterface
       errors.add(:start_date, :invalid) unless start_date
     end
 
-    def end_date_valid_or_blank
-      if end_date_year.blank? && end_date_month.blank?
-        errors.add(:end_date, :invalid) if end_date.nil?
-      end
-    end
-
     def start_date_before_end_date
       errors.add(:start_date, :before) unless start_date < end_date
     end

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -107,17 +107,17 @@ module CandidateInterface
 
     def end_date_before_current_year_and_month
       if end_date.year > Date.today.year || \
-        end_date.year == Date.today.year && end_date.month > Date.today.month
+          end_date.year == Date.today.year && end_date.month > Date.today.month
         errors.add(:end_date, :in_the_future)
       end
     end
 
     def start_date_and_end_date_valid?
-      end_date && !errors.include?(:start_date) && !errors.include?(:end_date)
+      end_date && start_date
     end
 
     def end_date_valid?
-      end_date && !errors.include?(:end_date)
+      end_date
     end
   end
 end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -222,5 +222,5 @@ en:
               invalid: Enter a start date in the correct format, for example 5 2018
               before: Enter a start date that is before the end date
             end_date:
-              invalid: Enter a end date in the correct format, for example 5 2019
+              invalid: Enter an end date in the correct format, for example 5 2019
               in_the_future: Enter an end date that is not in the future

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -223,4 +223,4 @@ en:
               before: Enter a start date that is before the end date
             end_date:
               invalid: Enter a end date in the correct format, for example 5 2019
-              year_after: Enter a end date year that is the current year or in the past
+              in_the_future: Enter an end date that is not in the future

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -221,3 +221,6 @@ en:
             start_date:
               invalid: Enter a start date in the correct format, for example 5 2018
               before: Enter a start date that is before the end date
+            end_date:
+              invalid: Enter a end date in the correct format, for example 5 2019
+              year_after: Enter a end date year that is the current year or in the past

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,7 @@ en:
     degree: Degree
     add_undergraduate_degree: Add undergraduate degree
     work_history_destroy: Are you sure you want to delete this entry?
-    edit_job: Add job
+    edit_job: Edit job
     add_another_degree: Add another degree
     out_of_work: Tell us why you’ve been out of the workplace
   layout:

--- a/spec/models/candidate_interface/work_experience_form_spec.rb
+++ b/spec/models/candidate_interface/work_experience_form_spec.rb
@@ -72,6 +72,40 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
     end
 
     describe 'end date' do
+      it 'is valid if left completely blank' do
+        work_experience = CandidateInterface::WorkExperienceForm.new(
+          end_date_month: '', end_date_year: '',
+        )
+
+        work_experience.validate
+
+        expect(work_experience.errors.full_messages_for(:end_date)).to be_empty
+      end
+
+      it 'is invalid if month left blank' do
+        work_experience = CandidateInterface::WorkExperienceForm.new(
+          end_date_month: '', end_date_year: '2019',
+        )
+
+        work_experience.validate
+
+        expect(work_experience.errors.full_messages_for(:end_date)).to eq(
+          ["End date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.invalid')}"],
+        )
+      end
+
+      it 'is invalid if year left blank' do
+        work_experience = CandidateInterface::WorkExperienceForm.new(
+          end_date_month: '5', end_date_year: '',
+        )
+
+        work_experience.validate
+
+        expect(work_experience.errors.full_messages_for(:end_date)).to eq(
+          ["End date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.invalid')}"],
+        )
+      end
+
       it 'is invalid if not well-formed' do
         work_experience = CandidateInterface::WorkExperienceForm.new(
           end_date_month: '99', end_date_year: '2019',
@@ -93,8 +127,33 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
           work_experience.validate
 
           expect(work_experience.errors.full_messages_for(:end_date)).to eq(
-            ["End date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.year_after')}"],
+            ["End date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.in_the_future')}"],
           )
+        end
+      end
+
+      it 'is invalid if year is the current year but month is after the current month' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          work_experience = CandidateInterface::WorkExperienceForm.new(
+            end_date_month: '11', end_date_year: '2019',
+          )
+
+          work_experience.validate
+
+          expect(work_experience.errors.full_messages_for(:end_date)).to eq(
+            ["End date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.in_the_future')}"],
+          )
+        end
+      end
+
+      it 'is valid if year and month are before the current year and month' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          work_experience = CandidateInterface::WorkExperienceForm.new(
+            end_date_month: '9', end_date_year: '2019',
+          )
+
+          work_experience.validate
+          expect(work_experience.errors.full_messages_for(:end_date)).to be_empty
         end
       end
     end

--- a/spec/models/candidate_interface/work_experience_form_spec.rb
+++ b/spec/models/candidate_interface/work_experience_form_spec.rb
@@ -144,5 +144,19 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
 
       expect(work_experience_form).to have_attributes(form_data)
     end
+
+    it 'returns an empty string if end date is nil' do
+      data[:end_date] = nil
+      application_work_experience = ApplicationWorkExperience.new(data)
+      work_experience_form = CandidateInterface::WorkExperienceForm.build_from_experience(
+        application_work_experience,
+      )
+
+      expect(work_experience_form).to have_attributes(
+        end_date_day: '',
+        end_date_month: '',
+        end_date_year: '',
+      )
+    end
   end
 end

--- a/spec/models/candidate_interface/work_experience_form_spec.rb
+++ b/spec/models/candidate_interface/work_experience_form_spec.rb
@@ -70,6 +70,34 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
         )
       end
     end
+
+    describe 'end date' do
+      it 'is invalid if not well-formed' do
+        work_experience = CandidateInterface::WorkExperienceForm.new(
+          end_date_month: '99', end_date_year: '2019',
+        )
+
+        work_experience.validate
+
+        expect(work_experience.errors.full_messages_for(:end_date)).to eq(
+          ["End date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.invalid')}"],
+        )
+      end
+
+      it 'is invalid if year is beyond the current year' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          work_experience = CandidateInterface::WorkExperienceForm.new(
+            end_date_month: '1', end_date_year: '2029',
+          )
+
+          work_experience.validate
+
+          expect(work_experience.errors.full_messages_for(:end_date)).to eq(
+            ["End date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.year_after')}"],
+          )
+        end
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -29,7 +29,10 @@ RSpec.feature 'Entering their work history' do
     then_i_should_see_my_completed_job
 
     when_i_click_on_change
-    and_i_change_the_job_title
+    and_i_change_the_job_title_to_be_blank
+    then_i_should_see_validation_errors
+
+    when_i_change_the_job_title
     then_i_should_see_my_updated_job
 
     when_i_mark_this_section_as_completed
@@ -94,12 +97,12 @@ RSpec.feature 'Entering their work history' do
 
     within('[data-qa="start-date"]') do
       fill_in 'Month', with: '5'
-      fill_in 'Year', with: '2119'
+      fill_in 'Year', with: '2014'
     end
 
     within('[data-qa="end-date"]') do
       fill_in 'Month', with: '1'
-      fill_in 'Year', with: '2129'
+      fill_in 'Year', with: '2019'
     end
 
     fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
@@ -129,7 +132,16 @@ RSpec.feature 'Entering their work history' do
     first('.govuk-summary-list__actions').click_link 'Change'
   end
 
-  def and_i_change_the_job_title
+  def and_i_change_the_job_title_to_be_blank
+    fill_in t('application_form.work_history.role.label'), with: ''
+    click_button t('application_form.work_history.complete_form_button')
+  end
+
+  def then_i_should_see_validation_errors
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.role.blank')
+  end
+
+  def when_i_change_the_job_title
     fill_in t('application_form.work_history.role.label'), with: 'Chief Executive Officer'
     click_button t('application_form.work_history.complete_form_button')
   end


### PR DESCRIPTION
### Context

While product reviewing the ability to add work history, Rachel found that there was some missing date validations and errors.

### Changes proposed in this pull request

This PR adds validation for `end_date`, ensuring that it is shows when editing a job and that it is not beyond the current year. Also enables nil handling for end date.

### Guidance to review

Go through commits.

There's probably a nicer way to handle the conditional validations, ideas are welcome!

### Link to Trello card

[192 - Adding work history](https://trello.com/c/G8slDphi/192-adding-work-history)