### PR TITLE
Reverse the touch between application_choice and application_form

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -1,7 +1,7 @@
 class ApplicationChoice < ApplicationRecord
   before_create :set_initial_status
 
-  belongs_to :application_form, touch: true
+  belongs_to :application_form
   belongs_to :course_option
   has_one :course, through: :course_option
   has_one :site, through: :course_option

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -10,6 +10,10 @@ class ApplicationForm < ApplicationRecord
 
   MINIMUM_COMPLETE_REFERENCES = 2
 
+  after_save -> {
+    application_choices.update_all(updated_at: Time.zone.now)
+  }
+
   def submitted?
     application_choices.any? && !application_choices.first.unsubmitted?
   end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -1,18 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationChoice, type: :model do
-  describe '#update' do
-    it 'updates the form as well' do
-      original_time = Time.now - 1.day
-      application_form = create(:application_form, updated_at: original_time)
-      application_choice = create(:application_choice, application_form: application_form)
-
-      application_choice.update!(personal_statement: 'Something else')
-
-      expect(application_form.updated_at).not_to eql(original_time)
-    end
-  end
-
   describe '#create' do
     it 'starts in the "unsubmitted" status' do
       course_option = create(:course_option)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -14,4 +14,22 @@ RSpec.describe ApplicationForm do
       expect(application_form.own_and_associated_audits.count).to eq 5
     end
   end
+
+  describe '#update' do
+    it 'updates the application_choices updated_at as well' do
+      original_time = Time.now - 1.day
+      application_form = create(:application_form)
+      application_choices = create_list(
+        :application_choice,
+        2,
+        application_form: application_form,
+        updated_at: original_time,
+      )
+
+      application_form.update!(first_name: 'Something else')
+      application_choices.each(&:reload)
+
+      expect(application_choices.map(&:updated_at)).not_to include(original_time)
+    end
+  end
 end


### PR DESCRIPTION
### Context

Currently when an application_choice is updated by a provider the parent application_form is also updated.
This may cause some odd behaviours for other providers.

### Changes proposed in this pull request

Reverse the touch relationship between application_choice and application_form.

### Guidance to review

This is a Draft PR to discuss and get feedback.

### Link to Trello card

[123 - Example Trello card](http://trello.com/123-example-card)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
