### PR TITLE
Add ability to add and review other qualification

### DIFF
--- a/app/components/other_qualifications_review_component.html.erb
+++ b/app/components/other_qualifications_review_component.html.erb
@@ -1,0 +1,9 @@
+<% @qualifications.each do |qualification| %>
+  <%= render(SummaryCardComponent, rows: other_qualifications_rows(qualification)) do %>
+    <header class="app-summary-card__header">
+      <h3 class="app-summary-card__title">
+        <%= qualification.title %>
+      </h3>
+    </header>
+  <% end %>
+<% end %>

--- a/app/components/other_qualifications_review_component.rb
+++ b/app/components/other_qualifications_review_component.rb
@@ -1,0 +1,55 @@
+class OtherQualificationsReviewComponent < ActionView::Component::Base
+  validates :application_form, presence: true
+
+  def initialize(application_form:)
+    @application_form = application_form
+    @qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(
+      @application_form,
+    )
+  end
+
+  def other_qualifications_rows(qualification)
+    [
+      qualification_row(qualification),
+      award_year_row(qualification),
+      grade_row(qualification),
+    ]
+  end
+
+private
+
+  attr_reader :application_form
+
+  def qualification_row(qualification)
+    {
+      key: t('application_form.other_qualification.qualification.label'),
+      DANGEROUS_html_value: formatted_qualification(qualification),
+      action: t('application_form.other_qualification.qualification.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def award_year_row(qualification)
+    {
+      key: t('application_form.other_qualification.award_year.review_label'),
+      value: qualification.award_year,
+      action: t('application_form.other_qualification.award_year.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def grade_row(qualification)
+    {
+      key: t('application_form.other_qualification.grade.label'),
+      value: qualification.grade,
+      action: t('application_form.other_qualification.grade.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def formatted_qualification(qualification)
+    [qualification.title, qualification.institution_name]
+      .map { |line| sanitize(line, tags: []) }
+      .join('<br>')
+  end
+end

--- a/app/components/support_interface/audit_trail_item_component.html.erb
+++ b/app/components/support_interface/audit_trail_item_component.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row gov uk-accordion__section">
   <td class="govuk-table__cell" title="<%= l(audit.created_at, format: :long_with_seconds) %>">
-    <%= l(audit.created_at.to_date, format: :long) %> <br/><%= l(audit.created_at, format: :time) %>
+    <%= l(audit.created_at.to_date, format: :long) %> <br><%= l(audit.created_at, format: :time) %>
   </td>
   <td class="govuk-table__cell">
     <div class="govuk-!-margin-0">
@@ -10,11 +10,7 @@
       </div>
       <dl class="govuk-summary-list govuk-!-margin-bottom-0 govuk-!-font-size-16">
         <% changes.each_with_index do |(attr, values), index| %>
-          <%= render SupportInterface::AuditTrailChangeComponent,
-            attribute: attr,
-            values: values,
-            last_change: index + 1 == changes.size
-          %>
+          <%= render SupportInterface::AuditTrailChangeComponent, attribute: attr, values: values, last_change: index + 1 == changes.size %>
         <% end %>
       </dl>
     </div>

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -1,0 +1,26 @@
+module CandidateInterface
+  class OtherQualifications::BaseController < CandidateInterfaceController
+    def new
+      @qualification = OtherQualificationForm.new
+    end
+
+    def create
+      @qualification = OtherQualificationForm.new(other_qualification_params)
+      application_form = current_candidate.current_application
+
+      if @qualification.save(application_form)
+        redirect_to candidate_interface_review_other_qualifications_path
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def other_qualification_params
+      params.require(:candidate_interface_other_qualification_form).permit(
+        :id, :qualification_type, :subject, :institution_name, :grade, :award_year
+      )
+    end
+  end
+end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,0 +1,7 @@
+module CandidateInterface
+  class OtherQualifications::ReviewController < CandidateInterfaceController
+    def show
+      @application_form = current_candidate.current_application
+    end
+  end
+end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -2,6 +2,7 @@ class ApplicationQualification < ApplicationRecord
   belongs_to :application_form
 
   scope :degrees, -> { where level: 'degree' }
+  scope :other, -> { where level: 'other' }
 
   enum level: {
     degree: 'degree',

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -42,6 +42,10 @@ module CandidateInterface
       true
     end
 
+    def title
+      "#{qualification_type} #{subject}"
+    end
+
   private
 
     def award_year_is_date_and_before_current_year

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -11,6 +11,22 @@ module CandidateInterface
 
     validate :award_year_is_date_and_before_current_year, if: :award_year
 
+    def save(application_form)
+      return false unless valid?
+
+      application_form.application_qualifications.create!(
+        level: ApplicationQualification.levels[:other],
+        qualification_type: qualification_type,
+        subject: subject,
+        institution_name: institution_name,
+        grade: grade,
+        predicted_grade: false,
+        award_year: award_year,
+      )
+
+      true
+    end
+
   private
 
     def award_year_is_date_and_before_current_year

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -11,6 +11,21 @@ module CandidateInterface
 
     validate :award_year_is_date_and_before_current_year, if: :award_year
 
+    class << self
+      def build_all_from_application(application_form)
+        application_form.application_qualifications.other.map do |qualification|
+          new(
+            id: qualification.id,
+            qualification_type: qualification.qualification_type,
+            subject: qualification.subject,
+            institution_name: qualification.institution_name,
+            grade: qualification.grade,
+            award_year: qualification.award_year,
+          )
+        end
+      end
+    end
+
     def save(application_form)
       return false unless valid?
 

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -1,0 +1,26 @@
+module CandidateInterface
+  class OtherQualificationForm
+    include ActiveModel::Model
+
+    attr_accessor :id, :qualification_type, :subject, :institution_name, :grade,
+                  :award_year
+
+    validates :qualification_type, :subject, :institution_name, :grade, :award_year, presence: true
+
+    validates :qualification_type, :subject, :institution_name, :grade, length: { maximum: 255 }
+
+    validate :award_year_is_date_and_before_current_year, if: :award_year
+
+  private
+
+    def award_year_is_date_and_before_current_year
+      valid_award_year = award_year.match?(/^[1-9]\d{3}$/)
+
+      if !valid_award_year
+        errors.add(:award_year, :invalid)
+      elsif Date.new(award_year.to_i, 1, 1).year > Date.today.year
+        errors.add(:award_year, :in_the_future)
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -71,7 +71,7 @@
         <%= govuk_link_to 'Science GCSE or equivalent', candidate_interface_gcse_details_edit_type_path(subject: :science), class: 'app-task-list__task-name' %>
       </li>
       <li class="app-task-list__item">
-        <%= govuk_link_to 'TODO: Other relevant academic and non-academic qualifications', '#', class: 'app-task-list__task-name' %>
+        <%= govuk_link_to t('page_titles.other_qualification'), candidate_interface_new_other_qualification_path, class: 'app-task-list__task-name' %>
       </li>
     </ol>
 

--- a/app/views/candidate_interface/other_qualifications/base/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/new.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, page_title(:add_other_qualification) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification, url: candidate_interface_create_other_qualification_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('page_titles.add_other_qualification') %>
+          </h1>
+        </legend>
+
+        <p class="govuk-body">
+          Enter your other qualifications as completely as you can, including all
+          your GCSEs, A levels, and undergraduate and postgraduate degrees.
+        </p>
+        <p class="govuk-body">
+          You should also tell us about your vocational, practical and creative qualifications.
+        </p>
+
+        <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.hint_text') %>
+        <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
+        <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
+        <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
+        <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, width: 4 %>
+
+        <%= f.govuk_submit t('application_form.other_qualification.base.button') %>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -1,0 +1,8 @@
+<% content_for :title, page_title(:other_qualification) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.other_qualification') %>
+</h1>
+
+<%= render(OtherQualificationsReviewComponent, application_form: @application_form) %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -206,6 +206,24 @@ en:
             award_year:
               blank: Enter your graduation year
               invalid: Enter a real graduation year
+        candidate_interface/other_qualification_form:
+          attributes:
+            qualification_type:
+              blank: Enter the type of qualification
+              too_long: Type of qualification must be %{count} characters or fewer
+            subject:
+              blank: Enter the subject
+              too_long: Subject must be %{count} characters or fewer
+            institution_name:
+              blank: Enter the institution where you studied
+              too_long: The institution where you studied must be %{count} characters or fewer
+            grade:
+              blank: Enter the grade
+              too_long: The grade must be %{count} characters or fewer
+            award_year:
+              blank: Enter the year the qualification was awarded
+              invalid: Enter a real year
+              in_the_future: Enter a year that is not in the future
         candidate_interface/work_experience_form:
           attributes:
             role:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -134,6 +134,26 @@ en:
         button: Add another degree
       delete: Delete degree
       confirm_delete: Yes I’m sure - delete this degree
+    other_qualification:
+      qualification:
+        label: Qualification
+        change_action: qualification
+      qualification_type:
+        label: Type of qualification
+        hint_text: For example, GCSE, A level, BTEC, NVQ or non-UK other, please specify
+      subject:
+        label: Subject
+      institution_name:
+        label: Institution where you studied
+      grade:
+        label: Grade
+        change_action: grade
+      award_year:
+        label: Year qualification was awarded
+        review_label: Year awarded
+        change_action: year
+      base:
+        button: Save and continue
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,6 +53,8 @@ en:
     out_of_work: Tell us why you’ve been out of the workplace
     destroy_degree: Are you sure you want to delete this degree?
     edit_degree: Edit degree
+    other_qualification: Other relevant academic and non-academic qualifications
+    add_other_qualification: Other relevant qualifications
   layout:
     service_name: Apply for teacher training
     phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -87,6 +87,13 @@ Rails.application.routes.draw do
         get '/delete/:id' => 'degrees/destroy#confirm_destroy', as: :confirm_degrees_destroy
         delete '/delete/:id' => 'degrees/destroy#destroy'
       end
+
+      scope '/other-qualifications' do
+        get '/' => 'other_qualifications/base#new', as: :new_other_qualification
+        post '/' => 'other_qualifications/base#create', as: :create_other_qualification
+
+        get '/review' => 'other_qualifications/review#show', as: :review_other_qualifications
+      end
     end
   end
 

--- a/spec/components/other_qualifications_review_component_spec.rb
+++ b/spec/components/other_qualifications_review_component_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe OtherQualificationsReviewComponent do
+  let(:application_form) do
+    create(:application_form) do |form|
+      form.application_qualifications.create(
+        id: 1,
+        level: 'other',
+        qualification_type: 'A-Level',
+        subject: 'Making Doggo Sounds',
+        institution_name: 'Doggo Sounds College',
+        grade: 'A',
+        predicted_grade: false,
+        award_year: '2012',
+      )
+      form.application_qualifications.create(
+        id: 2,
+        level: 'other',
+        qualification_type: 'A-Level',
+        subject: 'Making Cat Sounds',
+      )
+    end
+  end
+
+  it 'renders component with correct values for a qualification' do
+    result = render_inline(OtherQualificationsReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.qualification.label'))
+    expect(result.css('.govuk-summary-list__value').to_html).to include('A-Level Making Doggo Sounds<br>Doggo Sounds College')
+    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include('#')
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.qualification.change_action')}")
+  end
+
+  it 'renders component with correct values for an award year' do
+    result = render_inline(OtherQualificationsReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.award_year.review_label'))
+    expect(result.css('.govuk-summary-list__value').text).to include('2012')
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.award_year.change_action')}")
+  end
+
+  it 'renders component with correct values for a grade' do
+    result = render_inline(OtherQualificationsReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.grade.label'))
+    expect(result.css('.govuk-summary-list__value').text).to include('A')
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.grade.change_action')}")
+  end
+
+  it 'renders component with correct values for multiple qualifications' do
+    result = render_inline(OtherQualificationsReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
+    expect(result.css('.app-summary-card__title').text).to include('A-Level Making Cat Sounds')
+  end
+end

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:qualification_type) }
+    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_presence_of(:institution_name) }
+    it { is_expected.to validate_presence_of(:grade) }
+    it { is_expected.to validate_presence_of(:award_year) }
+
+    it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(255) }
+    it { is_expected.to validate_length_of(:institution_name).is_at_most(255) }
+    it { is_expected.to validate_length_of(:grade).is_at_most(255) }
+
+    describe 'award year' do
+      ['a year', '200'].each do |invalid_date|
+        it "is invalid if the award year is '#{invalid_date}'" do
+          qualification = CandidateInterface::OtherQualificationForm.new(award_year: invalid_date)
+          error_message = t('activemodel.errors.models.candidate_interface/other_qualification_form.attributes.award_year.invalid')
+
+          qualification.validate
+
+          expect(qualification.errors.full_messages_for(:award_year)).to eq(
+            ["Award year #{error_message}"],
+          )
+        end
+      end
+
+      it 'is valid if the award year is 4 digits' do
+        qualification = CandidateInterface::OtherQualificationForm.new(award_year: '2009')
+
+        qualification.validate
+
+        expect(qualification.errors.full_messages_for(:award_year)).to be_empty
+      end
+
+      it 'is invalid if the award year is before the current year' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          qualification = CandidateInterface::OtherQualificationForm.new(award_year: '2029')
+          error_message = t('activemodel.errors.models.candidate_interface/other_qualification_form.attributes.award_year.in_the_future')
+
+          qualification.validate
+
+          expect(qualification.errors.full_messages_for(:award_year)).to eq(
+            ["Award year #{error_message}"],
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -49,4 +49,28 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
       end
     end
   end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      qualification = CandidateInterface::OtherQualificationForm.new
+
+      expect(qualification.save(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'saves the provided ApplicationForm if valid' do
+      form_data = {
+        qualification_type: 'BTEC',
+        subject: 'Being a Superhero',
+        institution_name: 'School of Heroes',
+        grade: 'Distinction',
+        award_year: '2012',
+      }
+      application_form = create(:application_form)
+      qualification = CandidateInterface::OtherQualificationForm.new(form_data)
+
+      expect(qualification.save(application_form)).to eq(true)
+      expect(application_form.application_qualifications.other.first)
+        .to have_attributes(form_data)
+    end
+  end
 end

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -50,6 +50,46 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     end
   end
 
+  describe '.build_all_from_application' do
+    let(:application_form) do
+      create(:application_form) do |form|
+        form.application_qualifications.create(
+          id: 1,
+          level: 'other',
+          qualification_type: 'BTEC',
+          subject: 'Being a Superhero',
+          institution_name: 'School of Heroes',
+          grade: 'Distinction',
+          predicted_grade: false,
+          award_year: '2012',
+        )
+        form.application_qualifications.create(level: 'degree')
+        form.application_qualifications.create(level: 'gcse')
+      end
+    end
+
+    it 'creates an array of objects based on the provided ApplicationForm' do
+      qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(application_form)
+
+      expect(qualifications).to match_array([
+        have_attributes(
+          id: 1,
+          qualification_type: 'BTEC',
+          subject: 'Being a Superhero',
+          institution_name: 'School of Heroes',
+          grade: 'Distinction',
+          award_year: '2012',
+        ),
+      ])
+    end
+
+    it 'only includes other qualifications and not degrees or GCSEs' do
+      qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(application_form)
+
+      expect(qualifications.count).to eq(1)
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       qualification = CandidateInterface::OtherQualificationForm.new

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -113,4 +113,12 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
         .to have_attributes(form_data)
     end
   end
+
+  describe '#title' do
+    it 'concatenates the qualification type and subject' do
+      qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'BTEC', subject: 'Being a Supervillain')
+
+      expect(qualification.title).to eq('BTEC Being a Supervillain')
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their other qualifications' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their other qualifications' do
+    given_i_am_not_signed_in
+    and_i_visit_the_other_qualifications_page
+    then_i_see_the_homepage
+
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_other_qualifications
+    then_i_see_the_other_qualifications_form
+
+    when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
+    and_i_submit_the_other_qualification_form
+    then_i_see_validation_errors_for_my_qualification
+
+    when_i_fill_in_my_qualification
+    and_i_submit_the_other_qualification_form
+    then_i_can_check_my_qualification
+  end
+
+  def given_i_am_not_signed_in; end
+
+  def and_i_visit_the_other_qualifications_page
+    visit candidate_interface_new_other_qualification_path
+  end
+
+  def then_i_see_the_homepage
+    expect(page).to have_current_path(candidate_interface_start_path)
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_other_qualifications
+    click_link t('page_titles.other_qualification')
+  end
+
+  def then_i_see_the_other_qualifications_form
+    expect(page).to have_content(t('page_titles.add_other_qualification'))
+  end
+
+  def when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
+    fill_in t('application_form.other_qualification.qualification_type.label'), with: 'A-Level'
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
+  end
+
+  def and_i_submit_the_other_qualification_form
+    click_button t('application_form.other_qualification.base.button')
+  end
+
+  def then_i_see_validation_errors_for_my_qualification
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/other_qualification_form.attributes.institution_name.blank')
+  end
+
+  def when_i_fill_in_my_qualification
+    fill_in t('application_form.other_qualification.qualification_type.label'), with: 'A-Level'
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
+    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
+    fill_in t('application_form.other_qualification.grade.label'), with: 'A'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
+  end
+
+  def then_i_can_check_my_qualification
+    expect(page).to have_content t('application_form.other_qualification.qualification.label')
+    expect(page).to have_content 'A-Level Believing in the Heart of the Cards'
+  end
+end


### PR DESCRIPTION
### Context

Candidates should be able to add other qualifications, not just degrees and English, Maths and Science GCSEs.

### Changes proposed in this pull request

This PR adds the ability to add an other qualification with validation and then review it by introducing:

- the form object `OtherQualificationForm` with validation
- the review component `OtherQualificationsReviewComponent`

![image](https://user-images.githubusercontent.com/42817036/68325291-fd343780-00c0-11ea-8053-99c3e9efc543.png)

![image](https://user-images.githubusercontent.com/42817036/68325325-0a512680-00c1-11ea-8ded-f7b479bc1219.png)

![image](https://user-images.githubusercontent.com/42817036/68325386-2b197c00-00c1-11ea-9e92-d7b3d420937a.png)

![image](https://user-images.githubusercontent.com/42817036/68325408-38cf0180-00c1-11ea-8325-947026c1b1bf.png)

![image](https://user-images.githubusercontent.com/42817036/68325422-43899680-00c1-11ea-8fdc-268b7623acfa.png)

### Guidance to review

The diff is large but chunks of it are just tests and translations. The code written is following patterns we have set out before so my assumption is that it won't be complex to review. Recommend going through commits. 

However, please let me know if my assumption is wrong and I'll happily split this into separate PRs!

### Link to Trello card

[204 - Adding other qualifications](https://trello.com/c/qU3R6EVL/204-adding-other-qualifications)