### PR TITLE
Add OtherQualificationForm form object

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.html.erb
+++ b/app/components/support_interface/audit_trail_item_component.html.erb
@@ -1,6 +1,6 @@
 <tr class="govuk-table__row gov uk-accordion__section">
   <td class="govuk-table__cell" title="<%= l(audit.created_at, format: :long_with_seconds) %>">
-    <%= l(audit.created_at.to_date, format: :long) %> <br/><%= l(audit.created_at, format: :time) %>
+    <%= l(audit.created_at.to_date, format: :long) %> <br><%= l(audit.created_at, format: :time) %>
   </td>
   <td class="govuk-table__cell">
     <div class="govuk-!-margin-0">
@@ -10,11 +10,7 @@
       </div>
       <dl class="govuk-summary-list govuk-!-margin-bottom-0 govuk-!-font-size-16">
         <% changes.each_with_index do |(attr, values), index| %>
-          <%= render SupportInterface::AuditTrailChangeComponent,
-            attribute: attr,
-            values: values,
-            last_change: index + 1 == changes.size
-          %>
+          <%= render SupportInterface::AuditTrailChangeComponent, attribute: attr, values: values, last_change: index + 1 == changes.size %>
         <% end %>
       </dl>
     </div>

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -2,6 +2,7 @@ class ApplicationQualification < ApplicationRecord
   belongs_to :application_form
 
   scope :degrees, -> { where level: 'degree' }
+  scope :other, -> { where level: 'other' }
 
   enum level: {
     degree: 'degree',

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -42,6 +42,10 @@ module CandidateInterface
       true
     end
 
+    def title
+      "#{qualification_type} #{subject}"
+    end
+
   private
 
     def award_year_is_date_and_before_current_year

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -11,6 +11,22 @@ module CandidateInterface
 
     validate :award_year_is_date_and_before_current_year, if: :award_year
 
+    def save(application_form)
+      return false unless valid?
+
+      application_form.application_qualifications.create!(
+        level: ApplicationQualification.levels[:other],
+        qualification_type: qualification_type,
+        subject: subject,
+        institution_name: institution_name,
+        grade: grade,
+        predicted_grade: false,
+        award_year: award_year,
+      )
+
+      true
+    end
+
   private
 
     def award_year_is_date_and_before_current_year

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -11,6 +11,21 @@ module CandidateInterface
 
     validate :award_year_is_date_and_before_current_year, if: :award_year
 
+    class << self
+      def build_all_from_application(application_form)
+        application_form.application_qualifications.other.map do |qualification|
+          new(
+            id: qualification.id,
+            qualification_type: qualification.qualification_type,
+            subject: qualification.subject,
+            institution_name: qualification.institution_name,
+            grade: qualification.grade,
+            award_year: qualification.award_year,
+          )
+        end
+      end
+    end
+
     def save(application_form)
       return false unless valid?
 

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -1,0 +1,26 @@
+module CandidateInterface
+  class OtherQualificationForm
+    include ActiveModel::Model
+
+    attr_accessor :id, :qualification_type, :subject, :institution_name, :grade,
+                  :award_year
+
+    validates :qualification_type, :subject, :institution_name, :grade, :award_year, presence: true
+
+    validates :qualification_type, :subject, :institution_name, :grade, length: { maximum: 255 }
+
+    validate :award_year_is_date_and_before_current_year, if: :award_year
+
+  private
+
+    def award_year_is_date_and_before_current_year
+      valid_award_year = award_year.match?(/^[1-9]\d{3}$/)
+
+      if !valid_award_year
+        errors.add(:award_year, :invalid)
+      elsif Date.new(award_year.to_i, 1, 1).year > Date.today.year
+        errors.add(:award_year, :in_the_future)
+      end
+    end
+  end
+end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -206,6 +206,24 @@ en:
             award_year:
               blank: Enter your graduation year
               invalid: Enter a real graduation year
+        candidate_interface/other_qualification_form:
+          attributes:
+            qualification_type:
+              blank: Enter the type of qualification
+              too_long: Type of qualification must be %{count} characters or fewer
+            subject:
+              blank: Enter the subject
+              too_long: Subject must be %{count} characters or fewer
+            institution_name:
+              blank: Enter the institution where you studied
+              too_long: The institution where you studied must be %{count} characters or fewer
+            grade:
+              blank: Enter the grade
+              too_long: The grade must be %{count} characters or fewer
+            award_year:
+              blank: Enter the year the qualification was awarded
+              invalid: Enter a real year
+              in_the_future: Enter a year that is not in the future
         candidate_interface/work_experience_form:
           attributes:
             role:

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -54,6 +54,46 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     end
   end
 
+  describe '.build_all_from_application' do
+    let(:application_form) do
+      create(:application_form) do |form|
+        form.application_qualifications.create(
+          id: 1,
+          level: 'other',
+          qualification_type: 'BTEC',
+          subject: 'Being a Superhero',
+          institution_name: 'School of Heroes',
+          grade: 'Distinction',
+          predicted_grade: false,
+          award_year: '2012',
+        )
+        form.application_qualifications.create(level: 'degree')
+        form.application_qualifications.create(level: 'gcse')
+      end
+    end
+
+    it 'creates an array of objects based on the provided ApplicationForm' do
+      qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(application_form)
+
+      expect(qualifications).to match_array([
+        have_attributes(
+          id: 1,
+          qualification_type: 'BTEC',
+          subject: 'Being a Superhero',
+          institution_name: 'School of Heroes',
+          grade: 'Distinction',
+          award_year: '2012',
+        ),
+      ])
+    end
+
+    it 'only includes other qualifications and not degrees or GCSEs' do
+      qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(application_form)
+
+      expect(qualifications.count).to eq(1)
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       qualification = CandidateInterface::OtherQualificationForm.new

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -117,4 +117,12 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
         .to have_attributes(form_data)
     end
   end
+
+  describe '#title' do
+    it 'concatenates the qualification type and subject' do
+      qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'BTEC', subject: 'Being a Supervillain')
+
+      expect(qualification.title).to eq('BTEC Being a Supervillain')
+    end
+  end
 end

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -53,4 +53,28 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
       end
     end
   end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      qualification = CandidateInterface::OtherQualificationForm.new
+
+      expect(qualification.save(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'saves the provided ApplicationForm if valid' do
+      form_data = {
+        qualification_type: 'BTEC',
+        subject: 'Being a Superhero',
+        institution_name: 'School of Heroes',
+        grade: 'Distinction',
+        award_year: '2012',
+      }
+      application_form = create(:application_form)
+      qualification = CandidateInterface::OtherQualificationForm.new(form_data)
+
+      expect(qualification.save(application_form)).to eq(true)
+      expect(application_form.application_qualifications.other.first)
+        .to have_attributes(form_data)
+    end
+  end
 end

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
+  let(:error_message_scope) do
+    'activemodel.errors.models.candidate_interface/other_qualification_form.attributes.'
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:qualification_type) }
+    it { is_expected.to validate_presence_of(:subject) }
+    it { is_expected.to validate_presence_of(:institution_name) }
+    it { is_expected.to validate_presence_of(:grade) }
+    it { is_expected.to validate_presence_of(:award_year) }
+
+    it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(255) }
+    it { is_expected.to validate_length_of(:institution_name).is_at_most(255) }
+    it { is_expected.to validate_length_of(:grade).is_at_most(255) }
+
+    describe 'award year' do
+      it 'is valid if the award year is 4 digits' do
+        qualification = CandidateInterface::OtherQualificationForm.new(award_year: '2009')
+
+        qualification.validate
+
+        expect(qualification.errors.full_messages_for(:award_year)).to be_empty
+      end
+
+      ['a year', '200'].each do |invalid_date|
+        it "is invalid if the award year is '#{invalid_date}'" do
+          qualification = CandidateInterface::OtherQualificationForm.new(award_year: invalid_date)
+          error_message = t('award_year.invalid', scope: error_message_scope)
+
+          qualification.validate
+
+          expect(qualification.errors.full_messages_for(:award_year)).to eq(
+            ["Award year #{error_message}"],
+          )
+        end
+      end
+
+      it 'is invalid if the award year is before the current year' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          qualification = CandidateInterface::OtherQualificationForm.new(award_year: '2029')
+          error_message = t('award_year.in_the_future', scope: error_message_scope)
+
+          qualification.validate
+
+          expect(qualification.errors.full_messages_for(:award_year)).to eq(
+            ["Award year #{error_message}"],
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Candidates should be able to add other qualifications, not just degrees and English, Maths and Science GCSEs.

### Changes proposed in this pull request

This PR adds the form object `OtherQualificationForm` with methods to save and build all the other qualifications saved on an application form. These are the necessary methods for allowing a candidate to add and review their other relevant qualifications.

### Guidance to review

Had to satisfy erblint for `AuditTrailItemComponent`, seems weird?

### Link to Trello card

[204 - Adding other qualifications](https://trello.com/c/qU3R6EVL/204-adding-other-qualifications)
