### PR TITLE
Update phase banner for different environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 This service enables postgraduate candidates to apply for initial teacher
 training.
 
+## Environments
+
+| Name | URL | Description |
+| -- | -- | -- |
+| Production | [www.apply-for-teacher-training.education.gov.uk](https://www.apply-for-teacher-training.education.gov.uk/candidate) | Public site |
+| Staging | [staging.apply-for-teacher-training.education.gov.uk](https://staging.apply-for-teacher-training.education.gov.uk) | For internal use by DfE to test deploys |
+| Sandbox | [sandbox.apply-for-teacher-training.education.gov.uk](https://sandbox.apply-for-teacher-training.education.gov.uk) | Demo environment for software vendors who integrate with our API |
+| QA | [qa.apply-for-teacher-training.education.gov.uk](https://qa.apply-for-teacher-training.education.gov.uk) | For internal use by DfE for testing. Automatically deployed from master |
+
 ## Table of Contents
 
 * [Dependencies](#dependencies)
@@ -98,7 +107,7 @@ Regenerate this diagram with `bundle exec rake generate_state_diagram`.
 
 **NOTE: Environment variables should not start with *endpoint*, *input*, *secret*, or *securefile* (irrespective of capitalisation) due to them being protected variable names within the Azure DevOps environment.** If this cannot be avoided variable mapping will have to be used, but wherever possible it is simpler not to use these protected names.
 
-Environment variables have to be defined in several places depending upon where they are required, some are common to both local development and the Azure hosted deployment, while others are specific to the envirionments they relate, all of which are described below
+Environment variables have to be defined in several places depending upon where they are required, some are common to both local development and the Azure hosted deployment, while others are specific to the environments they relate, all of which are described below
 
 #### <a name="documentation-env-vars-dockerfile"></a>Dockerfile
 

--- a/app/frontend/styles/_environments.scss
+++ b/app/frontend/styles/_environments.scss
@@ -1,0 +1,45 @@
+$app-colour-production: govuk-colour("red", $legacy: "bright-red");
+$app-colour-qa: govuk-colour("orange");
+$app-colour-sandbox: govuk-colour("bright-purple");
+$app-colour-staging: govuk-colour("red");
+$app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
+
+.app-header--production .govuk-header__container {
+  border-bottom-color: $app-colour-production;
+}
+
+.app-header--qa .govuk-header__container {
+  border-bottom-color: $app-colour-qa;
+}
+
+.app-header--staging .govuk-header__container {
+  border-bottom-color: $app-colour-staging;
+}
+
+.app-header--sandbox .govuk-header__container {
+  border-bottom-color: $app-colour-sandbox;
+}
+
+.app-header--development .govuk-header__container {
+  border-bottom-color: $app-colour-development;
+}
+
+.app-environment-tag--production {
+  background-color: $app-colour-production;
+}
+
+.app-environment-tag--qa {
+  background-color: $app-colour-qa;
+}
+
+.app-environment-tag--staging {
+  background-color: $app-colour-staging;
+}
+
+.app-environment-tag--sandbox {
+  background-color: $app-colour-sandbox;
+}
+
+.app-environment-tag--development {
+  background-color: $app-colour-development;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -13,6 +13,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "_task-list";
 @import "_summary-card";
 @import "_styled-content";
+@import "_environments";
 
 .autocomplete__wrapper, .autocomplete__input, .autocomplete__hint {
   font-family: $govuk-font-family;

--- a/app/lib/azure_environment.rb
+++ b/app/lib/azure_environment.rb
@@ -1,9 +1,0 @@
-module AzureEnvironment
-  def self.authorised_hosts
-    ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
-  end
-
-  def self.hostname
-    ENV.fetch('CUSTOM_HOSTNAME', authorised_hosts.first)
-  end
-end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,0 +1,42 @@
+module HostingEnvironment
+  def self.authorised_hosts
+    ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
+  end
+
+  def self.hostname
+    ENV.fetch('CUSTOM_HOSTNAME', authorised_hosts.first)
+  end
+
+  def self.phase
+    case environment_name
+    when 'www'
+      'beta'
+    else
+      environment_name
+    end
+  end
+
+  def self.phase_banner_text
+    case environment_name
+    when 'www'
+      'This is a new service - <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Apply+feedback" class="govuk-link">give feedback or report a problem</a>'.html_safe
+    when 'qa'
+      'This the QA version of the Apply service'
+    when 'sandbox'
+      'This is a demo environment for software vendors who integrate with our API'
+    when 'staging'
+      'This is a internal environment used by DfE to test deploys'
+    when 'development'
+      'This is a development version of the Apply service'
+    end
+  end
+
+  def self.environment_name
+    hostname = ENV['CUSTOM_HOSTNAME']
+    if hostname
+      hostname.split('.').first
+    else
+      'development'
+    end
+  end
+end

--- a/app/lib/logstash_logging.rb
+++ b/app/lib/logstash_logging.rb
@@ -1,5 +1,5 @@
 class LogstashLogging
-  DOMAIN_FOR_LOGS = Rails.env.production? ? AzureEnvironment.hostname : Socket.gethostname
+  DOMAIN_FOR_LOGS = Rails.env.production? ? HostingEnvironment.hostname : Socket.gethostname
 
   def self.enable(config)
     config.log_level = :info # :debug does not make sense with lograge + logstash

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
-    <header class="govuk-header " role="banner" data-module="header">
+    <header class="govuk-header app-header--<%= HostingEnvironment.environment_name %>" role="banner" data-module="header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
           <%= link_to service_link, class: 'govuk-header__link govuk-header__link--homepage' do %>
@@ -75,11 +75,11 @@
     </header>
     <div class="govuk-width-container">
       <div class="govuk-phase-banner">
-        <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag ">
-          work in progress
+        <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--<%= HostingEnvironment.environment_name %>">
+          <%= HostingEnvironment.phase %>
         </strong>
         <span class="govuk-phase-banner__text">
-          <%= t('layout.phase_banner_text') %>
+          <%= HostingEnvironment.phase_banner_text %>
         </span>
         </p>
       </div>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,7 +2,7 @@
 require_relative 'application'
 
 # Avoid constant autoloading in initializers deprecation warnings
-require './app/lib/azure_environment'
+require './app/lib/hosting_environment'
 require './app/lib/logstash_logging'
 require './app/warden/magic_link_strategy'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
     api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
   }
   config.action_mailer.default_url_options = {
-    host: AzureEnvironment.hostname
+    host: HostingEnvironment.hostname
   }
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -96,7 +96,7 @@ Rails.application.configure do
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
 
   # Whitelist the production domains for HostAuthorization
-  AzureEnvironment.authorised_hosts.each do |host|
+  HostingEnvironment.authorised_hosts.each do |host|
     config.hosts << host
   end
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,5 @@
 if Rails.env.production?
   Raven.tags_context(
-    azure_host: AzureEnvironment.hostname,
+    azure_host: HostingEnvironment.hostname,
   )
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,7 +55,6 @@ en:
     edit_degree: Edit degree
   layout:
     service_name: Apply for teacher training
-    phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.
     accessibility: Accessibility
   activemodel:
     attributes:


### PR DESCRIPTION
### Context

This adds a different phase banner and header colour for each of the 5 environments. It allows us to differentiate between the different versions, and reduces the risk of doing the wrong thing on production.

### Changes proposed in this pull request

<img width="1084" alt="Screenshot 2019-11-07 at 14 08 57" src="https://user-images.githubusercontent.com/233676/68395986-aaae5600-0168-11ea-8cbd-8d6f61ae81ca.png">
<img width="1084" alt="Screenshot 2019-11-07 at 14 09 12" src="https://user-images.githubusercontent.com/233676/68395988-ab46ec80-0168-11ea-96a0-7fc3cb4c0e9e.png">
<img width="1084" alt="Screenshot 2019-11-07 at 14 09 34" src="https://user-images.githubusercontent.com/233676/68395990-ab46ec80-0168-11ea-908d-2404998a8694.png">
<img width="1084" alt="Screenshot 2019-11-07 at 14 09 53" src="https://user-images.githubusercontent.com/233676/68395992-ab46ec80-0168-11ea-84cc-9ed6b5962140.png">
<img width="1084" alt="Screenshot 2019-11-07 at 14 10 10" src="https://user-images.githubusercontent.com/233676/68395994-ab46ec80-0168-11ea-9a89-b6eb3ece879b.png">


### Guidance to review

Do the colours work? Does the text make sense?

### Link to Trello card

https://trello.com/c/0zmKTRYg

### Env vars

- [x] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
