### PR TITLE
Simplify rendering of lists in summary card

### DIFF
--- a/app/components/contact_details_review_component.rb
+++ b/app/components/contact_details_review_component.rb
@@ -28,7 +28,7 @@ private
   def address_row
     {
       key: t('application_form.contact_details.full_address.label'),
-      DANGEROUS_html_value: full_address,
+      value: full_address,
       action: t('application_form.contact_details.full_address.change_action'),
       change_path: Rails.application.routes.url_helpers.candidate_interface_contact_details_edit_address_path,
     }
@@ -42,8 +42,6 @@ private
       @contact_details_form.address_line4,
       @contact_details_form.postcode,
     ]
-      .map { |line| sanitize(line, tags: []) }
       .reject(&:blank?)
-      .join('<br>')
   end
 end

--- a/app/components/degrees_review_component.rb
+++ b/app/components/degrees_review_component.rb
@@ -23,7 +23,7 @@ private
   def qualification_row(degree)
     {
       key: t('application_form.degree.qualification.label'),
-      DANGEROUS_html_value: formatted_qualification(degree),
+      value: formatted_qualification(degree),
       action: t('application_form.degree.qualification.change_action'),
       change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
     }
@@ -49,8 +49,6 @@ private
 
   def formatted_qualification(degree)
     [degree.title, degree.institution_name]
-      .map { |line| sanitize(line, tags: []) }
-      .join('<br>')
   end
 
   def formatted_grade(degree)

--- a/app/components/other_qualifications_review_component.rb
+++ b/app/components/other_qualifications_review_component.rb
@@ -23,7 +23,7 @@ private
   def qualification_row(qualification)
     {
       key: t('application_form.other_qualification.qualification.label'),
-      DANGEROUS_html_value: formatted_qualification(qualification),
+      value: [qualification.title, qualification.institution_name],
       action: t('application_form.other_qualification.qualification.change_action'),
       change_path: '#',
     }
@@ -45,11 +45,5 @@ private
       action: t('application_form.other_qualification.grade.change_action'),
       change_path: '#',
     }
-  end
-
-  def formatted_qualification(qualification)
-    [qualification.title, qualification.institution_name]
-      .map { |line| sanitize(line, tags: []) }
-      .join('<br>')
   end
 end

--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -8,10 +8,10 @@
             <%= row[:key] %>
           </dt>
           <dd class="govuk-summary-list__value">
-            <% if row[:DANGEROUS_html_value].nil? %>
-              <%= row[:value] %>
+            <% if row[:value].is_a?(Array) %>
+              <% row[:value].each do |value| %><%= value %><br><% end %>
             <% else %>
-              <%= render inline: row[:DANGEROUS_html_value] %>
+              <%= row[:value] %>
             <% end %>
           </dd>
 

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -33,9 +33,7 @@ private
   def job_row(work)
     {
       key: 'Job',
-      DANGEROUS_html_value: [work.role, work.organisation]
-        .map { |field| sanitize(field, tags: []) }
-        .join('<br>'),
+      value: [work.role, work.organisation],
       action: 'job',
       change_path: candidate_interface_work_history_edit_path(work.id),
     }

--- a/spec/components/contact_details_review_component_spec.rb
+++ b/spec/components/contact_details_review_component_spec.rb
@@ -44,6 +44,6 @@ RSpec.describe ContactDetailsReviewComponent do
 
     result = render_inline(ContactDetailsReviewComponent, application_form: application_form)
 
-    expect(result.css('.govuk-summary-list__value').to_html).to include('42 Much Wow Street<br>London<br>England<br>SW1P 3BT')
+    expect(result.css('.govuk-summary-list__value').to_html).to include('42 &lt;script&gt;Much&lt;/script&gt; Wow Street<br>London<br>England<br>SW1P 3BT')
   end
 end

--- a/spec/components/summary_card_component_spec.rb
+++ b/spec/components/summary_card_component_spec.rb
@@ -16,15 +16,15 @@ RSpec.describe SummaryCardComponent do
     expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
   end
 
-  it 'renders dangerous HTML content when passed in' do
+  it 'renders arrays content when passed in' do
     rows = [
       key: 'Address:',
-      DANGEROUS_html_value: 'Whoa Drive,<br>Wewvile<br>London',
+      value: ['Whoa Drive', 'Wewvile', 'London'],
       action: 'Name',
       change_path: '/some/url',
     ]
     result = render_inline(SummaryCardComponent, rows: rows)
 
-    expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive,<br>Wewvile<br>London')
+    expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
   end
 end


### PR DESCRIPTION
### Context

Sometimes the value in a summary card is made up of multiple different elements, like the different parts of an address. We're currently `joining` those in the presenter with a `<br>` in between.

This means that we have to render the value as HTML, which is a security risk. We've mitigated against that by being careful about which things to render as HTML using the `DANGEROUS_html_value` argument. This was introduced in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/394.

### Changes proposed in this pull request

This commit changes the approach to avoid all sanitising and passing of unsafe values.

I also considered the following:

```rb
<% if row[:value].is_a?(Array) %>
<%= safe_join(row[:value], '<br>'.html_safe) %>
...
```

But I don't think that is clearer.

### Guidance to review

Code

### Link to Trello card

No card.

### Env vars

- [x] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
