### PR TITLE
Add ability to add another qualification and delete an other qualification

### DIFF
--- a/app/components/other_qualifications_review_component.html.erb
+++ b/app/components/other_qualifications_review_component.html.erb
@@ -5,7 +5,7 @@
         <%= qualification.title %>
       </h3>
       <div class="app-summary-card__actions">
-        <%= link_to t('application_form.other_qualification.delete'), '#', class: 'govuk-link' %>
+        <%= link_to t('application_form.other_qualification.delete'), candidate_interface_confirm_destroy_other_qualification_path(qualification.id), class: 'govuk-link' %>
       </div>
     </header>
   <% end %>

--- a/app/components/other_qualifications_review_component.html.erb
+++ b/app/components/other_qualifications_review_component.html.erb
@@ -4,6 +4,9 @@
       <h3 class="app-summary-card__title">
         <%= qualification.title %>
       </h3>
+      <div class="app-summary-card__actions">
+        <%= link_to t('application_form.other_qualification.delete'), '#', class: 'govuk-link' %>
+      </div>
     </header>
   <% end %>
 <% end %>

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -1,0 +1,26 @@
+module CandidateInterface
+  class OtherQualifications::DestroyController < CandidateInterfaceController
+    def confirm_destroy
+      application_form = current_candidate.current_application
+      @qualification = OtherQualificationForm.build_from_application(
+        application_form,
+        current_other_qualification_id,
+      )
+    end
+
+    def destroy
+      current_candidate.current_application
+        .application_qualifications
+        .find(current_other_qualification_id)
+        .destroy!
+
+      redirect_to candidate_interface_review_other_qualifications_path
+    end
+
+  private
+
+    def current_other_qualification_id
+      params.permit(:id)[:id]
+    end
+  end
+end

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -14,15 +14,27 @@ module CandidateInterface
     class << self
       def build_all_from_application(application_form)
         application_form.application_qualifications.other.map do |qualification|
-          new(
-            id: qualification.id,
-            qualification_type: qualification.qualification_type,
-            subject: qualification.subject,
-            institution_name: qualification.institution_name,
-            grade: qualification.grade,
-            award_year: qualification.award_year,
-          )
+          new_other_qualification_form(qualification)
         end
+      end
+
+      def build_from_application(application_form, qualification_id)
+        qualification = application_form.application_qualifications.find(qualification_id)
+
+        new_other_qualification_form(qualification)
+      end
+
+    private
+
+      def new_other_qualification_form(qualification)
+        new(
+          id: qualification.id,
+          qualification_type: qualification.qualification_type,
+          subject: qualification.subject,
+          institution_name: qualification.institution_name,
+          grade: qualification.grade,
+          award_year: qualification.award_year,
+        )
       end
     end
 

--- a/app/views/candidate_interface/other_qualifications/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/other_qualifications/destroy/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, page_title(:destroy_other_qualification) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification, url: candidate_interface_confirm_destroy_other_qualification_path(@qualification.id), method: :delete do |f| %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @qualification.title %></span>
+            <%= t('page_titles.destroy_other_qualification') %>
+          </h1>
+        </legend>
+
+        <%= f.submit t('application_form.other_qualification.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to 'Cancel', candidate_interface_review_other_qualifications_path %>
+        </p>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -6,3 +6,5 @@
 </h1>
 
 <%= render(OtherQualificationsReviewComponent, application_form: @application_form) %>
+
+<%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_new_other_qualification_path, class: 'govuk-button--secondary' %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -156,6 +156,8 @@ en:
         button: Save and continue
       another:
         button: Add another qualification
+      delete: Delete qualification
+      confirm_delete: Yes I’m sure - delete this qualification
   activemodel:
     errors:
       models:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -154,6 +154,8 @@ en:
         change_action: year
       base:
         button: Save and continue
+      another:
+        button: Add another qualification
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
     edit_degree: Edit degree
     other_qualification: Other relevant academic and non-academic qualifications
     add_other_qualification: Other relevant qualifications
+    destroy_other_qualification: Are you sure you want to delete this qualification?
   layout:
     service_name: Apply for teacher training
     phase_banner_text: This is a development version of a new service. The data is not real and parts may not work yet.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,6 +93,9 @@ Rails.application.routes.draw do
         post '/' => 'other_qualifications/base#create', as: :create_other_qualification
 
         get '/review' => 'other_qualifications/review#show', as: :review_other_qualifications
+
+        get '/delete/:id' => 'other_qualifications/destroy#confirm_destroy', as: :confirm_destroy_other_qualification
+        delete '/delete/:id' => 'other_qualifications/destroy#destroy'
       end
     end
   end

--- a/spec/components/other_qualifications_review_component_spec.rb
+++ b/spec/components/other_qualifications_review_component_spec.rb
@@ -56,4 +56,11 @@ RSpec.describe OtherQualificationsReviewComponent do
     expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
     expect(result.css('.app-summary-card__title').text).to include('A-Level Making Cat Sounds')
   end
+
+  it 'renders component along with a delete link for each degree' do
+    result = render_inline(OtherQualificationsReviewComponent, application_form: application_form)
+
+    expect(result.css('.app-summary-card__actions').text).to include(t('application_form.other_qualification.delete'))
+    expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include('#')
+  end
 end

--- a/spec/components/other_qualifications_review_component_spec.rb
+++ b/spec/components/other_qualifications_review_component_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe OtherQualificationsReviewComponent do
     result = render_inline(OtherQualificationsReviewComponent, application_form: application_form)
 
     expect(result.css('.app-summary-card__actions').text).to include(t('application_form.other_qualification.delete'))
-    expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include('#')
+    expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
+      Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(2),
+    )
   end
 end

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -94,6 +94,28 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     end
   end
 
+  describe '.build_from_application' do
+    it 'returns a new OtherQualificationForm object using the id' do
+      application_form = create(:application_form) do |form|
+        form.application_qualifications.create(
+          id: 1,
+          level: 'other',
+          qualification_type: 'BTEC',
+          subject: 'Being a Sidekick',
+          institution_name: 'School of Sidekicks',
+          grade: 'Merit',
+          predicted_grade: false,
+          award_year: '2010',
+        )
+        form.application_qualifications.create(id: 2, level: 'other')
+      end
+
+      qualification = CandidateInterface::OtherQualificationForm.build_from_application(application_form, 1)
+
+      expect(qualification).to have_attributes(qualification_type: 'BTEC', subject: 'Being a Sidekick')
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       qualification = CandidateInterface::OtherQualificationForm.new

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -21,6 +21,13 @@ RSpec.feature 'Entering their other qualifications' do
     when_i_fill_in_my_qualification
     and_i_submit_the_other_qualification_form
     then_i_can_check_my_qualification
+
+    when_i_click_on_add_another_qualification
+    then_i_see_the_other_qualifications_form
+
+    when_i_fill_in_another_qualification
+    and_i_submit_the_other_qualification_form
+    then_i_can_check_additional_qualification
   end
 
   def given_i_am_not_signed_in; end
@@ -73,5 +80,30 @@ RSpec.feature 'Entering their other qualifications' do
   def then_i_can_check_my_qualification
     expect(page).to have_content t('application_form.other_qualification.qualification.label')
     expect(page).to have_content 'A-Level Believing in the Heart of the Cards'
+  end
+
+  def when_i_click_on_add_another_qualification
+    click_link t('application_form.other_qualification.another.button')
+  end
+
+  def then_i_see_the_other_qualifications_form_with_some_details_of_my_last_autofilled
+    then_i_see_the_other_qualifications_form
+
+    expect(page).to have_selector("input[value='A-Level']")
+    expect(page).to have_selector("input[value='Yugi College']")
+    expect(page).to have_selector("input[value='2015']")
+  end
+
+  def when_i_fill_in_another_qualification
+    fill_in t('application_form.other_qualification.qualification_type.label'), with: 'A-Level'
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Losing to Yugi'
+    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Kaiba College'
+    fill_in t('application_form.other_qualification.grade.label'), with: 'C'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2016'
+  end
+
+  def then_i_can_check_additional_qualification
+    expect(page).to have_content t('application_form.other_qualification.qualification.label')
+    expect(page).to have_content 'A-Level Losing to Yugi'
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -28,6 +28,10 @@ RSpec.feature 'Entering their other qualifications' do
     when_i_fill_in_another_qualification
     and_i_submit_the_other_qualification_form
     then_i_can_check_additional_qualification
+
+    when_i_click_on_delete_my_additional_qualification
+    and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    then_i_can_only_see_my_qualification
   end
 
   def given_i_am_not_signed_in; end
@@ -105,5 +109,18 @@ RSpec.feature 'Entering their other qualifications' do
   def then_i_can_check_additional_qualification
     expect(page).to have_content t('application_form.other_qualification.qualification.label')
     expect(page).to have_content 'A-Level Losing to Yugi'
+  end
+
+  def when_i_click_on_delete_my_additional_qualification
+    click_link(t('application_form.other_qualification.delete'), match: :first)
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    click_button t('application_form.other_qualification.confirm_delete')
+  end
+
+  def then_i_can_only_see_my_qualification
+    then_i_can_check_my_qualification
+    expect(page).not_to have_content 'A-Level Losing to Yugi'
   end
 end


### PR DESCRIPTION
### Context

Currently, candidates can only add other relevant qualifications.

### Changes proposed in this pull request

This PR adds the ability to add another qualification by just adding an `Add another qualification` link on the review page that links to the form. In the prototype, we autofill some values but this a stretch goal according to the Trello card (however I would like to add this in but not in this PR).

Mainly this PR allows a candidate to delete a qualification by adding a `#build_from_application` for `OtherQualificationForm` and a link to the `OtherQualificationsReviewComponent`.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68388525-c01b8400-0158-11ea-8d2b-c096f1dfd6e1.png)

![image](https://user-images.githubusercontent.com/42817036/68388545-ca3d8280-0158-11ea-8369-b79b964816f0.png)

![image](https://user-images.githubusercontent.com/42817036/68388558-d1fd2700-0158-11ea-8771-594cd757307c.png)

### Guidance to review

Go through commits and try it out.

### Link to Trello card

[204 - Adding other qualifications](https://trello.com/c/qU3R6EVL/204-adding-other-qualifications)
