### PR TITLE
Add ability to edit an other qualification

### DIFF
--- a/app/components/other_qualifications_review_component.rb
+++ b/app/components/other_qualifications_review_component.rb
@@ -25,7 +25,7 @@ private
       key: t('application_form.other_qualification.qualification.label'),
       value: [qualification.title, qualification.institution_name],
       action: t('application_form.other_qualification.qualification.change_action'),
-      change_path: '#',
+      change_path: Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id),
     }
   end
 
@@ -34,7 +34,7 @@ private
       key: t('application_form.other_qualification.award_year.review_label'),
       value: qualification.award_year,
       action: t('application_form.other_qualification.award_year.change_action'),
-      change_path: '#',
+      change_path: Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id),
     }
   end
 
@@ -43,7 +43,7 @@ private
       key: t('application_form.other_qualification.grade.label'),
       value: qualification.grade,
       action: t('application_form.other_qualification.grade.change_action'),
-      change_path: '#',
+      change_path: Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id),
     }
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -15,7 +15,27 @@ module CandidateInterface
       end
     end
 
+    def edit
+      application_form = current_candidate.current_application
+      @qualification = OtherQualificationForm.build_from_application(application_form, current_other_qualification_id)
+    end
+
+    def update
+      @qualification = OtherQualificationForm.new(other_qualification_params)
+      application_form = current_candidate.current_application
+
+      if @qualification.update(application_form)
+        redirect_to candidate_interface_review_other_qualifications_path
+      else
+        render :edit
+      end
+    end
+
   private
+
+    def current_other_qualification_id
+      params.permit(:id)[:id]
+    end
 
     def other_qualification_params
       params.require(:candidate_interface_other_qualification_form).permit(

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -54,6 +54,21 @@ module CandidateInterface
       true
     end
 
+    def update(application_form)
+      return false unless valid?
+
+      qualification = application_form.application_qualifications.find(id)
+
+      qualification.update!(
+        qualification_type: qualification_type,
+        subject: subject,
+        institution_name: institution_name,
+        grade: grade,
+        predicted_grade: false,
+        award_year: award_year,
+      )
+    end
+
     def title
       "#{qualification_type} #{subject}"
     end

--- a/app/views/candidate_interface/other_qualifications/base/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/_form.html.erb
@@ -1,0 +1,15 @@
+<p class="govuk-body">
+  Enter your other qualifications as completely as you can, including all
+  your GCSEs, A levels, and undergraduate and postgraduate degrees.
+</p>
+<p class="govuk-body">
+  You should also tell us about your vocational, practical and creative qualifications.
+</p>
+
+<%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.hint_text') %>
+<%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
+<%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
+<%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
+<%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, width: 4 %>
+
+<%= f.govuk_submit t('application_form.other_qualification.base.button') %>

--- a/app/views/candidate_interface/other_qualifications/base/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, page_title(:edit_other_qualification) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification, url: candidate_interface_edit_other_qualification_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('page_titles.edit_other_qualification') %>
+          </h1>
+        </legend>
+
+        <%= f.hidden_field :id, value: @qualification.id %>
+        <%= render 'form', f: f %>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/other_qualifications/base/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/new.html.erb
@@ -13,21 +13,7 @@
           </h1>
         </legend>
 
-        <p class="govuk-body">
-          Enter your other qualifications as completely as you can, including all
-          your GCSEs, A levels, and undergraduate and postgraduate degrees.
-        </p>
-        <p class="govuk-body">
-          You should also tell us about your vocational, practical and creative qualifications.
-        </p>
-
-        <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.hint_text') %>
-        <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
-        <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
-        <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
-        <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, width: 4 %>
-
-        <%= f.govuk_submit t('application_form.other_qualification.base.button') %>
+        <%= render 'form', f: f %>
       </fieldset>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
     edit_degree: Edit degree
     other_qualification: Other relevant academic and non-academic qualifications
     add_other_qualification: Other relevant qualifications
+    edit_other_qualification: Other relevant qualifications
     destroy_other_qualification: Are you sure you want to delete this qualification?
   layout:
     service_name: Apply for teacher training

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,9 @@ Rails.application.routes.draw do
 
         get '/review' => 'other_qualifications/review#show', as: :review_other_qualifications
 
+        get '/edit/:id' => 'other_qualifications/base#edit', as: :edit_other_qualification
+        post '/edit/:id' => 'other_qualifications/base#update'
+
         get '/delete/:id' => 'other_qualifications/destroy#confirm_destroy', as: :confirm_destroy_other_qualification
         delete '/delete/:id' => 'other_qualifications/destroy#destroy'
       end

--- a/spec/components/other_qualifications_review_component_spec.rb
+++ b/spec/components/other_qualifications_review_component_spec.rb
@@ -28,7 +28,9 @@ RSpec.describe OtherQualificationsReviewComponent do
     expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
     expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.qualification.label'))
     expect(result.css('.govuk-summary-list__value').to_html).to include('A-Level Making Doggo Sounds<br>Doggo Sounds College')
-    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include('#')
+    expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
+      Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(1),
+    )
     expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.qualification.change_action')}")
   end
 

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -140,6 +140,42 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     end
   end
 
+  describe '#update' do
+    it 'returns false if not valid' do
+      qualification = CandidateInterface::OtherQualificationForm.new
+
+      expect(qualification.update(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm if valid' do
+      form_data = {
+        id: 1,
+        qualification_type: 'BTEC',
+        subject: 'Being a Everyday Hero',
+        institution_name: 'School of Humans',
+        grade: 'Distinction',
+        award_year: '2011',
+      }
+      qualification = CandidateInterface::OtherQualificationForm.new(form_data)
+      application_form = create(:application_form) do |form|
+        form.application_qualifications.create(
+          id: 1,
+          level: 'other',
+          qualification_type: 'BTEC',
+          subject: 'Being a Everyday Hero',
+          institution_name: 'School of Hoomans',
+          grade: 'Pass',
+          predicted_grade: false,
+          award_year: '2011',
+        )
+      end
+
+      expect(qualification.update(application_form)).to eq(true)
+      expect(application_form.application_qualifications.other.first)
+        .to have_attributes(form_data)
+    end
+  end
+
   describe '#title' do
     it 'concatenates the qualification type and subject' do
       qualification = CandidateInterface::OtherQualificationForm.new(qualification_type: 'BTEC', subject: 'Being a Supervillain')

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -32,6 +32,13 @@ RSpec.feature 'Entering their other qualifications' do
     when_i_click_on_delete_my_additional_qualification
     and_i_confirm_that_i_want_to_delete_my_additional_qualification
     then_i_can_only_see_my_qualification
+
+    when_i_click_to_change_my_qualification
+    then_i_see_my_qualification_filled_in
+
+    when_i_change_my_qualification
+    and_i_submit_the_other_qualification_form
+    then_i_can_check_my_revised_qualification
   end
 
   def given_i_am_not_signed_in; end
@@ -122,5 +129,25 @@ RSpec.feature 'Entering their other qualifications' do
   def then_i_can_only_see_my_qualification
     then_i_can_check_my_qualification
     expect(page).not_to have_content 'A-Level Losing to Yugi'
+  end
+
+  def when_i_click_to_change_my_qualification
+    first('.govuk-summary-list__actions').click_link 'Change'
+  end
+
+  def then_i_see_my_qualification_filled_in
+    expect(page).to have_selector("input[value='A-Level']")
+    expect(page).to have_selector("input[value='Believing in the Heart of the Cards']")
+    expect(page).to have_selector("input[value='Yugi College']")
+    expect(page).to have_selector("input[value='A']")
+    expect(page).to have_selector("input[value='2015']")
+  end
+
+  def when_i_change_my_qualification
+    fill_in t('application_form.other_qualification.subject.label'), with: 'How to Win Against Kaiba'
+  end
+
+  def then_i_can_check_my_revised_qualification
+    expect(page).to have_content 'A-Level How to Win Against Kaiba'
   end
 end


### PR DESCRIPTION
### Context

Currently, candidates can only add and delete other relevant qualifications, they should also be able to change their answers.

### Changes proposed in this pull request

This PR adds the ability to edit an other relevant qualification by adding an `#update` method for `OtherQualifcationForm`.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68398001-f8788d80-016b-11ea-82c1-5319fd5e99b6.png)

![image](https://user-images.githubusercontent.com/42817036/68399560-78075c00-016e-11ea-9d02-3df2c7e7699c.png)

![image](https://user-images.githubusercontent.com/42817036/68399588-85244b00-016e-11ea-9f8d-ed0d946e2c5a.png)

### Guidance to review

Go through commits and try it out.

### Link to Trello card

[204 - Adding other qualifications](https://trello.com/c/qU3R6EVL/204-adding-other-qualifications)
