### PR TITLE
Quickfix - Handle the case in which provider 'ABC' exists

### DIFF
--- a/app/services/generate_test_data.rb
+++ b/app/services/generate_test_data.rb
@@ -70,10 +70,9 @@ private
   end
 
   def fake_provider
-    Provider.find_or_create_by(
-      name: 'Example Training Provider',
-      code: 'ABC',
-    )
+    Provider.find_or_create_by(code: 'ABC') do |provider|
+      provider.name = 'Example Training Provider'
+    end
   end
 
   def random_code(klass, provider)

--- a/spec/services/generate_test_data_spec.rb
+++ b/spec/services/generate_test_data_spec.rb
@@ -41,6 +41,11 @@ RSpec.describe GenerateTestData do
       expect { GenerateTestData.new(1, provider).generate }.to change { ApplicationForm.count }.by(1)
     end
 
+    it 'does not throw an error and creates an application when there is a duplicate provider code' do
+      create(:provider, code: 'ABC', name: 'Some other name')
+      expect { GenerateTestData.new(1).generate }.to change { ApplicationForm.count }.by(1)
+    end
+
     it 'associates application forms to candidates with matching email addresses' do
       GenerateTestData.new(1, create(:provider, code: 'DEF')).generate
       application_form = ApplicationForm.first


### PR DESCRIPTION
`GenerateTestData` hits a uniqueness constraint if you have an existing provider with code `ABC` and a different name.

### Context

This is just a quickfix to address an issue that we found in development.

### Changes proposed in this pull request

If a `Provider` with `code` `ABC` exists use that regardless of it's original `name`.

### Guidance to review

- Does the test adequately describe the problem?
- Does it matter if the test provider is given a different name? i.e. is there any code that looks it up by name? (I didn't find any).

### Link to Trello card

No card for this one

### Env vars

No
