### PR TITLE
Edit existing gcse qualifications

### DIFF
--- a/app/components/gcse_qualification_review_component.rb
+++ b/app/components/gcse_qualification_review_component.rb
@@ -1,6 +1,7 @@
 class GcseQualificationReviewComponent < ActionView::Component::Base
-  def initialize(application_qualification:)
+  def initialize(application_qualification:, subject:)
     @application_qualification = application_qualification
+    @subject = subject
   end
 
   def gcse_qualification_rows
@@ -13,13 +14,13 @@ class GcseQualificationReviewComponent < ActionView::Component::Base
 
 private
 
-  attr_reader :application_qualification
+  attr_reader :application_qualification, :subject
 
   def qualification_row
     {
       key: t('application_form.degree.qualification.label'),
-      value: application_qualification.qualification_type.upcase,
-      change_path: 'edit_qualification_details_path',
+      value: gcse_qualification_types[application_qualification.qualification_type.to_sym],
+      change_path: candidate_interface_gcse_details_edit_type_path(subject: subject),
     }
   end
 
@@ -27,7 +28,7 @@ private
     {
       key: 'Year awarded',
       value: application_qualification.award_year,
-      change_path: 'edit_qualification_details_path',
+      change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
     }
   end
 
@@ -35,7 +36,16 @@ private
     {
       key: 'Grade',
       value: application_qualification.grade,
-      change_path: 'edit_qualification_details_path',
+      change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
+    }
+  end
+
+  def gcse_qualification_types
+    {
+      gcse: 'GCSE',
+      gce_o_level: 'GCE O Level',
+      scottish_higher: 'Scottish Higher',
+      other_uk: 'Other UK qualification',
     }
   end
 end

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -4,14 +4,18 @@ module CandidateInterface
 
     # 2nd step - Edit grade and award year
     def edit
-      @application_qualification = GcseQualificationDetailsForm.build_from_qualification(current_qualification)
+      @application_qualification = GcseQualificationDetailsForm.build_from_qualification(
+        current_application.qualification_in_subject(:gcse, subject_param),
+      )
     end
 
     def update
-      details_form = GcseQualificationDetailsForm.build_from_qualification(current_qualification)
+      details_form = GcseQualificationDetailsForm.build_from_qualification(
+        current_application.qualification_in_subject(:gcse, subject_param),
+      )
 
-      details_form.grade = params[:candidate_interface_gcse_qualification_details_form][:grade]
-      details_form.award_year = params[:candidate_interface_gcse_qualification_details_form][:award_year]
+      details_form.grade = details_params[:grade]
+      details_form.award_year = details_params[:award_year]
 
       @application_qualification = details_form.save_base
 
@@ -24,12 +28,6 @@ module CandidateInterface
       end
     end
 
-    def review
-      @application_qualification = ApplicationQualification.last
-
-      render :review
-    end
-
   private
 
     def set_subject
@@ -40,12 +38,8 @@ module CandidateInterface
       params.require(:subject)
     end
 
-    def current_qualification
-      current_candidate
-        .current_application
-        .application_qualifications
-        .where(level: ApplicationQualification.levels[:gcse], subject: subject_param)
-        .first
+    def details_params
+      params.require(:candidate_interface_gcse_qualification_details_form).permit(%i[grade award_year])
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -4,30 +4,23 @@ module CandidateInterface
 
     # 2nd step - Edit grade and award year
     def edit
-      application_qualification = ApplicationQualification.last
-
-      @application_qualification = GcseQualificationDetailsForm.new(
-        grade: application_qualification.grade,
-        award_year: application_qualification.award_year,
-      )
+      @application_qualification = GcseQualificationDetailsForm.build_from_qualification(current_qualification)
     end
 
     def update
-      current_application_qualification = ApplicationQualification.last
+      details_form = GcseQualificationDetailsForm.build_from_qualification(current_qualification)
 
-      details_form = GcseQualificationDetailsForm.new(
-        grade: params[:candidate_interface_gcse_qualification_details_form][:grade],
-        award_year: params[:candidate_interface_gcse_qualification_details_form][:award_year],
-      )
+      details_form.grade = params[:candidate_interface_gcse_qualification_details_form][:grade]
+      details_form.award_year = params[:candidate_interface_gcse_qualification_details_form][:award_year]
 
-      @application_qualification = details_form.save_base(current_application_qualification)
+      @application_qualification = details_form.save_base
 
       if @application_qualification
         redirect_to candidate_interface_gcse_review_path
       else
         @application_qualification = details_form
 
-        render :edit_details
+        render :edit
       end
     end
 
@@ -45,6 +38,14 @@ module CandidateInterface
 
     def subject_param
       params.require(:subject)
+    end
+
+    def current_qualification
+      current_candidate
+        .current_application
+        .application_qualifications
+        .where(level: ApplicationQualification.levels[:gcse], subject: subject_param)
+        .first
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :set_subject
 
     def show
-      @application_qualification = ApplicationQualification.last
+      @application_qualification = current_qualification
     end
 
   private
@@ -14,6 +14,14 @@ module CandidateInterface
 
     def subject_param
       params.require(:subject)
+    end
+
+    def current_qualification
+      current_candidate
+        .current_application
+        .application_qualifications
+        .where(level: ApplicationQualification.levels[:gcse], subject: subject_param)
+        .first
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :set_subject
 
     def show
-      @application_qualification = current_qualification
+      @application_qualification = current_application.qualification_in_subject(:gcse, subject_param)
     end
 
   private
@@ -14,14 +14,6 @@ module CandidateInterface
 
     def subject_param
       params.require(:subject)
-    end
-
-    def current_qualification
-      current_candidate
-        .current_application
-        .application_qualifications
-        .where(level: ApplicationQualification.levels[:gcse], subject: subject_param)
-        .first
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -4,10 +4,14 @@ module CandidateInterface
 
     # 1th step - Edit qualification type
     def edit
-      @application_qualification = GcseQualificationTypeForm.new(
-        subject: subject_param,
-        level: ApplicationQualification.levels[:gcse],
-      )
+      @application_qualification = if current_qualification
+                                     GcseQualificationTypeForm.build_from_qualification(current_qualification)
+                                   else
+                                     GcseQualificationTypeForm.new(
+                                       subject: subject_param,
+                                       level: ApplicationQualification.levels[:gcse],
+                                       )
+                                   end
     end
 
     def update
@@ -34,6 +38,13 @@ module CandidateInterface
 
     def qualification_type_param
       (params[:candidate_interface_gcse_qualification_type_form] || {}).fetch(:qualification_type, '')
+    end
+
+    def current_qualification
+      current_candidate
+        .current_application
+        .application_qualifications
+        .find_by(level: ApplicationQualification.levels[:gcse], subject: subject_param)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -15,11 +15,17 @@ module CandidateInterface
     end
 
     def update
-      @application_qualification = GcseQualificationTypeForm.new(qualification_type: qualification_type_param,
-                                                                 subject: subject_param,
-                                                                 level: ApplicationQualification.levels[:gcse])
+      if current_qualification
+        @application_qualification = GcseQualificationTypeForm.build_from_qualification(current_qualification)
+      else
+        @application_qualification ||= GcseQualificationTypeForm.new(subject: subject_param, level: ApplicationQualification.levels[:gcse])
+      end
 
-      if @application_qualification.save_base(current_application)
+      @application_qualification.qualification_type = qualification_type_param
+
+      application_form = current_candidate.current_application
+
+      if @application_qualification.save_base(application_form)
         redirect_to candidate_interface_gcse_details_edit_details_path
       else
         render :edit
@@ -44,7 +50,8 @@ module CandidateInterface
       current_candidate
         .current_application
         .application_qualifications
-        .find_by(level: ApplicationQualification.levels[:gcse], subject: subject_param)
+        .where(level: ApplicationQualification.levels[:gcse], subject: subject_param)
+        .first
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -4,28 +4,14 @@ module CandidateInterface
 
     # 1th step - Edit qualification type
     def edit
-      @application_qualification = if current_qualification
-                                     GcseQualificationTypeForm.build_from_qualification(current_qualification)
-                                   else
-                                     GcseQualificationTypeForm.new(
-                                       subject: subject_param,
-                                       level: ApplicationQualification.levels[:gcse],
-                                       )
-                                   end
+      @application_qualification = find_or_build_qualification_form
     end
 
     def update
-      if current_qualification
-        @application_qualification = GcseQualificationTypeForm.build_from_qualification(current_qualification)
-      else
-        @application_qualification ||= GcseQualificationTypeForm.new(subject: subject_param, level: ApplicationQualification.levels[:gcse])
-      end
+      @application_qualification = find_or_build_qualification_form
+      @application_qualification.qualification_type = qualification_type
 
-      @application_qualification.qualification_type = qualification_type_param
-
-      application_form = current_candidate.current_application
-
-      if @application_qualification.save_base(application_form)
+      if @application_qualification.save_base(current_candidate.current_application)
         redirect_to candidate_interface_gcse_details_edit_details_path
       else
         render :edit
@@ -33,6 +19,19 @@ module CandidateInterface
     end
 
   private
+
+    def find_or_build_qualification_form
+      current_qualification = current_application.qualification_in_subject(:gcse, subject_param)
+
+      if current_qualification
+        GcseQualificationTypeForm.build_from_qualification(current_qualification)
+      else
+        GcseQualificationTypeForm.new(
+          subject: subject_param,
+          level: ApplicationQualification.levels[:gcse],
+        )
+      end
+    end
 
     def set_subject
       @subject = subject_param
@@ -42,16 +41,8 @@ module CandidateInterface
       params.require(:subject)
     end
 
-    def qualification_type_param
-      (params[:candidate_interface_gcse_qualification_type_form] || {}).fetch(:qualification_type, '')
-    end
-
-    def current_qualification
-      current_candidate
-        .current_application
-        .application_qualifications
-        .where(level: ApplicationQualification.levels[:gcse], subject: subject_param)
-        .first
+    def qualification_type
+      params.dig(:candidate_interface_gcse_qualification_type_form, :qualification_type)
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -16,5 +16,12 @@ class ApplicationForm < ApplicationRecord
     references.any? && references.all?(&:complete?)
   end
 
+  def qualification_in_subject(level, subject)
+    application_qualifications
+      .where(level: level, subject: subject)
+      .order(created_at: 'asc')
+      .first
+  end
+
   audited
 end

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -2,11 +2,21 @@ module CandidateInterface
   class GcseQualificationDetailsForm
     include ActiveModel::Model
 
-    attr_accessor :grade, :award_year
-    validates :grade, :award_year, presence: true
+    attr_accessor :grade, :award_year, :qualification_id
+    validates :grade, :award_year, :qualification_id, presence: true
 
-    def save_base(qualification)
+    def self.build_from_qualification(qualification)
+      new(
+        grade: qualification.grade,
+        award_year: qualification.award_year,
+        qualification_id: qualification.id,
+        )
+    end
+
+    def save_base
       return false unless valid?
+
+      qualification = ApplicationQualification.find(qualification_id)
 
       qualification.update!(grade: grade, award_year: award_year)
     end

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -4,6 +4,7 @@ module CandidateInterface
 
     attr_accessor :grade, :award_year, :qualification_id
     validates :grade, :award_year, :qualification_id, presence: true
+    validate :validate_award_year_is_date, if: :award_year
 
     def self.build_from_qualification(qualification)
       new(
@@ -18,7 +19,14 @@ module CandidateInterface
 
       qualification = ApplicationQualification.find(qualification_id)
 
-      qualification.update!(grade: grade, award_year: award_year)
+      qualification.update(grade: grade, award_year: award_year)
+    end
+
+  private
+
+    def validate_award_year_is_date
+      valid_award_year = award_year.match(/^[1-9]\d{3}$/)
+      errors.add(:award_year, :invalid) unless valid_award_year
     end
   end
 end

--- a/app/models/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_type_form.rb
@@ -9,11 +9,11 @@ module CandidateInterface
       return false unless valid?
 
       if new_record?
-        application_form.application_qualifications.create!(
+        application_form.application_qualifications.create(
           level: level,
           subject: subject,
           qualification_type: qualification_type,
-          )
+        )
       else
         qualification = ApplicationQualification.find(qualification_id)
 
@@ -23,8 +23,6 @@ module CandidateInterface
           qualification_type: qualification_type,
         )
       end
-
-      true
     end
 
     def self.build_from_qualification(qualification)

--- a/app/models/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_type_form.rb
@@ -2,18 +2,42 @@ module CandidateInterface
   class GcseQualificationTypeForm
     include ActiveModel::Model
 
-    attr_accessor :subject, :level, :qualification_type
+    attr_accessor :subject, :level, :qualification_type, :qualification_id
     validates :subject, :level, :qualification_type, presence: true
 
     def save_base(application_form)
       return false unless valid?
 
-      application_form.application_qualifications.create!(
-        level: level,
-        subject: subject,
-        qualification_type: qualification_type,
+      if new_record?
+        application_form.application_qualifications.create!(
+          level: level,
+          subject: subject,
+          qualification_type: qualification_type,
+          )
+      else
+        qualification = ApplicationQualification.find(qualification_id)
+
+        qualification.update(
+          level: level,
+          subject: subject,
+          qualification_type: qualification_type,
         )
+      end
+
       true
+    end
+
+    def self.build_from_qualification(qualification)
+      new(
+        level: qualification.level,
+        subject: qualification.subject,
+        qualification_type: qualification.qualification_type,
+        qualification_id: qualification.id,
+      )
+    end
+
+    def new_record?
+      qualification_id.nil?
     end
   end
 end

--- a/app/views/candidate_interface/gcse/details/edit.html.erb
+++ b/app/views/candidate_interface/gcse/details/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, page_title('Grade and award year') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_details_edit_type_path, 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_details_edit_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -4,5 +4,5 @@
 <div class="govuk-grid-row">
   <h1 class="govuk-heading-xl"><%= heading_for_gcse_show(@subject) %></h1>
 
-  <%= render(GcseQualificationReviewComponent, application_qualification: @application_qualification) %>
+  <%= render(GcseQualificationReviewComponent, application_qualification: @application_qualification, subject: @subject) %>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -307,7 +307,8 @@ en:
             grade:
               blank: Enter the grade
             award_year:
-              blank: Enter the year
+              blank: Enter your graduation year
+              invalid: Enter a real graduation year
         candidate_interface/gcse_qualification_type_form:
           attributes:
             qualification_type:

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
   describe '#save_base' do
     it 'return false if not valid' do
       qualification = ApplicationQualification.new
+      form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
 
-      form = CandidateInterface::GcseQualificationDetailsForm.new({})
-      expect(form.save_base(qualification)).to eq(false)
+      expect(form.save_base).to eq(false)
     end
 
     it 'updates qualification details if valid' do

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -14,14 +14,16 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
       expect(form.save_base(qualification)).to eq(false)
     end
 
-    it 'save qualification details if valid' do
+    it 'updates qualification details if valid' do
       application_form = create(:application_form)
-
       qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)
+      details_form = CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
 
-      details_form = CandidateInterface::GcseQualificationDetailsForm.new(grade: 'AB', award_year: '1990')
+      details_form.grade = 'AB'
+      details_form.award_year = '1990'
 
-      details_form.save_base(qualification)
+      details_form.save_base
+      qualification.reload
 
       expect(qualification.grade).to eq('AB')
       expect(qualification.award_year).to eq('1990')

--- a/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -23,5 +23,40 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
 
       expect(gcse_qualification_type.save_base(application_form)).to eq(true)
     end
+
+    it 'builds the Form from the qualification model' do
+      application_form = create(:application_form)
+      qualification = application_form.application_qualifications.create!(
+        level: 'gcse',
+        subject: 'maths',
+        qualification_type: 'gcse',
+        )
+
+      form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+
+      expect(qualification.level).to eq 'gcse'
+      expect(qualification.subject).to eq 'maths'
+      expect(qualification.qualification_type).to eq 'gcse'
+      expect(qualification.id).to eq qualification.id
+      expect(form.new_record?).to be false
+    end
+
+
+    it 'update the existing qualification model' do
+      application_form = create(:application_form)
+      qualification = application_form.application_qualifications.create!(
+        level: 'gcse',
+        subject: 'maths',
+        qualification_type: 'gcse',
+        )
+
+      form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
+
+      form.qualification_type = 'gce_o_level'
+
+      form.save_base(application_form)
+
+      expect(qualification.reload.qualification_type).to eq 'gce_o_level'
+    end
   end
 end

--- a/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -18,10 +18,14 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
     it 'creates a new qualification if valid' do
       application_form = create(:application_form)
 
-      gcse_qualification_type = CandidateInterface::GcseQualificationTypeForm
-                                  .new(subject: 'maths', level: 'gcse', qualification_type: 'gsce')
+      form = CandidateInterface::GcseQualificationTypeForm
+                                  .new(subject: 'maths', level: 'gcse', qualification_type: 'gcse')
 
-      expect(gcse_qualification_type.save_base(application_form)).to eq(true)
+      form.save_base(application_form)
+
+      expect(form.subject).to eq('maths')
+      expect(form.level).to eq('gcse')
+      expect(form.qualification_type).to eq('gcse')
     end
 
     it 'builds the Form from the qualification model' do

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Candidate entering GCSE details' do
   include CandidateHelper
 
-  scenario 'Candidate submits their maths GCSE details' do
+  scenario 'Candidate submits their maths GCSE details and then update them' do
     given_i_am_signed_in
     and_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
@@ -16,22 +16,19 @@ RSpec.feature 'Candidate entering GCSE details' do
     when_i_fill_in_grade_and_year
     and_i_click_save_and_continue
 
-    then_i_see_the_review_for_maths_gcse
-    and_i_see_correct_grade_and_awarded_year
-  end
+    then_i_see_the_review_page_with_correct_details
 
-  scenario 'Candidate submits their type and then try to edit it' do
-    given_i_am_signed_in
-    and_i_visit_the_candidate_application_page
-    and_i_click_on_the_maths_gcse_link
-    then_i_see_the_add_gcse_maths_page
+    # Sub-scenario: Edit Type of Qualification
+    when_i_click_to_change_qualification_type
+    then_i_see_the_gcse_option_selected
 
-    when_i_select_gcse_option
+    when_i_select_a_different_qualification_type
     and_i_click_save_and_continue
-    then_i_see_add_grade_and_year_page
 
-    when_i_click_the_back_link
-    i_see_the_gcse_option_selected
+    and_i_edit_my_details
+    and_i_click_save_and_continue
+
+    then_i_see_the_review_page_with_updated_details
   end
 
   scenario 'Candidate does not provide a qualification level' do
@@ -66,15 +63,15 @@ RSpec.feature 'Candidate entering GCSE details' do
     choose('GCSE')
   end
 
+  def when_i_select_gce_option
+    choose('GCE O Level')
+  end
+
   def and_i_click_save_and_continue
     click_button 'Save and continue'
   end
 
   def and_i_do_not_select_any_gcse_option; end
-
-  def then_i_see_the_review_for_maths_gcse
-    expect(page).to have_content 'Maths GCSE or equivalent'
-  end
 
   def then_i_see_the_review_for_english_gcse
     expect(page).to have_content 'English GCSE or equivalent'
@@ -96,17 +93,26 @@ RSpec.feature 'Candidate entering GCSE details' do
     expect(page).to have_content t('gcse_edit_details.heading.maths')
   end
 
-  def and_i_see_correct_grade_and_awarded_year
-    expect(page).to have_content 'AB'
+  def then_i_see_the_review_page_with_correct_details
+    expect(page).to have_content 'Maths GCSE or equivalent'
+
+    expect(page).to have_content 'GCSE'
+    expect(page).to have_content 'AA'
     expect(page).to have_content '1990'
   end
 
+  def then_i_see_the_review_page_with_updated_details
+    expect(page).to have_content 'Scottish Higher'
+    expect(page).to have_content 'BB'
+    expect(page).to have_content '2000'
+  end
+
   def then_i_see_add_grade_and_year_page
-    expect(page).to have_content 'Maths qualification grade and year'
+    expect(page).to have_content t('gcse_edit_details.heading.maths')
   end
 
   def when_i_fill_in_grade_and_year
-    fill_in 'Enter your qualification grade', with: 'AB'
+    fill_in 'Enter your qualification grade', with: 'AA'
     fill_in 'Enter the year you gained your qualification', with: '1990'
   end
 
@@ -114,11 +120,20 @@ RSpec.feature 'Candidate entering GCSE details' do
     expect(page).to have_content 'Enter the type of qualification'
   end
 
-  def when_i_click_the_back_link
-    click_link 'Back'
+  def then_i_see_the_gcse_option_selected
+    expect(find_field('GCSE')).to be_checked
   end
 
-  def i_see_the_gcse_option_selected
-    expect(find_field('GCSE')).to be_checked
+  def when_i_select_a_different_qualification_type
+    choose('Scottish Higher')
+  end
+
+  def when_i_click_to_change_qualification_type
+    find_link('Change', href: candidate_interface_gcse_details_edit_type_path(subject: 'maths')).click
+  end
+
+  def and_i_edit_my_details
+    fill_in 'Enter your qualification grade', with: 'BB'
+    fill_in 'Enter the year you gained your qualification', with: '2000'
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -20,6 +20,20 @@ RSpec.feature 'Candidate entering GCSE details' do
     and_i_see_correct_grade_and_awarded_year
   end
 
+  scenario 'Candidate submits their type and then try to edit it' do
+    given_i_am_signed_in
+    and_i_visit_the_candidate_application_page
+    and_i_click_on_the_maths_gcse_link
+    then_i_see_the_add_gcse_maths_page
+
+    when_i_select_gcse_option
+    and_i_click_save_and_continue
+    then_i_see_add_grade_and_year_page
+
+    when_i_click_the_back_link
+    i_see_the_gcse_option_selected
+  end
+
   scenario 'Candidate does not provide a qualification level' do
     given_i_am_signed_in
     and_i_visit_the_candidate_application_page
@@ -98,5 +112,13 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   def then_i_see_the_qualification_type_error
     expect(page).to have_content 'Enter the type of qualification'
+  end
+
+  def when_i_click_the_back_link
+    click_link 'Back'
+  end
+
+  def i_see_the_gcse_option_selected
+    expect(find_field('GCSE')).to be_checked
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature 'Candidate entering GCSE details' do
 
     then_i_see_the_review_page_with_correct_details
 
-    # Sub-scenario: Edit Type of Qualification
     when_i_click_to_change_qualification_type
     then_i_see_the_gcse_option_selected
 


### PR DESCRIPTION
### Context

This PR allows to edit the existing GCSE qualifications (maths/English/science).

### Changes proposed in this pull request
Basically I am using the same principles we are using for the other forms.

Note: inside the form, I check if the `qualification_id` param exists, in that case, I make an update to the qualification model.

Note2: This might need some refactoring, but at the moment, since we are on MVP-focused mode, we prefer to bring some small tech debt and go faster.

### Guidance to review

Check the scenario that this PR is covering: `Candidate submits their maths GCSE details and then update them' 

### Link to Trello card
https://trello.com/c/eLRbW1Xo/301-editing-adding-maths-english-and-science-gcse-information
