### PR TITLE
Use `GOVUKDesignSystemFormBuilder` by default

### DIFF
--- a/app/views/candidate_interface/application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/application_form/submit_show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @further_information_form, url: candidate_interface_application_submit_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :post do |f| %>
+    <%= form_with model: @further_information_form, url: candidate_interface_application_submit_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_address_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/degrees/base/edit.html.erb
+++ b/app/views/candidate_interface/degrees/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @degree, url: candidate_interface_degrees_edit_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @degree, url: candidate_interface_degrees_edit_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/degrees/base/new_another.html.erb
+++ b/app/views/candidate_interface/degrees/base/new_another.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @degree, url: candidate_interface_degrees_create_base_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @degree, url: candidate_interface_degrees_create_base_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/degrees/base/new_undergraduate.html.erb
+++ b/app/views/candidate_interface/degrees/base/new_undergraduate.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @degree, url: candidate_interface_degrees_create_base_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @degree, url: candidate_interface_degrees_create_base_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/degrees/review/show.html.erb
+++ b/app/views/candidate_interface/degrees/review/show.html.erb
@@ -9,7 +9,7 @@
 
 <%= govuk_button_link_to t('application_form.degree.another.button'), candidate_interface_degrees_new_base_path, class: 'govuk-button--secondary' %>
 
-<%= form_with model: @application_form, url: candidate_interface_degrees_complete_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= form_with model: @application_form, url: candidate_interface_degrees_complete_path do |f| %>
   <div class='govuk-form-group'>
     <%= f.hidden_field :degrees_completed, value: false %>
     <%= f.govuk_check_box :degrees_completed, true, multiple: false, label: { text: t('application_form.degree.review.completed_checkbox') } %>

--- a/app/views/candidate_interface/gcse/details/edit.html.erb
+++ b/app/views/candidate_interface/gcse/details/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_details_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :patch do |f| %>
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_details_path, method: :patch do |f| %>
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
         <h1 class="govuk-fieldset__heading"><%= heading_for_gcse_edit_details(@subject) %></h1>
       </legend>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_type_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, method: :post do |f| %>
+    <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_type_path, method: :post do |f| %>
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
         <h1 class="govuk-fieldset__heading"><%= heading_for_gcse_edit_type(@subject) %></h1>
       </legend>

--- a/app/views/candidate_interface/other_qualifications/base/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @qualification, url: candidate_interface_edit_other_qualification_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @qualification, url: candidate_interface_edit_other_qualification_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/other_qualifications/base/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @qualification, url: candidate_interface_create_other_qualification_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @qualification, url: candidate_interface_create_other_qualification_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_update_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body-l">Enter the email address you used to register with, and we will send you a link to sign in.</p>
 
-    <%= form_with model: @candidate, url: candidate_interface_sign_in_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
+    <%= form_with model: @candidate, url: candidate_interface_sign_in_path, html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, type: :email, width: 'two-thirds' %>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -9,7 +9,7 @@
 
     <p class="govuk-body-l">Please give us your email address so that you can save and return to your application.</p>
 
-    <%= form_with model: @candidate, url: candidate_interface_sign_up_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
+    <%= form_with model: @candidate, url: candidate_interface_sign_up_path, html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint_text: t('authentication.sign_up.email_address.hint_label'), type: :email, width: 'two-thirds' %>

--- a/app/views/candidate_interface/work_history/edit/edit.html.erb
+++ b/app/views/candidate_interface/work_history/edit/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_experience_form, url: candidate_interface_work_history_edit_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @work_experience_form, url: candidate_interface_work_history_edit_path do |f| %>
       <fieldset class="govuk-fieldset">
         <%= f.govuk_error_summary %>
 

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_experience_form, url: candidate_interface_work_history_create_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @work_experience_form, url: candidate_interface_work_history_create_path do |f| %>
       <fieldset class="govuk-fieldset">
         <%= f.govuk_error_summary %>
 

--- a/app/views/candidate_interface/work_history/explanation/show.html.erb
+++ b/app/views/candidate_interface/work_history/explanation/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_explanation_form, url: candidate_interface_work_history_explanation_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @work_explanation_form, url: candidate_interface_work_history_explanation_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_details_form, url: candidate_interface_work_history_length_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @work_details_form, url: candidate_interface_work_history_length_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/work_history/review/show.html.erb
+++ b/app/views/candidate_interface/work_history/review/show.html.erb
@@ -13,7 +13,7 @@
   <%= govuk_button_link_to t('application_form.work_history.add_job'), candidate_interface_work_history_new_path, class: 'govuk-button--secondary' %>
 <% end %>
 
-<%= form_with model: @application_form, url: candidate_interface_work_history_complete_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= form_with model: @application_form, url: candidate_interface_work_history_complete_path do |f| %>
   <div class='govuk-form-group'>
     <%= f.hidden_field :work_history_completed, value: false %>
     <%= f.govuk_check_box :work_history_completed, true, multiple: false, label: { text: t('application_form.work_history.review.completed_checkbox') } %>

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'API tokens' %>
 <h1 class='govuk-heading-xl'>API tokens</h1>
 
-<%= form_with model: VendorApiToken.new, url: support_interface_api_tokens_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+<%= form_with model: VendorApiToken.new, url: support_interface_api_tokens_path do |f| %>
   <%= f.govuk_collection_select :provider_id, Provider.all, :id, :name, label: { text: 'Provider' } %>
   <%= f.govuk_submit 'Create new token' %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module ApplyForPostgraduateTeacherTraining
     config.providers_to_sync = config_for(:providers_to_sync)
 
     config.time_zone = 'London'
+
+    config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
   end
 end


### PR DESCRIPTION
### Context

We use `GOVUKDesignSystemFormBuilder`, and we need to tell Rails that we do.

### Changes proposed in this pull request

Setting it as the default means we don't have to specify it every. single. time.

### Guidance to review

Does it make sense?