### PR TITLE
Add 'current_application` helper

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -3,19 +3,19 @@ module CandidateInterface
     def show
       return redirect_to candidate_interface_application_form_path if params[:token]
 
-      if current_candidate.current_application.submitted?
-        @application_form = current_candidate.current_application
+      if current_application.submitted?
+        @application_form = current_application
 
         render :complete
       else
-        @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_candidate.current_application)
+        @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
 
         render :show
       end
     end
 
     def review
-      @application_form = current_candidate.current_application
+      @application_form = current_application
     end
 
     def submit_show
@@ -24,10 +24,9 @@ module CandidateInterface
 
     def submit
       @further_information_form = FurtherInformationForm.new(further_information_params)
-      application_form = current_candidate.current_application
 
-      if @further_information_form.save(application_form)
-        SubmitApplication.new(application_form).call
+      if @further_information_form.save(current_application)
+        SubmitApplication.new(current_application).call
 
         redirect_to candidate_interface_application_submit_success_path
       else
@@ -36,7 +35,7 @@ module CandidateInterface
     end
 
     def submit_success
-      @support_reference = current_candidate.current_application.support_reference
+      @support_reference = current_application.support_reference
     end
 
   private

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -13,5 +13,9 @@ module CandidateInterface
       super
       payload[:candidate_id] = current_candidate.id if current_candidate
     end
+
+    def current_application
+      @current_application ||= current_candidate.current_application
+    end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class ContactDetails::AddressController < CandidateInterfaceController
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
-        current_candidate.current_application,
+        current_application,
       )
     end
 
     def update
       @contact_details_form = ContactDetailsForm.new(contact_details_params)
 
-      if @contact_details_form.save_address(current_candidate.current_application)
+      if @contact_details_form.save_address(current_application)
         redirect_to candidate_interface_contact_details_review_path
       else
         render :edit

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -2,17 +2,16 @@ module CandidateInterface
   class ContactDetails::BaseController < CandidateInterfaceController
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
-        current_candidate.current_application,
+        current_application,
       )
     end
 
     def update
       @contact_details_form = ContactDetailsForm.new(contact_details_params)
-      application_form = current_candidate.current_application
 
-      if @contact_details_form.save_base(application_form)
+      if @contact_details_form.save_base(current_application)
         updated_contact_details_form = ContactDetailsForm.build_from_application(
-          application_form,
+          current_application,
         )
 
         if updated_contact_details_form.valid?(:address)

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class ContactDetails::ReviewController < CandidateInterfaceController
     def show
-      @application_form = current_candidate.current_application
+      @application_form = current_application
     end
   end
 end

--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -8,9 +8,8 @@ module CandidateInterface
 
     def create
       @degree = DegreeForm.new(degree_params)
-      application_form = current_candidate.current_application
 
-      if @degree.save(application_form)
+      if @degree.save(current_application)
         redirect_to candidate_interface_degrees_review_path
       else
         render_new
@@ -18,15 +17,13 @@ module CandidateInterface
     end
 
     def edit
-      application_form = current_candidate.current_application
-      @degree = DegreeForm.build_from_application(application_form, current_degree_id)
+      @degree = DegreeForm.build_from_application(current_application, current_degree_id)
     end
 
     def update
       @degree = DegreeForm.new(degree_params)
-      application_form = current_candidate.current_application
 
-      if @degree.update(application_form)
+      if @degree.update(current_application)
         redirect_to candidate_interface_degrees_review_path
       else
         render_new
@@ -47,7 +44,7 @@ module CandidateInterface
     end
 
     def render_new
-      degrees = DegreeForm.build_all_from_application(current_candidate.current_application)
+      degrees = DegreeForm.build_all_from_application(current_application)
 
       if degrees.count.zero?
         render :new_undergraduate

--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -1,12 +1,11 @@
 module CandidateInterface
   class Degrees::DestroyController < CandidateInterfaceController
     def confirm_destroy
-      application_form = current_candidate.current_application
-      @degree = DegreeForm.build_from_application(application_form, current_degree_id)
+      @degree = DegreeForm.build_from_application(current_application, current_degree_id)
     end
 
     def destroy
-      current_candidate.current_application
+      current_application
         .application_qualifications
         .find(current_degree_id)
         .destroy!

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -1,13 +1,11 @@
 module CandidateInterface
   class Degrees::ReviewController < CandidateInterfaceController
     def show
-      @application_form = current_candidate.current_application
+      @application_form = current_application
     end
 
     def complete
-      @application_form = current_candidate.current_application
-
-      @application_form.update!(application_form_params)
+      current_application.update!(application_form_params)
 
       redirect_to candidate_interface_application_form_path
     end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -15,9 +15,7 @@ module CandidateInterface
                                                                  subject: subject_param,
                                                                  level: ApplicationQualification.levels[:gcse])
 
-      application_form = current_candidate.current_application
-
-      if @application_qualification.save_base(application_form)
+      if @application_qualification.save_base(current_application)
         redirect_to candidate_interface_gcse_details_edit_details_path
       else
         render :edit

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -6,9 +6,8 @@ module CandidateInterface
 
     def create
       @qualification = OtherQualificationForm.new(other_qualification_params)
-      application_form = current_candidate.current_application
 
-      if @qualification.save(application_form)
+      if @qualification.save(current_application)
         redirect_to candidate_interface_review_other_qualifications_path
       else
         render :new
@@ -16,15 +15,13 @@ module CandidateInterface
     end
 
     def edit
-      application_form = current_candidate.current_application
-      @qualification = OtherQualificationForm.build_from_application(application_form, current_other_qualification_id)
+      @qualification = OtherQualificationForm.build_from_application(current_application, current_other_qualification_id)
     end
 
     def update
       @qualification = OtherQualificationForm.new(other_qualification_params)
-      application_form = current_candidate.current_application
 
-      if @qualification.update(application_form)
+      if @qualification.update(current_application)
         redirect_to candidate_interface_review_other_qualifications_path
       else
         render :edit

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -1,15 +1,14 @@
 module CandidateInterface
   class OtherQualifications::DestroyController < CandidateInterfaceController
     def confirm_destroy
-      application_form = current_candidate.current_application
       @qualification = OtherQualificationForm.build_from_application(
-        application_form,
+        current_application,
         current_other_qualification_id,
       )
     end
 
     def destroy
-      current_candidate.current_application
+      current_application
         .application_qualifications
         .find(current_other_qualification_id)
         .destroy!

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class OtherQualifications::ReviewController < CandidateInterfaceController
     def show
-      @application_form = current_candidate.current_application
+      @application_form = current_application
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
     def edit
       @personal_details_form = PersonalDetailsForm.build_from_application(
-        current_candidate.current_application,
+        current_application,
       )
     end
 
@@ -10,7 +10,7 @@ module CandidateInterface
       @personal_details_form = PersonalDetailsForm.new(personal_details_params)
       @personal_details_review = PersonalDetailsReviewPresenter.new(@personal_details_form)
 
-      if @personal_details_form.save(current_candidate.current_application)
+      if @personal_details_form.save(current_application)
         render :show
       else
         render :edit
@@ -19,7 +19,7 @@ module CandidateInterface
 
     def show
       personal_details_form = PersonalDetailsForm.build_from_application(
-        current_candidate.current_application,
+        current_application,
       )
       @personal_details_review = PersonalDetailsReviewPresenter.new(personal_details_form)
     end

--- a/app/controllers/candidate_interface/work_history/destroy_controller.rb
+++ b/app/controllers/candidate_interface/work_history/destroy_controller.rb
@@ -1,12 +1,12 @@
 module CandidateInterface
   class WorkHistory::DestroyController < CandidateInterfaceController
     def confirm_destroy
-      @work_experience = current_candidate.current_application
+      @work_experience = current_application
         .application_work_experiences.find(work_experience_params[:id])
     end
 
     def destroy
-      current_candidate.current_application
+      current_application
         .application_work_experiences
         .find(work_experience_params[:id])
         .destroy!

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     def create
       @work_experience_form = WorkExperienceForm.new(work_experience_form_params)
 
-      if @work_experience_form.save(current_candidate.current_application)
+      if @work_experience_form.save(current_application)
         redirect_to candidate_interface_work_history_show_path
       else
         render :new
@@ -15,13 +15,13 @@ module CandidateInterface
     end
 
     def edit
-      work_experience = current_candidate.current_application
+      work_experience = current_application
         .application_work_experiences.find(work_experience_params[:id])
       @work_experience_form = WorkExperienceForm.build_from_experience(work_experience)
     end
 
     def update
-      work_experience = current_candidate.current_application
+      work_experience = current_application
         .application_work_experiences
         .find(work_experience_params[:id])
       @work_experience_form = WorkExperienceForm.new(work_experience_form_params)

--- a/app/controllers/candidate_interface/work_history/explanation_controller.rb
+++ b/app/controllers/candidate_interface/work_history/explanation_controller.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class WorkHistory::ExplanationController < CandidateInterfaceController
     def show
       @work_explanation_form = WorkExplanationForm.build_from_application(
-        current_candidate.current_application,
+        current_application,
       )
     end
 
     def submit
       @work_explanation_form = WorkExplanationForm.new(work_explanation_form_params)
 
-      if @work_explanation_form.save(current_candidate.current_application)
+      if @work_explanation_form.save(current_application)
         redirect_to candidate_interface_work_history_show_path
       else
         render :show

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -1,13 +1,11 @@
 module CandidateInterface
   class WorkHistory::ReviewController < CandidateInterfaceController
     def show
-      @application_form = current_candidate.current_application
+      @application_form = current_application
     end
 
     def complete
-      @application_form = current_candidate.current_application
-
-      @application_form.update!(application_form_params)
+      current_application.update!(application_form_params)
 
       redirect_to candidate_interface_application_form_path
     end


### PR DESCRIPTION
### Context

In the candidate interface we often interact with the current application.

### Changes proposed in this pull request

Add a shortcut to the `current_application`.

### Guidance to review

Does this make sense? Have I missed opportunities to tidy up the controllers?
