### PR TITLE
Link to the course page from support

### DIFF
--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -22,7 +22,23 @@
     <% @providers.each do |provider| %>
       <tr class='govuk-table__row'>
         <td class='govuk-table__cell'><%= provider.name %> (<%= provider.code %>)</td>
-        <td class='govuk-table__cell'><%= provider.courses.size %></td>
+        <td class='govuk-table__cell'>
+          <details class='govuk-details' data-module='govuk-details'>
+            <summary class='govuk-details__summary'>
+              <span class='govuk-details__summary-text'>
+                <%= pluralize provider.courses.size, 'course' %>
+              </span>
+            </summary>
+            <div class='govuk-details__text'>
+              <ul class='govuk-list'>
+              <% provider.courses.each do |course| %>
+                <li><%= govuk_link_to course.name, candidate_interface_apply_path(providerCode: course.provider.code, courseCode: course.code) %></li>
+              <% end %>
+              </ul>
+            </div>
+          </details>
+
+        </td>
         <td class='govuk-table__cell'><%= provider.sites.size %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
### Context

We have a "launch" page for all courses in the system, [like this one](https://qa.apply-for-teacher-training.education.gov.uk/candidate/apply?courseCode=2392&providerCode=1N1). 

<img width="707" alt="Screenshot 2019-11-08 at 11 07 23" src="https://user-images.githubusercontent.com/233676/68472934-8a8a9f80-0219-11ea-9fc4-b9ed94bcdaa1.png">

While testing I couldn't find out how to see one since I didn't know provider and course codes.

### Changes proposed in this pull request

This adds a link to the "dual running" / course launch page for courses from the support page. This makes it easier to manually test the system.

<img width="952" alt="Screenshot 2019-11-08 at 11 16 34" src="https://user-images.githubusercontent.com/233676/68472803-3da6c900-0219-11ea-83a9-00563441b84a.png">

### Guidance to review

I haven't added explicit tests because it's a bit of a speculative feature that might be changed at some point.
