### PR TITLE
Add autofill when adding other qualifications

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -1,7 +1,17 @@
 module CandidateInterface
   class OtherQualifications::BaseController < CandidateInterfaceController
     def new
-      @qualification = OtherQualificationForm.new
+      qualifications = OtherQualificationForm.build_all_from_application(current_application)
+
+      @qualification = if qualifications.any?
+                         OtherQualificationForm.new(
+                           qualification_type: qualifications.last.qualification_type,
+                           institution_name: qualifications.last.institution_name,
+                           award_year: qualifications.last.award_year,
+                         )
+                       else
+                         OtherQualificationForm.new
+                       end
     end
 
     def create

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -13,7 +13,7 @@ module CandidateInterface
 
     class << self
       def build_all_from_application(application_form)
-        application_form.application_qualifications.other.map do |qualification|
+        application_form.application_qualifications.other.order(:created_at).map do |qualification|
           new_other_qualification_form(qualification)
         end
       end

--- a/spec/components/other_qualifications_review_component_spec.rb
+++ b/spec/components/other_qualifications_review_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe OtherQualificationsReviewComponent do
     expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
     expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.qualification.label'))
     expect(result.css('.govuk-summary-list__value').to_html).to include('A-Level Making Doggo Sounds<br>Doggo Sounds College')
-    expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
+    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
       Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(1),
     )
     expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.qualification.change_action')}")
@@ -63,7 +63,7 @@ RSpec.describe OtherQualificationsReviewComponent do
     result = render_inline(OtherQualificationsReviewComponent, application_form: application_form)
 
     expect(result.css('.app-summary-card__actions').text).to include(t('application_form.other_qualification.delete'))
-    expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
+    expect(result.css('.app-summary-card__actions a')[1].attr('href')).to include(
       Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(2),
     )
   end

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -58,6 +58,10 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     let(:application_form) do
       create(:application_form) do |form|
         form.application_qualifications.create(
+          level: 'other',
+          created_at: DateTime.new(2019, 1, 1, 1, 9, 0, 0),
+        )
+        form.application_qualifications.create(
           id: 1,
           level: 'other',
           qualification_type: 'BTEC',
@@ -66,6 +70,7 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
           grade: 'Distinction',
           predicted_grade: false,
           award_year: '2012',
+          created_at: DateTime.new(2019, 1, 1, 21, 0, 0),
         )
         form.application_qualifications.create(level: 'degree')
         form.application_qualifications.create(level: 'gcse')
@@ -75,7 +80,7 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     it 'creates an array of objects based on the provided ApplicationForm' do
       qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(application_form)
 
-      expect(qualifications).to match_array([
+      expect(qualifications).to include(
         have_attributes(
           id: 1,
           qualification_type: 'BTEC',
@@ -84,13 +89,22 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
           grade: 'Distinction',
           award_year: '2012',
         ),
-      ])
+      )
     end
 
     it 'only includes other qualifications and not degrees or GCSEs' do
       qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(application_form)
 
-      expect(qualifications.count).to eq(1)
+      expect(qualifications.count).to eq(2)
+    end
+
+    it 'orders other qualifications by created at' do
+      qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(application_form)
+
+      expect(qualifications.last).to have_attributes(
+        qualification_type: 'BTEC',
+        subject: 'Being a Superhero',
+      )
     end
   end
 

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Entering their other qualifications' do
     then_i_can_check_my_qualification
 
     when_i_click_on_add_another_qualification
-    then_i_see_the_other_qualifications_form
+    then_i_see_the_other_qualifications_form_with_some_details_of_my_last_autofilled
 
     when_i_fill_in_another_qualification
     and_i_submit_the_other_qualification_form
@@ -131,7 +131,9 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def when_i_click_on_delete_my_additional_qualification
-    click_link(t('application_form.other_qualification.delete'), match: :first)
+    within(all('.app-summary-card')[1]) do
+      click_link(t('application_form.other_qualification.delete'))
+    end
   end
 
   def and_i_confirm_that_i_want_to_delete_my_additional_qualification


### PR DESCRIPTION
### Context

It's likely that candidates will need to add a number of other qualifications.

### Changes proposed in this pull request

This PR adds autofill for `Type of Qualification`, `Institution where you studied` and `Year qualification was awarded` from their last created other relevant qualification when adding a new one.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68475077-05a28480-021f-11ea-83d6-1d20f20de901.png)

![image](https://user-images.githubusercontent.com/42817036/68475080-09360b80-021f-11ea-9d0d-723096f58070.png)

### Guidance to review

Smol edits had to be made on some specs as ordering had changed.

### Link to Trello card

[204 - Adding other qualifications](https://trello.com/c/qU3R6EVL/204-adding-other-qualifications)
