### PR TITLE
Provider Receive Application business rules

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -18,10 +18,6 @@ class ApplicationChoice < ApplicationRecord
       .having('count("references"."feedback") >= 2')
   }
 
-  # ApplicationChoice.joins(application_form: :references).where('feedback is not null').where('edit_by < ?', Time.zone.now)
-  #     .where(status: :application_complete)
-  #     .group('application_choices.id')
-  #     .having('count("references"."feedback") >= 2')
   enum status: {
     unsubmitted: 'unsubmitted',
     awaiting_references: 'awaiting_references',

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -9,15 +9,6 @@ class ApplicationChoice < ApplicationRecord
 
   audited associated_with: :application_form
 
-  scope :ready_to_send_to_provider, -> {
-    joins(application_form: :references)
-      .where('feedback is not null')
-      .where('edit_by < ?', Time.zone.now)
-      .where(status: :application_complete)
-      .group('application_choices.id')
-      .having('count("references"."feedback") >= 2')
-  }
-
   enum status: {
     unsubmitted: 'unsubmitted',
     awaiting_references: 'awaiting_references',

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -13,11 +13,15 @@ class ApplicationChoice < ApplicationRecord
     joins(application_form: :references)
       .where('feedback is not null')
       .where('edit_by < ?', Time.zone.now)
-      .where(state: :application_complete)
+      .where(status: :application_complete)
       .group('application_choices.id')
       .having('count("references"."feedback") >= 2')
   }
 
+  # ApplicationChoice.joins(application_form: :references).where('feedback is not null').where('edit_by < ?', Time.zone.now)
+  #     .where(status: :application_complete)
+  #     .group('application_choices.id')
+  #     .having('count("references"."feedback") >= 2')
   enum status: {
     unsubmitted: 'unsubmitted',
     awaiting_references: 'awaiting_references',

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -9,6 +9,15 @@ class ApplicationChoice < ApplicationRecord
 
   audited associated_with: :application_form
 
+  scope :ready_to_send_to_provider, -> {
+    joins(application_form: :references)
+      .where('feedback is not null')
+      .where('edit_by < ?', Time.zone.now)
+      .where(state: :application_complete)
+      .group('application_choices.id')
+      .having('count("references"."feedback") >= 2')
+  }
+
   enum status: {
     unsubmitted: 'unsubmitted',
     awaiting_references: 'awaiting_references',

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -23,6 +23,10 @@ class ApplicationChoice < ApplicationRecord
     withdrawn: 'withdrawn',
   }
 
+  def edit_by_expired?
+    edit_by.present? && edit_by < Time.zone.now
+  end
+
 private
 
   def generate_alphanumeric_id

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -8,12 +8,14 @@ class ApplicationForm < ApplicationRecord
   has_many :application_qualifications
   has_many :references
 
+  MINIMUM_REFERENCES = 2
+
   def submitted?
     application_choices.any? && !application_choices.first.unsubmitted?
   end
 
   def references_complete?
-    references.any? && references.all?(&:complete?)
+    references.select(&:complete?).count >= MINIMUM_REFERENCES
   end
 
   def qualification_in_subject(level, subject)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -8,14 +8,14 @@ class ApplicationForm < ApplicationRecord
   has_many :application_qualifications
   has_many :references
 
-  MINIMUM_REFERENCES = 2
+  MINIMUM_COMPLETE_REFERENCES = 2
 
   def submitted?
     application_choices.any? && !application_choices.first.unsubmitted?
   end
 
   def references_complete?
-    references.select(&:complete?).count >= MINIMUM_REFERENCES
+    references.select(&:complete?).count == MINIMUM_COMPLETE_REFERENCES
   end
 
   def qualification_in_subject(level, subject)

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -19,6 +19,7 @@ class ApplicationStateChange
 
     state :awaiting_references do
       event :references_complete, transitions_to: :application_complete
+      event :send_to_provider, transitions_to: :awaiting_provider_decision
       event :withdraw, transitions_to: :withdrawn
     end
 

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -18,10 +18,7 @@ class ApplicationStateChange
     end
 
     state :awaiting_references do
-      event :receive_reference, transitions_to: :application_complete,
-                                if: :references_complete?
-      event :receive_reference, transitions_to: :awaiting_references,
-                                unless: :references_complete?
+      event :references_complete, transitions_to: :application_complete
       event :withdraw, transitions_to: :withdrawn
     end
 
@@ -71,9 +68,5 @@ class ApplicationStateChange
 
   def self.valid_states
     workflow_spec.states.keys
-  end
-
-  def references_complete?
-    application_choice.application_form.references_complete?
   end
 end

--- a/app/services/get_application_choices_ready_to_send_to_provider.rb
+++ b/app/services/get_application_choices_ready_to_send_to_provider.rb
@@ -1,10 +1,20 @@
 class GetApplicationChoicesReadyToSendToProvider
   def self.call
-    ApplicationChoice
+    application_choices_past_edit_by(
+      application_choices_with_references_complete(
+        ApplicationChoice.where(status: :application_complete),
+      ),
+    )
+  end
+
+  def self.application_choices_past_edit_by(scope)
+    scope.where('edit_by < ?', Time.zone.now)
+  end
+
+  def self.application_choices_with_references_complete(scope)
+    scope
       .joins(application_form: :references)
       .where('feedback is not null')
-      .where('edit_by < ?', Time.zone.now)
-      .where(status: :application_complete)
       .group('application_choices.id')
       .having('count("references"."feedback") >= 2')
   end

--- a/app/services/get_application_choices_ready_to_send_to_provider.rb
+++ b/app/services/get_application_choices_ready_to_send_to_provider.rb
@@ -1,0 +1,11 @@
+class GetApplicationChoicesReadyToSendToProvider
+  def self.call
+    ApplicationChoice
+      .joins(application_form: :references)
+      .where('feedback is not null')
+      .where('edit_by < ?', Time.zone.now)
+      .where(status: :application_complete)
+      .group('application_choices.id')
+      .having('count("references"."feedback") >= 2')
+  end
+end

--- a/app/services/get_application_choices_ready_to_send_to_provider.rb
+++ b/app/services/get_application_choices_ready_to_send_to_provider.rb
@@ -1,10 +1,8 @@
 class GetApplicationChoicesReadyToSendToProvider
   def self.call
-    application_choices_past_edit_by(
-      application_choices_with_references_complete(
-        ApplicationChoice.where(status: :application_complete),
-      ),
-    )
+    scope = ApplicationChoice.where(status: :application_complete)
+    scope = application_choices_with_references_complete(scope)
+    application_choices_past_edit_by(scope)
   end
 
   def self.application_choices_past_edit_by(scope)
@@ -16,6 +14,6 @@ class GetApplicationChoicesReadyToSendToProvider
       .joins(application_form: :references)
       .where('feedback is not null')
       .group('application_choices.id')
-      .having('count("references"."feedback") >= ?', ApplicationForm::MINIMUM_REFERENCES)
+      .having('count("references"."feedback") >= ?', ApplicationForm::MINIMUM_COMPLETE_REFERENCES)
   end
 end

--- a/app/services/get_application_choices_ready_to_send_to_provider.rb
+++ b/app/services/get_application_choices_ready_to_send_to_provider.rb
@@ -16,6 +16,6 @@ class GetApplicationChoicesReadyToSendToProvider
       .joins(application_form: :references)
       .where('feedback is not null')
       .group('application_choices.id')
-      .having('count("references"."feedback") >= 2')
+      .having('count("references"."feedback") >= ?', ApplicationForm::MINIMUM_REFERENCES)
   end
 end

--- a/app/services/import_references_from_csv.rb
+++ b/app/services/import_references_from_csv.rb
@@ -41,17 +41,19 @@ class ImportReferencesFromCsv
   end
 
   def self.import_reference(application_form, referee_email, referee_feedback)
-    reference = ReceiveReference.new(
+    receive_reference = ReceiveReference.new(
       application_form: application_form,
       referee_email: referee_email,
       feedback: referee_feedback,
     )
 
+    updated = receive_reference.save
+
     {
       referee_email: referee_email,
       application_form: application_form,
       updated: updated,
-      errors: updated ? nil : reference.errors.full_messages,
+      errors: updated ? nil : receive_reference.errors.full_messages,
     }
   end
 end

--- a/app/services/import_references_from_csv.rb
+++ b/app/services/import_references_from_csv.rb
@@ -44,10 +44,8 @@ class ImportReferencesFromCsv
     reference = ReceiveReference.new(
       application_form: application_form,
       referee_email: referee_email,
-      reference: referee_feedback,
+      feedback: referee_feedback,
     )
-
-    updated = !!reference.save
 
     {
       referee_email: referee_email,

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -28,6 +28,7 @@ class ReceiveReference
         end
       end
     end
+    true
   rescue Workflow::NoTransitionAllowed => e
     errors.add(:state, e.message)
     false

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -22,8 +22,10 @@ class ReceiveReference
         .find { |reference| reference.email_address == @referee_email }
         .update!(feedback: @feedback)
 
-      @application_form.application_choices.each do |application_choice|
-        ApplicationStateChange.new(application_choice).receive_reference!
+      if @application_form.references_complete?
+        @application_form.application_choices.each do |application_choice|
+          ApplicationStateChange.new(application_choice).references_complete!
+        end
       end
     end
   rescue Workflow::NoTransitionAllowed => e

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -1,16 +1,16 @@
 class ReceiveReference
   attr_reader :referee_email
-  attr_reader :reference
+  attr_reader :feedback
 
   include ActiveModel::Validations
 
   validates_presence_of :referee_email
   validate :referee_must_exist_on_application_form
 
-  def initialize(application_form:, referee_email:, reference:)
+  def initialize(application_form:, referee_email:, feedback:)
     @application_form = application_form
     @referee_email = referee_email
-    @reference = reference
+    @feedback = feedback
   end
 
   def save
@@ -19,8 +19,8 @@ class ReceiveReference
     ActiveRecord::Base.transaction do
       @application_form
         .references
-        .find_by!(email_address: @referee_email)
-        .update!(feedback: @reference)
+        .find { |reference| reference.email_address == @referee_email }
+        .update!(feedback: @feedback)
 
       @application_form.application_choices.each do |application_choice|
         ApplicationStateChange.new(application_choice).receive_reference!

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -14,7 +14,7 @@ class ReceiveReference
   end
 
   def save
-    return unless valid?
+    return false unless valid?
 
     ActiveRecord::Base.transaction do
       @application_form
@@ -24,7 +24,11 @@ class ReceiveReference
 
       if @application_form.references_complete?
         @application_form.application_choices.each do |application_choice|
-          ApplicationStateChange.new(application_choice).references_complete!
+          if application_choice.edit_by_expired?
+            ApplicationStateChange.new(application_choice).send_to_provider!
+          else
+            ApplicationStateChange.new(application_choice).references_complete!
+          end
         end
       end
     end

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -1,0 +1,7 @@
+class SendApplicationsToProvider
+  def call
+    ApplicationChoice.ready_to_send_to_provider.each do |application_choice|
+      ApplicationStateChange.new(application_choice).send_to_provider
+    end
+  end
+end

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -1,3 +1,4 @@
+# This service class will be called as a background job, scheduled to run nightly
 class SendApplicationsToProvider
   def call
     GetApplicationChoicesReadyToSendToProvider.call.each do |application_choice|

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -1,7 +1,7 @@
 class SendApplicationsToProvider
   def call
     ApplicationChoice.ready_to_send_to_provider.each do |application_choice|
-      ApplicationStateChange.new(application_choice).send_to_provider
+      ApplicationStateChange.new(application_choice).send_to_provider!
     end
   end
 end

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -1,6 +1,6 @@
 class SendApplicationsToProvider
   def call
-    ApplicationChoice.ready_to_send_to_provider.each do |application_choice|
+    GetApplicationChoicesReadyToSendToProvider.call.each do |application_choice|
       ApplicationStateChange.new(application_choice).send_to_provider!
     end
   end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -10,7 +10,7 @@ class SubmitApplication
     submit_application
 
     application_form.update!(support_reference: GenerateSupportRef.call,
-                             submitted_at: Time.now)
+                             submitted_at: Time.zone.now)
 
     CandidateMailer.submit_application_email(application_form).deliver_now
   end
@@ -20,6 +20,7 @@ private
   def submit_application
     ActiveRecord::Base.transaction do
       application_choices.each do |application_choice|
+        application_choice.edit_by = ApplicationDates.new(application_form).edit_by
         ApplicationStateChange.new(application_choice).submit!
       end
     end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -7,10 +7,11 @@ class SubmitApplication
   end
 
   def call
-    submit_application
-
-    application_form.update!(support_reference: GenerateSupportRef.call,
-                             submitted_at: Time.zone.now)
+    ActiveRecord::Base.transaction do
+      application_form.update!(support_reference: GenerateSupportRef.call,
+                               submitted_at: Time.zone.now)
+      submit_application
+    end
 
     CandidateMailer.submit_application_email(application_form).deliver_now
   end
@@ -18,11 +19,9 @@ class SubmitApplication
 private
 
   def submit_application
-    ActiveRecord::Base.transaction do
-      application_choices.each do |application_choice|
-        application_choice.edit_by = ApplicationDates.new(application_form).edit_by
-        ApplicationStateChange.new(application_choice).submit!
-      end
+    application_choices.each do |application_choice|
+      application_choice.edit_by = ApplicationDates.new(application_form).edit_by
+      ApplicationStateChange.new(application_choice).submit!
     end
   end
 end

--- a/db/migrate/20191108151128_add_application_choices_edit_by.rb
+++ b/db/migrate/20191108151128_add_application_choices_edit_by.rb
@@ -1,0 +1,5 @@
+class AddApplicationChoicesEditBy < ActiveRecord::Migration[6.0]
+  def change
+    add_column :application_choices, :edit_by, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2019_11_08_162019) do
     t.json "offer"
     t.string "rejection_reason"
     t.bigint "course_option_id", null: false
+    t.datetime "edit_by"
     t.index ["application_form_id"], name: "index_application_choices_on_application_form_id"
     t.index ["course_option_id"], name: "index_application_choices_on_course_option_id"
   end

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -32,8 +32,8 @@ When('{string} provides a reference') do |referee_email|
     application_form: @application_choice.application_form.reload,
     referee_email: referee_email,
     feedback: Faker::Lorem.paragraphs(number: 2),
-)
-  expect(action.save).to be_truthy
+  )
+  expect(action.save).to be true
 end
 
 When('the date is {string}') do |date|

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -26,6 +26,10 @@ When('{string} provides a reference') do |referee_email|
   expect(action.save).to be_truthy
 end
 
+When('the date is {string}') do |date|
+  Timecop.freeze(date)
+end
+
 Then('the new application choice status is {string}') do |new_application_status|
   expect(@application_choice.reload.status).to eq(new_application_status.parameterize(separator: '_'))
 end

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -21,7 +21,7 @@ When('{string} provides a reference') do |referee_email|
   action = ReceiveReference.new(
     application_form: @application_choice.application_form,
     referee_email: referee_email,
-    reference: Faker::Lorem.paragraphs(number: 2),
+    feedback: Faker::Lorem.paragraphs(number: 2),
 )
   expect(action.save).to be_truthy
 end
@@ -32,4 +32,8 @@ end
 
 Then('the new application choice status is {string}') do |new_application_status|
   expect(@application_choice.reload.status).to eq(new_application_status.parameterize(separator: '_'))
+end
+
+When('the daily application cron job has run') do
+  # TODO:
 end

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -1,5 +1,11 @@
-Given(/an application choice has "(.*)" status/) do |orginal_application_status|
-  @application_choice = FactoryBot.create(:application_choice, :single, status: orginal_application_status.gsub(' ', '_'))
+Given(/an application choice has "(.*)" status/) do |original_application_status|
+  application_form = FactoryBot.create(:application_form)
+  @application_choice = FactoryBot.create(
+    :application_choice,
+    :single,
+    application_form: application_form,
+    status: original_application_status.gsub(' ', '_'),
+  )
 end
 
 Given('the candidate has specified {string} and {string} as referees') do |referee1_email, referee2_email|
@@ -12,6 +18,10 @@ Given('the candidate has specified {string} and {string} as referees') do |refer
                     application_form: @application_choice.application_form)
 end
 
+When(/^the candidate submits the application$/) do
+  SubmitApplication.new(@application_choice.application_form).call
+end
+
 When(/^the (\w+) takes action "([\w\s]+)"$/) do |_actor, action|
   command_name = (action.gsub(' ', '_') + '!').to_sym
   ApplicationStateChange.new(@application_choice).send(command_name)
@@ -19,7 +29,7 @@ end
 
 When('{string} provides a reference') do |referee_email|
   action = ReceiveReference.new(
-    application_form: @application_choice.application_form,
+    application_form: @application_choice.application_form.reload,
     referee_email: referee_email,
     feedback: Faker::Lorem.paragraphs(number: 2),
 )
@@ -30,10 +40,10 @@ When('the date is {string}') do |date|
   Timecop.freeze(date)
 end
 
-Then('the new application choice status is {string}') do |new_application_status|
-  expect(@application_choice.reload.status).to eq(new_application_status.parameterize(separator: '_'))
+When('the daily application cron job has run') do
+  SendApplicationsToProvider.new.call
 end
 
-When('the daily application cron job has run') do
-  # TODO:
+Then('the new application choice status is {string}') do |new_application_status|
+  expect(@application_choice.reload.status).to eq(new_application_status.parameterize(separator: '_'))
 end

--- a/features/submitting_references.feature
+++ b/features/submitting_references.feature
@@ -11,7 +11,7 @@ Feature: references
   Scenario: an application isn't complete until it's received two references
     Given an application choice has "unsubmitted" status
     And the candidate has specified "j.moriarty@uni.ac.uk" and 's.skinner@springfield-elementary.edu' as referees
-    And the candidate takes action "submit"
+    And the candidate submits the application
     Then the new application choice status is "awaiting_references"
     When "j.moriarty@uni.ac.uk" provides a reference
     Then the new application choice status is "awaiting_references"
@@ -22,7 +22,7 @@ Feature: references
     Given an application choice has "unsubmitted" status
     And the candidate has specified "j.moriarty@uni.ac.uk" and 's.skinner@springfield-elementary.edu' as referees
     And the date is "2019-11-04"
-    And the candidate takes action "submit"
+    And the candidate submits the application
     And "j.moriarty@uni.ac.uk" provides a reference
     And "s.skinner@springfield-elementary.edu" provides a reference
     Then the new application choice status is "application_complete"

--- a/features/submitting_references.feature
+++ b/features/submitting_references.feature
@@ -29,4 +29,5 @@ Feature: references
     When the date is "2019-11-11"
     Then the new application choice status is "application_complete"
     When the date is "2019-11-12"
+    And the daily application cron job has run
     Then the new application choice status is "awaiting_provider_decision"

--- a/features/submitting_references.feature
+++ b/features/submitting_references.feature
@@ -4,19 +4,27 @@ Feature: references
 
   If a referee don't provide a reference within a certain period of time, a candidate is allowed to swap out that referee for another one. Candidates can't remove or swap out references once they've been submitted by the referees.
 
-  Providers don't see the application form until the references have both come back.
+  Providers don't see the application form until the references have both come back and 5 working days have elapsed since application submission.
 
   At Apply 2, the references are carried over from Apply 1.
 
   Scenario: an application isn't complete until it's received two references
     Given an application choice has "unsubmitted" status
     And the candidate has specified "j.moriarty@uni.ac.uk" and 's.skinner@springfield-elementary.edu' as referees
-    And the date is "2019-11-04"
     And the candidate takes action "submit"
     Then the new application choice status is "awaiting_references"
     When "j.moriarty@uni.ac.uk" provides a reference
     Then the new application choice status is "awaiting_references"
     When "s.skinner@springfield-elementary.edu" provides a reference
+    Then the new application choice status is "application_complete"
+
+  Scenario: an application is sent to a provider after it's received two references and 5 working days elapse after submission
+    Given an application choice has "unsubmitted" status
+    And the candidate has specified "j.moriarty@uni.ac.uk" and 's.skinner@springfield-elementary.edu' as referees
+    And the date is "2019-11-04"
+    And the candidate takes action "submit"
+    And "j.moriarty@uni.ac.uk" provides a reference
+    And "s.skinner@springfield-elementary.edu" provides a reference
     Then the new application choice status is "application_complete"
     When the date is "2019-11-11"
     Then the new application choice status is "application_complete"

--- a/features/submitting_references.feature
+++ b/features/submitting_references.feature
@@ -11,9 +11,14 @@ Feature: references
   Scenario: an application isn't complete until it's received two references
     Given an application choice has "unsubmitted" status
     And the candidate has specified "j.moriarty@uni.ac.uk" and 's.skinner@springfield-elementary.edu' as referees
+    And the date is "2019-11-04"
     And the candidate takes action "submit"
     Then the new application choice status is "awaiting_references"
     When "j.moriarty@uni.ac.uk" provides a reference
     Then the new application choice status is "awaiting_references"
     When "s.skinner@springfield-elementary.edu" provides a reference
     Then the new application choice status is "application_complete"
+    When the date is "2019-11-11"
+    Then the new application choice status is "application_complete"
+    When the date is "2019-11-12"
+    Then the new application choice status is "awaiting_provider_decision"

--- a/features/submitting_references.feature
+++ b/features/submitting_references.feature
@@ -27,6 +27,7 @@ Feature: references
     And "s.skinner@springfield-elementary.edu" provides a reference
     Then the new application choice status is "application_complete"
     When the date is "2019-11-11"
+    And the daily application cron job has run
     Then the new application choice status is "application_complete"
     When the date is "2019-11-12"
     And the daily application cron job has run

--- a/features/successful_application_statuses.feature
+++ b/features/successful_application_statuses.feature
@@ -61,16 +61,17 @@ Feature: successful application statuses
     Then the new application choice status is "<new status>"
 
     Examples:
-      | original status            | actor     | action                 | new status          |
-      | unsubmitted                | candidate | submit                 | awaiting references |
-      | awaiting_references        | candidate | withdraw               | withdrawn           |
-      | application complete       | candidate | withdraw               | withdrawn           |
-      | awaiting provider decision | provider  | make offer             | offer               |
-      | awaiting provider decision | provider  | reject application     | rejected            |
-      | awaiting provider decision | candidate | withdraw               | withdrawn           |
-      | offer                      | candidate | accept                 | pending conditions  |
-      | offer                      | candidate | decline                | declined            |
-      | pending conditions         | provider  | confirm conditions met | recruited           |
-      | pending conditions         | candidate | withdraw               | withdrawn           |
-      | recruited                  | provider  | confirm enrolment      | enrolled            |
-      | recruited                  | candidate | withdraw               | withdrawn           |
+      | original status            | actor     | action                 | new status           |
+      | unsubmitted                | candidate | submit                 | awaiting references  |
+      | awaiting_references        | candidate | withdraw               | withdrawn            |
+      | awaiting_references        | candidate | references_complete    | application_complete |
+      | application complete       | candidate | withdraw               | withdrawn            |
+      | awaiting provider decision | provider  | make offer             | offer                |
+      | awaiting provider decision | provider  | reject application     | rejected             |
+      | awaiting provider decision | candidate | withdraw               | withdrawn            |
+      | offer                      | candidate | accept                 | pending conditions   |
+      | offer                      | candidate | decline                | declined             |
+      | pending conditions         | provider  | confirm conditions met | recruited            |
+      | pending conditions         | candidate | withdraw               | withdrawn            |
+      | recruited                  | provider  | confirm enrolment      | enrolled             |
+      | recruited                  | candidate | withdraw               | withdrawn            |

--- a/features/successful_application_statuses.feature
+++ b/features/successful_application_statuses.feature
@@ -61,17 +61,19 @@ Feature: successful application statuses
     Then the new application choice status is "<new status>"
 
     Examples:
-      | original status            | actor     | action                 | new status           |
-      | unsubmitted                | candidate | submit                 | awaiting references  |
-      | awaiting_references        | candidate | withdraw               | withdrawn            |
-      | awaiting_references        | candidate | references_complete    | application_complete |
-      | application complete       | candidate | withdraw               | withdrawn            |
-      | awaiting provider decision | provider  | make offer             | offer                |
-      | awaiting provider decision | provider  | reject application     | rejected             |
-      | awaiting provider decision | candidate | withdraw               | withdrawn            |
-      | offer                      | candidate | accept                 | pending conditions   |
-      | offer                      | candidate | decline                | declined             |
-      | pending conditions         | provider  | confirm conditions met | recruited            |
-      | pending conditions         | candidate | withdraw               | withdrawn            |
-      | recruited                  | provider  | confirm enrolment      | enrolled             |
-      | recruited                  | candidate | withdraw               | withdrawn            |
+      | original status            | actor     | action                 | new status                 |
+      | unsubmitted                | candidate | submit                 | awaiting references        |
+      | awaiting_references        | candidate | withdraw               | withdrawn                  |
+      | awaiting_references        | candidate | references_complete    | application_complete       |
+      | awaiting_references        | candidate | send_to_provider       | awaiting_provider_decision |
+      | application complete       | candidate | withdraw               | withdrawn                  |
+      | application complete       | candidate | send_to_provider       | awaiting_provider_decision |
+      | awaiting provider decision | provider  | make offer             | offer                      |
+      | awaiting provider decision | provider  | reject application     | rejected                   |
+      | awaiting provider decision | candidate | withdraw               | withdrawn                  |
+      | offer                      | candidate | accept                 | pending conditions         |
+      | offer                      | candidate | decline                | declined                   |
+      | pending conditions         | provider  | confirm conditions met | recruited                  |
+      | pending conditions         | candidate | withdraw               | withdrawn                  |
+      | recruited                  | provider  | confirm enrolment      | enrolled                   |
+      | recruited                  | candidate | withdraw               | withdrawn                  |

--- a/spec/services/get_application_choices_ready_to_send_to_provider_spec.rb
+++ b/spec/services/get_application_choices_ready_to_send_to_provider_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe GetApplicationChoicesReadyToSendToProvider do
+  def create_application_with_references(days_ago: 6)
+    application_form = create :application_form
+    create :application_choice, application_form: application_form, status: 'unsubmitted'
+    Timecop.travel(days_ago.business_days.ago) do
+      SubmitApplication.new(application_form.reload).call
+    end
+    create_list :reference, 2, :unsubmitted, application_form: application_form
+    application_form
+  end
+
+  def complete_reference(application_form, email_address)
+    ReceiveReference.new(
+      application_form: application_form,
+      referee_email: email_address,
+      feedback: 'seems ok',
+    ).save
+  end
+
+  it 'returns an application submitted 6 working days ago with 2 references' do
+    application_form = create_application_with_references
+    application_form.references.each do |reference|
+      complete_reference(application_form, reference.email_address)
+    end
+    expect(described_class.call).to include application_form.application_choices.first
+  end
+
+  it 'does NOT return an application submitted 6 working days ago with only 1 reference' do
+    application_form = create_application_with_references
+    complete_reference(application_form, application_form.references.first.email_address)
+    expect(described_class.call).not_to include application_form.application_choices.first
+  end
+
+  it 'does NOT return an application submitted 6 working days ago with no references' do
+    application_form = create_application_with_references
+    expect(described_class.call).not_to include application_form.application_choices.first
+  end
+
+  it 'does NOT return an application submitted 5 working days ago with 2 references' do
+    application_form = create_application_with_references(days_ago: 5)
+    application_form.references.each do |reference|
+      complete_reference(application_form, reference.email_address)
+    end
+    expect(described_class.call).not_to include application_form.application_choices.first
+  end
+end

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ReceiveReference do
     )
 
     expect(action).to be_valid
-    expect(action.save).to be_truthy
+    expect(action.save).to be_falsey
 
     expect(application_form.references.find_by!(email_address: 'xy@z.com').feedback).to eq('A reference')
     expect(application_form.references.find_by!(email_address: 'ab@c.com').feedback).to be_nil

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ReceiveReference do
     action = ReceiveReference.new(
       application_form: application_form,
       referee_email: 'xy@z.com',
-      reference: 'A reference',
+      feedback: 'A reference',
     )
 
     expect(action).to be_valid
@@ -29,7 +29,7 @@ RSpec.describe ReceiveReference do
     action = ReceiveReference.new(
       application_form: application_form,
       referee_email: 'ab@c.com',
-      reference: 'A reference',
+      feedback: 'A reference',
     )
     action.save
 
@@ -42,7 +42,7 @@ RSpec.describe ReceiveReference do
       action = ReceiveReference.new(
         application_form: build_stubbed(:application_form),
         referee_email: nil,
-        reference: 'A reference',
+        feedback: 'A reference',
       )
 
       expect(action).not_to be_valid
@@ -52,7 +52,7 @@ RSpec.describe ReceiveReference do
       action = ReceiveReference.new(
         application_form: build_stubbed(:application_form),
         referee_email: 'madeupemail@example.com',
-        reference: 'A reference',
+        feedback: 'A reference',
       )
 
       expect(action).not_to be_valid

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ReceiveReference do
     )
 
     expect(action).to be_valid
-    expect(action.save).to be_falsey
+    expect(action.save).to be true
 
     expect(application_form.references.find_by!(email_address: 'xy@z.com').feedback).to eq('A reference')
     expect(application_form.references.find_by!(email_address: 'ab@c.com').feedback).to be_nil

--- a/spec/services/send_applications_to_provider_spec.rb
+++ b/spec/services/send_applications_to_provider_spec.rb
@@ -11,14 +11,18 @@ RSpec.describe SendApplicationsToProvider do
     application_form
   end
 
+  def complete_reference(reference)
+    ReceiveReference.new(
+      application_form: reference.application_form,
+      referee_email: reference.email_address,
+      feedback: 'seems ok',
+    ).save
+  end
+
   it 'sends an application submitted 6 working days ago with 2 references' do
     application_form = create_application_with_references
     application_form.references.each do |reference|
-      ReceiveReference.new(
-        application_form: application_form,
-        referee_email: reference.email_address,
-        feedback: 'seems ok',
-      ).save
+      complete_reference(reference)
     end
     SendApplicationsToProvider.new.call
     expect(application_form.application_choices.first.reload.status).to eq 'awaiting_provider_decision'
@@ -28,29 +32,5 @@ RSpec.describe SendApplicationsToProvider do
     application_form = create_application_with_references
     SendApplicationsToProvider.new.call
     expect(application_form.application_choices.first.reload.status).to eq 'awaiting_references'
-  end
-
-  it 'DOES NOT send an application submitted 6 working days ago with 1 reference' do
-    application_form = create_application_with_references
-    ReceiveReference.new(
-      application_form: application_form,
-      referee_email: application_form.references.first.email_address,
-      feedback: 'seems ok',
-    ).save
-    SendApplicationsToProvider.new.call
-    expect(application_form.application_choices.first.reload.status).to eq 'awaiting_references'
-  end
-
-  it 'DOES NOT send an applications submitted 5 working days ago with 2 references' do
-    application_form = create_application_with_references(days_ago: 5)
-    application_form.references.each do |reference|
-      ReceiveReference.new(
-        application_form: application_form,
-        referee_email: reference.email_address,
-        feedback: 'seems ok',
-      ).save
-    end
-    SendApplicationsToProvider.new.call
-    expect(application_form.application_choices.first.reload.status).to eq 'application_complete'
   end
 end

--- a/spec/services/send_applications_to_provider_spec.rb
+++ b/spec/services/send_applications_to_provider_spec.rb
@@ -1,12 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe SendApplicationsToProvider do
-  def create_application_with_references(days_ago: 6)
+  def create_application_with_references
     application_form = create :application_form
     create :application_choice, application_form: application_form, status: 'unsubmitted'
-    Timecop.travel(days_ago.business_days.ago) do
-      SubmitApplication.new(application_form.reload).call
-    end
+    SubmitApplication.new(application_form.reload).call
     create_list :reference, 2, :unsubmitted, application_form: application_form
     application_form
   end
@@ -24,13 +22,17 @@ RSpec.describe SendApplicationsToProvider do
     application_form.references.each do |reference|
       complete_reference(reference)
     end
-    SendApplicationsToProvider.new.call
+    Timecop.travel(6.business_days.from_now) do
+      SendApplicationsToProvider.new.call
+    end
     expect(application_form.application_choices.first.reload.status).to eq 'awaiting_provider_decision'
   end
 
   it 'DOES NOT send an application submitted 6 working days ago with no references' do
     application_form = create_application_with_references
-    SendApplicationsToProvider.new.call
+    Timecop.travel(6.business_days.from_now) do
+      SendApplicationsToProvider.new.call
+    end
     expect(application_form.application_choices.first.reload.status).to eq 'awaiting_references'
   end
 end

--- a/spec/services/send_applications_to_provider_spec.rb
+++ b/spec/services/send_applications_to_provider_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe SendApplicationsToProvider do
+  it 'sends applications that were submitted 6 working days ago with 2 references' do
+  end
+
+  it 'DOES NOT send applications that were submitted 6 working days ago with 1 reference' do
+  end
+
+  it 'DOES NOT send applications that were submitted 6 working days ago with no references' do
+  end
+
+  it 'DOES NOT send applications that were submitted 5 working days ago with 2 references' do
+  end
+end

--- a/spec/services/send_applications_to_provider_spec.rb
+++ b/spec/services/send_applications_to_provider_spec.rb
@@ -1,5 +1,22 @@
+require 'rails_helper'
+
 RSpec.describe SendApplicationsToProvider do
   it 'sends applications that were submitted 6 working days ago with 2 references' do
+    application_form = create :application_form
+    application_choice = create :application_choice, application_form: application_form, status: 'unsubmitted'
+    Timecop.travel(10.days.ago) do
+      SubmitApplication.new(application_form.reload).call
+    end
+    references = create_list :reference, 2, :unsubmitted, application_form: application_form
+    references.each do |reference|
+      ReceiveReference.new(
+        application_form: application_form,
+        referee_email: reference.email_address,
+        feedback: 'seems ok',
+      ).save
+    end
+    SendApplicationsToProvider.new.call
+    expect(application_choice.reload.status).to eq 'awaiting_provider_decision'
   end
 
   it 'DOES NOT send applications that were submitted 6 working days ago with 1 reference' do

--- a/spec/services/send_applications_to_provider_spec.rb
+++ b/spec/services/send_applications_to_provider_spec.rb
@@ -1,14 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe SendApplicationsToProvider do
-  it 'sends applications that were submitted 6 working days ago with 2 references' do
+  def create_application_with_references(days_ago: 6)
     application_form = create :application_form
-    application_choice = create :application_choice, application_form: application_form, status: 'unsubmitted'
-    Timecop.travel(10.days.ago) do
+    create :application_choice, application_form: application_form, status: 'unsubmitted'
+    Timecop.travel(days_ago.business_days.ago) do
       SubmitApplication.new(application_form.reload).call
     end
-    references = create_list :reference, 2, :unsubmitted, application_form: application_form
-    references.each do |reference|
+    create_list :reference, 2, :unsubmitted, application_form: application_form
+    application_form
+  end
+
+  it 'sends an application submitted 6 working days ago with 2 references' do
+    application_form = create_application_with_references
+    application_form.references.each do |reference|
       ReceiveReference.new(
         application_form: application_form,
         referee_email: reference.email_address,
@@ -16,15 +21,36 @@ RSpec.describe SendApplicationsToProvider do
       ).save
     end
     SendApplicationsToProvider.new.call
-    expect(application_choice.reload.status).to eq 'awaiting_provider_decision'
+    expect(application_form.application_choices.first.reload.status).to eq 'awaiting_provider_decision'
   end
 
-  it 'DOES NOT send applications that were submitted 6 working days ago with 1 reference' do
+  it 'DOES NOT send an application submitted 6 working days ago with no references' do
+    application_form = create_application_with_references
+    SendApplicationsToProvider.new.call
+    expect(application_form.application_choices.first.reload.status).to eq 'awaiting_references'
   end
 
-  it 'DOES NOT send applications that were submitted 6 working days ago with no references' do
+  it 'DOES NOT send an application submitted 6 working days ago with 1 reference' do
+    application_form = create_application_with_references
+    ReceiveReference.new(
+      application_form: application_form,
+      referee_email: application_form.references.first.email_address,
+      feedback: 'seems ok',
+    ).save
+    SendApplicationsToProvider.new.call
+    expect(application_form.application_choices.first.reload.status).to eq 'awaiting_references'
   end
 
-  it 'DOES NOT send applications that were submitted 5 working days ago with 2 references' do
+  it 'DOES NOT send an applications submitted 5 working days ago with 2 references' do
+    application_form = create_application_with_references(days_ago: 5)
+    application_form.references.each do |reference|
+      ReceiveReference.new(
+        application_form: application_form,
+        referee_email: reference.email_address,
+        feedback: 'seems ok',
+      ).save
+    end
+    SendApplicationsToProvider.new.call
+    expect(application_form.application_choices.first.reload.status).to eq 'application_complete'
   end
 end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -6,21 +6,17 @@ RSpec.describe SubmitApplication do
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
-      application_dates = instance_double(
-        ApplicationDates,
-        edit_by: Time.zone.local(2019, 11, 11, 11, 59, 0),
-      )
-      allow(ApplicationDates).to receive(:new).and_return(application_dates)
 
-      Timecop.freeze do
+      Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
+        expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day
         SubmitApplication.new(application_form).call
 
         expect(application_form.submitted_at).to eq Time.zone.now
         expect(application_form.application_choices[0]).to be_awaiting_references
         expect(application_form.application_choices[1]).to be_awaiting_references
         expect(application_form.support_reference).not_to be_empty
-        expect(application_form.application_choices[0].edit_by).to eq application_dates.edit_by
-        expect(application_form.application_choices[1].edit_by).to eq application_dates.edit_by
+        expect(application_form.application_choices[0].edit_by).to eq expected_edit_by
+        expect(application_form.application_choices[1].edit_by).to eq expected_edit_by
       end
     end
   end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -6,14 +6,21 @@ RSpec.describe SubmitApplication do
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
+      application_dates = instance_double(
+        ApplicationDates,
+        edit_by: Time.zone.local(2019, 11, 11, 11, 59, 0),
+      )
+      allow(ApplicationDates).to receive(:new).and_return(application_dates)
 
       Timecop.freeze do
         SubmitApplication.new(application_form).call
 
-        expect(application_form.submitted_at.utc).to eq Time.now.utc
+        expect(application_form.submitted_at).to eq Time.zone.now
         expect(application_form.application_choices[0]).to be_awaiting_references
         expect(application_form.application_choices[1]).to be_awaiting_references
         expect(application_form.support_reference).not_to be_empty
+        expect(application_form.application_choices[0].edit_by).to eq application_dates.edit_by
+        expect(application_form.application_choices[1].edit_by).to eq application_dates.edit_by
       end
     end
   end


### PR DESCRIPTION
### Context

After a candidate has submitted an application the business rules state that two things need to happen before a provider can see the application:

- Two references need to be received
- 5 working days must elapse after application submission

Visibility of the application is controlled by it's state, three states are important here:

- `awaiting_references` is the state immediately after submission
- `application_complete` indicates that references have been received but 5 working days have not yet elapsed
- `awaiting_provider_decision` indicates that both above conditions have been met and that the provider can now see the application

It is possible for an application to go straight from `awaiting_references` to `awaiting_provider_decision` if references are received after 5 working days.

### Changes proposed in this pull request

- [x] Cucumber scenario to specify the business rules above
- [x] Calculation and storage of the time at which the 5 working days elapse for each application choice at time of submission. Stored on `ApplicationChoice#edit_by` and calculated ahead of time rather than on the fly so that we can easily find applications that have passed the given date later. Note that setting `ApplicationChoice#edit_by` depends on using `SubmitApplication` service class (it's no good just setting status manually).
- [x] 'Service' class to check for applications that need to be progressed to `awaiting_provider_decision`. This one will be called by Clockwork (in a separate PR).
- [x] Changes to `ReceiveReferences` to factor logic out of state machine and into this service class. Also enforce the 2 reference minimum.

### Guidance to review

- There is an extra cucumber scenario, does it make sense? Are we all happy to use cucumber to specify the high-level business rule?
- Do the changes to `ReceiveReference` make sense?
- Are we happy that we have to use the service classes, e.g. `ReceiveReference` and `SubmitApplication` to get applications into the correct state?

### Link to Trello card

[1202 - Add Provider_Receive_Application](https://trello.com/c/oJ8RQ9mQ/1202-add-providerreceiveapplication)

### Env vars

No new env vars
