### PR TITLE
Remove email validation altogether

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -4,12 +4,6 @@ class Candidate < ApplicationRecord
   devise :timeoutable
   validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
 
-  # Validate against the pattern that notify use, because a mismatch will lead
-  # to a 400.
-  # From https://github.com/alphagov/notifications-utils/blob/ace25bd04f5802a1ca41633b8308600abce517fc/notifications_utils/__init__.py#L10-L11
-  NOTIFY_EMAIL_REGEXP = %r{\A[a-zA-Z0-9.!#$%&'*+=?^_`{|}~\\-]+@([^.@][^@\\s]+)\z}.freeze
-  validates :email_address, format: { with: NOTIFY_EMAIL_REGEXP }
-
   has_many :application_forms
 
   def current_application

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe Candidate, type: :model do
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
     it { is_expected.to validate_uniqueness_of :email_address }
-
-    it { is_expected.to allow_value('candidate@example.com').for(:email_address) }
-    it { is_expected.not_to allow_value('candidate.com').for(:email_address) }
   end
 
   describe '#delete' do


### PR DESCRIPTION
### Context

We're seeing problems with this regex, for example `test@test.com` isn't valid. 

### Changes proposed in this pull request

We don't have time at the moment to the intractable problem of email validation so let's do away with it altogether. We'll revisit it once we see this breaking for actual users.
