### PR TITLE
Link to self from header of Apply from Find page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,6 +23,9 @@ module ApplicationHelper
   end
 
   def service_link
+    custom_link = content_for(:service_link)
+    return custom_link if custom_link
+
     case current_namespace
     when 'provider_interface'
       provider_interface_path

--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, t('page_titles.application') %>
+<% content_for :service_link, candidate_interface_apply_from_find_path(providerCode: @course.provider_code, courseCode: @course.course_code) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/apply_from_find/show.html.erb
+++ b/app/views/candidate_interface/apply_from_find/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, t('page_titles.application') %>
+<% content_for :service_link, candidate_interface_apply_from_find_path(providerCode: @course.provider_code, courseCode: @course.course_code) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   def then_i_should_see_the_landing_page
     expect(page).to have_content t('apply_from_find.heading')
+    expect(page).to have_link href: candidate_interface_apply_from_find_path(providerCode: 'ABC', courseCode: 'XYZ1')
   end
 
   def and_i_should_see_the_provider_and_course_codes


### PR DESCRIPTION
### Context

This makes sure that the header links to the page itself from the Apply from Find page. If we don't do this, a click on the header will lead the user to a password protected area, which isn't friendly.

### Changes proposed in this pull request

See code.

### Link to Trello card

https://trello.com/c/96nQagv3/328-epic-launch-the-apply-from-find-page