### PR TITLE
Update content for submitted application email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,9 +1,9 @@
 class CandidateMailer < ApplicationMailer
-  def submit_application_email(to:, support_reference:)
-    @support_reference = support_reference
+  def submit_application_email(application_form)
+    @application_form = application_form
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: to,
+              to: application_form.candidate.email_address,
               subject: t('submit_application_success.email.subject'))
   end
 end

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -1,6 +1,10 @@
 class CandidateMailerPreview < ActionMailer::Preview
   def submit_application_email
-    application_form = FactoryBot.build_stubbed(:application_form, support_reference: 'ABC-DEF')
+    application_form = FactoryBot.build(
+      :completed_application_form,
+      support_reference: 'ABC-DEF',
+    )
+
     CandidateMailer.submit_application_email(application_form)
   end
 end

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -1,5 +1,6 @@
 class CandidateMailerPreview < ActionMailer::Preview
   def submit_application_email
-    CandidateMailer.submit_application_email(to: "#{SecureRandom.hex}@example.com", support_reference: 'APPLICATION-REF')
+    application_form = FactoryBot.build_stubbed(:application_form, support_reference: 'ABC-DEF')
+    CandidateMailer.submit_application_email(application_form)
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -1,10 +1,9 @@
 class SubmitApplication
-  attr_reader :application_form, :application_choices, :candidate_email
+  attr_reader :application_form, :application_choices
 
   def initialize(application_form)
     @application_form = application_form
     @application_choices = application_form.application_choices
-    @candidate_email = application_form.candidate.email_address
   end
 
   def call
@@ -13,9 +12,7 @@ class SubmitApplication
     application_form.update!(support_reference: GenerateSupportRef.call,
                              submitted_at: Time.now)
 
-    CandidateMailer
-      .submit_application_email(to: candidate_email, support_reference: application_form.support_reference)
-      .deliver_now
+    CandidateMailer.submit_application_email(application_form).deliver_now
   end
 
 private

--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -5,7 +5,7 @@ You have submitted an application to:
 You can track the progress of your application here:
 <%= candidate_interface_application_form_url %>
 
-Your application reference is <%= @support_reference %>
+Your application reference is <%= @application_form.support_reference %>
 
 # Next steps
 

--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -1,17 +1,34 @@
-# Thank you for completing your teacher training application
+Dear <%= @application_form.first_name %>,
 
-You have submitted an application to:
+# Application submitted
 
-You can track the progress of your application here:
+You have successfully submitted an application for:
+
+<% @application_form.application_choices.each do |application_choice| %>
+* <%= application_choice.provider.name %> - <%= application_choice.course.name %> (<%= application_choice.course.code %>)
+<% end %>
+
+Your application reference is <%= @application_form.support_reference %>.
+
+You can track the progress of your <%= 'application'.pluralize(@application_form.application_choices.count) %> here:
+
 <%= candidate_interface_application_form_url %>
 
-Your application reference is <%= @application_form.support_reference %>
+# Making changes to your application
 
-# Next steps
+You have 5 working days to edit your application or change your choice of provider, course or training location.
+
+To make changes, [sign back in to your account](<%= candidate_interface_sign_in_url %>).
+
+You can sign back in to change your name or contact details at any point up until enrolment. We’ll pass this information on to the training <%= 'provider'.pluralize(@application_form.application_choices.count) %>.
+
+# Withdrawing your application
+
+You can withdraw your application to <%= 'course'.pluralize(@application_form.application_choices.count) %> at any point, even after you've accepted an offer. [Sign in to your account](<%= candidate_interface_sign_in_url %>) and click ‘withdraw’ next to the <%= 'course'.pluralize(@application_form.application_choices.count) %> you want to withdraw. We'll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
 
 # References
 
-The Apply for teacher training service will now contact your referees to ask them for references.
+The Apply for teacher training service will contact your referees to ask them for references.
 
 Your referees will be given a short questionnaire about you and a free text box to describe you in their own words. They will not be given access to your completed application form.
 
@@ -23,4 +40,14 @@ Most training providers don’t reach a decision about your interview until they
 
 # Application decision
 
-Your training provider will respond to your application within 40 working days via email. If they decide to progress your application, they will communicate with you directly to organise an interview date and give you all the information you need.
+If a training provider decides to progress your application, they will communicate with you directly to organise an interview date and give you all the information you need.
+
+Your training provider will aim to make a decision on whether to make an offer within 40 working days of receiving your application.
+
+# Need help with your teacher training application?
+
+Call [Get into Teaching](https://getintoteaching.education.gov.uk/) on Freephone 0800 389 2500 or chat to an adviser using their [online chat service](https://getintoteaching.education.gov.uk/lp/live-chat) between 8am and 8pm, Monday to Friday.
+
+# Give feedback or report a problem
+
+Please contact the team on [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   subject(:mailer) { described_class }
 
   describe 'Send submit application email' do
-    let(:mail) { mailer.submit_application_email(to: 'test@example.com', support_reference: 'SUPPORT-REFERENCE') }
+    let(:mail) { mailer.submit_application_email(build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE')) }
 
     before { mail.deliver_now }
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include('Thank you for completing your teacher training application')
+      expect(mail.body.encoded).to include('Application submitted')
     end
 
     it 'sends an email containing the support reference' do

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -109,7 +109,7 @@ RSpec.feature 'Candidate submit the application' do
 
   def and_i_receive_an_email_with_my_support_ref
     open_email(current_candidate.email_address)
-    expect(current_email).to have_content 'Thank you for completing your teacher training application'
+    expect(current_email).to have_content 'Application submitted'
   end
 
   def when_i_click_on_track_your_application


### PR DESCRIPTION
### Context

This updates the email that candidates get after submitting the form.

### Changes proposed in this pull request

This updates the content of the email that is sent after the candidate
submits the application.

Changes versus the template in Notify (https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534/templates/99a20df5-564d-4612-810e-3788edf7285e).

- Properly pluralise provider/course instead of writing "course(s)"
- Skip start date for application choices list

![image](https://user-images.githubusercontent.com/233676/68484831-fe3aa580-0235-11ea-82ca-34e5af4b1b74.png)

### Guidance to review

Does it make sense?

### Link to Trello card

 https://trello.com/c/poDCwLT5