### PR TITLE
Tag Sentry events with the current hosting environment

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,3 @@
-if Rails.env.production?
-  Raven.tags_context(
-    azure_host: HostingEnvironment.hostname,
-  )
+Raven.configure do |config|
+  config.tags = { hosting_environment: HostingEnvironment.environment_name }
 end


### PR DESCRIPTION
### Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/392 we tried to add the environment to the Sentry events, but this doesn't seem to have worked.

### Changes proposed in this pull request

I've confirmed that this method works locally in https://sentry.io/organizations/dfe-bat/issues/1323159417.

<img width="1143" alt="Screenshot 2019-11-08 at 16 04 40" src="https://user-images.githubusercontent.com/233676/68490837-9f7b2900-0241-11ea-9de3-6b9bc4cee3f5.png">

### Guidance to review

Does it make sense?

### Link to Trello card

https://trello.com/c/oWoniugA