### PR TITLE
Return applications for accrediting providers

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -22,8 +22,8 @@ module ProviderInterface
     # by a proper ProviderUser when implementing Signin.
     def current_user
       fake_user_class = Struct.new(:provider)
-      fake_provider_class = Struct.new(:code)
-      fake_user_class.new(fake_provider_class.new('ABC'))
+      fake_provider = Provider.find_or_create_by(code: 'ABC')
+      fake_user_class.new(fake_provider)
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -22,7 +22,7 @@ module ProviderInterface
     # by a proper ProviderUser when implementing Signin.
     def current_user
       fake_user_class = Struct.new(:provider)
-      fake_provider = Provider.find_or_create_by(code: 'ABC')
+      fake_provider = Provider.find_by(code: 'ABC')
       fake_user_class.new(fake_provider)
     end
   end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -6,7 +6,7 @@ class ApplicationChoice < ApplicationRecord
   has_one :course, through: :course_option
   has_one :site, through: :course_option
   has_one :provider, through: :course
-  has_one :accrediting_provider, through: :course, class_name: "Provider"
+  has_one :accrediting_provider, through: :course, class_name: 'Provider'
 
   audited associated_with: :application_form
 

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -6,6 +6,7 @@ class ApplicationChoice < ApplicationRecord
   has_one :course, through: :course_option
   has_one :site, through: :course_option
   has_one :provider, through: :course
+  has_one :accrediting_provider, through: :course, class_name: "Provider"
 
   audited associated_with: :application_form
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,6 +2,7 @@ class Course < ApplicationRecord
   belongs_to :provider
   has_many :course_options
   has_many :application_choices, through: :course_options
+  belongs_to :accrediting_provider, class_name: "Provider", optional: true
 
   validates :level, presence: true
   validates :code, uniqueness: { scope: :provider_id }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,7 +2,7 @@ class Course < ApplicationRecord
   belongs_to :provider
   has_many :course_options
   has_many :application_choices, through: :course_options
-  belongs_to :accrediting_provider, class_name: "Provider", optional: true
+  belongs_to :accrediting_provider, class_name: 'Provider', optional: true
 
   validates :level, presence: true
   validates :code, uniqueness: { scope: :provider_id }

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -3,10 +3,9 @@ class GetApplicationChoicesForProvider
 
   def self.call(provider:)
     ApplicationChoice.includes(:course)
-    .where("courses.provider_id" => provider)
+    .where('courses.provider_id' => provider)
     .or(ApplicationChoice.includes(:course)
-      .where("courses.accrediting_provider_id" => provider)
-    )
+      .where('courses.accrediting_provider_id' => provider))
     .where('status NOT IN (?)', STATES_NOT_VISIBLE_TO_PROVIDER)
   end
 end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -2,9 +2,11 @@ class GetApplicationChoicesForProvider
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete].freeze
 
   def self.call(provider:)
-    ApplicationChoice
-    .includes(:course, :provider)
-    .where(providers: { code: provider.code })
+    ApplicationChoice.includes(:course)
+    .where("courses.provider_id" => provider)
+    .or(ApplicationChoice.includes(:course)
+      .where("courses.accrediting_provider_id" => provider)
+    )
     .where('status NOT IN (?)', STATES_NOT_VISIBLE_TO_PROVIDER)
   end
 end

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -31,6 +31,13 @@ class SyncProviderFromFind
     course.level = find_course.level
     course.start_date = Date.parse(find_course.start_date)
     course.exposed_in_find = find_course.findable?
+    if find_course[:accrediting_provider].present?
+      accrediting_provider = Provider.find_or_create_by(code: find_course[:accrediting_provider][:provider_code]) do |accredit_provider|
+        accredit_provider.name = find_course[:accrediting_provider][:provider_name]
+        accredit_provider.save
+      end
+      course.accrediting_provider = accrediting_provider
+    end
     course.save
 
     find_course.sites.each do |find_site|

--- a/db/migrate/20191107110337_add_accrediting_provider_to_courses.rb
+++ b/db/migrate/20191107110337_add_accrediting_provider_to_courses.rb
@@ -1,6 +1,5 @@
 class AddAccreditingProviderToCourses < ActiveRecord::Migration[6.0]
   def change
     add_column :courses, :accrediting_provider_id, :integer
-    add_index :courses, %i[accrediting_provider_id code], unique: true
   end
 end

--- a/db/migrate/20191107110337_add_accrediting_provider_to_courses.rb
+++ b/db/migrate/20191107110337_add_accrediting_provider_to_courses.rb
@@ -1,0 +1,6 @@
+class AddAccreditingProviderToCourses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :courses, :accrediting_provider_id, :integer
+    add_index :courses, %i[accrediting_provider_id code], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -153,6 +153,8 @@ ActiveRecord::Schema.define(version: 2019_11_14_103407) do
     t.string "level"
     t.date "start_date"
     t.boolean "exposed_in_find"
+    t.integer "accrediting_provider_id"
+    t.index ["accrediting_provider_id", "code"], name: "index_courses_on_accrediting_provider_id_and_code", unique: true
     t.index ["code"], name: "index_courses_on_code"
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -154,7 +154,6 @@ ActiveRecord::Schema.define(version: 2019_11_14_103407) do
     t.date "start_date"
     t.boolean "exposed_in_find"
     t.integer "accrediting_provider_id"
-    t.index ["accrediting_provider_id", "code"], name: "index_courses_on_accrediting_provider_id_and_code", unique: true
     t.index ["code"], name: "index_courses_on_code"
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"

--- a/spec/services/get_application_choices_for_provider_spec.rb
+++ b/spec/services/get_application_choices_for_provider_spec.rb
@@ -68,20 +68,20 @@ RSpec.describe GetApplicationChoicesForProvider do
       :application_choice,
       course_option: course_option_for_provider(provider: current_provider),
       status: 'awaiting_provider_decision',
-      application_form: create(:application_form, first_name: 'Aaron')
+      application_form: create(:application_form, first_name: 'Aaron'),
     )
 
     create(
       :application_choice,
       course_option: course_option_for_provider(provider: current_provider),
       status: 'awaiting_provider_decision',
-      application_form: create(:application_form, first_name: 'Jim')
+      application_form: create(:application_form, first_name: 'Jim'),
     )
     create(
       :application_choice,
       course_option: course_option_for_accrediting_provider(provider: alternate_provider, accrediting_provider: current_provider),
       status: 'awaiting_provider_decision',
-      application_form: create(:application_form, first_name: 'Harry')
+      application_form: create(:application_form, first_name: 'Harry'),
     )
 
     create_list(
@@ -93,6 +93,5 @@ RSpec.describe GetApplicationChoicesForProvider do
 
     returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
     expect(returned_applications.size).to be(3)
-
   end
 end

--- a/spec/services/get_application_choices_for_provider_spec.rb
+++ b/spec/services/get_application_choices_for_provider_spec.rb
@@ -59,4 +59,40 @@ RSpec.describe GetApplicationChoicesForProvider do
     valid_states = ApplicationStateChange.valid_states
     expect(valid_states).to include(*GetApplicationChoicesForProvider::STATES_NOT_VISIBLE_TO_PROVIDER)
   end
+
+  it 'returns application_choice that the provider is the accrediting body for' do
+    current_provider = create(:provider, code: 'BAT')
+    alternate_provider = create(:provider, code: 'DIFFERENT')
+
+    create(
+      :application_choice,
+      course_option: course_option_for_provider(provider: current_provider),
+      status: 'awaiting_provider_decision',
+      application_form: create(:application_form, first_name: 'Aaron')
+    )
+
+    create(
+      :application_choice,
+      course_option: course_option_for_provider(provider: current_provider),
+      status: 'awaiting_provider_decision',
+      application_form: create(:application_form, first_name: 'Jim')
+    )
+    create(
+      :application_choice,
+      course_option: course_option_for_accrediting_provider(provider: alternate_provider, accrediting_provider: current_provider),
+      status: 'awaiting_provider_decision',
+      application_form: create(:application_form, first_name: 'Harry')
+    )
+
+    create_list(
+      :application_choice,
+      4,
+      course_option: course_option_for_provider(provider: alternate_provider),
+      status: 'awaiting_provider_decision',
+    )
+
+    returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
+    expect(returned_applications.size).to be(3)
+
+  end
 end

--- a/spec/services/get_application_choices_for_provider_spec.rb
+++ b/spec/services/get_application_choices_for_provider_spec.rb
@@ -91,7 +91,17 @@ RSpec.describe GetApplicationChoicesForProvider do
       status: 'awaiting_provider_decision',
     )
 
+    create(
+      :application_choice,
+      course_option: course_option_for_provider(provider: alternate_provider),
+      status: 'awaiting_provider_decision',
+      application_form: create(:application_form, first_name: 'Alex'),
+    )
+
     returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
-    expect(returned_applications.size).to be(3)
+    returned_application_names = returned_applications.map { |a| a.application_form.first_name }
+
+    expect(returned_application_names).to include('Aaron', 'Jim', 'Harry')
+    expect(returned_application_names).not_to include('Alex')
   end
 end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe SyncProviderFromFind do
   include FindAPIHelper
 
   describe 'ingesting provider, courses, sites and course_options for a provider_code' do
-
     it 'correctly creates all the entities' do
       stub_find_api_provider_200(
         provider_code: 'ABC',
@@ -32,12 +31,12 @@ RSpec.describe SyncProviderFromFind do
         accrediting_provider_name: 'Test Accrediting Provider',
       )
 
-        SyncProviderFromFind.call(provider_code: 'ABC')
+      SyncProviderFromFind.call(provider_code: 'ABC')
 
-        course_option = CourseOption.last
+      course_option = CourseOption.last
 
-        expect(course_option.course.accrediting_provider.code).to eq 'DEF'
-        expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
+      expect(course_option.course.accrediting_provider.code).to eq 'DEF'
+      expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
     end
   end
 end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SyncProviderFromFind do
         course_code: '9CBA',
         site_code: 'G',
         findable: true,
+        accrediting_provider_code: 'DEF',
+        accrediting_provider_name: 'Test Accrediting Provider',
       )
     end
 
@@ -22,6 +24,8 @@ RSpec.describe SyncProviderFromFind do
       expect(course_option.course.code).to eq '9CBA'
       expect(course_option.course.exposed_in_find).to be true
       expect(course_option.site.code).to eq 'G'
+      expect(course_option.course.accrediting_provider.code).to eq 'DEF'
+      expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
     end
   end
 end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -4,18 +4,15 @@ RSpec.describe SyncProviderFromFind do
   include FindAPIHelper
 
   describe 'ingesting provider, courses, sites and course_options for a provider_code' do
-    before do
+
+    it 'correctly creates all the entities' do
       stub_find_api_provider_200(
         provider_code: 'ABC',
         course_code: '9CBA',
         site_code: 'G',
         findable: true,
-        accrediting_provider_code: 'DEF',
-        accrediting_provider_name: 'Test Accrediting Provider',
       )
-    end
 
-    it 'correctly creates all the entities' do
       SyncProviderFromFind.call(provider_code: 'ABC')
 
       course_option = CourseOption.last
@@ -24,8 +21,23 @@ RSpec.describe SyncProviderFromFind do
       expect(course_option.course.code).to eq '9CBA'
       expect(course_option.course.exposed_in_find).to be true
       expect(course_option.site.code).to eq 'G'
-      expect(course_option.course.accrediting_provider.code).to eq 'DEF'
-      expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
+    end
+
+    it 'correctly handles accrediting providers' do
+      stub_find_api_provider_200_with_accrediting_provider(
+        provider_code: 'ABC',
+        course_code: '9CBA',
+        site_code: 'G',
+        accrediting_provider_code: 'DEF',
+        accrediting_provider_name: 'Test Accrediting Provider',
+      )
+
+        SyncProviderFromFind.call(provider_code: 'ABC')
+
+        course_option = CourseOption.last
+
+        expect(course_option.course.accrediting_provider.code).to eq 'DEF'
+        expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
     end
   end
 end

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -11,4 +11,10 @@ module CourseOptionHelpers
     site = create(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end
+
+  def course_option_for_accrediting_provider(provider:, accrediting_provider:)
+    course = create(:course, provider: provider, accrediting_provider: accrediting_provider)
+    site = create(:site, provider: provider)
+    create(:course_option, course: course, site: site)
+  end
 end

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -34,7 +34,7 @@ module FindAPIHelper
       .to_return(status: 503)
   end
 
-  def stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', findable: true)
+  def stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', accrediting_provider_code: 'XYZ', accrediting_provider_name: 'Dummy Accrediting Provider', findable: true)
     stub_find_api_provider(provider_code)
       .to_return(
         status: 200,
@@ -78,6 +78,10 @@ module FindAPIHelper
                 'level': 'primary',
                 'start_date': 'September 2019',
                 'findable?': findable,
+                'accrediting_provider': {
+                  'provider_name': accrediting_provider_name,
+                  'provider_code': accrediting_provider_code,
+                },
               },
               'relationships': {
                 'sites': {

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -34,7 +34,67 @@ module FindAPIHelper
       .to_return(status: 503)
   end
 
-  def stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', accrediting_provider_code: 'XYZ', accrediting_provider_name: 'Dummy Accrediting Provider', findable: true)
+  def stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', findable: true)
+    stub_find_api_provider(provider_code)
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: {
+          'data': {
+            'id': '1',
+            'type': 'providers',
+            'attributes': {
+              'provider_name': provider_name,
+              'provider_code': provider_code,
+            },
+            'relationships': {
+              'sites': {
+                'data': [
+                  { 'id': '1', 'type': 'sites' },
+                ],
+              },
+              'courses': {
+                'data': [
+                  { 'id': '1', 'type': 'courses' },
+                ],
+              },
+            },
+          },
+          'included': [
+            {
+              'id': '1',
+              'type': 'sites',
+              'attributes': {
+                'code': site_code,
+                'location_name': 'Main Site',
+              },
+            },
+            {
+              'id': '1',
+              'type': 'courses',
+              'attributes': {
+                'course_code': course_code,
+                'name': 'Primary',
+                'level': 'primary',
+                'start_date': 'September 2019',
+                'findable?': findable,
+                'accrediting_provider': nil,
+              },
+              'relationships': {
+                'sites': {
+                  'data': [
+                    { 'id': '1', 'type': 'sites' },
+                  ],
+                },
+              },
+            },
+          ],
+          'jsonapi': { 'version': '1.0' },
+        }.to_json,
+      )
+  end
+
+  def stub_find_api_provider_200_with_accrediting_provider(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', accrediting_provider_code: 'XYZ', accrediting_provider_name: 'Dummy Accrediting Provider', findable: true)
     stub_find_api_provider(provider_code)
       .to_return(
         status: 200,

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.feature 'See applications' do
+  include CourseOptionHelpers
+
+  scenario 'Provider visits application page' do
+    given_i_am_a_provider_user
+    and_my_organisation_has_accredited_courses_with_applications
+    and_i_visit_the_provider_page
+    then_i_should_see_the_applications_from_my_organisation
+    but_not_the_applications_from_other_providers
+  end
+
+  def given_i_am_a_provider_user
+    # This is stubbed out for now in the controller.
+  end
+
+  def and_my_organisation_has_accredited_courses_with_applications
+    current_provider = create(:provider, code: 'ABC')
+    other_provier = create(:provider, code: 'ANOTHER_ORG')
+    course_option = course_option_for_provider(provider: current_provider)
+    accredited_course_option_where_current_provider_is_accrediting = course_option_for_accrediting_provider(provider: other_provier, accrediting_provider: current_provider)
+    accredited_course_option_where_current_provider_is_main_provider = course_option_for_accrediting_provider(provider: current_provider, accrediting_provider: other_provier)
+
+
+    other_course_option = course_option_for_provider(provider: other_provier)
+
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Jim', last_name: 'Jones'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: accredited_course_option_where_current_provider_is_accrediting, application_form: create(:application_form, first_name: 'Clancy'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: accredited_course_option_where_current_provider_is_main_provider, application_form: create(:application_form, first_name: 'Harry'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option, application_form: create(:application_form, first_name: 'Bert'))
+  end
+
+  def and_i_visit_the_provider_page
+    visit provider_interface_path
+  end
+
+  def then_i_should_see_the_applications_from_my_organisation
+    expect(page).to have_content 'Jim'
+    expect(page).to have_content 'Clancy'
+    expect(page).to have_content 'Harry'
+  end
+
+  def but_not_the_applications_from_other_providers
+    expect(page).not_to have_content 'Bert'
+  end
+end

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -40,9 +40,27 @@ RSpec.feature 'See providers' do
   end
 
   def and_i_click_the_sync_button
-    @request1 = stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Royal Academy of Dance', course_code: 'ABC-1')
-    @request2 = stub_find_api_provider_200(provider_code: 'DEF', provider_name: 'Gorse SCITT')
-    @request3 = stub_find_api_provider_200(provider_code: 'GHI', provider_name: 'Somerset SCITT Consortium')
+    @request1 = stub_find_api_provider_200(
+      provider_code: 'ABC',
+      provider_name: 'Royal Academy of Dance',
+      course_code: 'ABC-1',
+      site_code: 'X',
+    )
+
+    @request2 = stub_find_api_provider_200(
+      provider_code: 'DEF',
+      provider_name: 'Gorse SCITT',
+      course_code: 'DEF-1',
+      site_code: 'Y',
+    )
+
+    @request3 = stub_find_api_provider_200(
+      provider_code: 'GHI',
+      provider_name: 'Somerset SCITT Consortium',
+      course_code: 'GHI-1',
+      site_code: 'C',
+    )
+
     click_button 'Sync Providers from Find'
   end
 


### PR DESCRIPTION
### Context

Providers need to be able to retrieve applications for courses that they accredit.

### Changes proposed in this pull request

- Update `courses` table to include `accrediting_provider `relationship.
- Update `course` and `application_choice` model to include `accrediting_provider`.
- Update `get_application_choices_for_provider` service to allow a given provider to retrieve their applications for courses they are the main provider and accrediting provider for.
- Update `application_choice` controller `current_user` stub to use the `Provider` model.

Updates to Syncing data from find:
- Update `sync_providers_from_find` service to allow the creation of `accrediting_providers`.
- Update current and create new service specs to handle the retrieval and creation of `accrediting_providers`.
- Update `support_interface` provider system specs to handle above changes.

### Guidance to review

Run spec and ensure the correct application_choice are being retrieved. 

### Link to Trello card

[1194 - Return application for accrediting providers](https://trello.com/c/2j6Lt55j/1194-return-applications-from-multiple-organisations%F0%9F%8F%88-kick-off)

### Env vars

N\A