### PR TITLE
Update support section to expose data we have

### DIFF
--- a/app/controllers/support_interface/manage_vendors_controller.rb
+++ b/app/controllers/support_interface/manage_vendors_controller.rb
@@ -1,7 +1,6 @@
 module SupportInterface
   class ManageVendorsController < SupportInterfaceController
     def index
-      @providers = Provider.all
     end
 
     def create

--- a/app/controllers/support_interface/manage_vendors_controller.rb
+++ b/app/controllers/support_interface/manage_vendors_controller.rb
@@ -1,7 +1,6 @@
 module SupportInterface
   class ManageVendorsController < SupportInterfaceController
-    def index
-    end
+    def index; end
 
     def create
       GenerateVendorProviders.call

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -4,6 +4,10 @@ module SupportInterface
       @providers = Provider.includes(:sites, :courses).all
     end
 
+    def show
+      @provider = Provider.includes(:courses, :sites).find(params[:provider_id])
+    end
+
     def sync
       Rails.configuration.providers_to_sync[:codes].each do |code|
         SyncProviderFromFind.call(provider_code: code)

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -1,6 +1,6 @@
 module SupportInterface
   class SupportInterfaceController < ActionController::Base
-    layout 'application'
+    layout 'support_layout'
 
     http_basic_authenticate_with(
       name: ENV.fetch('SUPPORT_USERNAME'),

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,7 +1,7 @@
 module NavigationHelper
   def nav_link(text, url, active:)
     item_class = 'govuk-header__navigation-item'
-    item_class += ' govuk-header__navigation-item--active' if params[:controller] == active
+    item_class += ' govuk-header__navigation-item--active' if controller.controller_name == active
 
     tag.li class: item_class do
       link_to text, url, class: 'govuk-header__link'

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,0 +1,10 @@
+module NavigationHelper
+  def nav_link(text, url, active:)
+    item_class = 'govuk-header__navigation-item'
+    item_class += ' govuk-header__navigation-item--active' if params[:controller] == active
+
+    tag.li class: item_class do
+      link_to text, url, class: 'govuk-header__link'
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -14,4 +14,9 @@ class Course < ApplicationRecord
     secondary: 'Secondary',
     further_education: 'Further education',
   }, _suffix: :course
+
+
+  def name_and_code
+    "#{name} (#{code})"
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -3,4 +3,8 @@ class Provider < ApplicationRecord
   has_many :sites
   has_many :course_options, through: :courses
   has_many :application_choices, through: :course_options
+
+  def name_and_code
+    "#{name} (#{code})"
+  end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,4 +3,8 @@ class Site < ApplicationRecord
 
   validates :code, presence: true
   validates :name, presence: true
+
+  def name_and_code
+    "#{name} (#{code})"
+  end
 end

--- a/app/views/layouts/_candidate_header.html.erb
+++ b/app/views/layouts/_candidate_header.html.erb
@@ -1,0 +1,11 @@
+<% if candidate_signed_in? %>
+  <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+    <li class="govuk-header__navigation-item">
+      <b><%= current_candidate.email_address %></b>
+    </li>
+
+    <li class="govuk-header__navigation-item">
+      <%= link_to 'Sign out', candidate_interface_sign_out_path, class: 'govuk-header__link' %>
+    </li>
+  </ul>
+<% end %>

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -1,0 +1,6 @@
+<ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+  <%= nav_link 'Applications', support_interface_applications_path, active: 'support_interface/application_forms' %>
+  <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'support_interface/api_tokens' %>
+  <%= nav_link 'Vendors', support_interface_manage_vendors_path, active: 'support_interface/manage_vendors' %>
+  <%= nav_link 'Providers', support_interface_providers_path, active: 'support_interface/providers' %>
+</ul>

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -1,6 +1,6 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-  <%= nav_link 'Applications', support_interface_applications_path, active: 'support_interface/application_forms' %>
-  <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'support_interface/api_tokens' %>
-  <%= nav_link 'Vendors', support_interface_manage_vendors_path, active: 'support_interface/manage_vendors' %>
-  <%= nav_link 'Providers', support_interface_providers_path, active: 'support_interface/providers' %>
+  <%= nav_link 'Applications', support_interface_applications_path, active: 'application_forms' %>
+  <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
+  <%= nav_link 'Vendors', support_interface_manage_vendors_path, active: 'manage_vendors' %>
+  <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
 </ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title><%= yield(:title) %></title>
+    <title><%= yield(:title) %> - <%= service_name %></title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -83,7 +83,7 @@
       </div>
       <%= yield(:before_content) %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
-        <%= yield %>
+        <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
     </div>
     <footer class="govuk-footer " role="contentinfo">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,15 +60,13 @@
         <div class="govuk-header__content">
           <%= link_to service_name, service_link, class: 'govuk-header__link govuk-header__link--service-name' %>
 
-          <% if current_namespace == 'candidate_interface' && candidate_signed_in? %>
-            <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item">
-                <b><%= current_candidate.email_address %></b>
-              </li>
-              <li class="govuk-header__navigation-item">
-                <%= link_to 'Sign out', candidate_interface_sign_out_path, class: 'govuk-header__link' %>
-              </li>
-            </ul>
+          <% case current_namespace %>
+          <% when 'candidate_interface' %>
+            <%= render 'layouts/candidate_header' %>
+          <% when 'support_interface' %>
+            <%= render 'layouts/support_header' %>
+          <% when 'provider_interface' %>
+            <%= render 'layouts/provider_header' %>
           <% end %>
         </div>
       </div>

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -1,0 +1,6 @@
+<% content_for :content do %>
+  <h1 class='govuk-heading-xl'><%= yield :title %></h1>
+  <%= yield %>
+<% end %>
+
+<%= render template: 'layouts/application' %>

--- a/app/views/support_interface/api_tokens/index.html.erb
+++ b/app/views/support_interface/api_tokens/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, 'API tokens' %>
-<h1 class='govuk-heading-xl'>API tokens</h1>
 
 <%= form_with model: VendorApiToken.new, url: support_interface_api_tokens_path do |f| %>
   <%= f.govuk_collection_select :provider_id, Provider.all, :id, :name, label: { text: 'Provider' } %>

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,2 +1,3 @@
-<h1 class='govuk-heading-xl'><%= @application_form.full_name %> Application History</h1>
+<% content_for :title, "#{@application_form.full_name}'s application history" %>
+
 <%= render SupportInterface::AuditTrailComponent, application_form: @application_form %>

--- a/app/views/support_interface/application_forms/index.html.erb
+++ b/app/views/support_interface/application_forms/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class='govuk-heading-xl'>Applications</h1>
+<% content_for :title, 'Applications' %>
 
 <table class='govuk-table'>
   <thead class="govuk-table__head">

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class='govuk-heading-xl'><%= @application_form.full_name %>'s application</h1>
+<% content_for :title, "#{@application_form.full_name}'s application" %>
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">

--- a/app/views/support_interface/manage_vendors/index.html.erb
+++ b/app/views/support_interface/manage_vendors/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, 'Manage vendors' %>
-<h1 class='govuk-heading-xl'>Manage vendors</h1>
 
 <%= form_tag support_interface_vendors_path, method: :post do %>
   <%= submit_tag('Generate Vendor Providers', class: 'govuk-button govuk-button--secondary') %>

--- a/app/views/support_interface/manage_vendors/index.html.erb
+++ b/app/views/support_interface/manage_vendors/index.html.erb
@@ -3,21 +3,3 @@
 <%= form_tag support_interface_vendors_path, method: :post do %>
   <%= submit_tag('Generate Vendor Providers', class: 'govuk-button govuk-button--secondary') %>
 <% end %>
-
-<table class='govuk-table'>
-  <thead class='govuk-table__head'>
-    <tr class='govuk-table__row'>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Vendor Account</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Created at</th>
-    </tr>
-  </thead>
-
-  <tbody class='govuk-table__body'>
-    <% @providers.each do |provider| %>
-    <tr class='govuk-table__row'>
-      <td class='govuk-table__cell'><%= provider.name %></td>
-      <td class='govuk-table__cell'><%= provider.created_at.to_s(:lonProvg) %></td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, 'Providers' %>
-<h1 class='govuk-heading-xl'>Providers</h1>
 
 <%= form_tag support_interface_providers_sync_path, method: :post do %>
   <%= submit_tag('Sync Providers from Find', class: 'govuk-button') %>

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -20,25 +20,15 @@
   <tbody class='govuk-table__body'>
     <% @providers.each do |provider| %>
       <tr class='govuk-table__row'>
-        <td class='govuk-table__cell'><%= provider.name %> (<%= provider.code %>)</td>
         <td class='govuk-table__cell'>
-          <details class='govuk-details' data-module='govuk-details'>
-            <summary class='govuk-details__summary'>
-              <span class='govuk-details__summary-text'>
-                <%= pluralize provider.courses.size, 'course' %>
-              </span>
-            </summary>
-            <div class='govuk-details__text'>
-              <ul class='govuk-list'>
-              <% provider.courses.each do |course| %>
-                <li><%= govuk_link_to course.name, candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code) %></li>
-              <% end %>
-              </ul>
-            </div>
-          </details>
-
+          <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
         </td>
-        <td class='govuk-table__cell'><%= provider.sites.size %></td>
+        <td class='govuk-table__cell'>
+          <%= pluralize provider.courses.size, 'course' %>
+        </td>
+        <td class='govuk-table__cell'>
+          <%= provider.sites.size %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -1,0 +1,45 @@
+<% content_for :title, @provider.name_and_code %>
+
+<h2 class='govuk-heading-l'>Courses (<%= @provider.courses.size %>)</h2>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header'>Course</th>
+      <th scope='col' class='govuk-table__header'>Level</th>
+      <th scope='col' class='govuk-table__header'>Start date</th>
+      <th scope='col' class='govuk-table__header'>Apply from Find</th>
+      <th scope='col' class='govuk-table__header'>Page on Find</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @provider.courses.each do |course| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'><%= course.name_and_code %></td>
+        <td class='govuk-table__cell'><%= course.level %></td>
+        <td class='govuk-table__cell'><%= course.start_date %></td>
+        <td class='govuk-table__cell'><%= govuk_link_to 'Apply from Find page', candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code) %></td>
+        <td class='govuk-table__cell'><%= govuk_link_to 'Find course page', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<h2 class='govuk-heading-l'>Sites (<%= @provider.sites.size %>)</h2>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header'>Name</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @provider.sites.each do |site| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'><%= site.name_and_code %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,6 +178,7 @@ Rails.application.routes.draw do
 
     get '/providers' => 'providers#index', as: :providers
     post '/providers/sync' => 'providers#sync'
+    get '/providers/:provider_id' => 'providers#show', as: :provider
   end
 
   get '/check', to: 'healthcheck#show'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,7 +173,7 @@ Rails.application.routes.draw do
     get '/tokens' => 'api_tokens#index', as: :api_tokens
     post '/tokens' => 'api_tokens#create'
 
-    get '/vendors' => 'manage_vendors#index'
+    get '/vendors' => 'manage_vendors#index', as: :manage_vendors
     post '/vendors' => 'manage_vendors#create'
 
     get '/providers' => 'providers#index', as: :providers

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_be_on_the_application_history_page
-    expect(page).to have_content 'Alice Wunder Application History'
+    expect(page).to have_content "Alice Wunder's application history"
   end
 
   def then_i_should_be_able_to_see_history_events

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -10,6 +10,9 @@ RSpec.feature 'See providers' do
       and_i_click_the_sync_button
       then_requests_to_find_should_be_made
       and_i_should_see_the_updated_list_of_providers
+
+      when_i_click_on_a_provider
+      then_i_see_the_providers_courses_and_sites
     end
   end
 
@@ -37,7 +40,7 @@ RSpec.feature 'See providers' do
   end
 
   def and_i_click_the_sync_button
-    @request1 = stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Royal Academy of Dance')
+    @request1 = stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Royal Academy of Dance', course_code: 'ABC-1')
     @request2 = stub_find_api_provider_200(provider_code: 'DEF', provider_name: 'Gorse SCITT')
     @request3 = stub_find_api_provider_200(provider_code: 'GHI', provider_name: 'Somerset SCITT Consortium')
     click_button 'Sync Providers from Find'
@@ -53,5 +56,13 @@ RSpec.feature 'See providers' do
     expect(page).to have_content('Royal Academy of Dance')
     expect(page).to have_content('Gorse SCITT')
     expect(page).to have_content('Somerset SCITT Consortium')
+  end
+
+  def when_i_click_on_a_provider
+    click_link 'Royal Academy of Dance'
+  end
+
+  def then_i_see_the_providers_courses_and_sites
+    expect(page).to have_content 'ABC-1'
   end
 end


### PR DESCRIPTION
### Context

We now have providers, courses, and sites in the database, but it hasn't been exposed. In order to enable better manual testing by non-technical team members, this PR updates the support section to expose all of the data. It also adds all of the pages that we have in the support section.

### Changes proposed in this pull request

<img width="1063" alt="Screenshot 2019-11-12 at 09 27 36" src="https://user-images.githubusercontent.com/233676/68659452-2e808d80-052f-11ea-8879-44f9c82d29f8.png">
<img width="1063" alt="Screenshot 2019-11-12 at 09 27 38" src="https://user-images.githubusercontent.com/233676/68659454-2e808d80-052f-11ea-92c8-7de995c5f8ca.png">
<img width="1063" alt="Screenshot 2019-11-12 at 09 27 40" src="https://user-images.githubusercontent.com/233676/68659455-2f192400-052f-11ea-9a66-c04a628eea23.png">
<img width="1063" alt="Screenshot 2019-11-12 at 09 27 42" src="https://user-images.githubusercontent.com/233676/68659456-2fb1ba80-052f-11ea-9dee-91b43c8ab54a.png">
<img width="1063" alt="Screenshot 2019-11-12 at 09 27 48" src="https://user-images.githubusercontent.com/233676/68659458-2fb1ba80-052f-11ea-9d6c-8d4b82ad8701.png">
<img width="1063" alt="Screenshot 2019-11-12 at 09 27 51" src="https://user-images.githubusercontent.com/233676/68659459-2fb1ba80-052f-11ea-81df-815b99e56d07.png">

### Guidance to review

Does the structure make sense?

### Link to Trello card

https://trello.com/c/96nQagv3/328-epic-launch-the-apply-from-find-page
