### PR TITLE
Only allow test data generation in test environments

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -1,8 +1,18 @@
 module VendorApi
   class TestDataController < VendorApiController
+    before_action :check_this_is_a_test_environment
+
     def regenerate
       GenerateTestData.new([params[:count].to_i, 100].min, current_provider).generate
       render json: { data: { message: 'OK, regenerated the test data' } }
+    end
+
+  private
+
+    def check_this_is_a_test_environment
+      if HostingEnvironment.production?
+        render status: 400, json: { data: { message: 'Sorry, you can only generate test data in test environments' } }
+      end
     end
   end
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -8,8 +8,7 @@ module HostingEnvironment
   end
 
   def self.phase
-    case environment_name
-    when 'www'
+    if production?
       'beta'
     else
       environment_name
@@ -38,5 +37,9 @@ module HostingEnvironment
     else
       'development'
     end
+  end
+
+  def self.production?
+    environment_name == 'www'
   end
 end

--- a/app/services/generate_test_data.rb
+++ b/app/services/generate_test_data.rb
@@ -5,6 +5,8 @@ class GenerateTestData
   end
 
   def generate
+    raise 'You can\'t generate test data in production' if HostingEnvironment.production?
+
     # delete_all doesn't work on `through` associations
     provider.application_choices.map(&:delete)
 

--- a/app/services/generate_vendor_providers.rb
+++ b/app/services/generate_vendor_providers.rb
@@ -1,5 +1,7 @@
 class GenerateVendorProviders
   def self.call
+    raise 'You can\'t generate test data in production' if HostingEnvironment.production?
+
     providers = [
       { name: 'Tribal Provider', code: 'TRIB' },
       { name: 'Ellucian Provider', code: 'ELLU' },

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -190,7 +190,9 @@ paths:
       tags:
         - Testing
       summary: Regenerate test data
-      description: Deletes all applications and generates 100 new applications
+      description: |
+        Deletes all applications and generates 100 new applications. Only
+        available on sandbox.apply-for-teacher-training.education.gov.uk.
       parameters:
         - name: count
           description: How many items to generate (max 100)

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -7,12 +7,10 @@ info:
     email: becomingateacher@digital.education.gov.uk
   description: API for DfE's Apply for postgraduate teacher training service
 servers:
-  - description: Local development environment
-    url: http://localhost:3000/api/v1
-  - description: DfE development environment
-    url: https://qa.apply-for-teacher-training.education.gov.uk/api/v1
-  - description: Vendor sandbox
+  - description: Sandbox (test environment for vendors)
     url: https://sandbox.apply-for-teacher-training.education.gov.uk/api/v1
+  - description: Production
+    url: https://www.apply-for-teacher-training.education.gov.uk/api/v1
 paths:
   /applications:
     get:

--- a/spec/requests/vendor_api/post_test_data_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_spec.rb
@@ -9,4 +9,14 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/regenerate', type: :request 
     expect(Candidate.count).to be(3)
     expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
   end
+
+  it 'does not generate test data in production' do
+    ClimateControl.modify CUSTOM_HOSTNAME: 'www.apply-for-teacher-training.education.gov.uk' do
+      post_api_request '/api/v1/test-data/regenerate?count=3'
+    end
+
+    expect(Candidate.count).to be(0)
+    expect(response.code).to eql '400'
+    expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
+  end
 end


### PR DESCRIPTION
### Context

We're going to launch the Apply from Find page soon, which means we have to start treating production more carefully. This makes sure that we don't do test data generation on production.

### Changes proposed in this pull request

See commits.

### Guidance to review

Is there any other test data generation that we haven't taken into account?

### Link to Trello card

https://trello.com/c/96nQagv3/328-epic-launch-the-apply-from-find-page
