### PR TITLE
Specify view ordering for degrees

### DIFF
--- a/app/models/candidate_interface/degree_form.rb
+++ b/app/models/candidate_interface/degree_form.rb
@@ -19,7 +19,7 @@ module CandidateInterface
 
     class << self
       def build_all_from_application(application_form)
-        application_form.application_qualifications.degrees.map do |degree|
+        application_form.application_qualifications.degrees.order(created_at: :desc).map do |degree|
           new_degree_form(degree)
         end
       end


### PR DESCRIPTION
Our specs expect that clicking on the '.first' qualification will result
in a certain one being deleted. Intermittent failures point to the
ordering not being consistent, so enforce ordering by created_at DESC
(last created is first displayed).
