### PR TITLE
Add ability to say no to having volunteering or experience in school roles

### DIFF
--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -1,0 +1,12 @@
+<section class="app-summary-card govuk-!-margin-bottom-6">
+  <header class="app-summary-card__header">
+    <h3 class="app-summary-card__title">
+      <%= t('application_form.volunteering.no_experience.summary_card_title') %>
+    </h3>
+  </header>
+  <div class="app-summary-card__body">
+    The Department for Education have made it easier for teacher training
+    applicants to gain experience in school. Learn more at
+    <%= link_to 'Get school experience', 'https://schoolexperience.education.gov.uk/', class: 'govuk-link', target: :_blank %>.
+  </div>
+</section>

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -1,0 +1,11 @@
+class VolunteeringReviewComponent < ActionView::Component::Base
+  validates :application_form, presence: true
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+private
+
+  attr_reader :application_form
+end

--- a/app/controllers/candidate_interface/volunteering/experience_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/experience_controller.rb
@@ -1,0 +1,31 @@
+module CandidateInterface
+  class Volunteering::ExperienceController < CandidateInterfaceController
+    def show
+      @volunteering_experience_form = VolunteeringExperienceForm.new
+    end
+
+    def submit
+      @volunteering_experience_form = VolunteeringExperienceForm.new(volunteering_experience_form_params)
+
+      if @volunteering_experience_form.valid?
+        if @volunteering_experience_form.experience == 'no'
+          redirect_to candidate_interface_review_volunteering_experience_path
+        else
+          render :show
+        end
+      else
+        render :show
+      end
+    end
+
+  private
+
+    def volunteering_experience_form_params
+      return nil unless params.has_key?(:candidate_interface_volunteering_experience_form)
+
+      params.require(:candidate_interface_volunteering_experience_form).permit(
+        :experience,
+      )
+    end
+  end
+end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -1,0 +1,7 @@
+module CandidateInterface
+  class Volunteering::ReviewController < CandidateInterfaceController
+    def show
+      @application_form = current_application
+    end
+  end
+end

--- a/app/models/candidate_interface/volunteering_experience_form.rb
+++ b/app/models/candidate_interface/volunteering_experience_form.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class VolunteeringExperienceForm
+    include ActiveModel::Model
+
+    attr_accessor :experience
+
+    validates :experience, presence: true
+  end
+end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -48,7 +48,7 @@
         <% end %>
       </li>
       <li class="app-task-list__item">
-        <%= govuk_link_to 'TODO: School experience and volunteering', '#', class: 'app-task-list__task-name' %>
+        <%= govuk_link_to t('page_titles.volunteering.short'), candidate_interface_volunteering_experience_path, class: 'app-task-list__task-name' %>
       </li>
       <li class="app-task-list__item">
         <% if @application_form_presenter.training_with_a_disability_completed? %>

--- a/app/views/candidate_interface/volunteering/experience/show.html.erb
+++ b/app/views/candidate_interface/volunteering/experience/show.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, page_title('volunteering.long') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.volunteering.long') %>
+    </h1>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @volunteering_experience_form, url: candidate_interface_volunteering_experience_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <p class="govuk-body">
+        Use this section to tell us about any unpaid experience you’ve gained in
+        school or volunteering roles you've had in the wider community.
+        You can include:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>one-off observations in school</li>
+        <li>volunteering with children or young people in a school setting</li>
+        <li>volunteering with children or young people outside school</li>
+        <li>general involvement with school (for example as a parent governor)</li>
+      </ul>
+
+      <p class="govuk-body">
+        You can also tell us about volunteering with other age groups in your community.
+      </p>
+
+      <div class="govuk-!-margin-top-6">
+        <%= f.govuk_radio_buttons_fieldset :experience, legend: { size: 'm', text: t('application_form.volunteering.experience.label') } do %>
+          <%= f.govuk_radio_button :experience, :yes, label: { text: 'Yes' } %>
+          <%= f.govuk_radio_button :experience, :no, label: { text: 'No' } %>
+        <% end %>
+
+        <%= f.govuk_submit t('application_form.volunteering.experience.button') %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/volunteering/review/show.html.erb
+++ b/app/views/candidate_interface/volunteering/review/show.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, page_title('volunteering.short') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.volunteering.short') %>
+</h1>
+
+<%= render(VolunteeringReviewComponent, application_form: @application_form) %>
+

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -189,6 +189,12 @@ en:
         change_action: what you want to tell us about your disability
       review:
         button: Continue
+    volunteering:
+      experience:
+        label: Do you have experience volunteering with young people or in school?
+        button: Save and continue
+      no_experience:
+        summary_card_title: "Children and young people: no volunteering or experience in school roles entered"
   activemodel:
     errors:
       models:
@@ -326,3 +332,7 @@ en:
           attributes:
             qualification_type:
               blank: Enter the type of qualification
+        candidate_interface/volunteering_experience_form:
+          attributes:
+            experience:
+              blank: Choose whether or not you have experience volunteering with young people or in school

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,9 @@ en:
     subject_knowledge: What do you know about the subject you want to teach?
     interview_preferences: Interview preferences
     training_with_a_disability: Training with a disability
+    volunteering:
+      short: Volunteering with children and young people
+      long: "Children and young people: volunteering and experience in school"
   layout:
     service_name: Apply for teacher training
     accessibility: Accessibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,13 @@ Rails.application.routes.draw do
         delete '/delete/:id' => 'work_history/destroy#destroy'
       end
 
+      scope '/school-experience' do
+        get '/' => 'volunteering/experience#show', as: :volunteering_experience
+        post '/' => 'volunteering/experience#submit'
+
+        get '/review' => 'volunteering/review#show', as: :review_volunteering_experience
+      end
+
       scope '/degrees' do
         get '/' => 'degrees/base#new', as: :degrees_new_base
         post '/' => 'degrees/base#create', as: :degrees_create_base

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe VolunteeringReviewComponent do
+  context 'when they have no experience in volunteering' do
+    it 'renders component with how to get school experience' do
+      application_form = build_stubbed(:application_form)
+
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.app-summary-card__title').text).to include(
+        t('application_form.volunteering.no_experience.summary_card_title'),
+      )
+    end
+  end
+end

--- a/spec/models/candidate_interface/volunteering_experience_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_experience_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::VolunteeringExperienceForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:experience) }
+  end
+end

--- a/spec/system/candidate_interface/candidate_choosing_no_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/candidate_choosing_no_volunteering_and_school_experience_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.feature 'Choosing no volunteering and school experience' do
+  include CandidateHelper
+
+  scenario 'Candidate chooses no volunteering and school experience' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_volunteering_with_children_and_young_people
+    then_i_am_asked_if_i_have_experience_volunteering_with_young_people_or_in_school
+
+    when_i_omit_choosing_if_i_have_experience
+    then_i_see_validation_errors
+
+    when_i_choose_no_experience
+    and_i_submit_the_volunteering_experience_form
+    then_i_see_how_to_get_school_experience
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_volunteering_with_children_and_young_people
+    click_link t('page_titles.volunteering.short')
+  end
+
+  def then_i_am_asked_if_i_have_experience_volunteering_with_young_people_or_in_school
+    expect(page).to have_content(t('application_form.volunteering.experience.label'))
+  end
+
+  def when_i_omit_choosing_if_i_have_experience
+    click_button t('application_form.volunteering.experience.button')
+  end
+
+  def then_i_see_validation_errors
+    expect(page).to have_content(
+      t('activemodel.errors.models.candidate_interface/volunteering_experience_form.attributes.experience.blank'),
+    )
+  end
+
+  def when_i_choose_no_experience
+    choose 'No'
+  end
+
+  def and_i_submit_the_volunteering_experience_form
+    click_button t('application_form.volunteering.experience.button')
+  end
+
+  def then_i_see_how_to_get_school_experience
+    expect(page).to have_content('Get school experience')
+  end
+end


### PR DESCRIPTION
### Context

Candidates should be able to add whether or not they have volunteering or experience in school roles. 

### Changes proposed in this pull request

This PR is the first slice for adding this section of the application.

When adding volunteering, the candidate is first presented with a page which asks whether or not they have any experience. If they say no, they are sent to the review page with content about how to gain school experience. Currently if you say yes, nothing happens.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68670764-980b9680-0545-11ea-90a8-4e941607932d.png)


### Guidance to review

Pretty much followed how work history has implement its first page of entering the length of working.

### Link to Trello card

[123 - Example Trello card](http://trello.com/123-example-card)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
