### PR TITLE
Let candidates check that they're eligible for Apply 

### DIFF
--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -3,5 +3,22 @@ module CandidateInterface
     skip_before_action :authenticate_candidate!
 
     def show; end
+
+    def eligibility
+      @eligibility_form = EligibilityForm.new
+    end
+
+    def determine_eligibility
+      @eligibility_form = EligibilityForm.new(eligibility_params)
+      if @eligibility_form.eligible_to_use_dfe_apply?
+        redirect_to candidate_interface_sign_up_path
+      else
+        render :not_eligible
+      end
+    end
+
+    def eligibility_params
+      params.require(:candidate_interface_eligibility_form).permit(:eligible_citizen, :eligible_qualifications, :eligible_providers)
+    end
   end
 end

--- a/app/models/candidate_interface/eligibility_form.rb
+++ b/app/models/candidate_interface/eligibility_form.rb
@@ -1,0 +1,12 @@
+module CandidateInterface
+  class EligibilityForm
+    attr_accessor :eligible_citizen, :eligible_qualifications, :eligible_providers
+    include ActiveModel::Model
+
+    def eligible_to_use_dfe_apply?
+      eligible_citizen == 'yes' &&
+        eligible_qualifications == 'yes' &&
+        eligible_providers == 'yes'
+    end
+  end
+end

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -1,0 +1,41 @@
+<% content_for :title, t('page_titles.application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_start_path) %>
+
+<h1 class="govuk-heading-xl">
+  First, check you can use the new GOV.UK service
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: CandidateInterface::EligibilityForm.new, url: candidate_interface_eligibility_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK, EU or EEA?' } do %>
+        <%= f.govuk_radio_button :eligible_citizen, 'yes', label: { text: 'Yes' } %>
+        <%= f.govuk_radio_button :eligible_citizen, 'no', label: { text: 'No' } %>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset :eligible_qualifications, inline: true, legend: { size: 'm', text: 'Did you gain all your qualifications at institutions based in the UK?' } do %>
+        <%= f.govuk_radio_button :eligible_qualifications, 'yes', label: { text: 'Yes' } %>
+        <%= f.govuk_radio_button :eligible_qualifications, 'no', label: { text: 'No' } %>
+      <% end %>
+
+      <% fieldset_label = capture do %>
+        Are you applying to one of the following training providers?
+
+        <ul class='govuk-list govuk-list--bullet govuk-!-margin-top-2 govuk-hint'>
+          <li>The Royal Academy of Dance</li>
+          <li>Gorse SCITT</li>
+          <li>Somerset SCITT Consortium</li>
+        </ul>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset :eligible_providers, inline: true, legend: { size: 'm', text: fieldset_label } do %>
+        <%= f.govuk_radio_button :eligible_providers, 'yes', label: { text: 'Yes' } %>
+        <%= f.govuk_radio_button :eligible_providers, 'no', label: { text: 'No' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/start_page/not_eligible.html.erb
+++ b/app/views/candidate_interface/start_page/not_eligible.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, 'We’re sorry, but we’re not ready for you yet' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_eligibility_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      We’re sorry, but we’re not ready for you yet
+    </h1>
+
+    <p class="govuk-body">Apply for teacher training is still in development, so for now, we have to limit candidate numbers.</p>
+    <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
+    <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
+    <p class="govuk-body"><%= govuk_link_to 'Apply on UCAS', UCAS.apply_url %></p>
+  </div>
+</div>

--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -28,7 +28,7 @@
       You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status.
       <%= govuk_link_to('Learn more', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
     </p>
-    <%= link_to candidate_interface_sign_up_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start', 'data-module': 'govuk-button' do %>
+    <%= link_to candidate_interface_eligibility_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
   namespace :candidate_interface, path: '/candidate' do
     get '/' => 'start_page#show', as: :start
 
+    get '/eligibility' => 'start_page#eligibility', as: :eligibility
+    post '/eligibility' => 'start_page#determine_eligibility'
+
     get '/sign-up', to: 'sign_up#new', as: :sign_up
     post '/sign-up', to: 'sign_up#create'
 

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -44,6 +44,12 @@ RSpec.feature 'Candidate account' do
     visit '/'
 
     click_on t('application_form.begin_button')
+
+    find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
+    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
+    find('#candidate-interface-eligibility-form-eligible-providers-yes-field').click
+
+    click_on 'Continue'
   end
 
   def then_i_should_see_validation_errors_for_the_terms_and_conditions

--- a/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
   include CandidateHelper
 
   scenario 'Candidate submits why they want to be a teacher' do
-    given_i_am_not_signed_in
-    and_i_visit_the_becoming_a_teacher_page
-    then_i_should_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -32,18 +28,8 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     then_i_can_check_my_revised_answers
   end
 
-  def given_i_am_not_signed_in; end
-
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_i_visit_the_becoming_a_teacher_page
-    visit candidate_interface_becoming_a_teacher_edit_path
-  end
-
-  def then_i_should_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/candidate_eligibility_spec.rb
+++ b/spec/system/candidate_interface/candidate_eligibility_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate eligibility' do
+  scenario 'Candidate confirms that they are eligible' do
+    when_i_click_start_on_the_start_page
+    and_i_answer_no_to_some_questions
+    then_i_should_be_redirected_to_ucas
+
+    when_i_click_start_on_the_start_page
+    when_i_answer_yes_to_all_questions
+    then_should_be_redirected_to_the_signup_page
+  end
+
+  def when_i_click_start_on_the_start_page
+    visit '/'
+    click_on t('application_form.begin_button')
+  end
+
+  def and_i_answer_no_to_some_questions
+    find('#candidate-interface-eligibility-form-eligible-citizen-no-field').click
+    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
+    find('#candidate-interface-eligibility-form-eligible-providers-yes-field').click
+    click_on 'Continue'
+  end
+
+  def then_i_should_be_redirected_to_ucas
+    expect(page).to have_content 'We’re sorry, but we’re not ready for you yet'
+  end
+
+  def when_i_answer_yes_to_all_questions
+    find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
+    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
+    find('#candidate-interface-eligibility-form-eligible-providers-yes-field').click
+    click_on 'Continue'
+  end
+
+  def then_should_be_redirected_to_the_signup_page
+    expect(page).to have_content 'Create an Apply for teacher training account'
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering their contact details' do
   include CandidateHelper
 
   scenario 'Candidate submits their contact details' do
-    given_i_am_not_signed_in
-    and_i_visit_the_contact_details_page
-    then_i_should_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -46,16 +42,6 @@ RSpec.feature 'Entering their contact details' do
 
     when_i_click_on_contact_details
     then_i_can_check_my_revised_answers
-  end
-
-  def given_i_am_not_signed_in; end
-
-  def and_i_visit_the_contact_details_page
-    visit candidate_interface_contact_details_edit_base_path
-  end
-
-  def then_i_should_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering their degrees' do
   include CandidateHelper
 
   scenario 'Candidate submits their degrees' do
-    given_i_am_not_signed_in
-    and_i_visit_the_degrees_page
-    then_i_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -52,16 +48,6 @@ RSpec.feature 'Entering their degrees' do
 
     when_i_click_on_degree
     then_i_can_check_my_answers
-  end
-
-  def given_i_am_not_signed_in; end
-
-  def and_i_visit_the_degrees_page
-    visit candidate_interface_degrees_new_base_path
-  end
-
-  def then_i_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_entering_interview_preferences.rb
+++ b/spec/system/candidate_interface/candidate_entering_interview_preferences.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering interview preferences' do
   include CandidateHelper
 
   scenario 'Candidate submits their interview preferences' do
-    given_i_am_not_signed_in
-    and_i_visit_the_interview_preferences_page
-    then_i_should_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -32,18 +28,8 @@ RSpec.feature 'Entering interview preferences' do
     then_i_can_check_my_revised_answers
   end
 
-  def given_i_am_not_signed_in; end
-
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_i_visit_the_interview_preferences_page
-    visit candidate_interface_interview_preferences_edit_path
-  end
-
-  def then_i_should_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering their other qualifications' do
   include CandidateHelper
 
   scenario 'Candidate submits their other qualifications' do
-    given_i_am_not_signed_in
-    and_i_visit_the_other_qualifications_page
-    then_i_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -51,16 +47,6 @@ RSpec.feature 'Entering their other qualifications' do
     and_i_click_on_continue
     then_i_should_see_the_form
     and_that_the_section_is_completed
-  end
-
-  def given_i_am_not_signed_in; end
-
-  def and_i_visit_the_other_qualifications_page
-    visit candidate_interface_new_other_qualification_path
-  end
-
-  def then_i_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering their personal details' do
   include CandidateHelper
 
   scenario 'Candidate submits their personal details' do
-    given_i_am_not_signed_in
-    and_i_visit_the_personal_details_page
-    then_i_should_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -33,18 +29,8 @@ RSpec.feature 'Entering their personal details' do
     then_i_can_check_my_revised_answers
   end
 
-  def given_i_am_not_signed_in; end
-
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_i_visit_the_personal_details_page
-    visit candidate_interface_personal_details_edit_path
-  end
-
-  def then_i_should_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/candidate_entering_subject_knowledge_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_subject_knowledge_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering subject knowledge' do
   include CandidateHelper
 
   scenario 'Candidate submits their subject knowledge' do
-    given_i_am_not_signed_in
-    and_i_visit_the_subject_knowledge_page
-    then_i_should_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -32,18 +28,8 @@ RSpec.feature 'Entering subject knowledge' do
     then_i_can_check_my_revised_answers
   end
 
-  def given_i_am_not_signed_in; end
-
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_i_visit_the_subject_knowledge_page
-    visit candidate_interface_subject_knowledge_edit_path
-  end
-
-  def then_i_should_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Entering their work history' do
   include CandidateHelper
 
   scenario 'Candidate submits their work history' do
-    given_i_am_not_signed_in
-    and_i_visit_the_work_history_page
-    then_i_should_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -52,18 +48,8 @@ RSpec.feature 'Entering their work history' do
     and_that_the_section_is_completed
   end
 
-  def given_i_am_not_signed_in; end
-
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_i_visit_the_work_history_page
-    visit candidate_interface_work_history_length_path
-  end
-
-  def then_i_should_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -4,10 +4,6 @@ RSpec.feature 'Selecting a course' do
   include CandidateHelper
 
   scenario 'Candidate selects a course choice' do
-    given_i_am_not_signed_in
-    and_i_visit_the_contact_details_page
-    then_i_should_see_the_homepage
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -19,16 +15,6 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_course
     and_i_choose_a_location
     then_i_see_my_completed_course_choice
-  end
-
-  def given_i_am_not_signed_in; end
-
-  def and_i_visit_the_contact_details_page
-    visit candidate_interface_contact_details_edit_base_path
-  end
-
-  def then_i_should_see_the_homepage
-    expect(page).to have_current_path(candidate_interface_start_path)
   end
 
   def given_i_am_signed_in


### PR DESCRIPTION
### Context

This implements the eligibility checker feature.

### Changes proposed in this pull request

Instead of directly going to the signup page, the user first has to say "yes" to a number of questions.

<img width="1063" alt="Screenshot 2019-11-12 at 13 26 36" src="https://user-images.githubusercontent.com/233676/68675576-179e6300-0550-11ea-900b-ea9de2d3328b.png">

If the user says No to any question, or leaves one empty, they'll see:

<img width="1063" alt="Screenshot 2019-11-12 at 13 26 40" src="https://user-images.githubusercontent.com/233676/68675619-271dac00-0550-11ea-80df-4283f39d4b3d.png">

Otherwise they are redirected to the signup page.

### Guidance to review

Per commit.

### Link to Trello card

https://trello.com/c/qWizym9C/199-i-can-check-i-am-eligible-to-apply-on-dfe-apply

### Env vars

Nope.