### PR TITLE
Add checkbox for course confirmation

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class CourseChoicesController < CandidateInterfaceController
     def index
+      @application_form = current_application
       @course_choices = current_candidate.current_application.application_choices
     end
 
@@ -65,10 +66,26 @@ module CandidateInterface
       redirect_to candidate_interface_course_choices_index_path
     end
 
+    def complete
+      @application_form = current_application
+      @application_form.course_choices_present = true
+
+      if @application_form.update(application_form_params)
+        redirect_to candidate_interface_application_form_path
+      else
+        @course_choices = current_candidate.current_application.application_choices
+        render :index
+      end
+    end
+
   private
 
     def current_course_choice_id
       params.permit(:id)[:id]
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(:course_choices_completed)
     end
 
     def application_choice_params

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -14,6 +14,9 @@ class ApplicationForm < ApplicationRecord
     application_choices.update_all(updated_at: Time.zone.now)
   }
 
+  attr_accessor :course_choices_present
+  validates :course_choices_completed, acceptance: true, if: -> { course_choices_present }
+
   def submitted?
     application_choices.any? && !application_choices.first.unsubmitted?
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -59,5 +59,9 @@ module CandidateInterface
         (@application_form.disclose_disability == true && \
           @application_form.disability_disclosure.present?)
     end
+
+    def course_choices_completed?
+      @application_form.course_choices_completed
+    end
   end
 end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -10,12 +10,17 @@
       Courses
     </h2>
     <% unless @application_form_presenter.application_choices_added? %>
-      <p class="govuk-body"><%= t('application_form.courses') %></p>
+      <p class="govuk-body"><%= t('application_form.courses.intro') %></p>
     <% end %>
 
     <ol class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
-        <%= govuk_link_to 'Course choices', candidate_interface_course_choices_index_path %>
+        <% if @application_form_presenter.course_choices_completed? %>
+          <%= govuk_link_to t('page_titles.course_choices'), candidate_interface_course_choices_index_path, class: 'app-task-list__task-name', 'aria-describedby': 'courses-choices-completed' %>
+          <strong class="govuk-tag app-task-list__task-completed" id="course-choices-completed">Completed</strong>
+        <% else %>
+          <%= govuk_link_to t('page_titles.course_choices'), candidate_interface_course_choices_index_path, class: 'app-task-list__task-name' %>
+        <% end %>
       </li>
     </ol>
 

--- a/app/views/candidate_interface/course_choices/index.html.erb
+++ b/app/views/candidate_interface/course_choices/index.html.erb
@@ -1,24 +1,57 @@
 <% content_for :title, page_title('course_choices') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
+<h1 class='govuk-heading-xl'>
   <%= t('page_titles.course_choices') %>
 </h1>
 
-<% @course_choices.map.each do |course_choice| %>
-  <%= render(SummaryCardComponent, rows: [
-    { key: 'Course', value: "#{course_choice.course.name} (#{course_choice.course.code})" },
-    { key: 'Location', value: course_choice.site.name },
-  ]) do %>
-    <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
-        <%= course_choice.provider.name %>
-      </h3>
-      <div class="app-summary-card__actions">
-        <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
+<%= form_with model: @application_form, url: candidate_interface_course_choices_complete_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <% @course_choices.map.each do |course_choice| %>
+    <%= render(SummaryCardComponent, rows: [
+      { key: 'Course', value: "#{course_choice.course.name} (#{course_choice.course.code})" },
+      { key: 'Location', value: course_choice.site.name },
+    ]) do %>
+      <header class='app-summary-card__header'>
+        <h3 class='app-summary-card__title'>
+          <%= course_choice.provider.name %>
+        </h3>
+        <div class='app-summary-card__actions'>
+          <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
+        </div>
+      </header>
+    <% end %>
+  <% end %>
+
+  <% if @course_choices.count.between?(1, 2) %>
+    <div class='govuk-grid-row'>
+      <div class='govuk-grid-column-two-thirds'>
+        <h2 class='govuk-heading-m'>Do you want to add another course?</h2>
+        <p class='govuk-body'>You can apply to up to 3 courses at this stage of your application.</p>
+        <p class='govuk-body'>Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
+        <p class='govuk-body'>You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on Apply for teacher training.</p>
+        <p class='govuk-body'>Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
       </div>
-    </header>
+    </div>
+  <% end %>
+
+  <% if @course_choices.count < 3 %>
+    <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
+  <% end %>
+
+  <% if @course_choices.count >= 1 %>
+    <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: {} do %>
+      <%= f.hidden_field :course_choices_completed, value: false %>
+      <%= f.govuk_check_box :course_choices_completed,
+                            true,
+                            multiple: false,
+                            link_errors: true,
+                            label: {
+                              text: t('application_form.courses.complete.completed_checkbox'),
+                            } %>
+    <% end %>
+
+    <%= f.govuk_submit 'Continue' %>
   <% end %>
 <% end %>
-
-<%= govuk_button_link_to 'Add course', candidate_interface_course_choices_choose_path %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -5,6 +5,9 @@ en:
       intro: You can apply for up to 3 courses.
       delete: Delete choice
       confirm_delete: Yes I'm sure - delete this choice
+      complete:
+        completed_checkbox: I have completed this section
+        button: Continue
     personal_details:
       first_name:
         label: First name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -146,6 +146,8 @@ Rails.application.routes.draw do
 
         get '/provider/:provider_code/courses/:course_code' => 'course_choices#options_for_site', as: :course_choices_site
         post '/provider/:provider_code/courses/:course_code' => 'course_choices#pick_site'
+
+        patch '/complete' => 'course_choices#complete', as: :course_choices_complete
       end
 
       scope '/other-qualifications' do

--- a/db/migrate/20191112135402_add_course_choices_completed_to_application_forms.rb
+++ b/db/migrate/20191112135402_add_course_choices_completed_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddCourseChoicesCompletedToApplicationForms < ActiveRecord::Migration[6.0]
+  def change
+    add_column :application_forms, :course_choices_completed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,15 +69,16 @@ ActiveRecord::Schema.define(version: 2019_11_13_123956) do
     t.string "support_reference", limit: 10
     t.string "disability_disclosure"
     t.string "uk_residency_status"
-    t.boolean "degrees_completed", default: false, null: false
     t.boolean "work_history_completed", default: false, null: false
     t.text "work_history_explanation"
-    t.boolean "other_qualifications_completed", default: false, null: false
+    t.boolean "degrees_completed", default: false, null: false
     t.text "becoming_a_teacher"
     t.text "subject_knowledge"
     t.text "interview_preferences"
-    t.text "work_history_breaks"
+    t.boolean "other_qualifications_completed", default: false, null: false
     t.boolean "disclose_disability"
+    t.boolean "course_choices_completed", default: false, null: false
+    t.text "work_history_breaks"
     t.index ["candidate_id"], name: "index_application_forms_on_candidate_id"
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -13,7 +13,7 @@ module CandidateHelper
     visit candidate_interface_application_form_path
 
     click_link 'Course choices'
-    click_link 'Add course'
+    click_link 'Add another course'
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
 

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -19,7 +19,20 @@ RSpec.feature 'Selecting a course' do
     when_i_delete_my_course_choice
     and_i_confirm
     then_i_no_longer_see_my_course_choice
+
+    and_i_click_on_add_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_a_course
+    and_i_choose_a_location
+    then_i_see_my_completed_course_choice
+
+    when_i_mark_this_section_as_completed
+    when_i_click_continue
+    and_that_the_section_is_completed
   end
+
+  def given_i_am_not_signed_in; end
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
@@ -41,7 +54,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_click_on_add_course
-    click_link 'Add course'
+    click_link 'Add another course'
   end
 
   def and_i_choose_that_i_know_where_i_want_to_apply
@@ -80,5 +93,17 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_no_longer_see_my_course_choice
     expect(page).not_to have_content('Primary (2XT2)')
+  end
+
+  def when_i_mark_this_section_as_completed
+    check t('application_form.courses.complete.completed_checkbox')
+  end
+
+  def when_i_click_continue
+    click_button 'Continue'
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#course-choices-completed', text: 'Completed')
   end
 end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Candidate submit the application' do
     visit candidate_interface_application_form_path
 
     click_link 'Course choices'
-    click_link 'Add course'
+    click_link 'Add another course'
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
     select 'Gorse SCITT (1N1)'


### PR DESCRIPTION
### Context
Course selection UX

### Changes proposed in this pull request
Add confirmation checkbox to complete course selection

### Guidance to review
- Add courses
- Check completed checkbox

### Link to Trello card
[331 - Allow the course selection section to be marked complete and enable submission](https://trello.com/c/Ttl1Wr5Z/331-allow-the-course-selection-section-to-be-marked-complete-and-enable-submission)

### After
![localhost_3000_candidate_application_courses(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/68689695-b1720a00-0568-11ea-8bd3-35016c157511.png)

