### PR TITLE
Add dynamic validation for qualification grade

### DIFF
--- a/app/components/gcse_qualification_review_component.rb
+++ b/app/components/gcse_qualification_review_component.rb
@@ -27,7 +27,7 @@ private
   def award_year_row
     {
       key: 'Year awarded',
-      value: application_qualification.award_year,
+      value: application_qualification.award_year || t('gcse_summary.not_specified'),
       change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
     }
   end
@@ -35,7 +35,7 @@ private
   def grade_row
     {
       key: 'Grade',
-      value: application_qualification.grade.upcase,
+      value: application_qualification.grade ? application_qualification.grade.upcase : t('gcse_summary.not_specified'),
       change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
     }
   end

--- a/app/components/gcse_qualification_review_component.rb
+++ b/app/components/gcse_qualification_review_component.rb
@@ -35,7 +35,7 @@ private
   def grade_row
     {
       key: 'Grade',
-      value: application_qualification.grade,
+      value: application_qualification.grade.upcase,
       change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
     }
   end

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -5,6 +5,7 @@ module CandidateInterface
     attr_accessor :grade, :award_year, :qualification_id
     validates :grade, :award_year, :qualification_id, presence: true
     validate :validate_award_year, if: :award_year
+    validate :validate_grade_format
 
     def self.build_from_qualification(qualification)
       new(
@@ -17,16 +18,39 @@ module CandidateInterface
     def save_base
       return false unless valid?
 
-      qualification = ApplicationQualification.find(qualification_id)
-
       qualification.update(grade: grade, award_year: award_year)
     end
 
   private
-
     def validate_award_year
       valid_award_year = award_year.match(/^[1-9]\d{3}$/)
       errors.add(:award_year, :invalid) unless valid_award_year
+    end
+
+    def validate_grade_format
+      return if new_record? || qualification.qualification_type.nil?
+
+      qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
+
+      if qualification_rexp && grade.match(qualification_rexp)
+        errors.add(:grade, :invalid)
+      end
+    end
+
+    def qualification
+      @qualification ||= ApplicationQualification.find(qualification_id)
+    end
+
+    def invalid_grades
+      {
+        gcse: /[^1-9A-GU\*]/i,
+        gce_o_level: /[^A-EU]/i,
+        scottish_higher: /[^A-D1-7]/i,
+      }
+    end
+
+    def new_record?
+      qualification_id.nil?
     end
   end
 end

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -2,17 +2,19 @@ module CandidateInterface
   class GcseQualificationDetailsForm
     include ActiveModel::Model
 
-    attr_accessor :grade, :award_year, :qualification_id
-    validates :grade, :award_year, :qualification_id, presence: true
+
+    attr_accessor :grade, :award_year, :qualification
+    validates :grade, :award_yearpresence: true
     validate :validate_award_year, if: :award_year
+
     validate :validate_grade_format
 
     def self.build_from_qualification(qualification)
       new(
         grade: qualification.grade,
         award_year: qualification.award_year,
-        qualification_id: qualification.id,
-        )
+        qualification: qualification,
+      )
     end
 
     def save_base
@@ -37,10 +39,6 @@ module CandidateInterface
       end
     end
 
-    def qualification
-      @qualification ||= ApplicationQualification.find(qualification_id)
-    end
-
     def invalid_grades
       {
         gcse: /[^1-9A-GU\*]/i,
@@ -50,7 +48,7 @@ module CandidateInterface
     end
 
     def new_record?
-      qualification_id.nil?
+      qualification.nil?
     end
   end
 end

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -41,9 +41,9 @@ module CandidateInterface
 
     def invalid_grades
       {
-        gcse: /[^1-9A-GU\*]/i,
-        gce_o_level: /[^A-EU]/i,
-        scottish_higher: /[^A-D1-7]/i,
+        gcse: /[^1-9A-GU\*\s\-]/i,
+        gce_o_level: /[^A-EU\s\-]/i,
+        scottish_higher: /[^A-D1-7\s\-]/i,
       }
     end
 

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -4,8 +4,8 @@ module CandidateInterface
 
 
     attr_accessor :grade, :award_year, :qualification
-    validates :grade, :award_yearpresence: true
-    validate :validate_award_year, if: :award_year
+    validates :grade, :award_year, presence: true
+    validate :award_year_is_date, if: :award_year
 
     validate :validate_grade_format
 
@@ -24,7 +24,8 @@ module CandidateInterface
     end
 
   private
-    def validate_award_year
+
+    def award_year_is_date
       valid_award_year = award_year.match(/^[1-9]\d{3}$/)
       errors.add(:award_year, :invalid) unless valid_award_year
     end
@@ -43,7 +44,7 @@ module CandidateInterface
       {
         gcse: /[^1-9A-GU\*\s\-]/i,
         gce_o_level: /[^A-EU\s\-]/i,
-        scottish_higher: /[^A-D1-7\s\-]/i,
+        scottish_national_5: /[^A-D1-7\s\-]/i,
       }
     end
 

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -2,9 +2,9 @@ module CandidateInterface
   class GcseQualificationDetailsForm
     include ActiveModel::Model
 
-
     attr_accessor :grade, :award_year, :qualification
     validates :grade, :award_year, presence: true
+    validates :grade, length: { maximum: 6 }
     validate :award_year_is_date, if: :award_year
 
     validate :validate_grade_format

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -394,6 +394,7 @@ en:
           attributes:
             grade:
               blank: Enter the grade
+              invalid: Enter a real graduation grade
             award_year:
               blank: Enter your graduation year
               invalid: Enter a real graduation year

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -19,3 +19,4 @@ en:
       maths: Maths GCSE or equivalent
       english: English GCSE or equivalent
       science: Science GCSE or equivalent
+    not_specified: Not entered

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
 
     context 'when qualification type is Scottish National 5' do
       let(:form) { CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification) }
-      let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'scottish_higher', level: 'gcse') }
+      let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'scottish_national_5', level: 'gcse') }
 
       it 'returns no errors if grade is valid' do
         valid_grades = ['AAA', 'AAB', '765', 'CBD', 'aaa', 'C B D', 'C-B-D']

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -5,27 +5,82 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
     it { is_expected.to validate_presence_of(:grade) }
     it { is_expected.to validate_presence_of(:award_year) }
 
-    describe 'grade format' do
-      let(:form) do
-        qualification = FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gcse', level: 'gcse')
-        CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
-      end
-
-      it 'return validation error if grade is invalid' do
-        form.grade = 'aaz'
-
-        form.validate
-
-        expect(form.errors[:grade]).to include('Enter a real graduation grade')
-      end
+    context 'when qualification type is GCSE' do
+      let(:form) { CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification) }
+      let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gcse', level: 'gcse') }
 
       it 'returns no errors if grade is valid' do
-        %w[aaa a*a*a* AB 123].each do |grade|
-          form.grade = grade
+        valid_grades = ['A*A*A*', 'ABC', 'AA', '863', 'a*a*a*', 'A B C', 'A-B-C']
 
+        valid_grades.each do |grade|
+          form.grade = grade
           form.validate
 
           expect(form.errors[:grade]).to be_empty
+        end
+      end
+
+      it 'return validation error if grade is invalid' do
+        invalid_grades = %w[012 XYZ]
+
+        invalid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+          expect(form.errors[:grade]).to include('Enter a real graduation grade')
+        end
+      end
+    end
+
+    context 'when qualification type is GCE O LEVEL' do
+      let(:form) { CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification) }
+      let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gce_o_level', level: 'gcse') }
+
+      it 'returns no errors if grade is valid' do
+        valid_grades = ['ABC', 'AB', 'AA', 'abc', 'A B C', 'A-B-C']
+
+        valid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to be_empty
+        end
+      end
+
+      it 'return validation error if grade is invalid' do
+        invalid_grades = %w[123 A* XYZ]
+
+        invalid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to include('Enter a real graduation grade')
+        end
+      end
+    end
+
+    context 'when qualification type is Scottish National 5' do
+      let(:form) { CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification) }
+      let(:qualification) { FactoryBot.build_stubbed(:application_qualification, qualification_type: 'scottish_higher', level: 'gcse') }
+
+      it 'returns no errors if grade is valid' do
+        valid_grades = ['AAA', 'AAB', '765', 'CBD', 'aaa', 'C B D', 'C-B-D']
+
+        valid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to be_empty
+        end
+      end
+
+      it 'return validation error if grade is invalid' do
+        invalid_grades = %w[89 AE A*]
+
+        invalid_grades.each do |grade|
+          form.grade = grade
+          form.validate
+
+          expect(form.errors[:grade]).to include('Enter a real graduation grade')
         end
       end
     end

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -4,6 +4,30 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:grade) }
     it { is_expected.to validate_presence_of(:award_year) }
+
+    describe 'grade format' do
+      let(:form) do
+        qualification = ApplicationQualification.create(qualification_type: 'gcse', level: 'gcse',
+                                                        application_form: create(:application_form))
+        CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
+      end
+
+      it 'return validation error if grade is invalid' do
+        form.grade = 'aaz'
+
+        form.save_base
+        expect(form.errors[:grade]).to include('Enter a real graduation grade')
+      end
+
+      it 'returns no errors if grade is valid' do
+        %w[aaa a*a*a* AB 123].each do |grade|
+          form.grade = grade
+          form.save_base
+
+          expect(form.errors[:grade]).to be_empty
+        end
+      end
+    end
   end
 
   describe '#save_base' do

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:grade) }
     it { is_expected.to validate_presence_of(:award_year) }
+    it { is_expected.to validate_length_of(:grade).is_at_most(6) }
 
     context 'when qualification type is GCSE' do
       let(:form) { CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification) }

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -7,22 +7,23 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
 
     describe 'grade format' do
       let(:form) do
-        qualification = ApplicationQualification.create(qualification_type: 'gcse', level: 'gcse',
-                                                        application_form: create(:application_form))
+        qualification = FactoryBot.build_stubbed(:application_qualification, qualification_type: 'gcse', level: 'gcse')
         CandidateInterface::GcseQualificationDetailsForm.build_from_qualification(qualification)
       end
 
       it 'return validation error if grade is invalid' do
         form.grade = 'aaz'
 
-        form.save_base
+        form.validate
+
         expect(form.errors[:grade]).to include('Enter a real graduation grade')
       end
 
       it 'returns no errors if grade is valid' do
         %w[aaa a*a*a* AB 123].each do |grade|
           form.grade = grade
-          form.save_base
+
+          form.validate
 
           expect(form.errors[:grade]).to be_empty
         end


### PR DESCRIPTION
### Context

The Grades for validation need to respect the format specified in the doc:
https://docs.google.com/document/d/1NMUgKmzPSWJn85CVCUjkeArGuy1_WwlVeFZ9QNy6AeA/edit

NOTE: the logic in the doc is complex, for this MVP I **relaxed** the regular expressions:
it tests all the allowed letters/numbers but it does not consider the order.
Atm this tradeoff sounded reasonable to me, due the time restrictions.

### Changes proposed in this pull request
Add validations that consider the qualification type. 

### Guidance to review
see the screenshot and the new specs 

### Link to Trello card
https://trello.com/c/hvL9GGWZ/340-verifying-gcses-and-equivalents
