### PR TITLE
Referee emailer

### DIFF
--- a/app/mailers/previews/referee_mailer_preview.rb
+++ b/app/mailers/previews/referee_mailer_preview.rb
@@ -1,0 +1,8 @@
+class RefereeMailerPreview < ActionMailer::Preview
+  def reference_request_email
+    application_form = FactoryBot.build(:completed_application_form)
+    reference = application_form.references.first
+
+    RefereeMailer.reference_request_email(application_form, reference)
+  end
+end

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -1,0 +1,10 @@
+class RefereeMailer < ApplicationMailer
+  def reference_request_email(application_form, reference)
+    @application_form = application_form
+    @reference = reference
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: reference.email_address,
+              subject: t('reference_request.email.subject'))
+  end
+end

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -9,11 +9,20 @@ class RefereeMailer < ApplicationMailer
               subject: t('reference_request.email.subject', candidate_name: @candidate_name))
   end
 
+private
+
   def google_form_url_for(candidate_name, reference)
-    t('reference_request.google_form_url') + '?' +
+    # `to_query` replaces spaces with `+`, but a Google Form with a prefilled parameter
+    # shows a `+` in the actual form, eg "Jane Doe" becomes "Jane+Doe", so we need to
+    # switch them to %20 without stripping out a possible `+` in an email address
+    t('reference_request.google_form_url') +
+      '?' +
       {
         t('reference_request.email_entry') => reference.email_address,
         t('reference_request.reference_id_entry') => reference.id,
+      }.to_query +
+      '&' +
+      {
         t('reference_request.candidate_name_entry') => candidate_name,
         t('reference_request.referee_name_entry') => 'TODO: Referee name',
       }.to_query.gsub('+', '%20')

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -1,10 +1,21 @@
 class RefereeMailer < ApplicationMailer
   def reference_request_email(application_form, reference)
-    @application_form = application_form
     @reference = reference
+    @candidate_name = "#{application_form.first_name} #{application_form.last_name}"
+    @google_form_url = google_form_url_for(@candidate_name, @reference)
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,
-              subject: t('reference_request.email.subject'))
+              subject: t('reference_request.email.subject', candidate_name: @candidate_name))
+  end
+
+  def google_form_url_for(candidate_name, reference)
+    t('reference_request.google_form_url') + '?' +
+      {
+        t('reference_request.email_entry') => reference.email_address,
+        t('reference_request.reference_id_entry') => reference.id,
+        t('reference_request.candidate_name_entry') => candidate_name,
+        t('reference_request.referee_name_entry') => 'TODO: Referee name',
+      }.to_query.gsub('+', '%20')
   end
 end

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,23 +1,21 @@
 Dear ((name of referee)),
 
-# Please provide a reference for ((Candidate name))
+# Please provide a reference for <%= @candidate_name %>
 
-We’re contacting you from the Department for Education as ((Candidate name)) has asked you to provide a reference to support their teacher training application.
-
-((Candidate name)) has applied to:
-((list course names))
+We’re contacting you from the Department for Education as <%= @candidate_name %> has asked you to provide a reference to support their teacher training application.
 
 We would be grateful if you could provide a reference as soon as possible.
 
-Please use this form to complete your reference [link].
+Please use this form to complete your reference:
+<%= @google_form_url %>
 
 We’ll send you a reminder in a few days time.
 
-If we don’t receive your reference within 10 working days from the date of this email, we’ll ask ((Candidate name)) to suggest another referee.
+If we don’t receive your reference within 10 working days from the date of this email, we’ll ask <%= @candidate_name %> to suggest another referee.
 
 # Privacy notice
 
-((Candidate name)) out us in touch with you so that you can provide a reference for them.
+<%= @candidate_name %> put us in touch with you so that you can provide a reference for them.
 
 The Department for Education and the teacher training provider(s) the candidate has applied to have a ‘legitimate interest’ under data protection legislation to hold your data for the period needed to process the candidate’s application.
 

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,0 +1,26 @@
+Dear ((name of referee)),
+
+# Please provide a reference for ((Candidate name))
+
+We’re contacting you from the Department for Education as ((Candidate name)) has asked you to provide a reference to support their teacher training application.
+
+((Candidate name)) has applied to:
+((list course names))
+
+We would be grateful if you could provide a reference as soon as possible.
+
+Please use this form to complete your reference [link].
+
+We’ll send you a reminder in a few days time.
+
+If we don’t receive your reference within 10 working days from the date of this email, we’ll ask ((Candidate name)) to suggest another referee.
+
+# Privacy notice
+
+((Candidate name)) out us in touch with you so that you can provide a reference for them.
+
+The Department for Education and the teacher training provider(s) the candidate has applied to have a ‘legitimate interest’ under data protection legislation to hold your data for the period needed to process the candidate’s application.
+
+We’ll only use your data for this purpose and will delete it when no longer needed for this purpose.
+
+We currently use secure G Suite tools to process reference data. Your data will only be accessed by the staff who need it to process reference data.

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,24 +1,14 @@
 Dear ((name of referee)),
 
-# Please provide a reference for <%= @candidate_name %>
+# Please give a reference for <%= @candidate_name %>
 
-We’re contacting you from the Department for Education as <%= @candidate_name %> has asked you to provide a reference to support their teacher training application.
+<%= @candidate_name %> put us in touch with you to get a reference for their application for teacher training.
 
-We would be grateful if you could provide a reference as soon as possible.
+We would be grateful if you could submit a reference as soon as possible.
 
 Please use this form to complete your reference:
 <%= @google_form_url %>
 
-We’ll send you a reminder in a few days time.
+Don’t worry - we’ll only use your data to process your reference, unless you agree otherwise.
 
-If we don’t receive your reference within 10 working days from the date of this email, we’ll ask <%= @candidate_name %> to suggest another referee.
-
-# Privacy notice
-
-<%= @candidate_name %> put us in touch with you so that you can provide a reference for them.
-
-The Department for Education and the teacher training provider(s) the candidate has applied to have a ‘legitimate interest’ under data protection legislation to hold your data for the period needed to process the candidate’s application.
-
-We’ll only use your data for this purpose and will delete it when no longer needed for this purpose.
-
-We currently use secure G Suite tools to process reference data. Your data will only be accessed by the staff who need it to process reference data.
+We’ll ask <%= @candidate_name %> for another referee if we don’t hear from you within 10 working days.

--- a/config/locales/reference_request.yml
+++ b/config/locales/reference_request.yml
@@ -1,0 +1,4 @@
+en:
+  reference_request:
+    email:
+      subject: TODO Please give a reference to support the teacher training application

--- a/config/locales/reference_request.yml
+++ b/config/locales/reference_request.yml
@@ -1,4 +1,9 @@
 en:
   reference_request:
     email:
-      subject: TODO Please give a reference to support the teacher training application
+      subject: Please give a reference to support the teacher training application of %{candidate_name}
+    google_form_url: https://docs.google.com/forms/d/e/1FAIpQLSeLHV9XVqckn8XUjyAS3n7dzKU5OF-BLm5dYn51JcT6qa9pGg/viewform
+    email_entry: entry.409316871
+    reference_id_entry: entry.1515340886
+    candidate_name_entry: entry.1696393181
+    referee_name_entry: entry.994572146

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe RefereeMailer, type: :mailer do
+  subject(:mailer) { described_class }
+
+  describe 'Send request reference email' do
+    let(:application_form) { build(:completed_application_form) }
+    let(:reference) { application_form.references.first }
+    let(:mail) { mailer.reference_request_email(application_form, reference) }
+
+    before { mail.deliver_now }
+
+    it 'sends an email with the correct subject' do
+      expect(mail.subject).to include(t('reference_request.email.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(mail.body.encoded).to include('provide a reference for')
+    end
+  end
+end

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -6,16 +6,29 @@ RSpec.describe RefereeMailer, type: :mailer do
   describe 'Send request reference email' do
     let(:application_form) { build(:completed_application_form) }
     let(:reference) { application_form.references.first }
+    let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
     let(:mail) { mailer.reference_request_email(application_form, reference) }
 
     before { mail.deliver_now }
 
     it 'sends an email with the correct subject' do
-      expect(mail.subject).to include(t('reference_request.email.subject'))
+      expect(mail.subject).to include(t('reference_request.email.subject', candidate_name: candidate_name))
     end
 
     it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include('provide a reference for')
+      expect(mail.body.encoded).to include("provide a reference for #{candidate_name}")
+    end
+
+    it 'sends an email with a link to a prefilled Google form' do
+      body = mail.body.encoded
+      expect(body).to include(t('reference_request.google_form_url'))
+      expect(body).to include("=#{reference.id}")
+      expect(body).to include("=#{CGI.escape(reference.email_address)}")
+      # TODO: Referee name
+    end
+
+    it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
+      expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
     end
   end
 end

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -30,5 +30,13 @@ RSpec.describe RefereeMailer, type: :mailer do
     it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
       expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
     end
+
+    context 'an email containing a +' do
+      let(:reference) { build(:reference, email_address: 'email+email@email.com') }
+
+      it 'does not strip the plus from the email address' do
+        expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
+      end
+    end
   end
 end

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RefereeMailer, type: :mailer do
     end
 
     it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include("provide a reference for #{candidate_name}")
+      expect(mail.body.encoded).to include("give a reference for #{candidate_name}")
     end
 
     it 'sends an email with a link to a prefilled Google form' do


### PR DESCRIPTION
### Context

- Add mailer and template for requesting references from referees.

Personalise email by:
- including candidate name
- generating a link to a prefilled Google form

Referee name is missing at the moment, it's being added to the reference model in a separate PR by @aldavidson.

It’s not tied to any application state changes, I think for now we’d want to manually trigger them. But this means we don’t need to be copying and pasting long Google form URLs into Zendesk, plus other fields, and there’s less chance for human error (like confusing referee name and candidate name).

Based on the existing candidate_mailer.

https://trello.com/c/JcBL1Ejh/1249-build-system-to-request-and-receive-references
