### PR TITLE
Fix the broken build: specs and spec reporting failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,6 @@ ci.test: ## Run the tests with results formatted for CI
 	docker-compose run web /bin/sh -c 'mkdir $(RESULTS_PATH) && \
 		apk add nodejs yarn && \
 		bundle exec rails assets:precompile && \
-		bundle exec --verbose rspec --format RspecJunitFormatter --out $(RESULTS_PATH)/rspec-results.xml'
+		bundle exec --verbose rspec'
 	$(call copy_test_results)
 	docker-compose rm -f -v web

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,13 +96,6 @@ stages:
           true;
         else
           echo "ci.test failed"
-          if [ -f results/rspec-results.xml ]
-          then
-            echo "ERROR: Tests failed. results/rpsec-results.xml output:"
-            cat results/rspec-results.xml
-          else
-            echo "ERROR: Tests failed. Unable to read results/rpsec-results.xml. The file was either not created or the copy from the container failed."
-          fi
           false
         fi
       displayName: 'Execute tests'
@@ -146,14 +139,6 @@ stages:
       inputs:
         path: '$(System.DefaultWorkingDirectory)/azure/'
         artifactName: 'arm_template'
-
-    - task: PublishTestResults@2
-      displayName: 'Publish Test Results'
-      condition: succeededOrFailed()
-      inputs:
-        testRunner: JUnit
-        testResultsFiles: 'results/*.xml'
-
 
 - stage: deploy_qa
   displayName: 'Deploy - QA'


### PR DESCRIPTION
This code relied on an interface which has changed.

At the same time as correcting the call to ReceiveReference, roll in
the service now responsible for publishing applications to providers in
anticipation for simply invoking the cron job which will cause the
transition