### PR TITLE
Add ability to add a volunteering role with validation errors

### DIFF
--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -1,13 +1,34 @@
-<section class="app-summary-card govuk-!-margin-bottom-6">
-  <header class="app-summary-card__header">
-    <h3 class="app-summary-card__title">
-      <%= t('application_form.volunteering.no_experience.summary_card_title') %>
-    </h3>
-  </header>
+<% @volunteering_roles.each do |volunteering_role| %>
+  <%= render(SummaryCardComponent, rows: volunteering_role_rows(volunteering_role)) do %>
+    <header class="app-summary-card__header">
+      <h3 class="app-summary-card__title">
+        <%= volunteering_role.role %>
 
-  <div class="app-summary-card__body">
-    The Department for Education have made it easier for teacher training
-    applicants to gain experience in school. Learn more at
-    <%= link_to 'Get school experience', 'https://schoolexperience.education.gov.uk/', class: 'govuk-link', target: :_blank %>.
-  </div>
-</section>
+        <% if volunteering_role.working_with_children == 'true' %>
+          <span class="app-summary-card__meta">
+            <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+              <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+            </svg>
+            <%= t('application_form.volunteering.working_with_children.review_text') %>
+          </span>
+        <% end %>
+      </h3>
+    </header>
+  <% end %>
+<% end %>
+
+<% if @application_form.application_volunteering_experiences.empty? %>
+  <section class="app-summary-card govuk-!-margin-bottom-6">
+    <header class="app-summary-card__header">
+      <h3 class="app-summary-card__title">
+        <%= t('application_form.volunteering.no_experience.summary_card_title') %>
+      </h3>
+    </header>
+
+    <div class="app-summary-card__body">
+      The Department for Education have made it easier for teacher training
+      applicants to gain experience in school. Learn more at
+      <%= link_to 'Get school experience', 'https://schoolexperience.education.gov.uk/', class: 'govuk-link', target: :_blank %>.
+    </div>
+  </section>
+<% end %>

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -3,9 +3,64 @@ class VolunteeringReviewComponent < ActionView::Component::Base
 
   def initialize(application_form:)
     @application_form = application_form
+    @volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(
+      @application_form,
+    )
+  end
+
+  def volunteering_role_rows(volunteering_role)
+    [
+      role_row(volunteering_role),
+      organisation_row(volunteering_role),
+      length_and_details_row(volunteering_role),
+    ]
   end
 
 private
 
   attr_reader :application_form
+
+  def role_row(volunteering_role)
+    {
+      key: t('application_form.volunteering.role.review_label'),
+      value: volunteering_role.role,
+      action: t('application_form.volunteering.role.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def organisation_row(volunteering_role)
+    {
+      key: t('application_form.volunteering.organisation.review_label'),
+      value: volunteering_role.organisation,
+      action: t('application_form.volunteering.organisation.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def length_and_details_row(volunteering_role)
+    {
+      key: t('application_form.volunteering.length_and_details.review_label'),
+      value: formatted_length_and_details(volunteering_role),
+      action: t('application_form.volunteering.length_and_details.change_action'),
+      change_path: '#',
+    }
+  end
+
+  def formatted_length_and_details(volunteering_role)
+    [
+      "#{formatted_start_date(volunteering_role)} - #{formatted_end_date(volunteering_role)}",
+      simple_format(volunteering_role.details),
+    ]
+  end
+
+  def formatted_start_date(volunteering_role)
+    volunteering_role.start_date.strftime('%B %Y')
+  end
+
+  def formatted_end_date(volunteering_role)
+    return 'Present' if volunteering_role.end_date.nil? || volunteering_role.end_date == DateTime.now
+
+    volunteering_role.end_date.strftime('%B %Y')
+  end
 end

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -1,0 +1,49 @@
+module CandidateInterface
+  class Volunteering::BaseController < CandidateInterfaceController
+    def new
+      @volunteering_role = VolunteeringRoleForm.new
+    end
+
+    def create
+      @volunteering_role = VolunteeringRoleForm.new(volunteering_role_params)
+
+      if @volunteering_role.save(current_application)
+        redirect_to candidate_interface_review_volunteering_path
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def volunteering_role_params
+      params.require(:candidate_interface_volunteering_role_form)
+        .permit(
+          :role, :organisation, :details, :working_with_children,
+          :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
+          :"end_date(3i)", :"end_date(2i)", :"end_date(1i)"
+        )
+          .transform_keys { |key| start_date_field_to_attribute(key) }
+          .transform_keys { |key| end_date_field_to_attribute(key) }
+          .transform_keys(&:strip)
+    end
+
+    def start_date_field_to_attribute(key)
+      case key
+      when 'start_date(3i)' then 'start_date_day'
+      when 'start_date(2i)' then 'start_date_month'
+      when 'start_date(1i)' then 'start_date_year'
+      else key
+      end
+    end
+
+    def end_date_field_to_attribute(key)
+      case key
+      when 'end_date(3i)' then 'end_date_day'
+      when 'end_date(2i)' then 'end_date_month'
+      when 'end_date(1i)' then 'end_date_year'
+      else key
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/volunteering/experience_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/experience_controller.rb
@@ -9,9 +9,9 @@ module CandidateInterface
 
       if @volunteering_experience_form.valid?
         if @volunteering_experience_form.experience == 'no'
-          redirect_to candidate_interface_review_volunteering_experience_path
+          redirect_to candidate_interface_review_volunteering_path
         else
-          render :show
+          redirect_to candidate_interface_new_volunteering_role_path
         end
       else
         render :show

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -20,6 +20,23 @@ module CandidateInterface
     validate :end_date_before_current_year_and_month, if: :end_date_valid?
     validate :start_date_before_end_date, if: :start_date_and_end_date_valid?
 
+    class << self
+      def build_all_from_application(application_form)
+        application_form.application_volunteering_experiences.order(created_at: :desc).map do |volunteering_role|
+          new(
+            role: volunteering_role.role,
+            organisation: volunteering_role.organisation,
+            details: volunteering_role.details,
+            working_with_children: volunteering_role.working_with_children.to_s,
+            start_date_month: volunteering_role.start_date.month,
+            start_date_year: volunteering_role.start_date.year,
+            end_date_month: volunteering_role.end_date&.month || '',
+            end_date_year: volunteering_role.end_date&.year || '',
+          )
+        end
+      end
+    end
+
     def save(application_form)
       return false unless valid?
 

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -1,0 +1,84 @@
+# TODO: The validations have been lifted from `WorkExperienceForm`
+# and needs to be refactored out to remove the duplication.
+
+module CandidateInterface
+  class VolunteeringRoleForm
+    include ActiveModel::Model
+
+    attr_accessor :role, :organisation, :details, :working_with_children,
+                  :start_date_day, :start_date_month, :start_date_year,
+                  :end_date_day, :end_date_month, :end_date_year
+
+    validates :role, :organisation, :details, :working_with_children, presence: true
+
+    validates :role, :organisation, length: { maximum: 60 }
+
+    validates :details, word_count: { maximum: 150 }
+
+    validate :start_date_valid
+    validate :end_date_valid, unless: :end_date_blank?
+    validate :end_date_before_current_year_and_month, if: :end_date_valid?
+    validate :start_date_before_end_date, if: :start_date_and_end_date_valid?
+
+    def save(application_form)
+      return false unless valid?
+
+      application_form.application_volunteering_experiences.create!(
+        role: role,
+        organisation: organisation,
+        details: details,
+        working_with_children: ActiveModel::Type::Boolean.new.cast(working_with_children),
+        start_date: start_date,
+        end_date: end_date,
+      )
+
+      true
+    end
+
+    def start_date
+      valid_date_or_nil(start_date_year, start_date_month)
+    end
+
+    def end_date
+      valid_date_or_nil(end_date_year, end_date_month)
+    end
+
+  private
+
+    def valid_date_or_nil(year, month)
+      date_args = [year, month, 1].map(&:to_i)
+      Date.new(*date_args) if year.present? && Date.valid_date?(*date_args)
+    end
+
+    def end_date_blank?
+      end_date_year.blank? && end_date_month.blank?
+    end
+
+    def end_date_valid
+      errors.add(:end_date, :invalid) unless end_date
+    end
+
+    def start_date_valid
+      errors.add(:start_date, :invalid) unless start_date
+    end
+
+    def start_date_before_end_date
+      errors.add(:start_date, :before) unless start_date < end_date
+    end
+
+    def end_date_before_current_year_and_month
+      if end_date.year > Date.today.year || \
+          end_date.year == Date.today.year && end_date.month > Date.today.month
+        errors.add(:end_date, :in_the_future)
+      end
+    end
+
+    def start_date_and_end_date_valid?
+      end_date && start_date
+    end
+
+    def end_date_valid?
+      end_date
+    end
+  end
+end

--- a/app/views/candidate_interface/volunteering/base/new.html.erb
+++ b/app/views/candidate_interface/volunteering/base/new.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title, page_title(:add_volunteering_role) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @volunteering_role, url: candidate_interface_create_volunteering_role_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
+            <%= t('page_titles.add_volunteering_role') %>
+          </h1>
+        </legend>
+
+        <p class="govuk-body">Don’t include paid work in a school – enter these roles in ‘Work history’.</p>
+
+        <%= f.govuk_text_field :role, label: { text: t('application_form.volunteering.role.label'), size: 'm' } %>
+
+        <%= f.govuk_text_field :organisation, label: { text: t('application_form.volunteering.organisation.label'), size: 'm' } %>
+
+        <%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), tag: 'span' }, inline: true do %>
+          <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' } %>
+          <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
+        <% end %>
+
+        <h2 class="govuk-heading-m">How long have you been in this role and what does it involve?</h2>
+
+        <div class="app-work-experience__start-date" data-qa="start-date">
+          <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date.label'), size: 's', tag: 'span' }, hint_text: t('application_form.volunteering.start_date.hint_text') %>
+        </div>
+
+        <div class="app-work-experience__end-date" data-qa="end-date">
+          <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date.label'), size: 's', tag: 'span' }, hint_text: t('application_form.volunteering.end_date.hint_text') %>
+        </div>
+
+        <%= f.govuk_text_area :details, label: { text: t('application_form.volunteering.details.label'), size: 'm' }, hint_text: t('application_form.volunteering.details.hint_text'), max_words: 150 %>
+
+        <%= f.govuk_submit t('application_form.volunteering.complete_form_button') %>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -202,8 +202,12 @@ en:
         summary_card_title: "Children and young people: no volunteering or experience in school roles entered"
       role:
         label: Your role
+        review_label: Role
+        change_action: role
       organisation:
         label: Organisation where you gained experience or volunteered
+        review_label: Organisation
+        change_action: organisation
       working_with_children:
         label: Did this job involve working in a school or with children?
         review_text: This role involved working with children
@@ -211,7 +215,7 @@ en:
         label: How long have you been in this role and what does it involve?
       start_date:
         label: Start date
-        hint_text: For example, 5 2019
+        hint_text: For example, 5 2018
       end_date:
         label: End date (leave blank if this is your current role)
         hint_text: For example, 5 2019
@@ -220,6 +224,9 @@ en:
         hint_text: For example, ‘I volunteer in the classroom every Friday morning’
           or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved
           in activities throughout the year’
+      length_and_details:
+        review_label: Tell us how long you’ve been in this role and what it involves
+        change_action: dates and details
       complete_form_button: Save and continue
   activemodel:
     errors:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -200,6 +200,27 @@ en:
         button: Save and continue
       no_experience:
         summary_card_title: "Children and young people: no volunteering or experience in school roles entered"
+      role:
+        label: Your role
+      organisation:
+        label: Organisation where you gained experience or volunteered
+      working_with_children:
+        label: Did this job involve working in a school or with children?
+        review_text: This role involved working with children
+      length:
+        label: How long have you been in this role and what does it involve?
+      start_date:
+        label: Start date
+        hint_text: For example, 5 2019
+      end_date:
+        label: End date (leave blank if this is your current role)
+        hint_text: For example, 5 2019
+      details:
+        label: Enter details of your time commitment and responsibilities
+        hint_text: For example, ‘I volunteer in the classroom every Friday morning’
+          or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved
+          in activities throughout the year’
+      complete_form_button: Save and continue
   activemodel:
     errors:
       models:
@@ -346,3 +367,22 @@ en:
           attributes:
             experience:
               blank: Choose whether or not you have experience volunteering with young people or in school
+        candidate_interface/volunteering_role_form:
+          attributes:
+            role:
+              blank: Enter the role
+              too_long: Role must be %{count} characters or fewer
+            organisation:
+              blank: Enter the organisation where you gained experience or volunteered
+              too_long: The organisation must be %{count} characters or fewer
+            details:
+              blank: Enter details of your time commitment and responsibilities
+              too_long: Skills and experience must be %{count} characters or fewer
+            working_with_children:
+              blank: Choose if this role involves working in a school or with children
+            start_date:
+              invalid: Enter a start date in the correct format, for example 5 2018
+              before: Enter a start date that is before the end date
+            end_date:
+              invalid: Enter an end date in the correct format, for example 5 2019
+              in_the_future: Enter an end date that is not in the future

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,8 @@ en:
     volunteering:
       short: Volunteering with children and young people
       long: "Children and young people: volunteering and experience in school"
+      caption: Children and young people
+    add_volunteering_role: Add role
   layout:
     service_name: Apply for teacher training
     accessibility: Accessibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,7 +103,10 @@ Rails.application.routes.draw do
         get '/' => 'volunteering/experience#show', as: :volunteering_experience
         post '/' => 'volunteering/experience#submit'
 
-        get '/review' => 'volunteering/review#show', as: :review_volunteering_experience
+        get '/new' => 'volunteering/base#new', as: :new_volunteering_role
+        post '/new' => 'volunteering/base#create', as: :create_volunteering_role
+
+        get '/review' => 'volunteering/review#show', as: :review_volunteering
       end
 
       scope '/degrees' do

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe VolunteeringReviewComponent do
   context 'when they have no experience in volunteering' do
-    it 'renders component with how to get school experience' do
+    it 'shows how to get school experience' do
       application_form = build_stubbed(:application_form)
 
       result = render_inline(VolunteeringReviewComponent, application_form: application_form)
@@ -10,6 +10,80 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include(
         t('application_form.volunteering.no_experience.summary_card_title'),
       )
+    end
+
+    it 'does not show how to get school experience if volunteering experience' do
+      application_form = create(:completed_application_form, volunteering_experiences_count: 1)
+
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.app-summary-card__title').text).not_to include(
+        t('application_form.volunteering.no_experience.summary_card_title'),
+      )
+    end
+  end
+
+  context 'when they have experience in volunteering' do
+    let(:application_form) do
+      create(:application_form) do |form|
+        form.application_volunteering_experiences.create(
+          id: 1,
+          role: 'School Experience Intern',
+          organisation: Faker::Educator.secondary_school,
+          details: Faker::Lorem.paragraph_by_chars(number: 300),
+          working_with_children: false,
+          start_date: Time.zone.local(2018, 5, 1),
+          end_date: Time.zone.local(2019, 5, 1),
+        )
+        form.application_volunteering_experiences.create(
+          id: 2,
+          role: 'School Experience Intern',
+          organisation: 'A Noice School',
+          details: 'I interned.',
+          working_with_children: true,
+          start_date: Time.zone.local(2019, 8, 1),
+          end_date: nil,
+        )
+      end
+    end
+
+    it 'renders component with the role in the summary card title' do
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.app-summary-card__title').text).to include('School Experience Intern')
+    end
+
+    it 'renders component with working with children in the summary card title' do
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.app-summary-card__title')[0].text).to include(t('application_form.volunteering.working_with_children.review_text'))
+    end
+
+    it 'renders component with correct values for role' do
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.role.review_label'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('School Experience Intern')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('#')
+      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.role.change_action')}")
+    end
+
+    it 'renders component with correct values for organisation' do
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.organisation.review_label'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('A Noice School')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('#')
+      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.organisation.change_action')}")
+    end
+
+    it 'renders component with correct values for length and details of experience' do
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.length_and_details.review_label'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('August 2019 - Present<br><p>I interned.</p>')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('#')
+      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.length_and_details.change_action')}")
     end
   end
 end

--- a/spec/models/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_role_form_spec.rb
@@ -25,6 +25,38 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     }
   end
 
+  describe '.build_all_from_application' do
+    it 'creates an array of objects based on the provided ApplicationForm' do
+      application_form = create(:application_form) do |form|
+        form.application_volunteering_experiences.create(data)
+        form.application_volunteering_experiences.create(
+          role: 'School Experience Intern',
+          organisation: 'A Noice School',
+          details: 'I interned.',
+          working_with_children: true,
+          start_date: Time.zone.local(2018, 8, 1),
+          end_date: Time.zone.local(2019, 10, 1),
+        )
+      end
+
+      volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(application_form)
+
+      expect(volunteering_roles).to match_array([
+        have_attributes(form_data),
+        have_attributes(
+          role: 'School Experience Intern',
+          organisation: 'A Noice School',
+          details: 'I interned.',
+          working_with_children: 'true',
+          start_date_month: 8,
+          start_date_year: 2018,
+          end_date_month: 10,
+          end_date_year: 2019,
+        ),
+      ])
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       volunteering_role = CandidateInterface::VolunteeringRoleForm.new

--- a/spec/models/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_role_form_spec.rb
@@ -1,0 +1,175 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
+  let(:data) do
+    {
+      role: 'School Experience Intern',
+      organisation: Faker::Educator.secondary_school,
+      details: Faker::Lorem.paragraph_by_chars(number: 300),
+      working_with_children: [true, true, true, false].sample,
+      start_date: Time.zone.local(2018, 5, 1),
+      end_date: Time.zone.local(2019, 5, 1),
+    }
+  end
+
+  let(:form_data) do
+    {
+      role: data[:role],
+      organisation: data[:organisation],
+      details: data[:details],
+      working_with_children: data[:working_with_children].to_s,
+      start_date_month: data[:start_date].month,
+      start_date_year: data[:start_date].year,
+      end_date_month: data[:end_date].month,
+      end_date_year: data[:end_date].year,
+    }
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      volunteering_role = CandidateInterface::VolunteeringRoleForm.new
+
+      expect(volunteering_role.save(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'creates a new work experience if valid' do
+      application_form = create(:application_form)
+      volunteering_role = CandidateInterface::VolunteeringRoleForm.new(form_data)
+
+      expect(volunteering_role.save(application_form)).to eq(true)
+      expect(application_form.application_volunteering_experiences.first)
+        .to have_attributes(data)
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:role) }
+    it { is_expected.to validate_presence_of(:organisation) }
+    it { is_expected.to validate_presence_of(:details) }
+    it { is_expected.to validate_presence_of(:working_with_children) }
+
+    it { is_expected.to validate_length_of(:role).is_at_most(60) }
+    it { is_expected.to validate_length_of(:organisation).is_at_most(60) }
+
+    okay_text = Faker::Lorem.sentence(word_count: 150)
+    long_text = Faker::Lorem.sentence(word_count: 151)
+
+    it { is_expected.to allow_value(okay_text).for(:details) }
+    it { is_expected.not_to allow_value(long_text).for(:details) }
+
+    describe 'start date' do
+      it 'is invalid if not well-formed' do
+        volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+          start_date_month: '99', start_date_year: '99',
+        )
+
+        volunteering_role.validate
+
+        expect(volunteering_role.errors.full_messages_for(:start_date)).to eq(
+          ["Start date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.start_date.invalid')}"],
+        )
+      end
+
+      it 'is invalid if the date is after the end date' do
+        volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+          start_date_month: '5', start_date_year: '2018',
+          end_date_month: '5', end_date_year: '2017'
+        )
+
+        volunteering_role.validate
+
+        expect(volunteering_role.errors.full_messages_for(:start_date)).to eq(
+          ["Start date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.start_date.before')}"],
+        )
+      end
+    end
+
+    describe 'end date' do
+      it 'is valid if left completely blank' do
+        volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+          end_date_month: '', end_date_year: '',
+        )
+
+        volunteering_role.validate
+
+        expect(volunteering_role.errors.full_messages_for(:end_date)).to be_empty
+      end
+
+      it 'is invalid if month left blank' do
+        volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+          end_date_month: '', end_date_year: '2019',
+        )
+
+        volunteering_role.validate
+
+        expect(volunteering_role.errors.full_messages_for(:end_date)).to eq(
+          ["End date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.end_date.invalid')}"],
+        )
+      end
+
+      it 'is invalid if year left blank' do
+        volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+          end_date_month: '5', end_date_year: '',
+        )
+
+        volunteering_role.validate
+
+        expect(volunteering_role.errors.full_messages_for(:end_date)).to eq(
+          ["End date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.end_date.invalid')}"],
+        )
+      end
+
+      it 'is invalid if not well-formed' do
+        volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+          end_date_month: '99', end_date_year: '2019',
+        )
+
+        volunteering_role.validate
+
+        expect(volunteering_role.errors.full_messages_for(:end_date)).to eq(
+          ["End date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.end_date.invalid')}"],
+        )
+      end
+
+      it 'is invalid if year is beyond the current year' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+            end_date_month: '1', end_date_year: '2029',
+          )
+
+          volunteering_role.validate
+
+          expect(volunteering_role.errors.full_messages_for(:end_date)).to eq(
+            ["End date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.end_date.in_the_future')}"],
+          )
+        end
+      end
+
+      it 'is invalid if year is the current year but month is after the current month' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+            end_date_month: '11', end_date_year: '2019',
+          )
+
+          volunteering_role.validate
+
+          expect(volunteering_role.errors.full_messages_for(:end_date)).to eq(
+            ["End date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.end_date.in_the_future')}"],
+          )
+        end
+      end
+
+      it 'is valid if year and month are before the current year and month' do
+        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+          volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+            end_date_month: '9', end_date_year: '2019',
+          )
+
+          volunteering_role.validate
+
+          expect(volunteering_role.errors.full_messages_for(:end_date)).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering volunteering and school experience' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their volunteering and school experience' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_volunteering_with_children_and_young_people
+    then_i_am_asked_if_i_have_experience_volunteering_with_young_people_or_in_school
+
+    when_i_choose_yes_experience
+    and_i_submit_the_volunteering_experience_form
+    then_i_see_the_add_volunteering_role_form
+
+    when_i_fill_in_some_of_my_role_but_omit_some_required_details
+    and_i_submit_the_volunteering_role_form
+    then_i_see_validation_errors_for_my_volunteering_role
+
+    when_i_fill_in_my_volunteering_role
+    and_i_submit_the_volunteering_role_form
+    then_i_check_my_volunteering_role
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_volunteering_with_children_and_young_people
+    click_link t('page_titles.volunteering.short')
+  end
+
+  def then_i_am_asked_if_i_have_experience_volunteering_with_young_people_or_in_school
+    expect(page).to have_content(t('application_form.volunteering.experience.label'))
+  end
+
+  def when_i_choose_yes_experience
+    choose 'Yes'
+  end
+
+  def and_i_submit_the_volunteering_experience_form
+    click_button t('application_form.volunteering.experience.button')
+  end
+
+  def then_i_see_the_add_volunteering_role_form
+    expect(page).to have_content(t('page_titles.add_volunteering_role'))
+  end
+
+  def when_i_fill_in_some_of_my_role_but_omit_some_required_details
+    fill_in t('application_form.volunteering.role.label'), with: 'Classroom Volunteer'
+    fill_in t('application_form.volunteering.organisation.label'), with: 'A Noice School'
+  end
+
+  def and_i_submit_the_volunteering_role_form
+    click_button t('application_form.volunteering.complete_form_button')
+  end
+
+  def then_i_see_validation_errors_for_my_volunteering_role
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.start_date.invalid')
+  end
+
+  def when_i_fill_in_my_volunteering_role
+    fill_in t('application_form.volunteering.role.label'), with: 'Classroom Volunteer'
+    fill_in t('application_form.volunteering.organisation.label'), with: 'A Noice School'
+
+    choose 'Yes'
+
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '5'
+      fill_in 'Year', with: '2018'
+    end
+
+    within('[data-qa="end-date"]') do
+      fill_in 'Month', with: '1'
+      fill_in 'Year', with: '2019'
+    end
+
+    fill_in t('application_form.volunteering.details.label'), with: 'I volunteered.'
+  end
+
+  def then_i_check_my_volunteering_role
+    expect(page).to have_content('Classroom Volunteer')
+  end
+end


### PR DESCRIPTION
### Context

Currently in the application, a candidate can only say "No" to whether or not they have volunteering or school experience.

### Changes proposed in this pull request

This PR adds the ability to add a volunteering role with validation errors showing. It does so by:

- adding a form object `VolunteeringRoleForm`
- updating the `VolunteeringReviewComponent` to show all roles in review page

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68759031-dcab3680-0606-11ea-846e-54627043bd7d.png)

![image](https://user-images.githubusercontent.com/42817036/68759350-6a872180-0607-11ea-8954-14eff2b4f36a.png)

### Guidance to review

- Sorry, the diff is large mainly due to HTML, tests and translations
- Would recommend going through the commits, the code essentially follows what has been done in work history
- There is validation duplication between `VolunteeringRoleForm` and `WorkExperienceForm` and a `TODO` has been added for this to be refactored

### Link to Trello card

[193 - Adding school and volunteer experience](https://trello.com/c/XhtOYjDF/193-adding-school-and-volunteer-experience)