### PR TITLE
Add ability to delete a volunteering role

### DIFF
--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -14,7 +14,7 @@
         <% end %>
       </h3>
       <div class="app-summary-card__actions">
-        <%= link_to t('application_form.volunteering.delete'), '#', class: 'govuk-link' %>
+        <%= link_to t('application_form.volunteering.delete'), candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' %>
       </div>
     </header>
   <% end %>

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -13,6 +13,9 @@
           </span>
         <% end %>
       </h3>
+      <div class="app-summary-card__actions">
+        <%= link_to t('application_form.volunteering.delete'), '#', class: 'govuk-link' %>
+      </div>
     </header>
   <% end %>
 <% end %>

--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -1,0 +1,22 @@
+module CandidateInterface
+  class Volunteering::DestroyController < CandidateInterfaceController
+    def confirm_destroy
+      @volunteering_role = VolunteeringRoleForm.build_from_application(current_application, current_volunteering_role_id)
+    end
+
+    def destroy
+      current_application
+        .application_volunteering_experiences
+        .find(current_volunteering_role_id)
+        .destroy!
+
+      redirect_to candidate_interface_review_volunteering_path
+    end
+
+  private
+
+    def current_volunteering_role_id
+      params.permit(:id)[:id]
+    end
+  end
+end

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -23,18 +23,30 @@ module CandidateInterface
     class << self
       def build_all_from_application(application_form)
         application_form.application_volunteering_experiences.order(created_at: :desc).map do |volunteering_role|
-          new(
-            id: volunteering_role.id,
-            role: volunteering_role.role,
-            organisation: volunteering_role.organisation,
-            details: volunteering_role.details,
-            working_with_children: volunteering_role.working_with_children.to_s,
-            start_date_month: volunteering_role.start_date.month,
-            start_date_year: volunteering_role.start_date.year,
-            end_date_month: volunteering_role.end_date&.month || '',
-            end_date_year: volunteering_role.end_date&.year || '',
-          )
+          new_volunteering_role_form(volunteering_role)
         end
+      end
+
+      def build_from_application(application_form, volunteering_role_id)
+        volunteering_role = application_form.application_volunteering_experiences.find(volunteering_role_id)
+
+        new_volunteering_role_form(volunteering_role)
+      end
+
+    private
+
+      def new_volunteering_role_form(volunteering_role)
+        new(
+          id: volunteering_role.id,
+          role: volunteering_role.role,
+          organisation: volunteering_role.organisation,
+          details: volunteering_role.details,
+          working_with_children: volunteering_role.working_with_children.to_s,
+          start_date_month: volunteering_role.start_date.month,
+          start_date_year: volunteering_role.start_date.year,
+          end_date_month: volunteering_role.end_date&.month || '',
+          end_date_year: volunteering_role.end_date&.year || '',
+        )
       end
     end
 

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -5,7 +5,7 @@ module CandidateInterface
   class VolunteeringRoleForm
     include ActiveModel::Model
 
-    attr_accessor :role, :organisation, :details, :working_with_children,
+    attr_accessor :id, :role, :organisation, :details, :working_with_children,
                   :start_date_day, :start_date_month, :start_date_year,
                   :end_date_day, :end_date_month, :end_date_year
 
@@ -24,6 +24,7 @@ module CandidateInterface
       def build_all_from_application(application_form)
         application_form.application_volunteering_experiences.order(created_at: :desc).map do |volunteering_role|
           new(
+            id: volunteering_role.id,
             role: volunteering_role.role,
             organisation: volunteering_role.organisation,
             details: volunteering_role.details,

--- a/app/views/candidate_interface/volunteering/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/volunteering/destroy/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, page_title(:destroy_volunteering_role) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_volunteering_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @volunteering_role, url: candidate_interface_confirm_destroy_volunteering_role_path(@volunteering_role.id), method: :delete do |f| %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @volunteering_role.role %></span>
+            <%= t('page_titles.destroy_volunteering_role') %>
+          </h1>
+        </legend>
+
+        <%= f.submit t('application_form.volunteering.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to 'Cancel', candidate_interface_review_volunteering_path %>
+        </p>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -228,6 +228,8 @@ en:
         review_label: Tell us how long you’ve been in this role and what it involves
         change_action: dates and details
       complete_form_button: Save and continue
+      delete: Delete role
+      confirm_delete: Yes I'm sure - delete this role
   activemodel:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
       long: "Children and young people: volunteering and experience in school"
       caption: Children and young people
     add_volunteering_role: Add role
+    destroy_volunteering_role: Are you sure you want to delete this role?
   layout:
     service_name: Apply for teacher training
     accessibility: Accessibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,6 +107,9 @@ Rails.application.routes.draw do
         post '/new' => 'volunteering/base#create', as: :create_volunteering_role
 
         get '/review' => 'volunteering/review#show', as: :review_volunteering
+
+        get '/delete/:id' => 'volunteering/destroy#confirm_destroy', as: :confirm_destroy_volunteering_role
+        delete '/delete/:id' => 'volunteering/destroy#destroy'
       end
 
       scope '/degrees' do

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -85,5 +85,12 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('#')
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.length_and_details.change_action')}")
     end
+
+    it 'renders component along with a delete link for each role' do
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.app-summary-card__actions').text).to include(t('application_form.volunteering.delete'))
+      expect(result.css('.app-summary-card__actions a').attr('href').value).to include('#')
+    end
   end
 end

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -90,7 +90,9 @@ RSpec.describe VolunteeringReviewComponent do
       result = render_inline(VolunteeringReviewComponent, application_form: application_form)
 
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.volunteering.delete'))
-      expect(result.css('.app-summary-card__actions a').attr('href').value).to include('#')
+      expect(result.css('.app-summary-card__actions a').attr('href').value).to include(
+        Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_volunteering_role_path(2),
+      )
     end
   end
 end

--- a/spec/models/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_role_form_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     end
   end
 
+  describe '.build_from_application' do
+    it 'returns a new VolunteeringRoleForm object using the id' do
+      application_form = create(:application_form) do |form|
+        form.application_volunteering_experiences.create(id: 1, attributes: data)
+      end
+
+      volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_from_application(application_form, 1)
+
+      expect(volunteering_roles).to have_attributes(form_data)
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       volunteering_role = CandidateInterface::VolunteeringRoleForm.new

--- a/spec/models/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_role_form_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
   describe '.build_all_from_application' do
     it 'creates an array of objects based on the provided ApplicationForm' do
       application_form = create(:application_form) do |form|
-        form.application_volunteering_experiences.create(data)
+        form.application_volunteering_experiences.create(id: 1, attributes: data)
         form.application_volunteering_experiences.create(
+          id: 2,
           role: 'School Experience Intern',
           organisation: 'A Noice School',
           details: 'I interned.',
@@ -44,6 +45,7 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
       expect(volunteering_roles).to match_array([
         have_attributes(form_data),
         have_attributes(
+          id: 2,
           role: 'School Experience Intern',
           organisation: 'A Noice School',
           details: 'I interned.',

--- a/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -21,6 +21,10 @@ RSpec.feature 'Entering volunteering and school experience' do
     when_i_fill_in_my_volunteering_role
     and_i_submit_the_volunteering_role_form
     then_i_check_my_volunteering_role
+
+    when_i_delete_my_volunteering_role
+    and_i_confirm
+    then_i_no_longer_see_my_volunteering_role
   end
 
   def given_i_am_signed_in
@@ -85,5 +89,17 @@ RSpec.feature 'Entering volunteering and school experience' do
 
   def then_i_check_my_volunteering_role
     expect(page).to have_content('Classroom Volunteer')
+  end
+
+  def when_i_delete_my_volunteering_role
+    click_link t('application_form.volunteering.delete')
+  end
+
+  def and_i_confirm
+    click_button t('application_form.volunteering.confirm_delete')
+  end
+
+  def then_i_no_longer_see_my_volunteering_role
+    expect(page).not_to have_content('Classroom Volunteer')
   end
 end


### PR DESCRIPTION
### Context

A candidate currently can't delete a role they've added.

### Changes proposed in this pull request

This PR adds the ability to delete a volunteering role.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68764765-37e32600-0613-11ea-88b7-452ae761ef0f.png)

![image](https://user-images.githubusercontent.com/42817036/68765529-e340aa80-0614-11ea-8d2c-65150a672077.png)

![image](https://user-images.githubusercontent.com/42817036/68765632-28fd7300-0615-11ea-9f92-db2a287cc8a4.png)

### Guidance to review

Nothing in particular.

### Link to Trello card

[193 - Adding school and volunteer experience](https://trello.com/c/XhtOYjDF/193-adding-school-and-volunteer-experience)
