### PR TITLE
Do not use draft courses from Find 

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
       @courses = Provider
         .find_by(code: params[:provider_code])
         .courses
+        .that_candidates_can_apply_to
     end
 
     def pick_course

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -28,7 +28,7 @@ module CandidateInterface
       @courses = Provider
         .find_by(code: params[:provider_code])
         .courses
-        .that_candidates_can_apply_to
+        .where(exposed_in_find: true)
     end
 
     def pick_course

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -15,8 +15,6 @@ class Course < ApplicationRecord
     further_education: 'Further education',
   }, _suffix: :course
 
-  scope :that_candidates_can_apply_to, -> { where(exposed_in_find: true) }
-
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -15,6 +15,7 @@ class Course < ApplicationRecord
     further_education: 'Further education',
   }, _suffix: :course
 
+  scope :that_candidates_can_apply_to, -> { where(exposed_in_find: true) }
 
   def name_and_code
     "#{name} (#{code})"

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -1,5 +1,9 @@
 class SyncProviderFromFind
   def self.call(provider_code:)
+    # Request all providers, courses and sites.
+    #
+    # For the full response, see:
+    # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers/1N1/?include=sites,courses.sites
     find_provider = FindAPI::Provider
       .current_cycle
       .includes(:sites, courses: [:sites])
@@ -26,6 +30,7 @@ class SyncProviderFromFind
     course.name = find_course.name
     course.level = find_course.level
     course.start_date = Date.parse(find_course.start_date)
+    course.exposed_in_find = find_course.findable?
     course.save
 
     find_course.sites.each do |find_site|

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -19,8 +19,20 @@
         <td class='govuk-table__cell'><%= course.name_and_code %></td>
         <td class='govuk-table__cell'><%= course.level %></td>
         <td class='govuk-table__cell'><%= course.start_date %></td>
-        <td class='govuk-table__cell'><%= govuk_link_to 'Apply from Find page', candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code) %></td>
-        <td class='govuk-table__cell'><%= govuk_link_to 'Find course page', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></td>
+        <td class='govuk-table__cell'>
+          <% if course.exposed_in_find? %>
+            <%= govuk_link_to 'Apply from Find page', candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code) %>
+          <% else %>
+            <em>N/A - hidden in Find</em>
+          <% end %>
+        </td>
+        <td class='govuk-table__cell'>
+          <% if course.exposed_in_find? %>
+            <%= govuk_link_to 'Find course page', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %>
+          <% else %>
+            <em>N/A - hidden in Find</em>
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/db/migrate/20191113123956_add_exposed_in_find_to_courses.rb
+++ b/db/migrate/20191113123956_add_exposed_in_find_to_courses.rb
@@ -1,0 +1,5 @@
+class AddExposedInFindToCourses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :courses, :exposed_in_find, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_11_115654) do
+ActiveRecord::Schema.define(version: 2019_11_13_123956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2019_11_11_115654) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "level"
     t.date "start_date"
+    t.boolean "exposed_in_find"
     t.index ["code"], name: "index_courses_on_code"
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true
     t.index ["provider_id"], name: "index_courses_on_provider_id"

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SyncProviderFromFind do
         provider_code: 'ABC',
         course_code: '9CBA',
         site_code: 'G',
+        findable: true,
       )
     end
 
@@ -19,6 +20,7 @@ RSpec.describe SyncProviderFromFind do
 
       expect(course_option.course.provider.code).to eq 'ABC'
       expect(course_option.course.code).to eq '9CBA'
+      expect(course_option.course.exposed_in_find).to be true
       expect(course_option.site.code).to eq 'G'
     end
   end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -6,7 +6,7 @@ module CandidateHelper
   def candidate_completes_application_form
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
-    course = create(:course, name: 'Primary', code: '2XT2', provider: @provider)
+    course = create(:course, exposed_in_find: true, name: 'Primary', code: '2XT2', provider: @provider)
     create(:course_option, site: site, course: course, vacancy_status: 'B')
 
     create_and_sign_in_candidate

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -34,7 +34,7 @@ module FindAPIHelper
       .to_return(status: 503)
   end
 
-  def stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X')
+  def stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', findable: true)
     stub_find_api_provider(provider_code)
       .to_return(
         status: 200,
@@ -77,6 +77,7 @@ module FindAPIHelper
                 'name': 'Primary',
                 'level': 'primary',
                 'start_date': 'September 2019',
+                'findable?': findable,
               },
               'relationships': {
                 'sites': {

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Selecting a course' do
   def given_data_from_find_exists
     provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: provider)
-    course = create(:course, name: 'Primary', code: '2XT2', provider: provider)
+    course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true)
     create(:course_option, site: site, course: course, vacancy_status: 'B')
   end
 

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Candidate submit the application' do
   def and_i_have_chosen_a_course
     provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: provider)
-    course = create(:course, name: 'Primary', code: '2XT2', provider: provider)
+    course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true)
     create(:course_option, site: site, course: course, vacancy_status: 'B')
 
     visit candidate_interface_application_form_path


### PR DESCRIPTION
### Context

We currently [save all of the courses that Find returns](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/app/services/sync_provider_from_find.rb) in the database. It turns out the Find API also returns courses that are still in draft. For example, Gorse has a course "History", which is [returned by the API](https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers/1N1/?include=sites,courses.sites) but is not available on the Find site.

### Changes proposed in this pull request

As far as I can see, the `findable?` attribute on Find courses determines whether or not it's visible to normal users. This commit copies the `findable?` attribute to our local database, so that (later) we can make sure we only display courses that are also in Find.

I've also considered to stop creating courses that aren't `findable?` in the sync. This has the downside of not removing courses from the system that flip from `findable?` to not `findable?`. We would also have to remove the 5 draft courses that are currently in the Apply database.

On the support page for Gorse provider it looks like this:

![image](https://user-images.githubusercontent.com/233676/68774200-a1b7fb80-0624-11ea-8dc1-c648e0bd9c6e.png)

### Guidance to review

Does this make sense?

### Link to Trello card

https://trello.com/c/96nQagv3