### PR TITLE
Put the provider interface behind DfE Sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ LOGSTASH_REMOTE=false
 LOGSTASH_HOST=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-ls.logit.io
 LOGSTASH_PORT=22513
 LOGSTASH_SSL=true
+DFE_SIGN_IN_CLIENT_ID=
+DFE_SIGN_IN_SECRET=
+DFE_SIGN_IN_URI='https://signin-test-oidc-as.azurewebsites.net'

--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ LOGSTASH_PORT=22513
 LOGSTASH_SSL=true
 DFE_SIGN_IN_CLIENT_ID=
 DFE_SIGN_IN_SECRET=
-DFE_SIGN_IN_URI='https://signin-test-oidc-as.azurewebsites.net'
+DFE_SIGN_IN_URI=https://signin-test-oidc-as.azurewebsites.net

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'govuk-lint'
 gem 'erb_lint', require: false
 
 gem 'devise'
+gem 'omniauth'
+gem 'omniauth_openid_connect'
+
 gem 'workflow'
 gem 'audited'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,9 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    aes_key_wrap (1.0.1)
     ast (2.4.0)
+    attr_required (1.0.1)
     audited (4.9.0)
       activerecord (>= 4.2, < 6.1)
     backports (3.15.0)
@@ -72,6 +74,7 @@ GEM
       html_tokenizer (~> 0.0.6)
       parser (>= 2.4)
       smart_properties
+    bindata (2.4.4)
     bindex (0.8.1)
     brakeman (4.7.1)
     builder (3.2.3)
@@ -189,12 +192,18 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.0)
+    hashie (3.6.0)
     holidays (8.0.0)
     html_tokenizer (0.0.7)
+    httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.2.0)
+    json-jwt (1.11.0)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      bindata
     json-schema (2.8.1)
       addressable (>= 2.4)
     json_api_client (1.16.1)
@@ -249,6 +258,23 @@ GEM
       shellany (~> 0.0)
     notifications-ruby-client (4.0.0)
       jwt (>= 1.5, < 3)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
+    omniauth_openid_connect (0.3.3)
+      addressable (~> 2.5)
+      omniauth (~> 1.9)
+      openid_connect (~> 1.1)
+    openid_connect (1.1.8)
+      activemodel
+      attr_required (>= 1.0.0)
+      json-jwt (>= 1.5.0)
+      rack-oauth2 (>= 1.6.1)
+      swd (>= 1.0.0)
+      tzinfo
+      validate_email
+      validate_url
+      webfinger (>= 1.0.1)
     orm_adapter (0.5.0)
     parallel (1.18.0)
     parser (2.6.5.0)
@@ -266,6 +292,12 @@ GEM
     puma (4.3.0)
       nio4r (~> 2.0)
     rack (2.0.7)
+    rack-oauth2 (1.10.0)
+      activesupport
+      attr_required
+      httpclient
+      json-jwt (>= 1.9.0)
+      rack
     rack-protection (2.0.7)
       rack
     rack-proxy (0.6.5)
@@ -390,6 +422,10 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    swd (1.1.2)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      httpclient (>= 2.4)
     thor (0.20.3)
     thread_safe (0.3.6)
     timecop (0.9.1)
@@ -397,6 +433,12 @@ GEM
       thread_safe (~> 0.1)
     uk_postcode (2.1.5)
     unicode-display_width (1.6.0)
+    validate_email (0.1.6)
+      activemodel (>= 3.0)
+      mail (>= 2.2.5)
+    validate_url (1.0.8)
+      activemodel (>= 3.0.0)
+      public_suffix
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (4.0.1)
@@ -404,6 +446,9 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webfinger (1.1.0)
+      activesupport
+      httpclient (>= 2.4)
     webmock (3.7.6)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -453,6 +498,8 @@ DEPENDENCIES
   logstash-event
   logstash-logger
   mail-notify
+  omniauth
+  omniauth_openid_connect
   pg (~> 1.1.4)
   pry
   pry-byebug

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     def index
-      application_choices = GetApplicationChoicesForProvider.call(provider: current_user.provider)
+      application_choices = GetApplicationChoicesForProvider.call(provider: current_provider_user.provider)
         .order(updated_at: :desc)
 
       @application_choices = application_choices.map do |application_choice|
@@ -10,20 +10,10 @@ module ProviderInterface
     end
 
     def show
-      application_choice = GetApplicationChoicesForProvider.call(provider: current_user.provider)
+      application_choice = GetApplicationChoicesForProvider.call(provider: current_provider_user.provider)
         .find(params[:application_choice_id])
 
       @application_choice = ApplicationChoicePresenter.new(application_choice)
-    end
-
-  private
-
-    # Stub out the current user and their organisation. Will be replaced
-    # by a proper ProviderUser when implementing Signin.
-    def current_user
-      fake_user_class = Struct.new(:provider)
-      fake_provider = Provider.find_by(code: 'ABC')
-      fake_user_class.new(fake_provider)
     end
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -11,7 +11,7 @@ module ProviderInterface
     # Stub out the current user and their organisation. Will be replaced
     # by a proper ProviderUser when implementing Signin.
     def current_provider_user
-      if session[:provider_user]
+      if session['provider_user']
         fake_user_class = Struct.new(:provider, :email_address)
         fake_provider = Provider.find_by(code: 'ABC')
 

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -3,5 +3,27 @@ module ProviderInterface
     include BasicAuthHelper
     before_action :require_basic_auth_for_ui
     layout 'application'
+
+    helper_method :current_provider_user
+
+  private
+
+    # Stub out the current user and their organisation. Will be replaced
+    # by a proper ProviderUser when implementing Signin.
+    def current_provider_user
+      if session[:provider_user]
+        fake_user_class = Struct.new(:provider, :email_address)
+        fake_provider = Provider.find_by(code: 'ABC')
+
+        fake_user_class.new(
+          fake_provider,
+          session['provider_user']['email_address'],
+        )
+      end
+    end
+
+    def authenticate_provider_user!
+      redirect_to provider_interface_sign_in_path unless current_provider_user
+    end
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class ProviderInterfaceController < ActionController::Base
     include BasicAuthHelper
-    before_action :require_basic_auth_for_ui
+    before_action :authenticate_provider_user!
     layout 'application'
 
     helper_method :current_provider_user

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -1,0 +1,17 @@
+module ProviderInterface
+  class SessionsController < ProviderInterfaceController
+    skip_before_action :authenticate_provider_user!
+
+    def new; end
+
+    def callback
+      auth_hash = request.env['omniauth.auth']
+
+      session[:provider_user] = {
+        email_address: auth_hash['info']['email'],
+      }
+
+      redirect_to provider_interface_path
+    end
+  end
+end

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -7,8 +7,8 @@ module ProviderInterface
     def callback
       auth_hash = request.env['omniauth.auth']
 
-      session[:provider_user] = {
-        email_address: auth_hash['info']['email'],
+      session['provider_user'] = {
+        'email_address' => auth_hash['info']['email'],
       }
 
       redirect_to provider_interface_path

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,4 +1,12 @@
 module HostingEnvironment
+  def self.application_url
+    if Rails.env.production?
+      "https://#{hostname}"
+    else
+      'http://localhost:3000'
+    end
+  end
+
   def self.authorised_hosts
     ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
   end

--- a/app/views/layouts/_provider_header.html.erb
+++ b/app/views/layouts/_provider_header.html.erb
@@ -1,0 +1,7 @@
+<% if current_provider_user %>
+  <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+    <li class="govuk-header__navigation-item">
+      <b><%= current_provider_user.email_address %></b>
+    </li>
+  </ul>
+<% end %>

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -1,0 +1,1 @@
+<%= link_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -35,6 +35,9 @@ parameters:
   govukNotifyAPIKey:
   findBaseUrl:
   disableBasicAuthForLandingPage:
+  dfeSignInClientId:
+  dfeSignInSecret:
+  dfeSignInIssuer:
 
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
@@ -98,7 +101,10 @@ jobs:
                 -findBaseUrl "${{parameters.findBaseUrl}}"
                 -redisCacheName "$(redisCacheName)"
                 -containerInstanceNamePrefix "$(containerInstanceNamePrefix)"
-                -disableBasicAuthForLandingPage "${{parameters.disableBasicAuthForLandingPage}}"'
+                -disableBasicAuthForLandingPage "${{parameters.disableBasicAuthForLandingPage}}"
+                -dfeSignInClientId "${{parameters.dfeSignInClientId}}"
+                -dfeSignInSecret: "${{parameters.dfeSignInSecret}}"
+                -dfeSignInIssuer: "${{parameters.dfeSignInIssuer}}"'
               deploymentOutputs: DeploymentOutput
 
           - task: AzurePowerShell@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -181,7 +181,9 @@ stages:
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
       disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
-
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'
 
 - stage: deploy_staging
   displayName: 'Deploy - Staging'
@@ -224,6 +226,9 @@ stages:
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
       disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'
 
 
 - stage: deploy_sandbox
@@ -267,6 +272,9 @@ stages:
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
       disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'
 
 
 - stage: deploy_pentest
@@ -309,6 +317,9 @@ stages:
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
       disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'
 
 
 - stage: deploy_production
@@ -352,3 +363,6 @@ stages:
       govukNotifyAPIKey: '$(govukNotifyAPIKey)'
       findBaseUrl: '$(findBaseUrl)'
       disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'

--- a/azure/template.json
+++ b/azure/template.json
@@ -213,6 +213,24 @@
             "metadata": {
                 "description": "Should basic auth be disabled for the /candidate/apply landing page linked from Find?"
             }
+        },
+        "dfeSignInClientId": {
+            "type": "string",
+            "metadata": {
+                "description": "The DfE Sign-in client ID, obtained from the DfE Sign in management interface"
+            }
+        },
+        "dfeSignInSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "The DfE Sign-in secret, obtained from the DfE sign-in management interface"
+            }
+        },
+        "dfeSignInIssuer": {
+            "type": "string",
+            "metadata": {
+                "description": "The URL of the DfE Sign-in OIDC interface (differs for test, pre-prod and prod)"
+            }
         }
     },
     "variables": {
@@ -454,6 +472,18 @@
                             {
                                 "name": "DISABLE_BASIC_AUTH_FOR_LANDING_PAGE",
                                 "value": "[parameters('disableBasicAuthForLandingPage')]"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_CLIENT_ID",
+                                "value": "[parameters('dfeSignInClientId')]"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_SECRET",
+                                "value": "[parameters('dfeSignInSecret')]"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_ISSUER",
+                                "value": "[parameters('dfeSignInIssuer')]"
                             }
                         ]
                     }

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,9 @@
+options = {
+  name: :dfe,
+  callback_path: '/auth/dfe/callback',
+}
+
+class OmniAuth::Strategies::Dfe < OmniAuth::Strategies::OpenIDConnect; end
+
+Rails.application.config.middleware.use OmniAuth::Strategies::Dfe, options
+

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,9 +1,25 @@
+OmniAuth.config.logger = Rails.logger
+
+dfe_sign_in_identifier = ENV['DFE_SIGN_IN_CLIENT_ID']
+dfe_sign_in_secret = ENV['DFE_SIGN_IN_SECRET']
+dfe_sign_in_redirect_uri = URI.join(HostingEnvironment.application_url, '/auth/dfe/callback')
+dfe_sign_in_issuer_uri = ENV['DFE_SIGN_IN_URI'].present? ? URI(ENV['DFE_SIGN_IN_URI']) : nil
+
 options = {
   name: :dfe,
+  discovery: true,
+  response_type: :code,
+  scope: %i[email],
+  path_prefix: '/auth',
   callback_path: '/auth/dfe/callback',
+  client_options: {
+    port: dfe_sign_in_issuer_uri&.port,
+    scheme: dfe_sign_in_issuer_uri&.scheme,
+    host: dfe_sign_in_issuer_uri&.host,
+    identifier: dfe_sign_in_identifier,
+    secret: dfe_sign_in_secret,
+    redirect_uri: dfe_sign_in_redirect_uri&.to_s,
+  },
 }
 
-class OmniAuth::Strategies::Dfe < OmniAuth::Strategies::OpenIDConnect; end
-
-Rails.application.config.middleware.use OmniAuth::Strategies::Dfe, options
-
+Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -206,7 +206,11 @@ Rails.application.routes.draw do
 
     get '/applications' => 'application_choices#index'
     get '/applications/:application_choice_id' => 'application_choices#show', as: :application_choice
+
+    get '/sign-in' => 'sessions#new'
   end
+
+  get '/auth/dfe/callback' => 'provider_interface/sessions#callback'
 
   namespace :support_interface, path: '/support' do
     get '/' => redirect('/support/applications')

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,1 @@
+OmniAuth.config.test_mode = true

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -1,0 +1,12 @@
+module DfeSignInHelpers
+  def provider_exists_in_dfe_sign_in(email: 'email@example.com')
+    OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+      info: { email: email },
+    )
+  end
+
+  def provider_signs_in_using_dfe_sign_in
+    visit provider_interface_path
+    click_link 'Sign in using DfE Sign-in'
+  end
+end

--- a/spec/system/basic_auth_spec.rb
+++ b/spec/system/basic_auth_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe 'Require basic authentication', type: :request do
     it 'candidate requests raise KeyError' do
       expect { get candidate_interface_start_url }.to raise_error(KeyError)
     end
-
-    it 'provider requests raise KeyError' do
-      expect { get provider_interface_applications_url }.to raise_error(KeyError)
-    end
   end
 
   context 'candidate_interface' do
@@ -37,28 +33,6 @@ RSpec.describe 'Require basic authentication', type: :request do
 
     it 'requests with valid basic auth get 200' do
       get candidate_interface_start_url, headers: basic_auth_headers('basic', 'auth')
-
-      expect(response).to have_http_status(200)
-    end
-  end
-
-  context 'provider_interface' do
-    before { require_and_config_basic_auth }
-
-    it 'requests without basic auth get 401' do
-      get provider_interface_applications_url
-
-      expect(response).to have_http_status(401)
-    end
-
-    it 'requests with invalid basic auth get 401' do
-      get provider_interface_applications_url, headers: basic_auth_headers('wrong', 'auth')
-
-      expect(response).to have_http_status(401)
-    end
-
-    it 'requests with valid basic auth get 200' do
-      get provider_interface_applications_url, headers: basic_auth_headers('basic', 'auth')
 
       expect(response).to have_http_status(200)
     end

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'A provider authenticates via DfE Sign-in' do
+  include DfeSignInHelpers
+
+  scenario 'signing in successfully' do
+    given_i_have_a_dfe_sign_in_account
+
+    when_i_visit_the_provider_interface
+    and_i_sign_in_via_dfe_sign_in
+
+    then_i_should_be_redirected_to_the_provider_dashboard
+    and_i_should_see_my_email_address
+  end
+
+  def given_i_have_a_dfe_sign_in_account
+    provider_exists_in_dfe_sign_in(email: 'user@provider.com')
+  end
+
+  def when_i_visit_the_provider_interface
+    visit provider_interface_path
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    click_link 'Sign in using DfE Sign-in'
+  end
+
+  def then_i_should_be_redirected_to_the_provider_dashboard; end
+
+  def and_i_should_see_my_email_address
+    expect(page).to have_content('user@provider.com')
+  end
+end

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -2,17 +2,19 @@ require 'rails_helper'
 
 RSpec.feature 'See applications' do
   include CourseOptionHelpers
+  include DfeSignInHelpers
 
   scenario 'Provider visits application page' do
-    given_i_am_a_provider_user
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_accredited_courses_with_applications
     and_i_visit_the_provider_page
     then_i_should_see_the_applications_from_my_organisation
     but_not_the_applications_from_other_providers
   end
 
-  def given_i_am_a_provider_user
-    # This is stubbed out for now in the controller.
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
   end
 
   def and_my_organisation_has_accredited_courses_with_applications

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -19,13 +19,13 @@ RSpec.feature 'See applications' do
 
   def and_my_organisation_has_accredited_courses_with_applications
     current_provider = create(:provider, code: 'ABC')
-    other_provier = create(:provider, code: 'ANOTHER_ORG')
+    other_provider = create(:provider, code: 'ANOTHER_ORG')
     course_option = course_option_for_provider(provider: current_provider)
-    accredited_course_option_where_current_provider_is_accrediting = course_option_for_accrediting_provider(provider: other_provier, accrediting_provider: current_provider)
-    accredited_course_option_where_current_provider_is_main_provider = course_option_for_accrediting_provider(provider: current_provider, accrediting_provider: other_provier)
+    accredited_course_option_where_current_provider_is_accrediting = course_option_for_accrediting_provider(provider: other_provider, accrediting_provider: current_provider)
+    accredited_course_option_where_current_provider_is_main_provider = course_option_for_accrediting_provider(provider: current_provider, accrediting_provider: other_provider)
 
 
-    other_course_option = course_option_for_provider(provider: other_provier)
+    other_course_option = course_option_for_provider(provider: other_provider)
 
     create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Jim', last_name: 'Jones'))
     create(:application_choice, status: 'awaiting_provider_decision', course_option: accredited_course_option_where_current_provider_is_accrediting, application_form: create(:application_form, first_name: 'Clancy'))

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -2,9 +2,10 @@ require 'rails_helper'
 
 RSpec.feature 'See applications' do
   include CourseOptionHelpers
+  include DfeSignInHelpers
 
   scenario 'Provider visits application page' do
-    given_i_am_a_provider_user
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_applications
     and_i_visit_the_provider_page
     then_i_should_see_the_applications_from_my_organisation
@@ -14,8 +15,9 @@ RSpec.feature 'See applications' do
     then_i_should_be_on_the_application_view_page
   end
 
-  def given_i_am_a_provider_user
-    # This is stubbed out for now in the controller.
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
   end
 
   def and_my_organisation_has_applications


### PR DESCRIPTION
### Context

This is how providers will authenticate to the service.

### Changes proposed in this pull request

Add omniauth and configure DfE Sign-in as a provider on the model of Claim https://github.com/DFE-Digital/dfe-teachers-payment-service/blob/master/config/initializers/omniauth.rb

It is now possible to sign in to the provider interface at `/provider`. You assume the identity of provider `ABC` as this is still hardcoded in the controller. Also, it's impossible to log out 😏. 

### Guidance to review

You will need the DfE Sign in credentials for your `.env` — please slack me if you need them.

### Link to Trello card

https://trello.com/c/6SndwNfI/1241-integrate-provider-interface-with-dfe-sign-in

### Env vars

- [x] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
