### PR TITLE
Fix bug in page to show course isn't found

### DIFF
--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, t('page_titles.application') %>
-<% content_for :service_link, candidate_interface_apply_from_find_path(providerCode: @course.provider_code, courseCode: @course.course_code) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
@@ -4,14 +4,26 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   include FindAPIHelper
 
   scenario 'seeing their course information on the landing page' do
-    given_i_have_arrived_from_find_with_valid_course_parameters
+    when_i_have_arrive_from_find_with_invalid_course_parameters
+    then_i_should_see_an_error_page
+
+    when_i_have_arrived_from_find_with_valid_course_parameters
     then_i_should_see_the_landing_page
     and_i_should_see_the_provider_and_course_codes
     and_i_should_see_the_course_name_fetched_from_find
     and_i_should_be_able_to_apply_through_ucas
   end
 
-  def given_i_have_arrived_from_find_with_valid_course_parameters
+  def when_i_have_arrive_from_find_with_invalid_course_parameters
+    stub_find_api_course_404('NOT', 'REAL')
+    visit candidate_interface_apply_from_find_path providerCode: 'NOT', courseCode: 'REAL'
+  end
+
+  def then_i_should_see_an_error_page
+    expect(page).to have_content 'We couldn’t find the course you’re looking for'
+  end
+
+  def when_i_have_arrived_from_find_with_valid_course_parameters
     stub_find_api_course_200('ABC', 'XYZ1', 'Biology')
     visit candidate_interface_apply_from_find_path providerCode: 'ABC', courseCode: 'XYZ1'
   end


### PR DESCRIPTION
When a course isn't found, we show an error page. However, there's a stray link in the template which means the error page throws up an error.

Fixes https://sentry.io/organizations/dfe-bat/issues/1331456942