### PR TITLE
Request references from referees when application is submitted

### DIFF
--- a/app/mailers/previews/referee_mailer_preview.rb
+++ b/app/mailers/previews/referee_mailer_preview.rb
@@ -1,7 +1,7 @@
 class RefereeMailerPreview < ActionMailer::Preview
   def reference_request_email
     application_form = FactoryBot.build(:completed_application_form)
-    reference = application_form.references.first
+    reference = application_form.references.reload.first
 
     RefereeMailer.reference_request_email(application_form, reference)
   end

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -24,7 +24,7 @@ private
       '&' +
       {
         t('reference_request.candidate_name_entry') => candidate_name,
-        t('reference_request.referee_name_entry') => 'TODO: Referee name',
+        t('reference_request.referee_name_entry') => reference.name,
       }.to_query.gsub('+', '%20')
   end
 end

--- a/app/services/import_references_from_csv.rb
+++ b/app/services/import_references_from_csv.rb
@@ -14,9 +14,9 @@ class ImportReferencesFromCsv
   end
 
   def self.process_row(row)
-    referee_email    = row[1]
-    referee_feedback = row[4]
-    reference_id     = row[6]
+    referee_email    = row[2]
+    referee_feedback = row[5]
+    reference_id     = row[1]
 
     reference = Reference.find(reference_id)
     application_form = ApplicationForm.includes(:references).where(references: { id: reference_id }).first

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -14,9 +14,16 @@ class SubmitApplication
     end
 
     CandidateMailer.submit_application_email(application_form).deliver_now
+    send_reference_request_email_to_referees(application_form)
   end
 
 private
+
+  def send_reference_request_email_to_referees(application_form)
+    application_form.references.each do |reference|
+      RefereeMailer.reference_request_email(application_form, reference).deliver_now
+    end
+  end
 
   def submit_application
     application_choices.each do |application_choice|

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,4 +1,4 @@
-Dear ((name of referee)),
+Dear <%= @reference.name %>,
 
 # Please give a reference for <%= @candidate_name %>
 

--- a/app/views/support_interface/import_references/index.html.erb
+++ b/app/views/support_interface/import_references/index.html.erb
@@ -20,7 +20,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">
-        You’ll need to <a href="https://docs.google.com/spreadsheets/d/18Lr1SWD20o_sPbyj7gsTwkaJO9jwL-YZTTdQfQOuIiw/export?format=csv" class="govuk-link" rel="download">download a CSV of the latest reference responses</a> from Google Docs before you can upload it here.</p>
+        You’ll need to <a href="https://docs.google.com/spreadsheets/d/1pHPMbvRoMtyWOhRF0JQThxu5VxR43K2er7yjSLgsXfk/export?format=csv" class="govuk-link" rel="download">download a CSV of the latest reference responses</a> from Google Docs before you can upload it here.</p>
 
       <p class="govuk-body">Importing references will:</p>
       <ul class="govuk-list govuk-list--bullet">

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe RefereeMailer, type: :mailer do
       expect(body).to include(t('reference_request.google_form_url'))
       expect(body).to include("=#{reference.id}")
       expect(body).to include("=#{CGI.escape(reference.email_address)}")
-      # TODO: Referee name
     end
 
     it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
       expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
+      expect(mail.body.encoded).to include("=#{reference.name.gsub(' ', '%20')}")
     end
 
     context 'an email containing a +' do

--- a/spec/services/get_application_choices_ready_to_send_to_provider_spec.rb
+++ b/spec/services/get_application_choices_ready_to_send_to_provider_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe GetApplicationChoicesReadyToSendToProvider do
   def create_application_with_references
     application_form = create :application_form
     create :application_choice, application_form: application_form, status: 'unsubmitted'
-    SubmitApplication.new(application_form.reload).call
     create_list :reference, 2, :unsubmitted, application_form: application_form
+    SubmitApplication.new(application_form.reload).call
     application_form.reload
   end
 

--- a/spec/services/import_references_from_csv_spec.rb
+++ b/spec/services/import_references_from_csv_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe ImportReferencesFromCsv do
   let(:second_reference) { FactoryBot.create(:reference, :unsubmitted, email_address: 'xy@z.com', application_form: application_form) }
 
   # Timestamp, Email Address, Your name, Name of the person, Feedback, Confirm, Application ID
-  let(:csv_row) { ['2019', 'ab@c.com', 'My name', 'Their name', 'Feedback', 'I confirm', 'id'] }
+  let(:csv_row) { ['2019', 'id', 'ab@c.com', 'My name', 'Their name', 'Feedback', 'I confirm'] }
 
   before do
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
-    csv_row[6] = first_reference.id
+    csv_row[1] = first_reference.id
   end
 
   describe 'processing a reference row from CSV' do
@@ -27,9 +27,9 @@ RSpec.describe ImportReferencesFromCsv do
 
     it 'imports multiple valid references for a single application' do
       ImportReferencesFromCsv.process_row(csv_row)
-      csv_row[1] = 'xy@z.com'
-      csv_row[4] = 'More feedback'
-      csv_row[6] = second_reference.id
+      csv_row[2] = 'xy@z.com'
+      csv_row[5] = 'More feedback'
+      csv_row[1] = second_reference.id
       ImportReferencesFromCsv.process_row(csv_row)
 
       expect(application_form.references.find_by!(email_address: 'ab@c.com').feedback).to eq('Feedback')
@@ -40,9 +40,9 @@ RSpec.describe ImportReferencesFromCsv do
     it 'does not change existing feedback' do
       ImportReferencesFromCsv.process_row(csv_row)
 
-      csv_row[4] = 'Edited feedback'
+      csv_row[5] = 'Edited feedback'
       outcome = ImportReferencesFromCsv.process_row(csv_row)
-      expect(outcome[:referee_email]).to eq(csv_row[1])
+      expect(outcome[:referee_email]).to eq(csv_row[2])
       expect(outcome[:application_form]).to eq(application_form)
       expect(outcome[:updated]).to be false
       expect(outcome[:errors]).to eq(['Reference already has feedback'])
@@ -51,20 +51,20 @@ RSpec.describe ImportReferencesFromCsv do
     end
 
     it 'does not update if an application form is not found' do
-      csv_row[6] = 'not_an_id'
+      csv_row[1] = 'not_an_id'
       outcome = ImportReferencesFromCsv.process_row(csv_row)
 
-      expect(outcome[:referee_email]).to eq(csv_row[1])
+      expect(outcome[:referee_email]).to eq(csv_row[2])
       expect(outcome[:application_form]).to be_nil
       expect(outcome[:updated]).to be false
       expect(outcome[:errors]).to eq(["No application found for reference with ID 'not_an_id'"])
     end
 
     it 'does not update if the reference email is not associated with the application form' do
-      csv_row[1] = 'not_a_valid_email@email.com'
+      csv_row[2] = 'not_a_valid_email@email.com'
       outcome = ImportReferencesFromCsv.process_row(csv_row)
 
-      expect(outcome[:referee_email]).to eq(csv_row[1])
+      expect(outcome[:referee_email]).to eq(csv_row[2])
       expect(outcome[:application_form]).to eq(application_form)
       expect(outcome[:updated]).to eq(false)
       expect(outcome[:errors]).to eq(['Referee email does not match any of the provided referees'])

--- a/spec/services/send_applications_to_provider_spec.rb
+++ b/spec/services/send_applications_to_provider_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe SendApplicationsToProvider do
   def create_application_with_references
     application_form = create :application_form
     create :application_choice, application_form: application_form, status: 'unsubmitted'
-    SubmitApplication.new(application_form.reload).call
     create_list :reference, 2, :unsubmitted, application_form: application_form
+    SubmitApplication.new(application_form.reload).call
     application_form.reload
   end
 

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -16,30 +16,6 @@ RSpec.describe SubmitApplication do
       expect(application_form.support_reference).not_to be_empty
     end
 
-    context 'sending emails' do
-      let(:mailer) { double }
-
-      before { allow(mailer).to receive(:deliver_now) }
-
-      it 'sends an application submitted email' do
-        allow(CandidateMailer).to receive(:submit_application_email).and_return(mailer)
-
-        SubmitApplication.new(application_form).call
-        expect(CandidateMailer).to have_received(:submit_application_email).with(application_form)
-        expect(mailer).to have_received(:deliver_now)
-      end
-
-      it 'sends a reference request email to each referee' do
-        allow(RefereeMailer).to receive(:reference_request_email).and_return(mailer)
-
-        SubmitApplication.new(application_form).call
-        application_form.references.each do |r|
-          expect(RefereeMailer).to have_received(reference_request_email).with(application_form, r)
-          expect(mailer).to have_received(:deliver_now)
-        end
-      end
-    end
-
     it 'sets application_form.submitted_at' do
       Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
         expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -16,6 +16,30 @@ RSpec.describe SubmitApplication do
       expect(application_form.support_reference).not_to be_empty
     end
 
+    context 'sending emails' do
+      let(:mailer) { double }
+
+      before { allow(mailer).to receive(:deliver_now) }
+
+      it 'sends an application submitted email' do
+        allow(CandidateMailer).to receive(:submit_application_email).and_return(mailer)
+
+        SubmitApplication.new(application_form).call
+        expect(CandidateMailer).to have_received(:submit_application_email).with(application_form)
+        expect(mailer).to have_received(:deliver_now)
+      end
+
+      it 'sends a reference request email to each referee' do
+        allow(RefereeMailer).to receive(:reference_request_email).and_return(mailer)
+
+        SubmitApplication.new(application_form).call
+        application_form.references.each do |r|
+          expect(RefereeMailer).to have_received(reference_request_email).with(application_form, r)
+          expect(mailer).to have_received(:deliver_now)
+        end
+      end
+    end
+
     it 'sets application_form.submitted_at' do
       Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
         expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -2,19 +2,26 @@ require 'rails_helper'
 
 RSpec.describe SubmitApplication do
   describe 'Submit an application' do
-    it 'updates the application to Submitted and sets application_form.submitted_at' do
-      application_form = create(:application_form)
-      create(:application_choice, application_form: application_form, status: 'unsubmitted')
-      create(:application_choice, application_form: application_form, status: 'unsubmitted')
+    let(:application_form) { create(:application_form) }
 
+    before do
+      create(:application_choice, application_form: application_form, status: 'unsubmitted')
+      create(:application_choice, application_form: application_form, status: 'unsubmitted')
+    end
+
+    it 'updates the application to Submitted' do
+      SubmitApplication.new(application_form).call
+      expect(application_form.application_choices[0]).to be_awaiting_references
+      expect(application_form.application_choices[1]).to be_awaiting_references
+      expect(application_form.support_reference).not_to be_empty
+    end
+
+    it 'sets application_form.submitted_at' do
       Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
         expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day
         SubmitApplication.new(application_form).call
 
         expect(application_form.submitted_at).to eq Time.zone.now
-        expect(application_form.application_choices[0]).to be_awaiting_references
-        expect(application_form.application_choices[1]).to be_awaiting_references
-        expect(application_form.support_reference).not_to be_empty
         expect(application_form.application_choices[0].edit_by).to eq expected_edit_by
         expect(application_form.application_choices[1].edit_by).to eq expected_edit_by
       end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Candidate submit the application' do
     and_i_have_chosen_a_course
     and_i_filled_in_personal_details
     and_i_filled_in_contact_details
+    and_i_gave_two_referees
     and_reviewed_my_application
     and_i_confirm_my_application
 
@@ -21,6 +22,7 @@ RSpec.feature 'Candidate submit the application' do
 
     and_i_can_see_my_support_ref
     and_i_receive_an_email_with_my_support_ref
+    and_my_referees_receive_a_request_for_a_reference_by_email
 
     when_i_click_on_track_your_application
     then_i_can_see_my_submitted_application
@@ -62,6 +64,10 @@ RSpec.feature 'Candidate submit the application' do
     candidate_fills_in_contact_details
 
     click_button t('application_form.contact_details.address.button')
+  end
+
+  def and_i_gave_two_referees
+    candidate_provides_two_referees
   end
 
   def and_reviewed_my_application
@@ -110,6 +116,15 @@ RSpec.feature 'Candidate submit the application' do
   def and_i_receive_an_email_with_my_support_ref
     open_email(current_candidate.email_address)
     expect(current_email).to have_content 'Application submitted'
+  end
+
+  def and_my_referees_receive_a_request_for_a_reference_by_email
+    current_application = current_candidate.current_application
+    current_application.references.each do |reference|
+      open_email(reference.email_address)
+      expect(current_email).to have_content "Please give a reference for #{current_application.first_name}"
+      expect(current_email).to have_content reference.name
+    end
   end
 
   def when_i_click_on_track_your_application


### PR DESCRIPTION
### Context

If we manually send reference requests, we need to note their status somehow, either with a manual tracker spreadsheet or with a reference status.

Now we have the Referee emailer from #499, we can send the emails automatically.

### Changes proposed in this pull request

- Automatically send reference request emails when an application is submitted
- Add test coverage for all emails being sent
- Includes referee name in emails as it's now available

https://trello.com/c/6zDP7N8t/1262-allow-support-to-send-an-email-to-request-references