### PR TITLE
Render personal statement content  onto review page

### DIFF
--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -49,7 +49,9 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
 
-<p class="govuk-body">No personal statements entered.</p>
+<%= render(BecomingATeacherReviewComponent, application_form: @application_form) %>
+<%= render(SubjectKnowledgeReviewComponent, application_form: @application_form) %>
+<%= render(InterviewPreferencesReviewComponent, application_form: @application_form) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 

--- a/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
@@ -14,6 +14,9 @@ RSpec.feature 'Candidate reviews the answers' do
     and_i_can_see_my_degree
     and_i_can_see_my_other_qualification
     and_i_can_see_my_disability_info
+    and_i_can_see_my_becoming_a_teacher_info
+    and_i_can_see_my_subject_knowlegde_info
+    and_i_can_see_my_interview_preferences
   end
 
   def given_i_have_completed_my_application
@@ -58,5 +61,17 @@ RSpec.feature 'Candidate reviews the answers' do
 
   def and_i_can_see_my_disability_info
     expect(page).to have_content 'I have difficulty climbing stairs'
+  end
+
+  def and_i_can_see_my_becoming_a_teacher_info
+    expect(page).to have_content 'I WANT I WANT I WANT I WANT'
+  end
+
+  def and_i_can_see_my_subject_knowlegde_info
+    expect(page).to have_content 'Everything'
+  end
+
+  def and_i_can_see_my_interview_preferences
+    expect(page).to have_content 'NOT WEDNESDAY'
   end
 end


### PR DESCRIPTION
### Context
Application review page

### Changes proposed in this pull request
Add personal statement i.e. becoming a teacher, subject knowledge and interview preferences

### Guidance to review
`/candidate/application/review`

### After
<img width="754" alt="Screenshot 2019-11-13 at 22 10 11" src="https://user-images.githubusercontent.com/3071606/68808874-94216680-0662-11ea-8be1-f25fa8347b1e.png">

### Link to Trello card
[346 - Update the review page with all information entered](https://trello.com/c/kNQEcScn/346-update-the-review-page-with-all-information-entered)

### Env vars
n/a
