### PR TITLE
Delete course courses

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -51,7 +51,24 @@ module CandidateInterface
       redirect_to candidate_interface_course_choices_index_path
     end
 
+    def confirm_destroy
+      @course_choice = current_candidate.current_application.application_choices.find(params[:id])
+    end
+
+    def destroy
+      current_application
+        .application_choices
+        .find(current_course_choice_id)
+        .destroy!
+
+      redirect_to candidate_interface_course_choices_index_path
+    end
+
   private
+
+    def current_course_choice_id
+      params.permit(:id)[:id]
+    end
 
     def application_choice_params
       params.require(:application_choice).permit(:choice)

--- a/app/views/candidate_interface/course_choices/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/course_choices/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, page_title(:destroy_course_choice) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_index_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @course_choice, url: candidate_interface_confirm_destroy_course_choice_path(@course_choice.id), method: :delete do |f| %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl">Course choices</span>
+            <%= t('page_titles.destroy_course_choice') %>
+          </h1>
+        </legend>
+
+        <%= f.submit t('application_form.courses.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+        <p class="govuk-body">
+          <%= govuk_link_to 'Cancel', candidate_interface_course_choices_index_path %>
+        </p>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/index.html.erb
+++ b/app/views/candidate_interface/course_choices/index.html.erb
@@ -15,7 +15,7 @@
         <%= course_choice.provider.name %>
       </h3>
       <div class="app-summary-card__actions">
-        <%= link_to 'Delete choice', '#TODO', class: 'govuk-link' %>
+        <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
       </div>
     </header>
   <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1,7 +1,10 @@
 en:
   application_form:
     begin_button: Start now
-    courses: You can apply for up to 3 courses.
+    courses:
+      intro: You can apply for up to 3 courses.
+      delete: Delete choice
+      confirm_delete: Yes I'm sure - delete this choice
     personal_details:
       first_name:
         label: First name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
     out_of_work: Tell us why you’ve been out of the workplace
     destroy_degree: Are you sure you want to delete this degree?
     course_choices: Course choices
+    destroy_course_choice: Are you sure you want to delete this choice?
     have_you_chosen: Have you chosen a course to apply to?
     which_provider: Which training provider are you applying to?
     which_course: Which course are you applying to?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,9 @@ Rails.application.routes.draw do
         get '/choose' => 'course_choices#have_you_chosen', as: :course_choices_choose
         post '/choose' => 'course_choices#make_choice'
 
+        get '/delete/:id' => 'course_choices#confirm_destroy', as: :confirm_destroy_course_choice
+        delete '/delete/:id' => 'course_choices#destroy'
+
         get '/provider' => 'course_choices#options_for_provider', as: :course_choices_provider
         post '/provider' => 'course_choices#pick_provider'
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -101,7 +101,7 @@ FactoryBot.define do
   factory :course do
     provider
 
-    code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
+    code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
     name { Faker::Educator.subject }
     level { 'primary' }
     start_date { Date.new(2020, 9, 1) }

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -15,6 +15,10 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_course
     and_i_choose_a_location
     then_i_see_my_completed_course_choice
+
+    when_i_delete_my_course_choice
+    and_i_confirm
+    then_i_no_longer_see_my_course_choice
   end
 
   def given_i_am_signed_in
@@ -64,5 +68,17 @@ RSpec.feature 'Selecting a course' do
     expect(page).to have_content('Gorse SCITT')
     expect(page).to have_content('Primary (2XT2)')
     expect(page).to have_content('Main site')
+  end
+
+  def when_i_delete_my_course_choice
+    click_link t('application_form.courses.delete')
+  end
+
+  def and_i_confirm
+    click_button t('application_form.courses.confirm_delete')
+  end
+
+  def then_i_no_longer_see_my_course_choice
+    expect(page).not_to have_content('Primary (2XT2)')
   end
 end

--- a/spec/system/candidate_interface/candidate_viewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_application_spec.rb
@@ -18,6 +18,6 @@ RSpec.feature 'Viewing their new application' do
   end
 
   def then_i_should_see_that_i_have_made_no_choices
-    expect(page).to have_content(t('application_form.courses'))
+    expect(page).to have_content(t('application_form.courses.intro'))
   end
 end


### PR DESCRIPTION
### Context
Being able to delete course choices

### Changes proposed in this pull request
Hook up delete CTA

### Guidance to review
`/candidate/application/courses` click "delete" (assuming you have some course choices)

### Link to Trello card

[332 - Allow candidates to delete their course choice](https://trello.com/c/wfk6AyMy/332-allow-candidates-to-delete-their-course-choice)

### Env vars
n/a
