### PR TITLE
Convert summary card line breaks into HTML

### DIFF
--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -11,7 +11,7 @@
             <% if row[:value].is_a?(Array) %>
               <% row[:value].each do |value| %><%= value %><br><% end %>
             <% else %>
-              <%= row[:value] %>
+              <%= simple_format row[:value], { class: 'govuk-body' } %>
             <% end %>
           </dd>
 


### PR DESCRIPTION
### Context

Users may enter line breaks into text fields, but we're not displaying them at the moment.

### Changes proposed in this pull request

This turns the line breaks a user entered into a field into HTML breaks and paragraphs, using `simple_format`:

> Returns text transformed into HTML using simple formatting rules. Two or more consecutive newlines(\n\n or \r\n\r\n) are considered a paragraph and wrapped in <p> tags. One newline (\n or \r\n) is considered a linebreak and a <br /> tag is appended. This method does not remove the newlines from the text.

https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format

### Guidance to review

When you enter paragraphs:

<img width="655" alt="Screenshot 2019-11-14 at 09 30 23" src="https://user-images.githubusercontent.com/233676/68844595-f6f61a80-06c1-11ea-8dd5-0ee896139618.png">

They display correctly:

<img width="926" alt="Screenshot 2019-11-14 at 09 30 18" src="https://user-images.githubusercontent.com/233676/68844594-f6f61a80-06c1-11ea-9d33-4144ea86d3c7.png">

Single values still look the same:

<img width="907" alt="Screenshot 2019-11-14 at 09 32 56" src="https://user-images.githubusercontent.com/233676/68844596-f6f61a80-06c1-11ea-9335-199978837ede.png">

### Link to Trello card

Finishes up https://trello.com/c/Hd0PKANG/278-adding-personal-statement