### PR TITLE
Rename Scottish higher to Scottish national (+ small refactor)

### DIFF
--- a/app/components/gcse_qualification_review_component.rb
+++ b/app/components/gcse_qualification_review_component.rb
@@ -44,7 +44,7 @@ private
     {
       gcse: 'GCSE',
       gce_o_level: 'GCE O Level',
-      scottish_higher: 'Scottish Higher',
+      scottish_national_5: 'Scottish National 5',
       other_uk: application_qualification.other_uk_qualification_type,
     }
   end

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -1,0 +1,11 @@
+module GcseQualificationHelper
+  def select_gcse_qualification_type_options
+    option = Struct.new(:id, :label)
+
+    t('gcse_edit_type.types').map { |id, label| option.new(id, label) }
+  end
+
+  def conditional_radios_for_gcse_qualifications
+    { other_uk: [other_uk_qualification_type: 'Enter type of qualification'] }
+  end
+end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -32,7 +32,7 @@ module ViewHelper
     [
       [:gcse, 'GCSE'],
       [:gce_o_level, 'GCE O Level'],
-      [:scottish_higher, 'Scottish Higher'],
+      [:scottish_national_5, 'Scottish National 5'],
       [:other_uk, 'Other UK qualification'],
     ].map { |id, label| option.new(id, label) }
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -27,20 +27,6 @@ module ViewHelper
     ] + NATIONALITIES.map { |_, nationality| OpenStruct.new(id: nationality, name: nationality) }
   end
 
-  def select_gcse_qualification_type_options
-    option = Struct.new(:id, :label)
-    [
-      [:gcse, 'GCSE'],
-      [:gce_o_level, 'GCE O Level'],
-      [:scottish_national_5, 'Scottish National 5'],
-      [:other_uk, 'Other UK qualification'],
-    ].map { |id, label| option.new(id, label) }
-  end
-
-  def conditional_radios
-    { other_uk: [other_uk_qualification_type: 'Enter type of qualification'] }
-  end
-
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -12,7 +12,7 @@
 
       <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: 'Type of qualification' } do %>
         <% select_gcse_qualification_type_options.each do |option| %>
-          <% if conditional_radios[option.id] %>
+          <% if conditional_radios_for_gcse_qualifications[option.id] %>
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label } do %>
               <% f.govuk_text_field :other_uk_qualification_type, label: { text: 'Enter type of qualification' } %>
             <% end %>

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -4,6 +4,11 @@ en:
       maths: Add maths GCSE grade 4 (C) or above, or equivalent
       english: Add English GCSE grade 4 (C) or above, or equivalent
       science: Add science GCSE grade 4 (C) or above, or equivalent
+    types:
+      gcse: GCSE
+      gce_o_level: GCE O Level
+      scottish_national_5: Scottish National 5
+      other_uk: Other UK qualification
   gcse_edit_details:
     heading:
       maths: Maths qualification grade and year

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -89,7 +89,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def then_i_see_the_review_page_with_updated_details
-    expect(page).to have_content 'Scottish Higher'
+    expect(page).to have_content 'Scottish National 5'
     expect(page).to have_content 'BB'
     expect(page).to have_content '2000'
   end
@@ -112,7 +112,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def when_i_select_a_different_qualification_type
-    choose('Scottish Higher')
+    choose('Scottish National 5')
   end
 
   def when_i_click_to_change_qualification_type


### PR DESCRIPTION
### Context
Scottish higher option needs to be renamed to Scottish National 5.

### Changes proposed in this pull request
- rename of the Label values 
- rename the key value (note, we are *NOT migrating data*, I think it's safe since we do not have real user atm)
- Create new Helper for Gcse qualification

### Link to Trello card
https://trello.com/c/Pb9QRUPv/345-change-scottish-higher-to-scottish-national