### PR TITLE
Tweak provider application show and index views to match design 

### DIFF
--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -9,8 +9,8 @@ module ProviderInterface
       "#{application_choice.application_form.first_name} #{application_choice.application_form.last_name}"
     end
 
-    def course_name
-      "Course #{application_choice.course.name}"
+    def course_name_and_code
+      "#{application_choice.course.name} (#{application_choice.course.code})"
     end
 
     def status_name
@@ -18,7 +18,7 @@ module ProviderInterface
     end
 
     def updated_at
-      application_choice.updated_at.to_s(:short)
+      application_choice.updated_at.strftime('%e %b %Y %l:%M%P')
     end
 
     def to_param

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,22 +1,22 @@
-<h1 class='govuk-heading-xl'>Your applications</h1>
+<h1 class="govuk-heading-xl">Your applications</h1>
 
-<table class='govuk-table'>
-  <thead class='govuk-table__head'>
-    <tr class='govuk-table__row'>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Name</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Course</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
-      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Last update</th>
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last update</th>
     </tr>
   </thead>
 
-  <tbody class='govuk-table__body'>
+  <tbody class="govuk-table__body">
     <% @application_choices.each do |application_choice| %>
-    <tr class='govuk-table__row'>
-      <td class='govuk-table__cell'><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
-      <td class='govuk-table__cell'><%= application_choice.course_name %></td>
-      <td class='govuk-table__cell'><%= tag.strong application_choice.status_name, class: 'govuk-tag' %></td>
-      <td class='govuk-table__cell'><%= application_choice.updated_at %></td>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell"><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
+      <td class="govuk-table__cell"><%= application_choice.course_name %></td>
+      <td class="govuk-table__cell"><%= tag.strong application_choice.status_name, class: "govuk-tag" %></td>
+      <td class="govuk-table__cell"><%= application_choice.updated_at %></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,4 +1,6 @@
-<h1 class="govuk-heading-xl">Your applications</h1>
+<% content_for :title, 'Applications' %>
+
+<h1 class="govuk-heading-xl">Applications</h1>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">
@@ -6,7 +8,7 @@
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last update</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last updated</th>
     </tr>
   </thead>
 
@@ -14,8 +16,8 @@
     <% @application_choices.each do |application_choice| %>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell"><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
-      <td class="govuk-table__cell"><%= application_choice.course_name %></td>
-      <td class="govuk-table__cell"><%= tag.strong application_choice.status_name, class: "govuk-tag" %></td>
+      <td class="govuk-table__cell"><%= application_choice.course_name_and_code %></td>
+      <td class="govuk-table__cell"><%= tag.strong application_choice.status_name, class: 'govuk-tag' %></td>
       <td class="govuk-table__cell"><%= application_choice.updated_at %></td>
     </tr>
     <% end %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -1,4 +1,21 @@
-<h1 class='govuk-heading-xl'><%= @application_choice.full_name %>'s application</h1>
+<% content_for :title, "#{@application_choice.full_name} – #{@application_choice.course_name_and_code}" %>
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Applications', provider_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= @application_choice.full_name %>
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">Application for <%= @application_choice.course_name_and_code %></span>
+  <%= @application_choice.full_name %>
+</h1>
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -45,6 +45,7 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_be_on_the_application_view_page
-    expect(page).to have_content "Alice Wunder's application"
+    expect(page).to have_content 'Application for'
+    expect(page).to have_content 'Alice Wunder'
   end
 end


### PR DESCRIPTION
### Context

Begin making the pages look like the designs in https://manage-applications-beta.herokuapp.com/

### Changes proposed in this pull request

- Add breadcrumbs
- Update titles
- Add title for title element
- Show course name and code together

### Screenshots

![Screen Shot 2019-11-14 at 11 38 03](https://user-images.githubusercontent.com/319055/68854108-45f87b80-06d3-11ea-8d32-15447c523d82.png)
![Screen Shot 2019-11-14 at 11 38 10](https://user-images.githubusercontent.com/319055/68854109-45f87b80-06d3-11ea-88d3-ba97646e4394.png)


### Link to Trello card

Start of https://trello.com/c/6x5NIZRK/1232-provider-can-view-all-applications
