### PR TITLE
Add (candidate) privacy policy

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -7,6 +7,10 @@ class ContentController < ApplicationController
     render_content_page :terms_candidate
   end
 
+  def privacy_candidate
+    render_content_page :privacy_candidate
+  end
+
 private
 
   def render_content_page(page_name)

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -16,7 +16,11 @@
       <h2 class="govuk-heading-m">You won’t need a password to use this service</h2>
       <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we'll send you a link so you can return to your application.</p>
 
-      <h2 class="govuk-heading-m">Terms and conditions</h2>
+      <h2 class="govuk-heading-m">How we look after your data</h2>
+      <p class="govuk-body">Your data will be looked after by the Department for Education and the training providers you apply you. We use it to process your application, build a better application process, and improve policies relating to teacher recruitment and retention.</p>
+      <p class="govuk-body">Take a look at our <%= govuk_link_to 'privacy policy', '/candidate/privacy-statement' %> before starting your application to check you understand how we use your data.</p>
+
+      <h2 class="govuk-heading-m">Terms of use</h2>
       <p class="govuk-body">Our <%= govuk_link_to 'terms of use', '/candidate/terms-of-use' %> contain important information about:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>the application process</li>

--- a/app/views/content/privacy_candidate.md
+++ b/app/views/content/privacy_candidate.md
@@ -1,0 +1,120 @@
+## How we use your data when you use Apply for teacher training
+
+Apply for teacher training is part of the Department for Education.
+
+Department for Education (referred to as ‘we’, ‘us’ and ‘our’) uses and looks after the personal data that you give when using Apply for teacher training.
+
+We also share your data with the teacher training providers you apply to so that they can use and look after your data.
+
+Under data protection law, this means the relevant teacher training providers and the Department for Education are ‘joint controllers’ for your data.
+
+We have a data sharing agreement with [teacher training providers](#teacher-training-providers) so that they can only use your data for specific purposes.
+
+This page explains what data we collect, how we use and look after it, who we share it with, and how to contact us about your data.
+
+## What personal data we collect
+
+We collect the following personal data:
+
+* name
+* address
+* date of birth
+* phone number
+* email address
+* any other personal data that you choose to include in your application form, such as whether you’re disabled
+
+## How we use your data
+
+### Processing your application
+
+We will use your data to process your application. This means:
+
+* sending your application to your choice(s) of training provider
+* managing some communications between you and your choice(s) of training provider
+* managing communications between your referee(s) and your choice(s) of training provider
+* working out any funding you’re entitled to
+* getting in touch with you if necessary, regarding your application or your data
+
+### Improving Apply for teacher training
+
+We will use your data to improve Apply for teacher training. For example, we will look at any feedback you give us about the service to help us improve it.
+
+### Getting insight to make government policy better
+
+We might look at the information in your application form to get insight into teacher training applicants. This will help us improve government policy.
+
+## Making sure using your personal data is lawful
+
+We need to use your data for the purposes listed above. These purposes are a ‘public task’, outlined in data protection legislation.
+
+## Who we share your data with
+
+We need to share your data for the purposes listed above.
+
+We will share your data with:
+
+1. ### Teacher training providers
+
+    Your application form will be sent to the training providers you have applied to, who will use your data according to the data sharing agreement we have with them.
+
+    This agreement says that a provider can use your data to get in touch with you regarding your application or your data, make decisions on your application, get statistics for internal use, and enrol you if you’re successful.
+
+2. ### Your referees
+
+    We will share your name with your referees so they can identify you and provide a reference. To help them identify you, we may need to share a bit more information about you, such as when you worked or studied with them.
+
+3. ### UCAS
+
+    We will share your personal data with UCAS so that they can check if you’re using their system as well, and if so, that you’re using it correctly. For example, we may contact you if UCAS tell us that you’ve accepted offers on both UCAS and Apply for teacher training.
+
+4. ### External organisations who process data
+
+    #### Customer service systems
+
+    We use a customer service management system to process some of your data - for example, if you get in touch with us to give us feedback. Zendesk are currently our preferred customer service management system: [they use various safeguards to look after your data](https://www.zendesk.co.uk/company/customers-partners/master-subscription-agreement/?cta=msa#confidentiality).
+
+    #### Google
+
+    When you use our service, we’ll ask you if you want to consent to our use of cookies so that we can get statistics from Google Analytics. If you do so, Google may be able to retrieve your IP address. We use Google Analytics for statistics and won’t identify you personally from these.
+
+    During the pilot of the service we will also use the Google’s G Suite to process some personal data. For example, we’ll ask your referees to send a reference via Google Forms and process data using Google Sheets. According to the agreement we have with Google, they won’t access the data we hold within G Suite.
+
+    #### Hosting services
+
+    We host our service on Microsoft Azure Cloud, which encrypts your data to prevent it being accessed by unauthorised people.
+
+## How long we keep your data
+
+We only keep your data for as long as needed for the uses listed above.
+
+We will delete your data after 7 years.
+
+## Your rights
+
+Under the Data Protection Act 2018, you have the right to find out what data we have about you. These include the right to:
+
+* be informed about how your data is being used
+* access personal data
+* have incorrect data updated
+* have data erased
+* stop or restrict the processing of your data
+* get and reuse your data for different services
+* object to how your data is processed in certain circumstances
+
+You can find more information about how we handle personal data in our [personal information charter](https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter).
+
+## Getting help and raising a concern
+
+If you want to ask us to remove your data or get access to the data we have about you, email us at <becomingateacher@digital.education.gov.uk>.
+
+You can also use our [contact form to get in touch with our Data Protection Officer](https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen).
+
+Once you enrol with a teacher training provider, we won’t be able to ask them to remove your data from their systems. Please contact the provider separately.
+
+For further information or to raise a concern, visit the [Information Commissioner’s Office (ICO)](https://ico.org.uk/).
+
+## Keeping our privacy policy up to date
+
+We may need to update this privacy notice periodically. We recommend that you revisit this information from time to time.
+
+This version was last updated on 12 November 2019.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -97,6 +97,9 @@
               <li class="govuk-footer__inline-list-item">
                 <%= link_to t('layout.terms_of_use'), terms_candidate_path, class: 'govuk-footer__link' %>
               </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to t('layout.privacy_policy'), privacy_candidate_path, class: 'govuk-footer__link' %>
+              </li>
             </ul>
             <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
               <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,7 @@ en:
     review_application: Review your application
     accessibility: Accessibility statement for Apply for teacher training
     terms_candidate: Terms of use
+    privacy_candidate: Privacy policy
     contact_details: Contact details
     address: What is your address?
     work_history: Work history
@@ -79,6 +80,7 @@ en:
     service_name: Apply for teacher training
     accessibility: Accessibility
     terms_of_use: Terms of use
+    privacy_policy: Privacy policy
   activemodel:
     attributes:
       vendor_api/metadata:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
 
   get '/accessibility', to: 'content#accessibility'
   get '/candidate/terms-of-use', to: 'content#terms_candidate', as: :terms_candidate
+  get '/candidate/privacy-policy', to: 'content#privacy_candidate', as: :privacy_candidate
 
   namespace :candidate_interface, path: '/candidate' do
     get '/' => 'start_page#show', as: :start

--- a/spec/system/user_viewing_privacy_statement_spec.rb
+++ b/spec/system/user_viewing_privacy_statement_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing privacy policy' do
+  scenario 'User views the privacy policy' do
+    given_i_am_on_the_start_page
+    when_i_can_click_on_privacy_policy
+    then_i_can_see_the_privacy_policy
+  end
+
+  def given_i_am_on_the_start_page
+    visit '/'
+  end
+
+  def when_i_can_click_on_privacy_policy
+    within('.govuk-footer') { click_link t('layout.privacy_policy') }
+  end
+
+  def then_i_can_see_the_privacy_policy
+    expect(page).to have_content(t('page_titles.privacy_candidate'))
+  end
+end


### PR DESCRIPTION
### Context

Adds the privacy policy.

### Changes proposed in this pull request

* Adds a ‘Privacy policy’ link to footer
* Adds content to the ‘Create account’ page (linking to this new page):

![Screenshot 2019-11-14 at 12 29 02](https://user-images.githubusercontent.com/813383/68857281-624be680-06da-11ea-9edf-d7e49db9e3de.png)


### Guidance to review

How could someone else check this work? Which parts do you want more feedback on?

### Link to Trello card

[366 - Add privacy policy](https://trello.com/c/UrhpfvRX/366-add-privacy-policy)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
