### PR TITLE
Add ability to edit volunteering role

### DIFF
--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -25,7 +25,7 @@ private
       key: t('application_form.volunteering.role.review_label'),
       value: volunteering_role.role,
       action: t('application_form.volunteering.role.change_action'),
-      change_path: '#',
+      change_path: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role.id),
     }
   end
 
@@ -34,7 +34,7 @@ private
       key: t('application_form.volunteering.organisation.review_label'),
       value: volunteering_role.organisation,
       action: t('application_form.volunteering.organisation.change_action'),
-      change_path: '#',
+      change_path: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role.id),
     }
   end
 
@@ -43,7 +43,7 @@ private
       key: t('application_form.volunteering.length_and_details.review_label'),
       value: formatted_length_and_details(volunteering_role),
       action: t('application_form.volunteering.length_and_details.change_action'),
-      change_path: '#',
+      change_path: Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role.id),
     }
   end
 

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -14,12 +14,30 @@ module CandidateInterface
       end
     end
 
+    def edit
+      @volunteering_role = VolunteeringRoleForm.build_from_application(current_application, current_volunteering_role_id)
+    end
+
+    def update
+      @volunteering_role = VolunteeringRoleForm.new(volunteering_role_params)
+
+      if @volunteering_role.update(current_application)
+        redirect_to candidate_interface_review_volunteering_path
+      else
+        render :edit
+      end
+    end
+
   private
+
+    def current_volunteering_role_id
+      params.permit(:id)[:id]
+    end
 
     def volunteering_role_params
       params.require(:candidate_interface_volunteering_role_form)
         .permit(
-          :role, :organisation, :details, :working_with_children,
+          :id, :role, :organisation, :details, :working_with_children,
           :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
           :"end_date(3i)", :"end_date(2i)", :"end_date(1i)"
         )

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -53,16 +53,17 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      application_form.application_volunteering_experiences.create!(
-        role: role,
-        organisation: organisation,
-        details: details,
-        working_with_children: ActiveModel::Type::Boolean.new.cast(working_with_children),
-        start_date: start_date,
-        end_date: end_date,
-      )
+      application_form.application_volunteering_experiences.create!(map_attributes)
 
       true
+    end
+
+    def update(application_form)
+      return false unless valid?
+
+      volunteering_role = application_form.application_volunteering_experiences.find(id)
+
+      volunteering_role.update!(map_attributes)
     end
 
     def start_date
@@ -109,6 +110,17 @@ module CandidateInterface
 
     def end_date_valid?
       end_date
+    end
+
+    def map_attributes
+      {
+        role: role,
+        organisation: organisation,
+        details: details,
+        working_with_children: ActiveModel::Type::Boolean.new.cast(working_with_children),
+        start_date: start_date,
+        end_date: end_date,
+      }
     end
   end
 end

--- a/app/views/candidate_interface/volunteering/base/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/base/_form.html.erb
@@ -1,0 +1,24 @@
+<p class="govuk-body">Don’t include paid work in a school – enter these roles in ‘Work history’.</p>
+
+<%= f.govuk_text_field :role, label: { text: t('application_form.volunteering.role.label'), size: 'm' } %>
+
+<%= f.govuk_text_field :organisation, label: { text: t('application_form.volunteering.organisation.label'), size: 'm' } %>
+
+<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), tag: 'span' }, inline: true do %>
+  <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
+<% end %>
+
+<h2 class="govuk-heading-m">How long have you been in this role and what does it involve?</h2>
+
+<div class="app-work-experience__start-date" data-qa="start-date">
+  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: t('application_form.volunteering.start_date.label'), size: 's', tag: 'span' }, hint_text: t('application_form.volunteering.start_date.hint_text') %>
+</div>
+
+<div class="app-work-experience__end-date" data-qa="end-date">
+  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: t('application_form.volunteering.end_date.label'), size: 's', tag: 'span' }, hint_text: t('application_form.volunteering.end_date.hint_text') %>
+</div>
+
+<%= f.govuk_text_area :details, label: { text: t('application_form.volunteering.details.label'), size: 'm' }, hint_text: t('application_form.volunteering.details.hint_text'), max_words: 150 %>
+
+<%= f.govuk_submit t('application_form.volunteering.complete_form_button') %>

--- a/app/views/candidate_interface/volunteering/base/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/base/edit.html.erb
@@ -1,19 +1,20 @@
-<% content_for :title, page_title(:add_volunteering_role) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+<% content_for :title, page_title(:edit_volunteering_role) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_volunteering_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @volunteering_role, url: candidate_interface_create_volunteering_role_path do |f| %>
+    <%= form_with model: @volunteering_role, url: candidate_interface_edit_volunteering_role_path do |f| %>
       <%= f.govuk_error_summary %>
 
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
           <h1 class="govuk-fieldset__heading">
             <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
-            <%= t('page_titles.add_volunteering_role') %>
+            <%= t('page_titles.edit_volunteering_role') %>
           </h1>
         </legend>
 
+        <%= f.hidden_field :id, value: @volunteering_role.id %>
         <%= render 'form', f: f %>
       </fieldset>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,6 +74,7 @@ en:
       long: "Children and young people: volunteering and experience in school"
       caption: Children and young people
     add_volunteering_role: Add role
+    edit_volunteering_role: Edit role
     destroy_volunteering_role: Are you sure you want to delete this role?
   layout:
     service_name: Apply for teacher training

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -92,6 +92,7 @@ Rails.application.routes.draw do
 
         get '/new' => 'work_history/edit#new', as: :work_history_new
         post '/create' => 'work_history/edit#create', as: :work_history_create
+
         get '/edit/:id' => 'work_history/edit#edit', as: :work_history_edit
         post '/edit/:id' => 'work_history/edit#update'
 
@@ -108,6 +109,9 @@ Rails.application.routes.draw do
 
         get '/new' => 'volunteering/base#new', as: :new_volunteering_role
         post '/new' => 'volunteering/base#create', as: :create_volunteering_role
+
+        get '/edit/:id' => 'volunteering/base#edit', as: :edit_volunteering_role
+        post '/edit/:id' => 'volunteering/base#update'
 
         get '/review' => 'volunteering/review#show', as: :review_volunteering
         patch '/review' => 'volunteering/review#complete', as: :complete_volunteering

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe VolunteeringReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.role.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('School Experience Intern')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('#')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+      )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.role.change_action')}")
     end
 
@@ -73,7 +75,9 @@ RSpec.describe VolunteeringReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.organisation.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('A Noice School')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('#')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+      )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.organisation.change_action')}")
     end
 
@@ -82,7 +86,9 @@ RSpec.describe VolunteeringReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.length_and_details.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('August 2019 - Present<br><p>I interned.</p>')
-      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('#')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+      )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.length_and_details.change_action')}")
     end
 

--- a/spec/models/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_role_form_spec.rb
@@ -88,6 +88,36 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     end
   end
 
+  describe '#update' do
+    let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(id: 1) }
+    let(:application_form) do
+      create(:application_form) do |form|
+        form.application_volunteering_experiences.create(id: 1, attributes: data)
+      end
+    end
+
+    it 'returns false if not valid' do
+      expect(volunteering_role.update(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'updates the provided ApplicationForm if valid' do
+      form_data[:role] = 'Classroom Volunteer'
+      form_data[:organisation] = 'Some Other School'
+      volunteering_role.assign_attributes(form_data)
+
+      expect(volunteering_role.update(application_form)).to eq(true)
+      expect(application_form.application_volunteering_experiences.first)
+        .to have_attributes(
+          role: 'Classroom Volunteer',
+          organisation: 'Some Other School',
+          details: data[:details],
+          working_with_children: data[:working_with_children],
+          start_date: data[:start_date],
+          end_date: data[:end_date],
+        )
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:role) }
     it { is_expected.to validate_presence_of(:organisation) }

--- a/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -33,6 +33,13 @@ RSpec.feature 'Entering volunteering and school experience' do
     and_i_submit_the_volunteering_role_form
     then_i_check_my_volunteering_role
 
+    when_i_click_to_change_my_volunteering_role
+    then_i_see_my_volunteering_role_filled_in
+
+    when_i_change_my_volunteering_role
+    and_i_submit_the_volunteering_role_form
+    then_i_can_check_my_revised_volunteering_role
+
     when_i_mark_this_section_as_completed
     and_i_click_on_continue
     then_i_should_see_the_form
@@ -124,6 +131,28 @@ RSpec.feature 'Entering volunteering and school experience' do
 
   def when_i_fill_in_another_volunteering_role
     when_i_fill_in_my_volunteering_role
+  end
+
+  def when_i_click_to_change_my_volunteering_role
+    first('.govuk-summary-list__actions').click_link 'Change'
+  end
+
+  def then_i_see_my_volunteering_role_filled_in
+    expect(page).to have_selector("input[value='Classroom Volunteer']")
+    expect(page).to have_selector("input[value='A Noice School']")
+    expect(page).to have_selector("input[value='true']")
+    expect(page).to have_selector("input[value='5']")
+    expect(page).to have_selector("input[value='2018']")
+    expect(page).to have_selector("input[value='1']")
+    expect(page).to have_selector("input[value='2019']")
+  end
+
+  def when_i_change_my_volunteering_role
+    fill_in t('application_form.volunteering.organisation.label'), with: 'Much Wow School'
+  end
+
+  def then_i_can_check_my_revised_volunteering_role
+    expect(page).to have_content 'Much Wow School'
   end
 
   def when_i_mark_this_section_as_completed


### PR DESCRIPTION
### Context

Currently, a candidate can adit, delete and complete the volunteering and school experience section as well as review the section when they check all their answers upon application submission. However, they can't edit a volunteering role.

### Changes proposed in this pull request

This PR adds the ability to edit a volunteering role by adding an `#update` method for `VolunteeringRoleForm`.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/68852264-750cee00-06cf-11ea-8a1d-85e7ff8fca86.png)

![image](https://user-images.githubusercontent.com/42817036/68852341-98d03400-06cf-11ea-9c38-f3a611fa7d97.png)

![image](https://user-images.githubusercontent.com/42817036/68853803-b357dc80-06d2-11ea-8907-950ecfdeb339.png)

### Guidance to review

Nothing in particular.

### Link to Trello card

[193 - Adding school and volunteer experience](https://trello.com/c/XhtOYjDF/193-adding-school-and-volunteer-experience)
