### PR TITLE
Avoid reloading references in the receive references action

### DIFF
--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -19,7 +19,6 @@ class ReceiveReference
     ActiveRecord::Base.transaction do
       @application_form
         .references
-        .reload
         .find { |reference| reference.email_address == @referee_email }
         .update!(feedback: @feedback)
 

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe ReceiveReference do
   it 'updates the reference on an application form with the provided text' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
-    create(:reference, :unsubmitted, email_address: 'ab@c.com', application_form: application_form)
-    create(:reference, :unsubmitted, email_address: 'xy@z.com', application_form: application_form)
+    application_form.references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.references << build(:reference, :unsubmitted, email_address: 'xy@z.com')
 
     action = ReceiveReference.new(
       application_form: application_form,
@@ -23,8 +23,8 @@ RSpec.describe ReceiveReference do
   it 'progresses the application choices to the "application complete" status once all references have been received' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
-    create(:reference, :unsubmitted, email_address: 'ab@c.com', application_form: application_form)
-    create(:reference, :complete, application_form: application_form)
+    application_form.references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.references << build(:reference, :complete)
 
     action = ReceiveReference.new(
       application_form: application_form,
@@ -40,8 +40,8 @@ RSpec.describe ReceiveReference do
   it 'progresses the application choices to the "awaiting provider decision" status once all references have been received if edit_by date is in past' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.ago) }
-    create(:reference, :unsubmitted, email_address: 'ab@c.com', application_form: application_form)
-    create(:reference, :complete, application_form: application_form)
+    application_form.references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.references << build(:reference, :complete)
 
     action = ReceiveReference.new(
       application_form: application_form,
@@ -57,7 +57,7 @@ RSpec.describe ReceiveReference do
   it 'does not progress the application choices to the "application complete" status without minimum number of references' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
-    create(:reference, :unsubmitted, email_address: 'ab@c.com', application_form: application_form)
+    application_form.references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
 
     action = ReceiveReference.new(
       application_form: application_form,


### PR DESCRIPTION
Update to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/509.

We are currently reloading the application_form object in `ReceiveReference` because of the way we set up the test data in the specs.

By explicitly updating the `application_form.references` in the tests, the object will already be up to date when passed into the `ReceiveReference` and we won't have to `reload`.

https://trello.com/c/33rFaaqv/200-requesting-references-from-candidate