### PR TITLE
Add "completed" tags for GCSEs

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -34,6 +34,18 @@ module CandidateInterface
       @application_form.application_qualifications.degrees.any?
     end
 
+    def maths_gcse_completed?
+      @application_form.qualification_in_subject(:gcse, :maths).present?
+    end
+
+    def english_gcse_completed?
+      @application_form.qualification_in_subject(:gcse, :english).present?
+    end
+
+    def science_gcse_completed?
+      @application_form.qualification_in_subject(:gcse, :science).present?
+    end
+
     def other_qualifications_completed?
       @application_form.other_qualifications_completed
     end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -87,14 +87,32 @@
         <% end %>
       </li>
       <li class="app-task-list__item">
-        <%= govuk_link_to 'Maths GCSE or equivalent', candidate_interface_gcse_details_edit_type_path(subject: :maths), class: 'app-task-list__task-name' %>
+        <% if @application_form_presenter.maths_gcse_completed? %>
+          <%= govuk_link_to 'Maths GCSE or equivalent', candidate_interface_gcse_review_path(subject: :maths), class: 'app-task-list__task-name', 'aria-describedby': 'maths-qualifications-completed' %>
+          <strong class="govuk-tag app-task-list__task-completed" id="maths-qualifications-completed">Completed</strong>
+        <% else %>
+          <%= govuk_link_to 'Maths GCSE or equivalent', candidate_interface_gcse_details_edit_type_path(subject: :maths), class: 'app-task-list__task-name' %>
+        <% end %>
       </li>
+
       <li class="app-task-list__item">
-        <%= govuk_link_to 'English GCSE or equivalent', candidate_interface_gcse_details_edit_type_path(subject: :english), class: 'app-task-list__task-name' %>
+        <% if @application_form_presenter.english_gcse_completed? %>
+          <%= govuk_link_to 'English GCSE or equivalent', candidate_interface_gcse_review_path(subject: :english), class: 'app-task-list__task-name', 'aria-describedby': 'english-qualifications-completed' %>
+          <strong class="govuk-tag app-task-list__task-completed" id="english-qualifications-completed">Completed</strong>
+        <% else %>
+          <%= govuk_link_to 'English GCSE or equivalent', candidate_interface_gcse_details_edit_type_path(subject: :english), class: 'app-task-list__task-name' %>
+        <% end %>
       </li>
+
       <li class="app-task-list__item">
-        <%= govuk_link_to 'Science GCSE or equivalent', candidate_interface_gcse_details_edit_type_path(subject: :science), class: 'app-task-list__task-name' %>
+        <% if @application_form_presenter.science_gcse_completed? %>
+          <%= govuk_link_to 'Science GCSE or equivalent', candidate_interface_gcse_review_path(subject: :science), class: 'app-task-list__task-name', 'aria-describedby': 'science-qualifications-completed' %>
+          <strong class="govuk-tag app-task-list__task-completed" id="science-qualifications-completed">Completed</strong>
+        <% else %>
+          <%= govuk_link_to 'Science GCSE or equivalent', candidate_interface_gcse_details_edit_type_path(subject: :science), class: 'app-task-list__task-name' %>
+        <% end %>
       </li>
+
       <li class="app-task-list__item">
         <% if @application_form_presenter.other_qualifications_completed? %>
           <%= govuk_link_to t('page_titles.other_qualification'), candidate_interface_review_other_qualifications_path, class: 'app-task-list__task-name', 'aria-describedby': 'other-qualifications-completed' %>

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   scenario 'Candidate submits their maths GCSE details and then update them' do
     given_i_am_signed_in
-    and_i_visit_the_candidate_application_page
+    when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
 
@@ -28,11 +28,14 @@ RSpec.feature 'Candidate entering GCSE details' do
     and_i_click_save_and_continue
 
     then_i_see_the_review_page_with_updated_details
+
+    when_i_visit_the_candidate_application_page
+    i_see_the_maths_gcse_is_completed
   end
 
   scenario 'Candidate does not provide a qualification level' do
     given_i_am_signed_in
-    and_i_visit_the_candidate_application_page
+    when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
 
     then_i_see_the_add_gcse_maths_page
@@ -68,7 +71,7 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   def and_i_do_not_select_any_gcse_option; end
 
-  def and_i_visit_the_candidate_application_page
+  def when_i_visit_the_candidate_application_page
     visit '/candidate/application'
   end
 
@@ -122,5 +125,9 @@ RSpec.feature 'Candidate entering GCSE details' do
   def and_i_edit_my_details
     fill_in 'Enter your qualification grade', with: 'BB'
     fill_in 'Enter the year you gained your qualification', with: '2000'
+  end
+
+  def i_see_the_maths_gcse_is_completed
+    expect(page).to have_css('#maths-qualifications-completed', text: 'Completed')
   end
 end


### PR DESCRIPTION
#21 # Context

When a GCSE section has been completed, this now shows the "completed" tag.

### Guidance to review

<img width="895" alt="Screenshot 2019-11-14 at 14 20 10" src="https://user-images.githubusercontent.com/233676/68864955-e22d7d00-06e9-11ea-99bf-21e048c355d5.png">

### Link to Trello card

357-add-completion-bits-for-gcses