### PR TITLE
Fix for application_form.references needing explicit reload in tests

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -109,7 +109,7 @@ FactoryBot.define do
   factory :course do
     provider
 
-    code { Faker::Alphanumeric.alphanumeric(number: 4).upcase }
+    code { Faker::Alphanumeric.alphanumeric(number: 4, min_alpha: 1).upcase }
     name { Faker::Educator.subject }
     level { 'primary' }
     start_date { Date.new(2020, 9, 1) }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -51,6 +51,14 @@ FactoryBot.define do
         create_list(:application_volunteering_experience, evaluator.volunteering_experiences_count, application_form: application_form)
         create_list(:application_qualification, evaluator.qualifications_count, application_form: application_form)
         create_list(:reference, evaluator.references_count, application_form: application_form)
+        # The application_form validates the length of this collection when
+        # it is created, which is BEFORE we create the references here.
+        # This then *caches* the association on the  application_form, and means
+        # you have to explicitly reload it to pick up the created references.
+        # We do this here, so we only have to do it in one place, rather than
+        # everywhere we refer to application_form.references in tests.
+        # See https://github.com/thoughtbot/factory_bot/issues/549 for details.
+        application_form.references.reload
       end
     end
   end

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RefereeMailer, type: :mailer do
 
   describe 'Send request reference email' do
     let(:application_form) { create(:completed_application_form) }
-    let(:reference) { application_form.references.reload.first }
+    let(:reference) { application_form.references.first }
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
     let(:mail) { mailer.reference_request_email(application_form, reference) }
 

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -56,17 +56,13 @@ RSpec.describe Reference, type: :model do
   # be 1, so that we can still use that to describe 'First referee' etc in the
   # interface
   describe 'after deleting a reference' do
-    let!(:application_form) { create(:application_form) }
-
-    before do
-      create_list(:reference, 2, application_form: application_form)
-    end
+    let!(:application_form) { create(:completed_application_form, references_count: 2) }
 
     describe 'the ordinal of the remaining references' do
       let(:ordinals) { application_form.references.map(&:ordinal) }
 
       it 'still starts at 1' do
-        application_form.references.reload.first.destroy
+        application_form.references.first.destroy
         expect(ordinals.first).to eq(1)
       end
     end


### PR DESCRIPTION
### Context

A [known-issue with FactoryBot's way of creating dependent records](https://github.com/thoughtbot/factory_bot/issues/549) means that because we are validating the length of the `application_form.references` association in the application_form, we have to explicitly reload the association after creating references.

This gives counter-intuitive results, for instance: 
```
FactoryBot.build(:completed_application_form).references.length
=> 0
```

### Changes proposed in this pull request

There's no way to _fix_ this, so we have to workaround it. This PR adds an explicit `references.reload` after creating the references in the factory, so that we don't need to do that in tests which use that association. It also tidies up a couple of specs that can be less verbose as a result.

### Guidance to review

run the tests, if they're all green, we're good.

### Link to Trello card

No trello card created for this issue, but it was highlighted after merging PR #509 for [200 - Requesting references from candidate](https://trello.com/c/33rFaaqv/200-requesting-references-from-candidate)

### Env vars

n/a
