### PR TITLE
Add ability to choose another provider and course

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -22,8 +22,14 @@ module CandidateInterface
     end
 
     def pick_provider
-      redirect_to candidate_interface_course_choices_course_path(provider_code: provider_params[:code])
+      if provider_params[:code] == 'other'
+        redirect_to candidate_interface_course_choices_on_ucas_path
+      else
+        redirect_to candidate_interface_course_choices_course_path(provider_code: provider_params[:code])
+      end
     end
+
+    def ucas; end
 
     def options_for_course
       @courses = Provider

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -39,7 +39,11 @@ module CandidateInterface
     end
 
     def pick_course
-      redirect_to candidate_interface_course_choices_site_path(provider_code: params[:provider_code], course_code: course_params[:code])
+      if course_params[:code] == 'other'
+        redirect_to candidate_interface_course_choices_on_ucas_path
+      else
+        redirect_to candidate_interface_course_choices_site_path(provider_code: params[:provider_code], course_code: course_params[:code])
+      end
     end
 
     def options_for_site

--- a/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
+++ b/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
@@ -6,14 +6,14 @@
     <%= form_with model: @choice, url: candidate_interface_course_choices_choose_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <div class="govuk-!-margin-top-6">
-        <%= f.govuk_radio_buttons_fieldset :choice, legend: { size: 'xl', text: t('page_titles.have_you_chosen') } do %>
+      <%= f.govuk_radio_buttons_fieldset :choice, legend: { size: 'xl', text: t('page_titles.have_you_chosen') } do %>
+        <div class="govuk-!-margin-top-6">
           <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, I know where I want to apply' } %>
           <%= f.govuk_radio_button :choice, :no, label: { text: 'No, I need to find a course' } %>
-        <% end %>
+        </div>
+      <% end %>
 
-        <%= f.govuk_submit 'Continue' %>
-      </div>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -9,8 +9,12 @@
       <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
         <div class="govuk-!-margin-top-6">
           <% @courses.map do |course| %>
-            <%= f.govuk_radio_button :code, course.code, label: { text: "#{course.name} (#{course.code})", size: 'm' } %>
+            <%= f.govuk_radio_button :code, course.code, label: { text: "#{course.name} (#{course.code})" } %>
           <% end %>
+
+          <%= f.govuk_radio_divider %>
+
+          <%= f.govuk_radio_button :code, :other, label: { text: 'Another course' } %>
         </div>
       <% end %>
 

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -6,11 +6,13 @@
     <%= form_with model: Course.new, url: candidate_interface_course_choices_course_path(provider_code: params[:provider_code]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.which_course') %>
-      </h1>
-
-      <%= f.govuk_collection_select :code, @courses.map { |course| OpenStruct.new(code: course.code, name: "#{course.name} (#{course.code})") }, :code, :name, label: { text: 'Enter course name and code' } %>
+      <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
+        <div class="govuk-!-margin-top-6">
+          <% @courses.map do |course| %>
+            <%= f.govuk_radio_button :code, course.code, label: { text: "#{course.name} (#{course.code})", size: 'm' } %>
+          <% end %>
+        </div>
+      <% end %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -9,8 +9,12 @@
       <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_provider') } do %>
         <div class="govuk-!-margin-top-6">
           <% @providers.map do |provider| %>
-            <%= f.govuk_radio_button :code, provider.code, label: { text: "#{provider.name} (#{provider.code})", size: 'm' } %>
+            <%= f.govuk_radio_button :code, provider.code, label: { text: "#{provider.name} (#{provider.code})" } %>
           <% end %>
+
+          <%= f.govuk_radio_divider %>
+
+          <%= f.govuk_radio_button :code, :other, label: { text: 'Another provider' } %>
         </div>
       <% end %>
 

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -6,11 +6,13 @@
     <%= form_with model: Provider.new, url: candidate_interface_course_choices_provider_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.which_provider') %>
-      </h1>
-
-      <%= f.govuk_collection_select :code, @providers.map { |provider| OpenStruct.new(code: provider.code, name: "#{provider.name} (#{provider.code})") }, :code, :name, label: { text: 'Enter training provider name' } %>
+      <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_provider') } do %>
+        <div class="govuk-!-margin-top-6">
+          <% @providers.map do |provider| %>
+            <%= f.govuk_radio_button :code, provider.code, label: { text: "#{provider.name} (#{provider.code})", size: 'm' } %>
+          <% end %>
+        </div>
+      <% end %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/candidate_interface/course_choices/options_for_site.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_site.html.erb
@@ -7,9 +7,11 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :id, legend: { size: 'xl', text: t('page_titles.which_location') } do %>
-        <% @options.each do |option| %>
-          <%= f.govuk_radio_button :id, option.id, label: { text: option.site.name } %>
-        <% end %>
+        <div class="govuk-!-margin-top-6">
+          <% @options.each do |option| %>
+            <%= f.govuk_radio_button :id, option.id, label: { text: option.site.name } %>
+          <% end %>
+        </div>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/course_choices/ucas.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, page_title(:apply_on_ucas) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_provider_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      We’re sorry, but we’re not ready for you yet
+    </h1>
+
+    <p class="govuk-body">Apply for teacher training is still in development, so for now, we have to limit candidate numbers.</p>
+    <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
+    <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
+    <p class="govuk-body"><%= govuk_link_to 'Apply on UCAS', UCAS.apply_url %></p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
       - (should never appear)
       - First referee
       - Second referee
+    apply_on_ucas: We’re sorry, but we’re not ready for you yet
   layout:
     service_name: Apply for teacher training
     accessibility: Accessibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,6 +141,8 @@ Rails.application.routes.draw do
         get '/provider' => 'course_choices#options_for_provider', as: :course_choices_provider
         post '/provider' => 'course_choices#pick_provider'
 
+        get '/apply-on-ucas' => 'course_choices#ucas', as: :course_choices_on_ucas
+
         get '/provider/:provider_code/courses' => 'course_choices#options_for_course', as: :course_choices_course
         post '/provider/:provider_code/courses' => 'course_choices#pick_course'
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -17,7 +17,7 @@ module CandidateHelper
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
 
-    select 'Gorse SCITT (1N1)'
+    choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
 
     select 'Primary (2XT2)'

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -20,7 +20,7 @@ module CandidateHelper
     choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
 
-    select 'Primary (2XT2)'
+    choose 'Primary (2XT2)'
     click_button 'Continue'
 
     choose 'Main site'

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -13,6 +13,11 @@ RSpec.feature 'Selecting a course not on Apply' do
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_another_provider
     then_i_see_that_i_should_apply_on_ucas
+
+    when_i_click_on_back
+    and_i_choose_a_provider
+    and_i_choose_another_course
+    then_i_see_that_i_should_apply_on_ucas
   end
 
   def given_i_am_not_signed_in; end
@@ -52,5 +57,19 @@ RSpec.feature 'Selecting a course not on Apply' do
 
   def then_i_see_that_i_should_apply_on_ucas
     expect(page).to have_content(t('page_titles.apply_on_ucas'))
+  end
+
+  def when_i_click_on_back
+    click_link 'Back'
+  end
+
+  def and_i_choose_a_provider
+    choose 'Gorse SCITT (1N1)'
+    click_button 'Continue'
+  end
+
+  def and_i_choose_another_course
+    choose 'Another course'
+    click_button 'Continue'
   end
 end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a course not on Apply' do
+  include CandidateHelper
+
+  scenario 'Candidate selects a course choice that is not on Apply' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    given_data_from_find_exists
+    when_i_click_on_course_choices
+    and_i_click_on_add_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_another_provider
+    then_i_see_that_i_should_apply_on_ucas
+  end
+
+  def given_i_am_not_signed_in; end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def given_data_from_find_exists
+    provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    site = create(:site, name: 'Main site', code: '-', provider: provider)
+    course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true)
+    create(:course_option, site: site, course: course, vacancy_status: 'B')
+  end
+
+  def when_i_click_on_course_choices
+    click_link 'Course choices'
+  end
+
+  def and_i_click_on_add_course
+    click_link 'Add another course'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+  end
+
+  def and_i_choose_another_provider
+    choose 'Another provider'
+    click_button 'Continue'
+  end
+
+  def then_i_see_that_i_should_apply_on_ucas
+    expect(page).to have_content(t('page_titles.apply_on_ucas'))
+  end
+end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_a_provider
-    select 'Gorse SCITT (1N1)'
+    choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_a_course
-    select 'Primary (2XT2)'
+    choose 'Primary (2XT2)'
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Candidate submit the application' do
     click_button 'Continue'
     choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
-    select 'Primary (2XT2)'
+    choose 'Primary (2XT2)'
     click_button 'Continue'
     choose 'Main site'
     click_button 'Continue'

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Candidate submit the application' do
     click_link 'Add another course'
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
-    select 'Gorse SCITT (1N1)'
+    choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
     select 'Primary (2XT2)'
     click_button 'Continue'


### PR DESCRIPTION
### Context

With the current design, if a candidate wanted to make a course choice which we don't currently support they are left "stranded" on their user journey.

### Changes proposed in this pull request

This PR adds the option for "another" choice when choosing a provider and course. When choosing this, they are provided with the page to apply on UCAS.

### Screenshots (Updated 15/11, 13:35)

![image](https://user-images.githubusercontent.com/42817036/68947174-ba531d80-07ac-11ea-8ff3-5aa856377c7d.png)

![image](https://user-images.githubusercontent.com/42817036/68947189-c212c200-07ac-11ea-9b76-b176286d0ce0.png)

![image](https://user-images.githubusercontent.com/42817036/68947196-c8a13980-07ac-11ea-9615-57558eedcb9a.png)

### Guidance to review

Would like feedback from someone from the design team to verify that this is want we want.

### Link to Trello card

[364 - Make the provider dropdown a radio button, and allow candidates to choose "other" (which goes to UCAS)](https://trello.com/c/m8GDiRSz/364-make-the-provider-dropdown-a-radio-button-and-allow-candidates-to-choose-other-which-goes-to-ucas)

