### PR TITLE
add audit trail to References

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -6,6 +6,8 @@ class Reference < ApplicationRecord
 
   belongs_to :application_form
 
+  audited associated_with: :application_form
+
   def complete?
     feedback.present?
   end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe ApplicationForm do
 
     it 'can view audit records for ApplicationForm and its associated ApplicationChoices' do
       application_form = create :completed_application_form
-      expect(application_form.own_and_associated_audits.count).to eq 4
+      expect(application_form.own_and_associated_audits.count).to eq 6
       application_form.application_choices.first.update!(personal_statement: 'hello again')
-      expect(application_form.own_and_associated_audits.count).to eq 5
+      expect(application_form.own_and_associated_audits.count).to eq 7
     end
   end
 

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -71,13 +71,8 @@ RSpec.describe Reference, type: :model do
   describe 'auditing' do
     let(:application_form) { create(:application_form) }
 
-    it 'creates audit entries' do
-      reference = create :reference, application_form: application_form
-      expect(reference.audits.count).to eq 1
-      reference.update!(feedback: 'hello again')
-      expect(reference.audits.count).to eq 2
-    end
-
+    it { should be_audited.associated_with :application_form }
+    
     it 'creates an associated object in each audit record' do
       reference = create :reference, application_form: application_form
       expect(reference.audits.last.associated).to eq reference.application_form

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -67,4 +67,28 @@ RSpec.describe Reference, type: :model do
       end
     end
   end
+
+  describe 'auditing' do
+    let(:application_form) { create(:application_form) }
+
+    it 'creates audit entries' do
+      reference = create :reference, application_form: application_form
+      expect(reference.audits.count).to eq 1
+      reference.update!(feedback: 'hello again')
+      expect(reference.audits.count).to eq 2
+    end
+
+    it 'creates an associated object in each audit record' do
+      reference = create :reference, application_form: application_form
+      expect(reference.audits.last.associated).to eq reference.application_form
+    end
+
+    it 'audit record can be attributed to a candidate' do
+      candidate = create :candidate
+      reference = Audited.audit_class.as_user(candidate) do
+        create :reference, application_form: application_form
+      end
+      expect(reference.audits.last.user).to eq candidate
+    end
+  end
 end

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe Reference, type: :model do
   describe 'auditing' do
     let(:application_form) { create(:application_form) }
 
-    it { should be_audited.associated_with :application_form }
-    
+    it { is_expected.to be_audited.associated_with :application_form }
+
     it 'creates an associated object in each audit record' do
       reference = create :reference, application_form: application_form
       expect(reference.audits.last.associated).to eq reference.application_form

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ SimpleCov.start 'rails'
 
 require 'sidekiq/testing'
 require 'clockwork/test'
+require 'audited-rspec'
 ENV['SERVICE_TYPE'] = 'test' # this is used for logging
 
 RSpec.configure do |config|


### PR DESCRIPTION
### Context

all changes to an application form should be auditable

### Changes proposed in this pull request

Add the `audited` setup to the Reference model, and a test to make sure that it works.

### Guidance to review

1. Go to an application form. 
2. Add/update/delete a reference.
3. Go to the support interface /support/applications
4. Click on the application's "History" link
5. You should see the audit entries for the reference.

### Link to Trello card

[384 - Adding a referee didn't show up in the audit trail in the support app](https://trello.com/c/MPtdICu2/384-adding-a-referee-didnt-show-up-in-the-audit-trail-in-the-support-app)

### Env vars

N/A