### PR TITLE
Add validation for course selection

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -46,11 +46,19 @@ module CandidateInterface
       # TODO: add better validation
       redirect_back(fallback_location: root_path) && return unless params[:course_option]
 
-      current_candidate.current_application.application_choices.create!(
-        course_option: CourseOption.find(course_option_params[:id]),
-      )
+      @application_form = current_application
+      @course_choices = @application_form.application_choices
+      selected_courses = @course_choices.map(&:course)
 
-      redirect_to candidate_interface_course_choices_index_path
+      if selected_courses.include?(Course.find_by(code: params[:course_code]))
+        @application_form.errors[:base] << 'You have already selected this course'
+        render :index
+      else
+        @course_choices.create!(
+          course_option: CourseOption.find(course_option_params[:id]),
+        )
+        redirect_to candidate_interface_course_choices_index_path
+      end
     end
 
     def confirm_destroy

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -16,10 +16,25 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_location
     then_i_see_my_completed_course_choice
 
-    when_i_delete_my_course_choice
-    and_i_confirm
-    then_i_no_longer_see_my_course_choice
+    # attempt to add the same course
+    and_i_click_on_add_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_a_course
+    and_i_choose_a_location
+    then_i_see_an_error_message
 
+    when_i_mark_this_section_as_completed
+    when_i_click_continue
+    and_that_the_section_is_completed
+  end
+
+  scenario 'Candidate deletes a course choice' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    given_data_from_find_exists
+    when_i_click_on_course_choices
     and_i_click_on_add_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
@@ -27,9 +42,9 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_location
     then_i_see_my_completed_course_choice
 
-    when_i_mark_this_section_as_completed
-    when_i_click_continue
-    and_that_the_section_is_completed
+    when_i_delete_my_course_choice
+    and_i_confirm
+    then_i_no_longer_see_my_course_choice
   end
 
   def given_i_am_not_signed_in; end
@@ -105,5 +120,9 @@ RSpec.feature 'Selecting a course' do
 
   def and_that_the_section_is_completed
     expect(page).to have_css('#course-choices-completed', text: 'Completed')
+  end
+
+  def then_i_see_an_error_message
+    expect(page).to have_css('.govuk-error-summary', text: 'You have already selected this course')
   end
 end


### PR DESCRIPTION
### Context
Ensure users can't select the same course multiple times

### Changes proposed in this pull request
Add validation to stop the above happening

### Guidance to review
Try to add the same course twice.

### After
![localhost_3000_candidate_application_courses_provider_1N1_courses_238T(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/68963040-ef239c80-07cd-11ea-824d-b35b7bc21a00.png)

### Link to Trello card
[330 - Limit number of courses and types to choose](https://trello.com/c/1zJPPzBV/330-limit-number-of-courses-and-types-to-choose)

### Env vars
n/a