### PR TITLE
Validate reference email addresses are unique within an application_form

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,6 +1,8 @@
 class Reference < ApplicationRecord
   validates :name, presence: true, length: { minimum: 2, maximum: 200 }
-  validates :email_address, presence: true, length: { maximum: 100 }
+  validates :email_address, presence: true,
+                            length: { maximum: 100 },
+                            uniqueness: { scope: :application_form_id }
   validates :relationship, presence: true, length: { minimum: 2, maximum: 500 }
   validates_presence_of :application_form_id
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,7 @@ en:
               blank: Enter the referee’s email address
               too_long: Email address must be %{count} characters or fewer
               invalid: Enter an email address in the correct format, like name@example.com
+              taken: Please give a different email address for each referee
             name:
               blank: Enter the referee’s full name
               too_long: Full name must be %{count} characters or fewer

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -4,8 +4,12 @@ RSpec.describe Reference, type: :model do
   subject { build(:reference) }
 
   describe 'a valid reference' do
+    let(:application_form) { build(:application_form) }
+    subject { build(:reference, application_form: application_form) }
+
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
+    it { is_expected.to validate_uniqueness_of(:email_address).scoped_to(:application_form_id).ignoring_case_sensitivity }
 
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_length_of(:name).is_at_most(200) }

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Reference, type: :model do
 
   describe 'a valid reference' do
     let(:application_form) { build(:application_form) }
+
     subject { build(:reference, application_form: application_form) }
 
     it { is_expected.to validate_presence_of :email_address }


### PR DESCRIPTION
### Context

QA testing found that although the DB constraint prevented a duplicate email address being entered, it wasn't being validated - so the user just saw a 500 error page, rather than an explanatory form validation.

### Changes proposed in this pull request

Add a validation to catch this when the user tries to enter a duplicate referee email within an application form (see screenshot)

![Screen Shot 2019-11-15 at 14 02 12](https://user-images.githubusercontent.com/134501/68949791-bfb36680-07b2-11ea-8916-abc7401c81b8.png)


### Guidance to review

1. Go to an application form with no referees
2. Add a referee
3. Add a second referee with the same email address
4. You should see a validation error like in the screenshot above

### Link to Trello card

No specific trello card, but it cropped up in testing of [200 - requesting references from candidate](https://trello.com/c/33rFaaqv/200-requesting-references-from-candidate)

### Env vars

N/A