### PR TITLE
Show reference states in support

### DIFF
--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ApplicationFormsController < SupportInterfaceController
     def index
-      application_forms = ApplicationForm.includes(:application_choices)
+      application_forms = ApplicationForm.includes(:application_choices).sort_by(&:updated_at).reverse
 
       @application_forms = application_forms.map do |application_choice|
         ApplicationFormPresenter.new(application_choice)

--- a/app/presenters/support_interface/application_form_presenter.rb
+++ b/app/presenters/support_interface/application_form_presenter.rb
@@ -9,18 +9,18 @@ module SupportInterface
     end
 
     def updated_at
-      application_form.updated_at
+      application_form.updated_at.strftime('%e %b %Y at %l:%M%P')
     end
 
     def date_of_birth
       application_form.date_of_birth
     end
 
-    def name_and_support_reference
+    def email_and_support_reference
       if application_form.support_reference
-        "#{full_name} (#{application_form.support_reference})"
+        "#{application_form.candidate.email_address} (#{application_form.support_reference})"
       else
-        full_name
+        application_form.candidate.email_address
       end
     end
 
@@ -28,7 +28,25 @@ module SupportInterface
       application_form.id.to_s
     end
 
+    def first_reference_status
+      reference_status(application_form.references[0])
+    end
+
+    def second_reference_status
+      reference_status(application_form.references[1])
+    end
+
   private
+
+    def submitted?
+      application_form.submitted_at.present?
+    end
+
+    def reference_status(reference)
+      return 'Not applicable' unless reference && submitted?
+
+      reference.complete? ? 'Received' : 'Awaiting response'
+    end
 
     attr_reader :application_form
   end

--- a/app/presenters/support_interface/application_form_presenter.rb
+++ b/app/presenters/support_interface/application_form_presenter.rb
@@ -16,6 +16,14 @@ module SupportInterface
       application_form.date_of_birth
     end
 
+    def name_and_support_reference
+      if application_form.support_reference
+        "#{full_name} (#{application_form.support_reference})"
+      else
+        full_name
+      end
+    end
+
     def to_param
       application_form.id.to_s
     end

--- a/app/views/support_interface/application_forms/index.html.erb
+++ b/app/views/support_interface/application_forms/index.html.erb
@@ -5,19 +5,24 @@
 <table class='govuk-table'>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last update</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter"></th>
+      <th scope="col" class="govuk-table__header">Application</th>
+      <th scope="col" class="govuk-table__header">Reference 1</th>
+      <th scope="col" class="govuk-table__header">Reference 2</th>
+      <th scope="col" class="govuk-table__header">History</th>
+      <th scope="col" class="govuk-table__header">Last updated</th>
     </tr>
   </thead>
 
   <tbody class="govuk-table__body">
     <% @application_forms.each do |application_form| %>
-    <tr class="govuk-table__row">
+    <tr class="govuk-table__row" data-qa="application-form-<%= application_form.to_param %>">
       <td class="govuk-table__cell">
-        <%= govuk_link_to application_form.name_and_support_reference, support_interface_application_form_path(application_form) %></td>
-      <td class="govuk-table__cell"><%= application_form.updated_at.to_s(:long) %></td>
+        <%= govuk_link_to application_form.email_and_support_reference, support_interface_application_form_path(application_form) %>
+      </td>
+      <td class="govuk-table__cell"><%= application_form.first_reference_status %></td>
+      <td class="govuk-table__cell"><%= application_form.second_reference_status %></td>
       <td class="govuk-table__cell"><%= govuk_link_to 'History', support_interface_application_form_audit_path(application_form) %></td>
+      <td class="govuk-table__cell"><%= application_form.updated_at %></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/support_interface/application_forms/index.html.erb
+++ b/app/views/support_interface/application_forms/index.html.erb
@@ -14,7 +14,8 @@
   <tbody class="govuk-table__body">
     <% @application_forms.each do |application_form| %>
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell"><%= govuk_link_to application_form.full_name, support_interface_application_form_path(application_form) %></td>
+      <td class="govuk-table__cell">
+        <%= govuk_link_to application_form.name_and_support_reference, support_interface_application_form_path(application_form) %></td>
       <td class="govuk-table__cell"><%= application_form.updated_at.to_s(:long) %></td>
       <td class="govuk-table__cell"><%= govuk_link_to 'History', support_interface_application_form_audit_path(application_form) %></td>
     </tr>

--- a/spec/system/support_interface/manage_applications_spec.rb
+++ b/spec/system/support_interface/manage_applications_spec.rb
@@ -4,8 +4,10 @@ RSpec.feature 'See applications' do
   scenario 'Provider visits application page' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
+    and_an_application_has_received_a_reference
     and_i_visit_the_support_page
     then_i_should_see_the_applications
+    and_i_should_see_their_reference_statuses
 
     when_i_click_on_an_application
     then_i_should_be_on_the_application_view_page
@@ -16,9 +18,18 @@ RSpec.feature 'See applications' do
   end
 
   def and_there_are_applications_in_the_system
-    create(:application_choice, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
-    create(:application_choice, application_form: create(:application_form, first_name: 'Bob'))
-    create(:application_choice, application_form: create(:application_form, first_name: 'Charlie'))
+    @completed_application = create(:completed_application_form)
+    @unsubmitted_application = create(:application_form)
+    @application_with_reference = create(:completed_application_form)
+  end
+
+  def and_an_application_has_received_a_reference
+    action = ReceiveReference.new(
+      application_form: @application_with_reference,
+      referee_email: @application_with_reference.reload.references.first.email_address,
+      feedback: Faker::Lorem.paragraphs(number: 2),
+    )
+    action.save
   end
 
   def and_i_visit_the_support_page
@@ -26,16 +37,31 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_see_the_applications
-    expect(page).to have_content 'Alice'
-    expect(page).to have_content 'Bob'
-    expect(page).to have_content 'Charlie'
+    expect(page).to have_content @completed_application.candidate.email_address
+    expect(page).to have_content @application_with_reference.candidate.email_address
+    expect(page).to have_content @unsubmitted_application.candidate.email_address
+  end
+
+  def and_i_should_see_their_reference_statuses
+    within "[data-qa='application-form-#{@application_with_reference.id}']" do
+      expect(page).to have_content 'Received'
+      expect(page).to have_content 'Awaiting response'
+    end
+
+    within "[data-qa='application-form-#{@completed_application.id}']" do
+      expect(page).to have_content('Awaiting response', count: 2)
+    end
+
+    within "[data-qa='application-form-#{@unsubmitted_application.id}']" do
+      expect(page).to have_content('Not applicable', count: 2)
+    end
   end
 
   def when_i_click_on_an_application
-    click_on 'Alice'
+    click_on @completed_application.candidate.email_address
   end
 
   def then_i_should_be_on_the_application_view_page
-    expect(page).to have_content "Alice Wunder's application"
+    expect(page).to have_content "#{@completed_application.last_name}'s application"
   end
 end


### PR DESCRIPTION
### Context

- Add reference statuses to applications index
- Sort list of applications by updated at
- Use email as link to application, name and support reference aren't always available

![Screen Shot 2019-11-15 at 14 30 17](https://user-images.githubusercontent.com/319055/68954444-ec1fb080-07bb-11ea-9949-ef04b752e1ca.png)

https://trello.com/c/f5w4X1gi/1224-pilot-design-application-list-with-reference-statuses

This is a fairly crude first pass.