### PR TITLE
Update terms summary

### DIFF
--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -25,7 +25,6 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>the application process</li>
         <li>contacting us</li>
-        <li>our use of your data</li>
         <li>checking you’re safe to work with children</li>
       </ul>
 


### PR DESCRIPTION
### Context

Removes `our use of your data` from summary of terms of use on create account page (the privacy policy now covers this)