### PR TITLE
Add cookie policy page

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -11,12 +11,14 @@ class ContentController < ApplicationController
     render_content_page :privacy_candidate
   end
 
+  def cookies_candidate
+    render_content_page :cookies_candidate
+  end
+
 private
 
   def render_content_page(page_name)
-    markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML.new)
-
-    @converted_markdown = markdown.render(File.read("app/views/content/#{page_name}.md")).html_safe
+    @converted_markdown = Govuk::MarkdownRenderer.render(File.read("app/views/content/#{page_name}.md")).html_safe
     @page_name = page_name
     render 'rendered_markdown_template'
   end

--- a/app/lib/govuk/markdown_renderer.rb
+++ b/app/lib/govuk/markdown_renderer.rb
@@ -1,0 +1,36 @@
+module Govuk
+  class MarkdownRenderer < ::Redcarpet::Render::Safe
+    def table(header, body)
+      <<~HTML
+        <table class='govuk-table'>
+          <thead class='govuk-table__head'>
+            #{header}
+          </thead>
+          <tbody class='govuk-table__body'>
+            #{body}
+          </tbody>
+        </table>
+      HTML
+    end
+
+    def table_row(content)
+      <<~HTML
+        <tr class='govuk-table__row'>
+          #{content}
+        </tr>
+      HTML
+    end
+
+    def table_cell(content, _alignment)
+      <<~HTML
+        <td class='govuk-table__cell'>
+          #{content}
+        </td>
+      HTML
+    end
+
+    def self.render(content)
+      Redcarpet::Markdown.new(self, tables: true).render(content)
+    end
+  end
+end

--- a/app/views/content/cookies_candidate.md
+++ b/app/views/content/cookies_candidate.md
@@ -1,0 +1,51 @@
+’Apply for teacher training’ puts small files (known as ‘cookies’) onto your computer to collect information about how you use the site.
+
+Cookies are used to:
+
+* measure how you use the this service so it can be updated and improved based on your needs
+* remember the notifications you’ve seen so that we don’t show them to you again
+* remember who you are when you have logged in so we can show you your information and information relevant to you
+* ’Apply for teacher training’ cookies aren’t used to identify you personally.
+
+Find out more about [how to manage cookies](http://www.aboutcookies.org/).
+
+## How we use cookies
+
+### Measuring website usage (Google Analytics)
+
+We use Google Analytics software to collect information about how you use ‘Apply for teacher training. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
+
+Google Analytics stores information about:
+
+* the pages you visit on ‘Apply for teacher training’
+* how long you spend on each page
+* how you got to the site
+* what you click on while you’re visiting the site
+
+We don’t allow Google to use or share our analytics data.
+
+Google Analytics sets the following cookies:
+
+| Name     | Purpose                              | Expires     |
+| :------- | :----------------------------------- | :---------- |
+| \_ga     | Used to distinguish anonymous users  | 2 years     |
+| \_gid    | Used to distinguish anonymous users  | 24 hours    |
+| \_gat    | Throttle requests	                  | 10 minutes  |
+
+You can opt out of [Google Analytics](https://tools.google.com/dlpage/gaoptout).
+
+### Our introductory message
+
+You may see a pop-up welcome message when you first visit ‘Apply for teacher training. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.
+
+| Name                  | Purpose                                        | Expires  |
+| :-------------------  | :--------------------------------------------- | :------- |
+| seen\_cookie\_message | Show cookie policy banner on first visit only  | 1 month  |
+
+### Other cookies
+
+Other ‘Apply for teacher training’ cookies may include:
+
+| Name                                                   | Purpose                                        | Expires  |
+| :------------------------------------------------      | :--------------------------------------------- | :------- |
+| \_apply\_for\_postgraduate\_teacher\_training\_session | Used to remember your identity when signed in  | 6 hours  |

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -104,6 +104,9 @@
               <li class="govuk-footer__inline-list-item">
                 <%= link_to t('layout.privacy_policy'), privacy_candidate_path, class: 'govuk-footer__link' %>
               </li>
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to t('layout.cookie_policy'), cookies_candidate_path, class: 'govuk-footer__link' %>
+              </li>
             </ul>
             <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
               <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,6 +43,7 @@ en:
     accessibility: Accessibility statement for Apply for teacher training
     terms_candidate: Terms of use
     privacy_candidate: Privacy policy
+    cookies_candidate: Cookies
     contact_details: Contact details
     address: What is your address?
     work_history: Work history
@@ -89,6 +90,7 @@ en:
     accessibility: Accessibility
     terms_of_use: Terms of use
     privacy_policy: Privacy policy
+    cookie_policy: Cookie policy
   activemodel:
     attributes:
       vendor_api/metadata:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get '/accessibility', to: 'content#accessibility'
   get '/candidate/terms-of-use', to: 'content#terms_candidate', as: :terms_candidate
   get '/candidate/privacy-policy', to: 'content#privacy_candidate', as: :privacy_candidate
+  get '/candidate/cookies', to: 'content#cookies_candidate', as: :cookies_candidate
 
   namespace :candidate_interface, path: '/candidate' do
     get '/' => 'start_page#show', as: :start

--- a/spec/lib/govuk/markdown_renderer_spec.rb
+++ b/spec/lib/govuk/markdown_renderer_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+# Ignore whitespace
+def expect_equal_ignoring_ws(first, second)
+  expect(first.lines.map(&:strip).join('')).to eq(second.lines.map(&:strip).join(''))
+end
+
+RSpec.describe Govuk::MarkdownRenderer do
+  let(:html) { Govuk::MarkdownRenderer.render(markdown) }
+
+  context 'table' do
+    let(:markdown) do
+      <<~MD
+        | First name   | Last name    | DOB        |
+        | ------------ | ------------ | ---------- |
+        | John         | Smith        | 01-04-1970 |
+        | Alison       | Brown        | 02-05-1970 |
+        | Adam         | Sample       | 03-06-1970 |
+      MD
+    end
+
+    it 'renders correct HTML' do
+      expected_html = <<~HTML
+        <table class='govuk-table'>
+          <thead class='govuk-table__head'>
+            <tr class='govuk-table__row'>
+              <td class='govuk-table__cell'>First name</td>
+              <td class='govuk-table__cell'>Last name</td>
+              <td class='govuk-table__cell'>DOB</td>
+            </tr>
+          </thead>
+          <tbody class='govuk-table__body'>
+            <tr class='govuk-table__row'>
+              <td class='govuk-table__cell'>John</td>
+              <td class='govuk-table__cell'>Smith</td>
+              <td class='govuk-table__cell'>01-04-1970</td>
+            </tr>
+            <tr class='govuk-table__row'>
+              <td class='govuk-table__cell'>Alison</td>
+              <td class='govuk-table__cell'>Brown</td>
+              <td class='govuk-table__cell'>02-05-1970</td>
+            </tr>
+            <tr class='govuk-table__row'>
+              <td class='govuk-table__cell'>Adam</td>
+              <td class='govuk-table__cell'>Sample</td>
+              <td class='govuk-table__cell'>03-06-1970</td>
+            </tr>
+          </tbody>
+        </table>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+end

--- a/spec/system/user_viewing_cookie_policy_spec.rb
+++ b/spec/system/user_viewing_cookie_policy_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing cookie policy' do
+  scenario 'User views the cookie policy' do
+    given_i_am_on_the_start_page
+    when_i_can_click_on_cookie_policy
+    then_i_can_see_the_cookie_policy
+  end
+
+  def given_i_am_on_the_start_page
+    visit '/'
+  end
+
+  def when_i_can_click_on_cookie_policy
+    within('.govuk-footer') { click_link t('layout.cookie_policy') }
+  end
+
+  def then_i_can_see_the_cookie_policy
+    expect(page).to have_content(t('page_titles.cookies_candidate'))
+  end
+end


### PR DESCRIPTION
### Context
Cookie policy as per https://www.publish-teacher-training-courses.service.gov.uk/cookies

### Changes proposed in this pull request
Add cookie policy and some markdown overrides to get tables displaying correctly 😓 

### Guidance to review
`/cookies`

![localhost_3000_candidate_cookies(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/69009673-a693ec80-094f-11ea-9d80-02c96f5751ef.png)

### Link to Trello card
[84 - Create cookies page](https://trello.com/c/thu6GdXn/84-create-cookies-page)

### Env vars
n/a
