### PR TITLE
Move institution name into seperate row on other quals review page

### DIFF
--- a/app/components/other_qualifications_review_component.rb
+++ b/app/components/other_qualifications_review_component.rb
@@ -11,6 +11,7 @@ class OtherQualificationsReviewComponent < ActionView::Component::Base
   def other_qualifications_rows(qualification)
     [
       qualification_row(qualification),
+      institution_row(qualification),
       award_year_row(qualification),
       grade_row(qualification),
     ]
@@ -23,8 +24,17 @@ private
   def qualification_row(qualification)
     {
       key: t('application_form.other_qualification.qualification.label'),
-      value: [qualification.title, qualification.institution_name],
+      value: qualification.title,
       action: t('application_form.other_qualification.qualification.change_action'),
+      change_path: Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id),
+    }
+  end
+
+  def institution_row(qualification)
+    {
+      key: t('application_form.other_qualification.institution.label'),
+      value: qualification.institution_name,
+      action: t('application_form.other_qualification.institution.change_action'),
       change_path: Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id),
     }
   end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -156,6 +156,9 @@ en:
         label: Subject
       institution_name:
         label: Institution where you studied
+      institution:
+        label: Institution
+        change_action: institution
       grade:
         label: Grade
         change_action: grade

--- a/spec/components/other_qualifications_review_component_spec.rb
+++ b/spec/components/other_qualifications_review_component_spec.rb
@@ -27,11 +27,13 @@ RSpec.describe OtherQualificationsReviewComponent do
 
     expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
     expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.qualification.label'))
-    expect(result.css('.govuk-summary-list__value').to_html).to include('A-Level Making Doggo Sounds<br>Doggo Sounds College')
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.institution.label'))
+    expect(result.css('.govuk-summary-list__value').to_html).to include('A-Level Making Doggo Sounds')
+    expect(result.css('.govuk-summary-list__value').to_html).to include('Doggo Sounds College')
     expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
       Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(1),
     )
-    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.qualification.change_action')}")
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.institution.change_action')}")
   end
 
   it 'renders component with correct values for an award year' do


### PR DESCRIPTION
### Context
Institution name was next to Qualification name but it needs to be its own row

### Changes proposed in this pull request
Move Institution name into seperate row

### After
![localhost_3000_candidate_application_review(Laptop with MDPI screen) (1)](https://user-images.githubusercontent.com/3071606/69010017-e4464480-0952-11ea-9370-e56d6342a906.png)

### Guidance to review
`/candidate/application/review`

### Link to Trello card
[389 - Institution didn't show as a separate field within 'other relevant qualifications'](https://trello.com/c/etFWwQJJ/389-institution-didnt-show-as-a-separate-field-within-other-relevant-qualifications)

### Env vars
n/a
