### PR TITLE
Correctly reference the DFE_SIGN_IN_ISSUER ENV var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,4 @@ LOGSTASH_PORT=22513
 LOGSTASH_SSL=true
 DFE_SIGN_IN_CLIENT_ID=
 DFE_SIGN_IN_SECRET=
-DFE_SIGN_IN_URI=https://signin-test-oidc-as.azurewebsites.net
+DFE_SIGN_IN_ISSUER=https://signin-test-oidc-as.azurewebsites.net

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,7 +3,7 @@ OmniAuth.config.logger = Rails.logger
 dfe_sign_in_identifier = ENV['DFE_SIGN_IN_CLIENT_ID']
 dfe_sign_in_secret = ENV['DFE_SIGN_IN_SECRET']
 dfe_sign_in_redirect_uri = URI.join(HostingEnvironment.application_url, '/auth/dfe/callback')
-dfe_sign_in_issuer_uri = ENV['DFE_SIGN_IN_URI'].present? ? URI(ENV['DFE_SIGN_IN_URI']) : nil
+dfe_sign_in_issuer_uri = ENV['DFE_SIGN_IN_ISSUER'].present? ? URI(ENV['DFE_SIGN_IN_ISSUER']) : nil
 
 options = {
   name: :dfe,


### PR DESCRIPTION
We changed this to `_URI` in a rebase, and didn't update Azure, which meant `ENV['DFE_SIGN_IN_URI']` was nil and caused a runtime error.

https://sentry.io/organizations/dfe-bat/issues/1336427884/?project=1765973&referrer=slack

On reflection `_URI` is not an improvement anyway, as this is not the only useful URI provided by Sign-in (we'll need one for the DSI user API too). So rather than push through the change to `_URI` in the Azure pipeline config, revert it to `_ISSUER` and be done.

If we find ourselves creating needing more variables to configure the various DSI APIs then we can do some renaming later.