### PR TITLE
Fix work history path on Your application page when out of work

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -27,7 +27,11 @@ module CandidateInterface
     end
 
     def work_experience_path
-      @application_form.application_work_experiences.any? ? Rails.application.routes.url_helpers.candidate_interface_work_history_show_path : Rails.application.routes.url_helpers.candidate_interface_work_history_length_path
+      if @application_form.application_work_experiences.any? || @application_form.work_history_explanation.present?
+        Rails.application.routes.url_helpers.candidate_interface_work_history_show_path
+      else
+        Rails.application.routes.url_helpers.candidate_interface_work_history_length_path
+      end
     end
 
     def degrees_completed?

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -195,4 +195,33 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       end
     end
   end
+
+  describe '#work_experience_path' do
+    it 'returns the length path if no work experience' do
+      application_form = build(:completed_application_form, work_experiences_count: 0, work_history_explanation: '')
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.work_experience_path).to eq(
+        Rails.application.routes.url_helpers.candidate_interface_work_history_length_path,
+      )
+    end
+
+    it 'returns the review path if work experience' do
+      application_form = build(:completed_application_form, work_experiences_count: 1, work_history_explanation: '')
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.work_experience_path).to eq(
+        Rails.application.routes.url_helpers.candidate_interface_work_history_show_path,
+      )
+    end
+
+    it 'returns the review path if not recently worked' do
+      application_form = build_stubbed(:application_form, work_history_explanation: 'I was on a career break.')
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.work_experience_path).to eq(
+        Rails.application.routes.url_helpers.candidate_interface_work_history_show_path,
+      )
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_entering_work_history_not_worked_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_not_worked_spec.rb
@@ -22,6 +22,9 @@ RSpec.feature 'Entering their work history' do
     and_i_click_on_continue
     then_i_should_see_the_form
     and_that_the_section_is_completed
+
+    when_i_click_on_work_history
+    then_i_should_see_my_explanation
   end
 
   def given_i_am_signed_in


### PR DESCRIPTION
### Context

When product reviewing the work history section, Rachael noticed that from the "Your application" page if the candidate has entered they have been out of work, then they are taken to the "How long have you been working?" page. Instead, they should be redirected to the review page as they have already entered information related to their work history.

### Changes proposed in this pull request

This PR updates `ApplicationFormPresenter#work_experience_path` to provide the review path when the application form has `work_history_explanation` entered.

### Guidance to review

N/A

### Link to Trello card

[382 - Doesn't display review page for when a user has provided details of why they haven't been working](https://trello.com/c/O6oa0J9m/382-doesnt-display-review-page-for-when-a-user-has-provided-details-of-why-they-havent-been-working)

