### PR TITLE
Fix work history length page breaking when an error occurs

### DIFF
--- a/app/controllers/candidate_interface/work_history/length_controller.rb
+++ b/app/controllers/candidate_interface/work_history/length_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
           redirect_to candidate_interface_work_history_new_path
         end
       else
-        render :length
+        render :show
       end
     end
 

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -10,6 +10,9 @@ RSpec.feature 'Entering their work history' do
     when_i_click_on_work_history
     then_i_should_see_a_list_of_work_lengths
 
+    when_i_omit_choosing_from_the_list_of_work_lengths
+    then_i_should_see_work_history_length_validation_errors
+
     when_i_choose_more_than_5_years
     then_i_should_see_the_job_form
 
@@ -62,6 +65,14 @@ RSpec.feature 'Entering their work history' do
 
   def then_i_should_see_a_list_of_work_lengths
     expect(page).to have_content(t('application_form.work_history.more_than_5'))
+  end
+
+  def when_i_omit_choosing_from_the_list_of_work_lengths
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_work_history_length_validation_errors
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/work_history_form.attributes.work_history.blank')
   end
 
   def when_i_choose_more_than_5_years


### PR DESCRIPTION
### Context

When a radio button is not selected on the work history length page and the form is submitted, the application breaks as it's looking for a view template that does not exist.

### Changes proposed in this pull request

This PR renders the correct view template for work history length when errors occur.

### Guidance to review

N/A

### Link to Trello card

N/A