### PR TITLE
Use ’smart’ quotes

### DIFF
--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,3 +1,3 @@
-<% content_for :title, "#{@application_form.full_name}'s application history" %>
+<% content_for :title, "#{@application_form.full_name}’s application history" %>
 
 <%= render SupportInterface::AuditTrailComponent, application_form: @application_form %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "#{@application_form.full_name}'s application" %>
+<% content_for :title, "#{@application_form.full_name}’s application" %>
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -4,7 +4,7 @@ en:
     courses:
       intro: You can apply for up to 3 courses.
       delete: Delete choice
-      confirm_delete: Yes I'm sure - delete this choice
+      confirm_delete: Yes I’m sure - delete this choice
       complete:
         completed_checkbox: I have completed this section
         button: Continue
@@ -130,7 +130,7 @@ en:
           label: I am still studying for my degree
           conditional:
             label: Please give details of your predicted grade.
-            hint_text: Predicted grades must be validated by an academic referee in the ‘References' section.
+            hint_text: Predicted grades must be validated by an academic referee in the ‘References’ section.
       award_year:
         label: Graduation year
         hint_text: You must have successfully graduated by the time you start your course.
@@ -225,7 +225,7 @@ en:
         change_action: dates and details
       complete_form_button: Save and continue
       delete: Delete role
-      confirm_delete: Yes I'm sure - delete this role
+      confirm_delete: Yes I’m sure - delete this role
       another:
         button: Add another role
       review:

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -28,10 +28,10 @@ en:
       password_change:
         subject: "Password Changed"
     omniauth_callbacks:
-      failure: 'Could not authenticate you from %{kind} because "%{reason}".'
+      failure: "Could not authenticate you from %{kind} because “%{reason}”."
       success: "Successfully authenticated from %{kind} account."
     passwords:
-      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      no_token: "You can’t access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,17 +125,17 @@ en:
               too_long: Relationship must be %{count} characters or fewer
   application_choice:
     status_name:
-      unsubmitted: 'Not submitted yet'
-      awaiting_references: 'Awaiting references'
-      application_complete: 'New'
-      awaiting_provider_decision: 'Awaiting provider decision'
-      offer: 'Offer'
-      pending_conditions: 'Pending conditions'
-      recruited: 'Candidate recruited'
-      enrolled: 'Candidate  enrolled'
-      rejected: 'Provider rejected'
-      withdrawn: 'Candidate withdrawn'
-      declined: 'Candidate declined'
+      unsubmitted: Not submitted yet
+      awaiting_references: Awaiting references
+      application_complete: New
+      awaiting_provider_decision: Awaiting provider decision
+      offer: Offer
+      pending_conditions: Pending conditions
+      recruited: Candidate recruited
+      enrolled: Candidate  enrolled
+      rejected: Provider rejected
+      withdrawn: Candidate withdrawn
+      declined: Candidate declined
   date:
     formats:
       long: "%e %B %Y"

--- a/public/422.html
+++ b/public/422.html
@@ -59,7 +59,7 @@
   <div class="dialog">
     <div>
       <h1>The change you wanted was rejected.</h1>
-      <p>Maybe you tried to change something you didn't have access to.</p>
+      <p>Maybe you tried to change something you didn’t have access to.</p>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -61,7 +61,7 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_be_on_the_application_history_page
-    expect(page).to have_content "Alice Wunder's application history"
+    expect(page).to have_content 'Alice Wunder’s application history'
   end
 
   def then_i_should_be_able_to_see_history_events

--- a/spec/system/support_interface/manage_applications_spec.rb
+++ b/spec/system/support_interface/manage_applications_spec.rb
@@ -62,6 +62,6 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_be_on_the_application_view_page
-    expect(page).to have_content "#{@completed_application.last_name}'s application"
+    expect(page).to have_content "#{@completed_application.last_name}’s application"
   end
 end


### PR DESCRIPTION
### Context

Replace the few occurrences of dumb quotes (`'`) in running text to use smart alternatives (`’`)
