### PR TITLE
Make sure Sidekiq jobs report correct environment

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -550,6 +550,10 @@
                                 "secureValue": "[parameters('secretKeyBase')]"
                             },
                             {
+                                "name": "CUSTOM_HOSTNAME",
+                                "value": "[parameters('customHostName')]"
+                            },
+                            {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
                             },
@@ -658,6 +662,10 @@
                             {
                                 "name": "SECRET_KEY_BASE",
                                 "secureValue": "[parameters('secretKeyBase')]"
+                            },
+                            {
+                                "name": "CUSTOM_HOSTNAME",
+                                "value": "[parameters('customHostName')]"
                             },
                             {
                                 "name": "SENTRY_DSN",


### PR DESCRIPTION
### Context

We rely on `CUSTOM_HOSTNAME` to populate the "hosting environment" for reporting to Sentry (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/478).

### Changes proposed in this pull request

Because it's not set in the Sidekiq worker, they are currently reporting development (the fallback). For an example, see https://sentry.io/organizations/dfe-bat/issues/1341153288, which is happening on QA.

I've also added it the the clock process, which probably needs this is as well.

### Guidance to review

@tpinney is this enough to get the environment variable working?

### Link to Trello card

https://trello.com/c/YtFlMRNo/1268-allow-sidekiq-workers-to-access-the-database