### PR TITLE
Add filtering for provider options to exclude 'Example provider'

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -18,7 +18,8 @@ module CandidateInterface
     end
 
     def options_for_provider
-      @providers = Provider.all
+      # TODO: Remove when the QA environment no longer has the "Example provider" stored
+      @providers = Provider.where.not(name: 'Example provider')
     end
 
     def pick_provider


### PR DESCRIPTION
### Context

'Example provider' shows up in QA environment as spotted by Rachael.

![image](https://user-images.githubusercontent.com/42817036/69058311-57ab8d00-0a0b-11ea-8e0a-4118d1b3843e.png)

### Changes proposed in this pull request

This PR adds a quick and dirty filter when getting all the options for providers. 

### Guidance to review

A technical debt card will be added for this.

### Link to Trello card

[364 - Make the provider dropdown a radio button, and allow candidates to choose "other" (which goes to UCAS)](https://trello.com/c/m8GDiRSz/364-make-the-provider-dropdown-a-radio-button-and-allow-candidates-to-choose-other-which-goes-to-ucas)
