### PR TITLE
Keep track of validation errors only for the Grade field

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,16 +45,4 @@ module ApplicationHelper
   def current_namespace
     params[:controller].split('/').first
   end
-
-  def heading_for_gcse_edit_type(subject)
-    t("gcse_edit_type.heading.#{subject}")
-  end
-
-  def heading_for_gcse_edit_details(subject)
-    t("gcse_edit_details.heading.#{subject}")
-  end
-
-  def heading_for_gcse_show(subject)
-    t("gcse_summary.heading.#{subject}")
-  end
 end

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -8,4 +8,16 @@ module GcseQualificationHelper
   def conditional_radios_for_gcse_qualifications
     { other_uk: [other_uk_qualification_type: 'Enter type of qualification'] }
   end
+
+  def heading_for_gcse_edit_type(subject)
+    t("gcse_edit_type.heading.#{subject}")
+  end
+
+  def heading_for_gcse_edit_details(subject)
+    t("gcse_edit_details.heading.#{subject}")
+  end
+
+  def heading_for_gcse_show(subject)
+    t("gcse_summary.heading.#{subject}")
+  end
 end

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -18,7 +18,10 @@ module CandidateInterface
     end
 
     def save_base
-      return false unless valid?
+      if !valid?
+        log_validation_errors(:grade)
+        return false
+      end
 
       qualification.update(grade: grade, award_year: award_year)
     end
@@ -50,6 +53,16 @@ module CandidateInterface
 
     def new_record?
       qualification.nil?
+    end
+
+    def log_validation_errors(field)
+      error_message = {
+        field: field.to_s,
+        error_messages: errors[field].join(' - '),
+        value: instance_values[field.to_s],
+      }
+
+      Rails.logger.info("Validation error: #{error_message.inspect}")
     end
   end
 end

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
           expect(form.errors[:grade]).to include('Enter a real graduation grade')
         end
       end
+
+      it 'logs validation errors if grade is invalid' do
+        allow(Rails.logger).to receive(:info)
+        form.grade = 'XYZ'
+
+        form.save_base
+
+        expect(Rails.logger).to have_received(:info).with(
+          'Validation error: {:field=>"grade", :error_messages=>"Enter a real graduation grade", :value=>"XYZ"}',
+        )
+      end
     end
 
     context 'when qualification type is GCE O LEVEL' do


### PR DESCRIPTION
### Context

This PR has the purpose to keep track of the validation errors that occur on the field `Grade` (qualification table).

### Changes proposed in this pull request
We decided to log the validation error into logit.io

### Guidance to review
The change is simple, have a look at the method `log_validation_errors`

### Link to Trello card

https://trello.com/c/zlfQ2il2/358-keep-track-of-validation-errors-in-the-application-form
