### PR TITLE
Allow Sidekiq process to talk to Postgres

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,3 +70,6 @@ RSpec/InstanceVariable:
 RSpec/PredicateMatcher:
   Exclude:
     - 'spec/support_specs/clockwork_spec.rb'
+
+RSpec/DescribeClass:
+  Enabled: false

--- a/azure/template.json
+++ b/azure/template.json
@@ -841,7 +841,7 @@
                         "value": "AZURE_IP-"
                     },
                     "ipAddresses": {
-                        "value": "[reference('app-service').outputs.possibleOutboundIpAddresses.value]"
+                        "value": "[concat(reference('app-service').outputs.possibleOutboundIpAddresses.value, array(reference('container-instances-worker').outputs.containerIPv4Address.value))]"
                     },
                     "serverName": {
                         "value": "[variables('databaseServerName')]"

--- a/spec/azure/configuration_spec.rb
+++ b/spec/azure/configuration_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Configuration' do
+  describe 'azure/template.json' do
+    it 'is valid JSON' do
+      JSON.parse(File.read('azure/template.json'))
+    end
+  end
+
+  describe 'azure-pipelines.yml' do
+    it 'is valid YAML' do
+      YAML.load_file('azure-pipelines.yml')
+    end
+  end
+
+  describe 'azure-pipelines-deploy-template.yml' do
+    it 'is valid YAML' do
+      YAML.load_file('azure-pipelines-deploy-template.yml')
+    end
+  end
+end


### PR DESCRIPTION
### Context

This commit should configure the firewall to allow Postgres access from the Sidekiq worker.

Fixes errors like https://sentry.io/organizations/dfe-bat/issues/1341153288.

Paired with @tpinney.

### Guidance to review

Does this make sense?

### Link to Trello card

https://trello.com/c/YtFlMRNo/1268-allow-sidekiq-workers-to-access-the-database