### PR TITLE
Create separate release pipeline

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,5 +1,7 @@
 trigger: none
 
+pr: none
+
 variables:
 - group: Docker Shared variables
 - group: APPLY - Shared Variables

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -1,0 +1,220 @@
+trigger: none
+
+variables:
+- group: Docker Shared variables
+- group: APPLY - Shared Variables
+- name: imageName
+  value: 'apply-for-postgraduate-teacher-training'
+- name: debug
+  value: true
+
+stages:
+- stage: publish_arm_template
+  displayName: 'Publish ARM Template'
+  jobs:
+  - job: publish_artifacts
+    displayName: 'Publish Pipeline Artifact'
+    pool:
+      vmImage: 'Ubuntu-16.04'
+
+    variables:
+    - name: system.debug
+      value: $(debug)
+
+    steps:
+    - script: |
+        GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
+        docker_path=$(dockerHubUsername)/$(imageName)
+        echo '##vso[task.setvariable variable=compose_file]docker-compose.yml:docker-compose.azure.yml'
+        echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
+        echo "##vso[task.setvariable variable=docker_path;]$docker_path"
+      displayName: 'Set version number'
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Pipeline Artifacts'
+      inputs:
+        path: '$(System.DefaultWorkingDirectory)/azure/'
+        artifactName: 'arm_template'
+
+
+- stage: deploy_staging
+  displayName: 'Deploy - Staging'
+  dependsOn: publish_arm_template
+  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_staging, true))
+  variables:
+  - group: APPLY - ENV - Staging
+  jobs:
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      debug: $(debug)
+      subscriptionPrefix: 's106'
+      subscriptionName: 'Apply (106) - Test'
+      environment: 'staging'
+      resourceEnvironmentName: 't01'
+      serviceName: 'apply'
+      containerImageReference: '$(imageName):$(build.buildNumber)'
+      keyVaultName: 's106t01-shared-kv-01'
+      keyVaultResourceGroup: 's106t01-shared-rg'
+      customHostName: '$(govukHostname)'
+      databaseName: 'apply'
+      databaseUsername: 'applyadm512'
+      databasePassword: '$(databasePassword)'
+      databaseStorageAutoGrow: 'disabled'
+      databaseBackupRetentionDays: 7
+      dockerhubUsername: '$(dockerHubUsername)'
+      railsSecretKeyBase: '$(railsSecretKeyBase)'
+      railsEnv: 'production'
+      basicAuthUsername: '$(basicAuthUsername)'
+      basicAuthPassword: '$(basicAuthPassword)'
+      supportUsername: '$(supportUsername)'
+      supportPassword: '$(supportPassword)'
+      authorisedHosts: '$(authorisedHosts)'
+      sentryDSN: '$(sentryDSN)'
+      logstashEnable: '$(logstashEnable)'
+      logstashRemote: '$(logstashRemote)'
+      logstashHost: '$(logstashHost)'
+      logstashPort: '$(logstashPort)'
+      logstashSsl: '$(logstashSsl)'
+      govukNotifyAPIKey: '$(govukNotifyAPIKey)'
+      findBaseUrl: '$(findBaseUrl)'
+      disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'
+
+
+- stage: deploy_sandbox
+  displayName: 'Deploy - Sandbox'
+  dependsOn: publish_arm_template
+  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_sandbox, true))
+  variables:
+  - group: APPLY - ENV - Sandbox
+  jobs:
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      debug: $(debug)
+      subscriptionPrefix: 's106'
+      subscriptionName: 'Apply (106) - Test'
+      environment: 'sandbox'
+      resourceEnvironmentName: 't02'
+      serviceName: 'apply'
+      containerImageReference: '$(imageName):$(build.buildNumber)'
+      keyVaultName: 's106t01-shared-kv-01'
+      keyVaultResourceGroup: 's106t01-shared-rg'
+      customHostName: '$(govukHostname)'
+      databaseName: 'apply'
+      databaseUsername: 'applyadm512'
+      databasePassword: '$(databasePassword)'
+      databaseStorageAutoGrow: 'disabled'
+      databaseBackupRetentionDays: 7
+      dockerhubUsername: '$(dockerHubUsername)'
+      railsSecretKeyBase: '$(railsSecretKeyBase)'
+      railsEnv: 'production'
+      basicAuthUsername: '$(basicAuthUsername)'
+      basicAuthPassword: '$(basicAuthPassword)'
+      supportUsername: '$(supportUsername)'
+      supportPassword: '$(supportPassword)'
+      authorisedHosts: '$(authorisedHosts)'
+      sentryDSN: '$(sentryDSN)'
+      logstashEnable: '$(logstashEnable)'
+      logstashRemote: '$(logstashRemote)'
+      logstashHost: '$(logstashHost)'
+      logstashPort: '$(logstashPort)'
+      logstashSsl: '$(logstashSsl)'
+      govukNotifyAPIKey: '$(govukNotifyAPIKey)'
+      findBaseUrl: '$(findBaseUrl)'
+      disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'
+
+
+- stage: deploy_pentest
+  displayName: 'Deploy - Pentest'
+  dependsOn: publish_arm_template
+  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_pentest, true))
+  variables:
+  - group: APPLY - ENV - Pentest
+  jobs:
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      debug: $(debug)
+      subscriptionPrefix: 's106'
+      subscriptionName: 'Apply (106) - Test'
+      environment: 'pentest'
+      resourceEnvironmentName: 't03'
+      serviceName: 'apply'
+      containerImageReference: '$(imageName):$(build.buildNumber)'
+      keyVaultName: 's106t01-shared-kv-01'
+      keyVaultResourceGroup: 's106t01-shared-rg'
+      databaseName: 'apply'
+      databaseUsername: 'applyadm512'
+      databasePassword: '$(databasePassword)'
+      databaseStorageAutoGrow: 'disabled'
+      databaseBackupRetentionDays: 7
+      dockerhubUsername: '$(dockerHubUsername)'
+      railsSecretKeyBase: '$(railsSecretKeyBase)'
+      railsEnv: 'production'
+      basicAuthUsername: '$(basicAuthUsername)'
+      basicAuthPassword: '$(basicAuthPassword)'
+      supportUsername: '$(supportUsername)'
+      supportPassword: '$(supportPassword)'
+      authorisedHosts: '$(authorisedHosts)'
+      sentryDSN: '$(sentryDSN)'
+      logstashEnable: '$(logstashEnable)'
+      logstashRemote: '$(logstashRemote)'
+      logstashHost: '$(logstashHost)'
+      logstashPort: '$(logstashPort)'
+      logstashSsl: '$(logstashSsl)'
+      govukNotifyAPIKey: '$(govukNotifyAPIKey)'
+      findBaseUrl: '$(findBaseUrl)'
+      disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'
+
+
+- stage: deploy_production
+  displayName: 'Deploy - Production'
+  dependsOn: publish_arm_template
+  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_production, true))
+  variables:
+  - group: APPLY - ENV - Production
+  jobs:
+  - template: azure-pipelines-deploy-template.yml
+    parameters:
+      debug: $(debug)
+      subscriptionPrefix: 's106'
+      subscriptionName: 'Apply (106) - Production'
+      environment: 'production'
+      resourceEnvironmentName: 'p01'
+      serviceName: 'apply'
+      containerImageReference: '$(imageName):$(build.buildNumber)'
+      keyVaultName: 's106p01-shared-kv-01'
+      keyVaultResourceGroup: 's106p01-shared-rg'
+      customHostName: '$(govukHostname)'
+      databaseName: 'apply'
+      databaseUsername: 'applyadm512'
+      databasePassword: '$(databasePassword)'
+      databaseStorageAutoGrow: 'enabled'
+      databaseBackupRetentionDays: 35
+      dockerhubUsername: '$(dockerHubUsername)'
+      railsSecretKeyBase: '$(railsSecretKeyBase)'
+      railsEnv: 'production'
+      basicAuthUsername: '$(basicAuthUsername)'
+      basicAuthPassword: '$(basicAuthPassword)'
+      supportUsername: '$(supportUsername)'
+      supportPassword: '$(supportPassword)'
+      authorisedHosts: '$(authorisedHosts)'
+      sentryDSN: '$(sentryDSN)'
+      logstashEnable: '$(logstashEnable)'
+      logstashRemote: '$(logstashRemote)'
+      logstashHost: '$(logstashHost)'
+      logstashPort: '$(logstashPort)'
+      logstashSsl: '$(logstashSsl)'
+      govukNotifyAPIKey: '$(govukNotifyAPIKey)'
+      findBaseUrl: '$(findBaseUrl)'
+      disableBasicAuthForLandingPage: '$(disableBasicAuthForLandingPage)'
+      dfeSignInClientId: '$(dfeSignInClientId)'
+      dfeSignInSecret: '$(dfeSignInSecret)'
+      dfeSignInIssuer: '$(dfeSignInIssuer)'


### PR DESCRIPTION
### Context

Following on from an earlier PR today where the staging, sandbox, pentest and production environments were removed from the pipeline yaml file to overcome the approvals issues. This change re-introduces the ability to deploy to those environments through a new pipeline that is manually triggered.

### Changes proposed in this pull request

- New pipeline file called azure-pipelines-release.yml
- New pipeline named "apply-for-postgraduate-teacher-training-releases" has been created in Azure DevOps (https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary)

### Guidance to review

New builds are kicked off by going to https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=325&_a=summary and clicking the "Run Pipeline" button. If you leave the "Commit" box blank it will default to the most recent commit, otherwise you can enter a specific commit (long form) to deploy. The variables can be changed to true/false as desired for the deployment; the default is to deploy to staging only.

### Link to Trello card

[1258 - Improve the deployment process](https://trello.com/c/ASRjuzva/1258-improve-the-deployment-process)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
