### PR TITLE
Allow provider make an offer via provider UI

### DIFF
--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -1,9 +1,10 @@
 class SummaryCardComponent < ActionView::Component::Base
   validates :rows, presence: true
 
-  def initialize(rows:, border: true)
+  def initialize(rows:, border: true, bullet: false)
     @rows = rows
     @border = border
+    @bullet = bullet
   end
 
   def border_css_class

--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -1,10 +1,9 @@
 class SummaryCardComponent < ActionView::Component::Base
   validates :rows, presence: true
 
-  def initialize(rows:, border: true, bullet: false)
+  def initialize(rows:, border: true)
     @rows = rows
     @border = border
-    @bullet = bullet
   end
 
   def border_css_class

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -18,12 +18,13 @@ module ProviderInterface
     end
 
     def confirm_offer
-      standard_conditions_array = params.dig(:make_an_offer, :standard_conditions)
-      further_conditions_array = [params.dig(:make_an_offer, :first_condition), params.dig(:make_an_offer, :second_condition), params.dig(:make_an_offer, :third_condition), params.dig(:make_an_offer, :further_condition)].reject(&:blank?)
-      complete_conditions_array = [standard_conditions_array, further_conditions_array].compact.reduce([], :|)
+      offer_conditions = [
+        make_an_offer_params[:standard_conditions],
+        make_an_offer_params[:further_conditions]
+      ].flatten.reject(&:blank?)
       @application_offer = MakeAnOffer.new(
         application_choice: @application_choice,
-        offer_conditions: complete_conditions_array,
+        offer_conditions: offer_conditions,
       )
       render action: :new_offer if !@application_offer.valid?
     end
@@ -80,6 +81,10 @@ module ProviderInterface
         .find(params[:application_choice_id])
 
       @presenter = ApplicationChoicePresenter.new(@application_choice)
+    end
+
+    def make_an_offer_params
+      params.require(:make_an_offer)
     end
   end
 end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -14,7 +14,36 @@ module ProviderInterface
     end
 
     def new_offer
-      raise 'Not yet implemented'
+      @application_offer = MakeAnOffer.new(application_choice: @application_choice)
+    end
+
+    def confirm_offer
+      standard_conditions_array = params.dig(:make_an_offer, :standard_conditions)
+      further_conditions_array = [params.dig(:make_an_offer, :first_condition), params.dig(:make_an_offer, :second_condition), params.dig(:make_an_offer, :third_condition), params.dig(:make_an_offer, :further_condition)].reject(&:blank?)
+      complete_conditions_array = [standard_conditions_array, further_conditions_array].compact.reduce([], :|)
+      @application_offer = MakeAnOffer.new(
+        application_choice: @application_choice,
+        offer_conditions: complete_conditions_array
+      )
+      render action: :new_offer if !@application_offer.valid?
+    end
+
+    def create_offer
+      offer_conditions_array = JSON.parse(params.dig(:offer_conditions))
+
+      @application_offer = MakeAnOffer.new(
+        application_choice: @application_choice,
+        offer_conditions: offer_conditions_array
+      )
+
+      if @application_offer.save
+        flash[:success] = 'Application status changed to ‘Offer made’'
+        redirect_to provider_interface_application_choice_path(
+          application_choice_id: @application_choice.id,
+        )
+      else
+        render action: :new_offer
+      end
     end
 
     def new_reject

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -37,7 +37,7 @@ module ProviderInterface
       )
 
       if @application_offer.save
-        flash[:success] = 'Application status changed to ‘Offer made’'
+        flash[:success] = 'Application status changed to ‘Offer’'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,
         )

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -38,7 +38,7 @@ module ProviderInterface
       )
 
       if @application_offer.save
-        flash[:success] = 'Application status changed to ‘Offer’'
+        flash[:success] = 'Application status changed to ‘Offer Made’'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,
         )

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -20,7 +20,7 @@ module ProviderInterface
     def confirm_offer
       offer_conditions = [
         make_an_offer_params[:standard_conditions],
-        make_an_offer_params[:further_conditions]
+        make_an_offer_params[:further_conditions],
       ].flatten.reject(&:blank?)
       @application_offer = MakeAnOffer.new(
         application_choice: @application_choice,

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -23,7 +23,7 @@ module ProviderInterface
       complete_conditions_array = [standard_conditions_array, further_conditions_array].compact.reduce([], :|)
       @application_offer = MakeAnOffer.new(
         application_choice: @application_choice,
-        offer_conditions: complete_conditions_array
+        offer_conditions: complete_conditions_array,
       )
       render action: :new_offer if !@application_offer.valid?
     end
@@ -33,7 +33,7 @@ module ProviderInterface
 
       @application_offer = MakeAnOffer.new(
         application_choice: @application_choice,
-        offer_conditions: offer_conditions_array
+        offer_conditions: offer_conditions_array,
       )
 
       if @application_offer.save

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -1,4 +1,6 @@
 class MakeAnOffer
+  attr_accessor :offer_conditions
+
   include ActiveModel::Validations
 
   MAX_CONDITIONS_COUNT = 20
@@ -6,7 +8,7 @@ class MakeAnOffer
 
   validate :validate_offer_conditions
 
-  def initialize(application_choice:, offer_conditions:)
+  def initialize(application_choice:, offer_conditions: nil)
     @application_choice = application_choice
     @offer_conditions = offer_conditions
   end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -65,7 +65,7 @@
     <div class="app-status-box">
       <h2 class="govuk-heading-m">Status</h2>
         <strong class="govuk-tag <%= @application_choice.status_tag_class %> govuk-!-margin-bottom-4">
-          <%= @application_choice.status_tag_text %>
+          <%= @application_choice.status_name %>
         </strong>
       <div class="actions">
         <% if @application_choice.status == 'awaiting_provider_decision' %>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -24,7 +24,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body govuk-!-font-weight-bold">
-        Please make a note of the conditions and recommendations you have set.
+        Please make a note of the conditions you have set.
       </p>
       <p class="govuk-body">
         When you confirm this offer, you guarantee this candidate a place on their chosen course, if they meet the conditions you have set out.

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -16,11 +16,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
 
-      <%= render(
-        SummaryCardComponent, rows: [ { key: 'Conditions', value: @application_offer.offer_conditions },],
-        border: false,
-        bullet: true
-      ) %>
+      <%= render(SummaryCardComponent, rows: [{ key: 'Conditions', value: @application_offer.offer_conditions }], border: false, bullet: true) %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     </div>
   </div>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -14,12 +14,27 @@
 <%= form_with model: @application_offer, url: provider_interface_application_choice_create_offer_path(@application_choice.id), method: :post do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_error_summary %>
-      <% if @application_offer.offer_conditions.empty? %>
-        <%= render(SummaryCardComponent, rows: [{ key: 'Conditions', value: 'Unconditional Offer' }], border: false) %>
-      <% else %>
-        <%= render(SummaryCardComponent, rows: [{ key: 'Conditions', value: @application_offer.offer_conditions }], border: false, bullet: true) %>
-      <% end %>
+       <%= f.govuk_error_summary %>
+      <section class="app-summary-card govuk-!-margin-bottom-6 no-border">
+        <div class="app-summary-card__body">
+        <dl class="govuk-summary-list">
+         <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+              Conditions
+          </dt>
+          <dd class="govuk-summary-list__value">
+            <% if @application_offer.offer_conditions.empty? %>
+              Unconditional Offer
+            <% else %>
+              <ul class="govuk-list govuk-list--bullet">
+                <% @application_offer.offer_conditions.each do |value| %>
+                  <li><%= value %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </dd>
+        </div>
+      </section>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     </div>
   </div>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -15,8 +15,11 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
-
-      <%= render(SummaryCardComponent, rows: [{ key: 'Conditions', value: @application_offer.offer_conditions }], border: false, bullet: true) %>
+      <% if @application_offer.offer_conditions.empty? %>
+        <%= render(SummaryCardComponent, rows: [{ key: 'Conditions', value: 'Unconditional Offer' }], border: false) %>
+      <% else %>
+        <%= render(SummaryCardComponent, rows: [{ key: 'Conditions', value: @application_offer.offer_conditions }], border: false, bullet: true) %>
+      <% end %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     </div>
   </div>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -16,9 +16,11 @@
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
 
-      <%= render(SummaryCardComponent, rows: [
-        { key: 'Conditions', value: @application_offer.offer_conditions },
-      ], border: false) %>
+      <%= render(
+        SummaryCardComponent, rows: [ { key: 'Conditions', value: @application_offer.offer_conditions },],
+        border: false,
+        bullet: true
+      ) %>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     </div>
   </div>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -1,0 +1,44 @@
+<% content_for :title, t('page_titles.application') %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_offer_path(@application_choice.id)) %>
+
+<%= render(FlashMessageComponent, flash: flash) %>
+
+<span class="govuk-caption-xl">
+  Application for <%= @presenter.course_name_and_code %>
+</span>
+
+<h1 class="govuk-heading-xl">
+  Confirm offer
+</h1>
+
+<%= form_with model: @application_offer, url: provider_interface_application_choice_create_offer_path(@application_choice.id), method: :post do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_error_summary %>
+
+      <%= render(SummaryCardComponent, rows: [
+        { key: 'Conditions', value: @application_offer.offer_conditions },
+      ], border: false) %>
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body govuk-!-font-weight-bold">
+        Please make a note of the conditions and recommendations you have set.
+      </p>
+      <p class="govuk-body">
+        When you confirm this offer, you guarantee this candidate a place on their chosen course, if they meet the conditions you have set out.
+      </p>
+      <p class="govuk-body">
+          You can only change the conditions of this offer with the candidate’s permission.
+      </p>
+
+      <%= hidden_field_tag :offer_conditions, @application_offer.offer_conditions.to_json %>
+      <%= f.govuk_submit 'Confirm offer' %>
+
+      <p class="govuk-body"><a href="<%= provider_interface_application_choice_path(@application_choice.id) %>">Cancel</a></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -45,13 +45,14 @@
           Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.
         </span>
 
-        <%= f.govuk_text_area :first_condition, label: { text: 'First condition', size: 's' }, rows: 3, id: 'first_condition', 'aria-describedby': 'first_condition' %>
+        <%= f.govuk_text_area :further_conditions, label: { text: 'First condition', size: 's' }, id: 'first_condition', rows: 3, multiple: true %>
 
-        <%= f.govuk_text_area :second_condition, label: { text: 'Second condition', size: 's' }, rows: 3, id: 'second_condition', 'aria-describedby': 'second_condition' %>
+        <%= f.govuk_text_area :further_conditions, label: { text: 'Second condition', size: 's' }, id: 'second_condition', rows: 3, multiple: true %>
 
-        <%= f.govuk_text_area :third_condition, label: { text: 'Third condition', size: 's' }, rows: 3, id: 'third_condition', 'aria-describedby': 'third_condition' %>
+        <%= f.govuk_text_area :further_conditions, label: { text: 'Third condition', size: 's' }, id: 'third_condition', rows: 3, multiple: true %>
 
-        <%= f.govuk_text_area :further_condition, label: { text: 'Further condition', size: 's' }, rows: 3, id: 'further_condition', 'aria-describedby': 'further_condition' %>
+        <%= f.govuk_text_area :further_conditions, label: { text: 'Further condition', size: 's' }, id: 'further_condition', rows: 3, multiple: true %>
+
       </div>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -28,18 +28,12 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: "Standard conditions", size: "m" } do %>
-          <%= f.govuk_check_box :standard_conditions,
-            'Fitness to teach check',
-            label: { text: "Fitness to teach check" } %>
+      <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: 'Standard conditions', size: 'm' } do %>
+          <%= f.govuk_check_box :standard_conditions, 'Fitness to teach check', label: { text: 'Fitness to teach check' } %>
 
-          <%= f.govuk_check_box :standard_conditions,
-            'Disclosure and barring service check',
-            label: { text: "Disclosure and barring service check" } %>
+          <%= f.govuk_check_box :standard_conditions, 'Disclosure and barring service check', label: { text: 'Disclosure and barring service check' } %>
 
-          <%= f.govuk_check_box :standard_conditions,
-            'Payment of fees',
-            label: { text: "Payment of fees" } %>
+          <%= f.govuk_check_box :standard_conditions, 'Payment of fees', label: { text: 'Payment of fees' } %>
       <% end %>
 
       <div class="govuk-form-group">
@@ -51,29 +45,13 @@
           Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.
         </span>
 
-        <%= f.govuk_text_area :first_condition,
-          label: { text: 'First condition', size: "s" },
-          rows: 3,
-          id: 'first_condition',
-          'aria-describedby': 'first_condition' %>
+        <%= f.govuk_text_area :first_condition, label: { text: 'First condition', size: 's' }, rows: 3, id: 'first_condition', 'aria-describedby': 'first_condition' %>
 
-        <%= f.govuk_text_area :second_condition,
-          label: { text: 'Second condition', size: "s" },
-          rows: 3,
-          id: 'second_condition',
-          'aria-describedby': 'second_condition' %>
+        <%= f.govuk_text_area :second_condition, label: { text: 'Second condition', size: 's' }, rows: 3, id: 'second_condition', 'aria-describedby': 'second_condition' %>
 
-        <%= f.govuk_text_area :third_condition,
-          label: { text: 'Third condition', size: "s" },
-          rows: 3,
-          id: 'third_condition',
-          'aria-describedby': 'third_condition' %>
+        <%= f.govuk_text_area :third_condition, label: { text: 'Third condition', size: 's' }, rows: 3, id: 'third_condition', 'aria-describedby': 'third_condition' %>
 
-        <%= f.govuk_text_area :further_condition,
-          label: { text: 'Further condition', size: "s" },
-          rows: 3,
-          id: 'further_condition',
-          'aria-describedby': 'further_condition' %>
+        <%= f.govuk_text_area :further_condition, label: { text: 'Further condition', size: 's' }, rows: 3, id: 'further_condition', 'aria-describedby': 'further_condition' %>
       </div>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -1,0 +1,100 @@
+<% content_for :title, t('page_titles.application') %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
+
+<%= render(FlashMessageComponent, flash: flash) %>
+
+<span class="govuk-caption-xl">
+  Application for <%= @presenter.course_name_and_code %>
+</span>
+
+<h1 class="govuk-heading-xl">
+  Conditions of offer
+
+</h1>
+
+<%= form_with model: @application_offer, url: provider_interface_application_choice_confirm_offer_path(@application_choice.id), method: :post do |f| %>
+
+  <div class="govuk-grid-row">
+    <%= f.govuk_error_summary %>
+
+    <%= render(SummaryCardComponent, rows: [
+      { key: 'Full name', value: @presenter.full_name },
+      { key: 'Course', value: @presenter.course_name_and_code },
+      { key: 'Starting', value: @presenter.course_start_date.strftime('%B %Y') },
+      { key: 'Preferred location', value: @presenter.course_preferred_location },
+    ], border: false) %>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: "Standard conditions", size: "m" } do %>
+          <%= f.govuk_check_box :standard_conditions,
+            'Fitness to teach check',
+            label: { text: "Fitness to teach check" } %>
+
+          <%= f.govuk_check_box :standard_conditions,
+            'Disclosure and barring service check',
+            label: { text: "Disclosure and barring service check" } %>
+
+          <%= f.govuk_check_box :standard_conditions,
+            'Payment of fees',
+            label: { text: "Payment of fees" } %>
+      <% end %>
+
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-label--m" for="further_conditions">
+          Further conditions (optional)
+        </label>
+
+        <span id="further_conditions-hint" class="govuk-hint">
+          Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.
+        </span>
+
+        <%= f.govuk_text_area :first_condition,
+          label: { text: 'First condition', size: "s" },
+          rows: 3,
+          id: 'first_condition',
+          'aria-describedby': 'first_condition' %>
+
+        <%= f.govuk_text_area :second_condition,
+          label: { text: 'Second condition', size: "s" },
+          rows: 3,
+          id: 'second_condition',
+          'aria-describedby': 'second_condition' %>
+
+        <%= f.govuk_text_area :third_condition,
+          label: { text: 'Third condition', size: "s" },
+          rows: 3,
+          id: 'third_condition',
+          'aria-describedby': 'third_condition' %>
+
+        <%= f.govuk_text_area :further_condition,
+          label: { text: 'Further condition', size: "s" },
+          rows: 3,
+          id: 'further_condition',
+          'aria-describedby': 'further_condition' %>
+      </div>
+
+      <div class="govuk-form-group">
+        <label class="govuk-label govuk-label--m" for="recomendations">
+          Recommendations (optional)
+        </label>
+
+        <span id="recomendations-hint" class="govuk-hint">
+          Outline any recommendations (for example, organising school experience).
+        </span>
+
+        <%= f.govuk_text_area :recomendation,
+          label: { text: 'First condition', hidden: true },
+          rows: 3,
+          id: 'recomendation',
+          'aria-describedby': 'recomendation' %>
+      </div>
+
+      <%= f.govuk_submit 'Continue' %>
+
+      <p class="govuk-body"><a href="<%= provider_interface_application_choice_path(@application_choice.id) %>">Cancel</a></p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -76,22 +76,6 @@
           'aria-describedby': 'further_condition' %>
       </div>
 
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-label--m" for="recomendations">
-          Recommendations (optional)
-        </label>
-
-        <span id="recomendations-hint" class="govuk-hint">
-          Outline any recommendations (for example, organising school experience).
-        </span>
-
-        <%= f.govuk_text_area :recomendation,
-          label: { text: 'First condition', hidden: true },
-          rows: 3,
-          id: 'recomendation',
-          'aria-describedby': 'recomendation' %>
-      </div>
-
       <%= f.govuk_submit 'Continue' %>
 
       <p class="govuk-body"><a href="<%= provider_interface_application_choice_path(@application_choice.id) %>">Cancel</a></p>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -14,7 +14,7 @@
     <%= form_with model: @application_choice, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%- offer_text = 'Make an offer (including any conditions or recommendations)' %>
+      <%- offer_text = 'Make an offer (including any conditions)' %>
       <%- reject_text = 'Reject application' %>
       <%= f.govuk_radio_buttons_fieldset :decision, inline: true, legend: { size: 'm', text: '' } do %>
         <%= f.govuk_radio_button :decision, 'offer', label: { text: offer_text } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -131,7 +131,7 @@ en:
       awaiting_references: Awaiting references
       application_complete: New
       awaiting_provider_decision: Awaiting provider decision
-      offer: Offer
+      offer: Offer made
       pending_conditions: Pending conditions
       recruited: Candidate recruited
       enrolled: Candidate  enrolled

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,6 +209,9 @@ Rails.application.routes.draw do
     get '/applications/:application_choice_id/reject' => 'decisions#new_reject', as: :application_choice_new_reject
     post '/applications/:application_choice_id/reject/confirm' => 'decisions#confirm_reject', as: :application_choice_confirm_reject
     post '/applications/:application_choice_id/reject' => 'decisions#create_reject', as: :application_choice_create_reject
+    post '/applications/:application_choice_id/offer/confirm' => 'decisions#confirm_offer', as: :application_choice_confirm_offer
+    post '/applications/:application_choice_id/offer' => 'decisions#create_offer', as: :application_choice_create_offer
+
 
     get '/sign-in' => 'sessions#new'
   end

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MakeAnOffer do
   describe 'validation' do
     it 'accepts nil conditions' do
       decision = MakeAnOffer.new(
-        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        application_choice: build_stubbed(:application_choice, status: :awaiting_provider_decision),
         offer_conditions: nil,
       )
 
@@ -13,7 +13,7 @@ RSpec.describe MakeAnOffer do
 
     it 'only accepts conditions as an array' do
       decision = MakeAnOffer.new(
-        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        application_choice: build_stubbed(:application_choice, status: :awaiting_provider_decision),
         offer_conditions: 'SPLAT',
       )
 
@@ -22,7 +22,7 @@ RSpec.describe MakeAnOffer do
 
     it 'limits the number of conditions to 20' do
       decision = MakeAnOffer.new(
-        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        application_choice: build_stubbed(:application_choice, status: :awaiting_provider_decision),
         offer_conditions: Array.new(21) { 'a condition' },
       )
 
@@ -31,7 +31,7 @@ RSpec.describe MakeAnOffer do
 
     it 'limits the length of conditions to 255 characters' do
       decision = MakeAnOffer.new(
-        application_choice: build_stubbed(:application_choice, status: :application_complete),
+        application_choice: build_stubbed(:application_choice, status: :awaiting_provider_decision),
         offer_conditions: ['a' * 256],
       )
 

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes an offer' do
+  include CourseOptionHelpers
+  include DfeSignInHelpers
+
+  let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
+  let(:application_awaiting_provider_decision) {
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
+  }
+
+  scenario 'Provider makes an offer' do
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    when_i_respond_to_an_application
+    and_i_choose_to_make_an_offer
+    then_i_see_some_application_info
+    when_i_select_standard_reasons
+    and_i_add_optional_further_conditions
+    and_i_click_to_continue
+    then_i_am_asked_to_confirm_the_offer
+    when_i_confirm_the_offer
+    then_i_am_back_to_the_application_page
+    and_i_can_see_the_application_has_has_offer_made
+  end
+
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_respond_to_an_application
+    visit provider_interface_application_choice_respond_path(
+      application_awaiting_provider_decision.id,
+    )
+  end
+
+  def and_i_choose_to_make_an_offer
+    choose 'Make an offer (including any conditions or recommendations)'
+    click_on 'Continue'
+  end
+
+  def then_i_see_some_application_info
+    expect(page).to have_content \
+      application_awaiting_provider_decision.course.name_and_code
+    expect(page).to have_content \
+      application_awaiting_provider_decision.application_form.first_name
+    expect(page).to have_content \
+      application_awaiting_provider_decision.application_form.last_name
+  end
+
+  def when_i_select_standard_reasons
+    choose 'Fitness to teach check'
+    choose 'Payment of fees'
+  end
+
+  def and_i_add_optional_further_conditions
+    fill_in('First condition', with: 'A further condition')
+  end
+
+  def and_i_click_to_continue
+    click_on 'Continue'
+  end
+
+  def then_i_am_asked_to_confirm_the_offer
+    expect(page).to have_current_path(
+      provider_interface_application_choice_confirm_reject_path(
+        application_awaiting_provider_decision.id,
+      ),
+    )
+  end
+
+  def when_i_confirm_the_offer
+    click_on 'Confirm offer'
+  end
+
+  def then_i_am_back_to_the_application_page
+    expect(page).to have_current_path(
+      provider_interface_application_choice_path(
+        application_awaiting_provider_decision.id,
+      ),
+    )
+  end
+
+  def and_i_can_see_the_application_has_has_offer_made
+    expect(page).to have_content 'Application status changed to ‘Offer made’'
+  end
+end

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -88,6 +88,8 @@ RSpec.feature 'Provider makes an offer' do
         application_awaiting_provider_decision.id,
       ),
     )
+    expect(page).to have_content application_awaiting_provider_decision.application_form.first_name
+    expect(page).to have_content application_awaiting_provider_decision.application_form.last_name
   end
 
   def and_i_can_see_the_application_has_an_offer_made

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_choose_to_make_an_offer
-    choose 'Make an offer (including any conditions or recommendations)'
+    choose 'Make an offer (including any conditions)'
     click_on 'Continue'
   end
 

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -11,17 +11,20 @@ RSpec.feature 'Provider makes an offer' do
 
   scenario 'Provider makes an offer' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+
     when_i_respond_to_an_application
     and_i_choose_to_make_an_offer
     then_i_see_some_application_info
+
     when_i_select_standard_reasons
     and_i_add_optional_further_conditions
     and_i_click_to_continue
     then_i_am_asked_to_confirm_the_offer
     and_i_see_the_correct_offer_conditions
+
     when_i_confirm_the_offer
     then_i_am_back_to_the_application_page
-    and_i_can_see_the_application_has_has_offer_made
+    and_i_can_see_the_application_has_an_offer_made
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
@@ -67,6 +70,7 @@ RSpec.feature 'Provider makes an offer' do
         application_awaiting_provider_decision.id,
       ),
     )
+    expect(page).to have_content 'Confirm offer'
   end
 
   def and_i_see_the_correct_offer_conditions
@@ -86,7 +90,7 @@ RSpec.feature 'Provider makes an offer' do
     )
   end
 
-  def and_i_can_see_the_application_has_has_offer_made
-    expect(page).to have_content 'Application status changed to ‘Offer made’'
+  def and_i_can_see_the_application_has_an_offer_made
+    expect(page).to have_content 'Application status changed to ‘Offer’'
   end
 end

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Provider makes an offer' do
     and_i_add_optional_further_conditions
     and_i_click_to_continue
     then_i_am_asked_to_confirm_the_offer
+    and_i_see_the_correct_offer_conditions
     when_i_confirm_the_offer
     then_i_am_back_to_the_application_page
     and_i_can_see_the_application_has_has_offer_made
@@ -66,6 +67,12 @@ RSpec.feature 'Provider makes an offer' do
         application_awaiting_provider_decision.id,
       ),
     )
+  end
+
+  def and_i_see_the_correct_offer_conditions
+    expect(page).to have_content 'Payment of fees'
+    expect(page).to have_content 'A further condition'
+
   end
 
   def when_i_confirm_the_offer

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -93,6 +93,6 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_can_see_the_application_has_an_offer_made
-    expect(page).to have_content 'Application status changed to ‘Offer’'
+    expect(page).to have_content 'Application status changed to ‘Offer Made’'
   end
 end

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -49,12 +49,11 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_select_standard_reasons
-    choose 'Fitness to teach check'
-    choose 'Payment of fees'
+    page.check 'Payment of fees', allow_label_click: true
   end
 
   def and_i_add_optional_further_conditions
-    fill_in('First condition', with: 'A further condition')
+    fill_in('first_condition', with: 'A further condition')
   end
 
   def and_i_click_to_continue
@@ -63,7 +62,7 @@ RSpec.feature 'Provider makes an offer' do
 
   def then_i_am_asked_to_confirm_the_offer
     expect(page).to have_current_path(
-      provider_interface_application_choice_confirm_reject_path(
+      provider_interface_application_choice_confirm_offer_path(
         application_awaiting_provider_decision.id,
       ),
     )

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -72,7 +72,6 @@ RSpec.feature 'Provider makes an offer' do
   def and_i_see_the_correct_offer_conditions
     expect(page).to have_content 'Payment of fees'
     expect(page).to have_content 'A further condition'
-
   end
 
   def when_i_confirm_the_offer

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Provider makes an offer' do
   include CourseOptionHelpers
-  include DfeSignInHelpers
+  include DfESignInHelpers
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
   let(:application_awaiting_provider_decision) {

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -53,9 +53,9 @@ RSpec.feature 'Provider responds to application' do
 
   def then_i_can_see_its_status(application)
     if application.status == 'awaiting_provider_decision'
-      expect(page).to have_content 'Awaiting Provider Decision'
+      expect(page).to have_content 'Awaiting provider decision'
     elsif application.status == 'rejected'
-      expect(page).to have_content 'Rejected'
+      expect(page).to have_content 'Provider rejected'
     end
   end
 


### PR DESCRIPTION
### Context

Providers using the UI need a process for making offers on applications

### Changes proposed in this pull request

Adding pages for `new_offer` and `confirm_offer`.
Updating `routes` and `decisions_controller` to use the new pages.
Add system spec to test the happy path of creating an offer.

<img width="1271" alt="Screenshot 2019-11-18 at 16 23 16" src="https://user-images.githubusercontent.com/47318392/69070409-fd68f700-0a1f-11ea-9f70-3f63b56705ed.png">

<img width="1220" alt="Screenshot 2019-11-18 at 16 24 26" src="https://user-images.githubusercontent.com/47318392/69070400-fa6e0680-0a1f-11ea-804c-8f431df04b8b.png">

<img width="1343" alt="Screenshot 2019-11-18 at 16 24 37" src="https://user-images.githubusercontent.com/47318392/69070391-f7731600-0a1f-11ea-97b4-f8519980df0d.png">
### Guidance to review

How could someone else check this work? Which parts do you want more feedback on?

### Link to Trello card

[1256 - Make an offer using provider UI](https://trello.com/c/QP87Ig3k/1256-provider-make-an-offer)

### Env vars

None
