### PR TITLE
Remove completion checkbox for course choices

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class CourseChoicesController < CandidateInterfaceController
     def index
-      @application_form = current_application
       @course_choices = current_candidate.current_application.application_choices
     end
 
@@ -77,26 +76,10 @@ module CandidateInterface
       redirect_to candidate_interface_course_choices_index_path
     end
 
-    def complete
-      @application_form = current_application
-      @application_form.course_choices_present = true
-
-      if @application_form.update(application_form_params)
-        redirect_to candidate_interface_application_form_path
-      else
-        @course_choices = current_candidate.current_application.application_choices
-        render :index
-      end
-    end
-
   private
 
     def current_course_choice_id
       params.permit(:id)[:id]
-    end
-
-    def application_form_params
-      params.require(:application_form).permit(:course_choices_completed)
     end
 
     def application_choice_params

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -17,9 +17,6 @@ class ApplicationForm < ApplicationRecord
     application_choices.update_all(updated_at: Time.zone.now)
   }
 
-  attr_accessor :course_choices_present
-  validates :course_choices_completed, acceptance: true, if: -> { course_choices_present }
-
   def submitted?
     application_choices.any? && !application_choices.first.unsubmitted?
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -75,7 +75,7 @@ module CandidateInterface
     end
 
     def course_choices_completed?
-      @application_form.course_choices_completed
+      @application_form.application_choices.count >= 1
     end
 
     def volunteering_completed?

--- a/app/views/candidate_interface/course_choices/index.html.erb
+++ b/app/views/candidate_interface/course_choices/index.html.erb
@@ -5,53 +5,38 @@
   <%= t('page_titles.course_choices') %>
 </h1>
 
-<%= form_with model: @application_form, url: candidate_interface_course_choices_complete_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-  <%= f.govuk_error_summary %>
-
-  <% @course_choices.map.each do |course_choice| %>
-    <%= render(SummaryCardComponent, rows: [
-      { key: 'Course', value: "#{course_choice.course.name} (#{course_choice.course.code})" },
-      { key: 'Location', value: course_choice.site.name },
-    ]) do %>
-      <header class='app-summary-card__header'>
-        <h3 class='app-summary-card__title'>
-          <%= course_choice.provider.name %>
-        </h3>
-        <div class='app-summary-card__actions'>
-          <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
-        </div>
-      </header>
-    <% end %>
-  <% end %>
-
-  <% if @course_choices.count.between?(1, 2) %>
-    <div class='govuk-grid-row'>
-      <div class='govuk-grid-column-two-thirds'>
-        <h2 class='govuk-heading-m'>Do you want to add another course?</h2>
-        <p class='govuk-body'>You can apply to up to 3 courses at this stage of your application.</p>
-        <p class='govuk-body'>Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
-        <p class='govuk-body'>You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on Apply for teacher training.</p>
-        <p class='govuk-body'>Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+<% @course_choices.map.each do |course_choice| %>
+  <%= render(SummaryCardComponent, rows: [
+    { key: 'Course', value: "#{course_choice.course.name} (#{course_choice.course.code})" },
+    { key: 'Location', value: course_choice.site.name },
+  ]) do %>
+    <header class='app-summary-card__header'>
+      <h3 class='app-summary-card__title'>
+        <%= course_choice.provider.name %>
+      </h3>
+      <div class='app-summary-card__actions'>
+        <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
       </div>
-    </div>
-  <% end %>
-
-  <% if @course_choices.count < 3 %>
-    <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
-  <% end %>
-
-  <% if @course_choices.count >= 1 %>
-    <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: {} do %>
-      <%= f.hidden_field :course_choices_completed, value: false %>
-      <%= f.govuk_check_box :course_choices_completed,
-                            true,
-                            multiple: false,
-                            link_errors: true,
-                            label: {
-                              text: t('application_form.courses.complete.completed_checkbox'),
-                            } %>
-    <% end %>
-
-    <%= f.govuk_submit 'Continue' %>
+    </header>
   <% end %>
 <% end %>
+
+<% if @course_choices.count.between?(1, 2) %>
+  <div class='govuk-grid-row'>
+    <div class='govuk-grid-column-two-thirds'>
+      <h2 class='govuk-heading-m'>Do you want to add another course?</h2>
+      <p class='govuk-body'>You can apply to up to 3 courses at this stage of your application.</p>
+      <p class='govuk-body'>Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
+      <p class='govuk-body'>You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on Apply for teacher training.</p>
+      <p class='govuk-body'>Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+    </div>
+  </div>
+<% end %>
+
+<% if @course_choices.count < 3 %>
+  <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
+<% end %>
+
+<p class='govuk-body'>
+  <%= link_to 'Continue', candidate_interface_application_form_path, class: 'govuk-button' %>
+</p>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -6,7 +6,6 @@ en:
       delete: Delete choice
       confirm_delete: Yes I'm sure - delete this choice
       complete:
-        completed_checkbox: I have completed this section
         button: Continue
     personal_details:
       first_name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -149,8 +149,6 @@ Rails.application.routes.draw do
 
         get '/provider/:provider_code/courses/:course_code' => 'course_choices#options_for_site', as: :course_choices_site
         post '/provider/:provider_code/courses/:course_code' => 'course_choices#pick_site'
-
-        patch '/complete' => 'course_choices#complete', as: :course_choices_complete
       end
 
       scope '/other-qualifications' do

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -16,10 +16,16 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_location
     then_i_see_my_completed_course_choice
 
-    when_i_delete_my_course_choice
-    and_i_confirm
-    then_i_no_longer_see_my_course_choice
+    when_i_click_continue
+    and_that_the_section_is_completed
+  end
 
+  scenario 'Candidate deletes a course choice' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    given_data_from_find_exists
+    when_i_click_on_course_choices
     and_i_click_on_add_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
@@ -27,9 +33,9 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_location
     then_i_see_my_completed_course_choice
 
-    when_i_mark_this_section_as_completed
-    when_i_click_continue
-    and_that_the_section_is_completed
+    when_i_delete_my_course_choice
+    and_i_confirm
+    then_i_no_longer_see_my_course_choice
   end
 
   def given_i_am_not_signed_in; end
@@ -95,12 +101,8 @@ RSpec.feature 'Selecting a course' do
     expect(page).not_to have_content('Primary (2XT2)')
   end
 
-  def when_i_mark_this_section_as_completed
-    check t('application_form.courses.complete.completed_checkbox')
-  end
-
   def when_i_click_continue
-    click_button 'Continue'
+    click_link 'Continue'
   end
 
   def and_that_the_section_is_completed


### PR DESCRIPTION
### Context
Course choice section  

### Changes proposed in this pull request
- Remove checkbox and completion confirmation

### Guidance to review
Add a course via `/candidate/application/courses`

### Link to Trello card
[393 - Remove checkbox completion got course choices](https://trello.com/c/CpXISNBS/393-validation-message-for-course-choices-i-have-completed-this-section?menu=filter&filter=label:Dev)

### Env vars
n/a
