### PR TITLE
Providers can view qualifications for an application

### DIFF
--- a/app/components/provider_interface/qualification_row_component.html.erb
+++ b/app/components/provider_interface/qualification_row_component.html.erb
@@ -1,0 +1,5 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell"><%= render QualificationTitleComponent, qualification: qualification %></td>
+  <td class="govuk-table__cell"><%= qualification.award_year %></td>
+  <td class="govuk-table__cell"><%= grade %></td>
+</tr>

--- a/app/components/provider_interface/qualification_row_component.rb
+++ b/app/components/provider_interface/qualification_row_component.rb
@@ -1,0 +1,24 @@
+module ProviderInterface
+  class QualificationRowComponent < ActionView::Component::Base
+    validates :qualification, presence: true
+    attr_reader :qualification
+
+    def initialize(qualification:)
+      @qualification = qualification
+    end
+
+    def grade
+      qualification.predicted_grade ? "#{friendly_grade} (predicted)" : friendly_grade
+    end
+
+  private
+
+    def friendly_grade
+      if qualification.degree?
+        t("application_form.degree.grade.#{qualification.grade}.label", default: qualification.grade)
+      else
+        qualification.grade
+      end
+    end
+  end
+end

--- a/app/components/provider_interface/qualifications_table_component.html.erb
+++ b/app/components/provider_interface/qualifications_table_component.html.erb
@@ -1,0 +1,16 @@
+<% if qualifications.any? %>
+  <table class="govuk-table" data-qa="qualifications-table-<%= type_label.parameterize %>">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-half"><%= type_label %></th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Awarded</th>
+        <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Grade</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% qualifications.each do |qualification| %>
+        <%= render ProviderInterface::QualificationRowComponent, qualification: qualification %>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/components/provider_interface/qualifications_table_component.rb
+++ b/app/components/provider_interface/qualifications_table_component.rb
@@ -1,0 +1,10 @@
+module ProviderInterface
+  class QualificationsTableComponent < ActionView::Component::Base
+    attr_reader :qualifications, :type_label
+
+    def initialize(qualifications:, type_label:)
+      @qualifications = qualifications
+      @type_label = type_label
+    end
+  end
+end

--- a/app/components/qualification_title_component.html.erb
+++ b/app/components/qualification_title_component.html.erb
@@ -1,0 +1,1 @@
+<%= @qualification.qualification_type %> <%= @qualification.subject %>

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -1,0 +1,5 @@
+class QualificationTitleComponent < ActionView::Component::Base
+  def initialize(qualification:)
+    @qualification = qualification
+  end
+end

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -2,6 +2,7 @@ class ApplicationQualification < ApplicationRecord
   belongs_to :application_form
 
   scope :degrees, -> { where level: 'degree' }
+  scope :gcses, -> { where level: 'gcse' }
   scope :other, -> { where level: 'other' }
 
   enum level: {

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ApplicationChoicePresenter
+    delegate :application_qualifications, to: :application_form
+
     def initialize(application_choice)
       @application_choice = application_choice
       @application_form = application_choice.application_form
@@ -66,6 +68,18 @@ module ProviderInterface
 
     def email_address
       application_form.candidate.email_address
+    end
+
+    def degrees
+      application_qualifications.degrees
+    end
+
+    def gcses_or_equivalent
+      application_qualifications.gcses
+    end
+
+    def other_qualifications
+      application_qualifications.other
     end
 
   private

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -79,3 +79,9 @@
     </div>
   </div>
 </div>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
+
+<%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.degrees, type_label: 'Degree' %>
+<%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.gcses_or_equivalent, type_label: 'GCSE or equivalent' %>
+<%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.other_qualifications, type_label: 'Other qualification' %>

--- a/spec/components/provider_interface/qualification_row_component_spec.rb
+++ b/spec/components/provider_interface/qualification_row_component_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::QualificationRowComponent do
+  it 'renders a qualification table row' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :degree,
+      qualification_type: 'BSc',
+      subject: 'Psychology',
+      award_year: '2018',
+      grade: :upper_second,
+    )
+
+    result = render_inline(described_class, qualification: qualification)
+
+    expect(result.text).to include('BSc Psychology')
+    expect(result.text).to include('2018')
+    expect(result.text).to include('2:1')
+  end
+
+  it 'renders a qualification with a predicted grade' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :degree,
+      qualification_type: 'MEng',
+      subject: 'Engineering',
+      award_year: '2020',
+      grade: :first,
+      predicted_grade: true,
+    )
+
+    result = render_inline(described_class, qualification: qualification)
+
+    expect(result.text).to include('MEng Engineering')
+    expect(result.text).to include('2020')
+    expect(result.text).to include('First (predicted)')
+  end
+
+  it 'renders a qualification with a free text grade' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :degree,
+      qualification_type: 'BSc',
+      subject: 'Chemistry',
+      award_year: '2001',
+      grade: 'I did my best',
+    )
+
+    result = render_inline(described_class, qualification: qualification)
+
+    expect(result.text).to include('BSc Chemistry')
+    expect(result.text).to include('2001')
+    expect(result.text).to include('I did my best')
+  end
+end

--- a/spec/components/provider_interface/qualifications_table_component_spec.rb
+++ b/spec/components/provider_interface/qualifications_table_component_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::QualificationsTableComponent do
+  it 'renders nothing when no qualifications present' do
+    result = render_inline(described_class, qualifications: [], type_label: 'My label')
+
+    expect(result).to be_blank
+  end
+
+  it 'renders a qualifications table' do
+    qualifications = [
+      build_stubbed(:application_qualification),
+    ]
+    result = render_inline(described_class, qualifications: qualifications, type_label: 'My label')
+
+    expect(result.css('th').text).to include('My label')
+  end
+end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe 'A Provider viewing an individual application' do
     when_i_visit_that_application_in_the_provider_interface
 
     then_i_should_see_the_candidates_degrees
+    and_i_should_see_the_candidates_gcses
+    and_i_should_see_the_candidates_other_qualifications
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
@@ -22,13 +24,9 @@ RSpec.describe 'A Provider viewing an individual application' do
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     application_form = create(:application_form)
 
-    create(:application_qualification,
-           application_form: application_form,
-           level: :degree,
-           qualification_type: 'BSc',
-           subject: 'Psychology',
-           award_year: '2018',
-           grade: :upper_second)
+    create_list(:application_qualification, 1, application_form: application_form, level: :degree)
+    create_list(:application_qualification, 2, application_form: application_form, level: :gcse)
+    create_list(:application_qualification, 3, application_form: application_form, level: :other)
 
     @application_choice = create(:application_choice,
                                  status: 'awaiting_provider_decision',
@@ -41,6 +39,14 @@ RSpec.describe 'A Provider viewing an individual application' do
   end
 
   def then_i_should_see_the_candidates_degrees
-    expect(page).to have_content('BSc — Psychology')
+    expect(page).to have_selector('[data-qa="qualifications-table-degree"] tbody tr', count: 1)
+  end
+
+  def and_i_should_see_the_candidates_gcses
+    expect(page).to have_selector('[data-qa="qualifications-table-gcse-or-equivalent"] tbody tr', count: 2)
+  end
+
+  def and_i_should_see_the_candidates_other_qualifications
+    expect(page).to have_selector('[data-qa="qualifications-table-other-qualification"] tbody tr', count: 3)
   end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'A Provider viewing an individual application' do
+  include CourseOptionHelpers
+  include DfeSignInHelpers
+
+  scenario 'the application data is visible' do
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_my_organisation_has_received_an_application
+
+    when_i_visit_that_application_in_the_provider_interface
+
+    then_i_should_see_the_candidates_degrees
+  end
+
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_my_organisation_has_received_an_application
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    application_form = create(:application_form)
+
+    create(:application_qualification,
+           application_form: application_form,
+           level: :degree,
+           qualification_type: 'BSc',
+           subject: 'Psychology',
+           award_year: '2018',
+           grade: :upper_second)
+
+    @application_choice = create(:application_choice,
+                                 status: 'awaiting_provider_decision',
+                                 course_option: course_option,
+                                 application_form: application_form)
+  end
+
+  def when_i_visit_that_application_in_the_provider_interface
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def then_i_should_see_the_candidates_degrees
+    expect(page).to have_content('BSc — Psychology')
+  end
+end


### PR DESCRIPTION
### Context

Begin showing a candidate's application form to providers

We've intentionally not refactored any candidate parts.

Paired with @duncanjbrown 

### Changes proposed in this pull request

- Create QualificationTitle, QualificationRow and QualificationsTable components
- Indicate if a grade is predicted or not
- Use friendly versions of grades for degrees

(note: Test data uses degree grade types for things other than degree)
![Screen Shot 2019-11-18 at 16 48 23](https://user-images.githubusercontent.com/319055/69072269-453d4d80-0a23-11ea-8072-343ab764701f.png)


https://trello.com/c/lf08PU3R/1233-provider-can-view-an-application
