### PR TITLE
Allow app service to talk to Redis

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,3 +70,6 @@ RSpec/InstanceVariable:
 RSpec/PredicateMatcher:
   Exclude:
     - 'spec/support_specs/clockwork_spec.rb'
+
+RSpec/DescribeClass:
+  Enabled: false

--- a/azure/template.json
+++ b/azure/template.json
@@ -488,6 +488,10 @@
                             {
                                 "name": "DFE_SIGN_IN_ISSUER",
                                 "value": "[parameters('dfeSignInIssuer')]"
+                            },
+                            {
+                                "name": "REDIS_URL",
+                                "secureValue": "[concat('rediss://:', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')), '2018-03-01').primaryKey, '@', parameters('redisCacheName'), '.redis.cache.windows.net:6380')]"
                             }
                         ]
                     }

--- a/spec/azure/configuration_spec.rb
+++ b/spec/azure/configuration_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Configuration' do
+  describe 'azure/template.json' do
+    it 'is valid JSON' do
+      JSON.parse(File.read('azure/template.json'))
+    end
+  end
+
+  describe 'azure-pipelines.yml' do
+    it 'is valid YAML' do
+      YAML.load_file('azure-pipelines.yml')
+    end
+  end
+
+  describe 'azure-pipelines-deploy-template.yml' do
+    it 'is valid YAML' do
+      YAML.load_file('azure-pipelines-deploy-template.yml')
+    end
+  end
+end


### PR DESCRIPTION
### Context

The app service should be able to talk to Redis to schedule background jobs.

### Changes proposed in this pull request

Add the `REDIS_URL` environment variable, which should automatically configure the app.

https://trello.com/c/YtFlMRNo