### PR TITLE
Show guidance on choosing course in all states

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -3,6 +3,11 @@ module CandidateInterface
     def index
       @application_form = current_application
       @course_choices = current_candidate.current_application.application_choices
+      @page_title = if @course_choices.count < 1
+                      t('page_titles.choosing_courses')
+                    else
+                      t('page_titles.course_choices')
+                    end
     end
 
     def have_you_chosen

--- a/app/views/candidate_interface/course_choices/_guidance.html.erb
+++ b/app/views/candidate_interface/course_choices/_guidance.html.erb
@@ -1,0 +1,4 @@
+<p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
+<p class="govuk-body">Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
+<p class="govuk-body">You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on Apply for teacher training.</p>
+<p class="govuk-body">Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>

--- a/app/views/candidate_interface/course_choices/index.html.erb
+++ b/app/views/candidate_interface/course_choices/index.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, page_title('course_choices') %>
+<% content_for :title, @page_title %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class='govuk-heading-xl'>
-  <%= t('page_titles.course_choices') %>
+<h1 class="govuk-heading-xl">
+  <%= @page_title %>
 </h1>
 
 <%= form_with model: @application_form, url: candidate_interface_course_choices_complete_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
@@ -13,45 +13,46 @@
       { key: 'Course', value: "#{course_choice.course.name} (#{course_choice.course.code})" },
       { key: 'Location', value: course_choice.site.name },
     ]) do %>
-      <header class='app-summary-card__header'>
-        <h3 class='app-summary-card__title'>
+      <header class="app-summary-card__header">
+        <h3 class="app-summary-card__title">
           <%= course_choice.provider.name %>
         </h3>
-        <div class='app-summary-card__actions'>
+        <div class="app-summary-card__actions">
           <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
         </div>
       </header>
     <% end %>
   <% end %>
 
-  <% if @course_choices.count.between?(1, 2) %>
-    <div class='govuk-grid-row'>
-      <div class='govuk-grid-column-two-thirds'>
-        <h2 class='govuk-heading-m'>Do you want to add another course?</h2>
-        <p class='govuk-body'>You can apply to up to 3 courses at this stage of your application.</p>
-        <p class='govuk-body'>Not all courses and training providers are signed up to Apply for teacher training. If you choose a course that isn’t signed up to the service, you’ll be directed to UCAS to continue your application.</p>
-        <p class='govuk-body'>You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on Apply for teacher training.</p>
-        <p class='govuk-body'>Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @course_choices.count.present? %>
+        <% if @course_choices.count < 1 %>
+          <%= render 'guidance' %>
+          <%= link_to 'Continue', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-!-margin-bottom-9' %>
+        <% end %>
+
+        <% if @course_choices.count.between?(1, 2) %>
+          <h2 class="govuk-heading-m">Do you want to add another course?</h2>
+          <%= render 'guidance' %>
+          <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
+        <% end %>
+
+        <% if @course_choices.count >= 1 %>
+          <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: {} do %>
+            <%= f.hidden_field :course_choices_completed, value: false %>
+            <%= f.govuk_check_box :course_choices_completed,
+                                  true,
+                                  multiple: false,
+                                  link_errors: true,
+                                  label: {
+                                    text: t('application_form.courses.complete.completed_checkbox'),
+                                  } %>
+          <% end %>
+
+          <%= f.govuk_submit 'Continue' %>
+        <% end %>
       </div>
     </div>
-  <% end %>
-
-  <% if @course_choices.count < 3 %>
-    <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
-  <% end %>
-
-  <% if @course_choices.count >= 1 %>
-    <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: {} do %>
-      <%= f.hidden_field :course_choices_completed, value: false %>
-      <%= f.govuk_check_box :course_choices_completed,
-                            true,
-                            multiple: false,
-                            link_errors: true,
-                            label: {
-                              text: t('application_form.courses.complete.completed_checkbox'),
-                            } %>
-    <% end %>
-
-    <%= f.govuk_submit 'Continue' %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,6 +56,7 @@ en:
     add_another_degree: Add another degree
     out_of_work: Tell us why you’ve been out of the workplace
     destroy_degree: Are you sure you want to delete this degree?
+    choosing_courses: Choosing courses
     course_choices: Course choices
     destroy_course_choice: Are you sure you want to delete this choice?
     have_you_chosen: Have you chosen a course to apply to?

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -13,7 +13,7 @@ module CandidateHelper
     visit candidate_interface_application_form_path
 
     click_link 'Course choices'
-    click_link 'Add another course'
+    click_link 'Continue'
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
 

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Selecting a course not on Apply' do
   end
 
   def and_i_click_on_add_course
-    click_link 'Add another course'
+    click_link 'Continue'
   end
 
   def and_i_choose_that_i_know_where_i_want_to_apply

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_click_on_add_course
-    click_link 'Add another course'
+    click_link 'Continue'
   end
 
   def and_i_choose_that_i_know_where_i_want_to_apply

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Candidate submit the application' do
     visit candidate_interface_application_form_path
 
     click_link 'Course choices'
-    click_link 'Add another course'
+    click_link 'Continue'
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
     choose 'Gorse SCITT (1N1)'


### PR DESCRIPTION
### Context

Show guidance about choosing courses when there are no courses selected, as well as when there are less than 3 selected.

Also updated/simplified logic on this page, with help from @mnacos and @RobertM905.

### Changes proposed in this pull request

#### Before

![Screenshot 2019-11-18 at 17 09 31](https://user-images.githubusercontent.com/813383/69073991-63587d00-0a26-11ea-91c1-278adf487f4c.png)

#### After

![Screenshot 2019-11-18 at 17 00 49](https://user-images.githubusercontent.com/813383/69074030-808d4b80-0a26-11ea-9690-7c96045c838d.png)


### Guidance to review

How could someone else check this work? Which parts do you want more feedback on?

### Link to Trello card

[399 - Add content for course choices page when no course choices made](https://trello.com/c/6yhsftDX/399-add-content-for-course-choices-page-when-no-course-choices-made)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
