### PR TITLE
Fake DfE Sign-in in development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ LOGSTASH_SSL=true
 DFE_SIGN_IN_CLIENT_ID=
 DFE_SIGN_IN_SECRET=
 DFE_SIGN_IN_ISSUER=https://signin-test-oidc-as.azurewebsites.net
+BYPASS_DFE_SIGN_IN=true

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class SessionsController < ProviderInterfaceController
     skip_before_action :authenticate_provider_user!
+    protect_from_forgery except: :bypass_callback
 
     def new; end
 
@@ -13,5 +14,7 @@ module ProviderInterface
 
       redirect_to provider_interface_path
     end
+
+    alias :bypass_callback :callback
   end
 end

--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -1,0 +1,5 @@
+module DfESignIn
+  def self.bypass?
+    Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
+  end
+end

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -1,1 +1,5 @@
-<%= link_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
+<% if DfESignIn.bypass? %>
+  <%= link_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
+<% else %>
+  <%= link_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
+<% end %>

--- a/config/initializers/inflector.rb
+++ b/config/initializers/inflector.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym('DfE')
+end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -22,4 +22,12 @@ options = {
   },
 }
 
-Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
+if DfESignIn.bypass?
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :developer,
+             fields: %i[uid email],
+             uid_field: :uid
+  end
+else
+  Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,6 +214,7 @@ Rails.application.routes.draw do
   end
 
   get '/auth/dfe/callback' => 'provider_interface/sessions#callback'
+  post '/auth/developer/callback' => 'provider_interface/sessions#bypass_callback'
 
   namespace :support_interface, path: '/support' do
     get '/' => redirect('/support/applications')

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -1,4 +1,4 @@
-module DfeSignInHelpers
+module DfESignInHelpers
   def provider_exists_in_dfe_sign_in(email: 'email@example.com')
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       info: { email: email },

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'A provider authenticates via DfE Sign-in' do
-  include DfeSignInHelpers
+  include DfESignInHelpers
 
   scenario 'signing in successfully' do
     given_i_have_a_dfe_sign_in_account

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Provider rejects application' do
   include CourseOptionHelpers
-  include DfeSignInHelpers
+  include DfESignInHelpers
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
   let(:application_awaiting_provider_decision) {

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Provider responds to application' do
   include CourseOptionHelpers
-  include DfeSignInHelpers
+  include DfESignInHelpers
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
   let(:application_awaiting_provider_decision) {

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'See applications' do
   include CourseOptionHelpers
-  include DfeSignInHelpers
+  include DfESignInHelpers
 
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'See applications' do
   include CourseOptionHelpers
-  include DfeSignInHelpers
+  include DfESignInHelpers
 
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in


### PR DESCRIPTION
Use the Omniauth "Developer" strategy to provide a fake DfE Sign in interface so we don't depend on it for development. You can provide a UID and an email of your choosing on Sign-in and the system will act as though those details came back from DSI after a successful authentication.

Double-lock on the feature: it works if and only if an env var is set and we're in development mode. The env var is not added to the Azure config so it will be impossible to enable it in prod.

No test included as Omniauth uses Rack middleware for implementation, the initializer runs before RSpec, and swapping middleware at runtime requires unpleasant contortions. Not a public-facing feature, and if it breaks we'll know about it, so I held off.

https://trello.com/c/6SndwNfI/1241-integrate-provider-interface-with-dfe-sign-in