### PR TITLE
Handle internal error in POST requests

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,7 +237,11 @@ Rails.application.routes.draw do
   end
 
   get '/check', to: 'healthcheck#show'
-  get '/404', to: 'errors#not_found'
-  get '/500', to: 'errors#internal_server_error'
+
+  scope via: :all do
+    match '/404', to: 'errors#not_found'
+    match '/500', to: 'errors#internal_server_error'
+  end
+
   get '*path', to: 'errors#not_found'
 end


### PR DESCRIPTION
### Context

Currently, when an exception occurs we're not seeing the proper error page, but a blank page instead. This is because we haven't configured the 500 page to show for POST requests (only GET).

### Changes proposed in this pull request

Adds request routes for all HTTP methods. I've taken this from https://github.com/alphagov/content-publisher/commit/d97db8f4f9bcfcb9def8d4c4a1217e3ceac99d02, because when in doubt you should always copy @kevindew's code.

### Guidance to review

Write a bug, deploy to QA, observe the error.

### Link to Trello card

https://trello.com/c/YtFlMRNo