### PR TITLE
Do not 500 when Notify errors with a 400

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,9 @@
 class ApplicationMailer < Mail::Notify::Mailer
+  rescue_from Notifications::Client::BadRequestError, with: :report_notify_error
+
+  def report_notify_error(e)
+    Raven.capture_exception(e)
+  end
+
   GENERIC_NOTIFY_TEMPLATE = '2744ea53-34f1-431f-8173-8388fadd826a'.freeze
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer do
+  describe 'when Notify throws an exception' do
+    let(:fake_mailer) do
+      Class.new(described_class) do
+        def notify_error
+          notify_request_stub = Struct.new(:code, :body).new(400, 'irrelevant')
+          raise Notifications::Client::BadRequestError.new(notify_request_stub)
+        end
+      end
+    end
+
+    it 'rescues the exception and reports it to sentry' do
+      allow(Raven).to receive(:capture_exception)
+
+      fake_mailer.notify_error.deliver_now
+
+      expect(Raven).to have_received(:capture_exception)
+    end
+  end
+end


### PR DESCRIPTION
Instead report the error to Sentry and continue as though nothing
happened.

Handles `BadRequestError`s, ie:

- "BadRequestError: Can't send to this recipient using a team-only API key"
- "BadRequestError: Can't send to this recipient when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode"

https://docs.notifications.service.gov.uk/ruby.html#error-codes