### PR TITLE
Set REDIS_URL correctly for web app

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -497,7 +497,7 @@
                             },
                             {
                                 "name": "REDIS_URL",
-                                "secureValue": "[concat('rediss://:', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')), '2018-03-01').primaryKey, '@', parameters('redisCacheName'), '.redis.cache.windows.net:6380')]"
+                                "value": "[concat('rediss://:', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')), '2018-03-01').primaryKey, '@', parameters('redisCacheName'), '.redis.cache.windows.net:6380')]"
                             }
                         ]
                     }


### PR DESCRIPTION
Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/558. The web app can't read secureValue, because the resource type.

This should fix the web app not being able to talk to Redis.