### PR TITLE
Update vendor-api spec to add declined to application status

### DIFF
--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -312,6 +312,7 @@ components:
             - rejected
             - declined
             - withdrawn
+            - declined
           example: application_complete
         submitted_at:
           type: string


### PR DESCRIPTION
## Context

The `declined` status was previously remove in error. 
This PR adds it back.

### Changes proposed in this pull request

Add `declined` status back in open-api spec.

### Guidance to review


### Link to Trello card

[1267 - Update tech docs to include state declined](https://trello.com/c/ndSAZAQX/1267-update-tech-docs-to-include-state-declined)

Link to PR on Tech Docs Repo
https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-tech-docs/pull/109

### Env vars

