### PR TITLE
Use native sentry environment to report errors

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,3 +1,3 @@
 Raven.configure do |config|
-  config.tags = { hosting_environment: HostingEnvironment.environment_name }
+  config.current_environment = HostingEnvironment.environment_name
 end


### PR DESCRIPTION
Somehow I convinced myself to use the `tags` feature of Raven to report the environment.

However, the correct option is to use `current_environment`, which will mean that we can filter much better in Sentry, since the environment is a first-class thingy in the interface.

https://trello.com/c/GktNU8hV