### PR TITLE
Add email validation to references

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -1,6 +1,7 @@
 class Reference < ApplicationRecord
   validates :name, presence: true, length: { minimum: 2, maximum: 200 }
   validates :email_address, presence: true,
+                            email_address: true,
                             length: { maximum: 100 },
                             uniqueness: { scope: :application_form_id }
   validates :relationship, presence: true, length: { minimum: 2, maximum: 500 }

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,0 +1,7 @@
+class EmailAddressValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.blank? || !value.match?(/@/)
+      record.errors[attribute] << I18n.t('activerecord.errors.models.candidate.attributes.email_address.invalid')
+    end
+  end
+end

--- a/spec/validators/email_address_validator_spec.rb
+++ b/spec/validators/email_address_validator_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe EmailAddressValidator do
+  before do
+    stub_const('Validatable', Class.new).class_eval do
+      include ActiveModel::Validations
+      attr_accessor :email_address
+      validates :email_address, email_address: true
+    end
+  end
+
+  context 'when an email address is in an invalid format' do
+    let(:model) { Validatable.new }
+
+    before do
+      model.email_address = 'foo'
+      model.validate(:no_context)
+    end
+
+    it 'returns invalid' do
+      expect(model).not_to be_valid
+    end
+
+    it 'returns the correct error message' do
+      expect(model.errors[:email_address]).to include(t('activerecord.errors.models.candidate.attributes.email_address.invalid'))
+    end
+  end
+end


### PR DESCRIPTION
### Context
Validate email format for references

### Changes proposed in this pull request
Add rails email validation for references

### Guidance to review
Add a new reference with an invalid email address

### Link to Trello card
[392 - No email validation on 'Reference'](https://trello.com/c/Uz2Lohwl/392-no-email-validation-on-reference)

### Env vars
n/a
