### PR TITLE
Extract summary list into SummaryListComponent

### DIFF
--- a/app/components/summary_card_component.html.erb
+++ b/app/components/summary_card_component.html.erb
@@ -1,33 +1,6 @@
 <section class="app-summary-card govuk-!-margin-bottom-6 <%= border_css_class %>">
   <%= content %>
   <div class="app-summary-card__body">
-    <dl class="govuk-summary-list">
-      <% rows.each do |row| %>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            <%= row[:key] %>
-          </dt>
-          <dd class="govuk-summary-list__value">
-            <% if row[:value].is_a?(Array) %>
-              <% row[:value].each do |value| %><%= value %><br><% end %>
-            <% else %>
-              <%= simple_format row[:value], { class: 'govuk-body' } %>
-            <% end %>
-          </dd>
-
-          <% if row[:change_path] %>
-            <dd class="govuk-summary-list__actions">
-              <%= link_to row[:change_path], class: 'govuk-link' do %>
-                Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
-              <% end %>
-            </dd>
-          <% elsif row[:action_path] %>
-            <dd class="govuk-summary-list__actions">
-              <%= link_to row[:action], row[:action_path], class: 'govuk-link' %>
-            </dd>
-          <% end %>
-        </div>
-      <% end %>
-    </dl>
+    <%= render SummaryListComponent, rows: rows %>
   </div>
 </section>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -7,6 +7,8 @@
       <dd class="govuk-summary-list__value">
         <% if row[:value].is_a?(Array) %>
           <% row[:value].each do |value| %><%= value %><br><% end %>
+        <% elsif row[:value].html_safe? %>
+          <%= row[:value] %>
         <% else %>
           <%= simple_format row[:value], { class: 'govuk-body' } %>
         <% end %>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -1,0 +1,28 @@
+<dl class="govuk-summary-list">
+  <% rows.each do |row| %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        <%= row[:key] %>
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if row[:value].is_a?(Array) %>
+          <% row[:value].each do |value| %><%= value %><br><% end %>
+        <% else %>
+          <%= simple_format row[:value], { class: 'govuk-body' } %>
+        <% end %>
+      </dd>
+
+      <% if row[:change_path] %>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to row[:change_path], class: 'govuk-link' do %>
+            Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
+          <% end %>
+        </dd>
+      <% elsif row[:action_path] %>
+        <dd class="govuk-summary-list__actions">
+          <%= link_to row[:action], row[:action_path], class: 'govuk-link' %>
+        </dd>
+      <% end %>
+    </div>
+  <% end %>
+</dl>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -1,0 +1,11 @@
+class SummaryListComponent < ActionView::Component::Base
+  validates :rows, presence: true
+
+  def initialize(rows:)
+    @rows = rows
+  end
+
+private
+
+  attr_reader :rows
+end

--- a/spec/components/summary_card_component_spec.rb
+++ b/spec/components/summary_card_component_spec.rb
@@ -1,45 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe SummaryCardComponent do
-  it 'renders component with correct structure' do
+  it 'renders a summary list component for rows' do
     rows = [
       key: 'Name:',
-      value: 'Lando Calrissian',
-      action: 'Name',
-      change_path: '/some/url',
+      value: 'Lando Calrissian'
     ]
     result = render_inline(SummaryCardComponent, rows: rows)
 
-    expect(result.css('.govuk-summary-list__key').text).to include('Name:')
+    expect(result.css).to include('.govuk-summary-list')
     expect(result.css('.govuk-summary-list__value').text).to include('Lando Calrissian')
-    expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/some/url')
-    expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
-  end
-
-  it 'renders arrays content when passed in' do
-    rows = [
-      key: 'Address:',
-      value: ['Whoa Drive', 'Wewvile', 'London'],
-      action: 'Name',
-      change_path: '/some/url',
-    ]
-    result = render_inline(SummaryCardComponent, rows: rows)
-
-    expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
-  end
-
-  it 'renders component with correct struture using action_path' do
-    rows = [
-      key: 'Please enter the sound a cat makes',
-      value: 'Meow',
-      action: 'Enter cat sounds',
-      action_path: '/cat/sounds',
-    ]
-    result = render_inline(SummaryCardComponent, rows: rows)
-
-    expect(result.css('.govuk-summary-list__key').text).to include('Please enter the sound a cat makes')
-    expect(result.css('.govuk-summary-list__value').text).to include('Meow')
-    expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/cat/sounds')
-    expect(result.css('.govuk-summary-list__actions').text).to include('Enter cat sounds')
   end
 end

--- a/spec/components/summary_card_component_spec.rb
+++ b/spec/components/summary_card_component_spec.rb
@@ -1,14 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe SummaryCardComponent do
-  it 'renders a summary list component for rows' do
-    rows = [
-      key: 'Name:',
-      value: 'Lando Calrissian'
+  let(:rows) do
+    [
+      key: 'Character',
+      value: 'Lando Calrissian',
     ]
-    result = render_inline(SummaryCardComponent, rows: rows)
+  end
 
-    expect(result.css).to include('.govuk-summary-list')
+  it 'renders a summary list component for rows' do
+    result = render_inline(SummaryCardComponent, rows: rows)
     expect(result.css('.govuk-summary-list__value').text).to include('Lando Calrissian')
+    expect(result.css('.govuk-summary-list__key').text).to include('Character')
+  end
+
+  it 'renders content at the top of a summary card' do
+    result = render_inline(SummaryCardComponent, rows: rows) { 'In a galaxy' }
+    expect(result.text).to include('In a galaxy')
   end
 end

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe SummaryListComponent do
+  it 'renders component with correct structure' do
+    rows = [
+      key: 'Name:',
+      value: 'Lando Calrissian',
+      action: 'Name',
+      change_path: '/some/url',
+    ]
+    result = render_inline(SummaryListComponent, rows: rows)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Name:')
+    expect(result.css('.govuk-summary-list__value').text).to include('Lando Calrissian')
+    expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/some/url')
+    expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
+  end
+
+  it 'renders arrays content when passed in' do
+    rows = [
+      key: 'Address:',
+      value: ['Whoa Drive', 'Wewvile', 'London'],
+      action: 'Name',
+      change_path: '/some/url',
+    ]
+    result = render_inline(SummaryListComponent, rows: rows)
+
+    expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
+  end
+
+  it 'renders component with correct struture using action_path' do
+    rows = [
+      key: 'Please enter the sound a cat makes',
+      value: 'Meow',
+      action: 'Enter cat sounds',
+      action_path: '/cat/sounds',
+    ]
+    result = render_inline(SummaryListComponent, rows: rows)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Please enter the sound a cat makes')
+    expect(result.css('.govuk-summary-list__value').text).to include('Meow')
+    expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/cat/sounds')
+    expect(result.css('.govuk-summary-list__actions').text).to include('Enter cat sounds')
+  end
+end

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -42,4 +42,24 @@ RSpec.describe SummaryListComponent do
     expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/cat/sounds')
     expect(result.css('.govuk-summary-list__actions').text).to include('Enter cat sounds')
   end
+
+  it 'renders HTML in values when safe' do
+    rows = [
+      key: 'Safe',
+      value: '<span class="safe-html">This is safe</span>'.html_safe,
+    ]
+
+    result = render_inline(SummaryListComponent, rows: rows)
+    expect(result.css('.govuk-summary-list__value > .safe-html').text).to include('This is safe')
+  end
+
+  it 'uses simple_format to safely render unsafe HTML' do
+    rows = [
+      key: 'Unsafe',
+      value: '<span class="unsafe-html"><script>Unsafe</script></span>',
+    ]
+
+    result = render_inline(SummaryListComponent, rows: rows)
+    expect(result.css('.unsafe-html').to_html).to eq('<span class="unsafe-html">Unsafe</span>')
+  end
 end


### PR DESCRIPTION
Summary card now wraps a simpler lower level component that can be more aligned with https://design-system.service.gov.uk/components/summary-list/

We need this component for the provider interface.

- Extract component from SummaryCardComponent
- Expand test coverage of SummaryCardComponent
- Allow SummaryListComponent to receive and render safe HTML