### PR TITLE
Fix for grade error appearing when there is an error on the awarded year 

### DIFF
--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     validates :grade, length: { maximum: 6 }
     validate :award_year_is_date, if: :award_year
 
-    validate :validate_grade_format
+    validate :validate_grade_format, unless: :new_record?
 
     def self.build_from_qualification(qualification)
       new(
@@ -34,7 +34,7 @@ module CandidateInterface
     end
 
     def validate_grade_format
-      return if new_record? || qualification.qualification_type.nil?
+      return if qualification.qualification_type.nil? || qualification.qualification_type == 'other_uk'
 
       qualification_rexp = invalid_grades[qualification.qualification_type.to_sym]
 
@@ -56,6 +56,8 @@ module CandidateInterface
     end
 
     def log_validation_errors(field)
+      return unless errors.key?(field)
+
       error_message = {
         field: field.to_s,
         error_messages: errors[field].join(' - '),

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -383,11 +383,12 @@ en:
         candidate_interface/gcse_qualification_details_form:
           attributes:
             grade:
-              blank: Enter the grade
-              invalid: Enter a real graduation grade
+              blank: Enter your qualification grade
+              invalid: Enter a real qualification grade
+              too_long: Qualification grade must be %{count} characters or fewer
             award_year:
-              blank: Enter your graduation year
-              invalid: Enter a real graduation year
+              blank: Enter the year you gained your qualification
+              invalid: Enter a real year
         candidate_interface/gcse_qualification_type_form:
           attributes:
             qualification_type:

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
         invalid_grades.each do |grade|
           form.grade = grade
           form.validate
-          expect(form.errors[:grade]).to include('Enter a real graduation grade')
+          expect(form.errors[:grade]).to include('Enter a real qualification grade')
         end
       end
 
@@ -38,7 +38,7 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
         form.save_base
 
         expect(Rails.logger).to have_received(:info).with(
-          'Validation error: {:field=>"grade", :error_messages=>"Enter a real graduation grade", :value=>"XYZ"}',
+          'Validation error: {:field=>"grade", :error_messages=>"Enter a real qualification grade", :value=>"XYZ"}',
         )
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
           form.grade = grade
           form.validate
 
-          expect(form.errors[:grade]).to include('Enter a real graduation grade')
+          expect(form.errors[:grade]).to include('Enter a real qualification grade')
         end
       end
     end
@@ -92,7 +92,7 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
           form.grade = grade
           form.validate
 
-          expect(form.errors[:grade]).to include('Enter a real graduation grade')
+          expect(form.errors[:grade]).to include('Enter a real qualification grade')
         end
       end
     end


### PR DESCRIPTION
Fix for grade error appearing when there is an error on the awarded year
weird but true.

Thanks @chubberlisk and @tvararu for helping with this.

### Link to Trello card
No trello, but Racheal is aware of this.
