### PR TITLE
Use GOV.UK blue in the header

### DIFF
--- a/app/frontend/styles/_environments.scss
+++ b/app/frontend/styles/_environments.scss
@@ -1,11 +1,10 @@
-$app-colour-production: govuk-colour("red", $legacy: "bright-red");
 $app-colour-qa: govuk-colour("orange");
 $app-colour-sandbox: govuk-colour("bright-purple");
 $app-colour-staging: govuk-colour("red");
 $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 
 .app-header--production .govuk-header__container {
-  border-bottom-color: $app-colour-production;
+  // default blue styling
 }
 
 .app-header--qa .govuk-header__container {
@@ -26,7 +25,7 @@ $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 }
 
 .app-environment-tag--production {
-  background-color: $app-colour-production;
+  // default blue styling
 }
 
 .app-environment-tag--qa {


### PR DESCRIPTION
### Context

Somehow I made the production colour red - it should be the default blue.

### Changes proposed in this pull request

#### Before

![image](https://user-images.githubusercontent.com/233676/69159595-11742d80-0ae0-11ea-8bdf-cdc3e5e7c479.png)

#### After

![image](https://user-images.githubusercontent.com/233676/69159621-1f29b300-0ae0-11ea-8cdd-a9e466de935d.png)

### Link to Trello card

https://trello.com/c/GktNU8hV

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
