### PR TITLE
Update application presenter to display dual nationalities correctly

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -148,11 +148,10 @@ module VendorApi
     end
 
     def nationalities
-      nationalities_by_name = NATIONALITIES.map(&:reverse)
       [
         application_form.first_nationality,
         application_form.second_nationality,
-      ].map { |n| nationalities_by_name.to_h[n] }.compact
+      ].map { |n| NATIONALITIES_BY_NAME[n] }.compact
     end
 
     def course

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -148,12 +148,11 @@ module VendorApi
     end
 
     def nationalities
+      nationalities_by_name = NATIONALITIES.map(&:reverse)
       [
         application_form.first_nationality,
         application_form.second_nationality,
-      ].map { |n|
-        NATIONALITIES.to_h.invert[n]
-      }.compact
+      ].map { |n| nationalities_by_name.to_h[n] }.compact
     end
 
     def course

--- a/config/initializers/nationalities.rb
+++ b/config/initializers/nationalities.rb
@@ -225,4 +225,5 @@ NATIONALITIES = [
   ['ZW', 'Zimbabwean'],
 ].freeze
 
+NATIONALITIES_BY_NAME = NATIONALITIES.map(&:reverse).to_h
 NATIONALITY_DEMONYMS = NATIONALITIES.map(&:second)

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe VendorApi::SingleApplicationPresenter do
+  describe '#candidate' do
+    it 'returns nationality in the correct format' do
+      application_form = create(:completed_application_form) do |form|
+        form.first_nationality = 'British'
+        form.second_nationality = 'American'
+      end
+      application_choice = create(:application_choice, application_form: application_form)
+      single_application_presenter = VendorApi::SingleApplicationPresenter.new(application_choice)
+
+      expect(single_application_presenter.as_json[:attributes][:candidate][:nationality]).to eq(%w[GB US])
+    end
+  end
+end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Vendor receives the application' do
           first_name: 'Lando',
           last_name: 'Calrissian',
           date_of_birth: '1937-04-06',
-          nationality: %w[US], # TODO: BROKEN, should be [UK, US]
+          nationality: %w[GB US],
           uk_residency_status: nil,
           english_main_language: true,
           english_language_qualifications:  "I'm great at Galactic Basic so English is a piece of cake",


### PR DESCRIPTION
### Context

Nationality in the `SingleApplicationPresenter` was only showing one of the nationalities
when returning api response JSON. 

e.g. 
If a candidate has British and American dual nationality we expect he JSON response for nationality to be `["GB", "US"]`, but we only get `["US"]`.

### Changes proposed in this pull request

- Update `SingleApplicationPresenter` to return nationalities correctly.
- Update `system/vendor_api/vendor_receives_application_spec.rb` spec to assert on both nationalities.
- Add `SingleApplication` presenter to allow granular tests for `SingleApplicationPresenter`.

### Guidance to review

Run Specs and ensure both nationalities are being returned by the vendor api.

### Link to Trello card

[1250 - Return real data within the api response](https://trello.com/c/S43gJ9xx/1250-return-real-data-within-the-api-response)

### Env vars
