### PR TITLE
Parameterise instance sizes

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -5,7 +5,14 @@ parameters:
   environment:
   resourceEnvironmentName:
   serviceName:
+  redisCacheSKU: 'Basic'
+  redisCacheFamily: 'C'
+  redisCacheCapacity: 1
   containerImageReference:
+  ciClockCpus: '1'
+  ciClockMemory: '1.5'
+  ciWorkerCpus: '1'
+  ciWorkerMemory: '1.5'
   keyVaultName:
   keyVaultResourceGroup:
   customHostName:
@@ -76,6 +83,13 @@ jobs:
                 -keyVaultName "${{parameters.keyVaultName}}"
                 -keyVaultResourceGroup "${{parameters.keyVaultResourceGroup}}"
                 -customHostName "${{parameters.customHostName}}"
+                -redisCacheSKU ${{parameters.redisCacheSKU}}
+                -redisCacheFamily ${{parameters.redisCacheFamily}}
+                -redisCacheCapacity ${{parameters.redisCacheCapacity}}
+                -ciClockCpus ${{parameters.ciClockCpus}}
+                -ciClockMemory ${{parameters.ciClockMemory}}
+                -ciWorkerCpus ${{parameters.ciWorkerCpus}}
+                -ciWorkerMemory ${{parameters.ciWorkerMemory}}
                 -databaseName "${{parameters.databaseName}}"
                 -databaseUsername "${{parameters.databaseUsername}}"
                 -databasePassword "${{parameters.databasePassword}}"
@@ -121,7 +135,10 @@ jobs:
                   [string] $environment = "${{parameters.environment}}"
                 )
 
-                Set-AzureRmResourceGroup -Name $resourceGroupName -Tag @{ Environment= "$environment" }
+                Set-AzureRmResourceGroup -Name $resourceGroupName -Tag @{ 
+                  Version = "$(Build.SourceVersion)";
+                  Environment = "$environment"
+                }
 
 
           - task: AzureAppServiceManage@0

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -191,6 +191,8 @@ stages:
       environment: 'production'
       resourceEnvironmentName: 'p01'
       serviceName: 'apply'
+      redisCacheSKU: 'Premium'
+      redisCacheFamily: 'P'
       containerImageReference: '$(imageName):$(build.buildNumber)'
       keyVaultName: 's106p01-shared-kv-01'
       keyVaultResourceGroup: 's106p01-shared-rg'

--- a/azure/template.json
+++ b/azure/template.json
@@ -39,6 +39,59 @@
                 "description": "Environment for the rails app."
             }
         },
+        "redisCacheSKU": {
+            "type": "string",
+            "metadata": {
+                "description": "Redis Cache service tier."
+            },
+            "allowedValues": [
+              "Basic",
+              "Standard",
+              "Premium"
+            ]
+        },
+        "redisCacheFamily": {
+            "type": "string",
+            "metadata": {
+                "description": "Redis Cache family, C for basic/standard and P for premium."
+            },
+            "allowedValues": [
+              "C",
+              "P"
+            ]
+        },
+        "redisCacheCapacity": {
+            "type": "int",
+            "metadata": {
+                "description": "Redis Cache capacity, the larger the number the more performant the cache. For premium this value can only be from 1-5."
+            },
+            "minValue": 0,
+            "maxValue": 6 
+        },
+        "ciClockCpus": {
+            "type": "string",
+            "metadata": {
+                "description": "The number of CPU cores allocated to the Clock service container instance."
+            }
+        },
+        "ciClockMemory": {
+            "type": "string",
+            "metadata": {
+                "description": "The amount of memory (in GB) allocated to the Clock service container instance."
+            }
+        },
+        "ciWorkerCpus": {
+            "type": "string",
+            "metadata": {
+                "description": "The number of CPU cores allocated to the Worker service container instance."
+            }
+        },
+        "ciWorkerMemory": {
+            "type": "string",
+            "metadata": {
+                "description": "The amount of memory (in GB) allocated to the Worker service container instance."
+            }
+        },
         "databaseName": {
             "type": "string",
             "metadata": {
@@ -282,6 +335,15 @@
                 "parameters": {
                     "redisCacheName": {
                         "value": "[parameters('redisCacheName')]"
+                    },
+                    "redisCacheSKU": {
+                        "value": "[parameters('redisCacheSKU')]"
+                    },
+                    "redisCacheFamily": {
+                        "value": "[parameters('redisCacheFamily')]"
+                    },
+                    "redisCacheCapacity": {
+                        "value": "[parameters('redisCacheCapacity')]"
                     },
                     "enableNonSslPort": {
                         "value": true
@@ -530,6 +592,12 @@
                     "imageName": {
                         "value": "[variables('containerImageName')]"
                     },
+                    "numberCpuCores": {
+                        "value": "[parameters('ciWorkerCpus')]"
+                    },
+                    "memory": {
+                        "value": "[parameters('ciWorkerMemory')]"
+                    },
 		    "command": {
 		        "value": ["/bin/sh",  "-c", "bundle exec sidekiq -c 5"]
 		    },
@@ -643,6 +711,12 @@
                     },
                     "imageName": {
                         "value": "[variables('containerImageName')]"
+                    },
+                    "numberCpuCores": {
+                        "value": "[parameters('ciClockCpus')]"
+                    },
+                    "memory": {
+                        "value": "[parameters('ciClockMemory')]"
                     },
 		    "command": {
 		        "value": ["/bin/sh", "-c", "bundle exec clockwork config/clock.rb"]


### PR DESCRIPTION
### Context

This changes exposes the Redis and container instance resource size configuration as parameters in the ARM template allowing differing configurations to be deployed to each environment.
This change also introduces a version tag on resource groups to identify the version of the app deployed.

### Changes proposed in this pull request

- Clock and worker processes have 1vCPU and 1.5GB RAM each by default in all environments.
- Redis is configured to use the Basic C1 tier which grants a single node with 1GB cache and no persistence by default. Production is the only divergence from this, using the Premium P1 tier which grants multi-node resiliency with 6GB cache and persisted data.
- The resource group tags have been updated to include the git commit number in the `Version` tag.

### Guidance to review

N/A

### Link to Trello card

[1218 Implement Redis in Azure pipeline](https://trello.com/c/HNaSg3LV/1218-implement-redis-in-azure-pipeline)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
