### PR TITLE
Update contact_details_form to set country to UK for pilot

### DIFF
--- a/app/models/candidate_interface/contact_details_form.rb
+++ b/app/models/candidate_interface/contact_details_form.rb
@@ -40,6 +40,7 @@ module CandidateInterface
         address_line3: address_line3,
         address_line4: address_line4,
         postcode: postcode,
+        country: 'UK',
       )
     end
   end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature 'Vendor receives the application' do
           address_line3: 'London',
           address_line4: '',
           postcode: 'SW1P 3BT',
-          country: nil,
+          country: 'UK',
           email: @current_candidate.email_address,
         },
         course: {


### PR DESCRIPTION
## Context

For the Pilot all candidates are based in the UK, 
but are not asked this in the candidate form so is not saved to the Database.

### Changes proposed in this pull request

- Update the `contact_details_form` model to set the contact details country to the UK. 
- Update system spec to include country in assert.

### Guidance to review

Run spec and ensure `contact_details.country` is being set to `"UK"` in the database.

### Link to Trello card

[1250 - Return real data within the api response](https://trello.com/c/S43gJ9xx/1250-return-real-data-within-the-api-response)
