### PR TITLE
Show personal statement, language skills and references to providers

### DIFF
--- a/app/components/provider_interface/language_skills_component.html.erb
+++ b/app/components/provider_interface/language_skills_component.html.erb
@@ -1,0 +1,3 @@
+<div data-qa="language-skills">
+  <%= render SummaryListComponent, rows: rows %>
+</div>

--- a/app/components/provider_interface/language_skills_component.rb
+++ b/app/components/provider_interface/language_skills_component.rb
@@ -1,0 +1,50 @@
+module ProviderInterface
+  class LanguageSkillsComponent < ActionView::Component::Base
+    validates :application_form, presence: true
+
+    delegate :english_main_language,
+             :english_language_details,
+             :other_language_details,
+             to: :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def rows
+      [
+        english_main_language_row,
+        language_details_row,
+      ]
+    end
+
+  private
+
+    def english_main_language_row
+      {
+        key: t('application_form.personal_details.english_main_language.label'),
+        value: english_main_language ? 'Yes' : 'No',
+      }
+    end
+
+    def language_details_row
+      english_main_language ? english_main_language_details_row : other_language_details_row
+    end
+
+    def english_main_language_details_row
+      {
+        key: t('application_form.personal_details.english_main_language_details.label'),
+        value: english_language_details.present? ? english_language_details : 'No details given',
+      }
+    end
+
+    def other_language_details_row
+      {
+        key: t('application_form.personal_details.other_language_details.label'),
+        value: other_language_details.present? ? other_language_details : 'No details given',
+      }
+    end
+
+    attr_reader :application_form
+  end
+end

--- a/app/components/provider_interface/personal_statement_component.html.erb
+++ b/app/components/provider_interface/personal_statement_component.html.erb
@@ -1,0 +1,1 @@
+<%= render SummaryListComponent, rows: rows %>

--- a/app/components/provider_interface/personal_statement_component.rb
+++ b/app/components/provider_interface/personal_statement_component.rb
@@ -1,0 +1,40 @@
+module ProviderInterface
+  class PersonalStatementComponent < ActionView::Component::Base
+    validates :application_form, presence: true
+
+    delegate :becoming_a_teacher,
+             :subject_knowledge,
+             :interview_preferences,
+             :further_information,
+             to: :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def rows
+      [
+        {
+          key: t('application_form.personal_statement.becoming_a_teacher.label'),
+          value: becoming_a_teacher,
+        },
+        {
+          key: 'Subject knowledge',
+          value: subject_knowledge,
+        },
+        {
+          key: t('application_form.personal_statement.interview_preferences.label'),
+          value: interview_preferences.present? ? interview_preferences : 'No preference given',
+        },
+        {
+          key: 'Further information',
+          value: further_information.present? ? further_information : 'No further information given',
+        },
+      ]
+    end
+
+  private
+
+    attr_reader :application_form
+  end
+end

--- a/app/components/provider_interface/reference_component.html.erb
+++ b/app/components/provider_interface/reference_component.html.erb
@@ -1,0 +1,3 @@
+<div data-qa="reference">
+  <%= render SummaryListComponent, rows: rows %>
+</div>

--- a/app/components/provider_interface/reference_component.rb
+++ b/app/components/provider_interface/reference_component.rb
@@ -1,0 +1,56 @@
+module ProviderInterface
+  class ReferenceComponent < ActionView::Component::Base
+    validates :reference, presence: true
+
+    delegate :feedback,
+             :name,
+             :email_address,
+             :relationship,
+             to: :reference
+
+    def initialize(reference:)
+      @reference = reference
+    end
+
+    def rows
+      [
+        name_row,
+        email_address_row,
+        relationship_row,
+        feedback_row,
+      ]
+    end
+
+  private
+
+    def name_row
+      {
+        key: 'Name',
+        value: name,
+      }
+    end
+
+    def email_address_row
+      {
+        key: 'Email address',
+        value: email_address,
+      }
+    end
+
+    def relationship_row
+      {
+        key: 'Relationship to candidate',
+        value: relationship,
+      }
+    end
+
+    def feedback_row
+      {
+        key: 'Reference',
+        value: feedback,
+      }
+    end
+
+    attr_reader :reference
+  end
+end

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class ApplicationChoicePresenter
-    delegate :application_qualifications, to: :application_form
+    delegate :application_qualifications, :references, to: :application_form
     attr_reader :application_form
 
     def initialize(application_choice)
@@ -81,6 +81,14 @@ module ProviderInterface
 
     def other_qualifications
       application_qualifications.other
+    end
+
+    def first_reference
+      references.first
+    end
+
+    def second_reference
+      references.second
     end
 
   private

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ApplicationChoicePresenter
     delegate :application_qualifications, to: :application_form
+    attr_reader :application_form
 
     def initialize(application_choice)
       @application_choice = application_choice
@@ -84,6 +85,6 @@ module ProviderInterface
 
   private
 
-    attr_reader :application_choice, :application_form
+    attr_reader :application_choice
   end
 end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -91,3 +91,11 @@
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
 
 <%= render ProviderInterface::PersonalStatementComponent, application_form: @application_choice.application_form %>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-8" id="first-reference">First reference</h2>
+
+<%= render ProviderInterface::ReferenceComponent, reference: @application_choice.first_reference %>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-8" id="second-reference">Second reference</h2>
+
+<%= render ProviderInterface::ReferenceComponent, reference: @application_choice.second_reference %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -84,6 +84,10 @@
 <%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.gcses_or_equivalent, type_label: 'GCSE or equivalent' %>
 <%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.other_qualifications, type_label: 'Other qualification' %>
 
+<h2 class="govuk-heading-l govuk-!-margin-top-8" id="language-skills">Language skills</h2>
+
+<%= render ProviderInterface::LanguageSkillsComponent, application_form: @application_choice.application_form %>
+
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
 
 <%= render ProviderInterface::PersonalStatementComponent, application_form: @application_choice.application_form %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -83,3 +83,7 @@
 <%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.degrees, type_label: 'Degree' %>
 <%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.gcses_or_equivalent, type_label: 'GCSE or equivalent' %>
 <%= render ProviderInterface::QualificationsTableComponent, qualifications: @application_choice.other_qualifications, type_label: 'Other qualification' %>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
+
+<%= render ProviderInterface::PersonalStatementComponent, application_form: @application_choice.application_form %>

--- a/spec/components/provider_interface/language_skills_component_spec.rb
+++ b/spec/components/provider_interface/language_skills_component_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::LanguageSkillsComponent do
+  it 'renders other languages spoken when english is the main language' do
+    application_form = build_stubbed(
+      :application_form,
+      english_main_language: true,
+
+      # english_language_details collects information about other languages spoken
+      # FIXME: english_language_details and other_language_details are wrong way around in candidate form
+      english_language_details: 'Details about other languages spoken',
+    )
+
+    result = render_inline(described_class, application_form: application_form)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Is English your main language?')
+    expect(result.css('.govuk-summary-list__value').text).to include('Yes')
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Other languages spoken')
+    expect(result.css('.govuk-summary-list__value').text).to include('Details about other languages spoken')
+  end
+
+  it 'renders details about English when not the main language' do
+    application_form = build_stubbed(
+      :application_form,
+      english_main_language: false,
+
+      # other_language_details collects information and English skills
+      # FIXME: english_language_details and other_language_details are wrong way around in candidate form
+      other_language_details: 'Details about my English skills',
+    )
+
+    result = render_inline(described_class, application_form: application_form)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Is English your main language?')
+    expect(result.css('.govuk-summary-list__value').text).to include('No')
+
+    expect(result.css('.govuk-summary-list__key').text).to include('English language qualifications and other languages spoken')
+    expect(result.css('.govuk-summary-list__value').text).to include('Details about my English skills')
+  end
+
+  it 'indicates when an other language details has not been filled in' do
+    application_form = build_stubbed(
+      :application_form,
+      english_main_language: false,
+      other_language_details: '',
+    )
+
+    result = render_inline(described_class, application_form: application_form)
+    expect(result.css('.govuk-summary-list__value').text).to include('No details given')
+  end
+
+  it 'indicates when english language details has not been filled in' do
+    application_form = build_stubbed(
+      :application_form,
+      english_main_language: true,
+      english_language_details: '',
+    )
+
+    result = render_inline(described_class, application_form: application_form)
+    expect(result.css('.govuk-summary-list__value').text).to include('No details given')
+  end
+end

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Provider rejects application' do
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
   let(:application_awaiting_provider_decision) {
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
   }
 
   scenario 'Provider rejects application' do

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -6,10 +6,10 @@ RSpec.feature 'Provider responds to application' do
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
   let(:application_awaiting_provider_decision) {
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
   }
   let(:application_rejected) {
-    create(:application_choice, status: 'rejected', course_option: course_option, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
+    create(:application_choice, status: 'rejected', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
   }
 
   scenario 'Provider can respond to application currently awaiting_provider_decision' do

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -24,9 +24,9 @@ RSpec.feature 'See applications' do
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
 
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Alice', last_name: 'Wunder'))
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:application_form, first_name: 'Bob'))
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option, application_form: create(:application_form, first_name: 'Charlie'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Bob'))
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option, application_form: create(:completed_application_form, first_name: 'Charlie'))
   end
 
   def and_i_visit_the_provider_page

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'A Provider viewing an individual application' do
     then_i_should_see_the_candidates_degrees
     and_i_should_see_the_candidates_gcses
     and_i_should_see_the_candidates_other_qualifications
+
+    and_i_should_see_the_candidates_personal_statement
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
@@ -22,7 +24,11 @@ RSpec.describe 'A Provider viewing an individual application' do
 
   def and_my_organisation_has_received_an_application
     course_option = course_option_for_provider_code(provider_code: 'ABC')
-    application_form = create(:application_form)
+    application_form = create(:application_form,
+                              becoming_a_teacher: 'This is my personal statement',
+                              subject_knowledge: 'This is my subject knowledge',
+                              interview_preferences: 'Any date is fine',
+                              further_information: 'Nothing further to add')
 
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)
     create_list(:application_qualification, 2, application_form: application_form, level: :gcse)
@@ -48,5 +54,12 @@ RSpec.describe 'A Provider viewing an individual application' do
 
   def and_i_should_see_the_candidates_other_qualifications
     expect(page).to have_selector('[data-qa="qualifications-table-other-qualification"] tbody tr', count: 3)
+  end
+
+  def and_i_should_see_the_candidates_personal_statement
+    expect(page).to have_content 'This is my personal statement'
+    expect(page).to have_content 'This is my subject knowledge'
+    expect(page).to have_content 'Any date is fine'
+    expect(page).to have_content 'Nothing further to add'
   end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'A Provider viewing an individual application' do
     and_i_should_see_the_candidates_other_qualifications
 
     and_i_should_see_the_candidates_personal_statement
+    and_i_should_see_the_candidates_language_skills
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
@@ -28,7 +29,9 @@ RSpec.describe 'A Provider viewing an individual application' do
                               becoming_a_teacher: 'This is my personal statement',
                               subject_knowledge: 'This is my subject knowledge',
                               interview_preferences: 'Any date is fine',
-                              further_information: 'Nothing further to add')
+                              further_information: 'Nothing further to add',
+                              english_main_language: true,
+                              english_language_details: 'I also speak Spanish and German')
 
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)
     create_list(:application_qualification, 2, application_form: application_form, level: :gcse)
@@ -61,5 +64,12 @@ RSpec.describe 'A Provider viewing an individual application' do
     expect(page).to have_content 'This is my subject knowledge'
     expect(page).to have_content 'Any date is fine'
     expect(page).to have_content 'Nothing further to add'
+  end
+
+  def and_i_should_see_the_candidates_language_skills
+    within '[data-qa="language-skills"]' do
+      expect(page).to have_content 'Yes'
+      expect(page).to have_content 'I also speak Spanish and German'
+    end
   end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'A Provider viewing an individual application' do
 
     and_i_should_see_the_candidates_personal_statement
     and_i_should_see_the_candidates_language_skills
+    and_i_should_see_the_candidates_references
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
@@ -36,6 +37,20 @@ RSpec.describe 'A Provider viewing an individual application' do
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)
     create_list(:application_qualification, 2, application_form: application_form, level: :gcse)
     create_list(:application_qualification, 3, application_form: application_form, level: :other)
+
+    create(:reference,
+           application_form: application_form,
+           name: 'R2D2',
+           email_address: 'r2d2@rebellion.org',
+           relationship: 'Astromech droid',
+           feedback: 'beep boop beep')
+
+    create(:reference,
+           application_form: application_form,
+           name: 'C3PO',
+           email_address: 'c3p0@rebellion.org',
+           relationship: 'Companion droid',
+           feedback: 'The possibility of successfully navigating training is approximately three thousand seven hundred and twenty to one')
 
     @application_choice = create(:application_choice,
                                  status: 'awaiting_provider_decision',
@@ -71,5 +86,19 @@ RSpec.describe 'A Provider viewing an individual application' do
       expect(page).to have_content 'Yes'
       expect(page).to have_content 'I also speak Spanish and German'
     end
+  end
+
+  def and_i_should_see_the_candidates_references
+    expect(page).to have_selector('[data-qa="reference"]', count: 2)
+
+    expect(page).to have_content 'R2D2'
+    expect(page).to have_content 'r2d2@rebellion.org'
+    expect(page).to have_content 'Astromech droid'
+    expect(page).to have_content 'beep boop beep'
+
+    expect(page).to have_content 'C3PO'
+    expect(page).to have_content 'c3p0@rebellion.org'
+    expect(page).to have_content 'Companion droid'
+    expect(page).to have_content 'The possibility of successfully'
   end
 end


### PR DESCRIPTION
### Context

Further fields showing a candidate's application form to providers

### Changes proposed in this pull request

- Language skills
- Personal statement, subject knowledge, interview preferences and further information
- First and second references

### Note

The english_language_details are collected in the candidate side with a label asking for information about other languages. And the other_language_details are collected with a label asking for details about how well you speak English. ie They are the wrong way around.

I've tried to indicate this as best I can.

https://trello.com/c/lf08PU3R/1233-provider-can-view-an-application