### PR TITLE
Remove the provider question from the eligibility page

### DIFF
--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -10,7 +10,10 @@ module CandidateInterface
 
     def determine_eligibility
       @eligibility_form = EligibilityForm.new(eligibility_params)
-      if @eligibility_form.eligible_to_use_dfe_apply?
+
+      if !@eligibility_form.valid?
+        render :eligibility
+      elsif @eligibility_form.eligible_to_use_dfe_apply?
         redirect_to candidate_interface_sign_up_path
       else
         render :not_eligible
@@ -18,7 +21,7 @@ module CandidateInterface
     end
 
     def eligibility_params
-      params.require(:candidate_interface_eligibility_form).permit(:eligible_citizen, :eligible_qualifications)
+      params.fetch(:candidate_interface_eligibility_form, {}).permit(:eligible_citizen, :eligible_qualifications)
     end
   end
 end

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -18,7 +18,7 @@ module CandidateInterface
     end
 
     def eligibility_params
-      params.require(:candidate_interface_eligibility_form).permit(:eligible_citizen, :eligible_qualifications, :eligible_providers)
+      params.require(:candidate_interface_eligibility_form).permit(:eligible_citizen, :eligible_qualifications)
     end
   end
 end

--- a/app/models/candidate_interface/eligibility_form.rb
+++ b/app/models/candidate_interface/eligibility_form.rb
@@ -1,7 +1,9 @@
 module CandidateInterface
   class EligibilityForm
-    attr_accessor :eligible_citizen, :eligible_qualifications
     include ActiveModel::Model
+
+    attr_accessor :eligible_citizen, :eligible_qualifications
+    validates :eligible_citizen, :eligible_qualifications, presence: true
 
     def eligible_to_use_dfe_apply?
       eligible_citizen == 'yes' &&

--- a/app/models/candidate_interface/eligibility_form.rb
+++ b/app/models/candidate_interface/eligibility_form.rb
@@ -1,12 +1,11 @@
 module CandidateInterface
   class EligibilityForm
-    attr_accessor :eligible_citizen, :eligible_qualifications, :eligible_providers
+    attr_accessor :eligible_citizen, :eligible_qualifications
     include ActiveModel::Model
 
     def eligible_to_use_dfe_apply?
       eligible_citizen == 'yes' &&
-        eligible_qualifications == 'yes' &&
-        eligible_providers == 'yes'
+        eligible_qualifications == 'yes'
     end
   end
 end

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: CandidateInterface::EligibilityForm.new, url: candidate_interface_eligibility_path, method: :post do |f| %>
+    <%= form_with model: @eligibility_form, url: candidate_interface_eligibility_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK, EU or EEA?' } do %>

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -30,11 +30,6 @@
         </ul>
       <% end %>
 
-      <%= f.govuk_radio_buttons_fieldset :eligible_providers, inline: true, legend: { size: 'm', text: fieldset_label } do %>
-        <%= f.govuk_radio_button :eligible_providers, 'yes', label: { text: 'Yes' } %>
-        <%= f.govuk_radio_button :eligible_providers, 'no', label: { text: 'No' } %>
-      <% end %>
-
       <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -252,6 +252,12 @@ en:
   activemodel:
     errors:
       models:
+        candidate_interface/eligibility_form:
+          attributes:
+            eligible_citizen:
+              blank: Choose if you are a citizen of the UK, EU or EEA
+            eligible_qualifications:
+              blank: Choose if you gained all your qualifications at institutions based in the UK
         candidate_interface/personal_details_form:
           attributes:
             first_name:

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -47,7 +47,6 @@ RSpec.feature 'Candidate account' do
 
     find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
     find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
-    find('#candidate-interface-eligibility-form-eligible-providers-yes-field').click
 
     click_on 'Continue'
   end

--- a/spec/system/candidate_interface/candidate_eligibility_spec.rb
+++ b/spec/system/candidate_interface/candidate_eligibility_spec.rb
@@ -19,7 +19,6 @@ RSpec.feature 'Candidate eligibility' do
   def and_i_answer_no_to_some_questions
     find('#candidate-interface-eligibility-form-eligible-citizen-no-field').click
     find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
-    find('#candidate-interface-eligibility-form-eligible-providers-yes-field').click
     click_on 'Continue'
   end
 
@@ -30,7 +29,6 @@ RSpec.feature 'Candidate eligibility' do
   def when_i_answer_yes_to_all_questions
     find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
     find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
-    find('#candidate-interface-eligibility-form-eligible-providers-yes-field').click
     click_on 'Continue'
   end
 

--- a/spec/system/candidate_interface/candidate_eligibility_spec.rb
+++ b/spec/system/candidate_interface/candidate_eligibility_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.feature 'Candidate eligibility' do
   scenario 'Candidate confirms that they are eligible' do
     when_i_click_start_on_the_start_page
+    and_i_press_continue
+    then_i_see_validation_errors
     and_i_answer_no_to_some_questions
     then_i_should_be_redirected_to_ucas
 
@@ -14,6 +16,14 @@ RSpec.feature 'Candidate eligibility' do
   def when_i_click_start_on_the_start_page
     visit '/'
     click_on t('application_form.begin_button')
+  end
+
+  def and_i_press_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_validation_errors
+    expect(page).to have_content 'Choose if you are a citizen of the UK, EU or EEA'
   end
 
   def and_i_answer_no_to_some_questions


### PR DESCRIPTION
### Context

> Candidates may not know the name of providers, so it might put potential candidates off the service. It would be better to wait until we can build in the course selection feature pre-application. 

### Changes proposed in this pull request

- Remove the question
- Add validation

### Guidance to review

See the code.

https://trello.com/c/G4wVhS9J