### PR TITLE
Add guidance and hint text for GCSE qualifications

### DIFF
--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -7,6 +7,7 @@ module CandidateInterface
       @application_qualification = GcseQualificationDetailsForm.build_from_qualification(
         current_application.qualification_in_subject(:gcse, subject_param),
       )
+      @qualification_type = @application_qualification.qualification.qualification_type
     end
 
     def update

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -8,4 +8,17 @@ module GcseQualificationHelper
   def conditional_radios_for_gcse_qualifications
     { other_uk: [other_uk_qualification_type: 'Enter type of qualification'] }
   end
+
+  def guidance_for_gcse_edit_details(subject, qualification_type)
+    if I18n.exists?("gcse_edit_details.guidance.#{subject}.#{qualification_type}")
+      tag.p(t("gcse_edit_details.guidance.#{subject}.#{qualification_type}"), class: 'govuk-body')
+    end
+  end
+
+  def hint_for_gcse_edit_details(subject, qualification_type)
+    subject = subject == 'science' ? 'science' : 'other'
+    if I18n.exists?("gcse_edit_details.hint.#{subject}.#{qualification_type}")
+      t("gcse_edit_details.hint.#{subject}.#{qualification_type}")
+    end
+  end
 end

--- a/app/views/candidate_interface/gcse/details/edit.html.erb
+++ b/app/views/candidate_interface/gcse/details/edit.html.erb
@@ -10,7 +10,9 @@
 
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :grade, label: { text: 'Enter your qualification grade', size: 'm' }, width: 10 %>
+      <%= guidance_for_gcse_edit_details(@subject, @qualification_type) %>
+
+      <%= f.govuk_text_field :grade, label: { text: 'Enter your qualification grade', size: 'm' }, hint_text: hint_for_gcse_edit_details(@subject, @qualification_type), width: 10 %>
       <%= f.govuk_text_field :award_year, label: { text: 'Enter the year you gained your qualification', size: 'm' }, width: 4 %>
 
       <%= f.submit 'Save and continue', class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -400,7 +400,7 @@ en:
             qualification_type:
               blank: Enter the type of qualification
             other_uk_qualification_type:
-              blank: Enter the type of your degree
+              blank: Enter the type of qualification
               too_long: Type of degree must be %{count} characters or fewer
         candidate_interface/volunteering_experience_form:
           attributes:

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -14,6 +14,23 @@ en:
       maths: Maths qualification grade and year
       english: English qualification grade and year
       science: Science qualification grade and year
+    guidance:
+      english:
+        gcse: Enter your grade for English Language GCSE. If you have a GCSE in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.
+        gce_o_level: Enter your grade for English Language O level. If you have an O level in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.
+      science:
+        gcse: If you have a single, double (also known as combined) or triple GCSE in science, enter your total grade.
+        gce_o_level: If you have a single, double or triple O Level in science, enter your total grade.
+        scottish_national_5: If you studied three science subjects separately or took a general science qualification, enter your total grade.
+    hint:
+      science:
+        gcse: For example, ‘A*A*A*’, ‘AA’, ‘B’, ‘999’, ‘88’, ‘7’
+        gce_o_level: For example, ‘ABC’, ‘AA’, ‘B’
+        scottish_national_5: For example, ‘A*A*A*’, ‘ABC’, ‘A’, ‘777’, ‘654’, ‘6’
+      other:
+        gcse: For example, ‘C’ or ‘4’
+        gce_o_level: For example, ‘C’
+        scottish_national_5: For example, ‘C’ or ‘4’
   gcse_summary:
     heading:
       maths: Maths GCSE or equivalent

--- a/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
         form = CandidateInterface::GcseQualificationTypeForm.build_from_qualification(qualification)
 
         expect(form.valid?).to eq false
-        expect(form.errors[:other_uk_qualification_type]).to include('Enter the type of your degree')
+        expect(form.errors[:other_uk_qualification_type]).to include('Enter the type of qualification')
       end
     end
 


### PR DESCRIPTION
### Context

Adds guidance and hint text to GCSE qualification (grade and year) pages. This guidance varies depending on subject and/or qualification type. Also updates the qualification validation message on the previous page, which previously mentioned ‘degree’. 

### Changes proposed in this pull request

Here’s an example page:

![Screenshot](https://user-images.githubusercontent.com/813383/69171559-1fcc4480-0af4-11ea-8ec3-672f72325c65.png)

### Guidance to review

How could someone else check this work? Which parts do you want more feedback on?

### Link to Trello card

[415 - Add guidance and hint text for GCSE grades/subjects](415-add-guidance-and-hint-text-for-gcse-grades-subjects)