### PR TITLE
Redirect to dashboard if application is submitted

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -1,20 +1,18 @@
 module CandidateInterface
   class ApplicationFormController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted, only: %i[show review]
+
     def show
       return redirect_to candidate_interface_application_form_path if params[:token]
 
-      if current_application.submitted?
-        @application_form = current_application
-
-        render :complete
-      else
-        @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
-
-        render :show
-      end
+      @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
     end
 
     def review
+      @application_form = current_application
+    end
+
+    def complete
       @application_form = current_application
     end
 

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -10,6 +10,10 @@ module CandidateInterface
 
   private
 
+    def redirect_to_dashboard_if_submitted
+      redirect_to candidate_interface_application_complete_path if current_application.submitted?
+    end
+
     # controller-specific additional info to include in logstash logs
     def add_identity_to_log
       RequestLocals.store[:identity] = { candidate_id: current_candidate&.id }

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class ContactDetails::AddressController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class ContactDetails::BaseController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class ContactDetails::ReviewController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @application_form = current_application
     end

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class CourseChoicesController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def index
       @application_form = current_application
       @course_choices = current_candidate.current_application.application_choices

--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Degrees::BaseController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def new
       @degree = DegreeForm.new
 

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Degrees::ReviewController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @application_form = current_application
     end

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Gcse::DetailsController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     before_action :set_subject
 
     # 2nd step - Edit grade and award year

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Gcse::ReviewController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     before_action :set_subject
 
     def show

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class Gcse::TypeController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
 
     # 1th step - Edit qualification type

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class OtherQualifications::BaseController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def new
       qualifications = OtherQualificationForm.build_all_from_application(current_application)
 

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class OtherQualifications::DestroyController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def confirm_destroy
       @qualification = OtherQualificationForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class OtherQualifications::ReviewController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @application_form = current_application
     end

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def edit
       @personal_details_form = PersonalDetailsForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class PersonalStatement::BecomingATeacherController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def edit
       @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class PersonalStatement::InterviewPreferencesController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def edit
       @interview_preferences_form = InterviewPreferencesForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class PersonalStatement::SubjectKnowledgeController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def edit
       @subject_knowledge_form = SubjectKnowledgeForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class RefereesController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
     before_action :set_referee, only: %i[edit update confirm_destroy destroy]
     before_action :set_referees, only: %i[index review]
 

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Volunteering::BaseController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def new
       @volunteering_role = VolunteeringRoleForm.new
     end

--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Volunteering::DestroyController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def confirm_destroy
       @volunteering_role = VolunteeringRoleForm.build_from_application(current_application, current_volunteering_role_id)
     end

--- a/app/controllers/candidate_interface/volunteering/experience_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/experience_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Volunteering::ExperienceController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @volunteering_experience_form = VolunteeringExperienceForm.new
     end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class Volunteering::ReviewController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @application_form = current_application
     end

--- a/app/controllers/candidate_interface/work_history/breaks_controller.rb
+++ b/app/controllers/candidate_interface/work_history/breaks_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class WorkHistory::BreaksController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def edit
       @work_breaks_form = WorkBreaksForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/work_history/destroy_controller.rb
+++ b/app/controllers/candidate_interface/work_history/destroy_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class WorkHistory::DestroyController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def confirm_destroy
       @work_experience = current_application
         .application_work_experiences.find(work_experience_params[:id])

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class WorkHistory::EditController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def new
       @work_experience_form = WorkExperienceForm.new
     end

--- a/app/controllers/candidate_interface/work_history/explanation_controller.rb
+++ b/app/controllers/candidate_interface/work_history/explanation_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class WorkHistory::ExplanationController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @work_explanation_form = WorkExplanationForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/work_history/length_controller.rb
+++ b/app/controllers/candidate_interface/work_history/length_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class WorkHistory::LengthController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @work_details_form = WorkHistoryForm.new
     end

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class WorkHistory::ReviewController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_submitted
+
     def show
       @application_form = current_application
     end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -18,7 +18,7 @@ class ApplicationForm < ApplicationRecord
   }
 
   def submitted?
-    application_choices.any? && !application_choices.first.unsubmitted?
+    submitted_at.present?
   end
 
   def references_complete?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       get '/' => 'application_form#show', as: :application_form
       get '/review' => 'application_form#review', as: :application_review
       get '/review/submitted' => 'application_form#review_submitted', as: :application_review_submitted
+      get '/complete' => 'application_form#complete', as: :application_complete
       get '/submit' => 'application_form#submit_show', as: :application_submit_show
       post '/submit' => 'application_form#submit', as: :application_submit
       get '/submit-success' => 'application_form#submit_success', as: :application_submit_success

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -27,6 +27,12 @@ RSpec.feature 'Candidate submit the application' do
 
     when_i_click_view_application
     then_i_can_see_my_submitted_application
+
+    when_i_attempt_to_edit_my_personal_details
+    then_i_can_see_my_application_dashboard
+
+    when_i_attempt_to_edit_my_contact_details
+    then_i_can_see_my_application_dashboard
   end
 
   def given_i_am_signed_in
@@ -62,6 +68,14 @@ RSpec.feature 'Candidate submit the application' do
     candidate_fills_in_personal_details(scope: 'application_form.personal_details')
 
     click_button t('complete_form_button', scope: 'application_form.personal_details')
+  end
+
+  def when_i_attempt_to_edit_my_personal_details
+    visit candidate_interface_personal_details_edit_path
+  end
+
+  def when_i_attempt_to_edit_my_contact_details
+    visit candidate_interface_contact_details_edit_base_path
   end
 
   def and_i_filled_in_contact_details


### PR DESCRIPTION
### Context
Don't allow completed applications to be edited i.e. going direct to a URL

### Changes proposed in this pull request
Redirect all routes to dashboard if the application is `submitted?`

### Guidance to review
Complete an application then manually navigate to a route i.e. `/candidate/application/courses`

### Link to Trello card
[402 - For a submitted application, don't allow users to manually edit their application if they manually navigate to an edit page](https://trello.com/c/SfoKiwYW/402-for-a-submitted-application-dont-allow-users-to-manually-edit-their-application-if-they-manually-navigate-to-an-edit-page?menu=filter&filter=label:Dev)

### Env vars
n/a
