### PR TITLE
Add middleware for Sidekiq to set audited 'user'

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -17,6 +17,8 @@ module SupportInterface
         "#{audit.user.email_address} (Candidate)"
       elsif audit.user_type == 'VendorApiUser'
         "#{audit.user.email_address} (Vendor API)"
+      elsif audit.username.present?
+        audit.username
       else
         '(Unknown User)'
       end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+require 'workers/audit_trail_attribution_middleware'
+
+Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add Workers::AuditTrailAttributionMiddleware
+  end
+end

--- a/lib/workers/audit_trail_attribution_middleware.rb
+++ b/lib/workers/audit_trail_attribution_middleware.rb
@@ -2,7 +2,7 @@ module Workers
   class AuditTrailAttributionMiddleware
     def initialize(_options = nil); end
 
-    AUDIT_USER_NAME = '(GOV.UK Apply User)'.freeze
+    AUDIT_USER_NAME = '(Automated process)'.freeze
 
     def call(_worker, _msg, _queue)
       Audited.audit_class.as_user(AUDIT_USER_NAME) do

--- a/lib/workers/audit_trail_attribution_middleware.rb
+++ b/lib/workers/audit_trail_attribution_middleware.rb
@@ -1,0 +1,13 @@
+module Workers
+  class AuditTrailAttributionMiddleware
+    def initialize(_options = nil); end
+
+    AUDIT_USER_NAME = '(GOV.UK Apply User)'.freeze
+
+    def call(_worker, _msg, _queue)
+      Audited.audit_class.as_user(AUDIT_USER_NAME) do
+        yield
+      end
+    end
+  end
+end

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('alice@example.com (Vendor API)')
   end
 
+  it 'renders an update application form audit record with the "System" user' do
+    audit.user = nil
+    audit.username = 'SYSTEM'
+    audit.action = 'update'
+    expect(render_result.text).to include('Update Application Form')
+    expect(render_result.text).to include('SYSTEM')
+  end
+
   it 'renders an update application form audit record without a user' do
     audit.user = nil
     audit.action = 'update'


### PR DESCRIPTION
### Context

Audit trail entries triggered by Sidekiq workers appear 'user' label that indicates that they were made by the 'the system' rather than '(Unknown User)'.

### Changes proposed in this pull request

This PR adds a simple Sidekiq middleware that sets the username for `audited` to a well-known hard-coded label `(GOV.UK Apply User)`

![image](https://user-images.githubusercontent.com/450843/69223347-17ffb500-0b73-11ea-9574-43ca84e39801.png)

### Guidance to review

- Does this make sense?
- Is there are better solution?

### Link to Trello card

[1283 - Add audit trail attribution for changes triggered by Sidekiq workers](https://trello.com/c/7G78nd8S/1283-add-audit-trail-attribution-for-changes-triggered-by-sidekiq-workers)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
