### PR TITLE
Send slack notifications for application state changes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ LOGSTASH_REMOTE=false
 LOGSTASH_HOST=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx-ls.logit.io
 LOGSTASH_PORT=22513
 LOGSTASH_SSL=true
+STATE_CHANGE_SLACK_URL=
 DFE_SIGN_IN_CLIENT_ID=
 DFE_SIGN_IN_SECRET=
 DFE_SIGN_IN_ISSUER=https://signin-test-oidc-as.azurewebsites.net

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,3 @@ RSpec/PredicateMatcher:
 
 RSpec/DescribeClass:
   Enabled: false
-
-RSpec/MessageSpies:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,6 @@ RSpec/PredicateMatcher:
 
 RSpec/DescribeClass:
   Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem 'request_store_rails'
 gem 'sidekiq'
 gem 'clockwork'
 
+# For outgoing http requests
+gem 'http'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -163,6 +165,9 @@ GEM
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     ffi (1.11.2)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     foreman (0.86.0)
     formatador (0.2.5)
     gherkin (5.1.0)
@@ -195,6 +200,16 @@ GEM
     hashie (3.6.0)
     holidays (8.0.0)
     html_tokenizer (0.0.7)
+    http (4.2.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.0)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    http-form_data (2.1.1)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
@@ -432,6 +447,9 @@ GEM
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uk_postcode (2.1.5)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
@@ -490,6 +508,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder (= 1.0.0)
   guard-rspec
   holidays
+  http
   json-schema
   json_api_client
   launchy

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -1,0 +1,36 @@
+class StateChangeNotifier
+  def self.call(event, candidate: nil, application_choice: nil)
+    helpers = Rails.application.routes.url_helpers
+
+    if application_choice
+      provider_name = application_choice&.course&.provider&.name
+      applicant = application_choice&.application_form&.first_name
+      application_form_id = application_choice&.application_form&.id
+      course_name = application_choice&.course&.name_and_code
+    end
+
+    case event
+    when :magic_link_sign_up
+      text = "New sign-up [candidate_id: #{candidate&.id}]"
+      url = helpers.support_interface_applications_url
+    when :submit_application
+      text = "#{applicant} applied for #{course_name} with #{provider_name}"
+      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+    when :send_application_to_provider
+      text = "#{applicant}'s application is ready to be reviewed by #{provider_name}"
+      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+    when :make_an_offer
+      text = "#{provider_name} has just made an offer to #{applicant}'s application"
+      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+    when :reject_application
+      text = "#{provider_name} has just rejected #{applicant}'s application"
+      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+    when :reject_application_by_default
+      text = "#{applicant}'s application has just been rejected by default"
+      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+    else
+      raise 'StateChangeNotifier: unsupported state transition event'
+    end
+    SlackNotificationWorker.perform_async(text, url)
+  end
+end

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -3,31 +3,30 @@ class StateChangeNotifier
     helpers = Rails.application.routes.url_helpers
 
     if application_choice
-      provider_name = application_choice&.course&.provider&.name
-      applicant = application_choice&.application_form&.first_name
-      application_form_id = application_choice&.application_form&.id
-      course_name = application_choice&.course&.name_and_code
+      provider_name = application_choice.course.provider.name
+      applicant = application_choice.application_form.first_name
+      application_form_id = application_choice.application_form.id
     end
 
     case event
     when :magic_link_sign_up
-      text = "New sign-up [candidate_id: #{candidate&.id}]"
+      text = "New sign-up [candidate_id: #{candidate.id}]"
       url = helpers.support_interface_applications_url
     when :submit_application
-      text = "#{applicant} applied for #{course_name} with #{provider_name}"
-      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+      text = "#{applicant} has just submitted an application"
+      url = helpers.support_interface_application_form_url(application_form_id)
     when :send_application_to_provider
       text = "#{applicant}'s application is ready to be reviewed by #{provider_name}"
-      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+      url = helpers.support_interface_application_form_url(application_form_id)
     when :make_an_offer
       text = "#{provider_name} has just made an offer to #{applicant}'s application"
-      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+      url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application
       text = "#{provider_name} has just rejected #{applicant}'s application"
-      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+      url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application_by_default
       text = "#{applicant}'s application has just been rejected by default"
-      url = helpers.support_interface_application_form_url(application_form_id) rescue nil
+      url = helpers.support_interface_application_form_url(application_form_id)
     else
       raise 'StateChangeNotifier: unsupported state transition event'
     end

--- a/app/services/magic_link_sign_up.rb
+++ b/app/services/magic_link_sign_up.rb
@@ -3,5 +3,6 @@ class MagicLinkSignUp
     magic_link_token = MagicLinkToken.new
     AuthenticationMailer.sign_up_email(to: candidate.email_address, token: magic_link_token.raw).deliver_now
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
+    StateChangeNotifier.call(:magic_link_sign_up, candidate: candidate)
   end
 end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -18,6 +18,7 @@ class MakeAnOffer
     @application_choice.offer = { 'conditions' => (@offer_conditions || []) }
 
     @application_choice.save
+    StateChangeNotifier.call(:make_an_offer, application_choice: @application_choice)
   rescue Workflow::NoTransitionAllowed => e
     errors.add(:state, e.message)
     false

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -1,7 +1,7 @@
 class RejectApplication
-  attr_accessor :rejection_reason
-
   include ActiveModel::Validations
+
+  attr_accessor :rejection_reason
 
   validates_presence_of :rejection_reason
   validates_length_of :rejection_reason, maximum: 255
@@ -16,10 +16,10 @@ class RejectApplication
 
     ActiveRecord::Base.transaction do
       ApplicationStateChange.new(@application_choice).reject_application!
-
       @application_choice.update!(
         rejection_reason: @rejection_reason,
       )
+      StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
   rescue Workflow::NoTransitionAllowed => e
     errors.add(:state, e.message)

--- a/app/services/reject_application_by_default.rb
+++ b/app/services/reject_application_by_default.rb
@@ -9,6 +9,7 @@ class RejectApplicationByDefault
     ActiveRecord::Base.transaction do
       application_choice.update(rejected_by_default: true)
       ApplicationStateChange.new(application_choice).reject_application!
+      StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice)
     end
   end
 end

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -1,5 +1,6 @@
 # This worker will be scheduled to run nightly
 class SendApplicationToProvider
+  include Rails.application.routes.url_helpers
   attr_accessor :application_choice
 
   def initialize(application_choice:)
@@ -10,6 +11,7 @@ class SendApplicationToProvider
     ActiveRecord::Base.transaction do
       set_reject_by_default
       ApplicationStateChange.new(application_choice).send_to_provider!
+      StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice)
     end
   end
 

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -1,6 +1,5 @@
 # This worker will be scheduled to run nightly
 class SendApplicationToProvider
-  include Rails.application.routes.url_helpers
   attr_accessor :application_choice
 
   def initialize(application_choice:)

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -29,6 +29,16 @@ private
     application_choices.each do |application_choice|
       application_choice.edit_by = ApplicationDates.new(application_form).edit_by
       ApplicationStateChange.new(application_choice).submit!
+      StateChangeNotifier.call(:submit_application, application_choice: application_choice)
     end
+  end
+
+  def notify_slack
+    course_name = @application_choice&.course&.name_and_code
+    applicant = @application_choice&.application_form&.first_name
+    application_form_id = @application_choice&.application_form&.id
+    text = "#{applicant}'s application for #{course_name} has just been submitted"
+    url = support_interface_application_form_url(application_form_id) rescue nil
+    SlackNotificationWorker.perform_async(text, url)
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -15,6 +15,7 @@ class SubmitApplication
 
     CandidateMailer.submit_application_email(application_form).deliver_now
     send_reference_request_email_to_referees(application_form)
+    StateChangeNotifier.call(:submit_application, application_choice: application_choices.first)
   end
 
 private
@@ -29,16 +30,6 @@ private
     application_choices.each do |application_choice|
       application_choice.edit_by = ApplicationDates.new(application_form).edit_by
       ApplicationStateChange.new(application_choice).submit!
-      StateChangeNotifier.call(:submit_application, application_choice: application_choice)
     end
-  end
-
-  def notify_slack
-    course_name = @application_choice&.course&.name_and_code
-    applicant = @application_choice&.application_form&.first_name
-    application_form_id = @application_choice&.application_form&.id
-    text = "#{applicant}'s application for #{course_name} has just been submitted"
-    url = support_interface_application_form_url(application_form_id) rescue nil
-    SlackNotificationWorker.perform_async(text, url)
   end
 end

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -2,11 +2,11 @@ require 'http'
 
 class SlackNotificationWorker
   include Sidekiq::Worker
-  INCOMING_WEBHOOK_URL = ENV['STATE_CHANGE_SLACK_URL']
 
   def perform(text, url)
+    @webhook_url = ENV['STATE_CHANGE_SLACK_URL']
     Rails.logger.debug "State change notification: #{text}"
-    if !INCOMING_WEBHOOK_URL.blank?
+    if !@webhook_url.blank?
       message = hyperlink text, url
       post_to_slack message
     end
@@ -25,7 +25,7 @@ private
       text: text,
       mrkdwn: true,
     }
-    response = HTTP.post INCOMING_WEBHOOK_URL, body: payload.to_json
+    response = HTTP.post @webhook_url, body: payload.to_json
     Rails.logger.warn "Notification to slack failed: #{response.status}" if !response.status.success?
   rescue StandardError => e
     Rails.logger.warn "Notification to slack failed: #{e.message}"

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -1,0 +1,33 @@
+require 'http'
+
+class SlackNotificationWorker
+  include Sidekiq::Worker
+  INCOMING_WEBHOOK_URL = ENV['STATE_CHANGE_SLACK_URL']
+
+  def perform(text, url)
+    Rails.logger.debug "State change notification: #{text}"
+    if !INCOMING_WEBHOOK_URL.blank?
+      message = hyperlink text, url
+      post_to_slack message
+    end
+  end
+
+private
+
+  def hyperlink(text, url)
+    "<#{url}|#{text}>"
+  end
+
+  def post_to_slack(text)
+    payload = {
+      username: 'ApplyBot',
+      icon_emoji: ':parrot:',
+      text: text,
+      mrkdwn: true,
+    }
+    response = HTTP.post INCOMING_WEBHOOK_URL, body: payload.to_json
+    Rails.logger.warn "Notification to slack failed: #{response.status}" if !response.status.success?
+  rescue StandardError => e
+    Rails.logger.warn "Notification to slack failed: #{e.message}"
+  end
+end

--- a/azure/template.json
+++ b/azure/template.json
@@ -290,6 +290,12 @@
             "metadata": {
                 "description": "The URL of the DfE Sign-in OIDC interface (differs for test, pre-prod and prod)"
             }
+        },
+        "stateChangeSlackUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "Set this to a Slack incoming webhook url for application state change notifications"
+            }
         }
     },
     "variables": {
@@ -538,6 +544,10 @@
                                 "value": "[parameters('findBaseUrl')]"
                             },
                             {
+                                "name": "STATE_CHANGE_SLACK_URL",
+                                "value": "[parameters('stateChangeSlackUrl')]"
+                            },
+                            {
                                 "name": "SERVICE_TYPE",
                                 "value": "web"
                             },
@@ -676,6 +686,10 @@
                                 "value": "[parameters('findBaseUrl')]"
                             },
                             {
+                                "name": "STATE_CHANGE_SLACK_URL",
+                                "value": "[parameters('stateChangeSlackUrl')]"
+                            },
+                            {
                                 "name": "SERVICE_TYPE",
                                 "value": "worker"
                             },
@@ -794,6 +808,10 @@
                             {
                                 "name": "FIND_BASE_URL",
                                 "value": "[parameters('findBaseUrl')]"
+                            },
+                            {
+                                "name": "STATE_CHANGE_SLACK_URL",
+                                "value": "[parameters('stateChangeSlackUrl')]"
                             },
                             {
                                 "name": "SERVICE_TYPE",

--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,0 +1,4 @@
+uri = URI(HostingEnvironment.application_url)
+Rails.application.routes.default_url_options[:host] = uri.host
+Rails.application.routes.default_url_options[:port] = uri.port
+Rails.application.routes.default_url_options[:protocol] = uri.scheme

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -22,3 +22,4 @@ services:
       - LOGSTASH_HOST
       - LOGSTASH_PORT
       - LOGSTASH_SSL
+      - STATE_CHANGE_SLACK_URL

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe StateChangeNotifier do
+  let(:helpers) { Rails.application.routes.url_helpers }
+
+  describe '#call' do
+    let(:candidate)           { create(:candidate) }
+    let(:application_choice)  { create(:application_choice) }
+    let(:applicant)           { application_choice.application_form.first_name }
+    let(:provider_name)       { application_choice.course.provider.name }
+    let(:application_form_id) { application_choice.application_form.id }
+    let(:course_name)         { application_choice.course.name_and_code }
+
+    before { allow(SlackNotificationWorker).to receive(:perform_async) }
+
+    describe ':magic_link_sign_up' do
+      before { StateChangeNotifier.call(:magic_link_sign_up, candidate: candidate) }
+
+      it 'mentions the candidate\'s id' do
+        arg1 = "New sign-up [candidate_id: #{candidate.id}]"
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
+      end
+
+      it 'links the notification to support interface' do
+        arg2 = helpers.support_interface_applications_url
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
+      end
+    end
+
+    describe ':submit_application' do
+      before { StateChangeNotifier.call(:submit_application, application_choice: application_choice) }
+
+      it 'mentions applicant\'s first name, course name and provider name' do
+        arg1 = "#{applicant} applied for #{course_name} with #{provider_name}"
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        arg2 = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
+      end
+    end
+
+    describe ':send_application_to_provider' do
+      before { StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice) }
+
+      it 'mentions applicant\'s first name and provider name' do
+        arg1 = "#{applicant}'s application is ready to be reviewed by #{provider_name}"
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        arg2 = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
+      end
+    end
+
+    describe ':make_an_offer' do
+      before { StateChangeNotifier.call(:make_an_offer, application_choice: application_choice) }
+
+      it 'mentions applicant\s first name and provider name' do
+        arg1 = "#{provider_name} has just made an offer to #{applicant}'s application"
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        arg2 = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
+      end
+    end
+
+    describe ':reject_application' do
+      before { StateChangeNotifier.call(:reject_application, application_choice: application_choice) }
+
+      it 'mentions applicant\s first name and provider name' do
+        arg1 = "#{provider_name} has just rejected #{applicant}'s application"
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        arg2 = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
+      end
+    end
+
+    describe ':reject_application_by_default' do
+      before { StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice) }
+
+      it 'mentions applicant\s first name' do
+        arg1 = "#{applicant}'s application has just been rejected by default"
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        arg2 = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
+      end
+    end
+  end
+end

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe StateChangeNotifier do
     describe ':submit_application' do
       before { StateChangeNotifier.call(:submit_application, application_choice: application_choice) }
 
-      it 'mentions applicant\'s first name, course name and provider name' do
-        arg1 = "#{applicant} applied for #{course_name} with #{provider_name}"
+      it 'mentions applicant\'s first name' do
+        arg1 = "#{applicant} has just submitted an application"
         expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
       end
 

--- a/spec/services/magic_link_sign_up_spec.rb
+++ b/spec/services/magic_link_sign_up_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe MagicLinkSignUp do
+  describe 'Candidate signs up' do
+    let(:candidate) { create(:candidate) }
+
+    it 'sends a Slack notification' do
+      expect(SlackNotificationWorker).to receive(:perform_async)
+
+      MagicLinkSignUp.call(candidate: candidate)
+    end
+  end
+end

--- a/spec/services/magic_link_sign_up_spec.rb
+++ b/spec/services/magic_link_sign_up_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe MagicLinkSignUp do
     let(:candidate) { create(:candidate) }
 
     it 'sends a Slack notification' do
-      expect(SlackNotificationWorker).to receive(:perform_async)
-
+      allow(SlackNotificationWorker).to receive(:perform_async)
       MagicLinkSignUp.call(candidate: candidate)
+      expect(SlackNotificationWorker).to have_received(:perform_async)
     end
   end
 end

--- a/spec/services/reject_application_by_default_spec.rb
+++ b/spec/services/reject_application_by_default_spec.rb
@@ -28,4 +28,10 @@ RSpec.describe RejectApplicationByDefault do
     described_class.new(application_choice: application_choice).call
     expect(application_choice.reload.rejected_by_default).to be true
   end
+
+  it 'sends a Slack notification' do
+    expect(SlackNotificationWorker).to receive(:perform_async)
+    application_choice = create_application
+    described_class.new(application_choice: application_choice).call
+  end
 end

--- a/spec/services/reject_application_by_default_spec.rb
+++ b/spec/services/reject_application_by_default_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe RejectApplicationByDefault do
   end
 
   it 'sends a Slack notification' do
-    expect(SlackNotificationWorker).to receive(:perform_async)
+    allow(SlackNotificationWorker).to receive(:perform_async)
     application_choice = create_application
     described_class.new(application_choice: application_choice).call
+    expect(SlackNotificationWorker).to have_received(:perform_async)
   end
 end

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -33,8 +33,9 @@ RSpec.describe SendApplicationToProvider do
   end
 
   it 'sends a Slack notification' do
+    allow(SlackNotificationWorker).to receive(:perform_async)
     application_choice = create_application
-    expect(SlackNotificationWorker).to receive(:perform_async)
     SendApplicationToProvider.new(application_choice: application_choice).call
+    expect(SlackNotificationWorker).to have_received(:perform_async)
   end
 end

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -31,4 +31,10 @@ RSpec.describe SendApplicationToProvider do
     expect(application_choice.reload.reject_by_default_at.round).to eq 20.business_days.from_now.end_of_day.round
     expect(application_choice.reject_by_default_days).to eq 20
   end
+
+  it 'sends a Slack notification' do
+    application_choice = create_application
+    expect(SlackNotificationWorker).to receive(:perform_async)
+    SendApplicationToProvider.new(application_choice: application_choice).call
+  end
 end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -26,5 +26,10 @@ RSpec.describe SubmitApplication do
         expect(application_form.application_choices[1].edit_by).to eq expected_edit_by
       end
     end
+
+    it 'sends Slack notifications' do
+      expect(SlackNotificationWorker).to receive(:perform_async).twice # two application choices
+      SubmitApplication.new(application_form).call
+    end
   end
 end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -28,8 +28,9 @@ RSpec.describe SubmitApplication do
     end
 
     it 'sends Slack notifications' do
-      expect(SlackNotificationWorker).to receive(:perform_async).twice # two application choices
+      allow(SlackNotificationWorker).to receive(:perform_async)
       SubmitApplication.new(application_form).call
+      expect(SlackNotificationWorker).to have_received(:perform_async).once # per application_form, not application_choices
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'sidekiq/testing'
 require 'clockwork/test'
 require 'audited-rspec'
 ENV['SERVICE_TYPE'] = 'test' # this is used for logging
+ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotificationWorker do
+  include TestHelpers::LoggingHelper
+  let(:rails_config) { environment_config_double }
+
+  describe 'SlackNotificationWorker' do
+    let(:text) { 'example text' }
+    let(:url) { 'https://example.com/support' }
+    let(:output) { capture_logstash_output(rails_config) { invoke_worker } }
+
+    def invoke_worker
+      SlackNotificationWorker.new.perform(text, url)
+    end
+
+    it 'logs it has run to the default Rails logger' do
+      expect(output).not_to be_blank
+    end
+
+    it 'includes the text supplied in the log' do
+      expect(output).to match(text)
+    end
+
+    it 'does not send a Slack notification if STATE_CHANGE_SLACK_URL is empty' do
+      stub_const('SlackNotificationWorker::INCOMING_WEBHOOK_URL', nil)
+      expect(HTTP).not_to receive(:post)
+      invoke_worker
+    end
+
+    context 'when STATE_CHANGE_SLACK_URL is set' do
+      before do
+        stub_const('SlackNotificationWorker::INCOMING_WEBHOOK_URL', 'https://example.com/webhook')
+      end
+
+      it 'sends a Slack notification to this webhook' do
+        expect(HTTP).to receive(:post)
+        invoke_worker
+      end
+
+      it 'warns about Slack notification failures in the logs' do
+        allow(HTTP).to receive(:post).and_raise(StandardError)
+        expect(output).to match(/Notification to slack failed/)
+      end
+
+      it 'includes hyperlinked text, a username and an emoji' do
+        expect(HTTP).to receive(:post).with \
+          'https://example.com/webhook',
+          body: '{"username":"ApplyBot","icon_emoji":":parrot:","text":"\u003chttps://example.com/support|example text\u003e","mrkdwn":true}'
+        invoke_worker
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

During the pilot, we'll be monitoring every single application manually. To do so, we have decided to post Slack notifications every time one of the following actions occur:

- New account creation
- SubmitApplication (status: ```awaiting_references```)
- SendApplicationToProvider (status: ```awaiting_provider_decision```)
- MakeAnOffer (status: ```offer```)
- RejectApplication (status: ```rejected```)

Additional requirements:

- Notification must be sent as a background job
- No PII is included within the notification or the job logs
- Notification must contain link to relevant support interface
- Notification must contain the candidate's first name (only)
- Notifications from production and non-production environments reach different channels

Slack supports incoming webhooks tied to specific channels, so we have decided to use this notification mechanism.

### Guidance to review

Make sure you set ```STATE_CHANGE_SLACK_URL``` in your environment, for example by adding:

```STATE_CHANGE_SLACK_URL=https://hooks.slack.com/services/T50RKXXXX/BQNXXXXXX/U8GLIeYxIp88kW1JXXXXXXXX```

to your ```.env.development``` (dm me for the actual url). You'll need to restart your rails server so that the relevant initialisation happens.

You can then trigger application state changes in the app and watch the relevant Slack notifications come in. The webhook url is hard-coded to a specific Slack channel (when you dm me I'll also invite you to the channel). We'll have separate channels for production and non-production environments.

If you do not set STATE_CHANGE_SLACK_URL, these notifications are disabled, but Rails will still log the notification text when loglevel is ```:debug```.

### Link to Trello card

[1269 - Slack notifications for application state changes](https://trello.com/c/jOrJD6W9)

### Env vars

A new environment variable is introduced:

```STATE_CHANGE_SLACK_URL```

If this is not set, Slack notifications for state changes are disabled.

- [x] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)

