### PR TITLE
Set the `rejected_by_default` flag

### DIFF
--- a/app/services/reject_application_by_default.rb
+++ b/app/services/reject_application_by_default.rb
@@ -6,6 +6,9 @@ class RejectApplicationByDefault
   end
 
   def call
-    ApplicationStateChange.new(application_choice).reject_application!
+    ActiveRecord::Base.transaction do
+      application_choice.update(rejected_by_default: true)
+      ApplicationStateChange.new(application_choice).reject_application!
+    end
   end
 end

--- a/features/reject_by_default.feature
+++ b/features/reject_by_default.feature
@@ -20,3 +20,4 @@ Feature: Reject by default
     When the date is "2019-07-14"
     And the daily application cron job has run
     Then the new application choice status is "rejected"
+    And the application choice is flagged as rejected by default

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -63,6 +63,10 @@ Then('the new application choice status is {string}') do |new_application_status
   expect(@application_choice.reload.status).to eq(new_application_status.parameterize(separator: '_'))
 end
 
+Then('the application choice is flagged as rejected by default') do
+  expect(@application_choice.reload.rejected_by_default).to be true
+end
+
 When(/^the candidate submits a complete application with reference feedback$/) do
   steps %{
     When an application choice has "unsubmitted" status

--- a/spec/services/reject_application_by_default_spec.rb
+++ b/spec/services/reject_application_by_default_spec.rb
@@ -22,4 +22,10 @@ RSpec.describe RejectApplicationByDefault do
     described_class.new(application_choice: application_choice).call
     expect(application_choice.reload.status).to eq 'rejected'
   end
+
+  it 'sets `rejected_by_default` to `true`' do
+    application_choice = create_application
+    described_class.new(application_choice: application_choice).call
+    expect(application_choice.reload.rejected_by_default).to be true
+  end
 end


### PR DESCRIPTION
### Context

This is a follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/517

Applications that are rejected automatically after a time limit (reject by default) are set to the `rejected` status but there is nothing to distinguish them from applications that were manually rejected by a provider. So that we can report on say the percentage of rejected applications that are being rejected by default we need to record this information in the database.

### Changes proposed in this pull request

- Set the `ApplicationChoice#rejected_by_default` boolean attribute to `true` if and only if an application is automatically rejected.

### Guidance to review

- does this change make sense?
- are there any edge cases that could cause issues?

### Link to Trello card

[1280 - Add Boolean attribute to distinguish application choices that have been rejected by default](https://trello.com/c/VrqWtwch/1280-add-boolean-attribute-to-distinguish-application-choices-that-have-been-rejected-by-default)

### Env vars

no new env vars