### PR TITLE
Make start page links accessible, be consistent in use of numerals

### DIFF
--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -24,12 +24,12 @@
       Before you start a teacher training course, your training provider will usually send you a health questionnaire to complete. This confirms you have the fitness and physical capacity to start training.
     </p>
     <h2 class="govuk-heading-m">If you have a disability</h2>
-      <p class="govuk-body">It is against the law for training providers to discriminate against teacher training candidates with disabilities or special educational needs. <%= govuk_link_to 'Learn more', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>.</p>
+      <p class="govuk-body">It is against the law for training providers to discriminate against teacher training candidates with disabilities or special educational needs. <%= govuk_link_to 'Learn more about training to teach if you have a disability', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>.</p>
 
     <h2 class="govuk-heading-m">If you do not have a degree</h2>
     <p class="govuk-body">
       You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status.
-      <%= govuk_link_to('Learn more', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
+      <%= govuk_link_to('Learn more about eligibility for teacher training', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
     </p>
     <%= link_to candidate_interface_eligibility_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>

--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -7,7 +7,7 @@ Using Apply for teacher training means you agree to these terms of use.
 
 ### Stage 1: submitting your initial application(s)
 
-During the first round of your application, you should apply to no more than three courses in total, whether you use Apply for teacher training, UCAS Teacher Training, or a combination of the two.
+During the first round of your application, you should apply to no more than 3 courses in total, whether you use Apply for teacher training, UCAS Teacher Training, or a combination of the two.
 
 **You can only accept 1 offer**, even if you use both services.
 
@@ -71,5 +71,5 @@ Contact [Get Into Teaching](https://getintoteaching.education.gov.uk/get-help-an
 chat service](https://getintoteaching.education.gov.uk/lp/live-chat).
 
 We typically respond within one working day for urgent queries. It can take up
-to five working days for less urgent queries. Unfortunately, we can’t provide
+to 5 working days for less urgent queries. Unfortunately, we can’t provide
 support over the weekend.


### PR DESCRIPTION
Two small content tweaks.

Use numerals not words:
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#numbers
We were doing this inconsistently (eg five working days and 5 working days in same document)

Expand learn more links to make them accessible:
- Base link text on titles of the GiT pages being linked to
- Avoid generic "Learn more" as the links don't make sense out of context, eg when using a screen reader (especially relevant for disability link)
