### PR TITLE
Map DfE Sign-in UIDs to providers

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -8,18 +8,8 @@ module ProviderInterface
 
   private
 
-    # Stub out the current user and their organisation. Will be replaced
-    # by a proper ProviderUser when implementing Signin.
     def current_provider_user
-      if session['provider_user']
-        fake_user_class = Struct.new(:provider, :email_address)
-        fake_provider = Provider.find_by(code: 'ABC')
-
-        fake_user_class.new(
-          fake_provider,
-          session['provider_user']['email_address'],
-        )
-      end
+      ProviderUser.load_from_session(session)
     end
 
     def authenticate_provider_user!

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -6,11 +6,8 @@ module ProviderInterface
     def new; end
 
     def callback
-      auth_hash = request.env['omniauth.auth']
-
-      session['provider_user'] = {
-        'email_address' => auth_hash['info']['email'],
-      }
+      dfe_sign_in_session = DfESignIn.parse_auth_hash(request.env['omniauth.auth'])
+      ProviderUser.begin_session!(session, dfe_sign_in_session)
 
       redirect_to provider_interface_path
     end

--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -4,7 +4,7 @@ module DfESignIn
   def self.parse_auth_hash(openid_auth_hash)
     DfESignInSession.new(
       openid_auth_hash['info']['email'],
-      openid_auth_hash['uid']
+      openid_auth_hash['uid'],
     )
   end
 

--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -1,4 +1,13 @@
 module DfESignIn
+  DfESignInSession = Struct.new(:email_address, :uid)
+
+  def self.parse_auth_hash(openid_auth_hash)
+    DfESignInSession.new(
+      openid_auth_hash['info']['email'],
+      openid_auth_hash['uid']
+    )
+  end
+
   def self.bypass?
     Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,5 +1,5 @@
 class ProviderUser
-  attr_reader :email_address
+  attr_reader :email_address, :dfe_sign_in_uid
 
   def self.begin_session!(session, dfe_sign_in_session)
     session['provider_user'] = {
@@ -23,6 +23,11 @@ class ProviderUser
   end
 
   def provider
-    Provider.find_by(code: 'ABC')
+    provider_code = Rails.application.config.provider_permissions
+      .select { |_code, permitted_uids| permitted_uids.include? dfe_sign_in_uid }
+      .keys
+      .first
+
+    Provider.find_by(code: provider_code)
   end
 end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,0 +1,28 @@
+class ProviderUser
+  attr_reader :email_address
+
+  def self.begin_session!(session, dfe_sign_in_session)
+    session['provider_user'] = {
+      'email_address' => dfe_sign_in_session.email_address,
+      'dfe_sign_in_uid' => dfe_sign_in_session.uid,
+    }
+  end
+
+  def self.load_from_session(session)
+    if session['provider_user']
+      new(
+        email_address: session['provider_user']['email_address'],
+        dfe_sign_in_uid: session['provider_user']['dfe_sign_in_uid'],
+      )
+    end
+  end
+
+  def initialize(email_address:, dfe_sign_in_uid:)
+    @email_address = email_address
+    @dfe_sign_in_uid = dfe_sign_in_uid
+  end
+
+  def provider
+    Provider.find_by(code: 'ABC')
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,6 +33,7 @@ module ApplyForPostgraduateTeacherTraining
     config.action_mailer.preview_path = "#{Rails.root}/app/mailers/previews"
 
     config.providers_to_sync = config_for(:providers_to_sync)
+    config.provider_permissions = config_for(:provider_permissions)
 
     config.time_zone = 'London'
 

--- a/config/provider_permissions.yml
+++ b/config/provider_permissions.yml
@@ -1,0 +1,5 @@
+development: &default
+  ABC:
+    - 'ABC' # Set this as the UID when bypassing DfE Sign-in to see applications for provider code ABC
+
+production:

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -1,7 +1,7 @@
 module DfESignInHelpers
-  def provider_exists_in_dfe_sign_in(email_address: 'email@provider.ac.uk')
+  def provider_exists_in_dfe_sign_in(email_address: 'email@provider.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
-      fake_dfe_sign_in_auth_hash(email_address: email_address),
+      fake_dfe_sign_in_auth_hash(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid),
     )
   end
 
@@ -10,10 +10,10 @@ module DfESignInHelpers
     click_link 'Sign in using DfE Sign-in'
   end
 
-  def fake_dfe_sign_in_auth_hash(email_address:)
+  def fake_dfe_sign_in_auth_hash(email_address:, dfe_sign_in_uid:)
     {
       'provider' => 'dfe',
-      'uid' => 'DFE_SIGN_IN_UID',
+      'uid' => dfe_sign_in_uid,
       'info' => {
         'name' => 'Firstname Lastname',
         'email' => email_address,
@@ -35,7 +35,7 @@ module DfESignInHelpers
       'extra' => {
         'raw_info' => {
           'email' => email_address,
-          'sub' => 'DFE_SIGN_IN_UID',
+          'sub' => dfe_sign_in_uid,
         },
       },
     }

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -1,12 +1,43 @@
 module DfESignInHelpers
-  def provider_exists_in_dfe_sign_in(email: 'email@example.com')
+  def provider_exists_in_dfe_sign_in(email_address: 'email@provider.ac.uk')
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
-      info: { email: email },
+      fake_dfe_sign_in_auth_hash(email_address: email_address),
     )
   end
 
   def provider_signs_in_using_dfe_sign_in
     visit provider_interface_path
     click_link 'Sign in using DfE Sign-in'
+  end
+
+  def fake_dfe_sign_in_auth_hash(email_address:)
+    {
+      'provider' => 'dfe',
+      'uid' => 'DFE_SIGN_IN_UID',
+      'info' => {
+        'name' => 'Firstname Lastname',
+        'email' => email_address,
+        'nickname' => nil,
+        'first_name' => 'Firstname',
+        'last_name' => 'Lastname',
+        'gender' => nil,
+        'image' => nil,
+        'phone' => nil,
+        'urls' => { 'website' => nil },
+      },
+      'credentials' => {
+        'id_token' => '',
+        'token' => 'DFE_SIGN_IN_TOKEN',
+        'refresh_token' => nil,
+        'expires_in' => 3600,
+        'scope' => 'email openid',
+      },
+      'extra' => {
+        'raw_info' => {
+          'email' => email_address,
+          'sub' => 'DFE_SIGN_IN_UID',
+        },
+      },
+    }
   end
 end

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
   end
 
   def given_i_have_a_dfe_sign_in_account
-    provider_exists_in_dfe_sign_in(email: 'user@provider.com')
+    provider_exists_in_dfe_sign_in(email_address: 'user@provider.com')
   end
 
   def when_i_visit_the_provider_interface

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -6,15 +6,24 @@ RSpec.feature 'See applications' do
 
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
     and_my_organisation_has_accredited_courses_with_applications
+
     and_i_visit_the_provider_page
     then_i_should_see_the_applications_from_my_organisation
     but_not_the_applications_from_other_providers
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-    provider_exists_in_dfe_sign_in
+    @dfe_sign_in_uid = 'MY_SIGN_IN_UID'
+
+    provider_exists_in_dfe_sign_in(dfe_sign_in_uid: @dfe_sign_in_uid)
     provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    allow(Rails.application.config).to receive(:provider_permissions)
+      .and_return(ABC: [@dfe_sign_in_uid])
   end
 
   def and_my_organisation_has_accredited_courses_with_applications

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -7,7 +7,9 @@ RSpec.feature 'See applications' do
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_applications
-    and_i_visit_the_provider_page
+    and_i_am_permitted_to_see_applications_for_my_provider
+
+    when_i_visit_the_provider_page
     then_i_should_see_the_applications_from_my_organisation
     but_not_the_applications_from_other_providers
 
@@ -16,8 +18,15 @@ RSpec.feature 'See applications' do
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-    provider_exists_in_dfe_sign_in
+    @dfe_sign_in_uid = 'MY_SIGN_IN_UID'
+
+    provider_exists_in_dfe_sign_in(dfe_sign_in_uid: @dfe_sign_in_uid)
     provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    allow(Rails.application.config).to receive(:provider_permissions)
+      .and_return(ABC: [@dfe_sign_in_uid])
   end
 
   def and_my_organisation_has_applications
@@ -29,7 +38,7 @@ RSpec.feature 'See applications' do
     create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option, application_form: create(:application_form, first_name: 'Charlie'))
   end
 
-  def and_i_visit_the_provider_page
+  def when_i_visit_the_provider_page
     visit provider_interface_path
   end
 

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -4,16 +4,15 @@ RSpec.feature 'See providers' do
   include FindAPIHelper
 
   scenario 'User visits providers page' do
-    given_providers_are_configured_to_be_synced do
-      given_i_am_a_support_user
-      when_i_visit_the_providers_page
-      and_i_click_the_sync_button
-      then_requests_to_find_should_be_made
-      and_i_should_see_the_updated_list_of_providers
+    given_i_am_a_support_user
+    and_providers_are_configured_to_be_synced
+    when_i_visit_the_providers_page
+    and_i_click_the_sync_button
+    then_requests_to_find_should_be_made
+    and_i_should_see_the_updated_list_of_providers
 
-      when_i_click_on_a_provider
-      then_i_see_the_providers_courses_and_sites
-    end
+    when_i_click_on_a_provider
+    then_i_see_the_providers_courses_and_sites
   end
 
   def given_i_am_a_support_user
@@ -24,13 +23,9 @@ RSpec.feature 'See providers' do
     visit support_interface_providers_path
   end
 
-  def given_providers_are_configured_to_be_synced
-    former_provider_list = Rails.application.config.providers_to_sync
-    new_provider_list = { codes: %w[ABC DEF GHI] }
-
-    Rails.application.config.providers_to_sync = new_provider_list
-    yield
-    Rails.application.config.providers_to_sync = former_provider_list
+  def and_providers_are_configured_to_be_synced
+    allow(Rails.application.config).to receive(:providers_to_sync)
+      .and_return(codes: %w[ABC DEF GHI])
   end
 
   def then_i_should_see_the_providers


### PR DESCRIPTION
### Context

When a provider logs in via DfE Sign-in (DSI), we need to show them only relevant applications.

### Changes proposed in this pull request

1. Pull code related to parsing DSI payloads out of the SessionsController and into a namespace. We also start using realistic test data for these payloads
1. Introduce `ProviderUser`, a map of `email_address` and `dfe_sign_in_uid` which lives in the session
1. Implement `ProviderUser#provider`, which takes the `dfe_sign_in_uid` and looks it up from a YAML mapping of provider codes to DSI UIDs. As we've been stubbing this interface so far then no further changes are required to keep the tests passing 🎉 

#### Notes

1. We do not yet support multiple providers per user.
1. The configuration uses Rails's `config_for` to maintain separate dev and prod editions of the data.
1. A convenience mapping is added for development where entering 'ABC' as the DSI Uid when bypassing DSI will let you see all the applications for our go-to default provider ABC.

### Link to Trello cards

https://trello.com/c/6SndwNfI/1241-integrate-provider-interface-with-dfe-sign-in

### Env vars

- N/A