### PR TITLE
Don't try to disable RSpec/DescribeClass twice in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,10 +34,6 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
-RSpec/DescribeClass:
-  Exclude:
-    - 'spec/system/**/*'
-
 RSpec/ContextWording:
   Enabled: false
 


### PR DESCRIPTION
It's already disabled at the bottom.

Without this fix `rubocop` prints an error on every run, which makes my text editor's linting plugin unhappy.