### PR TITLE
Remove whitespacing for award year of a degree

### DIFF
--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -41,6 +41,7 @@ module CandidateInterface
         :id, :qualification_type, :subject, :institution_name, :grade, :other_grade,
         :predicted_grade, :award_year
       )
+        .transform_values(&:strip)
     end
 
     def render_new

--- a/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
@@ -86,7 +86,8 @@ RSpec.feature 'Entering their degrees' do
 
     choose t('application_form.degree.grade.first.label')
 
-    fill_in t('application_form.degree.award_year.label'), with: '2009'
+    year_with_preceding_space = ' 2009'
+    fill_in t('application_form.degree.award_year.label'), with: year_with_preceding_space
   end
 
   def then_i_can_check_my_undergraduate_degree


### PR DESCRIPTION
### Context

If candidates enter " 2020" this is not accepted. We should allow this input and removing the whitespacing before and after if any.

### Changes proposed in this pull request

This PR adds a `.strip` when validating and saving the award year in `DegreeForm`.

### Guidance to review

Does it make sense?

### Link to Trello card

[408 - Update saving graduation year in degrees to remove whitespacing](https://trello.com/c/zUZ966Vg/408-update-saving-graduation-year-in-degrees-to-remove-whitespacing)
