### PR TITLE
Add ability to view application from application dashboard

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -38,6 +38,10 @@ module CandidateInterface
       @support_reference = current_application.support_reference
     end
 
+    def review_submitted
+      @application_form = current_application
+    end
+
   private
 
     def further_information_params

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,0 +1,53 @@
+<h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
+
+<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
+
+<h3 class="govuk-heading-m">Personal details</h3>
+
+<%= render(PersonalDetailsReviewComponent, application_form: application_form, editable: editable) %>
+
+<h3 class="govuk-heading-m">Contact details</h3>
+
+<%= render(ContactDetailsReviewComponent, application_form: application_form, editable: editable) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
+
+<%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
+
+<%= render(VolunteeringReviewComponent, application_form: application_form, editable: editable) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
+
+<h3 class="govuk-heading-m">Degree(s)</h3>
+
+<%= render(DegreesReviewComponent, application_form: application_form, editable: editable) %>
+
+<h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
+
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable) %>
+
+<h3 class="govuk-heading-m">English GCSE or equivalent</h3>
+
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable) %>
+
+<h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
+
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable) %>
+
+<h3 class="govuk-heading-m">Other relevant qualifications</h3>
+
+<%= render(OtherQualificationsReviewComponent, application_form: application_form, editable: editable) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
+
+<%= render(BecomingATeacherReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(SubjectKnowledgeReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(InterviewPreferencesReviewComponent, application_form: application_form, editable: editable) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
+
+<%= render(RefereesReviewComponent, application_form: application_form, editable: editable) %>

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -4,7 +4,7 @@
   <%= t('page_titles.application_dashboard') %>
 </h1>
 <p class="govuk-body govuk-hint govuk-!-margin-bottom-8">
-  Application submitted on <%= submitted_at_date %>.
+  Application submitted on <%= submitted_at_date %>. <%= govuk_link_to 'View application', candidate_interface_application_review_submitted_path %>
 </p>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -5,58 +5,6 @@
   <%= t('review_application.heading') %>
 </h1>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
-
-<%= render(CourseChoicesReviewComponent, application_form: @application_form) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
-
-<h3 class="govuk-heading-m">Personal details</h3>
-
-<%= render(PersonalDetailsReviewComponent, application_form: @application_form) %>
-
-<h3 class="govuk-heading-m">Contact details</h3>
-
-<%= render(ContactDetailsReviewComponent, application_form: @application_form) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
-
-<%= render(WorkHistoryReviewComponent, application_form: @application_form) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
-
-<%= render(VolunteeringReviewComponent, application_form: @application_form) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
-
-<h3 class="govuk-heading-m">Degree(s)</h3>
-
-<%= render(DegreesReviewComponent, application_form: @application_form) %>
-
-<h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
-
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.maths_gcse, subject: 'maths') %>
-
-<h3 class="govuk-heading-m">English GCSE or equivalent</h3>
-
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.english_gcse, subject: 'english') %>
-
-<h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
-
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science') %>
-
-<h3 class="govuk-heading-m">Other relevant qualifications</h3>
-
-<%= render(OtherQualificationsReviewComponent, application_form: @application_form) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
-
-<%= render(BecomingATeacherReviewComponent, application_form: @application_form) %>
-<%= render(SubjectKnowledgeReviewComponent, application_form: @application_form) %>
-<%= render(InterviewPreferencesReviewComponent, application_form: @application_form) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
-
-<%= render(RefereesReviewComponent, application_form: @application_form) %>
+<%= render 'review', application_form: @application_form, editable: true %>
 
 <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_application_submit_show_path %>

--- a/app/views/candidate_interface/application_form/review_submitted.html.erb
+++ b/app/views/candidate_interface/application_form/review_submitted.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, t('page_titles.submitted_application') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application dashboard') %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.submitted_application') %>
+</h1>
+
+<dl class="govuk-summary-list app-summary">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Date submitted
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= submitted_at_date %>
+    </dd>
+  </div>
+</dl>
+
+<%= render 'review', application_form: @application_form, editable: false %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
     application_dashboard: Application dashboard
     eligibility: First, check you can use the new GOV.UK service
     not_eligible_yet: We’re sorry, but we’re not ready for you yet
+    submitted_application: Your submitted application
     sign_up: Create an account
     sign_in: Sign in
     check_your_email: Check your email

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,7 @@ Rails.application.routes.draw do
     scope '/application' do
       get '/' => 'application_form#show', as: :application_form
       get '/review' => 'application_form#review', as: :application_review
+      get '/review/submitted' => 'application_form#review_submitted', as: :application_review_submitted
       get '/submit' => 'application_form#submit_show', as: :application_submit_show
       post '/submit' => 'application_form#submit', as: :application_submit
       get '/submit-success' => 'application_form#submit_success', as: :application_submit_success

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -5,10 +5,8 @@ RSpec.feature 'Candidate submit the application' do
 
   scenario 'Candidate with personal details and contact details' do
     given_i_am_signed_in
-    and_i_have_chosen_a_course
-    and_i_filled_in_personal_details
-    and_i_filled_in_contact_details
-    and_i_gave_two_referees
+    and_i_have_completed_my_application
+
     and_reviewed_my_application
     and_i_confirm_my_application
 
@@ -25,11 +23,18 @@ RSpec.feature 'Candidate submit the application' do
     and_my_referees_receive_a_request_for_a_reference_by_email
 
     when_i_click_on_track_your_application
+    then_i_can_see_my_application_dashboard
+
+    when_i_click_view_application
     then_i_can_see_my_submitted_application
   end
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_i_have_completed_my_application
+    candidate_completes_application_form
   end
 
   def and_i_have_chosen_a_course
@@ -131,11 +136,30 @@ RSpec.feature 'Candidate submit the application' do
     click_link t('submit_application_success.track_your_application')
   end
 
-  def then_i_can_see_my_submitted_application
+  def then_i_can_see_my_application_dashboard
     this_day = Time.now.strftime('%-e %B %Y')
     expect(page).to have_content t('page_titles.application_dashboard')
     expect(page).to have_content "Application submitted on #{this_day}"
     expect(page).to have_content 'Gorse SCITT'
     expect(page).to have_content current_candidate.current_application.references.first.name
+  end
+
+  def when_i_click_view_application
+    click_link 'View application'
+  end
+
+  def then_i_can_see_my_submitted_application
+    expect(page).to have_content t('page_titles.submitted_application')
+    expect(page).to have_content Time.now.strftime('%-e %B %Y')
+    expect(page).to have_content 'Gorse SCITT'
+    expect(page).to have_content 'Lando Calrissian'
+    expect(page).to have_content '07700 900 982'
+    expect(page).to have_content 'Classroom Volunteer'
+    expect(page).to have_content 'BA Doge'
+    expect(page).to have_content 'A-Level Believing in the Heart of the Cards'
+    expect(page).to have_content 'I WANT I WANT I WANT I WANT'
+    expect(page).to have_content 'Everything'
+    expect(page).to have_content 'NOT WEDNESDAY'
+    expect(page).to have_content 'Terri Tudor'
   end
 end


### PR DESCRIPTION
### Context

When a candidate has submitted their application, they should be able to view it from their `Application dashboard`.

### Changes proposed in this pull request

This PR adds a link from the `Application dashboard` to view their application. A partial has been created that renders all the review component as this is very similar to when a candidate review their application _before_ submission.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/69231267-b34b5700-0b80-11ea-9654-8731a40695bf.png)

![image](https://user-images.githubusercontent.com/42817036/69231292-be05ec00-0b80-11ea-88a1-ff3d4d75bb30.png)

### Guidance to review

Nothing in particular.

### Link to Trello card

[359 - Build dashboard for candidates after they've submitted](https://trello.com/c/8NgjUhNG/359-build-dashboard-for-candidates-after-theyve-submitted)
