### PR TITLE
Upgraded Redis instance to premium tier in staging environment.

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -54,6 +54,8 @@ stages:
       environment: 'staging'
       resourceEnvironmentName: 't01'
       serviceName: 'apply'
+      redisCacheSKU: 'Premium'
+      redisCacheFamily: 'P'
       containerImageReference: '$(imageName):$(build.buildNumber)'
       keyVaultName: 's106t01-shared-kv-01'
       keyVaultResourceGroup: 's106t01-shared-rg'


### PR DESCRIPTION
### Context

Staging environment should align with production in terms of instance sizes, which currently isn't the case for the Redis instance size.

### Changes proposed in this pull request

Configure staging environment to use the Redis P1 tier size.

### Guidance to review

N/A

### Link to Trello card

N/A

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
