### PR TITLE
Validate email_address format when signing up

### DIFF
--- a/app/models/candidate_interface/sign_up_form.rb
+++ b/app/models/candidate_interface/sign_up_form.rb
@@ -5,6 +5,7 @@ module CandidateInterface
     attr_accessor :email_address, :accept_ts_and_cs
     validates :email_address, :accept_ts_and_cs, presence: true
     validates :email_address, length: { maximum: 250 }
+    validates :email_address, email_address: true
 
 
     def save(candidate)

--- a/spec/models/candidate_interface/sign_up_form_spec.rb
+++ b/spec/models/candidate_interface/sign_up_form_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::SignUpForm, type: :model do
   let(:valid_email) { Faker::Internet.email }
-  let(:invalid_email) { Faker::Lorem.characters(number: 251) }
+  let(:too_long_email) { Faker::Lorem.characters(number: 251) }
+  let(:wrong_format_email) { 'abc' }
   let(:given_email) { valid_email }
   let(:candidate) { build_stubbed(:candidate, email_address: given_email) }
 
@@ -24,8 +25,8 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
       allow(candidate).to receive(:update!)
     end
 
-    context 'when email_address is invalid' do
-      let(:given_email) { invalid_email }
+    context 'when email_address is too long' do
+      let(:given_email) { too_long_email }
 
       it 'returns false' do
         expect(the_form.save(candidate)).to eq(false)
@@ -76,6 +77,7 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
     it { is_expected.to validate_presence_of(:email_address) }
 
     it { is_expected.to allow_value('test@example.com').for(:email_address) }
-    it { is_expected.not_to allow_value(invalid_email).for(:email_address) }
+    it { is_expected.not_to allow_value(too_long_email).for(:email_address) }
+    it { is_expected.not_to allow_value(wrong_format_email).for(:email_address) }
   end
 end


### PR DESCRIPTION
### Context

This is currently used for referees, but is useful for signup too.

### Guidance to review

Uses the validator from https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/573.

### After

![Screenshot 2019-11-20 at 12 16 35](https://user-images.githubusercontent.com/1650875/69238820-c0704200-0b90-11ea-8834-b6f126ffac65.png)


### Link to Trello card

[392 - Add email validation on 'Reference' and Signup](https://trello.com/c/Uz2Lohwl/392-add-email-validation-on-reference-and-signup)