### PR TITLE
Allow ProviderUsers to sign out

### DIFF
--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -12,6 +12,12 @@ module ProviderInterface
       redirect_to provider_interface_path
     end
 
+    def destroy
+      ProviderUser.end_session!(session)
+
+      redirect_to action: :new
+    end
+
     alias :bypass_callback :callback
   end
 end

--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,9 +1,11 @@
 require.context("govuk-frontend/govuk/assets");
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
+import Rails from "@rails/ujs";
 import initNationalityAutocomplete from "./nationality-autocomplete";
 
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import "../styles/application.scss";
 govUKFrontendInitAll();
+Rails.start();
 
 initNationalityAutocomplete();

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -17,6 +17,10 @@ class ProviderUser
     end
   end
 
+  def self.end_session!(session)
+    session.delete('provider_user')
+  end
+
   def initialize(email_address:, dfe_sign_in_uid:)
     @email_address = email_address
     @dfe_sign_in_uid = dfe_sign_in_uid

--- a/app/views/layouts/_provider_header.html.erb
+++ b/app/views/layouts/_provider_header.html.erb
@@ -5,7 +5,7 @@
     </li>
 
     <li class="govuk-header__navigation-item">
-      <%= link_to 'Sign out', provider_interface_sign_out_path, class: 'govuk-header__link' %>
+      <%= link_to 'Sign out', provider_interface_sign_out_path, method: 'delete', class: 'govuk-header__link' %>
     </li>
   </ul>
 <% end %>

--- a/app/views/layouts/_provider_header.html.erb
+++ b/app/views/layouts/_provider_header.html.erb
@@ -3,5 +3,9 @@
     <li class="govuk-header__navigation-item">
       <b><%= current_provider_user.email_address %></b>
     </li>
+
+    <li class="govuk-header__navigation-item">
+      <%= link_to 'Sign out', provider_interface_sign_out_path, class: 'govuk-header__link' %>
+    </li>
   </ul>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -212,6 +212,7 @@ Rails.application.routes.draw do
     post '/applications/:application_choice_id/reject' => 'decisions#create_reject', as: :application_choice_create_reject
 
     get '/sign-in' => 'sessions#new'
+    get '/sign-out' => 'sessions#destroy'
   end
 
   get '/auth/dfe/callback' => 'provider_interface/sessions#callback'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,6 +213,7 @@ Rails.application.routes.draw do
 
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
+    delete '/sign-out' => 'sessions#destroy'
   end
 
   get '/auth/dfe/callback' => 'provider_interface/sessions#callback'

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "apply-for-postgraduate-teacher-training",
   "private": true,
   "dependencies": {
+    "@rails/ujs": "^6.0.1",
     "@rails/webpacker": "^4.0.7",
     "accessible-autocomplete": "^2.0.1",
     "govuk-frontend": "^3.4.0"

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -11,6 +11,9 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
 
     then_i_should_be_redirected_to_the_provider_dashboard
     and_i_should_see_my_email_address
+
+    when_i_click_sign_out
+    then_i_should_see_the_login_page_again
   end
 
   def given_i_have_a_dfe_sign_in_account
@@ -29,5 +32,13 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
 
   def and_i_should_see_my_email_address
     expect(page).to have_content('user@provider.com')
+  end
+
+  def when_i_click_sign_out
+    click_link 'Sign out'
+  end
+
+  def then_i_should_see_the_login_page_again
+    expect(page).to have_content('Sign in using DfE Sign-in')
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,6 +680,11 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@rails/ujs@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.1.tgz#5eb013bd7f18a1cc7c314602d3b4d68302e20b60"
+  integrity sha512-IwUGMGke2u5W/hkJLOSU5xcQT3Y0gjIdiEsG27kHyLvsPOzdABKeAD8l37j6romhzeCmM56Wv52OGqSueUmyig==
+
 "@rails/webpacker@^4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-4.0.7.tgz#268571bf974e78ce57eca9fa478f5bd97fd5182c"


### PR DESCRIPTION
Only GET, as the benefits of DELETE (HTTP semantics, CSRF protection) aren't critical and they require `rails-ujs` which is a bit heavy for all that

![Screenshot 2019-11-20 at 12 25 30](https://user-images.githubusercontent.com/642279/69240555-a2a4dc00-0b94-11ea-9716-3dbcd3e2eafb.png)

https://trello.com/c/6SndwNfI/1241-integrate-provider-interface-with-dfe-sign-in