### PR TITLE
Use correct time formatting for last saved date

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     end
 
     def updated_at
-      "Last saved on #{@application_form.updated_at.strftime('%d %B %Y')} at #{@application_form.updated_at.strftime('%H:%M %p')}"
+      "Last saved on #{@application_form.updated_at.strftime('%d %B %Y')} at #{@application_form.updated_at.strftime('%l:%M%P')}"
     end
 
     def application_choices_added?


### PR DESCRIPTION
- We don't need 24 hour and am/pm
- am/pm should be lowercase
- no need to zero pad hours below 10 (eg 09)

09:43 AM becomes 9:43am
13:20 PM becomes 1:20pm

Matches GOV.UK style:
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#times