### PR TITLE
Use a nested factory, not a trait, to create completed_application_forms

### DIFF
--- a/spec/components/becoming_a_teacher_review_component_spec.rb
+++ b/spec/components/becoming_a_teacher_review_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BecomingATeacherReviewComponent do
-  let(:application_form) { create(:application_form, :completed_application_form) }
+  let(:application_form) { create(:completed_application_form) }
 
   context 'when becoming a teacher is editable' do
     it 'renders SummaryCardComponent with valid becoming a teacher' do

--- a/spec/components/interview_preferences_review_component_spec.rb
+++ b/spec/components/interview_preferences_review_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe InterviewPreferencesReviewComponent do
-  let(:application_form) { create(:application_form, :completed_application_form) }
+  let(:application_form) { create(:completed_application_form) }
 
   context 'when interview preferences is editable' do
     it 'renders SummaryCardComponent with valid becoming a teacher' do

--- a/spec/components/subject_knowledge_review_component_spec.rb
+++ b/spec/components/subject_knowledge_review_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SubjectKnowledgeReviewComponent do
-  let(:application_form) { create(:application_form, :completed_application_form) }
+  let(:application_form) { create(:completed_application_form) }
 
   context 'when subject knowledge is editable' do
     it 'renders SummaryCardComponent with valid becoming a teacher' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
   factory :application_form do
     candidate
 
-    trait :completed_application_form do
+    factory :completed_application_form do
       first_name { Faker::Name.first_name }
       last_name { Faker::Name.last_name }
       date_of_birth { Faker::Date.birthday }
@@ -42,9 +42,7 @@ FactoryBot.define do
         qualifications_count { 4 }
         references_count { 2 }
       end
-    end
 
-    factory :completed_application_form, traits: [:completed_application_form] do
       after(:build) do |application_form, evaluator|
         create_list(:application_choice, evaluator.application_choices_count, application_form: application_form)
         create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)


### PR DESCRIPTION
- It was confusing to have a trait with the same name as the factory
- Almost all callers used the factory anyway. A few used the
`:application_form` factory and added the trait, which was equivalent but
needlessly verbose. 

props @fofr for pointing out unnecessary complexity 🙂 