### PR TITLE
Revert "Add rails-ujs to support DELETE links"

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,11 +1,9 @@
 require.context("govuk-frontend/govuk/assets");
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
-import Rails from "@rails/ujs";
 import initNationalityAutocomplete from "./nationality-autocomplete";
 
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import "../styles/application.scss";
 govUKFrontendInitAll();
-Rails.start();
 
 initNationalityAutocomplete();

--- a/app/views/layouts/_provider_header.html.erb
+++ b/app/views/layouts/_provider_header.html.erb
@@ -5,7 +5,7 @@
     </li>
 
     <li class="govuk-header__navigation-item">
-      <%= link_to 'Sign out', provider_interface_sign_out_path, method: 'delete', class: 'govuk-header__link' %>
+      <%= link_to 'Sign out', provider_interface_sign_out_path, class: 'govuk-header__link' %>
     </li>
   </ul>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -213,7 +213,6 @@ Rails.application.routes.draw do
 
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
-    delete '/sign-out' => 'sessions#destroy'
   end
 
   get '/auth/dfe/callback' => 'provider_interface/sessions#callback'

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "apply-for-postgraduate-teacher-training",
   "private": true,
   "dependencies": {
-    "@rails/ujs": "^6.0.1",
     "@rails/webpacker": "^4.0.7",
     "accessible-autocomplete": "^2.0.1",
     "govuk-frontend": "^3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -680,11 +680,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@rails/ujs@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.1.tgz#5eb013bd7f18a1cc7c314602d3b4d68302e20b60"
-  integrity sha512-IwUGMGke2u5W/hkJLOSU5xcQT3Y0gjIdiEsG27kHyLvsPOzdABKeAD8l37j6romhzeCmM56Wv52OGqSueUmyig==
-
 "@rails/webpacker@^4.0.7":
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-4.0.7.tgz#268571bf974e78ce57eca9fa478f5bd97fd5182c"


### PR DESCRIPTION
This reverts commit 1d00041361820fb99d9e7494b7eb2681a8cb85ae.

Following deployment to QA candidate sign in was broken in Safari. Removing `Rails.start()` from the js file seems to fix it. UJS is not a hard requirement, so we are rolling it back to fix the build.