### PR TITLE
Fix template error caused by job with `nil` `end_date`

### DIFF
--- a/app/services/check_breaks_in_work_history.rb
+++ b/app/services/check_breaks_in_work_history.rb
@@ -4,16 +4,15 @@ class CheckBreaksInWorkHistory
       jobs = application_form.application_work_experiences.sort_by(&:start_date)
 
       return false if jobs.empty?
-      return break_between_only_job_and_current_date?(jobs.first) if jobs.one?
 
       jobs.each_cons(2).any? do |first_job, next_job|
         month_or_more_break_between?(first_job, next_job)
-      end
+      end || break_between_job_and_current_date?(jobs.last)
     end
 
   private
 
-    def break_between_only_job_and_current_date?(job)
+    def break_between_job_and_current_date?(job)
       if current_role?(job)
         false
       else
@@ -26,11 +25,11 @@ class CheckBreaksInWorkHistory
     end
 
     def month_or_more_break_between_end_date_and_current_date?(job)
-      job.end_date.next_month <= DateTime.now
+      job.end_date && job.end_date.next_month <= Time.zone.now
     end
 
     def month_or_more_break_between?(first_job, next_job)
-      first_job.end_date.next_month <= next_job.start_date
+      first_job.end_date && first_job.end_date.next_month <= next_job.start_date
     end
   end
 end

--- a/app/services/check_breaks_in_work_history.rb
+++ b/app/services/check_breaks_in_work_history.rb
@@ -3,22 +3,18 @@ class CheckBreaksInWorkHistory
     def call(application_form)
       jobs = application_form.application_work_experiences.sort_by(&:start_date)
 
-      previous_end_date = nil
+      latest_end_date = nil
       jobs.each do |job|
-        return true if month_or_more_break_between_dates?(previous_end_date, job.start_date)
+        return true if month_or_more_break_between_dates?(latest_end_date, job.start_date)
 
         return false if less_than_month_to_current_date?(job.end_date)
 
-        previous_end_date = [previous_end_date, job.end_date].compact.max
+        latest_end_date = [latest_end_date, job.end_date].compact.max
       end
-      month_or_more_break_between_end_date_and_current_date?(previous_end_date)
+      month_or_more_break_between_end_date_and_current_date?(latest_end_date)
     end
 
   private
-
-    def current_role?(job)
-      job.end_date.nil?
-    end
 
     def month_or_more_break_between_end_date_and_current_date?(end_date)
       month_or_more_break_between_dates?(end_date, Time.zone.now)

--- a/app/services/check_breaks_in_work_history.rb
+++ b/app/services/check_breaks_in_work_history.rb
@@ -3,11 +3,15 @@ class CheckBreaksInWorkHistory
     def call(application_form)
       jobs = application_form.application_work_experiences.sort_by(&:start_date)
 
-      return false if jobs.empty?
+      previous_end_date = nil
+      jobs.each do |job|
+        return true if previous_end_date && previous_end_date.next_month <= job.start_date
 
-      jobs.each_cons(2).any? do |first_job, next_job|
-        month_or_more_break_between?(first_job, next_job)
-      end || break_between_job_and_current_date?(jobs.last)
+        return false if job.end_date.nil? || job.end_date.next_month > Time.zone.now
+
+        previous_end_date = [previous_end_date, job.end_date].compact.max
+      end
+      previous_end_date.present? && previous_end_date.next_month <= Time.zone.now
     end
 
   private

--- a/app/services/check_breaks_in_work_history.rb
+++ b/app/services/check_breaks_in_work_history.rb
@@ -5,35 +5,31 @@ class CheckBreaksInWorkHistory
 
       previous_end_date = nil
       jobs.each do |job|
-        return true if previous_end_date && previous_end_date.next_month <= job.start_date
+        return true if month_or_more_break_between_dates?(previous_end_date, job.start_date)
 
-        return false if job.end_date.nil? || job.end_date.next_month > Time.zone.now
+        return false if less_than_month_to_current_date?(job.end_date)
 
         previous_end_date = [previous_end_date, job.end_date].compact.max
       end
-      previous_end_date.present? && previous_end_date.next_month <= Time.zone.now
+      month_or_more_break_between_end_date_and_current_date?(previous_end_date)
     end
 
   private
-
-    def break_between_job_and_current_date?(job)
-      if current_role?(job)
-        false
-      else
-        month_or_more_break_between_end_date_and_current_date?(job)
-      end
-    end
 
     def current_role?(job)
       job.end_date.nil?
     end
 
-    def month_or_more_break_between_end_date_and_current_date?(job)
-      job.end_date && job.end_date.next_month <= Time.zone.now
+    def month_or_more_break_between_end_date_and_current_date?(end_date)
+      month_or_more_break_between_dates?(end_date, Time.zone.now)
     end
 
-    def month_or_more_break_between?(first_job, next_job)
-      first_job.end_date && first_job.end_date.next_month <= next_job.start_date
+    def month_or_more_break_between_dates?(end_date, next_date)
+      end_date.present? && end_date.next_month <= next_date
+    end
+
+    def less_than_month_to_current_date?(end_date)
+      end_date.nil? || end_date.next_month > Time.zone.now
     end
   end
 end

--- a/spec/services/check_breaks_in_work_history_spec.rb
+++ b/spec/services/check_breaks_in_work_history_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe CheckBreaksInWorkHistory do
     let(:february2019) { Time.zone.local(2019, 2, 1) }
     let(:march2019) { Time.zone.local(2019, 3, 1) }
     let(:june2019) { Time.zone.local(2019, 6, 1) }
+    let(:july2019) { Time.zone.local(2019, 7, 1) }
     let(:august2019) { Time.zone.local(2019, 8, 1) }
     let(:september2019) { Time.zone.local(2019, 9, 1) }
     let(:october2019) { Time.zone.local(2019, 10, 1) }
@@ -242,6 +243,62 @@ RSpec.describe CheckBreaksInWorkHistory do
         breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
 
         expect(breaks_in_work_history).to eq(true)
+      end
+
+      it 'returns false if there are breaks in work history covered by current job' do
+        application_form = create(:application_form) do |form|
+          form.application_work_experiences.create(
+            start_date: november2018,
+            end_date: january2019,
+          )
+
+          form.application_work_experiences.create(
+            start_date: january2019,
+            end_date: nil,
+          )
+
+          form.application_work_experiences.create(
+            start_date: june2019,
+            end_date: july2019,
+          )
+
+          form.application_work_experiences.create(
+            start_date: september2019,
+            end_date: november2019,
+          )
+        end
+
+        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+
+        expect(breaks_in_work_history).to eq(false)
+      end
+
+      it 'returns false if there are breaks in work history overlapped by an earlier job' do
+        application_form = create(:application_form) do |form|
+          form.application_work_experiences.create(
+            start_date: november2018,
+            end_date: january2019,
+          )
+
+          form.application_work_experiences.create(
+            start_date: january2019,
+            end_date: october2019,
+          )
+
+          form.application_work_experiences.create(
+            start_date: june2019,
+            end_date: july2019,
+          )
+
+          form.application_work_experiences.create(
+            start_date: september2019,
+            end_date: november2019,
+          )
+        end
+
+        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+
+        expect(breaks_in_work_history).to eq(false)
       end
     end
   end

--- a/spec/services/check_breaks_in_work_history_spec.rb
+++ b/spec/services/check_breaks_in_work_history_spec.rb
@@ -5,13 +5,19 @@ RSpec.describe CheckBreaksInWorkHistory do
     let(:november2018) { Time.zone.local(2018, 11, 1) }
     let(:december2018) { Time.zone.local(2018, 12, 1) }
     let(:january2019) { Time.zone.local(2019, 1, 1) }
-    let(:febuary2019) { Time.zone.local(2019, 2, 1) }
+    let(:february2019) { Time.zone.local(2019, 2, 1) }
     let(:march2019) { Time.zone.local(2019, 3, 1) }
     let(:june2019) { Time.zone.local(2019, 6, 1) }
     let(:august2019) { Time.zone.local(2019, 8, 1) }
     let(:september2019) { Time.zone.local(2019, 9, 1) }
     let(:october2019) { Time.zone.local(2019, 10, 1) }
     let(:november2019) { Time.zone.local(2019, 11, 1) }
+
+    around do |example|
+      Timecop.freeze(Time.zone.local(2019, 11, 15)) do
+        example.run
+      end
+    end
 
     context 'when there are no jobs' do
       it 'returns false' do
@@ -99,7 +105,7 @@ RSpec.describe CheckBreaksInWorkHistory do
 
           form.application_work_experiences.create(
             start_date: january2019,
-            end_date: febuary2019,
+            end_date: february2019,
           )
         end
 
@@ -116,7 +122,7 @@ RSpec.describe CheckBreaksInWorkHistory do
           )
 
           form.application_work_experiences.create(
-            start_date: febuary2019,
+            start_date: february2019,
             end_date: march2019,
           )
         end
@@ -135,7 +141,7 @@ RSpec.describe CheckBreaksInWorkHistory do
 
           form.application_work_experiences.create(
             start_date: december2018,
-            end_date: febuary2019,
+            end_date: february2019,
           )
         end
 
@@ -153,7 +159,7 @@ RSpec.describe CheckBreaksInWorkHistory do
 
           form.application_work_experiences.create(
             start_date: december2018,
-            end_date: febuary2019,
+            end_date: february2019,
           )
         end
 
@@ -165,7 +171,7 @@ RSpec.describe CheckBreaksInWorkHistory do
       it 'returns true if there is a break regardless of creation order' do
         application_form = create(:application_form) do |form|
           form.application_work_experiences.create(
-            start_date: febuary2019,
+            start_date: february2019,
             end_date: march2019,
           )
 
@@ -196,7 +202,7 @@ RSpec.describe CheckBreaksInWorkHistory do
 
           form.application_work_experiences.create(
             start_date: august2019,
-            end_date: october2019,
+            end_date: november2019,
           )
         end
 

--- a/spec/services/check_breaks_in_work_history_spec.rb
+++ b/spec/services/check_breaks_in_work_history_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe CheckBreaksInWorkHistory do
 
           form.application_work_experiences.create(
             start_date: january2019,
-            end_date: february2019,
+            end_date: november2019,
           )
         end
 

--- a/spec/services/check_breaks_in_work_history_spec.rb
+++ b/spec/services/check_breaks_in_work_history_spec.rb
@@ -126,6 +126,42 @@ RSpec.describe CheckBreaksInWorkHistory do
         expect(breaks_in_work_history).to eq(true)
       end
 
+      it 'returns true if the second job ended more than a month ago' do
+        application_form = create(:application_form) do |form|
+          form.application_work_experiences.create(
+            start_date: november2018,
+            end_date: december2018,
+          )
+
+          form.application_work_experiences.create(
+            start_date: december2018,
+            end_date: febuary2019,
+          )
+        end
+
+        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+
+        expect(breaks_in_work_history).to eq(true)
+      end
+
+      it 'returns false if the second job ended more than a month ago but the first job is current' do
+        application_form = create(:application_form) do |form|
+          form.application_work_experiences.create(
+            start_date: november2018,
+            end_date: nil,
+          )
+
+          form.application_work_experiences.create(
+            start_date: december2018,
+            end_date: febuary2019,
+          )
+        end
+
+        breaks_in_work_history = CheckBreaksInWorkHistory.call(application_form)
+
+        expect(breaks_in_work_history).to eq(false)
+      end
+
       it 'returns true if there is a break regardless of creation order' do
         application_form = create(:application_form) do |form|
           form.application_work_experiences.create(


### PR DESCRIPTION
### Context

The trigger for this change was the following error on `qa`:

https://sentry.io/organizations/dfe-bat/issues/1343572021/?project=1765973&referrer=slack

It happens because the code that evaluates whether a candidate has gaps in work experience doesn't handle missing end dates except on the last job (ordered by start date). That assumption makes sense until you consider overlapping (part-time?) jobs.

### Changes proposed in this pull request

- [x] Handle `nil` `end_date` values for jobs that are not the most recently started.
- [x] Handle other cases of overlapping jobs.

### Guidance to review

- I'm making an assumption here that we permit overlapping jobs, including jobs that have not ended yet. Make sense?
- Do the specs cover enough of the various permutations?
- Does the modified logic make sense?

### Link to Trello card

[409 - Investigate ActionView::Template::Error in candidate work experience form](https://trello.com/c/oTji12v5/409-investigate-https-sentryio-organizations-dfe-bat-issues-1343572021-project1765973queryis3aunresolved)

### Env vars

no env vars added