### PR TITLE
Remove OGL licence from footer, update footer styles

### DIFF
--- a/app/frontend/styles/_footer.scss
+++ b/app/frontend/styles/_footer.scss
@@ -1,0 +1,13 @@
+.govuk-footer--app {
+  .govuk-footer__meta-custom {
+    max-width: 40rem;
+  }
+
+  .govuk-footer__inline-list {
+    margin-bottom: 0;
+  }
+
+  .govuk-footer__inline-list-item {
+    margin-bottom: 0;
+  }
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -10,12 +10,13 @@ $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
-@import "_task-list";
-@import "_summary-card";
 @import "_banner";
-@import "_status-box";
-@import "_styled-content";
 @import "_environments";
+@import "_footer";
+@import "_status-box";
+@import "_task-list";
+@import "_styled-content";
+@import "_summary-card";
 
 .autocomplete__wrapper, .autocomplete__input, .autocomplete__hint {
   font-family: $govuk-font-family;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -87,7 +87,7 @@
         <%= content_for?(:content) ? yield(:content) : yield %>
       </main>
     </div>
-    <footer class="govuk-footer" role="contentinfo">
+    <footer class="govuk-footer govuk-footer--app" role="contentinfo">
       <div class="govuk-width-container">
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
@@ -97,13 +97,6 @@
             <% when 'provider_interface' %>
               <%= render 'layouts/provider_footer' %>
             <% end %>
-            <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-            </svg>
-            <span class="govuk-footer__licence-description">
-              All content is available under the
-              <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-            </span>
           </div>
           <div class="govuk-footer__meta-item">
             <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>


### PR DESCRIPTION
### Context

Removes OGL licence text from footer (not relevant for this service), and tweaks footer styles to fix spacing and line lengths.

### Changes proposed in this pull request

Before:

<img width="1013" alt="Screenshot 2019-11-20 at 16 39 18" src="https://user-images.githubusercontent.com/813383/69258427-78fbad00-0bb4-11ea-98e7-1a5e65d5e177.png">

After:

<img width="1022" alt="Screenshot 2019-11-20 at 16 46 26" src="https://user-images.githubusercontent.com/813383/69258938-58802280-0bb5-11ea-8a71-4d94be6d2132.png">
