### PR TITLE
Add edit application information page

### DIFF
--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -7,6 +7,6 @@
       training location.
     </p>
 
-    <%= govuk_link_to 'TODO: Edit your application', '#' %>
+    <%= govuk_link_to 'Edit your application', candidate_interface_application_edit_path %>
   </div>
 <% end %>

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -12,6 +12,8 @@ module CandidateInterface
       @application_form = current_application
     end
 
+    def edit; end
+
     def complete
       @application_form = current_application
     end

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, t('page_titles.application_edit') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back to application dashboard') %>
+
+<h1 class="govuk-heading-xl govuk-heading-xl">
+  <%= t('page_titles.application_edit') %>
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">You have 5 working days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">To edit, you’ll need to email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>, explaining which changes you’d like to make.</p>
+    <p class="govuk-body">We can only edit your application once.</p>
+    <h2 class="govuk-heading-m">Course choice</h2>
+    <p class="govuk-body">We can change your choice of training provider, course or location within the 5 working day editing period.</p>
+    <p class="govuk-body">We can also delete a course choice.</p>
+    <p class="govuk-body">After this, you can email us asking to withdraw your application completely.</p>
+    <h2 class="govuk-heading-m">References</h2>
+    <p class="govuk-body">We can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
+    <h2 class="govuk-heading-m">Contact details</h2>
+    <p class="govuk-body">You can update your contact details at any point during the application process. To do this, email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,6 +3,7 @@ en:
     application: ''
     application_form: Your application
     application_dashboard: Application dashboard
+    application_edit: Editing your application
     eligibility: First, check you can use the new GOV.UK service
     not_eligible_yet: We’re sorry, but we’re not ready for you yet
     submitted_application: Your submitted application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
 
     scope '/application' do
       get '/' => 'application_form#show', as: :application_form
+      get '/edit' => 'application_form#edit', as: :application_edit
       get '/review' => 'application_form#review', as: :application_review
       get '/review/submitted' => 'application_form#review_submitted', as: :application_review_submitted
       get '/complete' => 'application_form#complete', as: :application_complete

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -33,6 +33,9 @@ RSpec.feature 'Candidate submit the application' do
 
     when_i_attempt_to_edit_my_contact_details
     then_i_can_see_my_application_dashboard
+
+    when_i_click_the_edit_application_link
+    then_i_see_edit_information_page
   end
 
   def given_i_am_signed_in
@@ -175,5 +178,13 @@ RSpec.feature 'Candidate submit the application' do
     expect(page).to have_content 'Everything'
     expect(page).to have_content 'NOT WEDNESDAY'
     expect(page).to have_content 'Terri Tudor'
+  end
+
+  def when_i_click_the_edit_application_link
+    click_link 'Edit your application'
+  end
+
+  def then_i_see_edit_information_page
+    expect(page).to have_content t('page_titles.application_edit')
   end
 end


### PR DESCRIPTION
### Context
Editing your application

### Changes proposed in this pull request
Add static information page sending users to zendesk/support

### After
![localhost_3000_candidate_application_edit(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/69323027-d6880c00-0c3d-11ea-9a79-8c63ead01c2c.png)



### Guidance to review
`/candidate/application/edit`

### Link to Trello card
[362 - Candidates can amend (via support email)](https://trello.com/c/oNx0ZGm8/362-candidates-can-amend-via-support-email)

### Env vars
n/a
