### PR TITLE
Delete aboutcookies.org link

### DIFF
--- a/app/views/content/cookies.md
+++ b/app/views/content/cookies.md
@@ -5,9 +5,7 @@ Cookies are used to:
 * measure how you use the this service so it can be updated and improved based on your needs
 * remember the notifications you’ve seen so that we don’t show them to you again
 * remember who you are when you have logged in so we can show you your information and information relevant to you
-* ’Apply for teacher training’ cookies aren’t used to identify you personally.
-
-Find out more about [how to manage cookies](http://www.aboutcookies.org/).
+* Apply for teacher training cookies aren’t used to identify you personally.
 
 ## How we use cookies
 

--- a/app/views/content/cookies_candidate.md
+++ b/app/views/content/cookies_candidate.md
@@ -7,8 +7,6 @@ Cookies are used to:
 * remember who you are when you have logged in so we can show you your information and information relevant to you
 * Apply for teacher training cookies aren’t used to identify you personally.
 
-Find out more about [how to manage cookies](http://www.aboutcookies.org/).
-
 ## How we use cookies
 
 ### Measuring website usage (Google Analytics)

--- a/app/views/content/cookies_provider.md
+++ b/app/views/content/cookies_provider.md
@@ -7,8 +7,6 @@ Cookies are used to:
 * remember who you are when you have logged in so we can show you your information and information relevant to you
 * Manage teacher training applications cookies aren’t used to identify you personally.
 
-Find out more about [how to manage cookies](http://www.aboutcookies.org/).
-
 ## How we use cookies
 
 ### Measuring website usage (Google Analytics)


### PR DESCRIPTION
It's not clear why we added this link to Find in April 2018. Information on this website appears out of date, does not cover GDPR and relates to 2011 cookie laws.

GOV.UK does not explain how to manage cookies.

See also https://github.com/DFE-Digital/search-and-compare-ui/pull/454
