### PR TITLE
Add references to api response

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -156,9 +156,7 @@ module VendorApi
       {
         name: reference.name,
         email: reference.email_address,
-        # phone_number: '07999 111111',
         relationship: reference.relationship,
-        # confirms_safe_to_work_with_children: true,
         reference: reference.feedback,
       }
     end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -76,48 +76,7 @@ module VendorApi
               },
             ],
           },
-          references: [
-            {
-              name: 'John Smith',
-              email: 'johnsmith@example.com',
-              phone_number: '07999 111111',
-              relationship: 'BA Geography course director at Imperial College. I tutored the candidate for one academic year.',
-              confirms_safe_to_work_with_children: true,
-              reference: <<~HEREDOC,
-                Fantastic personality. Great with people. Strong communicator .  Excellent character. Passionate about teaching . Great potential.  A charismatic talented able young person who is far better than her official degree result. An exceptional person.
-
-                Passion for their subject	7 / 10
-                Knowledge about their subject	10 / 10
-                General academic performance	9 / 10
-                Ability to meet deadlines and organise their time	7 / 10
-                Ability to think critically	10 / 10
-                Ability to work collaboratively	Don’t know
-                Mental and emotional resilience	8 / 10
-                Literacy	9 / 10
-                Numeracy	7 / 10
-              HEREDOC
-            },
-            {
-              name: 'Jane Brown',
-              email: 'janebrown@example.com',
-              phone_number: '07111 999999',
-              relationship: 'Headmistress at Harris Westminster Sixth Form',
-              confirms_safe_to_work_with_children: true,
-              reference: <<~HEREDOC,
-                An ideal teacher. Brisk and lively communicator. Intelligent and self-aware. Good with children. Led education outreach workshops.
-
-                Passion for their subject	7 / 10
-                Knowledge about their subject	10 / 10
-                General academic performance	9 / 10
-                Ability to meet deadlines and organise their time	7 / 10
-                Ability to think critically	10 / 10
-                Ability to work collaboratively	Don’t know
-                Mental and emotional resilience	8 / 10
-                Literacy	9 / 10
-                Numeracy	7 / 10
-              HEREDOC
-            },
-          ],
+          references: references,
           work_experience: {
             jobs: work_experience_jobs,
             volunteering: work_experience_volunteering,
@@ -184,6 +143,23 @@ module VendorApi
         working_with_children: experience.working_with_children,
         commitment: experience.commitment,
         description: experience.details,
+      }
+    end
+
+    def references
+      application_form.references.map do |reference|
+        reference_to_hash(reference)
+      end
+    end
+
+    def reference_to_hash(reference)
+      {
+        name: reference.name,
+        email: reference.email_address,
+        # phone_number: '07999 111111',
+        relationship: reference.relationship,
+        # confirms_safe_to_work_with_children: true,
+        reference: reference.feedback,
       }
     end
   end

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -593,9 +593,7 @@ components:
       required:
         - name
         - email
-        - phone_number
         - relationship
-        - confirms_safe_to_work_with_children
         - reference
       properties:
         name:
@@ -608,24 +606,16 @@ components:
           description: The referee’s email
           maxLength: 100
           example: julia@example.com
-        phone_number:
-          type: string
-          description: The referee’s phone number
-          maxLength: 100
-          example: '07890 123456'
         relationship:
           type: string
           description: The referee’s relationship to the candidate
           maxLength: 255
           example: Julia was my mentor at Cheadle Hulme High
-        confirms_safe_to_work_with_children:
-          type: boolean
-          description: Does the referee confirm the candidate is safe to work with children
-          example: true
         reference:
           type: string
           description: "Optional. The reference content provided by the referee, once it is available"
           example: Boris is committed to the profession of teaching...
+          nullable: true
     Rejection:
       type: object
       additionalProperties: false

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -127,46 +127,22 @@ RSpec.feature 'Vendor receives the application' do
             },
           ],
         },
-        references: [ # TODO: This section is hardcoded in the presenter
+        references: [ # TODO: Do we still include phone_number and confirms_safe_to_work_with_children?
           {
-            name: 'John Smith',
-            email: 'johnsmith@example.com',
-            phone_number: '07999 111111',
-            relationship: 'BA Geography course director at Imperial College. I tutored the candidate for one academic year.',
-            confirms_safe_to_work_with_children: true,
-            reference: <<~HEREDOC,
-              Fantastic personality. Great with people. Strong communicator .  Excellent character. Passionate about teaching . Great potential.  A charismatic talented able young person who is far better than her official degree result. An exceptional person.
-
-              Passion for their subject	7 / 10
-              Knowledge about their subject	10 / 10
-              General academic performance	9 / 10
-              Ability to meet deadlines and organise their time	7 / 10
-              Ability to think critically	10 / 10
-              Ability to work collaboratively	Don’t know
-              Mental and emotional resilience	8 / 10
-              Literacy	9 / 10
-              Numeracy	7 / 10
-            HEREDOC
+            name: 'Terri Tudor',
+            email: 'terri@example.com',
+            # phone_number: '07999 111111',
+            relationship: 'Tutor',
+            # confirms_safe_to_work_with_children: true,
+            reference: 'My ideal person',
           },
           {
-            name: 'Jane Brown',
-            email: 'janebrown@example.com',
-            phone_number: '07111 999999',
-            relationship: 'Headmistress at Harris Westminster Sixth Form',
-            confirms_safe_to_work_with_children: true,
-            reference: <<~HEREDOC,
-              An ideal teacher. Brisk and lively communicator. Intelligent and self-aware. Good with children. Led education outreach workshops.
-
-              Passion for their subject	7 / 10
-              Knowledge about their subject	10 / 10
-              General academic performance	9 / 10
-              Ability to meet deadlines and organise their time	7 / 10
-              Ability to think critically	10 / 10
-              Ability to work collaboratively	Don’t know
-              Mental and emotional resilience	8 / 10
-              Literacy	9 / 10
-              Numeracy	7 / 10
-            HEREDOC
+            name: 'Anne Other',
+            email: 'anne@other.com',
+            # phone_number: '07111 999999',
+            relationship: 'First boss',
+            # confirms_safe_to_work_with_children: true,
+            reference: 'Lovable',
           },
         ],
         rejection: nil,

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -127,21 +127,17 @@ RSpec.feature 'Vendor receives the application' do
             },
           ],
         },
-        references: [ # TODO: Do we still include phone_number and confirms_safe_to_work_with_children?
+        references: [
           {
             name: 'Terri Tudor',
             email: 'terri@example.com',
-            # phone_number: '07999 111111',
             relationship: 'Tutor',
-            # confirms_safe_to_work_with_children: true,
             reference: 'My ideal person',
           },
           {
             name: 'Anne Other',
             email: 'anne@other.com',
-            # phone_number: '07111 999999',
             relationship: 'First boss',
-            # confirms_safe_to_work_with_children: true,
             reference: 'Lovable',
           },
         ],


### PR DESCRIPTION
### Context

Currently application references are hardcoded in the SingleApplicationPresenter. 

### Changes proposed in this pull request

- Update SingleApplicationPresenter to use the ApplicationsForm's references.
- Update presenter and system specs to include testing the new references. 
- Remove `confirms_safe_to_work_with_children` from reference as it has been decided that this should be displayed in the `feedback` text field.
- Update reference `phone_number` to be nullable as this will be an optional field in the candidate UI.

### Guidance to review

Run specs and ensure the reference data is being presented correctly in the vendor api.

- Currently the reference `phone_number` is still hardcoded to `nil` in the presenter as it is not collected but still need to be represented in the api. 

### Link to Trello card

[1250 - Return real data within the api response](https://trello.com/c/S43gJ9xx/1250-return-real-data-within-the-api-response)

### Env vars
N/A
