### PR TITLE
Add some conditional course choices content on application dashboard

### DIFF
--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -1,4 +1,24 @@
-<% if @dates.form_open_to_editing? %>
+<% if any_offers? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    Some of your training providers haven’t reached a decision yet
+  </h2>
+
+  <p class="govuk-body">
+    Training providers must respond by <%= respond_by_date %>.
+  </p>
+
+  <p class="govuk-body">
+    If you accept an offer now, your remaining applications will be withdrawn.
+  </p>
+<% elsif any_awaiting_provider_decision? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses you’ve applied to</h2>
+
+  <p class="govuk-body">
+    Training providers must respond by <%= respond_by_date %>.
+  </p>
+<% elsif editable? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses you’ve applied to</h2>
+
   <div class="govuk-inset-text">
     <p class="govuk-body">
       You have <%= formatted_days_remaining %>

--- a/app/components/application_complete_content_component.rb
+++ b/app/components/application_complete_content_component.rb
@@ -8,6 +8,18 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
     @dates = ApplicationDates.new(@application_form)
   end
 
+  def any_awaiting_provider_decision?
+    @application_form.application_choices.map.any?(&:awaiting_provider_decision?)
+  end
+
+  def any_offers?
+    @application_form.application_choices.map.any?(&:offer?)
+  end
+
+  def editable?
+    @dates.form_open_to_editing?
+  end
+
 private
 
   attr_reader :application_form

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -1,17 +1,20 @@
 class CourseChoicesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, show_status: false)
     @application_form = application_form
     @course_choices = @application_form.application_choices
     @editable = editable
+    @show_status = show_status
   end
 
   def course_choice_rows(course_choice)
     [
       course_row(course_choice),
       location_row(course_choice),
-    ]
+    ].tap do |r|
+      r << status_row(course_choice) if @show_status
+    end
   end
 
 private
@@ -51,7 +54,7 @@ private
             end
     {
       key: 'Status',
-      value: render(TagComponent, text: t("application_states.#{course_choice.status}"), type: type),
+      value: render(TagComponent, text: t("candidate_application_states.#{course_choice.status}"), type: type),
     }
   end
 end

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -31,4 +31,27 @@ private
       value: course_choice.site.name,
     }
   end
+
+  def status_row(course_choice)
+    type =  case course_choice.status
+            when 'awaiting_references', 'application_complete'
+              :secondary
+            when 'awaiting_provider_decision'
+              :primary
+            when 'offer'
+              :info_unfilled
+            when 'rejected'
+              :danger
+            when 'pending_conditions'
+              :info
+            when 'declined'
+              :warning
+            else
+              ''
+            end
+    {
+      key: 'Status',
+      value: render(TagComponent, text: t("application_states.#{course_choice.status}"), type: type),
+    }
+  end
 end

--- a/app/components/tag_component.html.erb
+++ b/app/components/tag_component.html.erb
@@ -1,0 +1,3 @@
+<strong class="<%= @css_classes %>">
+  <%= @text %>
+</strong>

--- a/app/components/tag_component.rb
+++ b/app/components/tag_component.rb
@@ -1,0 +1,29 @@
+class TagComponent < ActionView::Component::Base
+  def initialize(text:, type:)
+    @text = text
+    @css_classes = css_classes(type)
+  end
+
+private
+
+  attr_reader :text
+
+  def css_classes(type)
+    tag_css_class = case type
+                    when :danger
+                      'app-tag--danger'
+                    when :secondary
+                      'app-tag--secondary'
+                    when :info
+                      'app-tag--info'
+                    when :info_unfilled
+                      'app-tag--info-unfilled'
+                    when :warning
+                      'app-tag--warning'
+                    else
+                      'app-tag--primary'
+                    end
+
+    "govuk-tag #{tag_css_class}"
+  end
+end

--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -1,0 +1,38 @@
+@mixin tag($color: "blue", $filled: true) {
+  white-space: nowrap;
+
+  @if $filled {
+    background-color: govuk-colour($color);
+    color: govuk-colour("white");
+  } @else {
+    background-color: govuk-colour("white");
+    border: 3px solid govuk-colour($color);
+    color: govuk-colour($color);
+    margin-top: -3px;
+    margin-bottom: -3px;
+  }
+}
+
+.app-tag--danger {
+  @include tag($color: "red");
+}
+
+.app-tag--primary {
+  @include tag("blue");
+}
+
+.app-tag--secondary {
+  @include tag("dark-grey");
+}
+
+.app-tag--info {
+  @include tag("turquoise");
+}
+
+.app-tag--info-unfilled {
+  @include tag("turquoise", $filled: false);
+}
+
+.app-tag--warning {
+  @include tag("orange");
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -14,9 +14,10 @@ $govuk-image-url-function: frontend-image-url;
 @import "_environments";
 @import "_footer";
 @import "_status-box";
-@import "_task-list";
 @import "_styled-content";
 @import "_summary-card";
+@import "_tag";
+@import "_task-list";
 
 .autocomplete__wrapper, .autocomplete__input, .autocomplete__hint {
   font-family: $govuk-font-family;

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -29,17 +29,17 @@ module ViewHelper
 
   def submitted_at_date
     dates = ApplicationDates.new(@application_form)
-    dates.submitted_at.strftime('%e %B %Y')
+    dates.submitted_at.strftime('%e %B %Y').strip
   end
 
   def respond_by_date
     dates = ApplicationDates.new(@application_form)
-    dates.reject_by_default_at&.strftime('%e %B %Y')
+    dates.reject_by_default_at.strftime('%e %B %Y').strip if dates.reject_by_default_at
   end
 
   def edit_by_date
     dates = ApplicationDates.new(@application_form)
-    dates.edit_by.strftime('%e %B %Y')
+    dates.edit_by.strftime('%e %B %Y').strip
   end
 
   def formatted_days_remaining

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -9,8 +9,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Courses you’ve applied to</h2>
-
     <%= render(ApplicationCompleteContentComponent, application_form: @application_form) %>
 
     <%= render(CourseChoicesReviewComponent, application_form: @application_form, editable: false, show_status: true) %>

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -13,13 +13,7 @@
 
     <%= render(ApplicationCompleteContentComponent, application_form: @application_form) %>
 
-    <% if respond_by_date %>
-      <p class="govuk-body">
-        Training providers must respond by <%= respond_by_date %>.
-      </p>
-    <% end %>
-
-    <%= render(CourseChoicesReviewComponent, application_form: @application_form, editable: false) %>
+    <%= render(CourseChoicesReviewComponent, application_form: @application_form, editable: false, show_status: true) %>
 
     <hr class="govuk-section-break govuk-section-break--m">
 

--- a/config/locales/candidate_application_states.yml
+++ b/config/locales/candidate_application_states.yml
@@ -1,0 +1,9 @@
+en:
+  candidate_application_states:
+    awaiting_references: Submitted
+    application_complete: Submitted
+    awaiting_provider_decision: Pending
+    offer: Offer
+    rejected: Rejected
+    pending_conditions: Accepted
+    declined: Declined

--- a/spec/components/application_complete_content_component_spec.rb
+++ b/spec/components/application_complete_content_component_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ApplicationCompleteContentComponent do
   let(:submitted_at) { Time.zone.local(2019, 10, 22, 12, 0, 0) }
+  let(:first_january2019) { Time.zone.local(2020, 1, 1, 12, 0, 0) }
 
   around do |example|
     Timecop.freeze(submitted_at) do
@@ -10,25 +11,89 @@ RSpec.describe ApplicationCompleteContentComponent do
   end
 
   before do
-    @application_dates = instance_double(
+    view_helper = instance_double(ViewHelper)
+    allow(view_helper).to receive(:respond_by_date).and_return('1 January 2020')
+  end
+
+  context 'when the application is editable' do
+    it 'renders with edit content' do
+      stub_application_dates_with_form_editable
+      application_form = create_application_form_with_course_choices(statuses: %w[awaiting_references])
+
+      render_result = render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+
+      expect(render_result.text).to include('Edit your application')
+    end
+  end
+
+  context 'when the application is not editable' do
+    it 'renders without edit content' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[awaiting_references])
+
+      render_result = render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+
+      expect(render_result.text).not_to include('Edit your application')
+    end
+  end
+
+  context 'when the application is waiting for a decision from providers' do
+    it 'renders the respond date for providers' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision])
+
+      render_result = render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+
+      expect(render_result.text).not_to include('Edit your application')
+      expect(render_result.text).to include('Training providers must respond by 1 January 2020.')
+    end
+  end
+
+  context 'when the application has an offer from a provider' do
+    it 'renders with some providers have made a decision content' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[offer awaiting_provider_decision])
+
+      render_result = render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+
+      expect(render_result.text).to include('Some of your training providers haven’t reached a decision yet')
+      expect(render_result.text).to include('Training providers must respond by 1 January 2020.')
+    end
+  end
+
+  def stub_application_dates_with_form_uneditable
+    application_dates = instance_double(
       ApplicationDates,
-      submitted_at: Time.zone.local(2019, 10, 22, 12, 0, 0),
-      reject_by_default_at: Time.zone.local(2019, 12, 17, 12, 0, 0),
-      edit_by: Time.zone.local(2019, 10, 29, 12, 0, 0),
-      days_remaining_to_edit: 7,
-      form_open_to_editing?: true,
+      form_open_to_editing?: false,
+      reject_by_default_at: first_january2019,
     )
-    allow(ApplicationDates).to receive(:new).and_return(@application_dates)
+    allow(ApplicationDates).to receive(:new).and_return(application_dates)
   end
 
-  def render_result
-    application_form = instance_double(ApplicationForm)
-    render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+  def stub_application_dates_with_form_editable
+    application_dates = instance_double(
+      ApplicationDates,
+      form_open_to_editing?: true,
+      days_remaining_to_edit: 5,
+      edit_by: Time.zone.local(2019, 10, 29, 12, 0, 0),
+      submitted_at: Time.zone.local(2019, 10, 22, 12, 0, 0),
+      reject_by_default_at: first_january2019,
+    )
+    allow(ApplicationDates).to receive(:new).and_return(application_dates)
   end
 
-  it 'renders without edit content after we have passed the expires_at date' do
-    allow(@application_dates).to receive(:days_remaining_to_edit).and_return(0)
-    allow(@application_dates).to receive(:form_open_to_editing?).and_return(false)
-    expect(render_result.text).not_to include('Edit your application')
+  def create_application_form_with_course_choices(statuses:)
+    application_form = create(:application_form)
+
+    statuses.each do |status|
+      create(
+        :application_choice,
+        application_form: application_form,
+        status: status,
+        reject_by_default_at: first_january2019,
+      )
+    end
+
+    application_form
   end
 end

--- a/spec/components/course_choices_review_component_spec.rb
+++ b/spec/components/course_choices_review_component_spec.rb
@@ -49,4 +49,72 @@ RSpec.describe CourseChoicesReviewComponent do
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.courses.delete'))
     end
   end
+
+  context 'when course choices are submitted' do
+    it 'renders component with the status as submitted when awaiting references' do
+      application_form = create_application_form_with_course_choice(status: 'awaiting_references')
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Submitted')
+    end
+
+    it 'renders component with the status as submitted when application is complete' do
+      application_form = create_application_form_with_course_choice(status: 'application_complete')
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Submitted')
+    end
+
+    it 'renders component with the status as pending when awaiting provider decision' do
+      application_form = create_application_form_with_course_choice(status: 'awaiting_provider_decision')
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Pending')
+    end
+
+    it 'renders component with the status as offer when an offer has been made' do
+      application_form = create_application_form_with_course_choice(status: 'offer')
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Offer')
+    end
+
+    it 'renders component with the status as accepted when the candidate has accepted an offer' do
+      application_form = create_application_form_with_course_choice(status: 'pending_conditions')
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Accepted')
+    end
+
+    it 'renders component with the status as accepted when the candidate has declined an offer' do
+      application_form = create_application_form_with_course_choice(status: 'declined')
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Declined')
+    end
+  end
+
+  def create_application_form_with_course_choice(status:)
+    application_form = create(:application_form)
+
+    create(
+      :application_choice,
+      application_form: application_form,
+      status: status,
+    )
+
+    application_form
+  end
 end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -159,6 +159,7 @@ RSpec.feature 'Candidate submit the application' do
     expect(page).to have_content "Application submitted on #{this_day}"
     expect(page).to have_content 'Gorse SCITT'
     expect(page).to have_content current_candidate.current_application.references.first.name
+    expect(page).to have_content 'Submitted'
   end
 
   def when_i_click_view_application


### PR DESCRIPTION
### Context

The `Application dashboard` should show content depending on the state of the application.

### Changes proposed in this pull request

This PR adds the ability to view the status of a course choices on the `Application dashboard` by updating the `CourseChoicesReviewComponent` and creating a new `TagComponent`.

These are:

- `SUBMITTED` when `awaiting_references` or `awaiting_provider_decision`
- `PENDING` when `awaiting_provider_decision`
- `OFFER` when `offer`
- `REJECTED` when `rejected`
- `ACCEPTED` when `pending_conditions`
- `DECLINED` when `declined`

![image](https://user-images.githubusercontent.com/42817036/69338471-32ad5900-0c5b-11ea-902f-9fea44d81043.png)

![image](https://user-images.githubusercontent.com/42817036/69338514-4789ec80-0c5b-11ea-867c-a2459faf1280.png)

![image](https://user-images.githubusercontent.com/42817036/69338564-61c3ca80-0c5b-11ea-8034-0680810cacd8.png)

![image](https://user-images.githubusercontent.com/42817036/69338631-828c2000-0c5b-11ea-9bf0-4b7f183a7806.png)

![image](https://user-images.githubusercontent.com/42817036/69338698-ab141a00-0c5b-11ea-82b7-9ef38b6465d6.png)

![image](https://user-images.githubusercontent.com/42817036/69338792-d6970480-0c5b-11ea-8b83-f21f97bfeee3.png)

It also adds conditional course choices content on the `Application dashboard` up to the selection phase (see https://apply-mvp-prototype.herokuapp.com/admin/phases).

![image](https://user-images.githubusercontent.com/42817036/69339231-c7fd1d00-0c5c-11ea-9f38-7c6bafe2d188.png)

### Guidance to review

- Have all the states of a course choice been covered?
- Have all the conditional content been covered up to and including the selection phase?

The next PR will include viewing the details of an offer.

### Link to Trello card

[360 - Candidates can receive and review an offer from the provider](https://trello.com/c/HhzbUnQO/360-candidates-can-receive-and-review-an-offer-from-the-provider)

