### PR TITLE
Add referee chaser email, update request email

### DIFF
--- a/app/mailers/previews/referee_mailer_preview.rb
+++ b/app/mailers/previews/referee_mailer_preview.rb
@@ -5,4 +5,11 @@ class RefereeMailerPreview < ActionMailer::Preview
 
     RefereeMailer.reference_request_email(application_form, reference)
   end
+
+  def reference_request_chaser_email
+    application_form = FactoryBot.build(:completed_application_form)
+    reference = application_form.references.reload.first
+
+    RefereeMailer.reference_request_chaser_email(application_form, reference)
+  end
 end

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -1,12 +1,24 @@
 class RefereeMailer < ApplicationMailer
   def reference_request_email(application_form, reference)
+    @application_form = application_form
     @reference = reference
     @candidate_name = "#{application_form.first_name} #{application_form.last_name}"
     @google_form_url = google_form_url_for(@candidate_name, @reference)
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,
-              subject: t('reference_request.email.subject', candidate_name: @candidate_name))
+              subject: t('reference_request.subject.initial', candidate_name: @candidate_name))
+  end
+
+  def reference_request_chaser_email(application_form, reference)
+    @application_form = application_form
+    @reference = reference
+    @candidate_name = "#{application_form.first_name} #{application_form.last_name}"
+    @google_form_url = google_form_url_for(@candidate_name, @reference)
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: reference.email_address,
+              subject: t('reference_request.subject.chaser', candidate_name: @candidate_name))
   end
 
 private

--- a/app/views/referee_mailer/reference_request_chaser_email.text.erb
+++ b/app/views/referee_mailer/reference_request_chaser_email.text.erb
@@ -2,17 +2,15 @@ Dear <%= @reference.name %>,
 
 # Give a reference for <%= @candidate_name %>
 
-<%= @candidate_name %> put us in touch with you to get a reference for their teacher training application. They applied to:
+We haven’t had your reference for <%= @candidate_name %>. They put us in touch with you to get a reference for their teacher training application. They applied to:
 
 <% @application_form.application_choices.each do |application_choice| %>
 * <%= application_choice.provider.name %> - <%= application_choice.course.name %>
 <% end %>
 
-Please use the link below to give a complete reference as soon as possible.
+Please use the link below to give a complete reference within 5 working days.
 
 <%= @google_form_url %>
-
-If we don’t hear from you within 5 working days we’ll send you a reminder.
 
 If you won’t give <%= @candidate_name %> a reference, please let us know as soon as possible by emailing: [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
 

--- a/config/locales/reference_request.yml
+++ b/config/locales/reference_request.yml
@@ -1,7 +1,8 @@
 en:
   reference_request:
-    email:
-      subject: Please give a reference to support the teacher training application of %{candidate_name}
+    subject:
+      initial: Give a reference to support the teacher training application of %{candidate_name}
+      chaser: "Reminder: %{candidate_name} still needs a reference for their teacher training application"
     google_form_url: https://docs.google.com/forms/d/e/1FAIpQLSeLHV9XVqckn8XUjyAS3n7dzKU5OF-BLm5dYn51JcT6qa9pGg/viewform
     email_entry: entry.409316871
     reference_id_entry: entry.1515340886

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -4,7 +4,22 @@ RSpec.describe RefereeMailer, type: :mailer do
   subject(:mailer) { described_class }
 
   describe 'Send request reference email' do
-    let(:application_form) { create(:completed_application_form, first_name: 'Harry', last_name: 'Potter') }
+    let(:first_application_choice) { create(:application_choice) }
+    let(:second_application_choice) { create(:application_choice) }
+    let(:third_application_choice) { create(:application_choice) }
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        first_name: 'Harry',
+        last_name: 'Potter',
+        application_choices_count: 0,
+        application_choices: [
+          first_application_choice,
+          second_application_choice,
+          third_application_choice,
+        ],
+      )
+    end
     let(:reference) { application_form.references.first }
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
     let(:mail) { mailer.reference_request_email(application_form, reference) }
@@ -12,11 +27,75 @@ RSpec.describe RefereeMailer, type: :mailer do
     before { mail.deliver_now }
 
     it 'sends an email with the correct subject' do
-      expect(mail.subject).to include(t('reference_request.email.subject', candidate_name: candidate_name))
+      expect(mail.subject).to include(t('reference_request.subject.initial', candidate_name: candidate_name))
     end
 
     it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include("give a reference for #{candidate_name}")
+      expect(mail.body.encoded).to include("Give a reference for #{candidate_name}")
+    end
+
+    it 'sends an email with the correct courses listed' do
+      expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
+      expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
+      expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
+    end
+
+    it 'sends an email with a link to a prefilled Google form' do
+      body = mail.body.encoded
+      expect(body).to include(t('reference_request.google_form_url'))
+      expect(body).to include("=#{reference.id}")
+      expect(body).to include("=#{CGI.escape(reference.email_address)}")
+    end
+
+    it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
+      expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
+      expect(mail.body.encoded).to include("=#{reference.name.gsub(' ', '%20')}")
+    end
+
+    context 'an email containing a +' do
+      let(:reference) { build(:reference, email_address: 'email+email@email.com') }
+
+      it 'does not strip the plus from the email address' do
+        expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
+      end
+    end
+  end
+
+  describe 'Send chasing reference email' do
+    let(:first_application_choice) { create(:application_choice) }
+    let(:second_application_choice) { create(:application_choice) }
+    let(:third_application_choice) { create(:application_choice) }
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        first_name: 'Harry',
+        last_name: 'Potter',
+        application_choices_count: 0,
+        application_choices: [
+          first_application_choice,
+          second_application_choice,
+          third_application_choice,
+        ],
+      )
+    end
+    let(:reference) { application_form.references.first }
+    let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
+    let(:mail) { mailer.reference_request_chaser_email(application_form, reference) }
+
+    before { mail.deliver_now }
+
+    it 'sends an email with the correct subject' do
+      expect(mail.subject).to include(t('reference_request.subject.chaser', candidate_name: candidate_name))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(mail.body.encoded).to include("Give a reference for #{candidate_name}")
+    end
+
+    it 'sends an email with the correct courses listed' do
+      expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
+      expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
+      expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
     end
 
     it 'sends an email with a link to a prefilled Google form' do

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'Candidate submit the application' do
     current_application = current_candidate.current_application
     current_application.references.each do |reference|
       open_email(reference.email_address)
-      expect(current_email).to have_content "Please give a reference for #{current_application.first_name}"
+      expect(current_email).to have_content "Give a reference for #{current_application.first_name}"
       expect(current_email).to have_content reference.name
     end
   end


### PR DESCRIPTION
### Context

* Updates email to referee requesting a reference
* Adds an email to send to referees after 5 days, reminding them to submit a reference. **This will be manually sent from support console, functionality that is not built yet**

### Link to Trello card

[416 - Email: Initial email to referee](https://trello.com/c/U6p4SPID/)
[417 - Email: Chase email to referee](https://trello.com/c/ffjNEQHc/)
