### PR TITLE
Add withdraw course information page

### DIFF
--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -9,6 +9,10 @@
         <div class='app-summary-card__actions'>
           <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
         </div>
+      <% else %>
+        <div class='app-summary-card__actions'>
+          <%= link_to t('application_form.courses.withdraw'), candidate_interface_course_choice_withdraw_path(course_choice.id), class: 'govuk-link' %>
+        </div>
       <% end %>
     </header>
   <% end %>

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class CourseChoicesController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_submitted, except: :withdraw
 
     def index
       @application_form = current_application
@@ -101,6 +101,10 @@ module CandidateInterface
         @course_choices = current_candidate.current_application.application_choices
         render :index
       end
+    end
+
+    def withdraw
+      @course_choice = current_candidate.current_application.application_choices.find(params[:id])
     end
 
   private

--- a/app/views/candidate_interface/course_choices/withdraw.html.erb
+++ b/app/views/candidate_interface/course_choices/withdraw.html.erb
@@ -1,0 +1,15 @@
+<% content_for :title, t('page_titles.withdraw_course_choice') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back to application dashboard') %>
+
+<h1 class="govuk-heading-xl govuk-heading-xl">
+  <%= t('page_titles.withdraw_course_choice') %>
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">You can withdraw your application to study:</p>
+    <p class="govuk-body"><strong><%= @course_choice.course.name_and_code %> at <%= @course_choice.provider.name %></strong></p>
+    <p class="govuk-body">by emailing us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+    <p class="govuk-body">We’ll contact your training provider and send you an email confirming that your application has been withdrawn.</p>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -5,6 +5,7 @@ en:
       intro: You can apply for up to 3 courses.
       delete: Delete choice
       confirm_delete: Yes I’m sure - delete this choice
+      withdraw: Withdraw
       complete:
         completed_checkbox: I have completed this section
         button: Continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     destroy_degree: Are you sure you want to delete this degree?
     choosing_courses: Choosing courses
     course_choices: Course choices
+    withdraw_course_choice: Withdrawal
     destroy_course_choice: Are you sure you want to delete this choice?
     have_you_chosen: Have you chosen a course to apply to?
     which_provider: Which training provider are you applying to?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -142,6 +142,8 @@ Rails.application.routes.draw do
         get '/delete/:id' => 'course_choices#confirm_destroy', as: :confirm_destroy_course_choice
         delete '/delete/:id' => 'course_choices#destroy'
 
+        get '/withdraw/:id' => 'course_choices#withdraw', as: :course_choice_withdraw
+
         get '/provider' => 'course_choices#options_for_provider', as: :course_choices_provider
         post '/provider' => 'course_choices#pick_provider'
 

--- a/spec/components/course_choices_review_component_spec.rb
+++ b/spec/components/course_choices_review_component_spec.rb
@@ -43,10 +43,11 @@ RSpec.describe CourseChoicesReviewComponent do
   end
 
   context 'when course choices are not editable' do
-    it 'renders component without a delete link' do
+    it 'renders component without a delete link and with a withdraw link' do
       result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false)
 
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.courses.delete'))
+      expect(result.css('.app-summary-card__actions').text).to include(t('application_form.courses.withdraw'))
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -36,6 +36,10 @@ RSpec.feature 'Candidate submit the application' do
 
     when_i_click_the_edit_application_link
     then_i_see_edit_information_page
+
+    when_i_visit_my_application_dashboard
+    and_i_click_withdraw_course
+    then_i_see_the_withdraw_information_page
   end
 
   def given_i_am_signed_in
@@ -186,5 +190,17 @@ RSpec.feature 'Candidate submit the application' do
 
   def then_i_see_edit_information_page
     expect(page).to have_content t('page_titles.application_edit')
+  end
+
+  def when_i_visit_my_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def and_i_click_withdraw_course
+    click_link 'Withdraw'
+  end
+
+  def then_i_see_the_withdraw_information_page
+    expect(page).to have_content t('page_titles.withdraw_course_choice')
   end
 end


### PR DESCRIPTION
### Context
Withdrawing a course choice from an application

### Changes proposed in this pull request
Add withdraw CTA with static information page

### Guidance to review
`/candidate/application/courses/withdraw/:id`

### After
![localhost_3000_candidate_application_complete(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/69343076-ccc5cf00-0c64-11ea-9ae3-7c88960327b0.png)

![localhost_3000_candidate_application_courses_withdraw_22(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/69342968-88d2ca00-0c64-11ea-9e3a-a0fa8d184a76.png)

### Link to Trello card
[371 - Withdrawing(via support)](https://trello.com/c/eYhDe9sl/371-withdrawing-via-support)

### Env vars
n/a
