### PR TITLE
Bugfix: Unselected radio buttons on have_you_chosen a course page

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -17,8 +17,7 @@ module CandidateInterface
     end
 
     def make_choice
-      @choice_form = CandidateInterface::CourseChosenForm.new
-      @choice_form.choice = application_choice_params[:choice]
+      @choice_form = CandidateInterface::CourseChosenForm.new(application_choice_params)
 
       if @choice_form.valid?
         if @choice_form.choice == 'yes'
@@ -122,7 +121,6 @@ module CandidateInterface
 
     def application_choice_params
       params.fetch(:candidate_interface_course_chosen_form, {}).permit(:choice)
-      # params.require(:application_choice).permit(:choice)
     end
 
     def provider_params

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -13,14 +13,21 @@ module CandidateInterface
     end
 
     def have_you_chosen
-      @choice = current_candidate.current_application.application_choices.new
+      @choice_form = CandidateInterface::CourseChosenForm.new
     end
 
     def make_choice
-      if application_choice_params[:choice] == 'yes'
-        redirect_to candidate_interface_course_choices_provider_path
+      @choice_form = CandidateInterface::CourseChosenForm.new
+      @choice_form.choice = application_choice_params[:choice]
+
+      if @choice_form.valid?
+        if @choice_form.choice == 'yes'
+          redirect_to candidate_interface_course_choices_provider_path
+        else
+          redirect_to 'https://find-postgraduate-teacher-training.education.gov.uk'
+        end
       else
-        redirect_to 'https://find-postgraduate-teacher-training.education.gov.uk'
+        render :have_you_chosen
       end
     end
 
@@ -114,7 +121,8 @@ module CandidateInterface
     end
 
     def application_choice_params
-      params.require(:application_choice).permit(:choice)
+      params.fetch(:candidate_interface_course_chosen_form, {}).permit(:choice)
+      # params.require(:application_choice).permit(:choice)
     end
 
     def provider_params

--- a/app/models/candidate_interface/course_chosen_form.rb
+++ b/app/models/candidate_interface/course_chosen_form.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class CourseChosenForm
+    include ActiveModel::Model
+
+    attr_accessor :choice
+
+    validates :choice, presence: true
+  end
+end

--- a/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
+++ b/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @choice, url: candidate_interface_course_choices_choose_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @choice_form, url: candidate_interface_course_choices_choose_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :choice, legend: { size: 'xl', text: t('page_titles.have_you_chosen') } do %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -428,3 +428,7 @@ en:
             end_date:
               invalid: Enter an end date in the correct format, for example 5 2019
               in_the_future: Enter an end date that is not in the future
+        candidate_interface/course_chosen_form:
+          attributes:
+            choice:
+              blank: Select if you have chosen a course or not.

--- a/spec/models/candidate_interface/course_chosen_form_spec.rb
+++ b/spec/models/candidate_interface/course_chosen_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::CourseChosenForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:choice) }
+  end
+end


### PR DESCRIPTION
### Context

This PR fixes the following Bug: 
When you do not select any radios in the page `have_you_chosen` (a course) an exception is triggered.

### Changes proposed in this pull request
It adds a small form object.

### Link to Trello card

https://trello.com/c/vngl84RE/424-radio-buttons-when-not-selected-error-page

NOTE: there are still more of this kind of error, this is the first of this kind fixed, more PRs fill follow to fix them.
