### PR TITLE
Allow support folks to toggle courses

### DIFF
--- a/app/controllers/support_interface/courses_controller.rb
+++ b/app/controllers/support_interface/courses_controller.rb
@@ -3,5 +3,16 @@ module SupportInterface
     def show
       @course = Course.find(params[:course_id])
     end
+
+    def update
+      @course = Course.find(params[:course_id])
+
+      if @course.update(params.require(:course).permit(:open_on_apply))
+        flash[:success] = 'Successfully updated course'
+        redirect_to support_interface_course_path(@course)
+      else
+        render :show
+      end
+    end
   end
 end

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -55,3 +55,14 @@
     </dd>
   </div>
 </dl>
+
+<%= form_with model: @course, url: support_interface_course_path(@course), method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_radio_buttons_fieldset :open_on_apply, legend: { size: 'm', text: 'Can candidates use Apply?' } do %>
+    <%= f.govuk_radio_button :open_on_apply, true, label: { text: 'Yes, this course is available on Apply and UCAS' } %>
+    <%= f.govuk_radio_button :open_on_apply, false, label: { text: 'No, this course is only available on UCAS' } %>
+  <% end %>
+
+  <%= f.govuk_submit 'Save' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -246,6 +246,7 @@ Rails.application.routes.draw do
     get '/providers/:provider_id' => 'providers#show', as: :provider
 
     get '/courses/:course_id' => 'courses#show', as: :course
+    post '/courses/:course_id' => 'courses#update'
 
     get '/import-references' => 'import_references#index'
     post '/import-references' => 'import_references#import'

--- a/db/migrate/20191121134801_change_default_for_open_on_apply.rb
+++ b/db/migrate/20191121134801_change_default_for_open_on_apply.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultForOpenOnApply < ActiveRecord::Migration[6.0]
+  def change
+    change_column_default :courses, :open_on_apply, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_19_160946) do
+ActiveRecord::Schema.define(version: 2019_11_21_134801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2019_11_19_160946) do
     t.date "start_date"
     t.integer "accrediting_provider_id"
     t.boolean "exposed_in_find"
-    t.boolean "open_on_apply", default: true, null: false
+    t.boolean "open_on_apply", default: false, null: false
     t.index ["code"], name: "index_courses_on_code"
     t.index ["exposed_in_find", "open_on_apply"], name: "index_courses_on_exposed_in_find_and_open_on_apply"
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -16,6 +16,9 @@ RSpec.feature 'See providers' do
 
     when_i_click_on_a_course
     then_i_see_the_course_information
+
+    when_i_choose_to_open_the_course_on_apply
+    then_it_should_be_open_on_apply
   end
 
   def given_i_am_a_support_user
@@ -90,5 +93,15 @@ RSpec.feature 'See providers' do
 
   def then_i_see_the_course_information
     expect(page).to have_title 'Primary (ABC-1)'
+  end
+
+  def when_i_choose_to_open_the_course_on_apply
+    expect(page).to have_content 'Open on Apply No'
+    choose 'Yes, this course is available on Apply and UCAS'
+    click_button 'Save'
+  end
+
+  def then_it_should_be_open_on_apply
+    expect(page).to have_content 'Open on Apply Yes'
   end
 end


### PR DESCRIPTION
### Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/576. This allows users in the support section to update whether or not a course is "Open on Apply"

### Changes proposed in this pull request

<img width="1092" alt="Screenshot 2019-11-21 at 13 52 08" src="https://user-images.githubusercontent.com/233676/69343783-24b10580-0c66-11ea-8d26-148bcff97f3e.png">
<img width="930" alt="Screenshot 2019-11-21 at 13 52 15" src="https://user-images.githubusercontent.com/233676/69343785-24b10580-0c66-11ea-9937-9a13daac66bf.png">

### Link to Trello card

https://trello.com/c/5wXHsiOC