### PR TITLE
Fix English and other language details fields

### DIFF
--- a/app/components/provider_interface/language_skills_component.rb
+++ b/app/components/provider_interface/language_skills_component.rb
@@ -34,14 +34,14 @@ module ProviderInterface
     def english_main_language_details_row
       {
         key: t('application_form.personal_details.other_language_details.label'),
-        value: english_language_details.present? ? english_language_details : 'No details given',
+        value: other_language_details.present? ? other_language_details : 'No details given',
       }
     end
 
     def other_language_details_row
       {
         key: t('application_form.personal_details.other_language_details.label'),
-        value: other_language_details.present? ? other_language_details : 'No details given',
+        value: english_language_details.present? ? english_language_details : 'No details given',
       }
     end
 

--- a/app/components/provider_interface/language_skills_component.rb
+++ b/app/components/provider_interface/language_skills_component.rb
@@ -33,7 +33,7 @@ module ProviderInterface
 
     def english_main_language_details_row
       {
-        key: t('application_form.personal_details.english_main_language_details.label'),
+        key: t('application_form.personal_details.other_language_details.label'),
         value: english_language_details.present? ? english_language_details : 'No details given',
       }
     end

--- a/app/components/provider_interface/language_skills_component.rb
+++ b/app/components/provider_interface/language_skills_component.rb
@@ -33,7 +33,7 @@ module ProviderInterface
 
     def english_main_language_details_row
       {
-        key: t('application_form.personal_details.other_language_details.label'),
+        key: t('application_form.personal_details.english_main_language_details.label'),
         value: other_language_details.present? ? other_language_details : 'No details given',
       }
     end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -48,9 +48,6 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      # attrs = { english_main_language: english_main_language?, english_language_details: english_main_language? ? '' : english_language_details, other_language_details: english_main_language? ? other_language_details : '' }.inspect
-      # raise attrs
-
       application_form.update(
         first_name: first_name,
         last_name: last_name,

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -48,14 +48,17 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
+      # attrs = { english_main_language: english_main_language?, english_language_details: english_main_language? ? '' : english_language_details, other_language_details: english_main_language? ? other_language_details : '' }.inspect
+      # raise attrs
+
       application_form.update(
         first_name: first_name,
         last_name: last_name,
         first_nationality: first_nationality,
         second_nationality: second_nationality,
         english_main_language: english_main_language?,
-        english_language_details: english_main_language? ? english_language_details : '',
-        other_language_details: english_main_language? ? '' : other_language_details,
+        english_language_details: english_main_language? ? '' : english_language_details,
+        other_language_details: english_main_language? ? other_language_details : '',
         date_of_birth: date_of_birth,
       )
     end

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -61,7 +61,7 @@ module CandidateInterface
 
     def english_main_language_details_row
       {
-        key: I18n.t('application_form.personal_details.other_language_details.label'),
+        key: I18n.t('application_form.personal_details.english_main_language_details.label'),
         value: @form.other_language_details,
         action: ('other languages' if @editable),
       }
@@ -69,7 +69,7 @@ module CandidateInterface
 
     def other_language_details_row
       {
-        key: I18n.t('application_form.personal_details.english_main_language_details.label'),
+        key: I18n.t('application_form.personal_details.other_language_details.label'),
         value: @form.english_language_details,
         action: ('english languages qualifications' if @editable),
       }

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -53,24 +53,24 @@ module CandidateInterface
 
     def language_details_row
       if @form.english_main_language?
-        english_main_language_details_row if @form.english_language_details.present?
-      elsif @form.other_language_details.present?
+        english_main_language_details_row if @form.other_language_details.present?
+      elsif @form.english_language_details.present?
         other_language_details_row
       end
     end
 
     def english_main_language_details_row
       {
-        key: I18n.t('application_form.personal_details.english_main_language_details.label'),
-        value: @form.english_language_details,
+        key: I18n.t('application_form.personal_details.other_language_details.label'),
+        value: @form.other_language_details,
         action: ('other languages' if @editable),
       }
     end
 
     def other_language_details_row
       {
-        key: I18n.t('application_form.personal_details.other_language_details.label'),
-        value: @form.other_language_details,
+        key: I18n.t('application_form.personal_details.english_main_language_details.label'),
+        value: @form.english_language_details,
         action: ('english languages qualifications' if @editable),
       }
     end

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -33,11 +33,11 @@
 
         <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label') } do %>
           <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' } do %>
-            <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
+            <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
           <% end %>
 
           <%= f.govuk_radio_button :english_main_language, 'no', label: { text: 'No' } do %>
-            <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
+            <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
           <% end %>
         <% end %>
 

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -33,11 +33,11 @@
 
         <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label') } do %>
           <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' } do %>
-            <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
+            <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
           <% end %>
 
           <%= f.govuk_radio_button :english_main_language, 'no', label: { text: 'No' } do %>
-            <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
+            <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
           <% end %>
         <% end %>
 

--- a/spec/components/provider_interface/language_skills_component_spec.rb
+++ b/spec/components/provider_interface/language_skills_component_spec.rb
@@ -5,10 +5,7 @@ RSpec.describe ProviderInterface::LanguageSkillsComponent do
     application_form = build_stubbed(
       :application_form,
       english_main_language: true,
-
-      # english_language_details collects information about other languages spoken
-      # FIXME: english_language_details and other_language_details are wrong way around in candidate form
-      english_language_details: 'Details about other languages spoken',
+      other_language_details: 'Details about other languages spoken',
     )
 
     result = render_inline(described_class, application_form: application_form)
@@ -16,7 +13,7 @@ RSpec.describe ProviderInterface::LanguageSkillsComponent do
     expect(result.css('.govuk-summary-list__key').text).to include('Is English your main language?')
     expect(result.css('.govuk-summary-list__value').text).to include('Yes')
 
-    expect(result.css('.govuk-summary-list__key').text).to include('Other languages spoken')
+    expect(result.css('.govuk-summary-list__key').text).to include('other languages spoken')
     expect(result.css('.govuk-summary-list__value').text).to include('Details about other languages spoken')
   end
 
@@ -24,10 +21,7 @@ RSpec.describe ProviderInterface::LanguageSkillsComponent do
     application_form = build_stubbed(
       :application_form,
       english_main_language: false,
-
-      # other_language_details collects information and English skills
-      # FIXME: english_language_details and other_language_details are wrong way around in candidate form
-      other_language_details: 'Details about my English skills',
+      english_language_details: 'Details about my English skills',
     )
 
     result = render_inline(described_class, application_form: application_form)

--- a/spec/components/provider_interface/language_skills_component_spec.rb
+++ b/spec/components/provider_interface/language_skills_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ProviderInterface::LanguageSkillsComponent do
     expect(result.css('.govuk-summary-list__key').text).to include('Is English your main language?')
     expect(result.css('.govuk-summary-list__value').text).to include('Yes')
 
-    expect(result.css('.govuk-summary-list__key').text).to include('other languages spoken')
+    expect(result.css('.govuk-summary-list__key').text).to include('Other languages spoken')
     expect(result.css('.govuk-summary-list__value').text).to include('Details about other languages spoken')
   end
 

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       first_nationality: NATIONALITY_DEMONYMS.sample,
       second_nationality: NATIONALITY_DEMONYMS.sample,
       english_main_language: true,
-      english_language_details: Faker::Lorem.paragraph_by_chars(number: 200),
-      other_language_details: '',
+      english_language_details: '',
+      other_language_details: Faker::Lorem.paragraph_by_chars(number: 200),
     }
   end
 
@@ -72,8 +72,9 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       expect(application_form).to have_attributes(data)
     end
 
-    it 'saves the English language details only if English is the main language' do
+    it 'saves the English language details only if English is not the main language' do
       application_form = FactoryBot.create(:application_form)
+      data[:english_main_language] = false
       personal_details = CandidateInterface::PersonalDetailsForm.new(form_data)
 
       personal_details.save(application_form)
@@ -82,9 +83,8 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
       expect(application_form.other_language_details).to eq('')
     end
 
-    it 'saves the other language details only if English is not the main language' do
+    it 'saves the other language details only if English is the main language' do
       application_form = FactoryBot.create(:application_form)
-      data[:english_main_language] = false
       data[:other_language_details] = Faker::Lorem.paragraph_by_chars(number: 200)
       personal_details = CandidateInterface::PersonalDetailsForm.new(form_data)
 

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -105,12 +105,12 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         personal_details_form = build(
           :personal_details_form,
           english_main_language: 'yes',
-          english_language_details: 'Mi nombre es Max.',
-          other_language_details: '',
+          english_language_details: '',
+          other_language_details: 'I speak French',
         )
 
         expect(rows(personal_details_form)).to include(
-          row_for(:english_main_language_details, 'Mi nombre es Max.'),
+          row_for(:english_main_language_details, 'I speak French'),
         )
       end
     end
@@ -159,8 +159,8 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         personal_details_form = build(
           :personal_details_form,
           english_main_language: 'no',
-          english_language_details: '',
-          other_language_details: 'Broken? Oh man, are you cereal?',
+          english_language_details: 'Broken? Oh man, are you cereal?',
+          other_language_details: '',
         )
 
         expect(rows(personal_details_form)).to include(

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'A Provider viewing an individual application' do
                               interview_preferences: 'Any date is fine',
                               further_information: 'Nothing further to add',
                               english_main_language: true,
-                              english_language_details: 'I also speak Spanish and German')
+                              other_language_details: 'I also speak Spanish and German')
 
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)
     create_list(:application_qualification, 2, application_form: application_form, level: :gcse)

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -83,8 +83,8 @@ RSpec.feature 'Vendor receives the application' do
           nationality: %w[GB US],
           uk_residency_status: nil,
           english_main_language: true,
-          english_language_qualifications:  "I'm great at Galactic Basic so English is a piece of cake",
-          other_languages: '',
+          other_languages:  "I'm great at Galactic Basic so English is a piece of cake",
+          english_language_qualifications: '',
           disability_disclosure: 'I have difficulty climbing stairs',
         },
         qualifications: { # TODO: This section is hardcoded in the presenter


### PR DESCRIPTION
### Context

This was reported as a bug - see Trello card linked below. The candidate interface was storing details about other languages spoken in the `english_language_details` attribute and details about English qualifications in the `other_language_details` attribute. They should be the other way round.

### Changes proposed in this pull request

- [x] Use `english_language_details` to store details about English qualifications for candidates whose first language is not English.
- [x] Use `other_language_details` to store details about other languages for candidates whose first language is English.
- [x] Check the Provider interface (manual testing as well as automated tests)
- [x] Check the Vendor API (via tests)
- [x] Manually check the candidate interface

![english-language](https://user-images.githubusercontent.com/450843/69347961-495cab80-0c6d-11ea-923b-2c5b6cb0ed7f.gif)

### Guidance to review

- Are there any areas that I've missed?
- There is an assumption here that we don't have an live applications in production that could be wrong so there is no data fixup migration etc.

### Link to Trello card

[1284 - English language details fields are named the wrong way around](https://trello.com/c/NKzxKYR6/1284-english-language-details-fields-are-named-the-wrong-way-around)

### Env vars

- no env vars
