### PR TITLE
Implement omniauth-rails_csrf_protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem 'erb_lint', require: false
 gem 'devise'
 gem 'omniauth'
 gem 'omniauth_openid_connect'
+gem 'omniauth-rails_csrf_protection'
 
 gem 'workflow'
 gem 'audited'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,9 @@ GEM
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     omniauth_openid_connect (0.3.3)
       addressable (~> 2.5)
       omniauth (~> 1.9)
@@ -518,6 +521,7 @@ DEPENDENCIES
   logstash-logger
   mail-notify
   omniauth
+  omniauth-rails_csrf_protection
   omniauth_openid_connect
   pg (~> 1.1.4)
   pry

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <% if DfESignIn.bypass? %>
-  <%= link_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
+  <%= button_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
 <% else %>
-  <%= link_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
+  <%= button_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
 <% end %>

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -7,7 +7,7 @@ module DfESignInHelpers
 
   def provider_signs_in_using_dfe_sign_in
     visit provider_interface_path
-    click_link 'Sign in using DfE Sign-in'
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def fake_dfe_sign_in_auth_hash(email_address:, dfe_sign_in_uid:)

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
   end
 
   def and_i_sign_in_via_dfe_sign_in
-    click_link 'Sign in using DfE Sign-in'
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def then_i_should_be_redirected_to_the_provider_dashboard; end
@@ -39,6 +39,6 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
   end
 
   def then_i_should_see_the_login_page_again
-    expect(page).to have_content('Sign in using DfE Sign-in')
+    expect(page).to have_button('Sign in using DfE Sign-in')
   end
 end


### PR DESCRIPTION
**When this is merged we can safely close the "We found a potential security vulnerability" notice appearing at the top of our GitHub repo**

This prevents a scenario where:

1. there is a CSRF vuln in DfE Sign-in that allows Mallory to sign Alice
into Mallory's DfE Sign-in account (AFAIK this is not the case)
2. Mallory does this so Alice is Mallory from DSI's point of view
3. Mallory causes Alice to visit /auth/dfe on apply
4. Mallory's DfE Sign-in account is connected to Alice's Apply account,
and Mallory can impersonate Alice on Apply

The fix is to accept only CSRF-controlled POSTs to /auth/dfe.

Further reading:
https://github.com/advisories/GHSA-ww4x-rwq6-qpgf
