### PR TITLE
Fix up GCSE error hints

### DIFF
--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
       details_form = GcseQualificationDetailsForm.build_from_qualification(
         current_application.qualification_in_subject(:gcse, subject_param),
       )
+      @qualification_type = details_form.qualification.qualification_type
 
       details_form.grade = details_params[:grade]
       details_form.award_year = details_params[:award_year]


### PR DESCRIPTION
### Context
🐛 

### Changes proposed in this pull request
Fix bug with hint text on GCSE requirements

### Guidance to review
### BEFORE
![localhost_3000_candidate_application_gcse_maths_details(Laptop with MDPI screen) (1)](https://user-images.githubusercontent.com/3071606/69355228-5a131e80-0c79-11ea-802b-ccd31a176088.png)

### AFTER
![localhost_3000_candidate_application_gcse_maths_details(Laptop with MDPI screen)](https://user-images.githubusercontent.com/3071606/69355057-11f3fc00-0c79-11ea-8cef-f7d4a74478cc.png)

### Link to Trello card
[468 - Code appearing on hint text on /candidate/application/gcse/english/details and /maths/details and /science/details](https://trello.com/c/wHnqSAxy/468-code-appearing-on-hint-text-on-candidate-application-gcse-english-details-and-maths-details-and-science-details)

### Env vars
n/a