### PR TITLE
See which courses are available on DFE Apply before starting

### DIFF
--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -17,5 +17,12 @@ module CandidateInterface
     def terms_candidate
       render_content_page :terms_candidate
     end
+
+    def providers
+      @courses_by_provider = Course
+        .visible_to_candidates
+        .includes(:provider)
+        .group_by { |c| c.provider.name }
+    end
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,6 +7,8 @@ class Course < ApplicationRecord
   validates :level, presence: true
   validates :code, uniqueness: { scope: :provider_id }
 
+  scope :visible_to_candidates, -> { where(exposed_in_find: true, open_on_apply: true) }
+
   CODE_LENGTH = 4
 
   # This enum is copied verbatim from Find to maintain consistency

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, t('page_titles.providers') %>
+
+<h1 class='govuk-heading-xl'>
+  <%= t('page_titles.providers') %>
+</h1>
+
+<div class='govuk-grid-row'>
+  <div class='govuk-grid-column-two-thirds'>
+    <div class='govuk-body'>
+      You can apply to the following training providers and courses using <%= govuk_link_to 'Apply for teacher training', candidate_interface_start_path %>.
+    </div>
+
+    <% @courses_by_provider.each do |provider_name, courses| %>
+      <h2 class='govuk-heading-m govuk-!-margin-bottom-2'><%= provider_name %></h2>
+      <ul class='govuk-list govuk-list--bullet'>
+        <% courses.sort_by(&:name).each do |course| %>
+          <li><%= govuk_link_to course.name_and_code, candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code) %></li>
+        <% end %>
+      </ul>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,6 +63,7 @@ en:
       - First referee
       - Second referee
     apply_on_ucas: We’re sorry, but we’re not ready for you yet
+    providers: Training providers available through Apply for teacher training
   layout:
     service_name: Apply for teacher training
     accessibility: Accessibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/cookies', to: 'content#cookies_candidate', as: :cookies
     get '/terms-of-use', to: 'content#terms_candidate', as: :terms
+    get '/providers', to: 'content#providers', as: :providers
 
     get '/eligibility' => 'start_page#eligibility', as: :eligibility
     post '/eligibility' => 'start_page#determine_eligibility'

--- a/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
     and_i_should_see_the_provider_and_course_codes
     and_i_should_see_the_course_name_fetched_from_find
     and_i_should_be_able_to_apply_through_ucas
+
+    when_i_visit_the_available_courses_page
+    i_should_see_the_available_providers_and_courses
   end
 
   def when_i_have_arrive_from_find_with_invalid_course_parameters
@@ -21,7 +24,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def when_i_have_arrived_from_find_with_valid_course_parameters
-    create(:course, exposed_in_find: true, code: 'XYZ1', name: 'Biology', provider: create(:provider, code: 'ABC'))
+    create(:course, exposed_in_find: true, open_on_apply: true, code: 'XYZ1', name: 'Biology', provider: create(:provider, code: 'ABC'))
     visit candidate_interface_apply_from_find_path providerCode: 'ABC', courseCode: 'XYZ1'
   end
 
@@ -41,5 +44,13 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   def and_i_should_be_able_to_apply_through_ucas
     expect(page).to have_content t('apply_from_find.apply_button')
+  end
+
+  def when_i_visit_the_available_courses_page
+    visit candidate_interface_providers_path
+  end
+
+  def i_should_see_the_available_providers_and_courses
+    expect(page).to have_content 'Biology'
   end
 end


### PR DESCRIPTION
### Context

This adds a page where candidates can see what courses are available on DfE Apply.

### Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/233676/69355316-7ca53780-0c79-11ea-9398-bf8eeb40b2f5.png)

### Guidance to review

The tests are a bit weird - I'll make those better in https://trello.com/c/5wXHsiOC.

### Link to Trello card

https://trello.com/c/POKDlIlJ/283-see-which-courses-are-available-on-dfe-apply-before-starting