### PR TITLE
Show missing sections in candidate review and prevent submission with missing sections

### DIFF
--- a/app/components/contact_details_review_component.html.erb
+++ b/app/components/contact_details_review_component.html.erb
@@ -1,1 +1,9 @@
-<%= render(SummaryCardComponent, rows: contact_details_form_rows, editable: @editable) %>
+<% if show_missing_section? %>
+  <%= render(SectionMissingBannerComponent, text: 'Contact details not entered') do %>
+    <%= link_to candidate_interface_contact_details_edit_base_path, class: 'govuk-link' do %>
+      Complete <span class="govuk-visually-hidden">contact details</span> section
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render(SummaryCardComponent, rows: contact_details_form_rows, editable: @editable) %>
+<% end %>

--- a/app/components/contact_details_review_component.rb
+++ b/app/components/contact_details_review_component.rb
@@ -13,6 +13,10 @@ class ContactDetailsReviewComponent < ActionView::Component::Base
     [phone_number_row, address_row]
   end
 
+  def show_missing_section?
+    !@contact_details_form.valid?(:base) && !@contact_details_form.valid?(:address) && @editable
+  end
+
 private
 
   attr_reader :application_form

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -34,3 +34,11 @@
 <% if any_withdrawable? %>
   <p class="govuk-body"><%= t('application_form.courses.withdrawal_information') %></p>
 <% end %>
+
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: 'Course choices are not marked as completed') do %>
+    <%= link_to candidate_interface_course_choices_index_path, class: 'govuk-link' do %>
+      Complete <span class="govuk-visually-hidden">course choices</span> section
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -1,11 +1,12 @@
 class CourseChoicesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, show_status: false)
+  def initialize(application_form:, editable: true, show_status: false, show_incomplete: false)
     @application_form = application_form
     @course_choices = @application_form.application_choices
     @editable = editable
     @show_status = show_status
+    @show_incomplete = show_incomplete
   end
 
   def course_choice_rows(course_choice)
@@ -25,6 +26,10 @@ class CourseChoicesReviewComponent < ActionView::Component::Base
     @application_form.application_choices.any? do |course_choice|
       withdrawable?(course_choice)
     end
+  end
+
+  def show_missing_banner?
+    @show_incomplete
   end
 
 private

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -12,5 +12,13 @@
     </header>
   <% end %>
 <% else %>
-  <p class="govuk-body">No GCSE entered.</p>
+  <% if @editable %>
+    <%= render(SectionMissingBannerComponent, text: 'Not entered') do %>
+      <%= link_to candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), class: 'govuk-link' do %>
+        Complete <span class="govuk-visually-hidden"><%= subject %> GCSE</span> section
+      <% end %>
+    <% end %>
+  <% else %>
+    <p class="govuk-body">No GCSE entered.</p>
+  <% end %>
 <% end %>

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -11,14 +11,12 @@
       </h2>
     </header>
   <% end %>
-<% else %>
-  <% if @editable %>
-    <%= render(SectionMissingBannerComponent, text: 'Not entered') do %>
-      <%= link_to candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), class: 'govuk-link' do %>
-        Complete <span class="govuk-visually-hidden"><%= subject %> GCSE</span> section
-      <% end %>
+<% elsif @editable %>
+  <%= render(SectionMissingBannerComponent, text: 'Not entered') do %>
+    <%= link_to candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), class: 'govuk-link' do %>
+      Complete <span class="govuk-visually-hidden"><%= subject %> GCSE</span> section
     <% end %>
-  <% else %>
-    <p class="govuk-body">No GCSE entered.</p>
   <% end %>
+<% else %>
+  <p class="govuk-body">No GCSE entered.</p>
 <% end %>

--- a/app/components/personal_details_review_component.html.erb
+++ b/app/components/personal_details_review_component.html.erb
@@ -1,5 +1,11 @@
 <% if @personal_details_form.valid? %>
   <%= render(SummaryCardComponent, rows: rows, editable: @editable) %>
+<% elsif @editable %>
+  <%= render(SectionMissingBannerComponent, text: 'Personal details not entered') do %>
+    <%= link_to candidate_interface_personal_details_edit_path, class: 'govuk-link' do %>
+      Complete <span class="govuk-visually-hidden">personal details</span> section
+    <% end %>
+  <% end %>
 <% else %>
   <p class="govuk-body">No personal details entered.</p>
 <% end %>

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,5 +1,5 @@
-<div class="app-banner app-banner--info">
-  <div class="app-banner__message app-banner__message--missing-section">
+<div class="app-banner app-banner--info app-banner--missing-section">
+  <div class="app-banner__message">
     <p class="govuk-body"><%= @text %></p>
     <% if content.present? %>
       <%= content %>

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,0 +1,8 @@
+<div class="app-banner app-banner--info">
+  <div class="app-banner__message app-banner__message--missing-section">
+    <p class="govuk-body"><%= @text %></p>
+    <% if content.present? %>
+      <%= content %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/section_missing_banner_component.rb
+++ b/app/components/section_missing_banner_component.rb
@@ -1,0 +1,9 @@
+class SectionMissingBannerComponent < ActionView::Component::Base
+  validates :text, presence: true
+
+  def initialize(text:)
+    @text = text
+  end
+
+  attr_reader :text
+end

--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -21,6 +21,20 @@
   @include govuk-font($size: 19);
   display: block;
   overflow: hidden;
+
+  &--missing-section {
+    @include govuk-media-query($from: desktop) {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+    }
+
+    p {
+      @include govuk-typography-weight-bold;
+      color: govuk-colour("blue");
+      margin: 0;
+    }
+  }
 }
 
 .app-banner__message *:last-child {

--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -3,6 +3,24 @@
   @include govuk-responsive-padding(4);
   @include govuk-responsive-margin(8, "bottom");
   border: $govuk-border-width solid govuk-colour("blue");
+
+  &--missing-section {
+    @include govuk-responsive-margin(4, "bottom");
+
+    .app-banner__message {
+      @include govuk-media-query($from: desktop) {
+        display: flex;
+        justify-content: space-between;
+        align-items: start;
+      }
+
+      p {
+        @include govuk-typography-weight-bold;
+        color: govuk-colour("blue");
+        margin: 0;
+      }
+    }
+  }
 }
 
 .app-banner--info {
@@ -21,20 +39,6 @@
   @include govuk-font($size: 19);
   display: block;
   overflow: hidden;
-
-  &--missing-section {
-    @include govuk-media-query($from: desktop) {
-      display: flex;
-      justify-content: space-between;
-      align-items: start;
-    }
-
-    p {
-      @include govuk-typography-weight-bold;
-      color: govuk-colour("blue");
-      margin: 0;
-    }
-  }
 }
 
 .app-banner__message *:last-child {

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
 
-<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable, show_incomplete: !application_form.course_choices_completed && editable) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 

--- a/spec/components/personal_details_review_component_spec.rb
+++ b/spec/components/personal_details_review_component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PersonalDetailsReviewComponent do
 
     it 'renders fallback text with invalid personal details' do
       application_form = build_stubbed(:application_form)
-      result = render_inline(PersonalDetailsReviewComponent, application_form: application_form)
+      result = render_inline(PersonalDetailsReviewComponent, application_form: application_form, editable: false)
 
       expect(result.text).to include('No personal details entered')
     end


### PR DESCRIPTION
### Context

We need to show candidates which sections still need to be completed, and we need to stop users from submitting when they haven't finished all sections.

### Changes proposed in this pull request

Add a component and use it in every review component. Update end to end tests to check for it.

### Guidance to review

Review commit by commit.

![Screenshot 2019-11-22 at 20 04 34](https://user-images.githubusercontent.com/1650875/69456771-683d6980-0d63-11ea-8044-49b9c1a10134.png)
![Screenshot 2019-11-22 at 20 05 07](https://user-images.githubusercontent.com/1650875/69456772-683d6980-0d63-11ea-84bd-e59b6c462b7b.png)
![Screenshot 2019-11-22 at 21 10 00](https://user-images.githubusercontent.com/1650875/69460685-a0957580-0d6c-11ea-9b4d-20cd804f764b.png)


TODO (follow-up PRs?):

- Improve content design

### Link to Trello card

[351 - Check that all questions are answered before submit](https://trello.com/c/TYfYUDKt/351-check-that-all-questions-are-answered-before-submit)