### PR TITLE
Localise GCSE qualification strings

### DIFF
--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -3,9 +3,9 @@
     <header class="app-summary-card__header">
       <h3 class="app-summary-card__title">
         <%= if @application_qualification.missing_qualification?
-              t('gcse_edit_type.types.missing')
+              t('application_form.gcse.qualification_types.missing')
             else
-              t('gcse_edit_type.types.gcse')
+              t('application_form.gcse.qualification_types.gcse')
             end
         %>
       </h3>

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
 
-    # 1th step - Edit qualification type
+    # 1st step - Edit qualification type
     def edit
       @application_qualification = find_or_build_qualification_form
     end

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -2,7 +2,7 @@ module GcseQualificationHelper
   def select_gcse_qualification_type_options
     option = Struct.new(:id, :label)
 
-    t('gcse_edit_type.types').map { |id, label| option.new(id, label) }
+    t('application_form.gcse.qualification_types').map { |id, label| option.new(id, label) }
   end
 
   def guidance_for_gcse_edit_details(subject, qualification_type)
@@ -12,7 +12,7 @@ module GcseQualificationHelper
   end
 
   def heading_for_gcse_edit_type(subject)
-    t("gcse_edit_type.heading.#{subject}")
+    t("gcse_edit_type.page_titles.#{subject}")
   end
 
   def hint_for_gcse_edit_details(subject, qualification_type)

--- a/app/views/candidate_interface/gcse/details/edit.html.erb
+++ b/app/views/candidate_interface/gcse/details/edit.html.erb
@@ -1,21 +1,21 @@
-<% content_for :title, t("gcse_edit_details.heading.#{@subject}") %>
+<% content_for :title, t("gcse_edit_details.page_titles.#{@subject}") %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_details_edit_type_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_details_path, method: :patch do |f| %>
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <h1 class="govuk-fieldset__heading"><%= t("gcse_edit_details.heading.#{@subject}") %></h1>
+        <h1 class="govuk-fieldset__heading"><%= t("gcse_edit_details.page_titles.#{@subject}") %></h1>
       </legend>
 
       <%= f.govuk_error_summary %>
 
       <%= guidance_for_gcse_edit_details(@subject, @qualification_type) %>
 
-      <%= f.govuk_text_field :grade, label: { text: 'What was your grade?', size: 'm' }, hint_text: hint_for_gcse_edit_details(@subject, @qualification_type), width: 10 %>
-      <%= f.govuk_text_field :award_year, label: { text: 'When did you get your qualification?', size: 'm' }, width: 4 %>
+      <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint_text: hint_for_gcse_edit_details(@subject, @qualification_type), width: 10 %>
+      <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, width: 4 %>
 
-      <%= f.submit 'Save and continue', class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
   <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -1,8 +1,8 @@
-<% content_for :title, t("gcse_summary.heading.#{@subject}") %>
+<% content_for :title, t("gcse_summary.page_titles.#{@subject}") %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
-  <h1 class="govuk-heading-xl"><%= t("gcse_summary.heading.#{@subject}") %></h1>
+  <h1 class="govuk-heading-xl"><%= t("gcse_summary.page_titles.#{@subject}") %></h1>
 
   <%= render(GcseQualificationReviewComponent, application_qualification: @application_qualification, subject: @subject) %>
 </div>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -1,28 +1,28 @@
-<% content_for :title, t("gcse_edit_type.heading.#{@subject}") %>
+<% content_for :title, t("gcse_edit_type.page_titles.#{@subject}") %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_type_path, method: :post do |f| %>
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <h1 class="govuk-fieldset__heading"><%= t("gcse_edit_type.heading.#{@subject}") %></h1>
+        <h1 class="govuk-fieldset__heading"><%= t("gcse_edit_type.page_titles.#{@subject}") %></h1>
       </legend>
 
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: 'Type of qualification' } do %>
+      <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: t('application_form.gcse.qualification_type.label') } do %>
         <% select_gcse_qualification_type_options.each do |option| %>
           <% if option.id == :other_uk %>
 
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label } do %>
-              <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('gcse_edit_type.label.other_uk'), size: 's' } %>
+              <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' } %>
             <% end %>
 
           <% elsif option.id == :missing %>
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label } do %>
               <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
               <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to 'Get into teaching', 'https://getintoteaching.education.gov.uk/get-help-and-support/' %>.</p>
-              <%= f.govuk_text_area :missing_explanation, label: { text: t('gcse_edit_type.label.missing_explanation'), size: 's' }, rows: 12, max_words: 200 do %>
+              <%= f.govuk_text_area :missing_explanation, label: { text: t('application_form.gcse.missing_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
               <% end %>
             <% end %>
           <% else %>
@@ -31,7 +31,7 @@
         <% end %>
       <% end %>
 
-      <%= f.submit 'Save and continue', class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
+      <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
   <% end %>
   </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -146,6 +146,24 @@ en:
         button: Add another degree
       delete: Delete degree
       confirm_delete: Yes I’m sure - delete this degree
+    gcse:
+      qualification_type:
+        label: Type of qualification
+      qualification_types:
+        gcse: GCSE
+        gce_o_level: GCE O Level
+        scottish_national_5: Scottish National 5
+        other_uk: Other UK qualification
+        missing: I don’t have this qualification yet
+      other_uk:
+        label: Enter type of qualification
+      missing_explanation:
+        label: If you are working towards this qualification, give us details (optional)
+      grade:
+        label: What was your grade?
+      award_year:
+        label: When did you get your qualification?
+      complete_form_button: Save and continue
     other_qualification:
       qualification:
         label: Qualification

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -1,20 +1,11 @@
 en:
   gcse_edit_type:
-    heading:
+    page_titles:
       maths: Add maths GCSE grade 4 (C) or above, or equivalent
       english: Add English GCSE grade 4 (C) or above, or equivalent
       science: Add science GCSE grade 4 (C) or above, or equivalent
-    types:
-      gcse: GCSE
-      gce_o_level: GCE O Level
-      scottish_national_5: Scottish National 5
-      other_uk: Other UK qualification
-      missing: I don’t have this qualification yet
-    label:
-      other_uk: Enter type of qualification
-      missing_explanation: If you are working towards this qualification, give us details (optional)
   gcse_edit_details:
-    heading:
+    page_titles:
       maths: Maths qualification grade and year
       english: English qualification grade and year
       science: Science qualification grade and year
@@ -36,7 +27,7 @@ en:
         gce_o_level: For example, ‘C’
         scottish_national_5: For example, ‘C’ or ‘4’
   gcse_summary:
-    heading:
+    page_titles:
       maths: Maths GCSE or equivalent
       english: English GCSE or equivalent
       science: Science GCSE or equivalent

--- a/spec/system/candidate_interface/candidate_entering_gcse_other_uk_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_other_uk_qualification_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def and_i_fill_in_the_type_of_qualification
-    fill_in t('gcse_edit_type.label.other_uk'), with: 'Scottish Baccalaureate'
+    fill_in t('application_form.gcse.other_uk.label'), with: 'Scottish Baccalaureate'
   end
 
   def and_i_click_save_and_continue

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def then_i_see_the_edit_details_page
-    expect(page).to have_content t('gcse_edit_details.heading.maths')
+    expect(page).to have_content t('gcse_edit_details.page_titles.maths')
   end
 
   def then_i_see_the_review_page_with_correct_details
@@ -98,7 +98,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def then_i_see_add_grade_and_year_page
-    expect(page).to have_content t('gcse_edit_details.heading.maths')
+    expect(page).to have_content t('gcse_edit_details.page_titles.maths')
   end
 
   def when_i_fill_in_grade_and_year

--- a/spec/system/candidate_interface/candidate_entering_gcse_with_missing_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_with_missing_qualification_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Candidate entering GCSE details' do
   end
 
   def and_i_enter_the_missing_explanation
-    fill_in t('gcse_edit_type.label.missing_explanation'),
+    fill_in t('application_form.gcse.missing_explanation.label'),
             with: "I'm expecting to complete my Biology course on next July"
   end
 


### PR DESCRIPTION
### Context

Following on from #637:

* Ensures labels in GCSE qualification section use localisable strings
* Moves some GCSE strings into `application_form.yml` alongside similar strings and validation errors
* `gcse_details.yml` is then reserved for strings that relate to maths/english/science variations
* Updates some key names to be consistent with those used elsewhere
