### PR TITLE
Do not show all applications to providers not in the permissions mapping 

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -4,6 +4,13 @@ module ProviderInterface
     before_action :authenticate_provider_user!
     layout 'application'
 
+    rescue_from MissingProvider, with: ->(e) {
+      Raven.extra_context dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid
+      Raven.capture_exception(e)
+
+      render template: 'provider_interface/account_creation_in_progress', status: 403
+    }
+
     helper_method :current_provider_user
 
   private

--- a/app/lib/missing_provider.rb
+++ b/app/lib/missing_provider.rb
@@ -1,0 +1,1 @@
+class MissingProvider < RuntimeError; end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -2,6 +2,8 @@ class GetApplicationChoicesForProvider
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete].freeze
 
   def self.call(provider:)
+    raise MissingProvider unless provider.present?
+
     ApplicationChoice.includes(:course)
       .where('courses.provider_id' => provider)
       .or(ApplicationChoice.includes(:course)

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -3,9 +3,9 @@ class GetApplicationChoicesForProvider
 
   def self.call(provider:)
     ApplicationChoice.includes(:course)
-    .where('courses.provider_id' => provider)
-    .or(ApplicationChoice.includes(:course)
+      .where('courses.provider_id' => provider)
+      .or(ApplicationChoice.includes(:course)
       .where('courses.accrediting_provider_id' => provider))
-    .where('status NOT IN (?)', STATES_NOT_VISIBLE_TO_PROVIDER)
+      .where('status NOT IN (?)', STATES_NOT_VISIBLE_TO_PROVIDER)
   end
 end

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, t('page_titles.application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Account creation in progress
+    </h1>
+    <p class="govuk-body">
+    You are seeing this page because you have successfully signed in to the
+    Apply for teacher training service, but your user account has not yet been
+    associated with your training provider.
+    </p>
+
+    <p class="govuk-body">
+    For more information please contact <%= mail_to 'becomingateacher@digital.education.gov.uk', 'becomingateacher@digital.education.gov.uk', class: 'govuk-link' %>.
+    </p>
+  </div>
+</div>

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -4,7 +4,6 @@ Given(/an application choice has "(.*)" status/) do |original_application_status
   application_form = FactoryBot.create(:application_form)
   @application_choice = FactoryBot.create(
     :application_choice,
-    :single,
     application_form: application_form,
     status: original_application_status.gsub(' ', '_'),
   )

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -43,6 +43,10 @@ FactoryBot.define do
         references_count { 2 }
       end
 
+      trait :without_application_choices do
+        application_choices_count { 0 }
+      end
+
       after(:build) do |application_form, evaluator|
         create_list(:application_choice, evaluator.application_choices_count, application_form: application_form)
         create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)
@@ -120,14 +124,13 @@ FactoryBot.define do
   end
 
   factory :application_choice do
-    association :application_form, factory: :completed_application_form
+    # application_forms come with 3 application_choices out of the box. if we're making
+    # an application_choice on its own, suppress these to avoid surprises
+    association :application_form, factory: %i[completed_application_form without_application_choices]
+
     course_option
     status { ApplicationStateChange.valid_states.sample }
     personal_statement { 'hello' }
-
-    trait :single do
-      association :application_form, factory: :completed_application_form, application_choices_count: 0
-    end
   end
 
   factory :vendor_api_user do

--- a/spec/requests/provider_interface/account_creation_in_progress_spec.rb
+++ b/spec/requests/provider_interface/account_creation_in_progress_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /provider/applications' do
+  context 'when the user is not associated with a provider' do
+    before do
+      allow(ProviderUser).to receive(:load_from_session)
+        .and_return(
+          ProviderUser.new(
+            email_address: 'email@example.com',
+            dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+          ),
+      )
+
+      # do not grant the user permission to view a provider's applications
+    end
+
+    it 'returns 403 with the account-creation-in-progress page' do
+      get '/provider/applications'
+
+      expect(response).to have_http_status 403
+      expect(response.body).to include('Account creation in progress')
+    end
+
+    it 'reports the error to Sentry, appending the Sign-in UID' do
+      allow(Raven).to receive(:extra_context)
+      allow(Raven).to receive(:capture_exception)
+
+      get '/provider/applications'
+
+      expect(Raven).to have_received(:extra_context), with: { dfe_sign_in_uid: 'DFE_SIGN_IN_UID' }
+      expect(Raven).to have_received(:capture_exception)
+    end
+  end
+end

--- a/spec/services/get_application_choices_for_provider_spec.rb
+++ b/spec/services/get_application_choices_for_provider_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe GetApplicationChoicesForProvider do
   include CourseOptionHelpers
 
+  it 'raises an exception when the provider is nil' do
+    expect {
+      GetApplicationChoicesForProvider.call(provider: nil)
+    }.to raise_error(MissingProvider)
+  end
+
   it 'returns the application for the given provider' do
     current_provider = create(:provider, code: 'BAT')
 

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -10,6 +10,11 @@ module DfESignInHelpers
     click_button 'Sign in using DfE Sign-in'
   end
 
+  def dfe_sign_in_uid_has_permission_to_view_applications_for_provider(dfe_sign_in_uid = 'DFE_SIGN_IN_UID', code = 'ABC')
+    allow(Rails.application.config).to receive(:provider_permissions)
+      .and_return(code => [dfe_sign_in_uid])
+  end
+
   def fake_dfe_sign_in_auth_hash(email_address:, dfe_sign_in_uid:)
     {
       'provider' => 'dfe',

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Provider makes an offer' do
 
   scenario 'Provider makes an offer' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
 
     when_i_respond_to_an_application
     and_i_choose_to_make_an_offer
@@ -30,6 +31,10 @@ RSpec.feature 'Provider makes an offer' do
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    dfe_sign_in_uid_has_permission_to_view_applications_for_provider
   end
 
   def when_i_respond_to_an_application

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -11,12 +11,16 @@ RSpec.feature 'Provider rejects application' do
 
   scenario 'Provider rejects application' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+
     when_i_respond_to_an_application
     and_i_choose_to_reject_it
     then_i_see_some_application_info
+
     when_i_add_a_rejection_reason
     and_i_click_to_continue
     then_i_am_asked_to_confirm_the_rejection
+
     when_i_confirm_the_rejection
     then_i_am_back_to_the_application_page
     and_i_can_see_the_application_has_just_been_rejected
@@ -25,6 +29,10 @@ RSpec.feature 'Provider rejects application' do
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    dfe_sign_in_uid_has_permission_to_view_applications_for_provider
   end
 
   def when_i_respond_to_an_application

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -5,18 +5,22 @@ RSpec.feature 'Provider responds to application' do
   include DfESignInHelpers
 
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
-  let(:application_awaiting_provider_decision) {
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
-  }
-  let(:application_rejected) {
-    create(:application_choice, status: 'rejected', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
-  }
 
-  scenario 'Provider can respond to application currently awaiting_provider_decision' do
+  let(:application_awaiting_provider_decision) do
+    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+  end
+
+  let(:application_rejected) { create(:application_choice, status: 'rejected', course_option: course_option) }
+
+  scenario 'Provider can respond to an application currently awaiting_provider_decision' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     when_i_visit_a_application_with_status_awaiting_provider_decision
     then_i_can_see_its_status application_awaiting_provider_decision
     and_i_can_respond_to_the_application
+
+    when_i_click_to_respond_to_the_application
+    then_i_am_given_the_option_to_make_an_offer
+    and_i_am_given_the_option_to_reject_the_application
   end
 
   scenario 'Provider cannot respond to application currently rejected' do
@@ -24,14 +28,6 @@ RSpec.feature 'Provider responds to application' do
     when_i_visit_a_application_with_status_rejected
     then_i_can_see_its_status application_rejected
     and_i_cannot_respond_to_the_application
-  end
-
-  scenario 'Provider is given two options when responding to an application' do
-    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-    when_i_visit_a_application_with_status_awaiting_provider_decision
-    and_i_click_to_respond_to_the_application
-    then_i_am_given_the_option_to_make_an_offer
-    and_i_am_given_the_option_to_reject_the_application
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
@@ -67,7 +63,7 @@ RSpec.feature 'Provider responds to application' do
     expect(page).not_to have_content 'Respond to application'
   end
 
-  def and_i_click_to_respond_to_the_application
+  def when_i_click_to_respond_to_the_application
     click_on 'Respond to application'
   end
 

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -14,6 +14,8 @@ RSpec.feature 'Provider responds to application' do
 
   scenario 'Provider can respond to an application currently awaiting_provider_decision' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+
     when_i_visit_a_application_with_status_awaiting_provider_decision
     then_i_can_see_its_status application_awaiting_provider_decision
     and_i_can_respond_to_the_application
@@ -25,6 +27,8 @@ RSpec.feature 'Provider responds to application' do
 
   scenario 'Provider cannot respond to application currently rejected' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+
     when_i_visit_a_application_with_status_rejected
     then_i_can_see_its_status application_rejected
     and_i_cannot_respond_to_the_application
@@ -33,6 +37,10 @@ RSpec.feature 'Provider responds to application' do
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    dfe_sign_in_uid_has_permission_to_view_applications_for_provider
   end
 
   def when_i_visit_a_application_with_status_awaiting_provider_decision

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -15,15 +15,12 @@ RSpec.feature 'See applications' do
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-    @dfe_sign_in_uid = 'MY_SIGN_IN_UID'
-
-    provider_exists_in_dfe_sign_in(dfe_sign_in_uid: @dfe_sign_in_uid)
+    provider_exists_in_dfe_sign_in
     provider_signs_in_using_dfe_sign_in
   end
 
   def and_i_am_permitted_to_see_applications_for_my_provider
-    allow(Rails.application.config).to receive(:provider_permissions)
-      .and_return(ABC: [@dfe_sign_in_uid])
+    dfe_sign_in_uid_has_permission_to_view_applications_for_provider
   end
 
   def and_my_organisation_has_accredited_courses_with_applications

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -33,9 +33,9 @@ RSpec.feature 'See applications' do
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
 
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Bob'))
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option, application_form: create(:completed_application_form, first_name: 'Charlie'))
+    @my_provider_choice1  = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    @my_provider_choice2  = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    @other_provider_choice = create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
   end
 
   def when_i_visit_the_provider_page
@@ -43,20 +43,20 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_see_the_applications_from_my_organisation
-    expect(page).to have_content 'Alice'
-    expect(page).to have_content 'Bob'
+    expect(page).to have_content @my_provider_choice1.application_form.first_name
+    expect(page).to have_content @my_provider_choice2.application_form.first_name
   end
 
   def but_not_the_applications_from_other_providers
-    expect(page).not_to have_content 'Charlie'
+    expect(page).not_to have_content @other_provider_choice.application_form.first_name
   end
 
   def when_i_click_on_an_application
-    click_on 'Alice'
+    click_on @my_provider_choice1.application_form.first_name
   end
 
   def then_i_should_be_on_the_application_view_page
     expect(page).to have_content 'Application for'
-    expect(page).to have_content 'Alice Wunder'
+    expect(page).to have_content @my_provider_choice1.application_form.first_name
   end
 end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -6,10 +6,14 @@ RSpec.feature 'See applications' do
 
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_my_training_provider_exists
     and_my_organisation_has_applications
-    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_have_not_been_assigned_to_my_training_provider # this is a manual process for now
+    and_i_visit_the_provider_page
+    then_i_should_see_the_account_creation_in_progress_page
 
-    when_i_visit_the_provider_page
+    when_i_have_been_assigned_to_my_training_provider
+    and_i_visit_the_provider_page
     then_i_should_see_the_applications_from_my_organisation
     but_not_the_applications_from_other_providers
 
@@ -17,16 +21,23 @@ RSpec.feature 'See applications' do
     then_i_should_be_on_the_application_view_page
   end
 
-  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-    @dfe_sign_in_uid = 'MY_SIGN_IN_UID'
+  def and_my_training_provider_exists
+    create(:provider, code: 'ABC')
+  end
 
-    provider_exists_in_dfe_sign_in(dfe_sign_in_uid: @dfe_sign_in_uid)
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
     provider_signs_in_using_dfe_sign_in
   end
 
-  def and_i_am_permitted_to_see_applications_for_my_provider
-    allow(Rails.application.config).to receive(:provider_permissions)
-      .and_return(ABC: [@dfe_sign_in_uid])
+  def and_i_have_not_been_assigned_to_my_training_provider; end
+
+  def then_i_should_see_the_account_creation_in_progress_page
+    expect(page).to have_content('Account creation in progress')
+  end
+
+  def when_i_have_been_assigned_to_my_training_provider
+    dfe_sign_in_uid_has_permission_to_view_applications_for_provider
   end
 
   def and_my_organisation_has_applications
@@ -38,7 +49,7 @@ RSpec.feature 'See applications' do
     @other_provider_choice = create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
   end
 
-  def when_i_visit_the_provider_page
+  def and_i_visit_the_provider_page
     visit provider_interface_path
   end
 

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'A Provider viewing an individual application' do
   scenario 'the application data is visible' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_received_an_application
+    and_i_am_permitted_to_see_applications_for_my_provider
 
     when_i_visit_that_application_in_the_provider_interface
 
@@ -23,6 +24,10 @@ RSpec.describe 'A Provider viewing an individual application' do
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
     provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    dfe_sign_in_uid_has_permission_to_view_applications_for_provider
   end
 
   def and_my_organisation_has_received_an_application


### PR DESCRIPTION
Draft, existing specs still broken

Due to an `or` condition in `GetApplicationsForProvider`, when a provider is `nil` we return all applications. (or at least all of the ones without an accrediting provider).

- [x] raise an exception if this happens
- [x] show the user a page saying their account is being set up
- [x] send a sentry notification

Couple of spec refactors up front to smooth the road.

<img width="810" alt="Screenshot 2019-11-21 at 16 46 24" src="https://user-images.githubusercontent.com/642279/69361204-e88c9d80-0c83-11ea-9d65-3e7665cf3af4.png">

### Guidance to review

commit by commit

https://trello.com/c/OTiDNrff/1295-provider-applications-are-not-scoped-on-the-provider-ui-you-can-see-everything