### PR TITLE
Add view and respond to offer link and conditionally show withdrawal link and content

### DIFF
--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -5,13 +5,17 @@
         <%= course_choice.provider.name %>
       </h3>
 
-      <% if @editable %>
+      <% if course_choice.offer? %>
         <div class='app-summary-card__actions'>
-          <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
+          <%= link_to t('application_form.courses.view_and_respond_to_offer'), '#', class: 'govuk-link' %>
         </div>
-      <% else %>
+      <% elsif withdrawable?(course_choice) %>
         <div class='app-summary-card__actions'>
           <%= link_to t('application_form.courses.withdraw'), candidate_interface_course_choice_withdraw_path(course_choice.id), class: 'govuk-link' %>
+        </div>
+      <% elsif @editable %>
+        <div class='app-summary-card__actions'>
+          <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
         </div>
       <% end %>
     </header>

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -21,3 +21,7 @@
     </header>
   <% end %>
 <% end %>
+
+<% if any_withdrawable? %>
+  <p class="govuk-body"><%= t('application_form.courses.withdrawal_information') %></p>
+<% end %>

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -21,6 +21,12 @@ class CourseChoicesReviewComponent < ActionView::Component::Base
     course_choice.awaiting_provider_decision? || course_choice.pending_conditions?
   end
 
+  def any_withdrawable?
+    @application_form.application_choices.any? do |course_choice|
+      withdrawable?(course_choice)
+    end
+  end
+
 private
 
   attr_reader :application_form

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -17,6 +17,10 @@ class CourseChoicesReviewComponent < ActionView::Component::Base
     end
   end
 
+  def withdrawable?(course_choice)
+    course_choice.awaiting_provider_decision? || course_choice.pending_conditions?
+  end
+
 private
 
   attr_reader :application_form

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -9,6 +9,7 @@ en:
       complete:
         completed_checkbox: I have completed this section
         button: Continue
+      view_and_respond_to_offer: View and respond to offer
     personal_details:
       first_name:
         label: First name

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -10,6 +10,10 @@ en:
         completed_checkbox: I have completed this section
         button: Continue
       view_and_respond_to_offer: View and respond to offer
+      withdrawal_information: >
+        You can withdraw an application from a training provider at any point,
+        even after you’ve accepted an offer. You won’t be penalised, but you
+        can’t substitute a different course or provider.
     personal_details:
       first_name:
         label: First name

--- a/spec/components/course_choices_review_component_spec.rb
+++ b/spec/components/course_choices_review_component_spec.rb
@@ -109,8 +109,9 @@ RSpec.describe CourseChoicesReviewComponent do
   end
 
   context 'when a course choice is awaiting provider decision' do
+    let(:application_form) { create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision]) }
+
     it 'renders component with a withdraw link' do
-      application_form = create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision])
       course_id = application_form.application_choices.first.id
 
       result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
@@ -119,6 +120,12 @@ RSpec.describe CourseChoicesReviewComponent do
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_course_choice_withdraw_path(course_id),
       )
+    end
+
+    it 'renders component with a withdrawal content' do
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.text).to include(t('application_form.courses.withdrawal_information'))
     end
   end
 
@@ -135,8 +142,9 @@ RSpec.describe CourseChoicesReviewComponent do
   end
 
   context 'when an offer has been accepted i.e. pending conditions' do
+    let(:application_form) { create_application_form_with_course_choices(statuses: %w[pending_conditions]) }
+
     it 'renders component with a withdraw link' do
-      application_form = create_application_form_with_course_choices(statuses: %w[pending_conditions])
       course_id = application_form.application_choices.first.id
 
       result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
@@ -145,6 +153,12 @@ RSpec.describe CourseChoicesReviewComponent do
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_course_choice_withdraw_path(course_id),
       )
+    end
+
+    it 'renders component with a withdrawal content' do
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.text).to include(t('application_form.courses.withdrawal_information'))
     end
   end
 

--- a/spec/components/course_choices_review_component_spec.rb
+++ b/spec/components/course_choices_review_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe CourseChoicesReviewComponent do
     end
   end
 
-  context 'when course choices are submitted' do
+  context 'when a course choice is awaiting references' do
     it 'renders component with the status as submitted when awaiting references' do
       application_form = create_application_form_with_course_choices(statuses: %w[awaiting_references])
 
@@ -61,7 +61,9 @@ RSpec.describe CourseChoicesReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Submitted')
     end
+  end
 
+  context 'when a course choice is application complete' do
     it 'renders component with the status as submitted when application is complete' do
       application_form = create_application_form_with_course_choices(statuses: %w[application_complete])
 
@@ -70,46 +72,17 @@ RSpec.describe CourseChoicesReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Submitted')
     end
+  end
 
-    it 'renders component with the status as pending when awaiting provider decision' do
-      application_form = create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision])
+  context 'when a course choice is awaiting provider decision' do
+    let(:application_form) { create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision]) }
 
+    it 'renders component with the status as pending' do
       result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Pending')
     end
-
-    it 'renders component with the status as offer when an offer has been made' do
-      application_form = create_application_form_with_course_choices(statuses: %w[offer])
-
-      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
-
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Offer')
-    end
-
-    it 'renders component with the status as accepted when the candidate has accepted an offer' do
-      application_form = create_application_form_with_course_choices(statuses: %w[pending_conditions])
-
-      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
-
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Accepted')
-    end
-
-    it 'renders component with the status as accepted when the candidate has declined an offer' do
-      application_form = create_application_form_with_course_choices(statuses: %w[declined])
-
-      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
-
-      expect(result.css('.govuk-summary-list__key').text).to include('Status')
-      expect(result.css('.govuk-summary-list__value').to_html).to include('Declined')
-    end
-  end
-
-  context 'when a course choice is awaiting provider decision' do
-    let(:application_form) { create_application_form_with_course_choices(statuses: %w[awaiting_provider_decision]) }
 
     it 'renders component with a withdraw link' do
       course_id = application_form.application_choices.first.id
@@ -130,6 +103,15 @@ RSpec.describe CourseChoicesReviewComponent do
   end
 
   context 'when an offer has been made to a course choice' do
+    it 'renders component with the status as offer when an offer has been made' do
+      application_form = create_application_form_with_course_choices(statuses: %w[offer])
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Offer')
+    end
+
     it 'renders component with view and respond to offer link' do
       application_form = create_application_form_with_course_choices(statuses: %w[offer])
 
@@ -141,8 +123,15 @@ RSpec.describe CourseChoicesReviewComponent do
     end
   end
 
-  context 'when an offer has been accepted i.e. pending conditions' do
+  context 'when an offer has been accepted i.e. pending conditions to a course choice' do
     let(:application_form) { create_application_form_with_course_choices(statuses: %w[pending_conditions]) }
+
+    it 'renders component with the status as accepted' do
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Accepted')
+    end
 
     it 'renders component with a withdraw link' do
       course_id = application_form.application_choices.first.id
@@ -159,6 +148,17 @@ RSpec.describe CourseChoicesReviewComponent do
       result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
 
       expect(result.text).to include(t('application_form.courses.withdrawal_information'))
+    end
+  end
+
+  context 'when an offer has been declined to a course choice' do
+    it 'renders component with the status as declined' do
+      application_form = create_application_form_with_course_choices(statuses: %w[declined])
+
+      result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Declined')
     end
   end
 

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -36,10 +36,6 @@ RSpec.feature 'Candidate submit the application' do
 
     when_i_click_the_edit_application_link
     then_i_see_edit_information_page
-
-    when_i_visit_my_application_dashboard
-    and_i_click_withdraw_course
-    then_i_see_the_withdraw_information_page
   end
 
   def given_i_am_signed_in
@@ -191,17 +187,5 @@ RSpec.feature 'Candidate submit the application' do
 
   def then_i_see_edit_information_page
     expect(page).to have_content t('page_titles.application_edit')
-  end
-
-  def when_i_visit_my_application_dashboard
-    visit candidate_interface_application_complete_path
-  end
-
-  def and_i_click_withdraw_course
-    click_link 'Withdraw'
-  end
-
-  def then_i_see_the_withdraw_information_page
-    expect(page).to have_content t('page_titles.withdraw_course_choice')
   end
 end


### PR DESCRIPTION
### Context

A candidate needs to be able to see if they have received an offer from a provider. This PR is the first smol step to do so.

### Changes proposed in this pull request

This PR:

- adds the `View and respond to offer` link to the `CourseChoicesReviewComponent`
- ensures that the `Withdraw` link is shown conditionally
- adds the guidance around withdrawing which is conditional as well.

The `View and respond to offer` only shows when an `application_choice` is in :

- the `offer` state

The `Withdraw` link only shows when an `application_choice` is in :

- the `awaiting_provider_decision` state or
- the `pending_conditions` state

The withdrawal guidance only shows when:

- any of the `application_choices` are in `awaiting_provider_decision` or `pending_conditions` state

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/69362018-92205e80-0c85-11ea-9dd7-1812018c78f0.png)

### Guidance to review

Maybe review commit by commit or the whole `CourseChoicesReviewComponent` spec at once without the diff as things moved around and were added.

Would like feedback on the logic! Please double check I have the conditional content correct.

The next PR will create the actual page to view and respond to an offer.

### Link to Trello card

[369 - Candidates can receive and review an offer from the provider](https://trello.com/c/HhzbUnQO/360-candidates-can-receive-and-review-an-offer-from-the-provider)
