### PR TITLE
Ensure no personal identifiable information is written to logs or Sentry

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,21 +2,20 @@
 
 # Configure sensitive parameters which will be filtered from the log file.
 SANITIZED_REQUEST_PARAMS = %i[
-  password
-  email
-  first_name
-  last_name
-  full_name
-  email_address
   address_line1
   address_line2
   address_line3
   address_line4
   country
-  postcode
   date_of_birth
-  phone_number
+  email
+  email_address
+  first_name
+  full_name
+  last_name
   magic_link_token
-  date_of_birth
+  password
+  phone_number
+  postcode
 ].freeze
 Rails.application.config.filter_parameters += SANITIZED_REQUEST_PARAMS

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,22 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+SANITIZED_REQUEST_PARAMS = %i[
+  password
+  email
+  first_name
+  last_name
+  full_name
+  email_address
+  address_line1
+  address_line2
+  address_line3
+  address_line4
+  country
+  postcode
+  date_of_birth
+  phone_number
+  magic_link_token
+  date_of_birth
+].freeze
+Rails.application.config.filter_parameters += SANITIZED_REQUEST_PARAMS

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,3 +1,4 @@
 Raven.configure do |config|
   config.current_environment = HostingEnvironment.environment_name
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end


### PR DESCRIPTION
### Context

We need to keep PII out of the application logs and avoid sharing with third-party services

### Changes proposed in this pull request

- [x] Create a blacklist of parameter names that should be masked/filtered out of the logs etc.
- [x] Use this list for Rails logs...
- [x] ...and Sentry

### Guidance to review

- The list of sanitized parameters in config/initializers/filter_parameter_logging.rb is a best guess at this stage. How do we work out what constitutes personal info in this context?
- I didn't add any tests because it's just config.

```
Started POST "/candidate/application/personal-details/review" for ::1 at 2019-11-21 17:09:37 +0000
Processing by CandidateInterface::PersonalDetailsController#update as HTML
  Parameters: {"utf8"=>"✓", "authenticity_token"=>"Cf03hNg35NWr5+LhsbvhuKQ7hL5y5B5Xleu2bqEsqib+aDYq652IbD7YPsQuyAobKaXX3beEtbq3ibxdVR6BBQ==", "candidate_interf
ace_personal_details_form"=>{"first_name"=>"[FILTERED]", "last_name"=>"[FILTERED]", "date_of_birth(3i)"=>"[FILTERED]", "date_of_birth(2i)"=>"[FILTERED]", "date
_of_birth(1i)"=>"[FILTERED]", "first_nationality"=>"British", "second_nationality"=>"", "english_language_details"=>"Que?", "english_main_language"=>"no", "oth
er_language_details"=>"I learnt how to speak English on the mean streets of Godalming"}, "commit"=>"Continue"}
```

### Link to Trello card

[1278 - Ensure no PII is sent in logs & Sentry](https://trello.com/c/eam3glK1/1278-ensure-no-pii-is-sent-in-logs-sentry)

### Env vars

no env vars
