### PR TITLE
Bugfix *Which training provider are you applying to*  when radios are unselected

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -31,15 +31,22 @@ module CandidateInterface
     end
 
     def options_for_provider
-      # TODO: Remove when the QA environment no longer has the "Example provider" stored
-      @providers = Provider.where.not(name: 'Example provider')
+      @providers = training_providers
+      @course_form = ChooseTrainingProviderForm.new
     end
 
     def pick_provider
-      if provider_params[:code] == 'other'
-        redirect_to candidate_interface_course_choices_on_ucas_path
+      @providers = training_providers
+      @course_form = ChooseTrainingProviderForm.new(provider_params)
+
+      if @course_form.valid?
+        if @course_form.is_another_provider_selected?
+          redirect_to candidate_interface_course_choices_on_ucas_path
+        else
+          redirect_to candidate_interface_course_choices_course_path(provider_code: @course_form.code)
+        end
       else
-        redirect_to candidate_interface_course_choices_course_path(provider_code: provider_params[:code])
+        render :options_for_provider
       end
     end
 
@@ -128,7 +135,7 @@ module CandidateInterface
     end
 
     def provider_params
-      params.require(:provider).permit(:code)
+      params.fetch(:candidate_interface_choose_training_provider_form, {}).permit(:code)
     end
 
     def course_params
@@ -137,6 +144,11 @@ module CandidateInterface
 
     def course_option_params
       params.require(:course_option).permit(:id)
+    end
+
+    def training_providers
+      # TODO: Remove when the QA environment no longer has the "Example provider" stored
+      @providers = Provider.where.not(name: 'Example provider')
     end
   end
 end

--- a/app/models/candidate_interface/choose_training_provider_form.rb
+++ b/app/models/candidate_interface/choose_training_provider_form.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  class ChooseTrainingProviderForm
+    include ActiveModel::Model
+
+    attr_accessor :code
+
+    validates :code, presence: true
+
+    def is_another_provider_selected?
+      code == 'other'
+    end
+  end
+end

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: Provider.new, url: candidate_interface_course_choices_provider_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @course_form, url: candidate_interface_course_choices_provider_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_provider') } do %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -432,4 +432,4 @@ en:
         candidate_interface/course_chosen_form:
           attributes:
             choice:
-              blank: Select if you have chosen a course or not.
+              blank: Select yes if you have chosen a course to apply to

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -433,3 +433,7 @@ en:
           attributes:
             choice:
               blank: Select yes if you have chosen a course to apply to
+        candidate_interface/choose_training_provider_form:
+          attributes:
+            code:
+              blank: Select which training provider you are applying to

--- a/spec/models/candidate_interface/choose_training_provider_form_spec.rb
+++ b/spec/models/candidate_interface/choose_training_provider_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ChooseTrainingProviderForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:code) }
+  end
+end

--- a/spec/models/candidate_interface/work_history_form_spec.rb
+++ b/spec/models/candidate_interface/work_history_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::WorkHistoryForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:work_history) }
+  end
+end


### PR DESCRIPTION
### Context

"Which training provider are you applying to" breaks when no radio button is selected.

### Changes proposed in this pull request
Add form object as usual.

### Link to Trello card

https://trello.com/c/vngl84RE/424-radio-buttons-when-not-selected-error-page
