### PR TITLE
Add ability to view an offer for a course choice

### DIFF
--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -7,7 +7,7 @@
 
       <% if course_choice.offer? %>
         <div class='app-summary-card__actions'>
-          <%= link_to t('application_form.courses.view_and_respond_to_offer'), '#', class: 'govuk-link' %>
+          <%= link_to t('application_form.courses.view_and_respond_to_offer'), candidate_interface_course_choice_offer_path(course_choice.id), class: 'govuk-link' %>
         </div>
       <% elsif withdrawable?(course_choice) %>
         <div class='app-summary-card__actions'>

--- a/app/components/offer_conditions_review_component.html.erb
+++ b/app/components/offer_conditions_review_component.html.erb
@@ -1,0 +1,9 @@
+<ul class="govuk-list govuk-list--bullet">
+  <% @conditions.each do |condition| %>
+    <li><%= condition %></li>
+  <% end %>
+</ul>
+
+<p class="govuk-body">
+  For help understanding or meeting your conditions, contact <%= @provider %> directly.
+</p>

--- a/app/components/offer_conditions_review_component.rb
+++ b/app/components/offer_conditions_review_component.rb
@@ -1,0 +1,12 @@
+class OfferConditionsReviewComponent < ActionView::Component::Base
+  validates :conditions, :provider, presence: true
+
+  def initialize(conditions:, provider:)
+    @conditions = conditions
+    @provider = provider
+  end
+
+private
+
+  attr_reader :conditions, :provider
+end

--- a/app/components/offer_review_component.html.erb
+++ b/app/components/offer_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(SummaryListComponent, rows: offer_rows) %>

--- a/app/components/offer_review_component.rb
+++ b/app/components/offer_review_component.rb
@@ -1,0 +1,52 @@
+class OfferReviewComponent < ActionView::Component::Base
+  validates :course_choice, presence: true
+
+  def initialize(course_choice:)
+    @course_choice = course_choice
+  end
+
+  def offer_rows
+    [
+      provider_row,
+      course_row,
+      location_row,
+      conditions_row,
+    ]
+  end
+
+private
+
+  attr_reader :course_choice
+
+  def provider_row
+    {
+      key: 'Provider',
+      value: @course_choice.course.provider.name,
+    }
+  end
+
+  def course_row
+    {
+      key: 'Course',
+      value: formatted_course_name_and_code,
+    }
+  end
+
+  def location_row
+    {
+      key: 'Location',
+      value: @course_choice.course_option.site.name,
+    }
+  end
+
+  def conditions_row
+    {
+      key: 'Conditions',
+      value: render(OfferConditionsReviewComponent, conditions: @course_choice.offer['conditions'], provider: @course_choice.course.provider.name),
+    }
+  end
+
+  def formatted_course_name_and_code
+    "#{@course_choice.course_option.course.name} (#{@course_choice.course_option.course.code})"
+  end
+end

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class CourseChoicesController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted, except: :withdraw
+    before_action :redirect_to_dashboard_if_submitted, except: %i[withdraw offer]
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def index
@@ -117,6 +117,10 @@ module CandidateInterface
     end
 
     def withdraw
+      @course_choice = current_candidate.current_application.application_choices.find(params[:id])
+    end
+
+    def offer
       @course_choice = current_candidate.current_application.application_choices.find(params[:id])
     end
 

--- a/app/views/candidate_interface/course_choices/offer.html.erb
+++ b/app/views/candidate_interface/course_choices/offer.html.erb
@@ -1,0 +1,40 @@
+<% content_for :title, t('page_titles.view_and_respond_to_offer') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back to application dashboard') %>
+
+<h1 class="govuk-heading-xl govuk-heading-xl">
+  <span class="govuk-caption-xl"><%= @course_choice.provider.name %> - <%= @course_choice.course_option.course.name %> (<%= @course_choice.course_option.course.code %>)</span>
+  <%= t('page_titles.view_and_respond_to_offer') %>
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(OfferReviewComponent, course_choice: @course_choice) %>
+
+    <p class="govuk-body">Remember:</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>you are under no obligation to accept or decline an offer at this stage</li>
+      <li>you can only accept one offer, across both Apply for teacher training and UCAS Teacher Training</li>
+    </ul>
+
+    <h2 class="govuk-heading-xl govuk-heading-m">
+      Do you want to respond to your offer to study
+      <%= @course_choice.course.name_and_code %>
+      at <%= @course_choice.provider.name %> now?
+    </h2>
+
+    <p class="govuk-body">
+      Please email us at <%= bat_contact_mail_to %> with your decision to:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>accept this offer and conditions</li>
+      <li>decline this offer</li>
+    </ul>
+
+    <p class="govuk-body">
+      We’ll notify your training provider and update your application to this
+      course on your application dashboard.
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,6 +64,7 @@ en:
       - Second referee
     apply_on_ucas: We’re sorry, but we’re not ready for you yet
     providers: Training providers available through Apply for teacher training
+    view_and_respond_to_offer: Details of offer
   layout:
     service_name: Apply for teacher training
     accessibility: Accessibility

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,6 +143,8 @@ Rails.application.routes.draw do
         get '/delete/:id' => 'course_choices#confirm_destroy', as: :confirm_destroy_course_choice
         delete '/delete/:id' => 'course_choices#destroy'
 
+        get '/offer/:id' => 'course_choices#offer', as: :course_choice_offer
+
         get '/withdraw/:id' => 'course_choices#withdraw', as: :course_choice_withdraw
 
         get '/provider' => 'course_choices#options_for_provider', as: :course_choices_provider

--- a/spec/components/course_choices_review_component_spec.rb
+++ b/spec/components/course_choices_review_component_spec.rb
@@ -114,12 +114,15 @@ RSpec.describe CourseChoicesReviewComponent do
 
     it 'renders component with view and respond to offer link' do
       application_form = create_application_form_with_course_choices(statuses: %w[offer])
+      course_id = application_form.application_choices.first.id
 
       result = render_inline(CourseChoicesReviewComponent, application_form: application_form, editable: false, show_status: true)
 
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.courses.withdraw'))
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.courses.view_and_respond_to_offer'))
-      expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include('#')
+      expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_course_choice_offer_path(course_id),
+      )
     end
   end
 

--- a/spec/components/offer_review_component_spec.rb
+++ b/spec/components/offer_review_component_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe OfferReviewComponent do
+  include CourseOptionHelpers
+
+  let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
+  let(:application_form) { create(:application_form, submitted_at: DateTime.now) }
+  let(:application_choice) do
+    create(
+      :application_choice,
+      status: 'offer',
+      offer: { 'conditions' => ['Fitness to teach check', 'Be cool'] },
+      course_option: course_option,
+      application_form: application_form,
+    )
+  end
+
+  it 'renders component with correct values for the provider' do
+    result = render_inline(OfferReviewComponent, course_choice: application_choice)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Provider')
+    expect(result.css('.govuk-summary-list__value').text).to include(course_option.course.provider.name)
+  end
+
+  it 'renders component with correct values for the course' do
+    result = render_inline(OfferReviewComponent, course_choice: application_choice)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Course')
+    expect(result.css('.govuk-summary-list__value').text).to include(
+      "#{course_option.course.name} (#{course_option.course.code})",
+    )
+  end
+
+  it 'renders component with correct values for the location' do
+    result = render_inline(OfferReviewComponent, course_choice: application_choice)
+
+    expect(result.css('.govuk-summary-list__value').text).to include(course_option.site.name)
+  end
+
+  it 'renders component with correct values for the conditions' do
+    result = render_inline(OfferReviewComponent, course_choice: application_choice)
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Conditions')
+    expect(result.css('.govuk-summary-list__value').text).to include('Fitness to teach')
+    expect(result.css('.govuk-summary-list__value').text).to include('Be cool')
+  end
+end

--- a/spec/system/candidate_interface/candidate_viewing_an_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_an_offer_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate views an offer' do
+  include CourseOptionHelpers
+
+  let(:candidate) { create(:candidate) }
+  let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
+  let(:application_form) { create(:application_form, candidate: candidate, submitted_at: DateTime.now) }
+
+  before do
+    create(
+      :application_choice,
+      status: 'offer',
+      offer: { 'conditions' => ['Fitness to teach check', 'Be cool'] },
+      course_option: course_option,
+      application_form: application_form,
+    )
+  end
+
+  scenario 'Candidate views an offer for a course choice' do
+    given_i_am_signed_in
+    and_i_am_on_the_application_dashboard_and_i_have_an_offer
+    then_i_see_the_view_and_respond_to_offer_link
+
+    when_i_click_on_view_and_respond_to_offer_link
+    then_i_see_the_offer
+  end
+
+  def given_i_am_signed_in
+    login_as(candidate)
+  end
+
+  def and_i_am_on_the_application_dashboard_and_i_have_an_offer
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_see_the_view_and_respond_to_offer_link
+    expect(page).to have_content(t('application_form.courses.view_and_respond_to_offer'))
+  end
+
+  def when_i_click_on_view_and_respond_to_offer_link
+    click_link t('application_form.courses.view_and_respond_to_offer')
+  end
+
+  def then_i_see_the_offer
+    provider = course_option.course.provider.name
+    expect(page).to have_content(provider)
+    expect(page).to have_content(t('page_titles.view_and_respond_to_offer'))
+    expect(page).to have_content(
+      "Do you want to respond to your offer to study #{course_option.course.name} (#{course_option.course.code}) at #{provider} now?",
+    )
+  end
+end


### PR DESCRIPTION
### Context

Currently we have a link which shows when an offer has been made to a candidate but currently you can't see what that offer is.

### Changes proposed in this pull request

This PR adds a page for viewing an offer for a course choice. It does so by adding a new component called `OfferReviewComponent` which uses `OfferConditionsReviewComponent`.

### Screenshots (updated 25 Nov, 11:20)

![image](https://user-images.githubusercontent.com/42817036/69536275-97c3c000-0f75-11ea-8d8f-2aa92a092f9d.png)

### Guidance to review

You can test this by using the provider interface to make an offer and then viewing it on the candidate side.

### Link to Trello card

[Candidates can receive and review an offer from the provider](https://trello.com/c/HhzbUnQO/360-candidates-can-receive-and-review-an-offer-from-the-provider)
