### PR TITLE
Show message to providers when no applications have been received yet

### DIFF
--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -2,24 +2,28 @@
 
 <h1 class="govuk-heading-xl">Applications</h1>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last updated</th>
-    </tr>
-  </thead>
+<% if @application_choices.any? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Name</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Status</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last updated</th>
+      </tr>
+    </thead>
 
-  <tbody class="govuk-table__body">
-    <% @application_choices.each do |application_choice| %>
-    <tr class="govuk-table__row">
-      <td class="govuk-table__cell"><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
-      <td class="govuk-table__cell"><%= application_choice.course_name_and_code %></td>
-      <td class="govuk-table__cell"><%= tag.strong application_choice.status_name, class: 'govuk-tag' %></td>
-      <td class="govuk-table__cell"><%= application_choice.updated_at %></td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
+    <tbody class="govuk-table__body">
+      <% @application_choices.each do |application_choice| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell"><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
+        <td class="govuk-table__cell"><%= application_choice.course_name_and_code %></td>
+        <td class="govuk-table__cell"><%= tag.strong application_choice.status_name, class: 'govuk-tag' %></td>
+        <td class="govuk-table__cell"><%= application_choice.updated_at %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <p class="govuk-body">You haven’t received any applications from Apply for teacher training.</p>
+<% end %>

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -4,10 +4,22 @@ RSpec.feature 'See applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
+  scenario 'Provider visits applications when there are none' do
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_my_training_provider_exists
+    and_another_organisation_has_applications
+
+    when_i_have_been_assigned_to_my_training_provider
+    and_i_visit_the_provider_page
+
+    then_i_should_see_no_applications
+  end
+
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_training_provider_exists
     and_my_organisation_has_applications
+    and_another_organisation_has_applications
     and_i_have_not_been_assigned_to_my_training_provider # this is a manual process for now
     and_i_visit_the_provider_page
     then_i_should_see_the_account_creation_in_progress_page
@@ -42,10 +54,14 @@ RSpec.feature 'See applications' do
 
   def and_my_organisation_has_applications
     course_option = course_option_for_provider_code(provider_code: 'ABC')
-    other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
 
     @my_provider_choice1  = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
     @my_provider_choice2  = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+  end
+
+  def and_another_organisation_has_applications
+    other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
+
     @other_provider_choice = create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
   end
 
@@ -56,6 +72,11 @@ RSpec.feature 'See applications' do
   def then_i_should_see_the_applications_from_my_organisation
     expect(page).to have_content @my_provider_choice1.application_form.first_name
     expect(page).to have_content @my_provider_choice2.application_form.first_name
+  end
+
+  def then_i_should_see_no_applications
+    expect(page).to have_content 'You haven’t received any applications'
+    expect(page).not_to have_selector('.govuk-table')
   end
 
   def but_not_the_applications_from_other_providers


### PR DESCRIPTION
For a short while, each provider will be in a state where they haven't received applications yet.
Indicate that with text rather than showing an empty table.

![Screen Shot 2019-11-22 at 14 48 02](https://user-images.githubusercontent.com/319055/69437108-8b075800-0d3a-11ea-8914-5f97ed3d9cb6.png)

https://trello.com/c/na2iMG8M/1299-design-empty-state-for-provider