### PR TITLE
Show guidance by default on work history length page

### DIFF
--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -25,33 +25,15 @@
 
       <div class="govuk-!-margin-top-6">
         <%= f.govuk_radio_buttons_fieldset :work_history, legend: { size: 'm', text: 'How long have you been working?', tag: 'h2' } do %>
-          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5') } do %>
-            <p class="govuk-body">
-              Give us as much of your work history as you can. For example, if
-              you are a recent graduate, tell us about your employment before,
-              during and since leaving university.
-            </p>
-          <% end %>
+          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5.label'), size: 's' }, hint_text: t('application_form.work_history.less_than_5.hint') %>
 
-          <%= f.govuk_radio_button :work_history, :more_than_5, label: { text: t('application_form.work_history.more_than_5') } do %>
-            <p class="govuk-body">
-              You can list your complete work history – or just the roles you
-              think are relevant – going back further than 5 years if you wish.
-            </p>
-          <% end %>
+          <%= f.govuk_radio_button :work_history, :more_than_5, label: { text: t('application_form.work_history.more_than_5.label'), size: 's' }, hint_text: t('application_form.work_history.more_than_5.hint') %>
 
-          <%= f.govuk_radio_button :work_history, :more_than_5_with_breaks, label: { text: t('application_form.work_history.more_than_5_with_breaks') } do %>
-            <p class="govuk-body">
-              You’ll be able to give details once you’ve entered your employment
-              history. Please explain any break longer than a month.
-            </p>
-          <% end %>
+          <%= f.govuk_radio_button :work_history, :more_than_5_with_breaks, label: { text: t('application_form.work_history.more_than_5_with_breaks.label'), size: 's' }, hint_text: t('application_form.work_history.more_than_5_with_breaks.hint') %>
 
-          <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing') } do %>
-            <p class="govuk-body">
-              You’ll be able to explain why you’ve been out of the workplace.
-            </p>
-          <% end %>
+          <%= f.govuk_radio_divider %>
+
+          <%= f.govuk_radio_button :work_history, :missing, label: { text: t('application_form.work_history.missing.label'), size: 's' }, hint_text: t('application_form.work_history.missing.hint') %>
         <% end %>
 
         <%= f.govuk_submit 'Continue' %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -77,10 +77,18 @@ en:
       review:
         button: Continue
     work_history:
-      less_than_5: Less than 5 years
-      more_than_5: More than 5 years
-      more_than_5_with_breaks: More than 5 years, but with breaks
-      missing: I have not worked in the last 5 years
+      less_than_5:
+        label: Less than 5 years
+        hint: Give us as much of your work history as you can. For example, if you are a recent graduate, tell us about your employment before, during and since leaving university.
+      more_than_5:
+        label: More than 5 years
+        hint: You can list your complete work history – or just the roles you think are relevant – going back further than 5 years if you wish.
+      more_than_5_with_breaks:
+        label: More than 5 years, but with breaks
+        hint: You’ll be able to give details once you’ve entered your employment history. Please explain any break longer than a month.
+      missing:
+        label: I have not worked in the last 5 years
+        hint: You’ll be able to explain why you’ve been out of the workplace.
       role:
         label: Job title
       organisation:

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -40,7 +40,7 @@ module CandidateHelper
     click_link t('application_form.contact_details.review.button')
 
     click_link t('page_titles.work_history')
-    choose t('application_form.work_history.more_than_5')
+    choose t('application_form.work_history.more_than_5.label')
     click_button 'Continue'
     candidate_fills_in_work_experience
     click_button t('application_form.work_history.complete_form_button')

--- a/spec/system/candidate_interface/candidate_entering_work_history_not_worked_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_not_worked_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_choose_not_worked
-    choose t('application_form.work_history.missing')
+    choose t('application_form.work_history.missing.label')
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -64,7 +64,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def then_i_should_see_a_list_of_work_lengths
-    expect(page).to have_content(t('application_form.work_history.more_than_5'))
+    expect(page).to have_content(t('application_form.work_history.more_than_5.label'))
   end
 
   def when_i_omit_choosing_from_the_list_of_work_lengths
@@ -76,7 +76,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_choose_more_than_5_years
-    choose t('application_form.work_history.more_than_5')
+    choose t('application_form.work_history.more_than_5.label')
     click_button 'Continue'
   end
 


### PR DESCRIPTION
### Context

Revealing guidance when selecting an option failed the accessibility audit. This implements the short-term tactical fix of showing guidance as hint text instead.

### Changes proposed in this pull request

Changes the options on the page to this:

<img width="645" alt="Screenshot_2019-11-22_at_10 33 32" src="https://user-images.githubusercontent.com/813383/69438569-2e596c80-0d3d-11ea-96b2-6898bb815633.png">

### Link to Trello card

[471 - Work history: revealing hint text](https://trello.com/c/mKPICYW7/)
