### PR TITLE
Always link the error summary to the first in a set of radio buttons

### DIFF
--- a/app/views/candidate_interface/application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/application_form/submit_show.html.erb
@@ -34,7 +34,7 @@
         </div>
 
         <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
-          <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' } do %>
+          <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>
             <%= f.govuk_text_area :further_information_details, label: { text: t('application_form.further_information.further_information_details.label') }, max_words: 300 %>
           <% end %>
 

--- a/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
+++ b/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
@@ -8,7 +8,7 @@
 
       <%= f.govuk_radio_buttons_fieldset :choice, legend: { size: 'xl', text: t('page_titles.have_you_chosen') } do %>
         <div class="govuk-!-margin-top-6">
-          <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, I know where I want to apply' } %>
+          <%= f.govuk_radio_button :choice, :yes, label: { text: 'Yes, I know where I want to apply' }, link_errors: true %>
           <%= f.govuk_radio_button :choice, :no, label: { text: 'No, I need to find a course' } %>
         </div>
       <% end %>

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -8,8 +8,8 @@
 
       <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
         <div class="govuk-!-margin-top-6">
-          <% @pick_course.available_courses.map do |course| %>
-            <%= f.govuk_radio_button :code, course.code, label: { text: "#{course.name} (#{course.code})" } %>
+          <% @pick_course.available_courses.each_with_index do |course, i| %>
+            <%= f.govuk_radio_button :code, course.code, label: { text: "#{course.name} (#{course.code})" }, link_errors: i.zero? %>
           <% end %>
 
           <%= f.govuk_radio_divider %>

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -8,8 +8,8 @@
 
       <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_provider') } do %>
         <div class="govuk-!-margin-top-6">
-          <% @pick_provider.available_providers.map do |provider| %>
-            <%= f.govuk_radio_button :code, provider.code, label: { text: "#{provider.name} (#{provider.code})" } %>
+          <% @pick_provider.available_providers.each_with_index do |provider, i| %>
+            <%= f.govuk_radio_button :code, provider.code, label: { text: "#{provider.name} (#{provider.code})" }, link_errors: i.zero? %>
           <% end %>
 
           <%= f.govuk_radio_divider %>

--- a/app/views/candidate_interface/course_choices/options_for_site.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_site.html.erb
@@ -8,8 +8,8 @@
 
       <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location') } do %>
         <div class="govuk-!-margin-top-6">
-          <% @pick_site.available_sites.each do |option| %>
-            <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name } %>
+          <% @pick_site.available_sites.each_with_index do |option, i| %>
+            <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, link_errors: i.zero? %>
           <% end %>
         </div>
       <% end %>

--- a/app/views/candidate_interface/degrees/base/_form.html.erb
+++ b/app/views/candidate_interface/degrees/base/_form.html.erb
@@ -2,8 +2,8 @@
 <%= f.govuk_text_field :institution_name, label: { text: t('application_form.degree.institution_name.label'), size: 'm' } %>
 <%= f.govuk_radio_buttons_fieldset :grade, legend: { text: t('application_form.degree.grade.label'), tag: 'span' } do %>
 
-  <% CandidateInterface::DegreeForm::CLASSES.each do |degree_class| %>
-    <%= f.govuk_radio_button :grade, degree_class, label: { text: t("application_form.degree.grade.#{degree_class}.label") } %>
+  <% CandidateInterface::DegreeForm::CLASSES.each_with_index do |degree_class, i| %>
+    <%= f.govuk_radio_button :grade, degree_class, label: { text: t("application_form.degree.grade.#{degree_class}.label") }, link_errors: i.zero? %>
   <% end %>
 
   <%= f.govuk_radio_button :grade, 'other', label: { text: t('application_form.degree.grade.other.label') } do %>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -11,22 +11,22 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: t('application_form.gcse.qualification_type.label') } do %>
-        <% select_gcse_qualification_type_options.each do |option| %>
+        <% select_gcse_qualification_type_options.each_with_index do |option, i| %>
           <% if option.id == :other_uk %>
 
-            <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label } do %>
+            <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
               <% f.govuk_text_field :other_uk_qualification_type, label: { text: t('application_form.gcse.other_uk.label'), size: 's' } %>
             <% end %>
 
           <% elsif option.id == :missing %>
-            <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label } do %>
+            <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
               <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
               <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to 'Get into teaching', 'https://getintoteaching.education.gov.uk/get-help-and-support/' %>.</p>
               <%= f.govuk_text_area :missing_explanation, label: { text: t('application_form.gcse.missing_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
               <% end %>
             <% end %>
           <% else %>
-            <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label } %>
+            <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -32,7 +32,7 @@
         </details>
 
         <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label') } do %>
-          <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' } do %>
+          <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' }, link_errors: true do %>
             <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
           <% end %>
 

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -11,12 +11,12 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK, EU or EEA?' } do %>
-        <%= f.govuk_radio_button :eligible_citizen, 'yes', label: { text: 'Yes' } %>
+        <%= f.govuk_radio_button :eligible_citizen, 'yes', label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :eligible_citizen, 'no', label: { text: 'No' } %>
       <% end %>
 
       <%= f.govuk_radio_buttons_fieldset :eligible_qualifications, inline: true, legend: { size: 'm', text: 'Did you gain all your qualifications at institutions based in the UK?' } do %>
-        <%= f.govuk_radio_button :eligible_qualifications, 'yes', label: { text: 'Yes' } %>
+        <%= f.govuk_radio_button :eligible_qualifications, 'yes', label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :eligible_qualifications, 'no', label: { text: 'No' } %>
       <% end %>
 

--- a/app/views/candidate_interface/volunteering/base/_form.html.erb
+++ b/app/views/candidate_interface/volunteering/base/_form.html.erb
@@ -5,7 +5,7 @@
 <%= f.govuk_text_field :organisation, label: { text: t('application_form.volunteering.organisation.label'), size: 'm' } %>
 
 <%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: t('application_form.volunteering.working_with_children.label'), tag: 'span' }, inline: true do %>
-  <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
 <% end %>
 

--- a/app/views/candidate_interface/volunteering/experience/show.html.erb
+++ b/app/views/candidate_interface/volunteering/experience/show.html.erb
@@ -29,7 +29,7 @@
 
       <div class="govuk-!-margin-top-6">
         <%= f.govuk_radio_buttons_fieldset :experience, legend: { size: 'm', text: t('application_form.volunteering.experience.label') } do %>
-          <%= f.govuk_radio_button :experience, :yes, label: { text: 'Yes' } %>
+          <%= f.govuk_radio_button :experience, :yes, label: { text: 'Yes' }, link_errors: true %>
           <%= f.govuk_radio_button :experience, :no, label: { text: 'No' } %>
         <% end %>
 

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -13,7 +13,7 @@
 <%= f.govuk_text_field :organisation, label: { text: t('application_form.work_history.organisation.label'), size: 'm' } %>
 
 <%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: 'Was this job full-time or part-time?', tag: 'span' } do %>
-  <%= f.govuk_radio_button :commitment, 'full_time', label: { text: 'Full-time' } %>
+  <%= f.govuk_radio_button :commitment, 'full_time', label: { text: 'Full-time' }, link_errors: true %>
 
   <%= f.govuk_radio_button :commitment, 'part_time', label: { text: 'Part-time' } %>
 <% end %>
@@ -29,7 +29,7 @@
 <%= f.govuk_text_area :details, label: { text: t('application_form.work_history.details.label'), size: 'm' }, hint_text: 'Give a brief overview of your role and explain how you developed transferable skills like communication, creativity and organisation', max_words: 150 %>
 
 <%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: 'Did this job involve working in a school or with children?', tag: 'span' }, inline: true do %>
-  <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' } %>
+  <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
 <% end %>
 

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -25,7 +25,7 @@
 
       <div class="govuk-!-margin-top-6">
         <%= f.govuk_radio_buttons_fieldset :work_history, legend: { size: 'm', text: 'How long have you been working?', tag: 'h2' } do %>
-          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5.label'), size: 's' }, hint_text: t('application_form.work_history.less_than_5.hint') %>
+          <%= f.govuk_radio_button :work_history, :less_than_5, label: { text: t('application_form.work_history.less_than_5.label'), size: 's' }, hint_text: t('application_form.work_history.less_than_5.hint'), link_errors: true %>
 
           <%= f.govuk_radio_button :work_history, :more_than_5, label: { text: t('application_form.work_history.more_than_5.label'), size: 's' }, hint_text: t('application_form.work_history.more_than_5.hint') %>
 

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -17,7 +17,7 @@
       <%- offer_text = 'Make an offer (including any conditions)' %>
       <%- reject_text = 'Reject application' %>
       <%= f.govuk_radio_buttons_fieldset :decision, inline: true, legend: { size: 'm', text: '' } do %>
-        <%= f.govuk_radio_button :decision, 'offer', label: { text: offer_text } %>
+        <%= f.govuk_radio_button :decision, 'offer', label: { text: offer_text }, link_errors: true %>
         <%= f.govuk_radio_button :decision, 'reject', label: { text: reject_text } %>
       <% end %>
 

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -60,7 +60,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :open_on_apply, legend: { size: 'm', text: 'Can candidates use Apply?' } do %>
-    <%= f.govuk_radio_button :open_on_apply, true, label: { text: 'Yes, this course is available on Apply and UCAS' } %>
+    <%= f.govuk_radio_button :open_on_apply, true, label: { text: 'Yes, this course is available on Apply and UCAS' }, link_errors: true %>
     <%= f.govuk_radio_button :open_on_apply, false, label: { text: 'No, this course is only available on UCAS' } %>
   <% end %>
 

--- a/spec/system/candidate_interface/candidate_eligibility_spec.rb
+++ b/spec/system/candidate_interface/candidate_eligibility_spec.rb
@@ -27,8 +27,14 @@ RSpec.feature 'Candidate eligibility' do
   end
 
   def and_i_answer_no_to_some_questions
-    find('#candidate-interface-eligibility-form-eligible-citizen-no-field').click
-    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
+    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
+      choose 'No'
+    end
+
+    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
+      choose 'Yes'
+    end
+
     click_on 'Continue'
   end
 
@@ -37,8 +43,14 @@ RSpec.feature 'Candidate eligibility' do
   end
 
   def when_i_answer_yes_to_all_questions
-    find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
-    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
+    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
+      choose 'Yes'
+    end
+
+    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
+      choose 'Yes'
+    end
+
     click_on 'Continue'
   end
 


### PR DESCRIPTION
### Context

The error summary links to checkbox groups did not work — clicking on them had no effect. This fixes them.

### Changes proposed in this pull request

The 'link_errors' option is provided by govuk_design_system_formbuilder:

    # @param link_errors [Boolean] controls whether this radio button should be linked to
    #   from the error summary. <b>Should only be set to +true+ for the first radio button in a fieldset</b>

This commit fixes links for all the `govuk_radio_buttons_fieldset`s in the repo by adding `link_errors: true` to the first radio button in each case.

Ideally the formbuilder would do this for us so we didn't have to remember it.

### Guidance to review

- Did we catch all of them?
- Do they all work?

### Link to Trello card

https://trello.com/c/DTWXk3Id/455-personal-details-english-question-error-summary-link-does-not-work