### PR TITLE
Missing word count component

### DIFF
--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
@@ -3,35 +3,29 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.becoming_a_teacher') %>
+    </h1>
+
+    <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
+    <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
+    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/' %> for help from a teacher training advisor.</p>
+
+    <p class="govuk-body govuk-!-font-weight-bold">You do not have to cover everything in this list, but suggested topics include:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>why you want to be a teacher</li>
+      <li>your passion for your subject and the age group you’ve chosen to teach</li>
+      <li>the welfare and education of children and/or young people</li>
+      <li>the demands and rewards of the profession</li>
+      <li>personal qualities that will make you a good teacher</li>
+      <li>your contribution to the life of the school outside the classroom  – for example, running extra-curricular activities and clubs</li>
+      <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
+    </ul>
+
     <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_becoming_a_teacher_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.becoming_a_teacher') %>
-          </h1>
-        </legend>
-
-        <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
-        <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
-        <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/' %> for help from a teacher training advisor.</p>
-
-        <p class="govuk-body govuk-!-font-weight-bold">You do not have to cover everything in this list, but suggested topics include:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>why you want to be a teacher</li>
-          <li>your passion for your subject and the age group you’ve chosen to teach</li>
-          <li>the welfare and education of children and/or young people</li>
-          <li>the demands and rewards of the profession</li>
-          <li>personal qualities that will make you a good teacher</li>
-          <li>your contribution to the life of the school outside the classroom  – for example, running extra-curricular activities and clubs</li>
-          <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
-        </ul>
-
-        <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
-
-        <%= f.govuk_submit 'Continue' %>
-      </fieldset>
+      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -3,27 +3,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.interview_preferences') %>
+    </h1>
+
+    <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>any disability, health or personal issue you feel is relevant</li>
+      <li>special arrangements or assistance you may need</li>
+      <li>dates you are unavailable for interview</li>
+    </ul>
+
     <%= form_with model: @interview_preferences_form, url: candidate_interface_interview_preferences_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.interview_preferences') %>
-          </h1>
-        </legend>
-
-        <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>any disability, health or personal issue you feel is relevant</li>
-          <li>special arrangements or assistance you may need</li>
-          <li>dates you are unavailable for interview</li>
-        </ul>
-
-        <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.label'), size: 'm' }, rows: 8, max_words: 200 %>
-
-        <%= f.govuk_submit 'Continue' %>
-      </fieldset>
+      <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.label'), size: 'm' }, rows: 8, max_words: 200 %>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
@@ -3,30 +3,24 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.becoming_a_teacher') %>
+    </h1>
+
+    <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to.</p>
+    <p class="govuk-body">Evidence can include:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>the subject of your undergraduate degree</li>
+      <li>modules you studied as part of your degree</li>
+      <li>postgraduate degrees (for example, a Masters or PhD)</li>
+      <li>your A level subjects</li>
+      <li>expertise you’ve gained at work</li>
+    </ul>
+
     <%= form_with model: @subject_knowledge_form, url: candidate_interface_subject_knowledge_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.subject_knowledge') %>
-          </h1>
-        </legend>
-
-        <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to.</p>
-        <p class="govuk-body">Evidence can include:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>the subject of your undergraduate degree</li>
-          <li>modules you studied as part of your degree</li>
-          <li>postgraduate degrees (for example, a Masters or PhD)</li>
-          <li>your A level subjects</li>
-          <li>expertise you’ve gained at work</li>
-        </ul>
-
-        <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
-
-        <%= f.govuk_submit 'Continue' %>
-      </fieldset>
+      <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context
Word count component

### Changes proposed in this pull request
- Fix bad markup on personal statement pages 
- Bump govuk_design_system_formbuilder to v1.1 to incorporate most recent changes from govuk-frontend

No visual change other than the word count now works.

### Guidance to review
All three personal statement pages

### Link to Trello card
[498 - Missing word count component](https://trello.com/c/UhH8vIxu/498-missing-word-count-component)

### Env vars
n/a