### PR TITLE
Fix up hidden name for change links

### DIFF
--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -1,21 +1,30 @@
 <% @course_choices.each do |course_choice| %>
   <%= render(SummaryCardComponent, rows: course_choice_rows(course_choice), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
+      <h2 class="app-summary-card__title">
         <%= course_choice.provider.name %>
-      </h3>
+      </h2>
 
       <% if course_choice.offer? %>
         <div class='app-summary-card__actions'>
-          <%= link_to t('application_form.courses.view_and_respond_to_offer'), candidate_interface_course_choice_offer_path(course_choice.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_course_choice_offer_path(course_choice.id), class: 'govuk-link' do %>
+            <%= t('application_form.courses.view_and_respond_to_offer') %>
+            <span class="govuk-visually-hidden"> <%= course_choice.course.name_and_code %></span>
+          <% end %>
         </div>
       <% elsif withdrawable?(course_choice) %>
         <div class='app-summary-card__actions'>
-          <%= link_to t('application_form.courses.withdraw'), candidate_interface_course_choice_withdraw_path(course_choice.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_course_choice_withdraw_path(course_choice.id), class: 'govuk-link' do %>
+            <%= t('application_form.courses.withdraw') %>
+            <span class="govuk-visually-hidden"> <%= course_choice.course.name_and_code %></span>
+          <% end %>
         </div>
       <% elsif @editable %>
         <div class='app-summary-card__actions'>
-          <%= link_to t('application_form.courses.delete'), candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link' do %>
+            <%= t('application_form.courses.delete') %>
+            <span class="govuk-visually-hidden"> <%= course_choice.course.name_and_code %></span>
+          <% end  %>
         </div>
       <% end %>
     </header>

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -1,12 +1,15 @@
 <% @degrees.each do |degree| %>
   <%= render(SummaryCardComponent, rows: degree_rows(degree), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
+      <h2 class="app-summary-card__title">
         <%= degree.title %>
-      </h3>
+      </h2>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to t('application_form.degree.delete'), candidate_interface_confirm_degrees_destroy_path(degree.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_confirm_degrees_destroy_path(degree.id), class: 'govuk-link' do %>
+            <%= t('application_form.degree.delete') %>
+            <span class="govuk-visually-hidden"> <%= degree.subject %></span>
+          <% end %>
         </div>
       <% end %>
     </header>

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -1,14 +1,14 @@
 <% if @application_qualification %>
   <%= render(SummaryCardComponent, rows: gcse_qualification_rows, editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
+      <h2 class="app-summary-card__title">
         <%= if @application_qualification.missing_qualification?
               t('application_form.gcse.qualification_types.missing')
             else
               t('application_form.gcse.qualification_types.gcse')
             end
         %>
-      </h3>
+      </h2>
     </header>
   <% end %>
 <% else %>

--- a/app/components/gcse_qualification_review_component.rb
+++ b/app/components/gcse_qualification_review_component.rb
@@ -25,6 +25,7 @@ private
     {
       key: t('application_form.degree.qualification.label'),
       value: gcse_qualification_types[application_qualification.qualification_type.to_sym],
+      action: 'qualification',
       change_path: candidate_interface_gcse_details_edit_type_path(subject: subject),
     }
   end
@@ -33,6 +34,7 @@ private
     {
       key: 'Year awarded',
       value: application_qualification.award_year || t('gcse_summary.not_specified'),
+      action: 'year awarded',
       change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
     }
   end
@@ -41,6 +43,7 @@ private
     {
       key: 'Grade',
       value: application_qualification.grade ? application_qualification.grade.upcase : t('gcse_summary.not_specified'),
+      action: 'grade',
       change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
     }
   end

--- a/app/components/other_qualifications_review_component.html.erb
+++ b/app/components/other_qualifications_review_component.html.erb
@@ -1,12 +1,15 @@
 <% @qualifications.each do |qualification| %>
   <%= render(SummaryCardComponent, rows: other_qualifications_rows(qualification), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
+      <h2 class="app-summary-card__title">
         <%= qualification.title %>
-      </h3>
+      </h2>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to t('application_form.other_qualification.delete'), candidate_interface_confirm_destroy_other_qualification_path(qualification.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id), class: 'govuk-link' do %>
+            <%= t('application_form.other_qualification.delete') %>
+            <span class="govuk-visually-hidden"> <%= qualification.subject %></span>
+          <% end %>
         </div>
       <% end %>
     </header>

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -6,7 +6,10 @@
       </h3>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to t('application_form.referees.delete'), candidate_interface_destroy_referee_path(referee.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_destroy_referee_path(referee.id), class: 'govuk-link' do %>
+            <%= t('application_form.referees.delete') %>
+            <span class="govuk-visually-hidden"> <%= referee.name %></span>
+          <% end %>
         </div>
       <% end %>
     </header>

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -1,9 +1,9 @@
 <% @application_form.references.each do |referee| %>
   <%= render(SummaryCardComponent, rows: referee_rows(referee), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
+      <h2 class="app-summary-card__title">
         <%= t('application_form.referees.nth_referee')[referee.ordinal] %>
-      </h3>
+      </h2>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_destroy_referee_path(referee.id), class: 'govuk-link' do %>

--- a/app/components/referees_review_component.rb
+++ b/app/components/referees_review_component.rb
@@ -23,7 +23,7 @@ private
     {
       key: 'Name',
       value: referee.name,
-      action: 'job',
+      action: 'name',
       change_path: candidate_interface_edit_referee_path(referee.id),
     }
   end
@@ -32,7 +32,7 @@ private
     {
       key: 'Email address',
       value: referee.email_address,
-      action: 'email_address',
+      action: 'email address',
       change_path: candidate_interface_edit_referee_path(referee.id),
     }
   end

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -1,7 +1,7 @@
 <% @volunteering_roles.each do |volunteering_role| %>
   <%= render(SummaryCardComponent, rows: volunteering_role_rows(volunteering_role), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
+      <h2 class="app-summary-card__title">
         <%= volunteering_role.role %>
 
         <% if volunteering_role.working_with_children == 'true' %>
@@ -12,10 +12,13 @@
             <%= t('application_form.volunteering.working_with_children.review_text') %>
           </span>
         <% end %>
-      </h3>
+      </h2>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to t('application_form.volunteering.delete'), candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' do %>
+            <%= t('application_form.volunteering.delete') %>
+            <span class="govuk-visually-hidden"> <%= volunteering_role.role %></span>
+          <% end %>
         </div>
       <% end %>
     </header>

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -13,7 +13,8 @@ class VolunteeringReviewComponent < ActionView::Component::Base
     [
       role_row(volunteering_role),
       organisation_row(volunteering_role),
-      length_and_details_row(volunteering_role),
+      length_row(volunteering_role),
+      details_row(volunteering_role),
     ]
   end
 
@@ -39,20 +40,30 @@ private
     }
   end
 
-  def length_and_details_row(volunteering_role)
+  def length_row(volunteering_role)
     {
-      key: t('application_form.volunteering.length_and_details.review_label'),
-      value: formatted_length_and_details(volunteering_role),
-      action: t('application_form.volunteering.length_and_details.change_action'),
+      key: t('application_form.volunteering.review_length.review_label'),
+      value: formatted_length(volunteering_role),
+      action: t('application_form.volunteering.review_length.change_action'),
       change_path: edit_path(volunteering_role),
     }
   end
 
-  def formatted_length_and_details(volunteering_role)
-    [
-      "#{formatted_start_date(volunteering_role)} - #{formatted_end_date(volunteering_role)}",
-      simple_format(volunteering_role.details),
-    ]
+  def details_row(volunteering_role)
+    {
+      key: t('application_form.volunteering.review_details.review_label'),
+      value: formatted_details(volunteering_role),
+      action: t('application_form.volunteering.review_details.change_action'),
+      change_path: edit_path(volunteering_role),
+    }
+  end
+
+  def formatted_length(volunteering_role)
+    "#{formatted_start_date(volunteering_role)} - #{formatted_end_date(volunteering_role)}"
+  end
+
+  def formatted_details(volunteering_role)
+    simple_format(volunteering_role.details)
   end
 
   def formatted_start_date(volunteering_role)

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -1,7 +1,7 @@
 <% @application_form.application_work_experiences.each do |work| %>
   <%= render(SummaryCardComponent, rows: work_experience_rows(work), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
+      <h2 class="app-summary-card__title">
         <%= work.role %>
         <% if work.working_with_children %>
           <span class="app-summary-card__meta">
@@ -11,10 +11,13 @@
             <%= t('application_form.work_history.working_with_children') %>
           </span>
         <% end %>
-      </h3>
+      </h2>
       <% if @editable %>
         <div class="app-summary-card__actions">
-          <%= link_to t('application_form.work_history.delete_entry'), candidate_interface_work_history_destroy_path(work.id), class: 'govuk-link' %>
+          <%= link_to candidate_interface_work_history_destroy_path(work.id), class: 'govuk-link' do %>
+            <%= t('application_form.work_history.delete_entry') %>
+            <span class="govuk-visually-hidden"> <%= work.role %></span>
+          <% end %>
         </div>
       <% end %>
     </header>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -252,9 +252,12 @@ en:
         hint_text: For example, ‘I volunteer in the classroom every Friday morning’
           or ‘I spent 1 day observing in this school’ or ‘I am a Scout Leader involved
           in activities throughout the year’
-      length_and_details:
-        review_label: Tell us how long you’ve been in this role and what it involves
-        change_action: dates and details
+      review_length:
+        review_label: Tell us how long you’ve been in this role
+        change_action: dates
+      review_details:
+        review_label: Tell us what it involves
+        change_action: details
       complete_form_button: Save and continue
       delete: Delete role
       confirm_delete: Yes I’m sure - delete this role

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -81,15 +81,26 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.organisation.change_action')}")
     end
 
-    it 'renders component with correct values for length and details of experience' do
+    it 'renders component with correct values for length' do
       result = render_inline(VolunteeringReviewComponent, application_form: application_form)
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.length_and_details.review_label'))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('August 2019 - Present<br><p>I interned.</p>')
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_length.review_label'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('August 2019 - Present')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
       )
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.length_and_details.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.review_length.change_action')}")
+    end
+
+    it 'renders component with correct values for details of experience' do
+      result = render_inline(VolunteeringReviewComponent, application_form: application_form)
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_details.review_label'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('<p>I interned.</p>')
+      expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+      )
+      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.review_details.change_action')}")
     end
 
     it 'renders component along with a delete link for each role' do


### PR DESCRIPTION
### Context
Accessibilty 

### Changes proposed in this pull request
- Add hidden names for GSCE qualifications
- Fix hidden names for referres 

### Guidance to review
- `/candidate/application/referees/review`
- `/candidate/application/gcse/maths/review`

### Link to Trello card
[462 - Some Review pages in the qualifications area are missing hidden contextual text on the change links](https://trello.com/c/AdPy8D75/462-some-review-pages-in-the-qualifications-area-are-missing-hidden-contextual-text-on-the-change-links)

### Env vars
n/a