### PR TITLE
Small support UI tweaks

### DIFF
--- a/app/components/support_interface/applications_table_component.rb
+++ b/app/components/support_interface/applications_table_component.rb
@@ -26,7 +26,7 @@ module SupportInterface
     attr_reader :application_forms
 
     def reference_status(reference, submitted)
-      return 'Not submitted' unless reference && submitted
+      return 'Not requested yet' unless reference && submitted
 
       reference.complete? ? 'Received' : 'Awaiting response'
     end

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, "Application history for application ##{@application_form.id}" %>
+<% content_for :browser_title, "Application history – Application ##{@application_form.id}" %>
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -1,4 +1,9 @@
 <% content_for :browser_title, "Application history – Application ##{@application_form.id}" %>
+<% content_for :title do %>
+  <span class="govuk-caption-xl"><%= @application_form.candidate.email_address %></span>
+  Application history
+<% end %>
+
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
@@ -14,10 +19,5 @@
     </ol>
   </div>
 <% end %>
-
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= @application_form.candidate.email_address %></span>
-  Application history
-</h1>
 
 <%= render SupportInterface::AuditTrailComponent, application_form: @application_form %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :browser_title, "Application ##{@application_form.id}" %>
-<% content_for :title, "Application ##{@application_form.id} - #{@application_form.first_name} #{@application_form.last_name}" %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
@@ -13,6 +12,11 @@
     </ol>
   </div>
 <% end %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
+  <%= @application_form.candidate.email_address %>
+</h1>
 
 <%= render SupportInterface::ApplicationSummaryComponent, application_form: @application_form %>
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,4 +1,8 @@
 <% content_for :browser_title, "Application ##{@application_form.id}" %>
+<% content_for :title do %>
+  <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
+  <%= @application_form.candidate.email_address %>
+<% end %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
@@ -12,11 +16,6 @@
     </ol>
   </div>
 <% end %>
-
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
-  <%= @application_form.candidate.email_address %>
-</h1>
 
 <%= render SupportInterface::ApplicationSummaryComponent, application_form: @application_form %>
 

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -50,7 +50,7 @@ RSpec.feature 'See applications' do
     end
 
     within "[data-qa='application-form-#{@unsubmitted_application.id}']" do
-      expect(page).to have_content('Not submitted', count: 2)
+      expect(page).to have_content('Not requested yet', count: 2)
     end
   end
 end


### PR DESCRIPTION
- Put email back into UI title, but not browser title following #661 
- Use a clearer reference status
