### PR TITLE
Whitelist subject param in the URL

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
         get '/review' => 'contact_details/review#show', as: :contact_details_review
       end
 
-      scope '/gcse/:subject' do
+      scope '/gcse/:subject', constraints: { subject: /(maths|english|science)/ } do
         get '/' => 'gcse/type#edit', as: :gcse_details_edit_type
         post '/' => 'gcse/type#update', as: :gcse_details_update_type
 


### PR DESCRIPTION
### Context

During a pentest we found that changing the `:subject` in a URL like:

http://localhost:3000/candidate/application/gcse/maths

into

http://localhost:3000/candidate/application/gcse/76a4sd76c

will return a 500 and raise a Sentry error.

### Changes proposed in this pull request

This restricts the values that are allowed for `:subject`, so that all other values will return a 404 instead.

I haven't added a test because there's no good place to put it, and the reverse is tested properly.

### Guidance to review

Test it locally.

### Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/1350451160
https://sentry.io/organizations/dfe-bat/issues/1350488058