### PR TITLE
Suppress all candidate_interface_*_form request params from logstash logs

### DIFF
--- a/app/lib/log_request_params.rb
+++ b/app/lib/log_request_params.rb
@@ -1,5 +1,8 @@
 module LogRequestParams
-  IGNORE_PARAMS = %w(authenticity_token).freeze
+  IGNORE_PARAMS = [
+    /^authenticity_token$/,
+    /^candidate_interface_.+_form$/,
+  ].freeze
 
   def self.included(base)
     base.class_eval do
@@ -8,6 +11,7 @@ module LogRequestParams
   end
 
   def add_params_to_request_store
-    RequestLocals.store[:params] = params.except(*IGNORE_PARAMS)
+    keys_to_ignore = IGNORE_PARAMS.map { |regexp| params.keys.grep(regexp) }.flatten.uniq
+    RequestLocals.store[:params] = params.except(*keys_to_ignore)
   end
 end

--- a/spec/support_specs/log_request_params_spec.rb
+++ b/spec/support_specs/log_request_params_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+class DummyController < ApplicationController
+  include LogRequestParams
+end
+
+RSpec.describe LogRequestParams do
+  context 'module inclusion' do
+    it 'adds #add_params_to_request_store to the class' do
+      expect(DummyController.new).to respond_to(:add_params_to_request_store)
+    end
+
+    it 'sets before_action :add_params_to_request_store' do
+      expect(DummyController._process_action_callbacks.map(&:filter)).to \
+        include :add_params_to_request_store
+    end
+  end
+
+  context 'excludes specific params' do
+    let(:controller) { DummyController.new }
+    let(:logged_params) { RequestLocals.fetch(:params) { nil } }
+
+    it 'excludes authenticity_token from the logs' do
+      allow(controller).to receive(:params).and_return(
+        non_excluded: 'true',
+        authenticity_token: 'xyz',
+      )
+
+      controller.add_params_to_request_store
+      expect(logged_params[:non_excluded]).not_to be_nil
+      expect(logged_params[:authenticity_token]).to be_nil
+    end
+
+    it 'excludes any candidate_interface form from the logs' do
+      allow(controller).to receive(:params).and_return(
+        non_excluded: 'true',
+        candidate_interface_sign_up_form: {
+          email_address: 'somebody@somewhere.com',
+          accept_ts_and_cs: 'true',
+        },
+      )
+
+      controller.add_params_to_request_store
+      expect(logged_params[:non_excluded]).not_to be_nil
+      expect(logged_params[:candidate_interface_sign_up_form]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Context

Logstash logs will include request params bypassing Rails param filtering.

### Changes proposed in this pull request

Suppress all candidate_interface_*_form params from logstash logs.

### Guidance to review

Set ```LOGSTASH_ENABLE=true``` in your local dev environment. Submit some forms (e.g. sign up).

### Link to Trello card

[1278 - Ensure no PII is sent in logs & Sentry](https://trello.com/c/eam3glK1)

### Env vars

No new vars.
