### PR TITLE
A single place for product names

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,14 +6,14 @@ module ApplicationHelper
 
   def service_name
     case current_namespace
-    when 'provider_interface'
-      'Manage teacher training applications'
     when 'candidate_interface'
-      'Apply for teacher training'
+      t('service_name.apply')
+    when 'provider_interface'
+      t('service_name.manage')
     when 'support_interface'
-      'Support for Apply'
+      t('service_name.support')
     else
-      'Apply for teacher training'
+      t('service_name.apply')
     end
   end
 

--- a/app/views/authentication_mailer/sign_in_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_email.text.erb
@@ -1,5 +1,5 @@
 # <%= t('authentication.sign_in.email.subject') %>
 
-Click the link below to sign in to the Apply for teacher training service.
+Click the link below to sign in to the <%= t('service_name.apply') %> service.
 
 <%= @magic_link %>

--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -1,9 +1,9 @@
 # <%= t('authentication.sign_up.email.subject') %>
 
-Click the link below to confirm your email address and go back to the Apply for teacher training service.
+Click the link below to confirm your email address and go back to the <%= t('service_name.apply') %> service.
 
 <%= @magic_link %>
 
 You will then be able to save and return to your application.
 
-By signing in, you also agree to the terms and conditions of the Apply for teacher training service.
+By signing in, you also agree to the terms and conditions of the <%= t('service_name.apply') %> service.

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -8,7 +8,7 @@
        You can apply for this course using a new GOV.UK service
     </h1>
     <p class="govuk-body">
-      Apply for teacher training is a streamlined new GOV.UK service which is
+      <%= service_name %> is a streamlined new GOV.UK service which is
       designed to make application easier. It comes with personalised support
       for candidates.
     </p>
@@ -19,10 +19,10 @@
 
     <h2 class="govuk-heading-l">Is this new service right for you?</h2>
 
-    <p class="govuk-body">Apply for teacher training is still in development. The service will eventually replace UCAS as the way candidates apply for teacher training. However, for now, it is limited to just a few courses.</p>
+    <p class="govuk-body"><%= service_name %> is still in development. The service will eventually replace UCAS as the way candidates apply for teacher training. However, for now, it is limited to just a few courses.</p>
 
     <p class='govuk-body'>
-      You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on Apply for teacher training.
+      You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.
     </p>
 
     <p class="govuk-body">For most courses, you’ll still need to apply through UCAS.</p>

--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      <%= t('layout.service_name') %>
+      <%= service_name %>
     </h1>
 
     <p class="govuk-body">

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -7,7 +7,7 @@
 <div class='govuk-grid-row'>
   <div class='govuk-grid-column-two-thirds'>
     <div class='govuk-body'>
-      You can apply to the following training providers and courses using <%= govuk_link_to 'Apply for teacher training', candidate_interface_start_path %>.
+      You can apply to the following training providers and courses using <%= govuk_link_to service_name, candidate_interface_start_path %>.
     </div>
 
     <% @courses_by_provider.each do |provider_name, courses| %>

--- a/app/views/candidate_interface/course_choices/_guidance.html.erb
+++ b/app/views/candidate_interface/course_choices/_guidance.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">You can apply to up to 3 courses at this stage of your application.</p>
-<p class="govuk-body">Not all courses and training providers are signed up to this service. If you choose a course that isn’t signed up to Apply for teacher training, you’ll be directed to UCAS to continue your application.</p>
-<p class="govuk-body">You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on Apply for teacher training.</p>
+<p class="govuk-body">Not all courses and training providers are signed up to this service. If you choose a course that isn’t signed up to <%= service_name %>, you’ll be directed to UCAS to continue your application.</p>
+<p class="govuk-body">You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on <%= service_name %>.</p>
 <p class="govuk-body">Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>

--- a/app/views/candidate_interface/course_choices/ucas.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas.html.erb
@@ -7,7 +7,7 @@
       We’re sorry, but we’re not ready for you yet
     </h1>
 
-    <p class="govuk-body">Apply for teacher training is still in development, so for now, we have to limit candidate numbers.</p>
+    <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers.</p>
     <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
     <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
     <p class="govuk-body"><%= govuk_link_to 'Apply on UCAS', UCAS.apply_url %></p>

--- a/app/views/candidate_interface/start_page/not_eligible.html.erb
+++ b/app/views/candidate_interface/start_page/not_eligible.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.not_eligible_yet') %>
     </h1>
 
-    <p class="govuk-body">Apply for teacher training is still in development, so for now, we have to limit candidate numbers.</p>
+    <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers.</p>
     <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
     <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
     <p class="govuk-body"><%= govuk_link_to 'Apply on UCAS', UCAS.apply_url %></p>

--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -3,14 +3,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Apply for postgraduate teacher training
+      <%= service_name %>
     </h1>
-    <p class="govuk-body">
-      Apply for teacher training is a new GOV.UK service being trialled with a small number of training providers.
+    <p class="govuk-body-l">
+      <%= service_name %> is a new GOV.UK service being trialled with a small number of training providers in England.
     </p>
     <div class="govuk-inset-text">
       Learn more about teacher training in <%= govuk_link_to('Wales', 'https://www.discoverteaching.wales/routes-into-teaching/', target: :_blank) %>, <%= govuk_link_to('Scotland', 'https://teachinscotland.scot/', target: :_blank) %> and <%= govuk_link_to('Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland', target: :_blank) %>
     </div>
+
     <h2 class="govuk-heading-m">What you’ll need</h2>
     <p class="govuk-body">
       To be eligible for teacher training, you need these qualifications (or their non-UK equivalents):

--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -28,7 +28,7 @@ You can withdraw your application to <%= 'course'.pluralize(@application_form.ap
 
 # References
 
-The Apply for teacher training service will contact your referees to ask them for references.
+The <%= t('service_name.apply') %> service will contact your referees to ask them for references.
 
 Your referees will be given a short questionnaire about you and a free text box to describe you in their own words. They will not be given access to your completed application form.
 

--- a/app/views/healthcheck/show.html.erb
+++ b/app/views/healthcheck/show.html.erb
@@ -1,3 +1,3 @@
 <p class="govuk-body">
-  Apply for teacher training is a new GOV.UK service.
+  <%= service_name %> is a new GOV.UK service.
 </p>

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -6,13 +6,13 @@
       Account creation in progress
     </h1>
     <p class="govuk-body">
-    You are seeing this page because you have successfully signed in to the
-    Apply for teacher training service, but your user account has not yet been
-    associated with your training provider.
+      You are seeing this page because you have successfully signed in to the
+      <%= service_name %> service, but your user account has
+      not yet been associated with your training provider.
     </p>
 
     <p class="govuk-body">
-    For more information please contact <%= mail_to 'becomingateacher@digital.education.gov.uk', 'becomingateacher@digital.education.gov.uk', class: 'govuk-link' %>.
+      For more information please contact <%= mail_to 'becomingateacher@digital.education.gov.uk', 'becomingateacher@digital.education.gov.uk', class: 'govuk-link' %>.
     </p>
   </div>
 </div>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -25,5 +25,5 @@
     </tbody>
   </table>
 <% else %>
-  <p class="govuk-body">You haven’t received any applications from Apply for teacher training.</p>
+  <p class="govuk-body">You haven’t received any applications from <%= t('service_name.apply') %>.</p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,8 @@
 en:
+  service_name:
+    apply: Apply for teacher training
+    manage: Manage teacher training applications
+    support: Support for Apply
   page_titles:
     application: ''
     application_form: Your application
@@ -65,7 +69,6 @@ en:
     apply_on_ucas: We’re sorry, but we’re not ready for you yet
     providers: Training providers available through Apply for teacher training
   layout:
-    service_name: Apply for teacher training
     accessibility: Accessibility
     terms_of_use: Terms of use
     privacy_policy: Privacy policy


### PR DESCRIPTION
### Context

I found a stray occurrence of the old service name ‘Apply for postgraduate teacher training’, so in replacing that, made all the service names localisable strings and then reference them from the views.
