### PR TITLE
Show error when not submitting a course

### DIFF
--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -23,6 +23,8 @@ module CandidateInterface
     end
 
     def user_cant_apply_to_same_course_twice
+      return unless code
+
       if application_form.application_choices.any? { |application_choice| application_choice.course == course }
         errors[:base] << 'You have already selected this course'
       end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -12,6 +12,10 @@ RSpec.feature 'Selecting a course' do
     and_i_click_on_add_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
+
+    when_submit_without_choosing_a_course
+    then_i_should_see_an_error
+
     and_i_choose_a_course
     and_i_choose_a_location
     then_i_see_my_completed_course_choice
@@ -64,6 +68,14 @@ RSpec.feature 'Selecting a course' do
   def and_i_choose_a_provider
     choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
+  end
+
+  def when_submit_without_choosing_a_course
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_an_error
+    expect(page).to have_content 'Select a course'
   end
 
   def and_i_choose_a_course


### PR DESCRIPTION
Fixes an issue in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/p
ull/660, where the error wasn't shown on the form because a `ActiveRecord::RecordNotFound` found error was triggered by the `user_cant_apply_to_same_course_twice` validation, which shows a 404 page.
