### PR TITLE
Add URL availability monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ These steps describe the process for making environment variables available to t
 
 ### <a name="documentation-pipeline-vars"></a>Pipeline Variables
 
-### <a name="documentation-pipeline-vars-availability"></a>Pipeline Variables - Availability Monitoring
+#### <a name="documentation-pipeline-vars-availability"></a>Availability Monitoring
 
 By default the `/check` path of the azurewebsites.net URL is automatically monitored in each environment, as is the same path on the education.gov.uk domain, if configured. To add extra URLs for monitoring ensure the following format is used in the `customAvailabilityMonitors` pipeline variable for each URL you wish to monitor.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A service for candidates to apply for initial teacher training.
   * [Domain Model](#documentation-domain-model)
   * [Application States](#documentation-application-states)
   * [Environment Variables](#documentation-env-vars)
+  * [Pipeline Variables](#documentation-pipeline-vars)
 
 ## <a name="dependencies"></a>Dependencies
 
@@ -230,3 +231,13 @@ These steps describe the process for making environment variables available to t
         "value": "[parameters('varName')]"
       }
       ```
+
+### <a name="documentation-pipeline-vars"></a>Pipeline Variables
+
+### <a name="documentation-pipeline-vars-availability"></a>Pipeline Variables - Availability Monitoring
+
+By default the `/check` path of the azurewebsites.net URL is automatically monitored in each environment, as is the same path on the education.gov.uk domain, if configured. To add extra URLs for monitoring ensure the following format is used in the `customAvailabilityMonitors` pipeline variable for each URL you wish to monitor.
+
+`["TEST-NAME1:DOMAIN1","TEST-NAME2:DOMAIN2"]`
+
+The `TEST-NAMEn` should be short, unique and descriptive and contain no spaces. The `DOMAINn` should be the complete domain without the protocol specified (i.e drop the "http(s)://").

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -46,6 +46,8 @@ parameters:
   dfeSignInSecret:
   dfeSignInIssuer:
   stateChangeSlackUrl:
+  customAvailabilityMonitors: []
+  alertRecipientEmails: []
 
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
@@ -121,7 +123,9 @@ jobs:
                 -dfeSignInClientId "${{parameters.dfeSignInClientId}}"
                 -stateChangeSlackUrl "${{parameters.stateChangeSlackUrl}}"
                 -dfeSignInSecret "${{parameters.dfeSignInSecret}}"
-                -dfeSignInIssuer "${{parameters.dfeSignInIssuer}}"'
+                -dfeSignInIssuer "${{parameters.dfeSignInIssuer}}"
+                -customAvailabilityMonitors "${{parameters.customAvailabilityMonitors}}"
+                -alertRecipientEmails "${{parameters.alertRecipientEmails}}"'
               deploymentOutputs: DeploymentOutput
 
           - task: AzurePowerShell@3

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -86,6 +86,9 @@ stages:
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'
       stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+      alertRecipientEmails: '$(alertRecipientEmails)'
+
 
 - stage: deploy_sandbox
   displayName: 'Deploy - Sandbox'
@@ -132,6 +135,8 @@ stages:
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'
       stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+      alertRecipientEmails: '$(alertRecipientEmails)'
 
 
 - stage: deploy_pentest
@@ -178,6 +183,8 @@ stages:
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'
       stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+      alertRecipientEmails: '$(alertRecipientEmails)'
 
 
 - stage: deploy_production
@@ -227,3 +234,5 @@ stages:
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'
       stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+      alertRecipientEmails: '$(alertRecipientEmails)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,6 @@ stages:
         echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
         echo "##vso[task.setvariable variable=docker_path;]$docker_path"
       displayName: 'Set version number'
-      condition: not(variables['deployOnly'])
 
     - script: make setup
       displayName: 'Build & setup'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,8 @@ variables:
   value: 'apply-for-postgraduate-teacher-training'
 - name: debug
   value: true
+- name: deployOnly
+  value: false
 
 stages:
 - stage: build_test_release
@@ -37,9 +39,11 @@ stages:
         echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
         echo "##vso[task.setvariable variable=docker_path;]$docker_path"
       displayName: 'Set version number'
+      condition: not(variables['deployOnly'])
 
     - script: make setup
       displayName: 'Build & setup'
+      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -51,6 +55,7 @@ stages:
 
     - script: make ci.lint-ruby
       displayName: 'Rubocop'
+      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -61,6 +66,7 @@ stages:
 
     - script: make ci.lint-erb
       displayName: 'ERB lint'
+      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -80,6 +86,7 @@ stages:
           false
         fi
       displayName: 'Cucumber specs'
+      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -99,6 +106,7 @@ stages:
           false
         fi
       displayName: 'Execute tests'
+      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -109,6 +117,7 @@ stages:
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
+      condition: not(variables['deployOnly'])
       inputs:
         command: Tag image
         imageName: "$(docker_path):latest"
@@ -116,6 +125,7 @@ stages:
 
     - task: Docker@1
       displayName: Docker Hub login
+      condition: not(variables['deployOnly'])
       inputs:
         command: "login"
         containerregistrytype: Container Registry
@@ -123,6 +133,7 @@ stages:
 
     - task: Docker@1
       displayName: Push tagged image
+      condition: not(variables['deployOnly'])
       inputs:
         command: Push an image
         imageName: "$(docker_path):$(Build.BuildNumber)"
@@ -186,6 +197,8 @@ stages:
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'
       stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+      alertRecipientEmails: '$(alertRecipientEmails)'
 
 
 - stage: deploy_devops
@@ -232,3 +245,5 @@ stages:
       dfeSignInSecret: '$(dfeSignInSecret)'
       dfeSignInIssuer: '$(dfeSignInIssuer)'
       stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+      alertRecipientEmails: '$(alertRecipientEmails)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,6 @@ variables:
   value: 'apply-for-postgraduate-teacher-training'
 - name: debug
   value: true
-- name: deployOnly
-  value: false
 
 stages:
 - stage: build_test_release
@@ -43,7 +41,6 @@ stages:
 
     - script: make setup
       displayName: 'Build & setup'
-      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -55,7 +52,6 @@ stages:
 
     - script: make ci.lint-ruby
       displayName: 'Rubocop'
-      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -66,7 +62,6 @@ stages:
 
     - script: make ci.lint-erb
       displayName: 'ERB lint'
-      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -86,7 +81,6 @@ stages:
           false
         fi
       displayName: 'Cucumber specs'
-      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -106,7 +100,6 @@ stages:
           false
         fi
       displayName: 'Execute tests'
-      condition: not(variables['deployOnly'])
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -117,7 +110,6 @@ stages:
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
-      condition: not(variables['deployOnly'])
       inputs:
         command: Tag image
         imageName: "$(docker_path):latest"
@@ -125,7 +117,6 @@ stages:
 
     - task: Docker@1
       displayName: Docker Hub login
-      condition: not(variables['deployOnly'])
       inputs:
         command: "login"
         containerregistrytype: Container Registry
@@ -133,7 +124,6 @@ stages:
 
     - task: Docker@1
       displayName: Push tagged image
-      condition: not(variables['deployOnly'])
       inputs:
         command: Push an image
         imageName: "$(docker_path):$(Build.BuildNumber)"

--- a/azure/template.json
+++ b/azure/template.json
@@ -296,6 +296,20 @@
             "metadata": {
                 "description": "Set this to a Slack incoming webhook url for application state change notifications"
             }
+        },
+        "customAvailabilityMonitors": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Array of paths to perform monitoring on. In form TEST_NAME:HOST where HOST is the complete URL minus the http(s):// prefix."
+            }
+        },
+        "alertRecipientEmails": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Array of recipients to receive availability email alerts. In form NAME:EMAIL_ADDRESS."
+            }
         }
     },
     "variables": {
@@ -308,7 +322,28 @@
         "storageAccountName": "[replace(concat(variables('resourceNamePrefix'), 'str'), '-', '')]",
         "databaseServerName": "[concat(variables('resourceNamePrefix'), '-psql')]",
         "keyVaultCertificateName": "[replace(parameters('customHostName'), '.', '-')]",
-        "rubyAuthHosts": "[if(greater(length(parameters('customHostName')), 0), concat(parameters('authorisedHosts'), ',', parameters('customHostName')), parameters('authorisedHosts'))]"
+        "rubyAuthHosts": "[if(greater(length(parameters('customHostName')), 0), concat(parameters('authorisedHosts'), ',', parameters('customHostName')), parameters('authorisedHosts'))]",
+        "defaultAvailabilityCheckHosts": "[if(greater(length(parameters('customHostName')), 0), createArray(concat('azcheck:', variables('appServiceName'), '.azurewebsites.net/check'), concat('check:', parameters('customHostName'), '/check')), createArray(concat('azcheck:', variables('appServiceName'), '.azurewebsites.net/check')))]",
+        "availabilityCheckHosts": "[if(greater(length(parameters('customAvailabilityMonitors')), 0), concat(variables('defaultAvailabilityCheckHosts'), parameters('customAvailabilityMonitors')), variables('defaultAvailabilityCheckHosts'))]",
+        "copy": [
+            {
+                "name": "availabilityTests",
+                "count": "[length(variables('availabilityCheckHosts'))]",
+                "input": {
+                    "nameSuffix": "[split(variables('availabilityCheckHosts')[copyIndex('availabilityTests')], ':')[0]]",
+                    "url": "[concat('https://', split(variables('availabilityCheckHosts')[copyIndex('availabilityTests')], ':')[1])]",
+                    "guid": "[guid(variables('availabilityCheckHosts')[copyIndex('availabilityTests')])]"
+                }
+            },
+            {
+                "name": "alertRecipients",
+                "count": "[length(parameters('alertRecipientEmails'))]",
+                "input": {
+                    "displayName": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[0]]",
+                    "emailAddress": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[1]]"
+                }
+            }
+        ]
     },
     "resources": [
         {
@@ -875,6 +910,9 @@
                     },
                     "attachedService": {
                         "value": "[variables('appServiceName')]"
+                    },
+                    "availabilityTests": {
+                        "value": "[variables('availabilityTests')]"
                     }
                 }
             }

--- a/azure/template.json
+++ b/azure/template.json
@@ -337,7 +337,7 @@
             },
             {
                 "name": "alertRecipients",
-                "count": "[length(parameters('alertRecipientEmails'))]",
+                "count": "[if(greater(length(parameters('alertRecipientEmails'), 0), length(parameters('alertRecipientEmails'), 1))]",
                 "input": {
                     "displayName": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[0]]",
                     "emailAddress": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[1]]"

--- a/azure/template.json
+++ b/azure/template.json
@@ -334,14 +334,6 @@
                     "url": "[concat('https://', split(variables('availabilityCheckHosts')[copyIndex('availabilityTests')], ':')[1])]",
                     "guid": "[guid(variables('availabilityCheckHosts')[copyIndex('availabilityTests')])]"
                 }
-            },
-            {
-                "name": "alertRecipients",
-                "count": "[if(greater(length(parameters('alertRecipientEmails')), 0), length(parameters('alertRecipientEmails')), 1)]",
-                "input": {
-                    "displayName": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[0]]",
-                    "emailAddress": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[1]]"
-                }
             }
         ]
     },

--- a/azure/template.json
+++ b/azure/template.json
@@ -337,7 +337,7 @@
             },
             {
                 "name": "alertRecipients",
-                "count": "[if(greater(length(parameters('alertRecipientEmails'), 0), length(parameters('alertRecipientEmails'), 1))]",
+                "count": "[if(greater(length(parameters('alertRecipientEmails')), 0), length(parameters('alertRecipientEmails')), 1)]",
                 "input": {
                     "displayName": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[0]]",
                     "emailAddress": "[split(parameters('alertRecipientEmails')[copyIndex('alertRecipients')], ':')[1]]"


### PR DESCRIPTION
### Context

This change introduces URL availability monitoring to the web applications associated with Apply. 
This change contains only the monitoring aspect, alerting will follow in a subsequent PR.

### Changes proposed in this pull request

- Adds monitoring of `/check` path on azurewebsites.net address and gov.uk address where used automatically.
- Added `customAvailabilityMonitors` pipeline variable to add custom availability monitors on a per environment basis if required.
- Added documentation in README.md

### Guidance to review

Availability monitoring results can be seen here on the DevOps Azure environment: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/289869cc-7183-46bd-8131-f673c5eb94ba/resourceGroups/s106d02-apply/providers/Microsoft.Insights/components/s106d02-apply-as/availability

The additional URL monitoring can be added by populating the `customAvailabilityMonitors` pipeline array variable in the following format:
`["TEST-NAME1:URL1", "TEST-NAME2:URL2"]`
The test name cannot contain any spaces.

### Link to Trello card

[1289 - Set up application uptime monitoring in code](https://trello.com/c/gNY8bLZK/1289-set-up-application-uptime-monitoring-in-code)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
