### PR TITLE
Show missing sections in candidate review and prevent submission with missing sections

### DIFF
--- a/app/components/becoming_a_teacher_review_component.html.erb
+++ b/app/components/becoming_a_teacher_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.becoming_a_teacher.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :becoming_a_teacher, text: t('review_application.becoming_a_teacher.incomplete')) do %>
     <%= link_to candidate_interface_becoming_a_teacher_edit_path, class: 'govuk-link' do %>
       <%= t('review_application.becoming_a_teacher.link_html') %>
     <% end %>

--- a/app/components/becoming_a_teacher_review_component.html.erb
+++ b/app/components/becoming_a_teacher_review_component.html.erb
@@ -1,1 +1,9 @@
-<%= render(SummaryCardComponent, rows: becoming_a_teacher_form_rows, editable: @editable) %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.becoming_a_teacher.incomplete')) do %>
+    <%= link_to candidate_interface_becoming_a_teacher_edit_path, class: 'govuk-link' do %>
+      <%= t('review_application.becoming_a_teacher.link_html') %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render(SummaryCardComponent, rows: becoming_a_teacher_form_rows, editable: @editable) %>
+<% end %>

--- a/app/components/becoming_a_teacher_review_component.rb
+++ b/app/components/becoming_a_teacher_review_component.rb
@@ -13,6 +13,10 @@ class BecomingATeacherReviewComponent < ActionView::Component::Base
     [becoming_a_teacher_form_row]
   end
 
+  def show_missing_banner?
+    !@becoming_a_teacher_form.valid? && @editable
+  end
+
 private
 
   attr_reader :application_form

--- a/app/components/contact_details_review_component.html.erb
+++ b/app/components/contact_details_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.contact_details.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :contact_details, text: t('review_application.contact_details.incomplete')) do %>
     <%= link_to candidate_interface_contact_details_edit_base_path, class: 'govuk-link' do %>
       <%= t('review_application.contact_details.link_html') %>
     <% end %>

--- a/app/components/contact_details_review_component.html.erb
+++ b/app/components/contact_details_review_component.html.erb
@@ -1,1 +1,9 @@
-<%= render(SummaryCardComponent, rows: contact_details_form_rows, editable: @editable) %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.contact_details.incomplete')) do %>
+    <%= link_to candidate_interface_contact_details_edit_base_path, class: 'govuk-link' do %>
+      <%= t('review_application.contact_details.link_html') %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render(SummaryCardComponent, rows: contact_details_form_rows, editable: @editable) %>
+<% end %>

--- a/app/components/contact_details_review_component.rb
+++ b/app/components/contact_details_review_component.rb
@@ -13,6 +13,10 @@ class ContactDetailsReviewComponent < ActionView::Component::Base
     [phone_number_row, address_row]
   end
 
+  def show_missing_banner?
+    !@contact_details_form.valid?(:base) && !@contact_details_form.valid?(:address) && @editable
+  end
+
 private
 
   attr_reader :application_form

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -36,9 +36,9 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.courses.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.course_choices.incomplete')) do %>
     <%= link_to candidate_interface_course_choices_index_path, class: 'govuk-link' do %>
-      <%= t('review_application.courses.link_html') %>
+      <%= t('review_application.course_choices.link_html') %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -36,7 +36,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.course_choices.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :course_choices, text: t('review_application.course_choices.incomplete')) do %>
     <%= link_to candidate_interface_course_choices_index_path, class: 'govuk-link' do %>
       <%= t('review_application.course_choices.link_html') %>
     <% end %>

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -34,3 +34,11 @@
 <% if any_withdrawable? %>
   <p class="govuk-body"><%= t('application_form.courses.withdrawal_information') %></p>
 <% end %>
+
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.courses.incomplete')) do %>
+    <%= link_to candidate_interface_course_choices_index_path, class: 'govuk-link' do %>
+      <%= t('review_application.courses.link_html') %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -1,11 +1,12 @@
 class CourseChoicesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, show_status: false)
+  def initialize(application_form:, editable: true, show_status: false, show_incomplete: false)
     @application_form = application_form
     @course_choices = @application_form.application_choices
     @editable = editable
     @show_status = show_status
+    @show_incomplete = show_incomplete
   end
 
   def course_choice_rows(course_choice)
@@ -25,6 +26,10 @@ class CourseChoicesReviewComponent < ActionView::Component::Base
     @application_form.application_choices.any? do |course_choice|
       withdrawable?(course_choice)
     end
+  end
+
+  def show_missing_banner?
+    @show_incomplete && !@application_form.course_choices_completed && @editable
   end
 
 private

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -15,3 +15,11 @@
     </header>
   <% end %>
 <% end %>
+
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.degrees.incomplete')) do %>
+     <%= link_to candidate_interface_degrees_new_base_path, class: 'govuk-link' do %>
+       <%= t('review_application.degrees.link_html') %>
+     <% end %>
+   <% end %>
+<% end %>

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.degrees.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :degrees, text: t('review_application.degrees.incomplete')) do %>
      <%= link_to candidate_interface_degrees_new_base_path, class: 'govuk-link' do %>
        <%= t('review_application.degrees.link_html') %>
      <% end %>

--- a/app/components/degrees_review_component.rb
+++ b/app/components/degrees_review_component.rb
@@ -1,12 +1,13 @@
 class DegreesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, show_incomplete: false)
     @application_form = application_form
     @degrees = CandidateInterface::DegreeForm.build_all_from_application(
       @application_form,
     )
     @editable = editable
+    @show_incomplete = show_incomplete
   end
 
   def degree_rows(degree)
@@ -15,6 +16,10 @@ class DegreesReviewComponent < ActionView::Component::Base
       award_year_row(degree),
       grade_row(degree),
     ]
+  end
+
+  def show_missing_banner?
+    @show_incomplete && !@application_form.degrees_completed && @editable
   end
 
 private

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -11,6 +11,12 @@
       </h2>
     </header>
   <% end %>
+<% elsif @editable %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.gcse.incomplete', subject: subject.capitalize)) do %>
+    <%= link_to candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), class: 'govuk-link' do %>
+      <%= t('review_application.gcse.link_html', subject: subject) %>
+    <% end %>
+  <% end %>
 <% else %>
   <p class="govuk-body">No GCSE entered.</p>
 <% end %>

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -12,7 +12,7 @@
     </header>
   <% end %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, text: t("review_application.#{subject}_gcse.incomplete")) do %>
+  <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", text: t("review_application.#{subject}_gcse.incomplete")) do %>
     <%= link_to candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), class: 'govuk-link' do %>
       <%= t("review_application.#{subject}_gcse.link_html") %>
     <% end %>

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -12,9 +12,9 @@
     </header>
   <% end %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.gcse.incomplete', subject: subject.capitalize)) do %>
+  <%= render(SectionMissingBannerComponent, text: t("review_application.#{subject}_gcse.incomplete")) do %>
     <%= link_to candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), class: 'govuk-link' do %>
-      <%= t('review_application.gcse.link_html', subject: subject) %>
+      <%= t("review_application.#{subject}_gcse.link_html") %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/components/interview_preferences_review_component.html.erb
+++ b/app/components/interview_preferences_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.interview_preferences.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :interview_preferences, text: t('review_application.interview_preferences.incomplete')) do %>
     <%= link_to candidate_interface_interview_preferences_edit_path, class: 'govuk-link' do %>
       <%= t('review_application.interview_preferences.link_html') %>
     <% end %>

--- a/app/components/interview_preferences_review_component.html.erb
+++ b/app/components/interview_preferences_review_component.html.erb
@@ -1,7 +1,7 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.interview.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.interview_preferences.incomplete')) do %>
     <%= link_to candidate_interface_interview_preferences_edit_path, class: 'govuk-link' do %>
-      <%= t('review_application.interview.link_html') %>
+      <%= t('review_application.interview_preferences.link_html') %>
     <% end %>
   <% end %>
 <% else %>

--- a/app/components/interview_preferences_review_component.html.erb
+++ b/app/components/interview_preferences_review_component.html.erb
@@ -1,1 +1,9 @@
-<%= render(SummaryCardComponent, rows: interview_preferences_form_rows, editable: @editable) %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.interview.incomplete')) do %>
+    <%= link_to candidate_interface_interview_preferences_edit_path, class: 'govuk-link' do %>
+      <%= t('review_application.interview.link_html') %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render(SummaryCardComponent, rows: interview_preferences_form_rows, editable: @editable) %>
+<% end %>

--- a/app/components/interview_preferences_review_component.rb
+++ b/app/components/interview_preferences_review_component.rb
@@ -13,6 +13,10 @@ class InterviewPreferencesReviewComponent < ActionView::Component::Base
     [interview_preferences_form_row]
   end
 
+  def show_missing_banner?
+    !@interview_preferences_form.valid? && @editable
+  end
+
 private
 
   attr_reader :application_form

--- a/app/components/other_qualifications_review_component.html.erb
+++ b/app/components/other_qualifications_review_component.html.erb
@@ -15,3 +15,7 @@
     </header>
   <% end %>
 <% end %>
+
+<% if @qualifications.empty? %>
+  <p class="govuk-body">No other qualifications entered.</p>
+<% end %>

--- a/app/components/personal_details_review_component.html.erb
+++ b/app/components/personal_details_review_component.html.erb
@@ -1,7 +1,7 @@
 <% if @personal_details_form.valid? %>
   <%= render(SummaryCardComponent, rows: rows, editable: @editable) %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.personal_details.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :personal_details, text: t('review_application.personal_details.incomplete')) do %>
     <%= link_to candidate_interface_personal_details_edit_path, class: 'govuk-link' do %>
       <%= t('review_application.personal_details.link_html') %>
     <% end %>

--- a/app/components/personal_details_review_component.html.erb
+++ b/app/components/personal_details_review_component.html.erb
@@ -1,5 +1,11 @@
 <% if @personal_details_form.valid? %>
   <%= render(SummaryCardComponent, rows: rows, editable: @editable) %>
+<% elsif @editable %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.personal_details.incomplete')) do %>
+    <%= link_to candidate_interface_personal_details_edit_path, class: 'govuk-link' do %>
+      <%= t('review_application.personal_details.link_html') %>
+    <% end %>
+  <% end %>
 <% else %>
   <p class="govuk-body">No personal details entered.</p>
 <% end %>

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -17,7 +17,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.references.incomplete', minimum_references: minimum_references)) do %>
+  <%= render(SectionMissingBannerComponent, section: :references, text: t('review_application.references.incomplete', minimum_references: minimum_references)) do %>
      <%= link_to candidate_interface_referees_path, class: 'govuk-link' do %>
        <%= t('review_application.references.link_html') %>
      <% end %>

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -17,9 +17,9 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.referees.incomplete', minimum_references: minimum_references)) do %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.references.incomplete', minimum_references: minimum_references)) do %>
      <%= link_to candidate_interface_referees_path, class: 'govuk-link' do %>
-       <%= t('review_application.referees.link_html') %>
+       <%= t('review_application.references.link_html') %>
      <% end %>
    <% end %>
 <% end %>

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -15,3 +15,11 @@
     </header>
   <% end %>
 <% end %>
+
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.referees.incomplete', minimum_references: minimum_references)) do %>
+     <%= link_to candidate_interface_referees_path, class: 'govuk-link' do %>
+       <%= t('review_application.referees.link_html') %>
+     <% end %>
+   <% end %>
+<% end %>

--- a/app/components/referees_review_component.rb
+++ b/app/components/referees_review_component.rb
@@ -1,9 +1,10 @@
 class RefereesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, show_incomplete: false)
     @application_form = application_form
     @editable = editable
+    @show_incomplete = show_incomplete
   end
 
   def referee_rows(work)
@@ -13,6 +14,14 @@ class RefereesReviewComponent < ActionView::Component::Base
       relationship_row(work),
     ]
       .compact
+  end
+
+  def minimum_references
+    ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+  end
+
+  def show_missing_banner?
+    @show_incomplete && @application_form.references.count < minimum_references && @editable
   end
 
 private

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,0 +1,8 @@
+<div class="app-banner app-banner--info app-banner--missing-section">
+  <div class="app-banner__message">
+    <p class="govuk-body"><%= @text %></p>
+    <% if content.present? %>
+      <%= content %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-banner app-banner--info app-banner--missing-section">
+<div class="app-banner app-banner--info app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
     <p class="govuk-body"><%= @text %></p>
     <% if content.present? %>

--- a/app/components/section_missing_banner_component.rb
+++ b/app/components/section_missing_banner_component.rb
@@ -1,9 +1,10 @@
 class SectionMissingBannerComponent < ActionView::Component::Base
-  validates :text, presence: true
+  validates :text, :section, presence: true
 
-  def initialize(text:)
+  def initialize(text:, section:)
     @text = text
+    @section = section
   end
 
-  attr_reader :text
+  attr_reader :text, :section
 end

--- a/app/components/section_missing_banner_component.rb
+++ b/app/components/section_missing_banner_component.rb
@@ -1,0 +1,9 @@
+class SectionMissingBannerComponent < ActionView::Component::Base
+  validates :text, presence: true
+
+  def initialize(text:)
+    @text = text
+  end
+
+  attr_reader :text
+end

--- a/app/components/subject_knowledge_review_component.html.erb
+++ b/app/components/subject_knowledge_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.subject_knowledge.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :subject_knowledge, text: t('review_application.subject_knowledge.incomplete')) do %>
     <%= link_to candidate_interface_subject_knowledge_edit_path, class: 'govuk-link' do %>
       <%= t('review_application.subject_knowledge.link_html') %>
     <% end %>

--- a/app/components/subject_knowledge_review_component.html.erb
+++ b/app/components/subject_knowledge_review_component.html.erb
@@ -1,1 +1,9 @@
-<%= render(SummaryCardComponent, rows: subject_knowledge_form_rows, editable: @editable) %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.subject_knowledge.incomplete')) do %>
+    <%= link_to candidate_interface_subject_knowledge_edit_path, class: 'govuk-link' do %>
+      <%= t('review_application.subject_knowledge.link_html') %>
+    <% end %>
+  <% end %>
+<% else %>
+  <%= render(SummaryCardComponent, rows: subject_knowledge_form_rows, editable: @editable) %>
+<% end %>

--- a/app/components/subject_knowledge_review_component.rb
+++ b/app/components/subject_knowledge_review_component.rb
@@ -13,6 +13,10 @@ class SubjectKnowledgeReviewComponent < ActionView::Component::Base
     [subject_knowledge_form_row]
   end
 
+  def show_missing_banner?
+    !@subject_knowledge_form.valid? && @editable
+  end
+
 private
 
   attr_reader :application_form

--- a/app/components/task_list_item_component.html.erb
+++ b/app/components/task_list_item_component.html.erb
@@ -1,4 +1,10 @@
 <%= govuk_link_to text, path, class: 'app-task-list__task-name', 'aria-describedby': tag_id %>
-<strong class="govuk-tag app-task-list__task-completed<%= " app-govuk-tag--incomplete" unless completed %>" id=<%= tag_id %>>
-  <%= completed ? "Completed" : "Incomplete" %>
-</strong>
+<% if completed %>
+  <strong class="govuk-tag app-task-list__task-completed" id=<%= tag_id %>>
+    Completed
+  </strong>
+<% elsif show_incomplete %>
+  <strong class="govuk-tag app-task-list__task-completed app-govuk-tag--incomplete" id=<%= tag_id %>>
+    Incomplete
+  </strong>
+<% end %>

--- a/app/components/task_list_item_component.rb
+++ b/app/components/task_list_item_component.rb
@@ -3,10 +3,11 @@ class TaskListItemComponent < ActionView::Component::Base
 
   validates :path, presence: true
 
-  def initialize(completed:, path:, text:)
+  def initialize(completed:, path:, text:, show_incomplete: true)
     @completed = completed
     @path = path
     @text = text
+    @show_incomplete = show_incomplete
   end
 
   def tag_id
@@ -15,5 +16,5 @@ class TaskListItemComponent < ActionView::Component::Base
 
 private
 
-  attr_reader :completed, :path, :text
+  attr_reader :completed, :path, :text, :show_incomplete
 end

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -25,7 +25,13 @@
   <% end %>
 <% end %>
 
-<% if @application_form.application_volunteering_experiences.empty? %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.volunteering.incomplete')) do %>
+     <%= link_to candidate_interface_volunteering_experience_path, class: 'govuk-link' do %>
+       <%= t('review_application.volunteering.link_html') %>
+     <% end %>
+   <% end %>
+<% elsif @application_form.application_volunteering_experiences.empty? %>
   <section class="app-summary-card govuk-!-margin-bottom-6">
     <header class="app-summary-card__header">
       <h3 class="app-summary-card__title">

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -26,7 +26,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.volunteering.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :volunteering, text: t('review_application.volunteering.incomplete')) do %>
      <%= link_to candidate_interface_volunteering_experience_path, class: 'govuk-link' do %>
        <%= t('review_application.volunteering.link_html') %>
      <% end %>

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -1,12 +1,13 @@
 class VolunteeringReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, show_incomplete: false)
     @application_form = application_form
     @volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(
       @application_form,
     )
     @editable = editable
+    @show_incomplete = show_incomplete
   end
 
   def volunteering_role_rows(volunteering_role)
@@ -16,6 +17,10 @@ class VolunteeringReviewComponent < ActionView::Component::Base
       length_row(volunteering_role),
       details_row(volunteering_role),
     ]
+  end
+
+  def show_missing_banner?
+    @show_incomplete && !@application_form.volunteering_completed && @editable
   end
 
 private

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -33,7 +33,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.work_experience.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, section: :work_experience, text: t('review_application.work_experience.incomplete')) do %>
      <%= link_to candidate_interface_work_history_length_path, class: 'govuk-link' do %>
        <%= t('review_application.work_experience.link_html') %>
      <% end %>

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -24,10 +24,18 @@
   <% end %>
 <% end %>
 
-<% if @application_form.application_work_experiences.empty? %>
+<% if !show_missing_banner? && @application_form.application_work_experiences.empty? %>
   <%= render(SummaryCardComponent, rows: no_work_experience_rows, editable: @editable) %>
 <% end %>
 
 <% if breaks_in_work_history? %>
   <%= render(SummaryCardComponent, rows: break_in_work_history_rows, editable: @editable) %>
+<% end %>
+
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.work.incomplete')) do %>
+     <%= link_to candidate_interface_work_history_length_path, class: 'govuk-link' do %>
+       <%= t('review_application.work.link_html') %>
+     <% end %>
+   <% end %>
 <% end %>

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -33,9 +33,9 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, text: t('review_application.work.incomplete')) do %>
+  <%= render(SectionMissingBannerComponent, text: t('review_application.work_experience.incomplete')) do %>
      <%= link_to candidate_interface_work_history_length_path, class: 'govuk-link' do %>
-       <%= t('review_application.work.link_html') %>
+       <%= t('review_application.work_experience.link_html') %>
      <% end %>
    <% end %>
 <% end %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -1,9 +1,10 @@
 class WorkHistoryReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, show_incomplete: false)
     @application_form = application_form
     @editable = editable
+    @show_incomplete = show_incomplete
   end
 
   def work_experience_rows(work)
@@ -40,6 +41,10 @@ class WorkHistoryReviewComponent < ActionView::Component::Base
 
   def breaks_in_work_history?
     CheckBreaksInWorkHistory.call(@application_form)
+  end
+
+  def show_missing_banner?
+    @show_incomplete
   end
 
 private

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -19,7 +19,16 @@ module CandidateInterface
     end
 
     def submit_show
-      @further_information_form = FurtherInformationForm.new
+      @application_form = current_application
+      @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if @application_form_presenter.ready_to_submit?
+        @further_information_form = FurtherInformationForm.new
+      else
+        @errors = @application_form_presenter.section_errors
+
+        render :review
+      end
     end
 
     def submit

--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -3,6 +3,24 @@
   @include govuk-responsive-padding(4);
   @include govuk-responsive-margin(8, "bottom");
   border: $govuk-border-width solid govuk-colour("blue");
+
+  &--missing-section {
+    @include govuk-responsive-margin(4, "bottom");
+
+    .app-banner__message {
+      @include govuk-media-query($from: desktop) {
+        display: flex;
+        justify-content: space-between;
+        align-items: start;
+      }
+
+      p {
+        @include govuk-typography-weight-bold;
+        color: govuk-colour("blue");
+        margin: 0;
+      }
+    }
+  }
 }
 
 .app-banner--info {

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -8,6 +8,44 @@ module CandidateInterface
       "Last saved on #{@application_form.updated_at.strftime('%d %B %Y')} at #{@application_form.updated_at.strftime('%l:%M%P')}"
     end
 
+    def sections_with_completion
+      [
+        # "Courses" section
+        [:course_choices, course_choices_completed?],
+
+        # "About you" section
+        [:personal_details, personal_details_completed?],
+        [:contact_details, contact_details_completed?],
+        [:work_experience, work_experience_completed?],
+        [:volunteering, volunteering_completed?],
+
+        # "Qualifications" section
+        [:degrees, degrees_completed?],
+        [:maths_gcse, maths_gcse_completed?],
+        [:english_gcse, english_gcse_completed?],
+        [:science_gcse, science_gcse_completed?],
+        # "Other qualifications" is intentionally omitted, since it's optional
+
+        # "Personal statement and interview" section
+        [:becoming_a_teacher, becoming_a_teacher_completed?],
+        [:subject_knowledge, subject_knowledge_completed?],
+        [:interview_preferences, interview_preferences_completed?],
+
+        # "References" section
+        [:references, all_referees_provided_by_candidate?],
+      ]
+    end
+
+    def section_errors
+      sections_with_completion
+        .reject(&:second)
+        .map(&:first)
+    end
+
+    def ready_to_submit?
+      sections_with_completion.map(&:second).all?
+    end
+
     def application_choices_added?
       @application_form.application_choices.present?
     end

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
 
-<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 
@@ -14,17 +14,17 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 
-<%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable, show_incomplete: !application_form.work_history_completed && editable) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
 
-<%= render(VolunteeringReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(VolunteeringReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
 <h3 class="govuk-heading-m">Degree(s)</h3>
 
-<%= render(DegreesReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(DegreesReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>
 
 <h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
 
@@ -50,4 +50,4 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 
-<%= render(RefereesReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(RefereesReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -1,5 +1,22 @@
-<% content_for :title, t('review_application.title') %>
+<% content_for :title, @errors.nil? ? t('review_application.title') : t('review_application.error_title') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+
+<% unless @errors.nil? %>
+  <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
+    <h2 id="error-summary-title" class="govuk-error-summary__title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% @errors.each do |section| %>
+          <li>
+            <a href="<%= "#missing-#{section}-error" %>"><%= t("review_application.#{section}.incomplete", minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES) %></a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
 
 <h1 class="govuk-heading-xl">
   <%= t('review_application.heading') %>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -58,7 +58,7 @@
       </li>
 
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent, text: t('page_titles.other_qualification'), completed: @application_form_presenter.other_qualifications_completed?, path: @application_form_presenter.other_qualification_path) %>
+        <%= render(TaskListItemComponent, text: t('page_titles.other_qualification'), completed: @application_form_presenter.other_qualifications_completed?, path: @application_form_presenter.other_qualification_path, show_incomplete: false) %>
       </li>
     </ol>
 

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -86,6 +86,7 @@
     </ol>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27">Review and submit</h2>
+
     <ol class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
         <%= govuk_link_to 'Check your answers before submitting',

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -11,7 +11,7 @@ en:
       incomplete: Contact details not entered
       link: Complete contact details section
       link_html: Complete <span class="govuk-visually-hidden">contact details</span> section
-    courses:
+    course_choices:
       incomplete: Course choices are not marked as completed
       link: Complete course choices section
       link_html: Complete <span class="govuk-visually-hidden">course choices</span> section
@@ -19,11 +19,19 @@ en:
       incomplete: Degree history is not marked as completed
       link: Complete degrees section
       link_html: Complete <span class="govuk-visually-hidden">degrees</span> section
-    gcse:
-      incomplete: "%{subject} GCSE not entered"
-      link: Complete %{subject} GCSE section
-      link_html: Complete <span class="govuk-visually-hidden">%{subject} GCSE</span> section
-    interview:
+    maths_gcse:
+      incomplete: Maths GCSE not entered
+      link: Complete Maths GCSE section
+      link_html: Complete <span class="govuk-visually-hidden">Maths GCSE</span> section
+    english_gcse:
+      incomplete: English GCSE not entered
+      link: Complete English GCSE section
+      link_html: Complete <span class="govuk-visually-hidden">English GCSE</span> section
+    science_gcse:
+      incomplete: Science GCSE not entered"
+      link: Complete Science GCSE section
+      link_html: Complete <span class="govuk-visually-hidden">Science GCSE</span> section
+    interview_preferences:
       incomplete: Tell us your interview preferences
       link: Complete interview preferences section
       link_html: Complete <span class="govuk-visually-hidden">interview preferences</span> section
@@ -31,7 +39,7 @@ en:
       incomplete: Personal details not entered
       link: Complete personal details section
       link_html: Complete <span class="govuk-visually-hidden">personal details</span> section
-    referees:
+    references:
       incomplete: Add %{minimum_references} referees to your application
       link: Complete references section
       link_html: Complete <span class="govuk-visually-hidden">references</span> section
@@ -43,7 +51,7 @@ en:
       incomplete: Volunteering history is not marked as completed
       link: Complete volunteering history section
       link_html: Complete <span class="govuk-visually-hidden">volunteering history</span> section
-    work:
+    work_experience:
       incomplete: Work history is not marked as completed
       link: Complete work history section
       link_html: Complete <span class="govuk-visually-hidden">work history</span> section

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -1,6 +1,7 @@
 en:
   review_application:
     title: Review your application
+    error_title: Error - Review your application
     heading: Review your application
     button_continue: Continue
     becoming_a_teacher:
@@ -28,7 +29,7 @@ en:
       link: Complete English GCSE section
       link_html: Complete <span class="govuk-visually-hidden">English GCSE</span> section
     science_gcse:
-      incomplete: Science GCSE not entered"
+      incomplete: Science GCSE not entered
       link: Complete Science GCSE section
       link_html: Complete <span class="govuk-visually-hidden">Science GCSE</span> section
     interview_preferences:

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -3,3 +3,47 @@ en:
     title: Review your application
     heading: Review your application
     button_continue: Continue
+    becoming_a_teacher:
+      incomplete: Tell us why you want to be a teacher
+      link: Complete becoming a teacher section
+      link_html: Complete <span class="govuk-visually-hidden">becoming a teacher</span> section
+    contact_details:
+      incomplete: Contact details not entered
+      link: Complete contact details section
+      link_html: Complete <span class="govuk-visually-hidden">contact details</span> section
+    courses:
+      incomplete: Course choices are not marked as completed
+      link: Complete course choices section
+      link_html: Complete <span class="govuk-visually-hidden">course choices</span> section
+    degrees:
+      incomplete: Degree history is not marked as completed
+      link: Complete degrees section
+      link_html: Complete <span class="govuk-visually-hidden">degrees</span> section
+    gcse:
+      incomplete: "%{subject} GCSE not entered"
+      link: Complete %{subject} GCSE section
+      link_html: Complete <span class="govuk-visually-hidden">%{subject} GCSE</span> section
+    interview:
+      incomplete: Tell us your interview preferences
+      link: Complete interview preferences section
+      link_html: Complete <span class="govuk-visually-hidden">interview preferences</span> section
+    personal_details:
+      incomplete: Personal details not entered
+      link: Complete personal details section
+      link_html: Complete <span class="govuk-visually-hidden">personal details</span> section
+    referees:
+      incomplete: Add %{minimum_references} referees to your application
+      link: Complete references section
+      link_html: Complete <span class="govuk-visually-hidden">references</span> section
+    subject_knowledge:
+      incomplete: Tell us about your knowledge about the subject you want to teach
+      link: Complete subject knowledge section
+      link_html: Complete <span class="govuk-visually-hidden">subject knowledge</span> section
+    volunteering:
+      incomplete: Volunteering history is not marked as completed
+      link: Complete volunteering history section
+      link_html: Complete <span class="govuk-visually-hidden">volunteering history</span> section
+    work:
+      incomplete: Work history is not marked as completed
+      link: Complete work history section
+      link_html: Complete <span class="govuk-visually-hidden">work history</span> section

--- a/spec/components/personal_details_review_component_spec.rb
+++ b/spec/components/personal_details_review_component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PersonalDetailsReviewComponent do
       application_form = build_stubbed(:application_form)
       result = render_inline(PersonalDetailsReviewComponent, application_form: application_form)
 
-      expect(result.text).to include('No personal details entered')
+      expect(result.text).to include('Personal details not entered')
     end
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -4,102 +4,49 @@ module CandidateHelper
   end
 
   def candidate_completes_application_form
-    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
-    site = create(:site, name: 'Main site', code: '-', provider: @provider)
-    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider)
-    create(:course_option, site: site, course: course, vacancy_status: 'B')
-
+    given_courses_exist
     create_and_sign_in_candidate
     visit candidate_interface_application_form_path
 
     click_link 'Course choices'
-    click_link 'Continue'
-    choose 'Yes, I know where I want to apply'
-    click_button 'Continue'
-
-    choose 'Gorse SCITT (1N1)'
-    click_button 'Continue'
-
-    choose 'Primary (2XT2)'
-    click_button 'Continue'
-
-    choose 'Main site'
-    click_button 'Continue'
-
-    click_link 'Back to application'
+    candidate_fills_in_course_choices
 
     click_link t('page_titles.personal_details')
-    candidate_fills_in_personal_details(scope: 'application_form.personal_details')
-    click_button t('complete_form_button', scope: 'application_form.personal_details')
-    click_link t('complete_form_button', scope: 'application_form.personal_details')
+    candidate_fills_in_personal_details
 
     click_link t('page_titles.contact_details')
     visit candidate_interface_contact_details_edit_base_path
     candidate_fills_in_contact_details
-    click_button t('application_form.contact_details.address.button')
-    click_link t('application_form.contact_details.review.button')
 
     click_link t('page_titles.work_history')
-    choose t('application_form.work_history.more_than_5.label')
-    click_button 'Continue'
     candidate_fills_in_work_experience
-    click_button t('application_form.work_history.complete_form_button')
-    check t('application_form.work_history.review.completed_checkbox')
-    click_button t('application_form.work_history.review.button')
 
     click_link t('page_titles.volunteering.short')
-    choose 'Yes' # "Do you have experience volunteering with young people or in school?"
-    click_button t('application_form.volunteering.experience.button')
     candidate_fills_in_volunteering_role
-    click_button t('application_form.volunteering.complete_form_button')
-    check t('application_form.volunteering.review.completed_checkbox')
-    click_button t('application_form.volunteering.review.button')
 
     click_link t('page_titles.degree')
-    visit candidate_interface_degrees_new_base_path
     candidate_fills_in_their_degree
-    click_button t('application_form.degree.base.button')
-    check t('application_form.degree.review.completed_checkbox')
-    click_button t('application_form.degree.review.button')
 
     click_link 'Maths GCSE or equivalent'
     candidate_fills_in_a_gcse
-    click_button 'Save and continue'
-    click_link 'Back to application'
 
     click_link 'English GCSE or equivalent'
     candidate_fills_in_a_gcse
-    click_button 'Save and continue'
-    click_link 'Back to application'
 
     click_link 'Science GCSE or equivalent'
     candidate_fills_in_a_gcse
-    click_button 'Save and continue'
-    click_link 'Back to application'
 
     click_link 'Other relevant academic and non-academic qualifications'
     candidate_fills_in_their_other_qualifications
-    click_button t('application_form.other_qualification.base.button')
-    check t('application_form.other_qualification.review.completed_checkbox')
-    click_button t('application_form.other_qualification.review.button')
 
     click_link 'Why do you want to be a teacher?'
-    fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I WANT I WANT I WANT I WANT'
-    click_button t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
-    # Confirmation page
-    click_link t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
+    candidate_fills_in_becoming_a_teacher
 
     click_link 'What do you know about the subject you want to teach?'
-    fill_in t('application_form.personal_statement.subject_knowledge.label'), with: 'Everything'
-    click_button t('application_form.personal_statement.subject_knowledge.complete_form_button')
-    # Confirmation page
-    click_link t('application_form.personal_statement.subject_knowledge.complete_form_button')
+    candidate_fills_in_subject_knowledge
 
     click_link 'Interview preferences'
-    fill_in t('application_form.personal_statement.interview_preferences.label'), with: 'NOT WEDNESDAY'
-    click_button t('application_form.personal_statement.interview_preferences.complete_form_button')
-    # Confirmation page
-    click_link t('application_form.personal_statement.interview_preferences.complete_form_button')
+    candidate_fills_in_interview_preferences
 
     candidate_provides_two_referees
   end
@@ -114,7 +61,33 @@ module CandidateHelper
     @application = ApplicationForm.last
   end
 
-  def candidate_fills_in_personal_details(scope:)
+  def given_courses_exist
+    @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
+    site = create(:site, name: 'Main site', code: '-', provider: @provider)
+    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider)
+    create(:course_option, site: site, course: course, vacancy_status: 'B')
+  end
+
+  def candidate_fills_in_course_choices
+    click_link 'Continue'
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+
+    choose 'Gorse SCITT (1N1)'
+    click_button 'Continue'
+
+    choose 'Primary (2XT2)'
+    click_button 'Continue'
+
+    choose 'Main site'
+    click_button 'Continue'
+
+    check t('application_form.courses.complete.completed_checkbox')
+    click_button 'Continue'
+  end
+
+  def candidate_fills_in_personal_details
+    scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: scope), with: 'Lando'
     fill_in t('last_name.label', scope: scope), with: 'Calrissian'
 
@@ -130,6 +103,9 @@ module CandidateHelper
 
     choose 'Yes'
     fill_in t('english_main_language.yes_label', scope: scope), with: "I'm great at Galactic Basic so English is a piece of cake", match: :prefer_exact
+
+    click_button t('complete_form_button', scope: scope)
+    click_link t('complete_form_button', scope: scope)
   end
 
   def candidate_fills_in_contact_details
@@ -139,9 +115,13 @@ module CandidateHelper
     fill_in t('application_form.contact_details.address_line1.label'), with: '42 Much Wow Street'
     fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
     fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'
+    click_button t('application_form.contact_details.address.button')
+    click_link t('application_form.contact_details.review.button')
   end
 
   def candidate_fills_in_their_degree
+    visit candidate_interface_degrees_new_base_path
+
     fill_in t('application_form.degree.qualification_type.label'), with: 'BA'
     fill_in t('application_form.degree.subject.label'), with: 'Doge'
     fill_in t('application_form.degree.institution_name.label'), with: 'University of Much Wow'
@@ -149,6 +129,10 @@ module CandidateHelper
     choose t('application_form.degree.grade.first.label')
 
     fill_in t('application_form.degree.award_year.label'), with: '2009'
+
+    click_button t('application_form.degree.base.button')
+    check t('application_form.degree.review.completed_checkbox')
+    click_button t('application_form.degree.review.button')
   end
 
   def candidate_fills_in_their_other_qualifications
@@ -157,9 +141,16 @@ module CandidateHelper
     fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
     fill_in t('application_form.other_qualification.grade.label'), with: 'A'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
+
+    click_button t('application_form.other_qualification.base.button')
+    check t('application_form.other_qualification.review.completed_checkbox')
+    click_button t('application_form.other_qualification.review.button')
   end
 
   def candidate_fills_in_work_experience
+    choose t('application_form.work_history.more_than_5.label')
+    click_button 'Continue'
+
     with_options scope: 'application_form.work_history' do |locale|
       fill_in locale.t('role.label'), with: 'Teacher'
       fill_in locale.t('organisation.label'), with: 'Oakleaf Primary School'
@@ -179,9 +170,16 @@ module CandidateHelper
 
       choose 'No'
     end
+
+    click_button t('application_form.work_history.complete_form_button')
+    check t('application_form.work_history.review.completed_checkbox')
+    click_button t('application_form.work_history.review.button')
   end
 
   def candidate_fills_in_volunteering_role
+    choose 'Yes' # "Do you have experience volunteering with young people or in school?"
+    click_button t('application_form.volunteering.experience.button')
+
     with_options scope: 'application_form.volunteering' do |locale|
       fill_in locale.t('role.label'), with: 'Classroom Volunteer'
       fill_in locale.t('organisation.label'), with: 'A Noice School'
@@ -200,6 +198,10 @@ module CandidateHelper
 
       fill_in locale.t('details.label'), with: 'I volunteered.'
     end
+
+    click_button t('application_form.volunteering.complete_form_button')
+    check t('application_form.volunteering.review.completed_checkbox')
+    click_button t('application_form.volunteering.review.button')
   end
 
   def candidate_fills_in_referee(params = {})
@@ -228,6 +230,29 @@ module CandidateHelper
     click_button 'Save and continue'
     fill_in 'What was your grade?', with: 'B'
     fill_in 'When did you get your qualification?', with: '1990'
+    click_button 'Save and continue'
+    click_link 'Back to application'
+  end
+
+  def candidate_fills_in_becoming_a_teacher
+    fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I WANT I WANT I WANT I WANT'
+    click_button t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
+    # Confirmation page
+    click_link t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
+  end
+
+  def candidate_fills_in_subject_knowledge
+    fill_in t('application_form.personal_statement.subject_knowledge.label'), with: 'Everything'
+    click_button t('application_form.personal_statement.subject_knowledge.complete_form_button')
+    # Confirmation page
+    click_link t('application_form.personal_statement.subject_knowledge.complete_form_button')
+  end
+
+  def candidate_fills_in_interview_preferences
+    fill_in t('application_form.personal_statement.interview_preferences.label'), with: 'NOT WEDNESDAY'
+    click_button t('application_form.personal_statement.interview_preferences.complete_form_button')
+    # Confirmation page
+    click_link t('application_form.personal_statement.interview_preferences.complete_form_button')
   end
 
   def current_candidate

--- a/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
@@ -8,23 +8,20 @@ RSpec.feature 'Candidate reviews the answers' do
     given_i_am_signed_in
 
     %i[
-      courses
+      course_choices
       personal_details
       contact_details
-      work
+      work_experience
       volunteering
       degrees
+      maths_gcse
+      english_gcse
+      science_gcse
       becoming_a_teacher
       subject_knowledge
-      interview
-      referees
+      interview_preferences
+      references
     ].map { |section| check_and_fill_in_section_for(section) }
-
-    %i[
-      maths
-      english
-      science
-    ].map { |section| check_and_fill_in_section_for(:gcse, subject: section) }
 
     and_i_fill_in_other_qualifications
 
@@ -136,38 +133,38 @@ RSpec.feature 'Candidate reviews the answers' do
     expect(page).to have_content 'First boss'
   end
 
-  def check_and_fill_in_section_for(section, options = {})
+  def check_and_fill_in_section_for(section)
     when_i_review_my_application
-    then_i_should_see_an_incomplete_banner_for(section, options)
+    then_i_should_see_an_incomplete_banner_for(section)
 
-    when_i_click_to_complete_section_for(section, options)
+    when_i_click_to_complete_section_for(section)
     then_i_should_be_able_to_complete_section_for(section)
 
     when_i_review_my_application
-    then_i_should_not_see_an_incomplete_banner_for(section, options)
+    then_i_should_not_see_an_incomplete_banner_for(section)
   end
 
-  def then_i_should_see_an_incomplete_banner_for(section, options)
-    expect(page).to have_content t("review_application.#{section}.link", options)
+  def then_i_should_see_an_incomplete_banner_for(section)
+    expect(page).to have_content t("review_application.#{section}.link")
   end
 
-  def when_i_click_to_complete_section_for(section, options)
-    click_link t("review_application.#{section}.link", options)
+  def when_i_click_to_complete_section_for(section)
+    click_link t("review_application.#{section}.link")
   end
 
-  def then_i_should_not_see_an_incomplete_banner_for(section, options)
-    expect(page).not_to have_content t("review_application.#{section}.link", options)
+  def then_i_should_not_see_an_incomplete_banner_for(section)
+    expect(page).not_to have_content t("review_application.#{section}.link")
   end
 
   def then_i_should_be_able_to_complete_section_for(section)
     case section
-    when :courses
+    when :course_choices
       candidate_fills_in_course_choices
     when :personal_details
       candidate_fills_in_personal_details
     when :contact_details
       candidate_fills_in_contact_details
-    when :work
+    when :work_experience
       candidate_fills_in_work_experience
     when :volunteering
       candidate_fills_in_volunteering_role
@@ -177,14 +174,18 @@ RSpec.feature 'Candidate reviews the answers' do
       candidate_fills_in_becoming_a_teacher
     when :subject_knowledge
       candidate_fills_in_subject_knowledge
-    when :interview
+    when :interview_preferences
       candidate_fills_in_interview_preferences
-    when :referees
+    when :references
       candidate_provides_two_referees
-    when :gcse
+    when :maths_gcse
+      candidate_fills_in_a_gcse
+    when :english_gcse
+      candidate_fills_in_a_gcse
+    when :science_gcse
       candidate_fills_in_a_gcse
     else
-      raise 'Unimplemented section'
+      raise "Unimplemented section #{section}"
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
@@ -4,9 +4,31 @@ RSpec.feature 'Candidate reviews the answers' do
   include CandidateHelper
 
   scenario 'Candidate with all sections filled in' do
-    given_i_have_completed_my_application
+    given_courses_exist
+    given_i_am_signed_in
 
-    when_i_click_on_check_your_answers
+    %i[
+      courses
+      personal_details
+      contact_details
+      work
+      volunteering
+      degrees
+      becoming_a_teacher
+      subject_knowledge
+      interview
+      referees
+    ].map { |section| check_and_fill_in_section_for(section) }
+
+    %i[
+      maths
+      english
+      science
+    ].map { |section| check_and_fill_in_section_for(:gcse, subject: section) }
+
+    and_i_fill_in_other_qualifications
+
+    when_i_review_my_application
 
     then_i_can_review_my_application
     then_i_can_see_my_course_choices
@@ -22,8 +44,19 @@ RSpec.feature 'Candidate reviews the answers' do
     and_i_can_see_my_referees
   end
 
-  def given_i_have_completed_my_application
-    candidate_completes_application_form
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_review_my_application
+    and_i_visit_the_application_form_page
+    when_i_click_on_check_your_answers
+  end
+
+  def and_i_fill_in_other_qualifications
+    and_i_visit_the_application_form_page
+    click_link 'Other relevant academic and non-academic qualifications'
+    candidate_fills_in_their_other_qualifications
   end
 
   def and_i_visit_the_application_form_page
@@ -101,5 +134,57 @@ RSpec.feature 'Candidate reviews the answers' do
     expect(page).to have_content 'Anne Other'
     expect(page).to have_content 'anne@other.com'
     expect(page).to have_content 'First boss'
+  end
+
+  def check_and_fill_in_section_for(section, options = {})
+    when_i_review_my_application
+    then_i_should_see_an_incomplete_banner_for(section, options)
+
+    when_i_click_to_complete_section_for(section, options)
+    then_i_should_be_able_to_complete_section_for(section)
+
+    when_i_review_my_application
+    then_i_should_not_see_an_incomplete_banner_for(section, options)
+  end
+
+  def then_i_should_see_an_incomplete_banner_for(section, options)
+    expect(page).to have_content t("review_application.#{section}.link", options)
+  end
+
+  def when_i_click_to_complete_section_for(section, options)
+    click_link t("review_application.#{section}.link", options)
+  end
+
+  def then_i_should_not_see_an_incomplete_banner_for(section, options)
+    expect(page).not_to have_content t("review_application.#{section}.link", options)
+  end
+
+  def then_i_should_be_able_to_complete_section_for(section)
+    case section
+    when :courses
+      candidate_fills_in_course_choices
+    when :personal_details
+      candidate_fills_in_personal_details
+    when :contact_details
+      candidate_fills_in_contact_details
+    when :work
+      candidate_fills_in_work_experience
+    when :volunteering
+      candidate_fills_in_volunteering_role
+    when :degrees
+      candidate_fills_in_their_degree
+    when :becoming_a_teacher
+      candidate_fills_in_becoming_a_teacher
+    when :subject_knowledge
+      candidate_fills_in_subject_knowledge
+    when :interview
+      candidate_fills_in_interview_preferences
+    when :referees
+      candidate_provides_two_referees
+    when :gcse
+      candidate_fills_in_a_gcse
+    else
+      raise 'Unimplemented section'
+    end
   end
 end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -5,6 +5,11 @@ RSpec.feature 'Candidate submits the application' do
 
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in
+
+    and_i_review_my_application
+    and_i_confirm_my_application
+    then_i_should_see_an_error_that_i_have_not_completed_everything
+
     and_i_have_completed_my_application
 
     and_i_review_my_application
@@ -46,31 +51,9 @@ RSpec.feature 'Candidate submits the application' do
     candidate_completes_application_form
   end
 
-  def and_i_have_chosen_a_course
-    provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
-    site = create(:site, name: 'Main site', code: '-', provider: provider)
-    course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true)
-    create(:course_option, site: site, course: course, vacancy_status: 'B')
-
-    visit candidate_interface_application_form_path
-
-    click_link 'Course choices'
-    click_link 'Continue'
-    choose 'Yes, I know where I want to apply'
-    click_button 'Continue'
-    choose 'Gorse SCITT (1N1)'
-    click_button 'Continue'
-    choose 'Primary (2XT2)'
-    click_button 'Continue'
-    choose 'Main site'
-    click_button 'Continue'
-  end
-
-  def and_i_filled_in_personal_details
-    visit candidate_interface_personal_details_edit_path
-    candidate_fills_in_personal_details(scope: 'application_form.personal_details')
-
-    click_button t('complete_form_button', scope: 'application_form.personal_details')
+  def then_i_should_see_an_error_that_i_have_not_completed_everything
+    expect(page).to have_content t('page_titles.review_application')
+    expect(page).to have_content 'There is a problem'
   end
 
   def when_i_attempt_to_edit_my_personal_details
@@ -79,17 +62,6 @@ RSpec.feature 'Candidate submits the application' do
 
   def when_i_attempt_to_edit_my_contact_details
     visit candidate_interface_contact_details_edit_base_path
-  end
-
-  def and_i_filled_in_contact_details
-    visit candidate_interface_contact_details_edit_base_path
-    candidate_fills_in_contact_details
-
-    click_button t('application_form.contact_details.address.button')
-  end
-
-  def and_i_gave_two_referees
-    candidate_provides_two_referees
   end
 
   def and_i_review_my_application

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submit the application' do
+RSpec.feature 'Candidate submits the application' do
   include CandidateHelper
 
-  scenario 'Candidate with personal details and contact details' do
+  scenario 'Candidate with a completed application' do
     given_i_am_signed_in
     and_i_have_completed_my_application
 
-    and_reviewed_my_application
+    and_i_review_my_application
     and_i_confirm_my_application
 
     when_i_choose_to_add_further_information_but_omit_adding_details
@@ -92,7 +92,7 @@ RSpec.feature 'Candidate submit the application' do
     candidate_provides_two_referees
   end
 
-  def and_reviewed_my_application
+  def and_i_review_my_application
     and_i_visit_the_application_form_page
     when_i_click_on_check_your_answers
   end


### PR DESCRIPTION
### Context

Re-do of https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/642, I merged the wrong thing due to a botched force push.

We need to show candidates which sections still need to be completed, and we need to stop users from submitting when they haven't finished all sections.

### Changes proposed in this pull request

Add a component and use it in every review component. Update end to end tests to check for it.

### Guidance to review

Review commit by commit.

![Screenshot 2019-11-22 at 20 04 34](https://user-images.githubusercontent.com/1650875/69456771-683d6980-0d63-11ea-8044-49b9c1a10134.png)
![Screenshot 2019-11-22 at 20 05 07](https://user-images.githubusercontent.com/1650875/69456772-683d6980-0d63-11ea-84bd-e59b6c462b7b.png)
![Screenshot 2019-11-22 at 21 10 00](https://user-images.githubusercontent.com/1650875/69460685-a0957580-0d6c-11ea-9b4d-20cd804f764b.png)


TODO (follow-up PRs?):

- Improve content design

### Link to Trello card

[351 - Check that all questions are answered before submit](https://trello.com/c/TYfYUDKt/351-check-that-all-questions-are-answered-before-submit)