### PR TITLE
Display content about course choices in subject knowledge

### DIFF
--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
       @subject_knowledge_form = SubjectKnowledgeForm.build_from_application(
         current_application,
       )
+      @course_names = chosen_course_names
     end
 
     def update
@@ -14,6 +15,7 @@ module CandidateInterface
       if @subject_knowledge_form.save(current_application)
         render :show
       else
+        @course_names = chosen_course_names
         render :edit
       end
     end
@@ -28,6 +30,10 @@ module CandidateInterface
       params.require(:candidate_interface_subject_knowledge_form).permit(
         :subject_knowledge,
       )
+    end
+
+    def chosen_course_names
+      current_application.application_choices.map(&:course).map(&:name_and_code)
     end
   end
 end

--- a/app/views/candidate_interface/course_choices/_guidance.html.erb
+++ b/app/views/candidate_interface/course_choices/_guidance.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">You can apply for up to 3 courses at this stage of your application.</p>
 <p class="govuk-body">Not all courses and training providers are signed up to this service. If you choose a course that isn’t signed up to <%= service_name %>, you’ll be directed to UCAS to continue your application.</p>
-<p class="govuk-body">You can preview <%= govuk_link_to 'courses currently available', '/apply/providers' %> on <%= service_name %>.</p>
+<p class="govuk-body">You can preview <%= govuk_link_to 'courses currently available', candidate_interface_providers_path %> on <%= service_name %>.</p>
 <p class="govuk-body">Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
@@ -7,7 +7,18 @@
       <%= t('page_titles.subject_knowledge') %>
     </h1>
 
-    <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to.</p>
+    <% if @course_names.any? %>
+      <p class="govuk-body">
+        Give us detailed evidence for the knowledge and interest you bring to:
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <% @course_names.each do |course_name| %>
+          <li><%= course_name %></li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to the subject(s) you’d like to teach.</p>
+    <% end %>
     <p class="govuk-body">Evidence can include:</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>the subject of your undergraduate degree</li>

--- a/spec/system/candidate_interface/candidate_entering_subject_knowledge_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_subject_knowledge_spec.rb
@@ -4,10 +4,14 @@ RSpec.feature 'Entering subject knowledge' do
   include CandidateHelper
 
   scenario 'Candidate submits their subject knowledge' do
+    given_courses_exist
+
     given_i_am_signed_in
     and_i_visit_the_site
+    and_i_have_chosen_a_course
 
     when_i_click_on_subject_knowledge
+    then_i_should_see_my_course_choices
     and_i_submit_the_form
     then_i_should_see_validation_errors
 
@@ -34,6 +38,15 @@ RSpec.feature 'Entering subject knowledge' do
 
   def and_i_visit_the_site
     visit candidate_interface_application_form_path
+  end
+
+  def and_i_have_chosen_a_course
+    click_link 'Course choices'
+    candidate_fills_in_course_choices
+  end
+
+  def then_i_should_see_my_course_choices
+    expect(page).to have_content('Primary (2XT2)')
   end
 
   def when_i_click_on_subject_knowledge


### PR DESCRIPTION
### Context

Content improvements based on course choices.

Plus a quick fix for the /candidate/providers URL in course choices.

### Guidance to review

Before:

![Screenshot 2019-11-25 at 13 38 41](https://user-images.githubusercontent.com/1650875/69545077-f2b2e280-0f88-11ea-8373-fec0f5458536.png)

After (without choices):

![Screenshot 2019-11-25 at 13 40 26](https://user-images.githubusercontent.com/1650875/69545176-2d1c7f80-0f89-11ea-9e79-c5673cf322b3.png)

After (with choices):

![Screenshot 2019-11-25 at 13 38 33](https://user-images.githubusercontent.com/1650875/69545080-f47ca600-0f88-11ea-82ac-ae6f4ae70fc5.png)

### Link to Trello card

No card!