### PR TITLE
Add hardcoded conditional content when all providers have reached a decision

### DIFF
--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -1,4 +1,14 @@
-<% if any_offers? %>
+<% if all_provider_decisions_made? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    All your training providers have now reached a decision
+  </h2>
+
+  <p class="govuk-body">
+  <!-- TODO: Update hardcoded date with decline by default date -->
+    You have 12 days (until 7 December 2019) to respond to any offers. If you
+    don’t respond, your applications will be automatically withdrawn.
+  </p>
+<% elsif any_offers? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     Some of your training providers haven’t reached a decision yet
   </h2>

--- a/app/components/application_complete_content_component.rb
+++ b/app/components/application_complete_content_component.rb
@@ -8,6 +8,13 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
     @dates = ApplicationDates.new(@application_form)
   end
 
+  def all_provider_decisions_made?
+    # TODO: Update with correct logic when decline by default is added
+    @application_form.application_choices.map.all? do |course_choice|
+      course_choice.offer? || course_choice.rejected?
+    end
+  end
+
   def any_awaiting_provider_decision?
     @application_form.application_choices.map.any?(&:awaiting_provider_decision?)
   end

--- a/spec/components/application_complete_content_component_spec.rb
+++ b/spec/components/application_complete_content_component_spec.rb
@@ -61,6 +61,30 @@ RSpec.describe ApplicationCompleteContentComponent do
     end
   end
 
+  context 'when the application has all decisions from providers' do
+    it 'renders with all providers have made a decision content if all offers' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[offer offer])
+
+      render_result = render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+
+      expect(render_result.text).to include('All your training providers have now reached a decision')
+      # TODO: Update hardcoded date with decline by default date
+      expect(render_result.text).to include('You have 12 days (until 7 December 2019) to respond to any offers.')
+    end
+
+    it 'renders with all providers have made a decision content if an offer and rejected' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[offer rejected])
+
+      render_result = render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+
+      # TODO: Update hardcoded date with decline by default date
+      expect(render_result.text).to include('All your training providers have now reached a decision')
+      expect(render_result.text).to include('You have 12 days (until 7 December 2019) to respond to any offers.')
+    end
+  end
+
   def stub_application_dates_with_form_uneditable
     application_dates = instance_double(
       ApplicationDates,


### PR DESCRIPTION
### Context

When a candidate receives all the decisions for their course choices, they should see different guidance.

### Changes proposed in this pull request

This PR adds the content for when all providers have reached a decision however, the date for when a candidate has to make a decision is hardcoded for now. This is because we need to add in the decline by default date to application choices. When this is done, we'll update the places where we have `TODO:`s.

### Guidance to review

Is this alright for now?

### Link to Trello card

[360 - Candidates can receive and review an offer from the provider](https://trello.com/c/HhzbUnQO/360-candidates-can-receive-and-review-an-offer-from-the-provider)
