### PR TITLE
Show correct provider statuses

### DIFF
--- a/app/components/provider_interface/application_status_tag_component.html.erb
+++ b/app/components/provider_interface/application_status_tag_component.html.erb
@@ -1,0 +1,1 @@
+<%= render TagComponent, text: text, type: type %>

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class ApplicationStatusTagComponent < ActionView::Component::Base
+    validates :application_choice, presence: true
+    delegate :status, to: :application_choice
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def text
+      I18n.t!("provider_application_states.#{status}")
+    end
+
+    def type
+      case status
+      when 'awaiting_provider_decision'
+        :primary_unfilled
+      when 'offer'
+        :info_unfilled
+      when 'rejected'
+        :danger
+      when 'pending_conditions'
+        :info
+      when 'declined'
+        :warning
+      else
+        ''
+      end
+    end
+
+  private
+
+    attr_reader :application_choice
+  end
+end

--- a/app/components/tag_component.rb
+++ b/app/components/tag_component.rb
@@ -20,6 +20,8 @@ private
                       'app-tag--info-unfilled'
                     when :warning
                       'app-tag--warning'
+                    when :primary_unfilled
+                      'app-tag--primary-unfilled'
                     else
                       'app-tag--primary'
                     end

--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -21,6 +21,10 @@
   @include tag("blue");
 }
 
+.app-tag--primary-unfilled {
+  @include tag("blue", $filled: false);
+}
+
 .app-tag--secondary {
   @include tag("dark-grey");
 }

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -47,10 +47,6 @@ module ProviderInterface
       application_choice.course.course_options.first.site.name
     end
 
-    def status_name
-      I18n.t!("provider_application_states.#{application_choice.status}")
-    end
-
     def updated_at
       application_choice.updated_at.strftime('%e %b %Y %l:%M%P')
     end

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -48,7 +48,7 @@ module ProviderInterface
     end
 
     def status_name
-      I18n.t!("application_choice.status_name.#{application_choice.status}")
+      I18n.t!("provider_application_states.#{application_choice.status}")
     end
 
     def updated_at

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -18,7 +18,7 @@
       <tr class="govuk-table__row">
         <td class="govuk-table__cell"><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
         <td class="govuk-table__cell"><%= application_choice.course_name_and_code %></td>
-        <td class="govuk-table__cell"><%= tag.strong application_choice.status_name, class: 'govuk-tag' %></td>
+        <td class="govuk-table__cell"><%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: application_choice %></td>
         <td class="govuk-table__cell"><%= application_choice.updated_at %></td>
       </tr>
       <% end %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -62,12 +62,10 @@
   <div class="govuk-grid-column-one-third">
     <div class="app-status-box">
       <h2 class="govuk-heading-m">Status</h2>
-        <strong class="govuk-tag <%= @application_choice.status_tag_class %> govuk-!-margin-bottom-4">
-          <%= @application_choice.status_name %>
-        </strong>
-      <div class="actions">
+      <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: @application_choice %>
+      <div class="govuk-!-margin-top-6">
         <% if @application_choice.status == 'awaiting_provider_decision' %>
-          <a href="<%= provider_interface_application_choice_respond_path(@application_choice.id) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-4" data-module="govuk-button">
+          <a href="<%= provider_interface_application_choice_respond_path(@application_choice.id) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">
           Respond to application
         <% end %>
         </a>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -1,0 +1,27 @@
+en:
+  candidate_application_states:
+    awaiting_references: Submitted
+    application_complete: Submitted
+    awaiting_provider_decision: Pending
+    offer: Offer
+    rejected: Rejected
+    pending_conditions: Accepted
+    declined: Declined
+  provider_application_states:
+    awaiting_provider_decision: New
+    offer: Offer
+    rejected: Rejected
+    pending_conditions: Accepted
+    declined: Declined
+  support_application_states:
+    unsubmitted: Not submitted yet
+    awaiting_references: Awaiting references
+    application_complete: New
+    awaiting_provider_decision: Awaiting provider decision
+    offer: Offer made
+    pending_conditions: Pending conditions
+    recruited: Candidate recruited
+    enrolled: Candidate enrolled
+    rejected: Provider rejected
+    withdrawn: Candidate withdrawn
+    declined: Candidate declined

--- a/config/locales/candidate_application_states.yml
+++ b/config/locales/candidate_application_states.yml
@@ -1,9 +1,0 @@
-en:
-  candidate_application_states:
-    awaiting_references: Submitted
-    application_complete: Submitted
-    awaiting_provider_decision: Pending
-    offer: Offer
-    rejected: Rejected
-    pending_conditions: Accepted
-    declined: Declined

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,19 +103,6 @@ en:
             relationship:
               blank: Tell us about the referee’s relationship to you and how long they’ve known you
               too_long: Relationship must be %{count} characters or fewer
-  application_choice:
-    status_name:
-      unsubmitted: Not submitted yet
-      awaiting_references: Awaiting references
-      application_complete: New
-      awaiting_provider_decision: Awaiting provider decision
-      offer: Offer made
-      pending_conditions: Pending conditions
-      recruited: Candidate recruited
-      enrolled: Candidate  enrolled
-      rejected: Provider rejected
-      withdrawn: Candidate withdrawn
-      declined: Candidate declined
   date:
     formats:
       long: "%e %B %Y"

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationStateChange do
   describe '#valid_states' do
     it 'has human readable translations' do
       expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('application_choice.status_name').keys)
+        .to match_array(I18n.t('support_application_states').keys)
     end
 
     it 'has corresponding entries in the ApplicationChoice#status enum' do

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -57,9 +57,9 @@ RSpec.feature 'Provider responds to application' do
 
   def then_i_can_see_its_status(application)
     if application.status == 'awaiting_provider_decision'
-      expect(page).to have_content 'Awaiting provider decision'
+      expect(page).to have_content 'New'
     elsif application.status == 'rejected'
-      expect(page).to have_content 'Provider rejected'
+      expect(page).to have_content 'Rejected'
     end
   end
 


### PR DESCRIPTION
### Context

Update provider applications list and show pages to use the correct status names and colours as designed in https://manage-applications-beta.herokuapp.com/ (https://bat-design-history.herokuapp.com/manage-applications/minimal-ui)

### Changes proposed in this pull request

- Move all status names into one locale
- Use a shorter list of statuses for providers
- Reuse tag component with a wrapper

<img width="990" alt="Screen Shot 2019-11-25 at 14 05 07" src="https://user-images.githubusercontent.com/319055/69547002-aff30980-0f8c-11ea-8c14-4e130e62b3ff.png">

### What's missing

What do we do for the other status tags not covered? eg Withdrawn, enrolled, recruited?