### PR TITLE
Add conditional content when candidate has accepted an offer

### DIFF
--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -1,4 +1,13 @@
-<% if all_provider_decisions_made? %>
+<% if any_accepted_offer? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    You have accepted an offer
+  </h2>
+
+  <p class="govuk-body">
+    We've sent you an email to confirm this. Your training provider will be in
+    touch with you direct to explain what happens next.
+  </p>
+<% elsif all_provider_decisions_made? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     All your training providers have now reached a decision
   </h2>

--- a/app/components/application_complete_content_component.rb
+++ b/app/components/application_complete_content_component.rb
@@ -8,6 +8,10 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
     @dates = ApplicationDates.new(@application_form)
   end
 
+  def any_accepted_offer?
+    @application_form.application_choices.map.any?(&:pending_conditions?)
+  end
+
   def all_provider_decisions_made?
     # TODO: Update with correct logic when decline by default is added
     @application_form.application_choices.map.all? do |course_choice|

--- a/spec/components/application_complete_content_component_spec.rb
+++ b/spec/components/application_complete_content_component_spec.rb
@@ -85,6 +85,17 @@ RSpec.describe ApplicationCompleteContentComponent do
     end
   end
 
+  context 'when the application has accepted an offer' do
+    it 'renders with accepted offer content' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[pending_conditions declined])
+
+      render_result = render_inline(ApplicationCompleteContentComponent, application_form: application_form)
+
+      expect(render_result.text).to include('You have accepted an offer')
+    end
+  end
+
   def stub_application_dates_with_form_uneditable
     application_dates = instance_double(
       ApplicationDates,


### PR DESCRIPTION
### Context

When a candidate has accepted an offer they should see different guidance.

### Changes proposed in this pull request

This PR adds the conditional content when a candidate has accepted an offer to an application choice.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/69552297-20525880-0f96-11ea-8d62-22dfa43ed257.png)

### Guidance to review

Nothing in particular.

### Link to Trello card

[360 - Candidates can receive and review an offer from the provider](https://trello.com/c/HhzbUnQO/360-candidates-can-receive-and-review-an-offer-from-the-provider)
