### PR TITLE
Add a rake task to set up local dev data

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ A service for candidates to apply for initial teacher training.
 
 See `Makefile` for the steps involved in building and running the app.
 
+The course and training provider data in the `Apply` service comes from its
+sister service `Find`. To populate your local database with course data from
+`Find`, run `bundle exec rake setup_local_dev_data`.
+
 ## <a name="docker-workflow"></a>Docker Workflow
 
 Under `docker-compose`, the database uses a Docker volume to persist

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -1,0 +1,10 @@
+desc 'Set up your local development environment with data from Find'
+task setup_local_dev_data: :environment do
+  puts 'Syncing data from Find...'
+  Rails.configuration.providers_to_sync[:codes].each do |code|
+    SyncProviderFromFind.call(provider_code: code)
+  end
+
+  puts 'Making all the courses open on Apply...'
+  Course.update_all(open_on_apply: true)
+end


### PR DESCRIPTION
Populate local dev database with data from find by running `rake setup_local_dev_data`