### PR TITLE
Update google tag manager configuration

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,17 +25,19 @@
     <%= stylesheet_pack_tag 'application' %>
 
     <% unless Rails.env.development? %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-112932657-3"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-112932657-3', { 'anonymize_ip': true });
-    </script>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-KW7NPTJ');</script>
     <% end %>
   </head>
 
   <body class="govuk-template__body">
+    <% unless Rails.env.development? %>
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KW7NPTJ"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <% end %>
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>


### PR DESCRIPTION
### Context

With the current GA configuration, we can't set up tag manager tags.

With this new configuration, the page views still propagate upstream to Google Analytics, but we can also set up Google Tag Manager tags.

### Changes proposed in this pull request

New GTM config in the page head.

### Guidance to review

Have tested this with Juan locally and it seems to work!

### Link to Trello card

[381 - Service tracking (for launch)](https://trello.com/c/gTpoImAk)