### PR TITLE
Configurable heading level for review components

### DIFF
--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -1,9 +1,9 @@
 <% @course_choices.each do |course_choice| %>
   <%= render(SummaryCardComponent, rows: course_choice_rows(course_choice), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
+      <h<%= @heading_level %> class="app-summary-card__title">
         <%= course_choice.provider.name %>
-      </h2>
+      </h<%= @heading_level %>>
 
       <% if course_choice.offer? %>
         <div class='app-summary-card__actions'>

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -1,10 +1,6 @@
 <% @course_choices.each do |course_choice| %>
   <%= render(SummaryCardComponent, rows: course_choice_rows(course_choice), editable: @editable) do %>
-    <header class="app-summary-card__header">
-      <h<%= @heading_level %> class="app-summary-card__title">
-        <%= course_choice.provider.name %>
-      </h<%= @heading_level %>>
-
+    <%= render(SummaryCardHeaderComponent, title: course_choice.provider.name, heading_level: @heading_level) do %>
       <% if course_choice.offer? %>
         <div class='app-summary-card__actions'>
           <%= link_to candidate_interface_course_choice_offer_path(course_choice.id), class: 'govuk-link' do %>
@@ -27,7 +23,7 @@
           <% end  %>
         </div>
       <% end %>
-    </header>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -1,10 +1,11 @@
 class CourseChoicesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, show_status: false, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_status: false, show_incomplete: false)
     @application_form = application_form
     @course_choices = @application_form.application_choices
     @editable = editable
+    @heading_level = heading_level
     @show_status = show_status
     @show_incomplete = show_incomplete
   end

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -1,9 +1,9 @@
 <% @degrees.each do |degree| %>
   <%= render(SummaryCardComponent, rows: degree_rows(degree), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
+      <h<%= @heading_level %> class="app-summary-card__title">
         <%= degree.title %>
-      </h2>
+      </h<%= @heading_level %>>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_degrees_destroy_path(degree.id), class: 'govuk-link' do %>

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -1,9 +1,6 @@
 <% @degrees.each do |degree| %>
   <%= render(SummaryCardComponent, rows: degree_rows(degree), editable: @editable) do %>
-    <header class="app-summary-card__header">
-      <h<%= @heading_level %> class="app-summary-card__title">
-        <%= degree.title %>
-      </h<%= @heading_level %>>
+    <%= render(SummaryCardHeaderComponent, title: degree.title, heading_level: @heading_level) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_degrees_destroy_path(degree.id), class: 'govuk-link' do %>
@@ -12,7 +9,7 @@
           <% end %>
         </div>
       <% end %>
-    </header>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/components/degrees_review_component.rb
+++ b/app/components/degrees_review_component.rb
@@ -1,12 +1,13 @@
 class DegreesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
     @application_form = application_form
     @degrees = CandidateInterface::DegreeForm.build_all_from_application(
       @application_form,
     )
     @editable = editable
+    @heading_level = heading_level
     @show_incomplete = show_incomplete
   end
 

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -1,14 +1,14 @@
 <% if @application_qualification %>
   <%= render(SummaryCardComponent, rows: gcse_qualification_rows, editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
+      <h<%= @heading_level %> class="app-summary-card__title">
         <%= if @application_qualification.missing_qualification?
               t('application_form.gcse.qualification_types.missing')
             else
               t('application_form.gcse.qualification_types.gcse')
             end
         %>
-      </h2>
+      </h<%= @heading_level %>>
     </header>
   <% end %>
 <% elsif @editable %>

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -1,15 +1,12 @@
 <% if @application_qualification %>
   <%= render(SummaryCardComponent, rows: gcse_qualification_rows, editable: @editable) do %>
-    <header class="app-summary-card__header">
-      <h<%= @heading_level %> class="app-summary-card__title">
-        <%= if @application_qualification.missing_qualification?
-              t('application_form.gcse.qualification_types.missing')
-            else
-              t('application_form.gcse.qualification_types.gcse')
-            end
-        %>
-      </h<%= @heading_level %>>
-    </header>
+    <% title = if @application_qualification.missing_qualification?
+                t('application_form.gcse.qualification_types.missing')
+              else
+                t('application_form.gcse.qualification_types.gcse')
+              end
+    %>
+    <%= render(SummaryCardHeaderComponent, title: title, heading_level: @heading_level) %>
   <% end %>
 <% elsif @editable %>
   <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", text: t("review_application.#{subject}_gcse.incomplete")) do %>

--- a/app/components/gcse_qualification_review_component.rb
+++ b/app/components/gcse_qualification_review_component.rb
@@ -1,8 +1,9 @@
 class GcseQualificationReviewComponent < ActionView::Component::Base
-  def initialize(application_qualification:, subject:, editable: true)
+  def initialize(application_qualification:, subject:, editable: true, heading_level: 2)
     @application_qualification = application_qualification
     @subject = subject
     @editable = editable
+    @heading_level = heading_level
   end
 
   def gcse_qualification_rows

--- a/app/components/other_qualifications_review_component.html.erb
+++ b/app/components/other_qualifications_review_component.html.erb
@@ -1,9 +1,6 @@
 <% @qualifications.each do |qualification| %>
   <%= render(SummaryCardComponent, rows: other_qualifications_rows(qualification), editable: @editable) do %>
-    <header class="app-summary-card__header">
-      <h<%= @heading_level %> class="app-summary-card__title">
-        <%= qualification.title %>
-      </h<%= @heading_level %>>
+    <%= render(SummaryCardHeaderComponent, title: qualification.title, heading_level: @heading_level) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id), class: 'govuk-link' do %>
@@ -12,7 +9,7 @@
           <% end %>
         </div>
       <% end %>
-    </header>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/components/other_qualifications_review_component.html.erb
+++ b/app/components/other_qualifications_review_component.html.erb
@@ -1,9 +1,9 @@
 <% @qualifications.each do |qualification| %>
   <%= render(SummaryCardComponent, rows: other_qualifications_rows(qualification), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
+      <h<%= @heading_level %> class="app-summary-card__title">
         <%= qualification.title %>
-      </h2>
+      </h<%= @heading_level %>>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id), class: 'govuk-link' do %>

--- a/app/components/other_qualifications_review_component.rb
+++ b/app/components/other_qualifications_review_component.rb
@@ -1,12 +1,13 @@
 class OtherQualificationsReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, heading_level: 2)
     @application_form = application_form
     @qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(
       @application_form,
     )
     @editable = editable
+    @heading_level = heading_level
   end
 
   def other_qualifications_rows(qualification)

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -1,9 +1,9 @@
 <% @application_form.references.each do |referee| %>
   <%= render(SummaryCardComponent, rows: referee_rows(referee), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
+      <h<%= @heading_level %> class="app-summary-card__title">
         <%= t('application_form.referees.nth_referee')[referee.ordinal] %>
-      </h2>
+      </h<%= @heading_level %>>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_destroy_referee_path(referee.id), class: 'govuk-link' do %>

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -1,9 +1,6 @@
 <% @application_form.references.each do |referee| %>
   <%= render(SummaryCardComponent, rows: referee_rows(referee), editable: @editable) do %>
-    <header class="app-summary-card__header">
-      <h<%= @heading_level %> class="app-summary-card__title">
-        <%= t('application_form.referees.nth_referee')[referee.ordinal] %>
-      </h<%= @heading_level %>>
+    <%= render(SummaryCardHeaderComponent, title: t('application_form.referees.nth_referee')[referee.ordinal], heading_level: @heading_level) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_destroy_referee_path(referee.id), class: 'govuk-link' do %>
@@ -12,7 +9,7 @@
           <% end %>
         </div>
       <% end %>
-    </header>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/components/referees_review_component.rb
+++ b/app/components/referees_review_component.rb
@@ -1,9 +1,10 @@
 class RefereesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
     @application_form = application_form
     @editable = editable
+    @heading_level = heading_level
     @show_incomplete = show_incomplete
   end
 

--- a/app/components/summary_card_header_component.html.erb
+++ b/app/components/summary_card_header_component.html.erb
@@ -1,0 +1,14 @@
+<header class="app-summary-card__header">
+  <h<%= @heading_level %> class="app-summary-card__title">
+    <%= @title %>
+    <% if @check_icon %>
+      <span class="app-summary-card__meta">
+        <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+          <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+        </svg>
+        <%= t('application_form.review.role_involved_working_with_children') %>
+      </span>
+    <% end %>
+  </h<%= @heading_level %>>
+  <%= content %>
+</header>

--- a/app/components/summary_card_header_component.rb
+++ b/app/components/summary_card_header_component.rb
@@ -1,0 +1,7 @@
+class SummaryCardHeaderComponent < ActionView::Component::Base
+  def initialize(title:, heading_level: 2, check_icon: false)
+    @title = title
+    @heading_level = heading_level
+    @check_icon = check_icon
+  end
+end

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -1,7 +1,7 @@
 <% @volunteering_roles.each do |volunteering_role| %>
   <%= render(SummaryCardComponent, rows: volunteering_role_rows(volunteering_role), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
+      <h<%= @heading_level %> class="app-summary-card__title">
         <%= volunteering_role.role %>
 
         <% if volunteering_role.working_with_children == 'true' %>
@@ -12,7 +12,7 @@
             <%= t('application_form.volunteering.working_with_children.review_text') %>
           </span>
         <% end %>
-      </h2>
+      </h<%= @heading_level %>>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' do %>

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -1,18 +1,6 @@
 <% @volunteering_roles.each do |volunteering_role| %>
   <%= render(SummaryCardComponent, rows: volunteering_role_rows(volunteering_role), editable: @editable) do %>
-    <header class="app-summary-card__header">
-      <h<%= @heading_level %> class="app-summary-card__title">
-        <%= volunteering_role.role %>
-
-        <% if volunteering_role.working_with_children == 'true' %>
-          <span class="app-summary-card__meta">
-            <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
-              <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
-            </svg>
-            <%= t('application_form.volunteering.working_with_children.review_text') %>
-          </span>
-        <% end %>
-      </h<%= @heading_level %>>
+    <%= render(SummaryCardHeaderComponent, title: volunteering_role.role, heading_level: @heading_level, check_icon: volunteering_role.working_with_children) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' do %>
@@ -21,7 +9,7 @@
           <% end %>
         </div>
       <% end %>
-    </header>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -33,11 +21,7 @@
    <% end %>
 <% elsif @application_form.application_volunteering_experiences.empty? %>
   <section class="app-summary-card govuk-!-margin-bottom-6">
-    <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
-        <%= t('application_form.volunteering.no_experience.summary_card_title') %>
-      </h3>
-    </header>
+    <%= render(SummaryCardHeaderComponent, title: t('application_form.volunteering.no_experience.summary_card_title')) %>
 
     <div class="app-summary-card__body">
       The Department for Education have made it easier for teacher training

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -1,12 +1,13 @@
 class VolunteeringReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
     @application_form = application_form
     @volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(
       @application_form,
     )
     @editable = editable
+    @heading_level = heading_level
     @show_incomplete = show_incomplete
   end
 

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -1,17 +1,6 @@
 <% @application_form.application_work_experiences.each do |work| %>
   <%= render(SummaryCardComponent, rows: work_experience_rows(work), editable: @editable) do %>
-    <header class="app-summary-card__header">
-      <h<%= @heading_level %> class="app-summary-card__title">
-        <%= work.role %>
-        <% if work.working_with_children %>
-          <span class="app-summary-card__meta">
-            <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
-              <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
-            </svg>
-            <%= t('application_form.work_history.working_with_children') %>
-          </span>
-        <% end %>
-      </h<%= @heading_level %>>
+    <%= render(SummaryCardHeaderComponent, title: work.role, heading_level: @heading_level, check_icon: work.working_with_children) do %>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_work_history_destroy_path(work.id), class: 'govuk-link' do %>
@@ -20,7 +9,7 @@
           <% end %>
         </div>
       <% end %>
-    </header>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -1,7 +1,7 @@
 <% @application_form.application_work_experiences.each do |work| %>
   <%= render(SummaryCardComponent, rows: work_experience_rows(work), editable: @editable) do %>
     <header class="app-summary-card__header">
-      <h2 class="app-summary-card__title">
+      <h<%= @heading_level %> class="app-summary-card__title">
         <%= work.role %>
         <% if work.working_with_children %>
           <span class="app-summary-card__meta">
@@ -11,7 +11,7 @@
             <%= t('application_form.work_history.working_with_children') %>
           </span>
         <% end %>
-      </h2>
+      </h<%= @heading_level %>>
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_work_history_destroy_path(work.id), class: 'govuk-link' do %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -1,9 +1,10 @@
 class WorkHistoryReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
     @application_form = application_form
     @editable = editable
+    @heading_level = heading_level
     @show_incomplete = show_incomplete
   end
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,6 +1,6 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
 
-<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>
+<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 
@@ -14,33 +14,33 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 
-<%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable, show_incomplete: !application_form.work_history_completed && editable) %>
+<%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
 
-<%= render(VolunteeringReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>
+<%= render(VolunteeringReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
 <h3 class="govuk-heading-m">Degree(s)</h3>
 
-<%= render(DegreesReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>
+<%= render(DegreesReviewComponent, application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true) %>
 
 <h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
 
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable) %>
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4) %>
 
 <h3 class="govuk-heading-m">English GCSE or equivalent</h3>
 
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable) %>
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4) %>
 
 <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
 
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable) %>
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4) %>
 
 <h3 class="govuk-heading-m">Other relevant qualifications</h3>
 
-<%= render(OtherQualificationsReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(OtherQualificationsReviewComponent, application_form: application_form, editable: editable, heading_level: 4) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
 
@@ -50,4 +50,4 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 
-<%= render(RefereesReviewComponent, application_form: application_form, editable: editable, show_incomplete: true) %>
+<%= render(RefereesReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -83,13 +83,13 @@
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="work-history">Work history</h2>
 
 <div data-qa="work-history">
-  <%= render WorkHistoryReviewComponent, application_form: @application_choice.application_form, editable: false %>
+  <%= render WorkHistoryReviewComponent, application_form: @application_choice.application_form, editable: false, heading_level: 3 %>
 </div>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="volunteering">School experience and volunteering</h2>
 
 <div data-qa="volunteering">
-  <%= render VolunteeringReviewComponent, application_form: @application_choice.application_form, editable: false %>
+  <%= render VolunteeringReviewComponent, application_form: @application_choice.application_form, editable: false, heading_level: 3 %>
 </div>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="language-skills">Language skills</h2>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1,6 +1,8 @@
 en:
   application_form:
     begin_button: Start now
+    review:
+      role_involved_working_with_children: This role involved working with children
     courses:
       intro: You can apply for up to 3 courses.
       delete: Delete choice
@@ -96,7 +98,6 @@ en:
       details:
         label: Skills and experience relevant to teaching you gained in this role
       complete_form_button: Save and continue
-      working_with_children: This role involved working with children
       delete_entry: Delete entry
       add_job: Add job
       add_another_job: Add another job
@@ -238,7 +239,6 @@ en:
         change_action: organisation
       working_with_children:
         label: Did this job involve working in a school or with children?
-        review_text: This role involved working with children
       length:
         label: How long have you been in this role and what does it involve?
       start_date:

--- a/spec/components/summary_card_header_component_spec.rb
+++ b/spec/components/summary_card_header_component_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe SummaryCardHeaderComponent do
+  it 'renders a summary card header component with a title only' do
+    result = render_inline(SummaryCardHeaderComponent, title: 'Lando Calrissian')
+    expect(result.css('.app-summary-card__title').text).to include('Lando Calrissian')
+    expect(result.css('.app-summary-card__meta').text).not_to be_present
+    expect(result.css('.app-icon').text).not_to be_present
+  end
+
+  it 'renders a summary card header component with a custom heading level' do
+    result = render_inline(SummaryCardHeaderComponent, title: 'Lando Calrissian', heading_level: 6)
+    expect(result.css('h6.app-summary-card__title')).to be_present
+  end
+
+  it 'renders a summary card header component with a title and check icon' do
+    result = render_inline(SummaryCardHeaderComponent, title: 'Lando Calrissian', check_icon: true)
+    expect(result.css('.app-summary-card__title').text).to include('Lando Calrissian')
+    expect(result.css('.app-summary-card__meta').text).to include(t('application_form.review.role_involved_working_with_children'))
+    expect(result.css('.app-icon')).to be_present
+  end
+end

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe VolunteeringReviewComponent do
     it 'renders component with working with children in the summary card title' do
       result = render_inline(VolunteeringReviewComponent, application_form: application_form)
 
-      expect(result.css('.app-summary-card__title')[0].text).to include(t('application_form.volunteering.working_with_children.review_text'))
+      expect(result.css('.app-summary-card__title')[0].text).to include(t('application_form.review.role_involved_working_with_children'))
     end
 
     it 'renders component with correct values for role' do

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe WorkHistoryReviewComponent do
           expect(result.text).to include(work.start_date.strftime('%B %Y'))
           expect(result.css('.govuk-summary-list__actions').text).to include('Change')
           if work.working_with_children
-            expect(result.text).to include(t('application_form.work_history.working_with_children'))
+            expect(result.text).to include(t('application_form.review.role_involved_working_with_children'))
           end
         end
       end


### PR DESCRIPTION
### Context

Ensures summary card headings use the right heading levels, defaulting to `h2`.

Does this address the findings in the accessibility audit, @adamsilver?

### Link to Trello card

[459 - All review pages in the qualifications area the heading on the dl is an h3 should be an h2](https://trello.com/c/aEmawxGN/)
