### PR TITLE
Improve markup of offer and rejection provider forms

### DIFF
--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -33,9 +33,7 @@
       <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: @application_choice %>
       <% if @application_choice.status == 'awaiting_provider_decision' %>
         <div class="govuk-!-margin-top-6">
-          <a href="<%= provider_interface_application_choice_respond_path(@application_choice.id) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">
-            Respond to application
-          </a>
+          <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice.id), class: 'govuk-!-margin-bottom-0' %>
         </div>
       <% end %>
     </div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -20,43 +20,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <dl class="govuk-summary-list">
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Full name
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_choice.full_name %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Date of birth
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_choice.date_of_birth %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Phone number
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_choice.phone_number %>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
-          Email address
-        </dt>
-        <dd class="govuk-summary-list__value">
-          <%= @application_choice.email_address %>
-        </dd>
-      </div>
-    </dl>
+    <%= render SummaryListComponent, rows: [
+      { key: 'Full name', value: @application_choice.full_name },
+      { key: 'Phone number', value: @application_choice.phone_number },
+      { key: 'Email address', value: @application_choice.email_address },
+    ] %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -31,13 +31,13 @@
     <div class="app-status-box">
       <h2 class="govuk-heading-m">Status</h2>
       <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: @application_choice %>
-      <div class="govuk-!-margin-top-6">
-        <% if @application_choice.status == 'awaiting_provider_decision' %>
+      <% if @application_choice.status == 'awaiting_provider_decision' %>
+        <div class="govuk-!-margin-top-6">
           <a href="<%= provider_interface_application_choice_respond_path(@application_choice.id) %>" role="button" draggable="false" class="govuk-button govuk-!-margin-bottom-0" data-module="govuk-button">
-          Respond to application
-        <% end %>
-        </a>
-      </div>
+            Respond to application
+          </a>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -54,7 +54,9 @@
       <%= hidden_field_tag :offer_conditions, @application_offer.offer_conditions.to_json %>
       <%= f.govuk_submit 'Confirm offer' %>
 
-      <p class="govuk-body"><a href="<%= provider_interface_application_choice_path(@application_choice.id) %>">Cancel</a></p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
     </div>
   </div>
 <% end %>

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -30,7 +30,9 @@
       <%= f.hidden_field :rejection_reason %>
       <%= f.govuk_submit 'Confirm rejection' %>
 
-      <p class="govuk-body"><a href="<%= provider_interface_application_choice_path(@application_choice.id) %>">Cancel</a></p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
     </div>
   </div>
 <% end %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -57,7 +57,9 @@
 
       <%= f.govuk_submit 'Continue' %>
 
-      <p class="govuk-body"><a href="<%= provider_interface_application_choice_path(@application_choice.id) %>">Cancel</a></p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
     </div>
   </div>
 <% end %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -31,9 +31,7 @@
       <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: 'Standard conditions', size: 'm' } do %>
           <%= f.govuk_check_box :standard_conditions, 'Fitness to teach check', label: { text: 'Fitness to teach check' } %>
 
-          <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service check', label: { text: 'Disclosure and Barring Service check' } %>
-
-          <%= f.govuk_check_box :standard_conditions, 'Payment of fees', label: { text: 'Payment of fees' } %>
+          <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check' } %>
       <% end %>
 
       <div class="govuk-form-group">

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -1,57 +1,41 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :browser_title, 'Conditions of offer' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent, flash: flash) %>
 
-<span class="govuk-caption-xl">
-  Application for <%= @presenter.course_name_and_code %>
-</span>
-
-<h1 class="govuk-heading-xl">
-  Conditions of offer
-
-</h1>
-
 <%= form_with model: @application_offer, url: provider_interface_application_choice_confirm_offer_path(@application_choice.id), method: :post do |f| %>
+  <%= f.govuk_error_summary %>
 
-  <div class="govuk-grid-row">
-    <%= f.govuk_error_summary %>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl">
+      Application for <%= @presenter.course_name_and_code %>
+    </span>
+    Conditions of offer
+  </h1>
 
-    <%= render(SummaryCardComponent, rows: [
-      { key: 'Full name', value: @presenter.full_name },
-      { key: 'Course', value: @presenter.course_name_and_code },
-      { key: 'Starting', value: @presenter.course_start_date.strftime('%B %Y') },
-      { key: 'Preferred location', value: @presenter.course_preferred_location },
-    ], border: false) %>
-  </div>
+  <%= render SummaryListComponent, rows: [
+    { key: 'Full name', value: @presenter.full_name },
+    { key: 'Course', value: @presenter.course_name_and_code },
+    { key: 'Starting', value: @presenter.course_start_date.strftime('%B %Y') },
+    { key: 'Preferred location', value: @presenter.course_preferred_location },
+  ] %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: 'Standard conditions', size: 'm' } do %>
           <%= f.govuk_check_box :standard_conditions, 'Fitness to teach check', label: { text: 'Fitness to teach check' } %>
-
           <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check' } %>
       <% end %>
 
-      <div class="govuk-form-group">
-        <label class="govuk-label govuk-label--m" for="further_conditions">
-          Further conditions (optional)
-        </label>
-
-        <span id="further_conditions-hint" class="govuk-hint">
-          Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.
-        </span>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
+        <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
         <%= f.govuk_text_area :further_conditions, label: { text: 'First condition', size: 's' }, id: 'first_condition', rows: 3, multiple: true %>
-
         <%= f.govuk_text_area :further_conditions, label: { text: 'Second condition', size: 's' }, id: 'second_condition', rows: 3, multiple: true %>
-
         <%= f.govuk_text_area :further_conditions, label: { text: 'Third condition', size: 's' }, id: 'third_condition', rows: 3, multiple: true %>
-
         <%= f.govuk_text_area :further_conditions, label: { text: 'Further condition', size: 's' }, id: 'further_condition', rows: 3, multiple: true %>
-
-      </div>
+      </fieldset>
 
       <%= f.govuk_submit 'Continue' %>
 

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -1,40 +1,32 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :browser_title, 'Reject application' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
-<span class="govuk-caption-xl">
-  Application for <%= @presenter.course_name_and_code %>
-</span>
+<%= form_with model: @reject_application,
+      url: provider_interface_application_choice_confirm_reject_path(@application_choice.id),
+      method: :post do |f| %>
+  <%= f.govuk_error_summary %>
 
-<h1 class="govuk-heading-xl">
-  Reject application
-</h1>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl">
+      Application for <%= @presenter.course_name_and_code %>
+    </span>
+    Reject application
+  </h1>
 
-<%= form_with model: @reject_application, url: provider_interface_application_choice_confirm_reject_path(@application_choice.id), method: :post do |f| %>
-
-  <div class="govuk-grid-row">
-    <%= f.govuk_error_summary %>
-
-    <%= render(SummaryCardComponent, rows: [
-      { key: 'Full name', value: @presenter.full_name },
-      { key: 'Course', value: @presenter.course_name_and_code },
-      { key: 'Starting', value: @presenter.course_start_date.strftime('%B %Y') },
-      { key: 'Preferred location', value: @presenter.course_preferred_location },
-    ], border: false) %>
-  </div>
+  <%= render SummaryListComponent, rows: [
+    { key: 'Full name', value: @presenter.full_name },
+    { key: 'Course', value: @presenter.course_name_and_code },
+    { key: 'Starting', value: @presenter.course_start_date.strftime('%B %Y') },
+    { key: 'Preferred location', value: @presenter.course_preferred_location },
+  ] %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-
       <div class="govuk-form-group">
-        <label class="govuk-label govuk-label--m" for="comments">
-          Please explain why this application was rejected
-        </label>
-
-        <span id="comments-hint" class="govuk-hint">
-          We will forward your feedback to the candidate
-        </span>
-
-        <%= f.govuk_text_area :rejection_reason, label: { text: 'Please explain why this application was rejected', hidden: true }, rows: 5, id: 'comments', 'aria-describedby': 'comments-hint' %>
+        <%= f.govuk_text_area :rejection_reason,
+                              label: { text: 'Please explain why this application was rejected', size: 'm' },
+                              hint_text: 'We will forward your feedback to the candidate',
+                              rows: 5 %>
       </div>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -39,7 +39,9 @@
 
       <%= f.govuk_submit 'Continue' %>
 
-      <p class="govuk-body"><a href="<%= provider_interface_application_choice_path(@application_choice.id) %>">Cancel</a></p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
     </div>
   </div>
 <% end %>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -22,7 +22,10 @@
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>
-      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id) %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_select_standard_reasons
-    page.check 'Payment of fees', allow_label_click: true
+    page.check 'Fitness to teach check', allow_label_click: true
   end
 
   def and_i_add_optional_further_conditions
@@ -79,7 +79,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_see_the_correct_offer_conditions
-    expect(page).to have_content 'Payment of fees'
+    expect(page).to have_content 'Fitness to teach check'
     expect(page).to have_content 'A further condition'
   end
 


### PR DESCRIPTION
### Context

- Remove Payment of fees standard condition
- Use SummaryListComponent instead of SummaryCardComponent
- Move errors above page title
- Add browser title
- Move error summary above title
- Remove duplicate labels
- Use SummaryListComponent rather than SummaryCardComponent
- Fix incorrect use of grid row
- Don't show visited state on cancel links 

Found https://trello.com/c/SOODVP0D/1316-labels-arent-assigned-with-inputs-for-condition-fields-when-making-an-offer-errors-are-wrong in the process of looking at this.

Error messages aren't great, but the fix isn't trivial as we need different messages for UI and API, that's being tracked here: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/compare/better-rejection-errors