### PR TITLE
Update language details strings and methods

### DIFF
--- a/app/components/provider_interface/language_skills_component.rb
+++ b/app/components/provider_interface/language_skills_component.rb
@@ -28,19 +28,19 @@ module ProviderInterface
     end
 
     def language_details_row
-      english_main_language ? english_main_language_details_row : other_language_details_row
-    end
-
-    def english_main_language_details_row
-      {
-        key: t('application_form.personal_details.english_main_language_details.label'),
-        value: other_language_details.present? ? other_language_details : 'No details given',
-      }
+      english_main_language ? other_language_details_row : english_language_details_row
     end
 
     def other_language_details_row
       {
         key: t('application_form.personal_details.other_language_details.label'),
+        value: other_language_details.present? ? other_language_details : 'No details given',
+      }
+    end
+
+    def english_language_details_row
+      {
+        key: t('application_form.personal_details.english_language_details.label'),
         value: english_language_details.present? ? english_language_details : 'No details given',
       }
     end

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -53,25 +53,25 @@ module CandidateInterface
 
     def language_details_row
       if @form.english_main_language?
-        english_main_language_details_row if @form.other_language_details.present?
+        other_language_details_row if @form.other_language_details.present?
       elsif @form.english_language_details.present?
-        other_language_details_row
+        english_language_details_row
       end
-    end
-
-    def english_main_language_details_row
-      {
-        key: I18n.t('application_form.personal_details.english_main_language_details.label'),
-        value: @form.other_language_details,
-        action: ('other languages' if @editable),
-      }
     end
 
     def other_language_details_row
       {
         key: I18n.t('application_form.personal_details.other_language_details.label'),
+        value: @form.other_language_details,
+        action: ('other languages' if @editable),
+      }
+    end
+
+    def english_language_details_row
+      {
+        key: I18n.t('application_form.personal_details.english_language_details.label'),
         value: @form.english_language_details,
-        action: ('english languages qualifications' if @editable),
+        action: ('English language qualifications' if @editable),
       }
     end
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -39,12 +39,12 @@ en:
         yes_label: If you are bilingual or very familiar with languages other than English, you can tell us about them here.
         no_label: Please tell us about your English language qualifications (including grades or scores), and give details of other languages you are fluent in.
         change_action: if English is your main language
-      english_main_language_details:
+      english_language_details:
+        label: English language qualifications and other languages spoken
+        change_action: English language qualifications
+      other_language_details:
         label: Other languages spoken
         change_action: other languages
-      other_language_details:
-        label: English language qualifications and other languages spoken
-        change_action: english languages qualifications
       complete_form_button: Continue
     further_information:
       further_information:

--- a/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/personal_details_review_presenter_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form)).not_to include(
-          row_for(:english_main_language_details, ''),
+          row_for(:other_language_details, ''),
         )
       end
 
@@ -97,7 +97,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form)).not_to include(
-          row_for(:other_language_details, 'Broken? Oh man, are you cereal?'),
+          row_for(:english_language_details, 'Broken? Oh man, are you cereal?'),
         )
       end
 
@@ -110,7 +110,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form)).to include(
-          row_for(:english_main_language_details, 'I speak French'),
+          row_for(:other_language_details, 'I speak French'),
         )
       end
     end
@@ -138,7 +138,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form)).not_to include(
-          row_for(:other_language_details, ''),
+          row_for(:english_language_details, ''),
         )
       end
 
@@ -151,7 +151,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form)).not_to include(
-          row_for(:english_main_language_details, 'Mi nombre es Max.'),
+          row_for(:other_language_details, 'Mi nombre es Max.'),
         )
       end
 
@@ -164,7 +164,7 @@ RSpec.describe CandidateInterface::PersonalDetailsReviewPresenter do
         )
 
         expect(rows(personal_details_form)).to include(
-          row_for(:other_language_details, 'Broken? Oh man, are you cereal?'),
+          row_for(:english_language_details, 'Broken? Oh man, are you cereal?'),
         )
       end
     end


### PR DESCRIPTION
### Context

We swapped the form fields around in #633, but didn't update some of the method names surrounding those fields.

Also improves grammar of change link for English language details.

![Screen Shot 2019-11-26 at 11 06 44](https://user-images.githubusercontent.com/319055/69624607-ea1be400-103c-11ea-975f-dd3e3fc24aa0.png)
![Screen Shot 2019-11-26 at 11 06 31](https://user-images.githubusercontent.com/319055/69624608-eab47a80-103c-11ea-8527-591fcb8e41a2.png)
