### PR TITLE
Update personal statement for single application presenter

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -13,7 +13,7 @@ module VendorApi
           status: application_choice.status,
           updated_at: application_choice.updated_at.iso8601,
           submitted_at: application_form.submitted_at.iso8601,
-          personal_statement: application_choice.personal_statement,
+          personal_statement: personal_statement,
           candidate: {
             first_name: application_form.first_name,
             last_name: application_form.last_name,
@@ -146,6 +146,10 @@ module VendorApi
       if qualification.institution_name
         [qualification.institution_name, qualification.institution_country].compact.join(', ')
       end
+    end
+
+    def personal_statement
+      "Why do you want to become a teacher?: #{application_form.becoming_a_teacher} What is your subject knowledge?: #{application_form.subject_knowledge}"
     end
   end
 end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -149,7 +149,7 @@ module VendorApi
     end
 
     def personal_statement
-      "Why do you want to become a teacher?: #{application_form.becoming_a_teacher} What is your subject knowledge?: #{application_form.subject_knowledge}"
+      "Why do you want to become a teacher?: #{application_form.becoming_a_teacher} \n What is your subject knowledge?: #{application_form.subject_knowledge}"
     end
   end
 end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Vendor receives the application' do
       id: @provider.application_choices.first.id.to_s,
       type: 'application',
       attributes: {
-        personal_statement: nil,
+        personal_statement: 'Why do you want to become a teacher?: I WANT I WANT I WANT I WANT What is your subject knowledge?: Everything',
         hesa_itt_data: {
           disability: '',
           ethnicity: '',

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Vendor receives the application' do
       id: @provider.application_choices.first.id.to_s,
       type: 'application',
       attributes: {
-        personal_statement: 'Why do you want to become a teacher?: I WANT I WANT I WANT I WANT What is your subject knowledge?: Everything',
+        personal_statement: "Why do you want to become a teacher?: I WANT I WANT I WANT I WANT \n What is your subject knowledge?: Everything",
         hesa_itt_data: {
           disability: '',
           ethnicity: '',


### PR DESCRIPTION
### Context
`SingleApplicationPresenter` was using the old applicationChoice personal statement,
but the candidate form has split personal statement into `ApplicationForm.becoming_a_teacher`
and `ApplicationForm.subject_knowledge`.

### Changes proposed in this pull request

Update `SingleApplicationPresenter.personal_statement` to merge `ApplicationForm.becoming_a_teacher` and `ApplicationForm.subject_knowledge` together to create a personal statement.

Update `vendor_recieves_application_spec.rb` to reflect these changes.

### Guidance to review

Run specs
Check the format of the `personal_statement`.
### Link to Trello card

[1250 - Return real data within the api response](https://trello.com/c/S43gJ9xx/1250-return-real-data-within-the-api-response)

### Env vars

