### PR TITLE
Fix bug in references importer

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -22,7 +22,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def references_complete?
-    references.select(&:complete?).count == MINIMUM_COMPLETE_REFERENCES
+    references.completed.count == MINIMUM_COMPLETE_REFERENCES
   end
 
   def qualification_in_subject(level, subject)

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -11,6 +11,8 @@ class Reference < ApplicationRecord
 
   audited associated_with: :application_form
 
+  scope :completed, -> { where('feedback IS NOT NULL') }
+
   def complete?
     feedback.present?
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
       end
 
       after(:build) do |application_form, evaluator|
-        create_list(:application_choice, evaluator.application_choices_count, application_form: application_form)
+        create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'awaiting_references')
         create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)
         create_list(:application_volunteering_experience, evaluator.volunteering_experiences_count, application_form: application_form)
         create_list(:application_qualification, evaluator.qualifications_count, application_form: application_form)

--- a/spec/system/support_interface/import_references_spec.rb
+++ b/spec/system/support_interface/import_references_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Import references' do
 
     when_i_click_on_an_application
     then_i_should_see_the_imported_references
+    and_the_applications_have_progressed_to_application_complete
   end
 
   def given_i_am_a_support_user
@@ -86,5 +87,10 @@ RSpec.feature 'Import references' do
 
   def then_i_should_see_the_imported_references
     expect(page).to have_content 'Imported feedback', count: 2
+  end
+
+  def and_the_applications_have_progressed_to_application_complete
+    statuses = @completed_applications.flat_map(&:application_choices).map(&:status)
+    expect(statuses.uniq).to eql(%w[application_complete])
   end
 end


### PR DESCRIPTION
### Context

A bug in `ReceiveReference` made it so that `references_complete?` is never true when the references are updated:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/b4c0b90808f407183186bc449183dcb56d08c4cd/app/services/receive_reference.rb#L20-L29

We think this is caused by the `@application_form.references` objects not being updated after the update. It's really weird because there's a explicit test for this:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/b4c0b90808f407183186bc449183dcb56d08c4cd/spec/services/receive_reference_spec.rb#L23-L38

I can't explain why this test passes.

### Changes proposed in this pull request

Initially I fixed this bug by adding `@application_form.reload` to `ReceiveReference`. This fixed the issue, but wouldn't fix recurrence in other places.

A more dependable fix is to use a new query to get the references that have feedback.

### Guidance to review

N/A

### Link to Trello card

https://trello.com/c/W0hxwS3A