### PR TITLE
Use route path variables for policy links

### DIFF
--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -19,10 +19,10 @@
       <h2 class="govuk-heading-m">How we look after your data</h2>
       <p class="govuk-body">Your data will be looked after by the Department for Education and the training providers you apply to.</p>
       <p class="govuk-body">We use it to process your application, build a better service and improve teacher recruitment and retention.</p>
-      <p class="govuk-body">Take a look at our <%= govuk_link_to 'privacy policy', '/candidate/privacy-statement' %> before starting your application to check you understand how we use your data.</p>
+      <p class="govuk-body">Take a look at our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> before starting your application to check you understand how we use your data.</p>
 
       <h2 class="govuk-heading-m">Guidance and terms of use</h2>
-      <p class="govuk-body">Our <%= govuk_link_to 'Guidance and terms of use', '/candidate/terms-of-use' %> contain useful information about:</p>
+      <p class="govuk-body">Our <%= govuk_link_to 'Guidance and terms of use', candidate_interface_terms_path %> contain useful information about:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>how the application process works</li>
         <li>contacting us if you need help</li>


### PR DESCRIPTION
### Context

Create account page was using an old link to the privacy policy. Updated the links on this page to use the route path variables.