### PR TITLE
Automatically detect weirdness in the system

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -1,0 +1,27 @@
+# Detect state that *should* be impossible in the system and report them to Sentry
+class DetectInvariants
+  include Sidekiq::Worker
+
+  def perform
+    detect_application_choices_stuck_in_awaiting_references_state
+  end
+
+  def detect_application_choices_stuck_in_awaiting_references_state
+    # Application choices with completed feedback, but still awaiting references
+    choices_in_wrong_state = begin
+      ApplicationChoice.where(status: 'awaiting_references', application_form: ApplicationForm.includes(:references).select(&:references_complete?))
+    end
+
+    if choices_in_wrong_state.any?
+      message = <<~MSG
+        One or more application choices in `awaiting_references` state, but all feedback is collected:
+
+        #{choices_in_wrong_state.map(&:id).join('\n')}
+      MSG
+
+      Raven.capture_exception(WeirdSituationDetected.new(message))
+    end
+  end
+
+  class WeirdSituationDetected < StandardError; end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -8,6 +8,7 @@ class Clock
 
   every(5.minutes, 'ClockworkCheck') { ClockworkCheck.perform_async }
   every(15.minutes, 'SyncFromFind') { SyncFromFind.perform_async }
+  every(1.hour, 'DetectInvariants') { DetectInvariants.perform_async }
   every(1.hour, 'SendApplicationsToProvider', at: '**:05') { SendApplicationsToProviderWorker.perform_async }
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
 end

--- a/spec/workers/detect_invariants_spec.rb
+++ b/spec/workers/detect_invariants_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe DetectInvariants do
+  before { allow(Raven).to receive(:capture_exception) }
+
+  describe '#perform' do
+    it 'detects weird references state' do
+      application_choice = create(:application_choice, status: 'application_complete')
+      create(:reference, application_form: application_choice.application_form, feedback: 'Definitely feedback')
+      create(:reference, application_form: application_choice.application_form, feedback: 'Definitely feedback')
+
+      application_choice = create(:application_choice, status: 'awaiting_references')
+      create(:reference, application_form: application_choice.application_form, feedback: 'Definitely feedback')
+      create(:reference, application_form: application_choice.application_form, feedback: 'Definitely feedback')
+
+      DetectInvariants.new.perform
+
+      expect(Raven).to have_received(:capture_exception).with(
+        DetectInvariants::WeirdSituationDetected.new(
+          <<~MSG,
+            One or more application choices in `awaiting_references` state, but all feedback is collected:
+
+            #{application_choice.id}
+          MSG
+      ),
+)
+    end
+  end
+end


### PR DESCRIPTION
### Changes proposed in this pull request

This adds a hourly check on the data to make sure the system is in a normal state. The first check would have caught the references bug fixed in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/701.

I envision this check being expanded in the future as we discover more situations that shouldn't happen, but have.

### Link to Trello card

https://trello.com/c/W0hxwS3A/1317-when-edited-by-time-is-updated-the-application-is-still-not-visible-in-the-provider-interface