### PR TITLE
Strip trailing spaces when submitting referees

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -58,6 +58,7 @@ module CandidateInterface
         :further_information,
         :further_information_details,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -24,6 +24,7 @@ module CandidateInterface
       params.require(:candidate_interface_contact_details_form).permit(
         :address_line1, :address_line2, :address_line3, :address_line4, :postcode
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -30,6 +30,7 @@ module CandidateInterface
 
     def contact_details_params
       params.require(:candidate_interface_contact_details_form).permit(:phone_number)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
 
     def application_form_params
       params.require(:application_form).permit(:degrees_completed)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -54,6 +54,7 @@ module CandidateInterface
     def qualification_params
       params.require(:candidate_interface_gcse_qualification_type_form)
         .permit(:qualification_type, :other_uk_qualification_type, :missing_explanation)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -50,6 +50,7 @@ module CandidateInterface
       params.require(:candidate_interface_other_qualification_form).permit(
         :id, :qualification_type, :subject, :institution_name, :grade, :award_year
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -18,6 +18,7 @@ module CandidateInterface
 
     def application_form_params
       params.require(:application_form).permit(:other_qualifications_completed)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -37,7 +37,7 @@ module CandidateInterface
         :english_language_details, :other_language_details
       )
         .transform_keys { |key| dob_field_to_attribute(key) }
-        .transform_keys(&:strip)
+        .transform_values(&:strip)
     end
 
     def dob_field_to_attribute(key)

--- a/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
       params.require(:candidate_interface_becoming_a_teacher_form).permit(
         :becoming_a_teacher,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
       params.require(:candidate_interface_interview_preferences_form).permit(
         :interview_preferences,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -30,6 +30,7 @@ module CandidateInterface
       params.require(:candidate_interface_subject_knowledge_form).permit(
         :subject_knowledge,
       )
+        .transform_values(&:strip)
     end
 
     def chosen_course_names

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -65,6 +65,7 @@ module CandidateInterface
         :email_address,
         :relationship,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -23,6 +23,7 @@ module CandidateInterface
 
     def eligibility_params
       params.fetch(:candidate_interface_eligibility_form, {}).permit(:eligible_citizen, :eligible_qualifications)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -45,7 +45,7 @@ module CandidateInterface
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) }
-          .transform_keys(&:strip)
+          .transform_values(&:strip)
     end
 
     def start_date_field_to_attribute(key)

--- a/app/controllers/candidate_interface/volunteering/experience_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/experience_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
       params.require(:candidate_interface_volunteering_experience_form).permit(
         :experience,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
 
     def application_form_params
       params.require(:application_form).permit(:volunteering_completed)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/breaks_controller.rb
+++ b/app/controllers/candidate_interface/work_history/breaks_controller.rb
@@ -24,6 +24,7 @@ module CandidateInterface
       params.require(:candidate_interface_work_breaks_form).permit(
         :work_history_breaks,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -46,7 +46,7 @@ module CandidateInterface
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) }
-          .transform_keys(&:strip)
+          .transform_values(&:strip)
     end
 
     def work_experience_params

--- a/app/controllers/candidate_interface/work_history/explanation_controller.rb
+++ b/app/controllers/candidate_interface/work_history/explanation_controller.rb
@@ -26,6 +26,7 @@ module CandidateInterface
       params.require(:candidate_interface_work_explanation_form).permit(
         :work_history_explanation,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/length_controller.rb
+++ b/app/controllers/candidate_interface/work_history/length_controller.rb
@@ -28,6 +28,7 @@ module CandidateInterface
       params.require(:candidate_interface_work_history_form).permit(
         :work_history,
       )
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
 
     def application_form_params
       params.require(:application_form).permit(:work_history_completed)
+        .transform_values(&:strip)
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -90,7 +90,8 @@ RSpec.feature 'Candidate adding referees' do
   end
 
   def and_i_fill_in_all_required_fields
-    fill_in('Full name', with: 'Bill Lumbergh')
+    full_name_with_trailing_space = 'Bill Lumbergh '
+    fill_in('Full name', with: full_name_with_trailing_space)
     fill_in('Email address', with: 'lumbergh@example.com')
     fill_in(t('application_form.referees.relationship.label'), with: 'manager for several years')
   end
@@ -100,7 +101,8 @@ RSpec.feature 'Candidate adding referees' do
     expect(page).to have_content('ajptaylor@example.com')
     expect(page).to have_content('Thats my tutor, that is')
 
-    expect(page).to have_content('Bill Lumbergh')
+    full_name_without_trailing_space = "Bill Lumbergh\n"
+    expect(page).to have_content(full_name_without_trailing_space)
     expect(page).to have_content('lumbergh@example.com')
     expect(page).to have_content('manager for several years')
   end


### PR DESCRIPTION
### Context

Without this, our emails and various sections in the website can look a bit weird.

### Changes proposed in this pull request

Add a `.transform_values` and a test.

### Guidance to review

Should we be doing this in a more generic way and reusing it on all the form components?

### Link to Trello card

[534 - Strip out spaces on referee name](https://trello.com/c/ewaXY108/534-strip-out-spaces-on-referee-name)