### PR TITLE
Use green button for UCAS Apply link

### DIFF
--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -37,7 +37,7 @@
     </div>
 
     <a href="<%= UCAS.apply_url %>" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start">
-      <%= t('apply_from_find.apply_button') %>
+      <%= t('apply_from_find.ucas_apply_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
       </svg>

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -38,7 +38,7 @@
     <p class='govuk-body'>or</p>
 
     <p class='govuk-body'>
-      <%= govuk_link_to 'Apply on UCAS', UCAS.apply_url %>
+      <%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %>
     </p>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/ucas.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas.html.erb
@@ -1,15 +1,15 @@
-<% content_for :title, t('page_titles.apply_on_ucas') %>
+<% content_for :title, t('page_titles.not_eligible_yet') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_provider_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      We’re sorry, but we’re not ready for you yet
+      <%= t('page_titles.not_eligible_yet') %>
     </h1>
 
     <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers.</p>
     <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
     <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
-    <p class="govuk-body"><%= govuk_link_to 'Apply on UCAS', UCAS.apply_url %></p>
+    <p class="govuk-body"><%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url, class: 'govuk-button' %></p>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/ucas.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas.html.erb
@@ -10,6 +10,6 @@
     <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers.</p>
     <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
     <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
-    <p class="govuk-body"><%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url, class: 'govuk-button' %></p>
+    <p class="govuk-body"><%= govuk_button_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %></p>
   </div>
 </div>

--- a/app/views/candidate_interface/start_page/not_eligible.html.erb
+++ b/app/views/candidate_interface/start_page/not_eligible.html.erb
@@ -10,6 +10,6 @@
     <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers.</p>
     <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
     <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
-    <p class="govuk-body"><%= govuk_link_to 'Apply on UCAS', UCAS.apply_url %></p>
+    <p class="govuk-body"><%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url, class: 'govuk-button' %></p>
   </div>
 </div>

--- a/app/views/candidate_interface/start_page/not_eligible.html.erb
+++ b/app/views/candidate_interface/start_page/not_eligible.html.erb
@@ -10,6 +10,6 @@
     <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers.</p>
     <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
     <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
-    <p class="govuk-body"><%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url, class: 'govuk-button' %></p>
+    <p class="govuk-body"><%= govuk_button_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %></p>
   </div>
 </div>

--- a/config/locales/apply_from_find.yml
+++ b/config/locales/apply_from_find.yml
@@ -1,6 +1,6 @@
 en:
   apply_from_find:
     heading: Apply for this course
-    apply_button: Apply through UCAS
+    ucas_apply_button: Apply through UCAS
     find_button: Find postgraduate teacher training
     heading_not_found: We couldn’t find the course you’re looking for

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,7 +66,6 @@ en:
       - (should never appear)
       - First referee
       - Second referee
-    apply_on_ucas: We’re sorry, but we’re not ready for you yet
     providers: Training providers available through Apply for teacher training
     view_and_respond_to_offer: Details of offer
   layout:

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Selecting a course not on Apply' do
   end
 
   def then_i_see_that_i_should_apply_on_ucas
-    expect(page).to have_content(t('page_titles.apply_on_ucas'))
+    expect(page).to have_content(t('page_titles.not_eligible_yet'))
   end
 
   def when_i_click_on_back


### PR DESCRIPTION
### Context

Uses green button for link to UCAS on ineligible page. Also uses (and rationalises) localised strings.

### Link to Trello card

[440 - Green button thrown off service when you are ineligible…](https://trello.com/c/6IercmPV/)
