### PR TITLE
Redirect to application form when signed in

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -14,6 +14,10 @@ module CandidateInterface
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
     end
 
+    def redirect_to_application_if_signed_in
+      redirect_to candidate_interface_application_form_path if candidate_signed_in?
+    end
+
     def show_pilot_holding_page_if_not_open
       return if FeatureFlag.active?('pilot_open')
 

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class SignInController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
+    before_action :redirect_to_application_if_signed_in
 
     def new
       @candidate = Candidate.new

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class SignUpController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
+    before_action :redirect_to_application_if_signed_in
     before_action :show_pilot_holding_page_if_not_open
 
     def new

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class StartPageController < CandidateInterfaceController
     before_action :show_pilot_holding_page_if_not_open
     skip_before_action :authenticate_candidate!
+    before_action :redirect_to_application_if_signed_in
 
     def show; end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,11 +25,7 @@ module ApplicationHelper
     when 'provider_interface'
       provider_interface_path
     when 'candidate_interface'
-      if candidate_signed_in?
-        candidate_interface_application_form_path
-      else
-        candidate_interface_start_path
-      end
+      candidate_interface_start_path
     when 'support_interface'
       support_interface_path
     else

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -87,7 +87,6 @@ RSpec.feature 'Candidate account' do
   def then_i_am_signed_in
     within 'header' do
       expect(page).to have_content @email
-      expect(page).to have_link(href: candidate_interface_application_form_path)
     end
   end
 


### PR DESCRIPTION
### Context

If a candidate is signed in and visit the start page, sign in page or sign up page, they should be redirected to the application form.

This means we can simplify the ApplicationHelper, because the start page always links to the form.

### Changes proposed in this pull request



I somehow can't get this to work in the system tests - but it works fine locally:

```
Started GET "/candidate" for ::1 at 2019-11-24 21:07:01 +0000
Processing by CandidateInterface::StartPageController#show as HTML
Redirected to http://localhost:3000/candidate/application
Filter chain halted as :redirect_to_application_if_signed_in rendered or redirected
```

### Link to Trello card

https://trello.com/c/W7CcNYk4
