### PR TITLE
Add custom exceptions for Notify errors

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,22 @@
 class ApplicationMailer < Mail::Notify::Mailer
+  rescue_from Notifications::Client::BadRequestError, with: :handle_notify_exception
+
   GENERIC_NOTIFY_TEMPLATE = '2744ea53-34f1-431f-8173-8388fadd826a'.freeze
+
+  def handle_notify_exception(e)
+    exception = case e.message
+                when 'BadRequestError: Can’t send to this recipient using a team-only API key'
+                  NotifyTeamOnlyAPIKeyError.new(e.message)
+                else
+                  NotifyOtherBadRequestError.new(e.message)
+                end
+
+    Raven.capture_exception(exception)
+
+    raise exception
+  end
+
+  class NotifyTeamOnlyAPIKeyError < StandardError; end
+
+  class NotifyOtherBadRequestError < StandardError; end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer do
+  describe 'exceptions' do
+    context 'when Notify returns a team-only API key error' do
+      let(:fake_mailer) do
+        Class.new(described_class) do
+          def notify_error
+            notify_request_stub = Struct.new(:code, :body).new(
+              400,
+              'BadRequestError: Can’t send to this recipient using a team-only API key',
+            )
+
+            raise Notifications::Client::BadRequestError.new(notify_request_stub)
+          end
+        end
+      end
+
+      it 'returns a NotifyTeamOnlyAPIKeyError' do
+        expect { fake_mailer.notify_error.deliver_now }.to raise_error(
+          ApplicationMailer::NotifyTeamOnlyAPIKeyError,
+          'BadRequestError: Can’t send to this recipient using a team-only API key',
+        )
+      end
+
+      it 'rescues the exception and reports it to sentry' do
+        allow(Raven).to receive(:capture_exception)
+
+        expect { fake_mailer.notify_error.deliver_now }.to raise_error(ApplicationMailer::NotifyTeamOnlyAPIKeyError) do
+          expect(Raven).to have_received(:capture_exception)
+        end
+      end
+    end
+
+    context 'when Notify returns any other error' do
+      let(:fake_mailer) do
+        Class.new(described_class) do
+          def notify_error
+            notify_request_stub = Struct.new(:code, :body).new(
+              400,
+              'BadRequestError: Document didn’t pass the virus scan',
+            )
+
+            raise Notifications::Client::BadRequestError.new(notify_request_stub)
+          end
+        end
+      end
+
+      it 'raises a NotifyOtherBadRequestError' do
+        expect { fake_mailer.notify_error.deliver_now }.to raise_error(
+          ApplicationMailer::NotifyOtherBadRequestError,
+          'BadRequestError: Document didn’t pass the virus scan',
+        )
+      end
+
+      it 'rescues the exception and reports it to sentry' do
+        allow(Raven).to receive(:capture_exception)
+
+        expect { fake_mailer.notify_error.deliver_now }.to raise_error(ApplicationMailer::NotifyOtherBadRequestError) do
+          expect(Raven).to have_received(:capture_exception)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently, when a bad request error from Notify occurs we get a `Notifications::Client::BadRequestError` but we're unable to see the message. https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/565 PR from Duncan was the starting point.

### Changes proposed in this pull request

This PR adds a custom exception for the `BadRequestError: Can't send to this recipient using a team-only API key` from Notify called `NotifyTeamOnlyAPIKeyError` and `NotifyOtherBadRequestError` or any others.

### Guidance to review

This was tested locally:

![image](https://user-images.githubusercontent.com/42817036/69635033-69b0af80-104b-11ea-81c3-7ba9a1b25e79.png)

and in order to trigger Sentry, `Raven.capture_exception(exception)` was needed. It didn't work otherwise.

Should we handle any other specific 400 errors from Notify? See https://docs.notifications.service.gov.uk/ruby.html#send-a-file-by-email-response.

### Link to Trello card

No card, spun up from [Staging error when logging in](https://trello.com/c/D9TzxvhY/548-staging-error-when-logging-in).
