### PR TITLE
Update account_creation_in_progress page to include new copy

### DIFF
--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -3,16 +3,17 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
-      Account creation in progress
+      Your account is not ready yet
     </h1>
     <p class="govuk-body">
-      You are seeing this page because you have successfully signed in to the
-      <%= service_name %> service, but your user account has
-      not yet been associated with your training provider.
+      You're seeing this page because you've signed in
+      to the Apply for teacher training service but your account
+      is not ready to use yet.
     </p>
 
     <p class="govuk-body">
-      For more information please contact <%= mail_to 'becomingateacher@digital.education.gov.uk', 'becomingateacher@digital.education.gov.uk', class: 'govuk-link' %>.
+      If you've registered to work with us and you think your account should be ready, contact
+      <%= mail_to 'becomingateacher@digital.education.gov.uk', 'becomingateacher@digital.education.gov.uk', class: 'govuk-link' %>.
     </p>
   </div>
 </div>

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -13,7 +13,7 @@
 
     <p class="govuk-body">
       If you've registered to work with us and you think your account should be ready, contact
-      <%= mail_to 'becomingateacher@digital.education.gov.uk', 'becomingateacher@digital.education.gov.uk', class: 'govuk-link' %>.
+      <%= bat_contact_mail_to %>.
     </p>
   </div>
 </div>

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -12,7 +12,7 @@
     </p>
 
     <p class="govuk-body">
-      If you've registered to work with us and you think your account should be ready, contact
+      If you’ve registered to work with us and you think your account should be ready, contact
       <%= bat_contact_mail_to %>.
     </p>
   </div>

--- a/app/views/provider_interface/account_creation_in_progress.html.erb
+++ b/app/views/provider_interface/account_creation_in_progress.html.erb
@@ -6,8 +6,8 @@
       Your account is not ready yet
     </h1>
     <p class="govuk-body">
-      You're seeing this page because you've signed in
-      to the Apply for teacher training service but your account
+      You’re seeing this page because you’ve signed in
+      to the <%= t('service_name.apply') %> service but your account
       is not ready to use yet.
     </p>
 

--- a/spec/requests/provider_interface/account_creation_in_progress_spec.rb
+++ b/spec/requests/provider_interface/account_creation_in_progress_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'GET /provider/applications' do
       get '/provider/applications'
 
       expect(response).to have_http_status 403
-      expect(response.body).to include('Account creation in progress')
+      expect(response.body).to include('Your account is not ready yet')
     end
 
     it 'reports the error to Sentry, appending the Sign-in UID' do

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'See applications' do
   def and_i_have_not_been_assigned_to_my_training_provider; end
 
   def then_i_should_see_the_account_creation_in_progress_page
-    expect(page).to have_content('Account creation in progress')
+    expect(page).to have_content('Your account is not ready yet')
   end
 
   def when_i_have_been_assigned_to_my_training_provider


### PR DESCRIPTION
### Context

There is new copy for the `Account creation in progress` page that needs to be added.

### Changes proposed in this pull request

Before

![image](https://user-images.githubusercontent.com/47318392/69636852-6b7c7200-104f-11ea-896e-2e0ae0d4d48d.png)
------------------------
After

<img width="1304" alt="Screenshot 2019-11-26 at 13 15 57" src="https://user-images.githubusercontent.com/47318392/69636879-79ca8e00-104f-11ea-83ec-fd4b87e07a66.png">

### Guidance to review

Would like some feedback on the layout 😺 

### Link to Trello card

[1314 Update copy on the account creation in progress screen](https://trello.com/c/EdusUFqj/1314-update-copy-on-the-account-creation-in-progress-screen)

### Env vars

N/A
