### PR TITLE
Expand second nationality details when present

### DIFF
--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -21,7 +21,7 @@
 
         <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
 
-        <details class="govuk-details" data-module="govuk-details" <%= "open" if @personal_details_form.second_nationality.present? %>>
+        <details class="govuk-details" data-module="govuk-details" <%= 'open' if @personal_details_form.second_nationality.present? %>>
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
               Add another nationality

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -20,7 +20,8 @@
         <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint_text: t('application_form.personal_details.date_of_birth.hint_text') %>
 
         <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
-        <details class="govuk-details" data-module="govuk-details">
+
+        <details class="govuk-details" data-module="govuk-details" <%= "open" if @personal_details_form.second_nationality.present? %>>
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
               Add another nationality


### PR DESCRIPTION
When editing, or if there's an error with field, keep the details element open so the value and error can be easily seen.

![Screen Shot 2019-11-26 at 15 07 59](https://user-images.githubusercontent.com/319055/69645869-c5d0ff00-105e-11ea-9dc4-018edb1bb4a9.png)
