### PR TITLE
Fix invariant error message

### DIFF
--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -16,7 +16,7 @@ class DetectInvariants
       message = <<~MSG
         One or more application choices in `awaiting_references` state, but all feedback is collected:
 
-        #{choices_in_wrong_state.map(&:id).join('\n')}
+        #{choices_in_wrong_state.map(&:id).join("\n")}
       MSG
 
       Raven.capture_exception(WeirdSituationDetected.new(message))


### PR DESCRIPTION
Shows up as `131\n132\n133` in Sentry if we use single quotes, have not tested this.