### PR TITLE
Use unique page title for address page

### DIFF
--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.contact_details') %>
+<% content_for :title, t('page_titles.address') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_base_path) %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
### Context

Address page should have a different page title than the one that proceeds it.