### PR TITLE
Calculate and store DBD (Declined By Default) date.

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -5,6 +5,9 @@ class TimeLimitConfig
     reject_by_default: [
       Rule.new(nil, nil, 40),
     ],
+    decline_by_default: [
+      Rule.new(nil, nil, 10),
+    ],
   }.freeze
 
   def self.limits_for(rule)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -25,6 +25,10 @@ class ApplicationForm < ApplicationRecord
     references.completed.count == MINIMUM_COMPLETE_REFERENCES
   end
 
+  def awaiting_provider_decisions?
+    application_choices.where(status: :awaiting_provider_decision).any?
+  end
+
   def qualification_in_subject(level, subject)
     application_qualifications
       .where(level: level, subject: subject)

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -18,7 +18,9 @@ class RejectApplication
       ApplicationStateChange.new(@application_choice).reject_application!
       @application_choice.update!(
         rejection_reason: @rejection_reason,
+        rejected_at: Time.zone.now,
       )
+      SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
   rescue Workflow::NoTransitionAllowed => e

--- a/app/services/reject_application_by_default.rb
+++ b/app/services/reject_application_by_default.rb
@@ -7,8 +7,9 @@ class RejectApplicationByDefault
 
   def call
     ActiveRecord::Base.transaction do
-      application_choice.update(rejected_by_default: true)
+      application_choice.update(rejected_by_default: true, rejected_at: Time.now)
       ApplicationStateChange.new(application_choice).reject_application!
+      SetDeclineByDefault.new(application_form: application_choice.application_form).call
       StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice)
     end
   end

--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -1,0 +1,42 @@
+class SetDeclineByDefault
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call
+    return false if pending_decisions? || no_offers?
+
+    most_recent_decision_date = [
+      application_choices.maximum(:offered_at),
+      application_choices.maximum(:rejected_at),
+    ].compact.max
+
+    dbd_days = TimeLimitCalculator.new(
+      rule: :decline_by_default,
+      effective_date: most_recent_decision_date,
+    ).call
+
+    dbd_date = dbd_days.business_days.after(most_recent_decision_date).end_of_day
+
+    application_choices.where('status = \'offer\' AND decline_by_default_at IS NULL').update_all(
+      decline_by_default_at: dbd_date,
+      decline_by_default_days: dbd_days,
+    )
+  end
+
+private
+
+  attr_reader :application_form
+
+  def application_choices
+    application_form.application_choices
+  end
+
+  def pending_decisions?
+    application_form.awaiting_provider_decisions?
+  end
+
+  def no_offers?
+    application_choices.where(status: :offer).none?
+  end
+end

--- a/db/migrate/20191125133202_add_decline_by_default_to_application_choice.rb
+++ b/db/migrate/20191125133202_add_decline_by_default_to_application_choice.rb
@@ -1,0 +1,6 @@
+class AddDeclineByDefaultToApplicationChoice < ActiveRecord::Migration[6.0]
+  def change
+    add_column :application_choices, :decline_by_default_at, :datetime
+    add_column :application_choices, :decline_by_default_days, :integer
+  end
+end

--- a/db/migrate/20191126120746_add_offered_at_to_application_choice.rb
+++ b/db/migrate/20191126120746_add_offered_at_to_application_choice.rb
@@ -1,0 +1,5 @@
+class AddOfferedAtToApplicationChoice < ActiveRecord::Migration[6.0]
+  def change
+    add_column :application_choices, :offered_at, :datetime
+  end
+end

--- a/db/migrate/20191126155317_add_rejected_at_to_application_choices.rb
+++ b/db/migrate/20191126155317_add_rejected_at_to_application_choices.rb
@@ -1,0 +1,5 @@
+class AddRejectedAtToApplicationChoices < ActiveRecord::Migration[6.0]
+  def change
+    add_column :application_choices, :rejected_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,10 @@ ActiveRecord::Schema.define(version: 2019_11_27_105827) do
     t.datetime "reject_by_default_at"
     t.boolean "rejected_by_default", default: false, null: false
     t.integer "reject_by_default_days"
+    t.datetime "decline_by_default_at"
+    t.integer "decline_by_default_days"
+    t.datetime "offered_at"
+    t.datetime "rejected_at"
     t.index ["application_form_id"], name: "index_application_choices_on_application_form_id"
     t.index ["course_option_id"], name: "index_application_choices_on_course_option_id"
   end

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe TimeLimitConfig do
+  describe '#limits_for' do
+    it ':reject_by_default returns a default limit of 40 days' do
+      expect(TimeLimitConfig.limits_for(:reject_by_default).first.limit).to eq(40)
+    end
+
+    it ':decline_by_default returns a default limit of 10 days' do
+      expect(TimeLimitConfig.limits_for(:decline_by_default).first.limit).to eq(10)
+    end
+  end
+end

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -1,6 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe MakeAnOffer do
+  describe '#save' do
+    it 'sets the offered_at date' do
+      application_choice = create(:application_choice, status: :awaiting_provider_decision)
+
+      MakeAnOffer.new(application_choice: application_choice)
+
+      Timecop.freeze do
+        MakeAnOffer.new(application_choice: application_choice).save
+
+        expect(application_choice.offered_at).to eq(Time.now)
+      end
+    end
+  end
+
   describe 'validation' do
     it 'accepts nil conditions' do
       decision = MakeAnOffer.new(
@@ -36,6 +50,25 @@ RSpec.describe MakeAnOffer do
       )
 
       expect(decision).not_to be_valid
+    end
+  end
+
+  describe 'decline by default' do
+    let(:application_form) { create :application_form }
+
+    let(:application_choice) {
+      create(:application_choice,
+             application_form: application_form,
+             status: 'awaiting_provider_decision',
+             edit_by: 2.business_days.ago)
+    }
+
+    it 'calls SetDeclineByDefault service' do
+      MakeAnOffer.new(application_choice: application_choice).save
+      application_choice.reload
+
+      expect(application_choice.decline_by_default_at).not_to be_nil
+      expect(application_choice.decline_by_default_days).not_to be_nil
     end
   end
 end

--- a/spec/services/reject_application_by_default_spec.rb
+++ b/spec/services/reject_application_by_default_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe RejectApplicationByDefault do
     expect(application_choice.reload.rejected_by_default).to be true
   end
 
+  it 'sets `rejected_at`' do
+    application_choice = create_application
+    described_class.new(application_choice: application_choice).call
+    expect(application_choice.reload.rejected_at).not_to be_nil
+  end
+
+  it 'calls SetDeclineByDefault service' do
+    service_double = instance_double(SetDeclineByDefault)
+    allow(service_double).to receive(:call)
+    allow(SetDeclineByDefault).to receive(:new).and_return(service_double)
+
+    application_choice = create_application
+    described_class.new(application_choice: application_choice).call
+    expect(service_double).to have_received(:call)
+  end
+
   it 'sends a Slack notification' do
     allow(SlackNotificationWorker).to receive(:perform_async)
     application_choice = create_application

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -1,0 +1,164 @@
+require 'rails_helper'
+
+RSpec.describe SetDeclineByDefault do
+  describe '#call' do
+    let(:application_form) { create(:completed_application_form) }
+    let(:choices) { application_form.application_choices }
+    let(:time_limit_calculator) { instance_double('TimeLimitCalculator', call: 10) }
+    let(:now) { Time.zone.local(2019, 11, 26, 12, 0, 0) }
+    let(:call_service) { SetDeclineByDefault.new(application_form: application_form).call }
+
+    before { allow(TimeLimitCalculator).to receive(:new).and_return(time_limit_calculator) }
+
+    around do |example|
+      Timecop.freeze(now) do
+        example.run
+      end
+    end
+
+    def expect_timestamps_to_match_excluding_milliseconds(first, second)
+      expect(first.change(usec: 0)).to eq(second.change(usec: 0))
+    end
+
+    def expect_all_relevant_decline_by_default_at_values_to_be(expected)
+      application_form.application_choices.reload.each do |application_choice|
+        if application_choice.offered_at
+          dbd_at = application_choice.decline_by_default_at
+
+          if !expected.nil?
+            expect_timestamps_to_match_excluding_milliseconds(dbd_at, expected)
+          else
+            expect(dbd_at).to be_nil
+          end
+        end
+      end
+    end
+
+    context 'when all the application choices have an offer' do
+      it 'the DBD is set to 10 business days from the date of the most recent offer' do
+        choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
+        choices[1].update(status: :offer, offered_at: 2.business_days.before(now))
+        choices[2].destroy # this tests that we can handle fewer than 3 choices
+
+        expected_dbd_date = 9.business_days.after(now).end_of_day
+
+        call_service
+
+        expect_all_relevant_decline_by_default_at_values_to_be expected_dbd_date
+      end
+    end
+
+    context 'when no offers or rejections have been made for any of the application choices' do
+      it 'the DBD is not set for any of the application_choices' do
+        choices[0].update(status: :awaiting_provider_decision)
+        choices[1].update(status: :awaiting_provider_decision)
+        choices[2].update(status: :awaiting_provider_decision)
+
+        call_service
+
+        expect_all_relevant_decline_by_default_at_values_to_be nil
+      end
+    end
+
+    context 'when one offer was made, and some decisions are pending' do
+      it 'the DBD is not set for any of the application_choices' do
+        choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
+        choices[1].update(status: :awaiting_provider_decision)
+        choices[2].update(status: :awaiting_provider_decision)
+
+        call_service
+
+        expect_all_relevant_decline_by_default_at_values_to_be nil
+      end
+    end
+
+    context 'when one offer was made, and two decisions are rejected' do
+      it 'the DBD is set to 10 business days from the date of the most recent decision' do
+        choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
+        choices[1].update(status: :rejected, rejected_at: 2.business_days.before(now))
+        choices[2].update(status: :rejected, rejected_at: 3.business_days.before(now))
+
+        expected_dbd_date = 9.business_days.after(now).end_of_day
+
+        call_service
+
+        expect_all_relevant_decline_by_default_at_values_to_be expected_dbd_date
+      end
+    end
+
+    context 'when the most recent decision is a rejection' do
+      it 'the DBD is set to 10 business days from the date of this rejection' do
+        choices[0].update(status: :rejected, rejected_at: 3.business_days.before(now))
+        choices[1].update(status: :offer, offered_at: 2.business_days.before(now))
+        choices[2].update(status: :rejected, rejected_at: 1.business_days.before(now))
+
+        expected_dbd_date = 9.business_days.after(now).end_of_day
+
+        call_service
+
+        expect_all_relevant_decline_by_default_at_values_to_be expected_dbd_date
+      end
+    end
+
+    context 'when all application choices have been rejected' do
+      it 'the DBD is not set for any of the application_choices' do
+        choices[0].update(status: :rejected, rejected_at: 1.business_days.before(now))
+        choices[1].update(status: :rejected, rejected_at: 2.business_days.before(now))
+
+        call_service
+
+        expect_all_relevant_decline_by_default_at_values_to_be nil
+      end
+    end
+
+    context 'when the service is run twice' do
+      it 'the DBD is not set again on choices which already have a DBD' do
+        old_dbd_date = 8.business_days.after(now).end_of_day
+
+        choices[0].update(status: :rejected, rejected_at: 4.business_days.before(now))
+        choices[1].update(status: :rejected, rejected_at: 3.business_days.before(now))
+        choices[2].update(
+          status: :offer,
+          offered_at: 2.business_days.before(now),
+          decline_by_default_at: old_dbd_date,
+          decline_by_default_days: 10,
+        )
+
+        choices[1].update(status: :offer, offered_at: 1.business_days.before(now))
+        new_dbd_date = 9.business_days.after(now).end_of_day
+        call_service
+
+        dbd_for_old_offer = choices[2].reload.decline_by_default_at
+        dbd_for_new_offer = choices[1].reload.decline_by_default_at
+
+        expect_timestamps_to_match_excluding_milliseconds(dbd_for_old_offer, old_dbd_date)
+        expect_timestamps_to_match_excluding_milliseconds(dbd_for_new_offer, new_dbd_date)
+      end
+    end
+
+    it 'the decline_by_default_days is set to 10 days when DBD is present' do
+      choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
+      choices[1].update(status: :offer, offered_at: 2.business_days.before(now))
+      choices[2].update(status: :offer, offered_at: 2.business_days.before(now))
+
+      call_service
+
+      choices.each do |choice|
+        expect(choice.reload.decline_by_default_days).to eq 10
+      end
+    end
+
+    it 'does not set DBD fields on non-offer application_choices (e.g. rejected/withdrawn)' do
+      choices[0].update(status: :offer, offered_at: 1.business_days.before(now))
+      choices[1].update(status: :rejected, rejected_at: 2.business_days.before(now))
+      choices[2].update(status: :withdrawn, offered_at: 3.business_days.before(now))
+
+      call_service
+
+      choices.where.not(status: :offer).each do |choice|
+        expect(choice.reload.decline_by_default_at).to be_nil
+        expect(choice.reload.decline_by_default_days).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Candidates are given 10 business days to accept or decline offers from providers for their application choices. The candidate dashboard will need to display the relevant deadline (not in scope for this PR) and the backend will need to calculate the relevant deadline (in scope) and eventually automatically process all applications to enforce it (not in scope). 

During kickoff, the following decisions were made:

- We'll store a ```:declined_by_default_at``` against ```ApplicationChoice```, as everything else related to provider workflows is stored against this model, not ```ApplicationForm```.
- The 'declined by default date' (DBD) should be the same for all application_choices.
- The DBD is only set for all choices when no more choices are left waiting for a provider decision. Until then it is ```nil```.
- The number of business days we are using to calculate the DBD may change in the future and may, in fact, vary according to different time periods (e.g. summer/winter). We'll use a similar approach to 'Reject by default', which uses ```TimeLimitConfig``` (which may be db-backed in the future).

### Changes proposed in this pull request

A ```SetDeclinedByDefault``` service is responsible for setting DBD on all application_choices for an application_form if these conditions are met:

- there is a decision (offer/rejected) for all of the application_choices, i.e. no pending decisions
- at least one of these decisions is an offer (we've decided if all choices are rejected we do nothing)

This service is triggered by provider actions, in particular:

- MakeAnOffer
- RejectApplication
- RejectApplicationByDefault

The reason we are triggering the service even for rejection events is that the timing and order of these provider decisions can vary. For example, imagine you have 3 choices, the first one is approved, the second one is rejected and the third one is rejected by default. Up to the point when the third one is rejected by default, you still have application choices awaiting for a provider decision, so DBD cannot be set. The rule for calculating DBD is 'add dbd_days to the date of the most recent decision'.

### Guidance to review

This is hard one to test manually, as the UI for exposing the DBD is not merged yet. Please look at the relevant specs.

### Link to Trello card

[531 - Calculate and store DBD date](https://trello.com/c/GKbPrlnp)
