### PR TITLE
Put word count validation messages in locale file and fix messages

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -4,7 +4,7 @@ class Reference < ApplicationRecord
                             email_address: true,
                             length: { maximum: 100 },
                             uniqueness: { scope: :application_form_id }
-  validates :relationship, presence: true, length: { minimum: 2, maximum: 500 }
+  validates :relationship, presence: true, word_count: { maximum: 50 }
   validates_presence_of :application_form_id
 
   belongs_to :application_form

--- a/app/validators/word_count_validator.rb
+++ b/app/validators/word_count_validator.rb
@@ -5,7 +5,7 @@ class WordCountValidator < ActiveModel::EachValidator
     # This RegExp should match the implementation in govuk-frontend:
     # https://github.com/alphagov/govuk-frontend/blob/aa30ee76a5f84e230a323bb92d341285a6da3a10/src/govuk/components/character-count/character-count.js#L82
     if value.scan(/\S+/).size > options[:maximum]
-      record.errors[attribute] << (options[:message] || "Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
+      record.errors.add(attribute, :too_many_words, count: options[:maximum])
     end
   end
 end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -324,6 +324,10 @@ en:
               inclusion: Select your second nationality from the list
             english_main_language:
               blank: Select if English is your main language
+            english_language_details:
+              too_many_words: English language qualifications and other languages spoken must be %{count} words or fewer
+            other_language_details:
+              too_many_words: Other languages spoken must be %{count} words or fewer
             date_of_birth:
               invalid: Enter a date of birth in the correct format
               future: Enter a date of birth that is in the past, for example 31 3 1980
@@ -348,6 +352,7 @@ en:
               blank: Select if you would like to add anything else to your application
             further_information_details:
               blank: Enter further information
+              too_many_words: Further information must be %{count} words or fewer
         candidate_interface/contact_details_form:
           attributes:
             phone_number:
@@ -374,10 +379,12 @@ en:
           attributes:
             work_history_breaks:
               blank: Please explain any breaks in your work history
+              too_many_words: Explanation for breaks in your work history must be %{count} words or fewer
         candidate_interface/work_explanation_form:
           attributes:
             work_history_explanation:
               blank: Please explain why you’ve been out of the workplace
+              too_many_words: Explanation for why you’ve been out of the workplace must be %{count} words or fewer
         candidate_interface/degree_form:
           attributes:
             qualification_type:
@@ -429,7 +436,7 @@ en:
               too_long: Name of the employer must be %{count} characters or fewer
             details:
               blank: Enter the relevant experience you gained in this role
-              too_long: Skills and experience must be %{count} characters or fewer
+              too_many_words: Skills and experience must be %{count} words or fewer
             working_with_children:
               blank: Select if this job involves working in a school or with children
             commitment:
@@ -458,6 +465,7 @@ en:
               too_long: Type of degree must be %{count} characters or fewer
             missing_explanation:
               blank: Give us some details
+              too_many_words: Details must be %{count} words or fewer
         candidate_interface/volunteering_experience_form:
           attributes:
             experience:
@@ -472,7 +480,7 @@ en:
               too_long: The organisation must be %{count} characters or fewer
             details:
               blank: Enter details of your time commitment and responsibilities
-              too_long: Skills and experience must be %{count} characters or fewer
+              too_many_words: Skills and experience must be %{count} words or fewer
             working_with_children:
               blank: Select if this role involves working in a school or with children
             start_date:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -331,17 +331,17 @@ en:
           attributes:
             becoming_a_teacher:
               blank: Tell us why you want to be a teacher
-              too_long: Tell us why you want to be a teacher must be %{count} words or fewer
+              too_many_words: Tell us why you want to be a teacher must be %{count} words or fewer
         candidate_interface/subject_knowledge_form:
           attributes:
             subject_knowledge:
               blank: Enter your subject knowledge
-              too_long: Your subject knowledge must be %{count} words or fewer
+              too_many_words: Your subject knowledge must be %{count} words or fewer
         candidate_interface/interview_preferences_form:
           attributes:
             interview_preferences:
               blank: Enter your interview preferences. If you do not have any, enter 'none'
-              too_long: Your interview preferences must be %{count} words or fewer
+              too_many_words: Your interview preferences must be %{count} words or fewer
         candidate_interface/further_information_form:
           attributes:
             further_information:
@@ -458,7 +458,6 @@ en:
               too_long: Type of degree must be %{count} characters or fewer
             missing_explanation:
               blank: Give us some details
-
         candidate_interface/volunteering_experience_form:
           attributes:
             experience:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -105,6 +105,9 @@ en:
             relationship:
               blank: Tell us about the referee’s relationship to you and how long they’ve known you
               too_long: Relationship must be %{count} characters or fewer
+  errors:
+    messages:
+      too_many_words: Must be %{count} words or fewer
   date:
     formats:
       long: "%e %B %Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,7 @@ en:
               too_long: Full name must be %{count} characters or fewer
             relationship:
               blank: Tell us about the referee’s relationship to you and how long they’ve known you
-              too_long: Relationship must be %{count} characters or fewer
+              too_many_words: Relationship to referee must be %{count} words or fewer
   errors:
     messages:
       too_many_words: Must be %{count} words or fewer

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -15,8 +15,11 @@ RSpec.describe Reference, type: :model do
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_length_of(:name).is_at_most(200) }
 
-    it { is_expected.to validate_presence_of :relationship }
-    it { is_expected.to validate_length_of(:relationship).is_at_most(500) }
+    valid_text = Faker::Lorem.sentence(word_count: 50)
+    invalid_text = Faker::Lorem.sentence(word_count: 51)
+
+    it { is_expected.to allow_value(valid_text).for(:relationship) }
+    it { is_expected.not_to allow_value(invalid_text).for(:relationship) }
   end
 
   describe '#complete?' do

--- a/spec/validators/word_count_validator_spec.rb
+++ b/spec/validators/word_count_validator_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe WordCountValidator do
     Validatable.new.tap { |model| model.some_words = some_words_field }
   }
 
-  let(:expected_errors) { ['Reduce the word count for some words'] }
+  let(:expected_errors) { ["Must be #{maximum} words or fewer"] }
 
   subject! {
     model.valid?


### PR DESCRIPTION
### Context

Previously we weren’t passing in a custom message, and error messages read quite generically, "Reduce the word count for X".

We had some `too_long` strings in the yml but they were never being used.

Switch to a custom error message, `too_many_words`, add a default message that includes the number of words and update existing error keys so they show correctly for becoming a teacher, subject knowledge and interview preferences.

Also switch referee relationship from being a character length validator to a word length one.

https://trello.com/c/nCljMNvt/562-error-for-word-count-should-include-maximum-word-count

Also relates to https://trello.com/c/dYpc40B1/563-a-list-of-small-problems-to-fix
