### PR TITLE
Do not show user input as HTML in summary tables

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -74,7 +74,7 @@ module SupportInterface
     def last_updated_row
       {
         key: 'Last updated',
-        value: "#{updated_at.strftime('%e %b %Y at %l:%M%P')} (#{govuk_link_to('History', support_interface_application_form_audit_path(application_form))})",
+        value: "#{updated_at.strftime('%e %b %Y at %l:%M%P')} (#{govuk_link_to('History', support_interface_application_form_audit_path(application_form))})".html_safe,
       }
     end
 

--- a/config/initializers/sanitise.rb
+++ b/config/initializers/sanitise.rb
@@ -1,0 +1,5 @@
+# Make `sanitize` strip all tags by default
+#
+# https://apidock.com/rails/ActionView/Helpers/SanitizeHelper/sanitize
+# Used by https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format
+ActionView::Base.sanitized_allowed_tags = %w[]

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -53,13 +53,13 @@ RSpec.describe SummaryListComponent do
     expect(result.css('.govuk-summary-list__value > .safe-html').text).to include('This is safe')
   end
 
-  it 'uses simple_format to safely render unsafe HTML' do
+  it 'uses simple_format to convert line breaks and strip HTML' do
     rows = [
       key: 'Unsafe',
       value: '<span class="unsafe-html"><script>Unsafe</script></span>',
     ]
 
     result = render_inline(SummaryListComponent, rows: rows)
-    expect(result.css('.unsafe-html').to_html).to eq('<span class="unsafe-html">Unsafe</span>')
+    expect(result.css('.govuk-summary-list__value p').to_html).to eq('<p class="govuk-body">Unsafe</p>')
   end
 end


### PR DESCRIPTION
### Context

During accessibility and pentesting, we noticed that some components display the unescaped HTML input:

![image](https://user-images.githubusercontent.com/233676/69713885-41818900-10fd-11ea-877f-b5b4506fa535.png)

This is caused by our usage of Rails' [simple_format](https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format). What we want from `simple_format` is to convert line breaks into paragraphs and `<br/>` tags, so that what we show on in the summary table matches what the user entered into the form. This was added in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/514.

It turns out I made an incorrect assumption about `simple_format`. What I assumed was that it would treat the content in paragraphs the same as other strings and _escape_ HTML tags.

In fact, `simple_format` calls [`sanitize`](https://apidock.com/rails/ActionView/Helpers/SanitizeHelper/sanitize) on the individual paragraphs. That method has a whitelist of tags that are allowed. This means that we allow the following tags that are presumed safe:

```
strong em b i p code pre tt samp kbd var sub sup dfn cite big small address hr br div span h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr acronym a img blockquote del ins
```

https://github.com/rails/rails-html-sanitizer/blob/93eb2491daa0f758e1e4d3e72833c911dfb71468/lib/rails/html/sanitizer.rb#L108-L111

Fun fact is that we actually added an explicit test for the current behaviour in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/574 - I just failed to connect the dots there.

### Changes proposed in this pull request

By setting the `ActionView::Base.sanitized_allowed_tags` to nothing, `sanitize` will strip everything. If we want to use `sanitize` in this app we can still use it, we just have to whitelist tags explicitly: `sanitize(html, tags: %w[p div])`.

I'm also considering adding a helper to Rails that implements what I expected `simple_format` to do. I might raise an issue for that when there's time.

#### Before

<img width="976" alt="Screenshot 2019-11-27 at 09 57 06" src="https://user-images.githubusercontent.com/233676/69715235-d5eceb00-10ff-11ea-9e26-7cc18ee9c77a.png">

#### After

<img width="978" alt="Screenshot 2019-11-27 at 09 56 36" src="https://user-images.githubusercontent.com/233676/69715249-dbe2cc00-10ff-11ea-94b4-ba089d9ab0f6.png">

### Guidance to review

Does this make sense?

### Link to Trello card

https://trello.com/c/Ex6Di7l1/556-its-possible-to-put-some-html-into-form-fields