### PR TITLE
Add autocomplete attribute to certain form fields

### DIFF
--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -16,11 +16,11 @@
           </h1>
         </legend>
 
-        <%= f.govuk_text_field :address_line1, label: { text: t('application_form.contact_details.address_line1.label') } %>
-        <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true } %>
-        <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds' %>
-        <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds' %>
-        <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10 %>
+        <%= f.govuk_text_field :address_line1, label: { text: t('application_form.contact_details.address_line1.label') }, autocomplete: 'address-line1' %>
+        <%= f.govuk_text_field :address_line2, label: { text: t('application_form.contact_details.address_line2.label'), hidden: true }, autocomplete: 'address-line2' %>
+        <%= f.govuk_text_field :address_line3, label: { text: t('application_form.contact_details.address_line3.label') }, width: 'two-thirds', autocomplete: 'address-level2' %>
+        <%= f.govuk_text_field :address_line4, label: { text: t('application_form.contact_details.address_line4.label') }, width: 'two-thirds', autocomplete: 'address-level1' %>
+        <%= f.govuk_text_field :postcode, label: { text: t('application_form.contact_details.postcode.label') }, width: 10, autocomplete: 'postal-code' %>
 
         <%= f.govuk_submit t('application_form.contact_details.address.button') %>
       </fieldset>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -13,7 +13,7 @@
           </h1>
         </legend>
 
-        <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20 %>
+        <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20, autocomplete: 'tel' %>
 
         <%= f.govuk_submit t('application_form.contact_details.base.button') %>
       </fieldset>

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -13,9 +13,9 @@
           </h1>
         </legend>
 
-        <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.first_name.hint_text') %>
+        <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.first_name.hint_text'), autocomplete: 'given-name' %>
 
-        <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.last_name.hint_text') %>
+        <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.last_name.hint_text'), autocomplete: 'family-name' %>
 
         <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint_text: t('application_form.personal_details.date_of_birth.hint_text') %>
 

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -13,7 +13,7 @@
     <%= form_with model: @candidate, url: candidate_interface_sign_in_path, html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, type: :email, width: 'two-thirds' %>
+      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, type: :email, width: 'two-thirds', autocomplete: 'email' %>
 
       <%= f.submit t('authentication.sign_up.button_continue'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
     <% end %>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -11,7 +11,7 @@
         <%= t('authentication.sign_up.heading') %>
       </h1>
 
-      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint_text: t('authentication.sign_up.email_address.hint_label'), type: :email, width: 'two-thirds' %>
+      <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint_text: t('authentication.sign_up.email_address.hint_label'), type: :email, width: 'two-thirds', autocomplete: 'email' %>
 
       <h2 class="govuk-heading-m">You won’t need a password to use this service</h2>
       <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we'll send you a link so you can return to your application.</p>


### PR DESCRIPTION
### Context

From accessibility audit (though this arguably relates more to usability), adds `autocomplete` value to the following fields:

* Create account - email
* Sign in - email
* Contact - phone
* Contact - address
* Personal details - first and last name
