### PR TITLE
Add hint text to indicate year format

### DIFF
--- a/app/views/candidate_interface/gcse/details/edit.html.erb
+++ b/app/views/candidate_interface/gcse/details/edit.html.erb
@@ -13,7 +13,7 @@
       <%= guidance_for_gcse_edit_details(@subject, @qualification_type) %>
 
       <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint_text: hint_for_gcse_edit_details(@subject, @qualification_type), width: 10 %>
-      <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, width: 4 %>
+      <%= f.govuk_text_field :award_year, label: { text: t('application_form.gcse.award_year.label'), size: 'm' }, hint_text: t('application_form.gcse.award_year.hint_text'), width: 4 %>
 
       <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
   <% end %>

--- a/app/views/candidate_interface/other_qualifications/base/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/_form.html.erb
@@ -10,6 +10,6 @@
 <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
 <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
 <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
-<%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, width: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
 
 <%= f.govuk_submit t('application_form.other_qualification.base.button') %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -148,7 +148,7 @@ en:
             hint_text: Predicted grades must be validated by an academic referee in the ‘References’ section.
       award_year:
         label: Graduation year
-        hint_text: You must have successfully graduated by the time you start your course.
+        hint_text: For example, 2002. You must have successfully graduated by the time you start your course.
         review_label: Year awarded
         change_action: year
       base:
@@ -177,6 +177,7 @@ en:
         label: What was your grade?
       award_year:
         label: When did you get your qualification?
+        hint_text: For example, 1996.
       complete_form_button: Save and continue
     other_qualification:
       qualification:
@@ -197,6 +198,7 @@ en:
         change_action: grade
       award_year:
         label: Year qualification was awarded
+        hint_text: For example, 1998.
         review_label: Year awarded
         change_action: year
       base:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -177,7 +177,7 @@ en:
         label: What was your grade?
       award_year:
         label: When did you get your qualification?
-        hint_text: For example, 1996.
+        hint_text: For example, 1996
       complete_form_button: Save and continue
     other_qualification:
       qualification:
@@ -198,7 +198,7 @@ en:
         change_action: grade
       award_year:
         label: Year qualification was awarded
-        hint_text: For example, 1998.
+        hint_text: For example, 1998
         review_label: Year awarded
         change_action: year
       base:


### PR DESCRIPTION
### Context

Provide hint text to indicate required year format (four digits, not two).

### Changes proposed in this pull request

Degree:
<img width="647" alt="degree" src="https://user-images.githubusercontent.com/813383/69722587-71398c80-110f-11ea-8147-34fc54bbbe4a.png">

GCSE:
<img width="440" alt="gcse" src="https://user-images.githubusercontent.com/813383/69722589-71398c80-110f-11ea-931b-b6541745327d.png">

Other qualification:
<img width="385" alt="other-qualification" src="https://user-images.githubusercontent.com/813383/69722590-71d22300-110f-11ea-96b8-2ff2ca625f20.png">
