### PR TITLE
Add validation to ensure referee email is not the same as the candidate

### DIFF
--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -4,6 +4,7 @@ class Reference < ApplicationRecord
                             email_address: true,
                             length: { maximum: 100 },
                             uniqueness: { scope: :application_form_id }
+  validate :email_address_not_own
   validates :relationship, presence: true, word_count: { maximum: 50 }
   validates_presence_of :application_form_id
 
@@ -19,5 +20,13 @@ class Reference < ApplicationRecord
 
   def ordinal
     self.application_form.references.find_index(self).to_i + 1
+  end
+
+  def email_address_not_own
+    return if self.application_form.nil?
+
+    candidate_email_address = self.application_form.candidate.email_address
+
+    errors.add(:email_address, :own) if email_address == candidate_email_address
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -99,6 +99,7 @@ en:
               too_long: Email address must be %{count} characters or fewer
               invalid: Enter an email address in the correct format, like name@example.com
               taken: Please give a different email address for each referee
+              own: Enter an email address that’s not your own
             name:
               blank: Enter the referee’s full name
               too_long: Full name must be %{count} characters or fewer

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -4,13 +4,25 @@ RSpec.describe Reference, type: :model do
   subject { build(:reference) }
 
   describe 'a valid reference' do
-    let(:application_form) { build(:application_form) }
+    let(:candidate) { build(:candidate) }
+    let(:application_form) { build(:application_form, candidate: candidate) }
 
     subject { build(:reference, application_form: application_form) }
 
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
     it { is_expected.to validate_uniqueness_of(:email_address).scoped_to(:application_form_id).ignoring_case_sensitivity }
+
+    context 'when a candidate uses their own email address' do
+      it 'adds an error' do
+        reference = build(:reference, application_form: application_form, email_address: candidate.email_address)
+
+        expect(reference.valid?).to eq(false)
+        expect(reference.errors.full_messages_for(:email_address)).to eq(
+          ["Email address #{t('activerecord.errors.models.reference.attributes.email_address.own')}"],
+        )
+      end
+    end
 
     it { is_expected.to validate_presence_of :name }
     it { is_expected.to validate_length_of(:name).is_at_most(200) }


### PR DESCRIPTION
### Context

A candidate can currently enter their own email address for a referee.

### Changes proposed in this pull request

This PR ensures that an email address for a referee cannot be set to the candidate's email.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/69724871-bad8a600-1114-11ea-95fd-6310d2ffc56c.png)

### Guidance to review

Nothing in particular.

### Link to Trello card

[557 - A candidate can enter their own email address as one of the references](https://trello.com/c/VylHlN0t/557-a-candidate-can-enter-their-own-email-address-as-one-of-the-references)

