### PR TITLE
Update sign_in controller to use candidate email validations

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -14,7 +14,7 @@ module CandidateInterface
         MagicLinkSignIn.call(candidate: @candidate)
         render 'candidate_interface/shared/check_your_email'
       elsif @candidate.valid?
-        #Valid Email but no account exists
+        AuthenticationMailer.sign_in_without_account_email(to: @candidate.email_address).deliver_now
         render 'candidate_interface/shared/check_your_email'
       else
         render :new

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -8,13 +8,17 @@ module CandidateInterface
     end
 
     def create
-      @candidate = Candidate.find_by(email_address: candidate_params[:email_address])
+      @candidate = Candidate.find_or_initialize_by(email_address: candidate_params[:email_address])
 
-      if @candidate.present?
+      if @candidate.persisted?
         MagicLinkSignIn.call(candidate: @candidate)
+        render 'candidate_interface/shared/check_your_email'
+      elsif @candidate.valid?
+        #Valid Email but no account exists
+        render 'candidate_interface/shared/check_your_email'
+      else
+        render :new
       end
-
-      render 'candidate_interface/shared/check_your_email'
     end
 
   private

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -14,4 +14,10 @@ class AuthenticationMailer < ApplicationMailer
               to: to,
               subject: t('authentication.sign_in.email.subject'))
   end
+
+  def sign_in_without_account_email(to:)
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: to,
+              subject: t('authentication.sign_in_without_account.email.subject'))
+  end
 end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -3,6 +3,7 @@ class Candidate < ApplicationRecord
   # Custom Warden strategy is used instead see app/warden/magic_link_token.rb
   devise :timeoutable
   validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
+  validates :email_address, email_address: true
 
   has_many :application_forms
 

--- a/app/views/authentication_mailer/sign_in_without_account_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_without_account_email.text.erb
@@ -1,0 +1,8 @@
+# <%= t('authentication.sign_in_without_account.email.subject') %>
+
+You attempted to sign in to the <%= t('service_name.apply') %>, but we could not find an account with your email address.
+
+Please click the link below to sign up.
+
+<%= candidate_interface_sign_up_url %>
+

--- a/app/views/authentication_mailer/sign_in_without_account_email.text.erb
+++ b/app/views/authentication_mailer/sign_in_without_account_email.text.erb
@@ -1,8 +1,8 @@
 # <%= t('authentication.sign_in_without_account.email.subject') %>
 
-You attempted to sign in to the <%= t('service_name.apply') %>, but we could not find an account with your email address.
+You attempted to sign in to the <%= t('service_name.apply') %> service, but we could not find an account with your email address.
 
-Please click the link below to sign up.
+Click the link below to sign up to the <%= t('service_name.apply') %> service.
 
 <%= candidate_interface_sign_up_url %>
 

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -26,3 +26,6 @@ en:
         subject: Sign in to Apply for teacher training
       email_address:
         label: Email address
+    sign_in_without_account:
+      email:
+        subject: Sign up to Apply for teacher training

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -40,4 +40,20 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       expect(mail.body.encoded).to include("http://localhost:3000/candidate/application?token=#{token}")
     end
   end
+
+  describe 'the candidate recieves an email when they try to sign in without an existing account' do
+    let(:mail) { mailer.sign_in_without_account_email(to: 'test@example.com') }
+
+    it 'sends an email with the correct subject' do
+      expect(mail.subject).to include(t('authentication.sign_in_without_account.email.subject'))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(mail.body.encoded).to include(t('authentication.sign_in_without_account.email.subject'))
+    end
+
+    it 'sends an email with a link to sign up' do
+      expect(mail.body.encoded).to include(candidate_interface_sign_up_url)
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -21,6 +21,10 @@ RSpec.feature 'Candidate account' do
     then_i_should_be_signed_out
 
     when_i_click_the_signin_link
+    and_i_submit_an_invalid_email_address
+    then_i_see_form_errors_on_the_page
+
+    when_i_click_the_signin_link
     and_i_submit_my_email_address
     then_i_receive_an_email_with_a_signin_link
     when_i_click_on_the_link_in_my_email
@@ -108,5 +112,14 @@ RSpec.feature 'Candidate account' do
     Timecop.travel(Time.now + 7.days + 1.second) do
       visit candidate_interface_application_form_path
     end
+  end
+
+  def and_i_submit_an_invalid_email_address
+    fill_in t('authentication.sign_up.email_address.label'), with: 'invalid email'
+    click_on t('authentication.sign_up.button_continue')
+  end
+
+  def then_i_see_form_errors_on_the_page
+    expect(page).to have_content 'There is a problem'
   end
 end

--- a/spec/system/candidate_interface/candidate_signs_in_without_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_in_without_account_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate tries to sign in without an account' do
+  scenario 'Candidate signs in and recieves an email inviting them to sign up' do
+    given_the_pilot_is_open
+
+    given_i_am_a_candidate_without_an_account
+
+    when_i_go_to_sign_in
+    and_i_submit_my_email_address
+    then_i_receive_an_email_inviting_me_to_sign_up
+
+    when_i_click_on_the_link_in_my_email
+    then_i_am_taken_to_the_sign_up_page
+  end
+
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def given_i_am_a_candidate_without_an_account
+    @email = "#{SecureRandom.hex}@example.com"
+  end
+
+  def when_i_go_to_sign_in
+    visit '/'
+    click_on 'sign in'
+  end
+
+  def and_i_submit_my_email_address
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    click_on t('authentication.sign_up.button_continue')
+  end
+
+  def then_i_receive_an_email_inviting_me_to_sign_up
+    open_email(@email)
+    expect(current_email.subject).to have_content t('authentication.sign_in_without_account.email.subject')
+  end
+
+  def when_i_click_on_the_link_in_my_email
+    current_email.find_css('a').first.click
+  end
+
+  def then_i_am_taken_to_the_sign_up_page
+    expect(page).to have_current_path(candidate_interface_sign_up_path)
+  end
+end


### PR DESCRIPTION
### Context

Currently when a candidate enters a blank or invalid email address on the sign in page they are directed to the "check your email page" instead of seeing form errors.

### Changes proposed in this pull request

- Update sign_in controller to use the candidate validations for email format and presence.
- Add steps in candidate_account_spec system spec to test sign in form errors.
- Add mailer to send an email to candidates who try to sign in without an account.

### Guidance to review

Run specs to ensure the email is being validated on the sign in page.
Waiting on copy for the `sign_in_without_account` email, but I've written some temporary copy for now.

### Link to Trello card

[515 Sign in allows empty or invalid email address](https://trello.com/c/Wm4t0gIm/515-sign-in-allows-empty-invalid-email-addressd)

### Env vars

N/A