### PR TITLE
Error summary placement

### DIFF
--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -4,11 +4,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_type_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
         <h1 class="govuk-fieldset__heading"><%= t("gcse_edit_type.page_titles.#{@subject}") %></h1>
       </legend>
-
-      <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: t('application_form.gcse.qualification_type.label'), tag: 'span' } do %>
         <% select_gcse_qualification_type_options.each_with_index do |option, i| %>

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
@@ -3,28 +3,25 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.becoming_a_teacher') %>
-    </h1>
-
-    <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
-    <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
-    <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/' %> for help from a teacher training adviser.</p>
-
-    <p class="govuk-body govuk-!-font-weight-bold">You do not have to cover everything in this list, but suggested topics include:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>why you want to be a teacher</li>
-      <li>your passion for your subject and the age group you’ve chosen to teach</li>
-      <li>the welfare and education of children and/or young people</li>
-      <li>the demands and rewards of the profession</li>
-      <li>personal qualities that will make you a good teacher</li>
-      <li>your contribution to the life of the school outside the classroom  – for example, running extra-curricular activities and clubs</li>
-      <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
-    </ul>
-
     <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_becoming_a_teacher_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
+      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), tag: 'h1', size: 'xl' }, rows: 20, max_words: 600 do %>
+        <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
+        <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
+        <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/' %> for help from a teacher training adviser.</p>
+
+        <p class="govuk-body govuk-!-font-weight-bold">You do not have to cover everything in this list, but suggested topics include:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>why you want to be a teacher</li>
+          <li>your passion for your subject and the age group you’ve chosen to teach</li>
+          <li>the welfare and education of children and/or young people</li>
+          <li>the demands and rewards of the profession</li>
+          <li>personal qualities that will make you a good teacher</li>
+          <li>your contribution to the life of the school outside the classroom  – for example, running extra-curricular activities and clubs</li>
+          <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
+        </ul>
+      <% end %>
+
       <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -3,20 +3,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.interview_preferences') %>
-    </h1>
-
-    <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>any disability, health or personal issue you feel is relevant</li>
-      <li>special arrangements or assistance you may need</li>
-      <li>dates you are unavailable for interview</li>
-    </ul>
-
     <%= form_with model: @interview_preferences_form, url: candidate_interface_interview_preferences_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.label'), size: 'm' }, rows: 8, max_words: 200 %>
+
+      <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.label'), tag: 'h1', size: 'xl' }, rows: 8, max_words: 200 do %>
+        <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>any disability, health or personal issue you feel is relevant</li>
+          <li>special arrangements or assistance you may need</li>
+          <li>dates you are unavailable for interview</li>
+        </ul>
+      <% end %>
+
       <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
@@ -3,34 +3,31 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('page_titles.subject_knowledge') %>
-    </h1>
-
-    <% if @course_names.any? %>
-      <p class="govuk-body">
-        Give us detailed evidence for the knowledge and interest you bring to:
-      </p>
-      <ul class="govuk-list govuk-list--bullet">
-        <% @course_names.each do |course_name| %>
-          <li><%= course_name %></li>
-        <% end %>
-      </ul>
-    <% else %>
-      <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to the subject(s) you’d like to teach.</p>
-    <% end %>
-    <p class="govuk-body">Evidence can include:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the subject of your undergraduate degree</li>
-      <li>modules you studied as part of your degree</li>
-      <li>postgraduate degrees (for example, a Masters or PhD)</li>
-      <li>your A level subjects</li>
-      <li>expertise you’ve gained at work</li>
-    </ul>
-
     <%= form_with model: @subject_knowledge_form, url: candidate_interface_subject_knowledge_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
+      <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), tag: 'h1', size: 'xl' }, rows: 20, max_words: 400 do %>
+        <% if @course_names.any? %>
+          <p class="govuk-body">
+            Give us detailed evidence for the knowledge and interest you bring to:
+          </p>
+          <ul class="govuk-list govuk-list--bullet">
+            <% @course_names.each do |course_name| %>
+              <li><%= course_name %></li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to the subject(s) you’d like to teach.</p>
+        <% end %>
+        <p class="govuk-body">Evidence can include:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>the subject of your undergraduate degree</li>
+          <li>modules you studied as part of your degree</li>
+          <li>postgraduate degrees (for example, a Masters or PhD)</li>
+          <li>your A level subjects</li>
+          <li>expertise you’ve gained at work</li>
+        </ul>
+      <% end %>
+
       <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/work_history/edit/edit.html.erb
+++ b/app/views/candidate_interface/work_history/edit/edit.html.erb
@@ -4,18 +4,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @work_experience_form, url: candidate_interface_work_history_edit_path do |f| %>
-      <fieldset class="govuk-fieldset">
-        <%= f.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= t('page_titles.work_history') %></span>
-            <%= t('page_titles.edit_job') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= t('page_titles.work_history') %></span>
+        <%= t('page_titles.edit_job') %>
+      </h1>
 
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -4,18 +4,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @work_experience_form, url: candidate_interface_work_history_create_path do |f| %>
-      <fieldset class="govuk-fieldset">
-        <%= f.govuk_error_summary %>
+      <%= f.govuk_error_summary %>
 
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= t('page_titles.work_history') %></span>
-            <%= t('page_titles.add_job') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= t('page_titles.work_history') %></span>
+        <%= t('page_titles.add_job') %>
+      </h1>
 
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -211,7 +211,7 @@ en:
     personal_statement:
       becoming_a_teacher:
         change_action: tell us why you want to be a teacher
-        label: Tell us why you want to be a teacher
+        label: Why do you want to be a teacher?
         complete_form_button: Continue
       subject_knowledge:
         key: Your knowledge about the subject you want to teach

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -216,7 +216,7 @@ en:
       subject_knowledge:
         key: Your knowledge about the subject you want to teach
         change_action:  evidence of subject knowledge
-        label: Enter your subject knowledge
+        label: What do you know about the subject you want to teach?
         complete_form_button: Continue
       interview_preferences:
         key: Interview preferences
@@ -339,7 +339,7 @@ en:
         candidate_interface/subject_knowledge_form:
           attributes:
             subject_knowledge:
-              blank: Enter your subject knowledge
+              blank: Please enter your subject knowledge
               too_many_words: Your subject knowledge must be %{count} words or fewer
         candidate_interface/interview_preferences_form:
           attributes:

--- a/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
   end
 
   def then_i_can_check_my_revised_answers
-    expect(page).to have_content 'Tell us why you want to be a teacher'
+    expect(page).to have_content 'Why do you want to be a teacher?'
     expect(page).to have_content 'Hello world again'
   end
 


### PR DESCRIPTION
### Context

From the accessibility audit, ensures error summary appears before page heading on the following pages:

* Add job page
* Add maths GCSE
* Add english GCSE
* Add science GCSE
* Tell us why you want to be a teacher
* Your subject knowledge
* Interview preferences

I will create a separate PR to fix where we are using `fieldset`s incorrectly (for entire pages) 