### PR TITLE
Prefix titles with "Error: " if there are errors

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -47,6 +47,10 @@ module ViewHelper
     pluralize(dates.days_remaining_to_edit, 'day')
   end
 
+  def title_with_error_prefix(title, error)
+    "#{t('page_titles.error_prefix') if error}#{title}"
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, @errors.nil? ? t('review_application.title') : t('review_application.error_title') %>
+<% content_for :title, title_with_error_prefix(t('review_application.title'), @errors && @errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <% unless @errors.nil? %>

--- a/app/views/candidate_interface/contact_details/address/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/address/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.address') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.address'), @contact_details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_contact_details_edit_base_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.contact_details') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.contact_details'), @contact_details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
+++ b/app/views/candidate_interface/course_choices/have_you_chosen.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.have_you_chosen') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.have_you_chosen'), @choice_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_index_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.which_course') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.which_course'), @pick_course.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_provider_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.which_provider') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.which_provider'), @pick_provider.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_choose_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/course_choices/options_for_site.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_site.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.which_location') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.which_location'), @pick_site.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(provider_code: params[:provider_code])) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/degrees/base/edit.html.erb
+++ b/app/views/candidate_interface/degrees/base/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.edit_degree') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.edit_degree'), @degree.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_degrees_review_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/degrees/base/new_another.html.erb
+++ b/app/views/candidate_interface/degrees/base/new_another.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.add_another_degree') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.add_another_degree'), @degree.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/degrees/base/new_undergraduate.html.erb
+++ b/app/views/candidate_interface/degrees/base/new_undergraduate.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.add_undergraduate_degree') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.add_undergraduate_degree'), @degree.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/gcse/details/edit.html.erb
+++ b/app/views/candidate_interface/gcse/details/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("gcse_edit_details.page_titles.#{@subject}") %>
+<% content_for :title, title_with_error_prefix(t("gcse_edit_details.page_titles.#{@subject}"), @application_qualification.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_gcse_details_edit_type_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t("gcse_edit_type.page_titles.#{@subject}") %>
+<% content_for :title, title_with_error_prefix(t("gcse_edit_type.page_titles.#{@subject}"), @application_qualification.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/other_qualifications/base/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.edit_other_qualification') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.edit_other_qualification'), @qualification.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_review_other_qualifications_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/other_qualifications/base/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.add_other_qualification') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.add_other_qualification'), @qualification.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.personal_details') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.personal_details'), @personal_details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.becoming_a_teacher') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.becoming_a_teacher'), @becoming_a_teacher_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.interview_preferences') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.interview_preferences'), @interview_preferences_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.subject_knowledge') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.subject_knowledge'), @subject_knowledge_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/referees/edit.html.erb
+++ b/app/views/candidate_interface/referees/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.add_referee') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.add_referee'), @referee.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/referees/new.html.erb
+++ b/app/views/candidate_interface/referees/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.add_referee') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.add_referee'), @referee.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.sign_in') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.sign_in'), @candidate.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.sign_up') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.sign_up'), @sign_up_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.eligibility') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.eligibility'), @eligibility_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_path) %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/volunteering/base/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/base/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.edit_volunteering_role') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.edit_volunteering_role'), @volunteering_role.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_review_volunteering_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/volunteering/base/new.html.erb
+++ b/app/views/candidate_interface/volunteering/base/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.add_volunteering_role') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.add_volunteering_role'), @volunteering_role.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/volunteering/experience/show.html.erb
+++ b/app/views/candidate_interface/volunteering/experience/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.volunteering.long') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.volunteering.long'), @volunteering_experience_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/work_history/breaks/edit.html.erb
+++ b/app/views/candidate_interface/work_history/breaks/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.work_history_breaks') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.work_history_breaks'), @work_breaks_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/work_history/edit/edit.html.erb
+++ b/app/views/candidate_interface/work_history/edit/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.edit_job') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.edit_job'), @work_experience_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path, 'Back') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/work_history/edit/new.html.erb
+++ b/app/views/candidate_interface/work_history/edit/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.add_job') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.add_job'), @work_experience_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/work_history/explanation/show.html.erb
+++ b/app/views/candidate_interface/work_history/explanation/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.work_history_explanation') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.work_history_explanation'), @work_explanation_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/work_history/length/show.html.erb
+++ b/app/views/candidate_interface/work_history/length/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.work_history') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.work_history'), @work_details_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
     application_dashboard: Application dashboard
     application_edit: Editing your application
     eligibility: First, check you can use this service
+    error_prefix: 'Error: '
     not_eligible_yet: We’re sorry, but we’re not ready for you yet
     submitted_application: Your submitted application
     sign_up: Create an account

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -1,7 +1,6 @@
 en:
   review_application:
     title: Review your application
-    error_title: Error - Review your application
     heading: Review your application
     button_continue: Continue
     becoming_a_teacher:


### PR DESCRIPTION
Follows guidance from:
https://design-system.service.gov.uk/components/error-summary/#how-it-works

https://trello.com/c/QZeMrz2Z/454-global-every-page-that-shows-an-error-needs-to-prefix-error-to-the-page-title-missing-in-every-page