### PR TITLE
Update phone number validator to include blank error message

### DIFF
--- a/app/validators/phone_number_validator.rb
+++ b/app/validators/phone_number_validator.rb
@@ -1,7 +1,9 @@
 class PhoneNumberValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    if value.blank? || is_invalid_phone_number_format?(value)
-      record.errors[attribute] << I18n.t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid')
+    if value.blank?
+      record.errors.add(attribute, :blank)
+    elsif is_invalid_phone_number_format?(value)
+      record.errors.add(attribute, :invalid)
     end
   end
 

--- a/spec/validators/phone_number_validator_spec.rb
+++ b/spec/validators/phone_number_validator_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe PhoneNumberValidator do
     it 'returns invalid' do
       expect(model).not_to be_valid
     end
-
-    it 'returns the correct error message' do
-      expect(model.errors[:phone_number]).to include(t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid'))
-    end
   end
 
   context 'when empty phone number' do
@@ -36,10 +32,6 @@ RSpec.describe PhoneNumberValidator do
 
     it 'returns invalid' do
       expect(model.valid?(:no_context)).to be false
-    end
-
-    it 'returns the correct error message' do
-      expect(model.errors[:phone_number]).to include(t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid'))
     end
   end
 


### PR DESCRIPTION
### Context

Currently when a candidate enters a blank phone number they see a `Enter a real phone number` when we want the error message to be `Enter your phone number` for blank entries.

### Changes proposed in this pull request

Before

<img width="771" alt="Screenshot 2019-11-27 at 14 55 52" src="https://user-images.githubusercontent.com/47318392/69734002-270fd580-1126-11ea-8e9f-c1fd469af788.png">

-------------
After

<img width="820" alt="Screenshot 2019-11-27 at 14 56 21" src="https://user-images.githubusercontent.com/47318392/69734016-2c6d2000-1126-11ea-96ef-9a992955de5e.png">


- Update phone number validator to use the `phone_number.blank` translation when the phone number is blank.
- Update phone_number validator spec to reflect the blank error message changes.

### Guidance to review

Run specs and ensure that the correct error message is displayed for blank phone numbers.

### Link to Trello card

[524 - Error message for blank phone number](https://trello.com/c/z0j3sutx/524-code-in-error-message-for-blank-phone-number)

### Env vars

N/A
