### PR TITLE
Remove unnecessary fieldsets

### DIFF
--- a/app/views/candidate_interface/application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/application_form/submit_show.html.erb
@@ -6,56 +6,53 @@
     <%= form_with model: @further_information_form, url: candidate_interface_application_submit_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('submit_application.heading') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('submit_application.heading') %>
+      </h1>
 
+      <p class="govuk-body">
+        I understand I will have to undergo an enhanced
+        <%= govuk_link_to t('submit_application.disclosure_link'), 'https://www.gov.uk/government/organisations/disclosure-and-barring-service' %>
+        as part of my application.
+      </p>
+
+      <div class="govuk-inset-text">
         <p class="govuk-body">
-          I understand I will have to undergo an enhanced
-          <%= govuk_link_to t('submit_application.disclosure_link'), 'https://www.gov.uk/government/organisations/disclosure-and-barring-service' %>
-          as part of my application.
+          As prospective teachers, all candidates must consent to an enhanced
+          DBS check. This will show up any past criminal convictions, both
+          spent and unspent. Some convictions, even if they are spent, will
+          disbar you from teaching.
         </p>
-        <div class="govuk-inset-text">
-          <p class="govuk-body">
-            As prospective teachers, all candidates must consent to an enhanced
-            DBS check. This will show up any past criminal convictions, both
-            spent and unspent. Some convictions, even if they are spent, will
-            disbar you from teaching.
-          </p>
-          <p class="govuk-body">
-            However, not all past convictions prevent you from training to be a
-            teacher. Talk to your provider about their policy on criminal
-            convictions.
-          </p>
-          <p class="govuk-body">
-            <%= govuk_link_to t('submit_application.conviction_link'), 'https://www.gov.uk/exoffenders-and-employment' %>.
-          </p>
-        </div>
+        <p class="govuk-body">
+          However, not all past convictions prevent you from training to be a
+          teacher. Talk to your provider about their policy on criminal
+          convictions.
+        </p>
+        <p class="govuk-body">
+          <%= govuk_link_to t('submit_application.conviction_link'), 'https://www.gov.uk/exoffenders-and-employment' %>.
+        </p>
+      </div>
 
-        <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
-          <p class="govuk-body">
-            Examples of further information include any disability, health or
-            other personal or professional issue you feel is relevant to your
-            application.
-          </p>
+      <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
+        <p class="govuk-body">
+          Examples of further information include any disability, health or
+          other personal or professional issue you feel is relevant to your
+          application.
+        </p>
 
-          <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>
-            <%= f.govuk_text_area :further_information_details, label: { text: t('application_form.further_information.further_information_details.label') }, max_words: 300 %>
-          <% end %>
-
-          <%= f.govuk_radio_button :further_information, false, label: { text: 'No' } %>
+        <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>
+          <%= f.govuk_text_area :further_information_details, label: { text: t('application_form.further_information.further_information_details.label') }, max_words: 300 %>
         <% end %>
 
-        <p class="govuk-body">
-          By submitting, I confirm that the information given is true, complete
-          and accurate.
-        </p>
+        <%= f.govuk_radio_button :further_information, false, label: { text: 'No' } %>
+      <% end %>
 
-        <%= f.govuk_submit t('submit_application.submit_button') %>
-      </fieldset>
+      <p class="govuk-body">
+        By submitting, I confirm that the information given is true, complete
+        and accurate.
+      </p>
+
+      <%= f.govuk_submit t('submit_application.submit_button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/contact_details/base/edit.html.erb
+++ b/app/views/candidate_interface/contact_details/base/edit.html.erb
@@ -6,17 +6,13 @@
     <%= form_with model: @contact_details_form, url: candidate_interface_contact_details_update_base_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.contact_details') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.contact_details') %>
+      </h1>
 
-        <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20, autocomplete: 'tel' %>
+      <%= f.govuk_phone_field :phone_number, label: { text: t('application_form.contact_details.phone_number.label'), size: 'm' }, hint_text: t('application_form.contact_details.phone_number.hint_text'), width: 20, autocomplete: 'tel' %>
 
-        <%= f.govuk_submit t('application_form.contact_details.base.button') %>
-      </fieldset>
+      <%= f.govuk_submit t('application_form.contact_details.base.button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/course_choices/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/course_choices/confirm_destroy.html.erb
@@ -4,20 +4,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @course_choice, url: candidate_interface_confirm_destroy_course_choice_path(@course_choice.id), method: :delete do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl">Course choices</span>
-            <%= t('page_titles.destroy_course_choice') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Course choices</span>
+        <%= t('page_titles.destroy_course_choice') %>
+      </h1>
 
-        <%= f.submit t('application_form.courses.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.courses.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
-        <p class="govuk-body">
-          <%= govuk_link_to 'Cancel', candidate_interface_course_choices_index_path %>
-        </p>
-      </fieldset>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', candidate_interface_course_choices_index_path %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/degrees/base/edit.html.erb
+++ b/app/views/candidate_interface/degrees/base/edit.html.erb
@@ -6,17 +6,13 @@
     <%= form_with model: @degree, url: candidate_interface_degrees_edit_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.edit_degree') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.edit_degree') %>
+      </h1>
 
-        <%= f.hidden_field :id, value: @degree.id %>
-        <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.degree.qualification_type.label'), size: 'm' }, hint_text: t('application_form.degree.qualification_type.hint_text.all') %>
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= f.hidden_field :id, value: @degree.id %>
+      <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.degree.qualification_type.label'), size: 'm' }, hint_text: t('application_form.degree.qualification_type.hint_text.all') %>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/degrees/base/new_another.html.erb
+++ b/app/views/candidate_interface/degrees/base/new_another.html.erb
@@ -6,16 +6,12 @@
     <%= form_with model: @degree, url: candidate_interface_degrees_create_base_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.add_another_degree') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.add_another_degree') %>
+      </h1>
 
-        <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.degree.qualification_type.label'), size: 'm' }, hint_text: t('application_form.degree.qualification_type.hint_text.another') %>
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.degree.qualification_type.label'), size: 'm' }, hint_text: t('application_form.degree.qualification_type.hint_text.another') %>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/degrees/base/new_undergraduate.html.erb
+++ b/app/views/candidate_interface/degrees/base/new_undergraduate.html.erb
@@ -6,25 +6,21 @@
     <%= form_with model: @degree, url: candidate_interface_degrees_create_base_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.add_undergraduate_degree') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.add_undergraduate_degree') %>
+      </h1>
 
-        <p class="govuk-body">
-          Your undergraduate degree confirms your eligibility to teach.
-          Enter the details of your degree as they appear on your certificate,
-          translating them into English if necessary.
-        </p>
-        <p class="govuk-body">
-          If you have further postgraduate degrees, you’ll be able to add them next.
-        </p>
+      <p class="govuk-body">
+        Your undergraduate degree confirms your eligibility to teach.
+        Enter the details of your degree as they appear on your certificate,
+        translating them into English if necessary.
+      </p>
+      <p class="govuk-body">
+        If you have further postgraduate degrees, you’ll be able to add them next.
+      </p>
 
-        <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.degree.qualification_type.label'), size: 'm' }, hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate') %>
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.degree.qualification_type.label'), size: 'm' }, hint_text: t('application_form.degree.qualification_type.hint_text.undergraduate') %>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/degrees/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/degrees/destroy/confirm_destroy.html.erb
@@ -4,20 +4,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @degree, url: candidate_interface_confirm_degrees_destroy_path(@degree.id), method: :delete do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @degree.title %></span>
-            <%= t('page_titles.destroy_degree') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @degree.title %></span>
+        <%= t('page_titles.destroy_degree') %>
+      </h1>
 
-        <%= f.submit t('application_form.degree.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.degree.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
-        <p class="govuk-body">
-          <%= govuk_link_to 'Cancel', candidate_interface_degrees_review_path %>
-        </p>
-      </fieldset>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', candidate_interface_degrees_review_path %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/gcse/details/edit.html.erb
+++ b/app/views/candidate_interface/gcse/details/edit.html.erb
@@ -4,9 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_details_path, method: :patch do |f| %>
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <h1 class="govuk-fieldset__heading"><%= t("gcse_edit_details.page_titles.#{@subject}") %></h1>
-      </legend>
+      <h1 class="govuk-heading-xl"><%= t("gcse_edit_details.page_titles.#{@subject}") %></h1>
 
       <%= f.govuk_error_summary %>
 

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -6,9 +6,9 @@
     <%= form_with model: @application_qualification, url: candidate_interface_gcse_details_update_type_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-        <h1 class="govuk-fieldset__heading"><%= t("gcse_edit_type.page_titles.#{@subject}") %></h1>
-      </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t("gcse_edit_type.page_titles.#{@subject}") %>
+      </h1>
 
       <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: t('application_form.gcse.qualification_type.label'), tag: 'span' } do %>
         <% select_gcse_qualification_type_options.each_with_index do |option, i| %>
@@ -32,6 +32,6 @@
       <% end %>
 
       <%= f.submit t('application_form.gcse.complete_form_button'), class: 'govuk-button', 'data-module': 'govuk-button', 'data-prevent-double-click': true %>
-  <% end %>
+    <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/other_qualifications/base/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/edit.html.erb
@@ -6,16 +6,12 @@
     <%= form_with model: @qualification, url: candidate_interface_edit_other_qualification_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.edit_other_qualification') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.edit_other_qualification') %>
+      </h1>
 
-        <%= f.hidden_field :id, value: @qualification.id %>
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= f.hidden_field :id, value: @qualification.id %>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/other_qualifications/base/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/new.html.erb
@@ -6,15 +6,11 @@
     <%= form_with model: @qualification, url: candidate_interface_create_other_qualification_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.add_other_qualification') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.add_other_qualification') %>
+      </h1>
 
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/other_qualifications/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/other_qualifications/destroy/confirm_destroy.html.erb
@@ -4,20 +4,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @qualification, url: candidate_interface_confirm_destroy_other_qualification_path(@qualification.id), method: :delete do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @qualification.title %></span>
-            <%= t('page_titles.destroy_other_qualification') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @qualification.title %></span>
+        <%= t('page_titles.destroy_other_qualification') %>
+      </h1>
 
-        <%= f.submit t('application_form.other_qualification.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.other_qualification.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
-        <p class="govuk-body">
-          <%= govuk_link_to 'Cancel', candidate_interface_review_other_qualifications_path %>
-        </p>
-      </fieldset>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', candidate_interface_review_other_qualifications_path %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/personal_details/edit.html.erb
+++ b/app/views/candidate_interface/personal_details/edit.html.erb
@@ -6,44 +6,40 @@
     <%= form_with model: @personal_details_form, url: candidate_interface_personal_details_update_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <%= t('page_titles.personal_details') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.personal_details') %>
+      </h1>
 
-        <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.first_name.hint_text'), autocomplete: 'given-name' %>
+      <%= f.govuk_text_field :first_name, label: { text: t('application_form.personal_details.first_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.first_name.hint_text'), autocomplete: 'given-name' %>
 
-        <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.last_name.hint_text'), autocomplete: 'family-name' %>
+      <%= f.govuk_text_field :last_name, label: { text: t('application_form.personal_details.last_name.label'), size: 'm' }, hint_text: t('application_form.personal_details.last_name.hint_text'), autocomplete: 'family-name' %>
 
-        <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint_text: t('application_form.personal_details.date_of_birth.hint_text') %>
+      <%= f.govuk_date_field :date_of_birth, date_of_birth: true, legend: { text: t('application_form.personal_details.date_of_birth.label'), tag: 'span' }, hint_text: t('application_form.personal_details.date_of_birth.hint_text') %>
 
-        <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
+      <%= f.govuk_collection_select :first_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.nationality.label'), size: 'm' } %>
 
-        <details class="govuk-details" data-module="govuk-details" <%= 'open' if @personal_details_form.second_nationality.present? %>>
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              Add another nationality
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <%= f.govuk_collection_select :second_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.second_nationality.label') } %>
-          </div>
-        </details>
+      <details class="govuk-details" data-module="govuk-details" <%= 'open' if @personal_details_form.second_nationality.present? %>>
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            Add another nationality
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <%= f.govuk_collection_select :second_nationality, select_nationality_options, :id, :name, label: { text: t('application_form.personal_details.second_nationality.label') } %>
+        </div>
+      </details>
 
-        <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label'), tag: 'span' } do %>
-          <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' }, link_errors: true do %>
-            <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
-          <% end %>
-
-          <%= f.govuk_radio_button :english_main_language, 'no', label: { text: 'No' } do %>
-            <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
-          <% end %>
+      <%= f.govuk_radio_buttons_fieldset :english_main_language, legend: { size: 'm', text: t('application_form.personal_details.english_main_language.label'), tag: 'span' } do %>
+        <%= f.govuk_radio_button :english_main_language, 'yes', label: { text: 'Yes' }, link_errors: true do %>
+          <%= f.govuk_text_area :other_language_details, label: { text: t('application_form.personal_details.english_main_language.yes_label') }, max_words: 200 %>
         <% end %>
 
-        <%= f.govuk_submit 'Continue' %>
-      </fieldset>
+        <%= f.govuk_radio_button :english_main_language, 'no', label: { text: 'No' } do %>
+          <%= f.govuk_text_area :english_language_details, label: { text: t('application_form.personal_details.english_main_language.no_label') }, max_words: 200 %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/referees/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/referees/confirm_destroy.html.erb
@@ -4,20 +4,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @referee, url: candidate_interface_destroy_referee_path(@referee.id), method: :delete do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @referee.name %></span>
-            <%= t('page_titles.referee_destroy') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @referee.name %></span>
+        <%= t('page_titles.referee_destroy') %>
+      </h1>
 
-        <%= f.submit t('application_form.referees.sure_delete_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.referees.sure_delete_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
-        <p class="govuk-body">
-          <%= govuk_link_to 'Cancel', candidate_interface_review_referees_path %>
-        </p>
-      </fieldset>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', candidate_interface_review_referees_path %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/referees/edit.html.erb
+++ b/app/views/candidate_interface/referees/edit.html.erb
@@ -6,18 +6,14 @@
     <%= form_with model: @referee, url: candidate_interface_update_referee_path(@referee) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl">
-              <%= t('page_titles.nth_referee')[@referee.ordinal] %>
-            </span>
-            <%= t('page_titles.add_referee') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">
+          <%= t('page_titles.nth_referee')[@referee.ordinal] %>
+        </span>
+        <%= t('page_titles.add_referee') %>
+      </h1>
 
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/referees/new.html.erb
+++ b/app/views/candidate_interface/referees/new.html.erb
@@ -6,18 +6,14 @@
     <%= form_with model: @referee, url: candidate_interface_referees_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl">
-              <%= t('page_titles.nth_referee')[@referee.ordinal] %>
-            </span>
-            <%= t('page_titles.add_referee') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">
+          <%= t('page_titles.nth_referee')[@referee.ordinal] %>
+        </span>
+        <%= t('page_titles.add_referee') %>
+      </h1>
 
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -1,14 +1,14 @@
 <% content_for :title, t('page_titles.eligibility') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_path) %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.eligibility') %>
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @eligibility_form, url: candidate_interface_eligibility_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.eligibility') %>
+      </h1>
 
       <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK, EU or EEA?', tag: 'span' } do %>
         <%= f.govuk_radio_button :eligible_citizen, 'yes', label: { text: 'Yes' }, link_errors: true %>

--- a/app/views/candidate_interface/volunteering/base/edit.html.erb
+++ b/app/views/candidate_interface/volunteering/base/edit.html.erb
@@ -6,17 +6,13 @@
     <%= form_with model: @volunteering_role, url: candidate_interface_edit_volunteering_role_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
-            <%= t('page_titles.edit_volunteering_role') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
+        <%= t('page_titles.edit_volunteering_role') %>
+      </h1>
 
-        <%= f.hidden_field :id, value: @volunteering_role.id %>
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= f.hidden_field :id, value: @volunteering_role.id %>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/volunteering/base/new.html.erb
+++ b/app/views/candidate_interface/volunteering/base/new.html.erb
@@ -6,16 +6,12 @@
     <%= form_with model: @volunteering_role, url: candidate_interface_create_volunteering_role_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
-            <%= t('page_titles.add_volunteering_role') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= t('page_titles.volunteering.caption') %></span>
+        <%= t('page_titles.add_volunteering_role') %>
+      </h1>
 
-        <%= render 'form', f: f %>
-      </fieldset>
+      <%= render 'form', f: f %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/volunteering/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/volunteering/destroy/confirm_destroy.html.erb
@@ -4,20 +4,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @volunteering_role, url: candidate_interface_confirm_destroy_volunteering_role_path(@volunteering_role.id), method: :delete do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @volunteering_role.role %></span>
-            <%= t('page_titles.destroy_volunteering_role') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @volunteering_role.role %></span>
+        <%= t('page_titles.destroy_volunteering_role') %>
+      </h1>
 
-        <%= f.submit t('application_form.volunteering.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.volunteering.confirm_delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
-        <p class="govuk-body">
-          <%= govuk_link_to 'Cancel', candidate_interface_review_volunteering_path %>
-        </p>
-      </fieldset>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', candidate_interface_review_volunteering_path %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/work_history/destroy/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/work_history/destroy/confirm_destroy.html.erb
@@ -4,20 +4,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @work_experience, url: candidate_interface_work_history_destroy_path(@work_experience.id), method: :delete do |f| %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @work_experience.role %></span>
-            <%= t('page_titles.work_history_destroy') %>
-          </h1>
-        </legend>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @work_experience.role %></span>
+        <%= t('page_titles.work_history_destroy') %>
+      </h1>
 
-        <%= f.submit t('application_form.work_history.sure_delete_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('application_form.work_history.sure_delete_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
-        <p class="govuk-body">
-          <%= govuk_link_to 'Cancel', candidate_interface_work_history_show_path %>
-        </p>
-      </fieldset>
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', candidate_interface_work_history_show_path %>
+      </p>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Context

There are quite a few places in which we are wrapping entire forms in a `fieldset`, when this is not necessary. The only exception is the address page. I think I’ve found and fixed all occurrences.

Also; moves one more error summary above its respective page title on Eligibility page.

[568 - Some forms incorrectly wrap all fields in a fieldset](https://trello.com/c/R61zH5MQ/)