### PR TITLE
Disabled pentest deployment environment.

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -139,52 +139,52 @@ stages:
       alertRecipientEmails: '$(alertRecipientEmails)'
 
 
-- stage: deploy_pentest
-  displayName: 'Deploy - Pentest'
-  dependsOn: publish_arm_template
-  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_pentest, true))
-  variables:
-  - group: APPLY - ENV - Pentest
-  jobs:
-  - template: azure-pipelines-deploy-template.yml
-    parameters:
-      debug: $(debug)
-      subscriptionPrefix: 's106'
-      subscriptionName: 'Apply (106) - Test'
-      environment: 'pentest'
-      resourceEnvironmentName: 't03'
-      serviceName: 'apply'
-      containerImageReference: '$(imageName):$(build.buildNumber)'
-      keyVaultName: 's106t01-shared-kv-01'
-      keyVaultResourceGroup: 's106t01-shared-rg'
-      databaseName: 'apply'
-      databaseUsername: 'applyadm512'
-      databasePassword: '$(databasePassword)'
-      databaseStorageAutoGrow: 'disabled'
-      databaseBackupRetentionDays: 7
-      dockerhubUsername: '$(dockerHubUsername)'
-      railsSecretKeyBase: '$(railsSecretKeyBase)'
-      railsEnv: 'production'
-      basicAuthEnabled: '$(basicAuthEnabled)'
-      basicAuthUsername: '$(basicAuthUsername)'
-      basicAuthPassword: '$(basicAuthPassword)'
-      supportUsername: '$(supportUsername)'
-      supportPassword: '$(supportPassword)'
-      authorisedHosts: '$(authorisedHosts)'
-      sentryDSN: '$(sentryDSN)'
-      logstashEnable: '$(logstashEnable)'
-      logstashRemote: '$(logstashRemote)'
-      logstashHost: '$(logstashHost)'
-      logstashPort: '$(logstashPort)'
-      logstashSsl: '$(logstashSsl)'
-      govukNotifyAPIKey: '$(govukNotifyAPIKey)'
-      findBaseUrl: '$(findBaseUrl)'
-      dfeSignInClientId: '$(dfeSignInClientId)'
-      dfeSignInSecret: '$(dfeSignInSecret)'
-      dfeSignInIssuer: '$(dfeSignInIssuer)'
-      stateChangeSlackUrl: '$(stateChangeSlackUrl)'
-      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
-      alertRecipientEmails: '$(alertRecipientEmails)'
+#- stage: deploy_pentest
+#  displayName: 'Deploy - Pentest'
+#  dependsOn: publish_arm_template
+#  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_pentest, true))
+#  variables:
+#  - group: APPLY - ENV - Pentest
+#  jobs:
+#  - template: azure-pipelines-deploy-template.yml
+#    parameters:
+#      debug: $(debug)
+#      subscriptionPrefix: 's106'
+#      subscriptionName: 'Apply (106) - Test'
+#      environment: 'pentest'
+#      resourceEnvironmentName: 't03'
+#      serviceName: 'apply'
+#      containerImageReference: '$(imageName):$(build.buildNumber)'
+#      keyVaultName: 's106t01-shared-kv-01'
+#      keyVaultResourceGroup: 's106t01-shared-rg'
+#      databaseName: 'apply'
+#      databaseUsername: 'applyadm512'
+#      databasePassword: '$(databasePassword)'
+#      databaseStorageAutoGrow: 'disabled'
+#      databaseBackupRetentionDays: 7
+#      dockerhubUsername: '$(dockerHubUsername)'
+#      railsSecretKeyBase: '$(railsSecretKeyBase)'
+#      railsEnv: 'production'
+#      basicAuthEnabled: '$(basicAuthEnabled)'
+#      basicAuthUsername: '$(basicAuthUsername)'
+#      basicAuthPassword: '$(basicAuthPassword)'
+#      supportUsername: '$(supportUsername)'
+#      supportPassword: '$(supportPassword)'
+#      authorisedHosts: '$(authorisedHosts)'
+#      sentryDSN: '$(sentryDSN)'
+#      logstashEnable: '$(logstashEnable)'
+#      logstashRemote: '$(logstashRemote)'
+#      logstashHost: '$(logstashHost)'
+#      logstashPort: '$(logstashPort)'
+#      logstashSsl: '$(logstashSsl)'
+#      govukNotifyAPIKey: '$(govukNotifyAPIKey)'
+#      findBaseUrl: '$(findBaseUrl)'
+#      dfeSignInClientId: '$(dfeSignInClientId)'
+#      dfeSignInSecret: '$(dfeSignInSecret)'
+#      dfeSignInIssuer: '$(dfeSignInIssuer)'
+#      stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+#      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+#      alertRecipientEmails: '$(alertRecipientEmails)'
 
 
 - stage: deploy_production


### PR DESCRIPTION
### Context

The pentest environment isn't currently required and is to be removed. Before it can be removed it needs to be removed from the release pipeline code to prevent it being redeployed after its been deleted.

### Changes proposed in this pull request

- Commented out the pent test environment code to prevent it running in future releases. I've not removed it entirely in case its required again for the pen test in a couple of weeks.

### Guidance to review

N/A

### Link to Trello card

N/A

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
