### PR TITLE
Audit provider user actions

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -21,6 +21,8 @@ module SupportInterface
         "#{audit.user.email_address} (Candidate)"
       elsif audit.user_type == 'VendorApiUser'
         "#{audit.user.email_address} (Vendor API)"
+      elsif audit.user_type == 'ProviderUser'
+        "#{audit.user.email_address} (Provider)"
       elsif audit.username.present?
         audit.username
       else

--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -21,8 +21,6 @@ module SupportInterface
         "#{audit.user.email_address} (Candidate)"
       elsif audit.user_type == 'VendorApiUser'
         "#{audit.user.email_address} (Vendor API)"
-      elsif audit.user_type == 'ProviderUser'
-        "#{audit.user.email_address} (Provider)"
       elsif audit.username.present?
         audit.username
       else

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -18,6 +18,7 @@ module ProviderInterface
     def current_provider_user
       ProviderUser.load_from_session(session)
     end
+    alias :audit_user :current_provider_user
 
     def authenticate_provider_user!
       redirect_to provider_interface_sign_in_path unless current_provider_user

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -53,14 +53,6 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('alice@example.com (Vendor API)')
   end
 
-  it 'renders an update application form audit record with a Provider user' do
-    audit.user = provider_user
-    audit.action = 'update'
-    expect(render_result.text).to include('1 October 2019 12:10')
-    expect(render_result.text).to include('Update Application Form')
-    expect(render_result.text).to include('jim@example.com (Provider)')
-  end
-
   it 'renders an update application form audit record with the username (rather than a persistent model)' do
     audit.user = nil
     audit.username = 'SYSTEM'

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('jim@example.com (Provider)')
   end
 
-  it 'renders an update application form audit record with the "System" user' do
+  it 'renders an update application form audit record with the username (rather than a persistent model)' do
     audit.user = nil
     audit.username = 'SYSTEM'
     audit.action = 'update'

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     @vendor_api_user ||= build :vendor_api_user, email_address: 'alice@example.com'
   end
 
+  def provider_user
+    @provider_user ||= ProviderUser.new(email_address: 'jim@example.com', dfe_sign_in_uid: 'abc')
+  end
+
   def audit
     @audit ||= Audited::Audit.new(
       user: candidate,
@@ -47,6 +51,14 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('Comment on Application Form')
     expect(render_result.text).to include('some comment')
     expect(render_result.text).to include('alice@example.com (Vendor API)')
+  end
+
+  it 'renders an update application form audit record with a Provider user' do
+    audit.user = provider_user
+    audit.action = 'update'
+    expect(render_result.text).to include('1 October 2019 12:10')
+    expect(render_result.text).to include('Update Application Form')
+    expect(render_result.text).to include('jim@example.com (Provider)')
   end
 
   it 'renders an update application form audit record with the "System" user' do

--- a/spec/requests/provider_interface/audit_trail_spec.rb
+++ b/spec/requests/provider_interface/audit_trail_spec.rb
@@ -2,31 +2,28 @@ require 'rails_helper'
 
 RSpec.describe 'Provider interface - audit trail', type: :request do
   def create_application
-    application_form = create :application_form
-    application_choice = create(
+    create(
       :application_choice,
-      application_form: application_form,
-      status: 'awaiting_provider_decision',
+      :awaiting_provider_decision,
     )
-    provider = create :provider, code: 'ABC'
-    application_choice.course.update(accrediting_provider: provider)
-    application_choice
   end
 
-  before do
+  def set_provider_permission(application_choice)
+    provider_code = application_choice.course.provider.code
     allow(ProviderUser).to receive(:load_from_session)
       .and_return(
         ProviderUser.new(
           email_address: 'alice@example.com',
-          dfe_sign_in_uid: 'ABC',
+          dfe_sign_in_uid: provider_code,
         ),
     )
 
-    allow(Rails.application.config).to receive(:provider_permissions).and_return(ABC: 'ABC')
+    allow(Rails.application.config).to receive(:provider_permissions).and_return(provider_code => provider_code)
   end
 
   it 'creates audit records attributed to the authenticated provider' do
     application_choice = create_application
+    set_provider_permission(application_choice)
     expect {
       post provider_interface_application_choice_create_offer_path(
         application_choice_id: application_choice.id,

--- a/spec/requests/provider_interface/audit_trail_spec.rb
+++ b/spec/requests/provider_interface/audit_trail_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Provider interface - audit trail', type: :request do
+  def create_application
+    application_form = create :application_form
+    application_choice = create(
+      :application_choice,
+      application_form: application_form,
+      status: 'awaiting_provider_decision',
+    )
+    provider = create :provider, code: 'ABC'
+    application_choice.course.update(accrediting_provider: provider)
+    application_choice
+  end
+
+  before do
+    allow(ProviderUser).to receive(:load_from_session)
+      .and_return(
+        ProviderUser.new(
+          email_address: 'alice@example.com',
+          dfe_sign_in_uid: 'ABC',
+        ),
+    )
+
+    allow(Rails.application.config).to receive(:provider_permissions).and_return(ABC: 'ABC')
+  end
+
+  it 'creates audit records attributed to the authenticated provider' do
+    application_choice = create_application
+    expect {
+      post provider_interface_application_choice_create_offer_path(
+        application_choice_id: application_choice.id,
+      ), params: { offer_conditions: '["must be clever"]' }
+    }.to(change { application_choice.audits.count })
+
+    expect(application_choice.audits.last.username).to eq 'alice@example.com (Provider)'
+  end
+end


### PR DESCRIPTION
### Context

We want to be able to see which user caused each change in the audit trail (Application History page in the support interface). This currently works for candidates and vendor API users. This PR adds support for provider users authenticated via DfE sign-in.

### Changes proposed in this pull request

- Set the `username` for that the audited gem uses to attribute audit entries to `<provider-email> (Provider)` in the `ProviderInterfaceController` base controller.
- The existing logic in the view components for application history displays provider audit records like this:

![image](https://user-images.githubusercontent.com/450843/69738621-5591ae80-112e-11ea-9300-0d913b8e907f.png)


### Guidance to review

- At the moment the only info we have about provider users is an email and they are not stored in the database so we are just setting the audit user as a `username` (String) rather than an associated persistent object (like we do with `Candidate`). We could review this in future if we have more info available.
- The request spec is an attempt to cover the logic in `ProviderInterfaceController` that sets up the audited `username`. I didn't want to just dump another assertion into an existing system spec because it's a cross cutting concern rather than main functionality. There could be an easier way to do this though.

### Link to Trello card

[1277 - Audit provider user actions](https://trello.com/c/FhGp8ffU/1277-placeholder-audit-provider-user-actions)

### Env vars

no env vars
