### PR TITLE
Refactor SectionMissingBannerComponent

### DIFF
--- a/app/components/becoming_a_teacher_review_component.html.erb
+++ b/app/components/becoming_a_teacher_review_component.html.erb
@@ -1,9 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :becoming_a_teacher, text: t('review_application.becoming_a_teacher.incomplete')) do %>
-    <%= link_to candidate_interface_becoming_a_teacher_edit_path, class: 'govuk-link' do %>
-      <%= t('review_application.becoming_a_teacher.link_html') %>
-    <% end %>
-  <% end %>
+  <%= render(SectionMissingBannerComponent, section: :becoming_a_teacher, section_path: candidate_interface_becoming_a_teacher_edit_path, text: t('review_application.becoming_a_teacher.incomplete')) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: becoming_a_teacher_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/becoming_a_teacher_review_component.html.erb
+++ b/app/components/becoming_a_teacher_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :becoming_a_teacher, section_path: candidate_interface_becoming_a_teacher_edit_path, text: t('review_application.becoming_a_teacher.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :becoming_a_teacher, section_path: candidate_interface_becoming_a_teacher_edit_path) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: becoming_a_teacher_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/contact_details_review_component.html.erb
+++ b/app/components/contact_details_review_component.html.erb
@@ -1,9 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :contact_details, text: t('review_application.contact_details.incomplete')) do %>
-    <%= link_to candidate_interface_contact_details_edit_base_path, class: 'govuk-link' do %>
-      <%= t('review_application.contact_details.link_html') %>
-    <% end %>
-  <% end %>
+  <%= render(SectionMissingBannerComponent, section: :contact_details, section_path: candidate_interface_contact_details_edit_base_path, text: t('review_application.contact_details.incomplete')) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: contact_details_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/contact_details_review_component.html.erb
+++ b/app/components/contact_details_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :contact_details, section_path: candidate_interface_contact_details_edit_base_path, text: t('review_application.contact_details.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :contact_details, section_path: candidate_interface_contact_details_edit_base_path) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: contact_details_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -32,9 +32,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :course_choices, text: t('review_application.course_choices.incomplete')) do %>
-    <%= link_to candidate_interface_course_choices_index_path, class: 'govuk-link' do %>
-      <%= t('review_application.course_choices.link_html') %>
-    <% end %>
-  <% end %>
+  <%= render(SectionMissingBannerComponent, section: :course_choices, section_path: candidate_interface_course_choices_index_path, text: t('review_application.course_choices.incomplete')) %>
 <% end %>

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -32,5 +32,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :course_choices, section_path: candidate_interface_course_choices_index_path, text: t('review_application.course_choices.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :course_choices, section_path: candidate_interface_course_choices_index_path) %>
 <% end %>

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -14,5 +14,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :degrees, section_path: candidate_interface_degrees_new_base_path, text: t('review_application.degrees.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :degrees, section_path: candidate_interface_degrees_new_base_path) %>
 <% end %>

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -14,9 +14,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :degrees, text: t('review_application.degrees.incomplete')) do %>
-     <%= link_to candidate_interface_degrees_new_base_path, class: 'govuk-link' do %>
-       <%= t('review_application.degrees.link_html') %>
-     <% end %>
-   <% end %>
+  <%= render(SectionMissingBannerComponent, section: :degrees, section_path: candidate_interface_degrees_new_base_path, text: t('review_application.degrees.incomplete')) %>
 <% end %>

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -9,7 +9,7 @@
     <%= render(SummaryCardHeaderComponent, title: title, heading_level: @heading_level) %>
   <% end %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), text: t("review_application.#{subject}_gcse.incomplete")) %>
+  <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym)) %>
 <% else %>
   <p class="govuk-body">No GCSE entered.</p>
 <% end %>

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -9,11 +9,7 @@
     <%= render(SummaryCardHeaderComponent, title: title, heading_level: @heading_level) %>
   <% end %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", text: t("review_application.#{subject}_gcse.incomplete")) do %>
-    <%= link_to candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), class: 'govuk-link' do %>
-      <%= t("review_application.#{subject}_gcse.link_html") %>
-    <% end %>
-  <% end %>
+  <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), text: t("review_application.#{subject}_gcse.incomplete")) %>
 <% else %>
   <p class="govuk-body">No GCSE entered.</p>
 <% end %>

--- a/app/components/interview_preferences_review_component.html.erb
+++ b/app/components/interview_preferences_review_component.html.erb
@@ -1,9 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :interview_preferences, text: t('review_application.interview_preferences.incomplete')) do %>
-    <%= link_to candidate_interface_interview_preferences_edit_path, class: 'govuk-link' do %>
-      <%= t('review_application.interview_preferences.link_html') %>
-    <% end %>
-  <% end %>
+  <%= render(SectionMissingBannerComponent, section: :interview_preferences, section_path: candidate_interface_interview_preferences_edit_path, text: t('review_application.interview_preferences.incomplete')) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: interview_preferences_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/interview_preferences_review_component.html.erb
+++ b/app/components/interview_preferences_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :interview_preferences, section_path: candidate_interface_interview_preferences_edit_path, text: t('review_application.interview_preferences.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :interview_preferences, section_path: candidate_interface_interview_preferences_edit_path) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: interview_preferences_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/personal_details_review_component.html.erb
+++ b/app/components/personal_details_review_component.html.erb
@@ -1,7 +1,7 @@
 <% if @personal_details_form.valid? %>
   <%= render(SummaryCardComponent, rows: rows, editable: @editable) %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, section: :personal_details, section_path: candidate_interface_personal_details_edit_path, text: t('review_application.personal_details.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :personal_details, section_path: candidate_interface_personal_details_edit_path) %>
 <% else %>
   <p class="govuk-body">No personal details entered.</p>
 <% end %>

--- a/app/components/personal_details_review_component.html.erb
+++ b/app/components/personal_details_review_component.html.erb
@@ -1,11 +1,7 @@
 <% if @personal_details_form.valid? %>
   <%= render(SummaryCardComponent, rows: rows, editable: @editable) %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, section: :personal_details, text: t('review_application.personal_details.incomplete')) do %>
-    <%= link_to candidate_interface_personal_details_edit_path, class: 'govuk-link' do %>
-      <%= t('review_application.personal_details.link_html') %>
-    <% end %>
-  <% end %>
+  <%= render(SectionMissingBannerComponent, section: :personal_details, section_path: candidate_interface_personal_details_edit_path, text: t('review_application.personal_details.incomplete')) %>
 <% else %>
   <p class="govuk-body">No personal details entered.</p>
 <% end %>

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -14,9 +14,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :references, text: t('review_application.references.incomplete', minimum_references: minimum_references)) do %>
-     <%= link_to candidate_interface_referees_path, class: 'govuk-link' do %>
-       <%= t('review_application.references.link_html') %>
-     <% end %>
-   <% end %>
+  <%= render(SectionMissingBannerComponent, section: :references, section_path: candidate_interface_referees_path, text: t('review_application.references.incomplete', minimum_references: minimum_references)) %>
 <% end %>

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,8 +1,8 @@
 <div class="app-banner app-banner--info app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
     <p class="govuk-body"><%= @text %></p>
-    <% if content.present? %>
-      <%= content %>
+    <%= link_to @section_path, class: 'govuk-link' do %>
+      Complete <span class="govuk-visually-hidden"><%= t("review_application.#{section}.complete_section_visually_hidden") %></span> section
     <% end %>
   </div>
 </div>

--- a/app/components/section_missing_banner_component.rb
+++ b/app/components/section_missing_banner_component.rb
@@ -1,10 +1,11 @@
 class SectionMissingBannerComponent < ActionView::Component::Base
-  validates :text, :section, presence: true
+  validates :section, :section_path, :text, presence: true
 
-  def initialize(text:, section:)
-    @text = text
+  def initialize(section:, section_path:, text:)
     @section = section
+    @section_path = section_path
+    @text = text
   end
 
-  attr_reader :text, :section
+  attr_reader :section, :section_path, :text
 end

--- a/app/components/section_missing_banner_component.rb
+++ b/app/components/section_missing_banner_component.rb
@@ -1,7 +1,7 @@
 class SectionMissingBannerComponent < ActionView::Component::Base
-  validates :section, :section_path, :text, presence: true
+  validates :section, :section_path, presence: true
 
-  def initialize(section:, section_path:, text:)
+  def initialize(section:, section_path:, text: t("review_application.#{section}.incomplete"))
     @section = section
     @section_path = section_path
     @text = text

--- a/app/components/subject_knowledge_review_component.html.erb
+++ b/app/components/subject_knowledge_review_component.html.erb
@@ -1,9 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :subject_knowledge, text: t('review_application.subject_knowledge.incomplete')) do %>
-    <%= link_to candidate_interface_subject_knowledge_edit_path, class: 'govuk-link' do %>
-      <%= t('review_application.subject_knowledge.link_html') %>
-    <% end %>
-  <% end %>
+  <%= render(SectionMissingBannerComponent, section: :subject_knowledge, section_path: candidate_interface_subject_knowledge_edit_path, text: t('review_application.subject_knowledge.incomplete')) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: subject_knowledge_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/subject_knowledge_review_component.html.erb
+++ b/app/components/subject_knowledge_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :subject_knowledge, section_path: candidate_interface_subject_knowledge_edit_path, text: t('review_application.subject_knowledge.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :subject_knowledge, section_path: candidate_interface_subject_knowledge_edit_path) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: subject_knowledge_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :volunteering, section_path: candidate_interface_volunteering_experience_path, text: t('review_application.volunteering.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :volunteering, section_path: candidate_interface_volunteering_experience_path) %>
 <% elsif @application_form.application_volunteering_experiences.empty? %>
   <section class="app-summary-card govuk-!-margin-bottom-6">
     <%= render(SummaryCardHeaderComponent, title: t('application_form.volunteering.no_experience.summary_card_title')) %>

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -14,11 +14,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :volunteering, text: t('review_application.volunteering.incomplete')) do %>
-     <%= link_to candidate_interface_volunteering_experience_path, class: 'govuk-link' do %>
-       <%= t('review_application.volunteering.link_html') %>
-     <% end %>
-   <% end %>
+  <%= render(SectionMissingBannerComponent, section: :volunteering, section_path: candidate_interface_volunteering_experience_path, text: t('review_application.volunteering.incomplete')) %>
 <% elsif @application_form.application_volunteering_experiences.empty? %>
   <section class="app-summary-card govuk-!-margin-bottom-6">
     <%= render(SummaryCardHeaderComponent, title: t('application_form.volunteering.no_experience.summary_card_title')) %>

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -22,9 +22,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :work_experience, text: t('review_application.work_experience.incomplete')) do %>
-     <%= link_to candidate_interface_work_history_length_path, class: 'govuk-link' do %>
-       <%= t('review_application.work_experience.link_html') %>
-     <% end %>
-   <% end %>
+  <%= render(SectionMissingBannerComponent, section: :work_experience, section_path: candidate_interface_work_history_length_path, text: t('review_application.work_experience.incomplete')) %>
 <% end %>

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -22,5 +22,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :work_experience, section_path: candidate_interface_work_history_length_path, text: t('review_application.work_experience.incomplete')) %>
+  <%= render(SectionMissingBannerComponent, section: :work_experience, section_path: candidate_interface_work_history_length_path) %>
 <% end %>

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -4,55 +4,43 @@ en:
     error_title: Error - Review your application
     heading: Review your application
     button_continue: Continue
+    link: Complete section
     becoming_a_teacher:
       incomplete: Tell us why you want to be a teacher
-      link: Complete becoming a teacher section
-      link_html: Complete <span class="govuk-visually-hidden">becoming a teacher</span> section
+      complete_section_visually_hidden: tell us why you want to be a teacher
     contact_details:
       incomplete: Contact details not entered
-      link: Complete contact details section
-      link_html: Complete <span class="govuk-visually-hidden">contact details</span> section
+      complete_section_visually_hidden: contact details
     course_choices:
       incomplete: Course choices are not marked as completed
-      link: Complete course choices section
-      link_html: Complete <span class="govuk-visually-hidden">course choices</span> section
+      complete_section_visually_hidden: course choices
     degrees:
-      incomplete: Degree history is not marked as completed
-      link: Complete degrees section
-      link_html: Complete <span class="govuk-visually-hidden">degrees</span> section
+      incomplete: Degree(s) are not marked as completed
+      complete_section_visually_hidden: degree(s)
     maths_gcse:
-      incomplete: Maths GCSE not entered
-      link: Complete Maths GCSE section
-      link_html: Complete <span class="govuk-visually-hidden">Maths GCSE</span> section
+      incomplete: Maths GCSE or equivalent not entered
+      complete_section_visually_hidden: Maths GCSE or equivalent
     english_gcse:
-      incomplete: English GCSE not entered
-      link: Complete English GCSE section
-      link_html: Complete <span class="govuk-visually-hidden">English GCSE</span> section
+      incomplete: English GCSE or equivalent not entered
+      complete_section_visually_hidden: English GCSE or equivalent
     science_gcse:
-      incomplete: Science GCSE not entered
-      link: Complete Science GCSE section
-      link_html: Complete <span class="govuk-visually-hidden">Science GCSE</span> section
+      incomplete: Science GCSE or equivalent not entered
+      complete_section_visually_hidden: Science GCSE or equivalent
     interview_preferences:
       incomplete: Tell us your interview preferences
-      link: Complete interview preferences section
-      link_html: Complete <span class="govuk-visually-hidden">interview preferences</span> section
+      complete_section_visually_hidden: interview preferences
     personal_details:
       incomplete: Personal details not entered
-      link: Complete personal details section
-      link_html: Complete <span class="govuk-visually-hidden">personal details</span> section
+      complete_section_visually_hidden: personal details
     references:
       incomplete: Add %{minimum_references} referees to your application
-      link: Complete references section
-      link_html: Complete <span class="govuk-visually-hidden">references</span> section
+      complete_section_visually_hidden: references
     subject_knowledge:
       incomplete: Tell us about your knowledge about the subject you want to teach
-      link: Complete subject knowledge section
-      link_html: Complete <span class="govuk-visually-hidden">subject knowledge</span> section
+      complete_section_visually_hidden: subject knowledge
     volunteering:
-      incomplete: Volunteering history is not marked as completed
-      link: Complete volunteering history section
-      link_html: Complete <span class="govuk-visually-hidden">volunteering history</span> section
+      incomplete: Volunteering with children and young people is not marked as completed
+      complete_section_visually_hidden: volunteering with children and young people
     work_experience:
       incomplete: Work history is not marked as completed
-      link: Complete work history section
-      link_html: Complete <span class="govuk-visually-hidden">work history</span> section
+      complete_section_visually_hidden: work history

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -4,7 +4,6 @@ en:
     error_title: Error - Review your application
     heading: Review your application
     button_continue: Continue
-    link: Complete section
     becoming_a_teacher:
       incomplete: Tell us why you want to be a teacher
       complete_section_visually_hidden: tell us why you want to be a teacher

--- a/spec/components/section_missing_banner_component_spec.rb
+++ b/spec/components/section_missing_banner_component_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe SectionMissingBannerComponent do
+  it 'renders a section missing banner component' do
+    result = render_inline(SectionMissingBannerComponent, section: 'degrees', section_path: '#', text: 'Degree(s) are not marked as completed')
+    expect(result.css('.app-banner__message .govuk-body').text).to include('Degree(s) are not marked as completed')
+    expect(result.css('.app-banner__message .govuk-link')).to be_present
+  end
+end

--- a/spec/components/section_missing_banner_component_spec.rb
+++ b/spec/components/section_missing_banner_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SectionMissingBannerComponent do
   it 'renders a section missing banner component' do
-    result = render_inline(SectionMissingBannerComponent, section: 'degrees', section_path: '#', text: 'Degree(s) are not marked as completed')
+    result = render_inline(SectionMissingBannerComponent, section: 'degrees', section_path: '#')
     expect(result.css('.app-banner__message .govuk-body').text).to include('Degree(s) are not marked as completed')
     expect(result.css('.app-banner__message .govuk-link')).to be_present
   end

--- a/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
@@ -145,15 +145,15 @@ RSpec.feature 'Candidate reviews the answers' do
   end
 
   def then_i_should_see_an_incomplete_banner_for(section)
-    expect(page).to have_content t("review_application.#{section}.link")
+    expect(page).to have_content "Complete #{t("review_application.#{section}.complete_section_visually_hidden")} section"
   end
 
   def when_i_click_to_complete_section_for(section)
-    click_link t("review_application.#{section}.link")
+    click_link "Complete #{t("review_application.#{section}.complete_section_visually_hidden")} section"
   end
 
   def then_i_should_not_see_an_incomplete_banner_for(section)
-    expect(page).not_to have_content t("review_application.#{section}.link")
+    expect(page).not_to have_content "Complete #{t("review_application.#{section}.complete_section_visually_hidden")} section"
   end
 
   def then_i_should_be_able_to_complete_section_for(section)


### PR DESCRIPTION
### Context

Updates link text to match section titles. Also DRYs out `SectionMissingBannerComponent` and adds a test for this component.

### Link to Trello card

[546 - Complete section links do not reflect h3s](https://trello.com/c/GqcnozMG/)
