### PR TITLE
Remove explicit call to Sentry in ApplicationMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -11,8 +11,6 @@ class ApplicationMailer < Mail::Notify::Mailer
                   NotifyOtherBadRequestError.new(e.message)
                 end
 
-    Raven.capture_exception(exception)
-
     raise exception
   end
 

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -22,14 +22,6 @@ RSpec.describe ApplicationMailer do
           'BadRequestError: Can’t send to this recipient using a team-only API key',
         )
       end
-
-      it 'rescues the exception and reports it to sentry' do
-        allow(Raven).to receive(:capture_exception)
-
-        expect { fake_mailer.notify_error.deliver_now }.to raise_error(ApplicationMailer::NotifyTeamOnlyAPIKeyError) do
-          expect(Raven).to have_received(:capture_exception)
-        end
-      end
     end
 
     context 'when Notify returns any other error' do
@@ -51,14 +43,6 @@ RSpec.describe ApplicationMailer do
           ApplicationMailer::NotifyOtherBadRequestError,
           'BadRequestError: Document didn’t pass the virus scan',
         )
-      end
-
-      it 'rescues the exception and reports it to sentry' do
-        allow(Raven).to receive(:capture_exception)
-
-        expect { fake_mailer.notify_error.deliver_now }.to raise_error(ApplicationMailer::NotifyOtherBadRequestError) do
-          expect(Raven).to have_received(:capture_exception)
-        end
       end
     end
   end


### PR DESCRIPTION
### Context

An explicit call to Sentry in the `ApplicationMailer` was made in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/710 when wrapping Notify errors. This was because when testing in development it was needed. 

However, @tijmenb raised concern that in QA or Staging it would cause Sentry to be triggered twice. @tvararu and myself tested this and Tijmen was right!

![image](https://user-images.githubusercontent.com/42817036/69742573-ed929680-1134-11ea-8a0f-d84dc65067d0.png)

### Changes proposed in this pull request

This PR removes the explicit call to Sentry in the `ApplicationMailer`. 

### Guidance to review

N/A

### Link to Trello card

No card.
