### PR TITLE
Resource lock to prevent database deletion.

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -994,6 +994,19 @@
             "dependsOn": [
                 "postgresql-server"
             ]
+        },
+        {
+            "apiVersion": "2017-04-01",
+            "name": "[concat(variables('databaseServerName'), '/Microsoft.Authorization/DbProtection')]",
+            "type": "Microsoft.DBforPostgreSQL/servers/providers/locks",
+            "properties": {
+                "level": "CanNotDelete",
+		"notes": "Prevents accidental deletion of the Postgres database and its backups."
+            },
+            "dependsOn": [
+		"postgresql-database",
+                "postgresql-server-firewall-rules"
+            ]
         }
     ],
     "outputs": {

--- a/azure/template.json
+++ b/azure/template.json
@@ -1001,10 +1001,10 @@
             "type": "Microsoft.DBforPostgreSQL/servers/providers/locks",
             "properties": {
                 "level": "CanNotDelete",
-		"notes": "Prevents accidental deletion of the Postgres database and its backups."
+                "notes": "Prevents accidental deletion of the Postgres database and its backups."
             },
             "dependsOn": [
-		"postgresql-database",
+                "postgresql-database",
                 "postgresql-server-firewall-rules"
             ]
         }


### PR DESCRIPTION
### Context

At the present time if anyone were to accidentally delete the database associated with any or our subscriptions we would also loose the Azure maintained backups of that database.

### Changes proposed in this pull request

- Add a resource lock to prevent accidental deletion of the database resource. To delete the database or any of its config the lock must first be deleted. The lock can then be reinstated manually or alternatively automatically upon the next run of the pipeline.

### Guidance to review

The delete lock has been tested on the s106d02-apply-psql database in the DevOps environment. You can confirm the effect of this resource lock by attempting to delete that database.

### Link to Trello card

[1324 - Add resource lock on production database](https://trello.com/c/dTPjQxYP/1324-add-resource-lock-on-production-database)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
