### PR TITLE
Style autocomplete error state

### DIFF
--- a/app/frontend/styles/_autocomplete.scss
+++ b/app/frontend/styles/_autocomplete.scss
@@ -1,0 +1,18 @@
+.autocomplete__wrapper,
+.autocomplete__input,
+.autocomplete__hint {
+  font-family: $govuk-font-family;
+}
+
+.govuk-form-group--error {
+  .autocomplete__input--default {
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+  }
+
+  .autocomplete__input--focused {
+    border-color: $govuk-input-border-colour;
+    // Remove `box-shadow` inherited from `:focus` as
+    // `autocomplete__input--default` already has the thicker border.
+    box-shadow: none;
+  }
+}

--- a/app/frontend/styles/_related.scss
+++ b/app/frontend/styles/_related.scss
@@ -1,0 +1,8 @@
+.app-related {
+  border-top: 2px solid $govuk-brand-colour;
+  padding-top: govuk-spacing(3);
+}
+
+.app-related + .app-related {
+  border-top-color: transparent;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -10,25 +10,14 @@ $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
+@import "_autocomplete";
 @import "_banner";
+@import "_cookie-banner";
 @import "_environments";
 @import "_footer";
+@import "_related";
 @import "_status-box";
 @import "_styled-content";
 @import "_summary-card";
 @import "_tag";
 @import "_task-list";
-@import "_cookie-banner";
-
-.autocomplete__wrapper, .autocomplete__input, .autocomplete__hint {
-  font-family: $govuk-font-family;
-}
-
-.app-related {
-  border-top: 2px solid $govuk-brand-colour;
-  padding-top: govuk-spacing(3);
-}
-
-.app-related + .app-related {
-  border-top-color: transparent;
-}


### PR DESCRIPTION
### Context

Not sure if there’s a better way of doing this (applying a class via JS?), but for now, this CSS solution styles the autocomplete input based on whether it’s parent is `govuk-form-group--error`.

Also moves `.app-related` styles into their own file.

### Changes proposed in this pull request

Before:

![image](https://user-images.githubusercontent.com/813383/69749154-c8f0eb80-1141-11ea-89bd-9a858b24136a.png)

After:

<img width="670" alt="Screenshot 2019-11-27 at 18 14 49" src="https://user-images.githubusercontent.com/813383/69749184-d908cb00-1141-11ea-8e3f-1a5504997372.png">

### Link to Trello card

[445 - Personal details autocomplete error not highlighted](https://trello.com/c/OwDs7lVS/)
