### PR TITLE
Add test helpers for Slack notifications

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@ FIND_BASE_URL=http://find-test/api/v3/
 SUPPORT_USERNAME=test
 SUPPORT_PASSWORD=test
 HOSTING_ENVIRONMENT_NAME=test
+STATE_CHANGE_SLACK_URL=https://example.com/slack-webhook

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,3 +69,7 @@ RSpec/PredicateMatcher:
 
 RSpec/DescribeClass:
   Enabled: false
+
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - 'spec/support/slack_notifications.rb'

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,0 +1,7 @@
+RSpec.configure do |config|
+  config.around sidekiq: true do |example|
+    Sidekiq::Testing.inline! do
+      example.run
+    end
+  end
+end

--- a/spec/support/slack_notifications.rb
+++ b/spec/support/slack_notifications.rb
@@ -1,0 +1,12 @@
+RSpec.configure do |config|
+  config.before do
+    stub_request(:post, 'https://example.com/slack-webhook').
+      to_return(status: 200, body: '{}')
+  end
+
+  def expect_slack_message_with_text(text)
+    expect(WebMock).to have_requested(:post, 'https://example.com/slack-webhook').with { |req|
+      JSON.parse(req.body)['text'].match(text)
+    }
+  end
+end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application' do
+RSpec.feature 'Candidate submits the application', sidekiq: true do
   include CandidateHelper
 
   scenario 'Candidate with a completed application' do
@@ -26,6 +26,7 @@ RSpec.feature 'Candidate submits the application' do
     and_i_can_see_my_support_ref
     and_i_receive_an_email_with_my_support_ref
     and_my_referees_receive_a_request_for_a_reference_by_email
+    and_a_slack_notification_is_sent
 
     when_i_click_on_track_your_application
     then_i_can_see_my_application_dashboard
@@ -119,6 +120,10 @@ RSpec.feature 'Candidate submits the application' do
       expect(current_email).to have_content "Give a reference for #{current_application.first_name}"
       expect(current_email).to have_content reference.name
     end
+  end
+
+  def and_a_slack_notification_is_sent
+    expect_slack_message_with_text 'Lando has just submitted their application'
   end
 
   def when_i_click_on_track_your_application


### PR DESCRIPTION
### Context

Extracted from https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/744 to avoid that PR from getting too big.

### Changes proposed in this pull request

These helpers make it easier to make sure we're sending the correct Slack messages in system tests. Used in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/744 to test new messages when candidates accept & decline offers.

### Guidance to review

Does this make sense?

### Link to Trello card

https://trello.com/c/gg1hElnB/361-candidates-can-accept-an-offer