### PR TITLE
Display user progress stats in the support console

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class PerformanceController < SupportInterfaceController
+    def index
+      @statistics = PerformanceStatistics.new
+    end
+  end
+end

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -1,0 +1,35 @@
+class PerformanceStatistics
+  QUERY = "
+  WITH raw_data AS (
+      SELECT
+          COUNT(c.id) FILTER (WHERE f.id IS NOT NULL) candidate_forms,
+          SUM(CASE WHEN f.id IS NOT NULL AND f.created_at < f.updated_at THEN 1 ELSE 0 END) candidate_started_form_count,
+          SUM(CASE WHEN f.id IS NOT NULL AND f.submitted_at IS NOT NULL THEN 1 ELSE 0 END) candidate_submitted_form_count
+      FROM
+          candidates c
+      LEFT JOIN
+          application_forms f ON f.candidate_id = c.id
+      WHERE
+          c.email_address NOT LIKE '%education.gov.uk%'
+      GROUP BY
+          c.id
+  )
+  SELECT
+      COUNT(*) AS total_non_dfe_sign_ups,
+      SUM(CASE WHEN candidate_forms = 0 THEN 1 ELSE 0 END) AS candidates_signed_up_but_not_signed_in,
+      SUM(CASE WHEN candidate_forms > 0 AND candidate_started_form_count = 0 THEN 1 ELSE 0 END) AS candidates_signed_in_but_not_entered_data,
+      SUM(CASE WHEN candidate_started_form_count > 0 AND candidate_submitted_form_count = 0 THEN 1 ELSE 0 END) AS candidates_with_unsubmitted_forms,
+      SUM(CASE WHEN candidate_submitted_form_count > 0 THEN 1 ELSE 0 END) AS candidates_with_submitted_forms
+  FROM
+      raw_data".freeze
+
+  def [](key)
+    results[key.to_s]
+  end
+
+private
+
+  def results
+    @results ||= ActiveRecord::Base.connection.execute(QUERY)[0]
+  end
+end

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -4,4 +4,5 @@
   <%= nav_link 'Vendors', support_interface_manage_vendors_path, active: 'manage_vendors' %>
   <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
   <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
+  <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
 </ul>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,0 +1,40 @@
+<% content_for :title, 'Service performance' %>
+
+<table class="govuk-table govuk-!-width-one-half">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Total sign ups<br>(excluding DfE users)</th>
+      <th scope="row" class="govuk-table__header" id="total-sign-ups">
+        <%= @statistics[:total_non_dfe_sign_ups] %>
+      </th>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Users who signed up but have not signed in</th>
+      <td class="govuk-table__cell">
+        <%= @statistics[:candidates_signed_up_but_not_signed_in] %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Users who have signed in but not entered data</th>
+      <td class="govuk-table__cell">
+        <%= @statistics[:candidates_signed_in_but_not_entered_data] %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Users with unsubmitted forms</th>
+      <td class="govuk-table__cell">
+        <%= @statistics[:candidates_with_unsubmitted_forms] %>
+      </td>
+    </tr>
+    <tr class="govuk-table__row">
+      <th scope="row" class="govuk-table__header">Users with submitted forms</th>
+      <td class="govuk-table__cell">
+        <%= @statistics[:candidates_with_submitted_forms] %>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,8 @@ Rails.application.routes.draw do
     post '/feature-flags/:feature_name/activate' => 'feature_flags#activate', as: :activate_feature_flag
     post '/feature-flags/:feature_name/deactivate' => 'feature_flags#deactivate', as: :deactivate_feature_flag
 
+    get '/performance' => 'performance#index', as: :performance
+
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes
     require 'sidekiq/web'
 

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe PerformanceStatistics, type: :model do
+  it 'excludes candidates with DfE addresses (as they are unlikely to be actually applying)' do
+    create(:candidate, email_address: 'ab@c.com')
+    create(:candidate, email_address: 'a.person@education.gov.uk')
+    create(:candidate, email_address: 'another.person@digitial.education.gov.uk')
+
+    stats = PerformanceStatistics.new
+
+    expect(stats[:total_non_dfe_sign_ups]).to eq(1)
+  end
+
+  it 'includes only those users in each category' do
+    create(:candidate)
+    create_list(:application_form, 2)
+    create_list(:application_form, 3, updated_at: 3.minutes.from_now) # changed forms
+    create_list(:completed_application_form, 4, updated_at: 3.minutes.from_now)
+
+    stats = PerformanceStatistics.new
+
+    expect(stats[:total_non_dfe_sign_ups]).to eq(10)
+    expect(stats[:candidates_signed_up_but_not_signed_in]).to eq(1)
+    expect(stats[:candidates_signed_in_but_not_entered_data]).to eq(2)
+    expect(stats[:candidates_with_unsubmitted_forms]).to eq(3)
+    expect(stats[:candidates_with_submitted_forms]).to eq(4)
+  end
+end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.feature 'Service performance' do
+  scenario 'View service statistics' do
+    given_i_am_a_support_user
+    and_there_are_candidates_in_the_system
+
+    when_i_visit_the_service_performance_page
+    then_i_should_see_the_total_count_of_candidates
+  end
+
+  def given_i_am_a_support_user
+    page.driver.browser.authorize('test', 'test')
+  end
+
+  def and_there_are_candidates_in_the_system
+    create_list(:candidate, 2)
+  end
+
+  def when_i_visit_the_service_performance_page
+    visit support_interface_performance_path
+  end
+
+  def then_i_should_see_the_total_count_of_candidates
+    within '#total-sign-ups' do
+      expect(page).to have_content '2'
+    end
+  end
+end


### PR DESCRIPTION
### Context

The product and support team needs a snapshot view of where candidates are in the application process.

### Changes proposed in this pull request

Add a table of service stats in the support console:

![image](https://user-images.githubusercontent.com/23801/69859665-7cfe8d80-128c-11ea-894b-c987cf761d82.png)

### Guidance to review

- These are the initial stats for right this minute. Subsequent PRs will add:
  - more stats for later stages of the application process
  - some kind of Slack integration so the stats can be automatically posted on a daily basis
- We try not to count DfE users in the stats since they're very unlikely to be lodging real applications, but rather exploring the service

### Link to Trello card

https://trello.com/c/asLhnXMe/398-show-performance-metrics-in-the-support-console