### PR TITLE
Add conditional showing of Science GCSE on Your application page

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
       return redirect_to candidate_interface_application_form_path if params[:token]
 
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+      @application_form = current_application
     end
 
     def review

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -124,7 +124,7 @@ module VendorApi
 
     def qualifications
       {
-        gcses: application_form.application_qualifications.gcses.map do |gcse| qualification_to_hash(gcse) end,
+        gcses: application_form.application_qualifications.gcses.order(:subject).map do |gcse| qualification_to_hash(gcse) end,
         degrees: application_form.application_qualifications.degrees.map do |degree| qualification_to_hash(degree) end,
         other_qualifications: application_form.application_qualifications.other.map do |other| qualification_to_hash(other) end,
       }

--- a/app/services/check_science_gcse_is_needed.rb
+++ b/app/services/check_science_gcse_is_needed.rb
@@ -1,0 +1,9 @@
+class CheckScienceGcseIsNeeded
+  class << self
+    def call(application_form)
+      application_form.application_choices.any? do |application_choice|
+        application_choice.course_option.course.primary_course?
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -50,9 +50,11 @@
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent, text: 'English GCSE or equivalent', completed: @application_form_presenter.english_gcse_completed?, path: @application_form_presenter.english_gcse_completed? ? candidate_interface_gcse_review_path(subject: :english) : candidate_interface_gcse_details_edit_type_path(subject: :english)) %>
       </li>
-      <li class="app-task-list__item">
-        <%= render(TaskListItemComponent, text: 'Science GCSE or equivalent', completed: @application_form_presenter.science_gcse_completed?, path: @application_form_presenter.science_gcse_completed? ? candidate_interface_gcse_review_path(subject: :science) : candidate_interface_gcse_details_edit_type_path(subject: :science)) %>
-      </li>
+      <% if CheckScienceGcseIsNeeded.call(@application_form) %>
+        <li class="app-task-list__item">
+          <%= render(TaskListItemComponent, text: 'Science GCSE or equivalent', completed: @application_form_presenter.science_gcse_completed?, path: @application_form_presenter.science_gcse_completed? ? candidate_interface_gcse_review_path(subject: :science) : candidate_interface_gcse_details_edit_type_path(subject: :science)) %>
+        </li>
+      <% end %>
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent, text: t('page_titles.other_qualification'), completed: @application_form_presenter.other_qualifications_completed?, path: @application_form_presenter.other_qualification_path, show_incomplete: false) %>
       </li>

--- a/spec/services/check_science_gcse_is_needed_spec.rb
+++ b/spec/services/check_science_gcse_is_needed_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe CheckScienceGcseIsNeeded do
+  describe '.call' do
+    context 'when a candidate has no course choices' do
+      it 'returns false' do
+        application_form = build_stubbed(:application_form)
+
+        science_gcse_is_needed = CheckScienceGcseIsNeeded.call(application_form)
+
+        expect(science_gcse_is_needed).to eq(false)
+      end
+    end
+
+    context 'when a candidate has a course choice that is primary' do
+      it 'returns true' do
+        application_form = application_form_with_course_option_for_provider_with(level: 'primary')
+
+        science_gcse_is_needed = CheckScienceGcseIsNeeded.call(application_form)
+
+        expect(science_gcse_is_needed).to eq(true)
+      end
+    end
+
+    context 'when a candidate has a course choice that is secondary' do
+      it 'returns false' do
+        application_form = application_form_with_course_option_for_provider_with(level: 'secondary')
+
+        science_gcse_is_needed = CheckScienceGcseIsNeeded.call(application_form)
+
+        expect(science_gcse_is_needed).to eq(false)
+      end
+    end
+
+    context 'when a candidate has a course choice that is further education' do
+      it 'returns false' do
+        application_form = application_form_with_course_option_for_provider_with(level: 'further_education')
+
+        science_gcse_is_needed = CheckScienceGcseIsNeeded.call(application_form)
+
+        expect(science_gcse_is_needed).to eq(false)
+      end
+    end
+
+    def application_form_with_course_option_for_provider_with(level:)
+      provider = build(:provider)
+      course = create(:course, level: level, provider: provider)
+      site = create(:site, provider: provider)
+      course_option = create(:course_option, course: course, site: site)
+      application_form = create(:application_form)
+
+      create(
+        :application_choice,
+        application_form: application_form,
+        course_option: course_option,
+      )
+
+      application_form
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_a_science_gcse_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate entering Science GCSE' do
+  include CandidateHelper
+
+  scenario 'Candidate enters a Science GCSE' do
+    given_i_am_signed_in
+    when_i_visit_the_site
+    then_i_dont_see_science_gcse
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_dont_see_science_gcse
+    expect(page).not_to have_content('Science GCSE or equivalent')
+  end
+end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -91,15 +91,6 @@ RSpec.feature 'Vendor receives the application' do
           gcses: [
             {
               qualification_type: 'gcse',
-              subject: 'science',
-              grade: 'B',
-              award_year: '1990',
-              institution_details: nil,
-              awarding_body: nil,
-              equivalency_details: nil,
-            },
-            {
-              qualification_type: 'gcse',
               subject: 'english',
               grade: 'B',
               award_year: '1990',
@@ -115,8 +106,17 @@ RSpec.feature 'Vendor receives the application' do
               institution_details: nil,
               awarding_body: nil,
               equivalency_details: nil,
-              },
-            ],
+            },
+            {
+              qualification_type: 'gcse',
+              subject: 'science',
+              grade: 'B',
+              award_year: '1990',
+              institution_details: nil,
+              awarding_body: nil,
+              equivalency_details: nil,
+            },
+          ],
          degrees: [
            {
               qualification_type: 'BA',


### PR DESCRIPTION
### Context

A candidate is only required to have a Science GCSE if the level of the course they have chosen is a primary one. Currently, we always show the Science GCSE section on the `Your application` page but this should be conditional on the courses chosen.

### Changes proposed in this pull request

This PR adds the showing of Science GCSE on the `Your application` page by using a new service called `CheckScienceGcseIsNeeded`. This returns `true` if any of courses chosen are primary and `false` for any other level.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/69864394-bfc56300-1296-11ea-9c61-8cad62dd490a.png)

### Guidance to review

Is a service the right way to go? I expect we can use this service when figuring out when Science GCSE is needed elsewhere.

Upcoming PRs will look at not showing it in the application review and not validating it at submission.

### Link to Trello card

[401 - Primary course conditional](https://trello.com/c/cTiIxGpC/401-primary-course-conditional)
