### PR TITLE
Fix referee review page title, and add missing space

### DIFF
--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -25,6 +25,6 @@
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
     <p class="govuk-body">You have 5 working days to make changes to a submitted application. We won't send your application to your training provider(s) until the 5 working days are up.</p>
-    <p class="govuk-body">To edit your application, return to your<%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_form_path %>.</p>
+    <p class="govuk-body">To edit your application, return to your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_form_path %>.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/referees/index.html.erb
+++ b/app/views/candidate_interface/referees/index.html.erb
@@ -4,17 +4,17 @@
   <div class="govuk-grid-column-two-thirds">
 
     <% if @referees.empty? %>
-      <% content_for :title, t('page_titles.referees') %>
+      <% content_for :title, t('page_titles.referees_choosing') %>
       <h1 class="govuk-heading-xl">
-        <%= t('page_titles.referees') %>
+        <%= t('page_titles.referees_choosing') %>
       </h1>
       <%= render partial: 'intro' %>
     <% else %>
       <%= render(RefereesReviewComponent, application_form: @application_form) %>
 
-      <% content_for :title, t('page_titles.review_referees') %>
+      <% content_for :title, t('page_titles.referees') %>
       <h1 class="govuk-heading-xl">
-        <%= t('page_titles.review_referees') %>
+        <%= t('page_titles.referees') %>
       </h1>
       <%= govuk_button_link_to t('application_form.referees.review.button'), candidate_interface_application_form_path %>
     <%- end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,7 +60,8 @@ en:
     add_volunteering_role: Add role
     edit_volunteering_role: Edit role
     destroy_volunteering_role: Are you sure you want to delete this role?
-    referees: Choosing your referees
+    referees: Referees
+    referees_choosing: Choosing your referees
     referee_destroy: Are you sure you want to delete this referee?
     add_referee: Details of referee
     nth_referee:


### PR DESCRIPTION
- Use correct title when reviewing referees
- Add missing space on application submitted page
