### PR TITLE
Split index and review pages for course choices

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -4,13 +4,12 @@ module CandidateInterface
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def index
-      @application_form = current_application
       @course_choices = current_candidate.current_application.application_choices
-      @page_title = if @course_choices.count < 1
-                      I18n.t!('page_titles.choosing_courses')
-                    else
-                      I18n.t!('page_titles.course_choices')
-                    end
+      if @course_choices.count < 1
+        render :index
+      else
+        redirect_to candidate_interface_course_choices_review_path
+      end
     end
 
     def have_you_chosen
@@ -92,6 +91,11 @@ module CandidateInterface
       end
     end
 
+    def review
+      @application_form = current_application
+      @course_choices = current_candidate.current_application.application_choices
+    end
+
     def confirm_destroy
       @course_choice = current_candidate.current_application.application_choices.find(params[:id])
     end
@@ -112,7 +116,7 @@ module CandidateInterface
         redirect_to candidate_interface_application_form_path
       else
         @course_choices = current_candidate.current_application.application_choices
-        render :index
+        render :review
       end
     end
 

--- a/app/views/candidate_interface/course_choices/index.html.erb
+++ b/app/views/candidate_interface/course_choices/index.html.erb
@@ -1,44 +1,12 @@
-<% content_for :title, @page_title %>
+<% content_for :title, t('page_titles.choosing_courses') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
-  <%= @page_title %>
-</h1>
-
-<%= form_with model: @application_form, url: candidate_interface_course_choices_complete_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
-  <%= f.govuk_error_summary %>
-
-  <%= render(CourseChoicesReviewComponent, application_form: @application_form) %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <% if @course_choices.count.present? %>
-        <% if @course_choices.count < 1 %>
-          <%= render 'guidance' %>
-          <%= link_to 'Continue', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-!-margin-bottom-9' %>
-        <% end %>
-
-        <% if @course_choices.count.between?(1, 2) %>
-          <h2 class="govuk-heading-m">Do you want to add another course?</h2>
-          <%= render 'guidance' %>
-          <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
-        <% end %>
-
-        <% if @course_choices.count >= 1 %>
-          <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: {} do %>
-            <%= f.hidden_field :course_choices_completed, value: false %>
-            <%= f.govuk_check_box :course_choices_completed,
-                                  true,
-                                  multiple: false,
-                                  link_errors: true,
-                                  label: {
-                                    text: t('application_form.courses.complete.completed_checkbox'),
-                                  } %>
-          <% end %>
-
-          <%= f.govuk_submit 'Continue' %>
-        <% end %>
-      </div>
-    </div>
-  <% end %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.choosing_courses') %>
+    </h1>
+    <%= render 'guidance' %>
+    <%= link_to 'Continue', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-!-margin-bottom-9' %>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/review.html.erb
+++ b/app/views/candidate_interface/course_choices/review.html.erb
@@ -1,0 +1,39 @@
+<% content_for :title, t('page_titles.course_choices') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.course_choices') %>
+</h1>
+
+<%= form_with model: @application_form, url: candidate_interface_course_choices_complete_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= render(CourseChoicesReviewComponent, application_form: @application_form) %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <% if @course_choices.count.present? %>
+        <% if @course_choices.count.between?(1, 2) %>
+          <h2 class="govuk-heading-m">Do you want to add another course?</h2>
+          <%= render 'guidance' %>
+          <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
+        <% end %>
+
+        <% if @course_choices.count >= 1 %>
+          <%= f.govuk_check_boxes_fieldset :course_choices_completed, legend: {} do %>
+            <%= f.hidden_field :course_choices_completed, value: false %>
+            <%= f.govuk_check_box :course_choices_completed,
+                                  true,
+                                  multiple: false,
+                                  link_errors: true,
+                                  label: {
+                                    text: t('application_form.courses.complete.completed_checkbox'),
+                                  } %>
+          <% end %>
+
+          <%= f.govuk_submit 'Continue' %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -154,7 +154,8 @@ Rails.application.routes.draw do
         get '/provider/:provider_code/courses/:course_code' => 'course_choices#options_for_site', as: :course_choices_site
         post '/provider/:provider_code/courses/:course_code' => 'course_choices#pick_site'
 
-        patch '/complete' => 'course_choices#complete', as: :course_choices_complete
+        get '/review' => 'course_choices#review', as: :course_choices_review
+        patch '/review' => 'course_choices#complete', as: :course_choices_complete
       end
 
       scope '/choice/:id' do


### PR DESCRIPTION
### Context

When first visiting the section on course choices, you are presented with guidance only. This has a different layout, and doesn’t require a form. When you return to this page with a choice(s), there is a mix of guidance and summary cards, and the page needs to be a form. Seems right that these two views be separated.

### Link to Trello card

[429 - Choose courses unnecessary form](https://trello.com/c/BleTTQX5/)
