### PR TITLE
Use `govuk_button_link_to` button helper, add (missing) localisation strings

### DIFF
--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -7,12 +7,12 @@
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
        You can apply for this course using a new GOV.UK service
     </h1>
+
     <p class="govuk-body">
       <%= service_name %> is a streamlined new GOV.UK service which is
       designed to make application easier. It comes with personalised support
       for candidates.
     </p>
-
     <p class="govuk-body">
       <a class="govuk-link" href="https://getintoteaching.education.gov.uk/the-way-you-apply-for-teacher-training-is-changing">
         Learn more about changes to teacher training applications
@@ -20,24 +20,29 @@
     </p>
 
     <h2 class="govuk-heading-l">Is this new service right for you?</h2>
-
-    <p class="govuk-body"><%= service_name %> is still in development. The service will eventually replace UCAS as the way candidates apply for teacher training. However, for now, it is limited to just a few courses.</p>
-
-    <p class='govuk-body'>
+    <p class="govuk-body">
+      <%= service_name %> is still in development. The service will eventually
+      replace UCAS as the way candidates apply for teacher training. However,
+      for now, it is limited to just a few courses.
+    </p>
+    <p class="govuk-body">
       You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.
     </p>
+    <p class="govuk-body">
+      For most courses, you’ll still need to apply through UCAS.
+    </p>
+    <p class="govuk-body">
+      Additionally, the service isn’t ready yet for international candidates or
+      candidates who’ve studied outside the UK.
+    </p>
 
-    <p class="govuk-body">For most courses, you’ll still need to apply through UCAS.</p>
+    <p class="govuk-body">
+      <%= govuk_button_link_to t('apply_from_find.apply_button'), candidate_interface_eligibility_path, class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-3' %>
+    </p>
 
-    <p class="govuk-body">Additionally, the service isn’t ready yet for international candidates or candidates who’ve studied outside the UK.</p>
+    <p class="govuk-body">or</p>
 
-    <a href="<%= candidate_interface_eligibility_path %>" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3">
-      Apply through the new service
-    </a>
-
-    <p class='govuk-body'>or</p>
-
-    <p class='govuk-body'>
+    <p class="govuk-body">
       <%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %>
     </p>
   </div>

--- a/app/views/candidate_interface/course_choices/index.html.erb
+++ b/app/views/candidate_interface/course_choices/index.html.erb
@@ -7,6 +7,6 @@
       <%= t('page_titles.choosing_courses') %>
     </h1>
     <%= render 'guidance' %>
-    <%= link_to 'Continue', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-!-margin-bottom-9' %>
+    <%= govuk_button_link_to 'Continue', candidate_interface_course_choices_choose_path, class: 'govuk-!-margin-bottom-9' %>
   </div>
 </div>

--- a/app/views/candidate_interface/referees/_intro.html.erb
+++ b/app/views/candidate_interface/referees/_intro.html.erb
@@ -27,6 +27,6 @@
 
 <p class="govuk-body">If your referees don’t respond, we’ll get back in touch with you to ask for a replacement.</p>
 
-<a href="<%= candidate_interface_new_referee_path %>" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-  Continue
-</a>
+<p class="govuk-body">
+  <%= govuk_button_link_to 'Continue', candidate_interface_new_referee_path %>
+</p>

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -10,7 +10,7 @@
 <%- if @referees.count < ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 <p>
   <% if @referees.any? %>
-    <%= govuk_button_link_to 'Add a second referee', candidate_interface_new_referee_path, class: 'govuk-button--secondary' %>
+    <%= govuk_button_link_to t('application_form.referees.add_second_referee'), candidate_interface_new_referee_path, class: 'govuk-button--secondary' %>
   <% else %>
     <%= govuk_button_link_to t('application_form.referees.add_referee'), candidate_interface_new_referee_path, class: 'govuk-button--secondary' %>
   <% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -269,6 +269,8 @@ en:
         button: Continue
         completed_checkbox: I have completed this section
     referees:
+      add_referee: Add referee
+      add_second_referee: Add a second referee
       complete_form_button: Save and continue
       delete: Delete referee
       email_address:

--- a/config/locales/apply_from_find.yml
+++ b/config/locales/apply_from_find.yml
@@ -2,5 +2,6 @@ en:
   apply_from_find:
     heading: Apply for this course
     ucas_apply_button: Apply through UCAS
+    apply_button: Apply through the new service
     find_button: Find postgraduate teacher training
     heading_not_found: We couldn’t find the course you’re looking for


### PR DESCRIPTION
### Context

Use `govuk_button_link_to` for few places we have a green button links but helper not used. In addition:

* standardises white space/wrapping on `apply_on_ucas_or_apply.html.erb`
* localises `Apply through the new service` as `apply_from_find.apply_button`
* localises `Add a second referee` as `application_form.referees.add_second_referee`
* adds missing localisation for `application_form.referees.add_referee`
