### PR TITLE
Downcase candidate email_address before saving/comparing

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -2,7 +2,9 @@ class Candidate < ApplicationRecord
   # Only Devise's :timeoutable module is enabled to handle session expiry
   # Custom Warden strategy is used instead see app/warden/magic_link_token.rb
   devise :timeoutable
-  validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
+
+  before_validation :downcase_email
+  validates :email_address, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 250 }
   validates :email_address, email_address: true
 
   has_many :application_forms
@@ -10,5 +12,11 @@ class Candidate < ApplicationRecord
   def current_application
     application_form = application_forms.first_or_create!
     application_form
+  end
+
+private
+
+  def downcase_email
+    email_address.try(:downcase!)
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Candidate, type: :model do
   describe 'a valid candidate' do
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
-    it { is_expected.to validate_uniqueness_of :email_address }
+    it { is_expected.to validate_uniqueness_of(:email_address).case_insensitive }
     it { is_expected.not_to allow_value(Faker::Lorem.characters(number: 251)).for(:email_address) }
   end
 


### PR DESCRIPTION
### Context

People are able to sign up twice with the same email_address (just different case).

### Changes proposed in this pull request

The downcase of email_address before saving to database or comparing for uniqueness.

### Guidance to review

Try to sign up with same email address in different case.

### Link to Trello card

[586 - Emails should be downcased before saving/comparing to the database](https://trello.com/c/OTOi5VAI)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
