### PR TITLE
Adjust responsiveness of task list component

### DIFF
--- a/app/frontend/styles/_task-list.scss
+++ b/app/frontend/styles/_task-list.scss
@@ -8,16 +8,15 @@
 .app-task-list__item {
   border-bottom: 1px solid $govuk-border-colour;
   margin-bottom: 0 !important;
-  padding-top: govuk-spacing(2);
-  padding-bottom: govuk-spacing(2);
+  padding-top: govuk-spacing(1);
+  padding-bottom: govuk-spacing(1);
   @include govuk-clearfix;
 
   .govuk-tag {
-    @include govuk-media-query($until: 450px) {
-      margin-top: govuk-spacing(2);
-    }
+    margin-top: govuk-spacing(1);
+    margin-bottom: govuk-spacing(1);
 
-    @include govuk-media-query($from: 450px) {
+    @include govuk-media-query($from: tablet) {
       float: right;
     }
   }
@@ -29,7 +28,11 @@
 
 .app-task-list__task-name {
   display: block;
-  @include govuk-media-query($from: 450px) {
+  padding: govuk-spacing(1);
+  padding-left: 0;
+  padding-right: govuk-spacing(2);
+
+  @include govuk-media-query($from: tablet) {
     float: left;
   }
 }


### PR DESCRIPTION
### Context

Prevent link text running into tag. Also increases tappable size of the link, by adding additional padding.

### Changes proposed in this pull request

Before:

<img width="457" alt="responsive_labelling" src="https://user-images.githubusercontent.com/813383/69879464-69204f00-12bf-11ea-94ea-f518dfc26353.png">

After: 

<img width="570" alt="Screenshot 2019-11-29 at 15 43 53" src="https://user-images.githubusercontent.com/813383/69879473-72112080-12bf-11ea-94d0-2768e186f2f8.png">

### Guidance to review

We could do smarter layout with a flex-based layout, not sure if we want to do that (maybe with this as a fallback) @fofr

### Link to Trello card

[577 - Responsive design for application page](https://trello.com/c/Jm7scXiA/)
