### PR TITLE
Asynchronous email sending

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: SERVICE_TYPE=web bundle exec puma -C config/puma.rb
-worker: SERVICE_TYPE=worker bundle exec sidekiq -c 5
+worker: SERVICE_TYPE=worker bundle exec sidekiq -c 5 -C config/sidekiq.yml
 clock: SERVICE_TYPE=clock bundle exec clockwork config/clock.rb

--- a/README.md
+++ b/README.md
@@ -40,12 +40,15 @@ A service for candidates to apply for initial teacher training.
 - Yarn 1.12.x
 - PostgreSQL 9.6
 - Graphviz 2.22+ (`brew install graphviz`) to generate the [domain model diagram](#domain-model)
+- Redis 5.0.x
 
 ## <a name="dev-prerequisites"></a>Prerequisites for development
 
 `docker` and `docker-compose`
 
 ## <a name="dev-env-setup"></a>Setting up the development environment
+
+If you are not planning to run the server processes in docker:
 
 1. Copy `.env.example` to `.env` and fill in the secrets
 1. Run `make setup`
@@ -56,6 +59,16 @@ See `Makefile` for the steps involved in building and running the app.
 The course and training provider data in the `Apply` service comes from its
 sister service `Find`. To populate your local database with course data from
 `Find`, run `bundle exec rake setup_local_dev_data`.
+
+### Background processing
+
+Certain features depend on Sidekiq running. e.g. Mailers and some of the
+business rules that set time-dependent state on applications. In order
+to run a local version of you need to make sure Redis is installed and
+running and then run Sidekiq. The simplest way to do that is with
+`docker-compose` (see below) or `foreman`. e.g.
+
+    $ foreman start
 
 ## <a name="docker-workflow"></a>Docker Workflow
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ A service for candidates to apply for initial teacher training.
 
 ## <a name="dev-env-setup"></a>Setting up the development environment
 
-If you are not planning to run the server processes in docker:
-
 1. Copy `.env.example` to `.env` and fill in the secrets
 1. Run `make setup`
 1. Run `make serve` to launch the app on https://localhost:3000

--- a/adr/0009-async-and-scheduled-jobs.md
+++ b/adr/0009-async-and-scheduled-jobs.md
@@ -60,7 +60,7 @@ While it is technically possible to perform any kind of processing within the 'c
 
 #### Background processing
 
-We will use the ```sidekiq``` gem, which is the current standard for Rails background processing. This also needs to be run as a separate process (e.g. ```bundle exec sidekiq -c 5```, where 5 is a concurrency setting), but it also introduces an infrastructure requirement for Redis.
+We will use the ```sidekiq``` gem, which is the current standard for Rails background processing. This also needs to be run as a separate process (e.g. ```bundle exec sidekiq -c 5 -C sidekiq.yml```, where 5 is a concurrency setting), but it also introduces an infrastructure requirement for Redis.
 
 Workers are usually placed within ```app/workers``` and can call any other classes within the Rails app, such as service objects to achieve their goals.
 

--- a/app/services/magic_link_sign_in.rb
+++ b/app/services/magic_link_sign_in.rb
@@ -1,7 +1,7 @@
 class MagicLinkSignIn
   def self.call(candidate:)
     magic_link_token = MagicLinkToken.new
-    AuthenticationMailer.sign_in_email(to: candidate.email_address, token: magic_link_token.raw).deliver_now
+    AuthenticationMailer.sign_in_email(to: candidate.email_address, token: magic_link_token.raw).deliver_later
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
   end
 end

--- a/app/services/magic_link_sign_up.rb
+++ b/app/services/magic_link_sign_up.rb
@@ -1,7 +1,7 @@
 class MagicLinkSignUp
   def self.call(candidate:)
     magic_link_token = MagicLinkToken.new
-    AuthenticationMailer.sign_up_email(to: candidate.email_address, token: magic_link_token.raw).deliver_now
+    AuthenticationMailer.sign_up_email(to: candidate.email_address, token: magic_link_token.raw).deliver_later
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
     StateChangeNotifier.call(:magic_link_sign_up, candidate: candidate)
   end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -13,7 +13,7 @@ class SubmitApplication
       submit_application
     end
 
-    CandidateMailer.submit_application_email(application_form).deliver_now
+    CandidateMailer.submit_application_email(application_form).deliver_later
     send_reference_request_email_to_referees(application_form)
     StateChangeNotifier.call(:submit_application, application_form: application_form)
   end
@@ -22,7 +22,7 @@ private
 
   def send_reference_request_email_to_referees(application_form)
     application_form.references.each do |reference|
-      RefereeMailer.reference_request_email(application_form, reference).deliver_now
+      RefereeMailer.reference_request_email(application_form, reference).deliver_later
     end
   end
 

--- a/azure/template.json
+++ b/azure/template.json
@@ -632,7 +632,7 @@
                         "value": "[parameters('ciWorkerMemory')]"
                     },
 		    "command": {
-		        "value": ["/bin/sh",  "-c", "bundle exec sidekiq -c 5"]
+		        "value": ["/bin/sh",  "-c", "bundle exec sidekiq -c 5 -C config/sidekiq.yml"]
 		    },
                     "environmentVariables": {
                         "value": [

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,7 @@ module ApplyForPostgraduateTeacherTraining
     config.action_view.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 
     config.action_view.raise_on_missing_translations = true
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,7 @@ Rails.application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Forces jobs that are normally queued to Sidekiq to run immediately
+  config.active_job.queue_adapter = :inline
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+---
+:queues:
+  - default
+  - mailers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - REDIS_URL=redis://redis:6379/1
     env_file:
       - .env
-    command: /bin/sh -c "bundle exec sidekiq -c 5"
+    command: /bin/sh -c "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
   clock:
     image: apply-for-postgraduate-teacher-training
     working_dir: /app

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     let(:token) { 'blub' }
     let(:mail) { mailer.sign_up_email(to: 'test@example.com', token: token) }
 
-    before { mail.deliver_now }
+    before { mail.deliver_later }
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('authentication.sign_up.email.subject'))
@@ -26,7 +26,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     let(:token) { 'blub' }
     let(:mail) { mailer.sign_in_email(to: 'test@example.com', token: token) }
 
-    before { mail.deliver_now }
+    before { mail.deliver_later }
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('authentication.sign_in.email.subject'))

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe 'Send submit application email' do
     let(:mail) { mailer.submit_application_email(build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE')) }
 
-    before { mail.deliver_now }
+    before { mail.deliver_later }
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('submit_application_success.email.subject'))


### PR DESCRIPTION
### Context

Sending emails should happen in a worker process rather than the main Web applications because (a) sending emails can be a bit slow so we keep response times snappy by offloading this to a worker and (b) if an email service is down at the first attempt we can try again later in a worker by just re-queueing the job.

### Changes proposed in this pull request

- [x] Configure ActiveJob to use sidekiq
- [x] Setup a `mailer` queue in Sidekiq (because this is what ActionMailer/ActiveJob use by default)
- [x] Switch all the calls to `deliver_now` to `deliver_later` so that they are queued to Sidekiq rather than executed inline.
- [x] Configure ActiveJob to run jobs immediately (`inline`) in tests
- [x] Update README

### Guidance to review

- Are there any gotchas relating to mailers working asynchronously?
- Have I covered them all?
- Is the change to Azure config right? (All I'm trying to do here is pass an extra command line arg to `sidekiq` for the config file)
- There are no new tests here - it's just reconfiguring existing functionality. Is there any other testing we can do?
- One inconvenience caused by this change is that in a dev environment you can no longer pick the magic sign-up link from the Rails log without Sidekiq and Redis running too. Do we need a way to bypass Sidekiq in dev (perhaps driven by an opt-in env var) so that things jobs run inline for simplicity?

### Link to Trello card

[1311 - Async Email Sending](https://trello.com/c/bwA7j7wa/1311-async-email-sending)

### Env vars

No new env vars.
