### PR TITLE
Make missing banners red if showing errors

### DIFF
--- a/app/components/becoming_a_teacher_review_component.html.erb
+++ b/app/components/becoming_a_teacher_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :becoming_a_teacher, section_path: candidate_interface_becoming_a_teacher_edit_path) %>
+  <%= render(SectionMissingBannerComponent, section: :becoming_a_teacher, section_path: candidate_interface_becoming_a_teacher_edit_path, error: @missing_error) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: becoming_a_teacher_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/becoming_a_teacher_review_component.rb
+++ b/app/components/becoming_a_teacher_review_component.rb
@@ -1,12 +1,13 @@
 class BecomingATeacherReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, missing_error: false)
     @application_form = application_form
     @becoming_a_teacher_form = CandidateInterface::BecomingATeacherForm.build_from_application(
       @application_form,
     )
     @editable = editable
+    @missing_error = missing_error
   end
 
   def becoming_a_teacher_form_rows

--- a/app/components/contact_details_review_component.html.erb
+++ b/app/components/contact_details_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :contact_details, section_path: candidate_interface_contact_details_edit_base_path) %>
+  <%= render(SectionMissingBannerComponent, section: :contact_details, section_path: candidate_interface_contact_details_edit_base_path, error: @missing_error) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: contact_details_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/contact_details_review_component.rb
+++ b/app/components/contact_details_review_component.rb
@@ -1,12 +1,13 @@
 class ContactDetailsReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, missing_error: false)
     @application_form = application_form
     @contact_details_form = CandidateInterface::ContactDetailsForm.build_from_application(
       @application_form,
     )
     @editable = editable
+    @missing_error = missing_error
   end
 
   def contact_details_form_rows

--- a/app/components/course_choices_review_component.html.erb
+++ b/app/components/course_choices_review_component.html.erb
@@ -32,5 +32,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :course_choices, section_path: candidate_interface_course_choices_index_path) %>
+  <%= render(SectionMissingBannerComponent, section: :course_choices, section_path: candidate_interface_course_choices_index_path, error: @missing_error) %>
 <% end %>

--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -1,13 +1,14 @@
 class CourseChoicesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, heading_level: 2, show_status: false, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_status: false, show_incomplete: false, missing_error: false)
     @application_form = application_form
     @course_choices = @application_form.application_choices
     @editable = editable
     @heading_level = heading_level
     @show_status = show_status
     @show_incomplete = show_incomplete
+    @missing_error = missing_error
   end
 
   def course_choice_rows(course_choice)

--- a/app/components/degrees_review_component.html.erb
+++ b/app/components/degrees_review_component.html.erb
@@ -14,5 +14,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :degrees, section_path: candidate_interface_degrees_new_base_path) %>
+  <%= render(SectionMissingBannerComponent, section: :degrees, section_path: candidate_interface_degrees_new_base_path, error: @missing_error) %>
 <% end %>

--- a/app/components/degrees_review_component.rb
+++ b/app/components/degrees_review_component.rb
@@ -1,7 +1,7 @@
 class DegreesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
     @application_form = application_form
     @degrees = CandidateInterface::DegreeForm.build_all_from_application(
       @application_form,
@@ -9,6 +9,7 @@ class DegreesReviewComponent < ActionView::Component::Base
     @editable = editable
     @heading_level = heading_level
     @show_incomplete = show_incomplete
+    @missing_error = missing_error
   end
 
   def degree_rows(degree)

--- a/app/components/gcse_qualification_review_component.html.erb
+++ b/app/components/gcse_qualification_review_component.html.erb
@@ -8,7 +8,7 @@
     <%= render(SummaryCardHeaderComponent, title: title, heading_level: @heading_level) %>
   <% end %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym)) %>
+  <%= render(SectionMissingBannerComponent, section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), error: @missing_error) %>
 <% else %>
   <p class="govuk-body">No GCSE entered.</p>
 <% end %>

--- a/app/components/gcse_qualification_review_component.rb
+++ b/app/components/gcse_qualification_review_component.rb
@@ -1,9 +1,10 @@
 class GcseQualificationReviewComponent < ActionView::Component::Base
-  def initialize(application_qualification:, subject:, editable: true, heading_level: 2)
+  def initialize(application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false)
     @application_qualification = application_qualification
     @subject = subject
     @editable = editable
     @heading_level = heading_level
+    @missing_error = missing_error
   end
 
   def gcse_qualification_rows

--- a/app/components/interview_preferences_review_component.html.erb
+++ b/app/components/interview_preferences_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :interview_preferences, section_path: candidate_interface_interview_preferences_edit_path) %>
+  <%= render(SectionMissingBannerComponent, section: :interview_preferences, section_path: candidate_interface_interview_preferences_edit_path, error: @missing_error) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: interview_preferences_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/interview_preferences_review_component.rb
+++ b/app/components/interview_preferences_review_component.rb
@@ -1,12 +1,13 @@
 class InterviewPreferencesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, missing_error: false)
     @application_form = application_form
     @interview_preferences_form = CandidateInterface::InterviewPreferencesForm.build_from_application(
       @application_form,
     )
     @editable = editable
+    @missing_error = missing_error
   end
 
   def interview_preferences_form_rows

--- a/app/components/other_qualifications_review_component.rb
+++ b/app/components/other_qualifications_review_component.rb
@@ -1,13 +1,14 @@
 class OtherQualificationsReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, heading_level: 2)
+  def initialize(application_form:, editable: true, heading_level: 2, missing_error: false)
     @application_form = application_form
     @qualifications = CandidateInterface::OtherQualificationForm.build_all_from_application(
       @application_form,
     )
     @editable = editable
     @heading_level = heading_level
+    @missing_error = missing_error
   end
 
   def other_qualifications_rows(qualification)

--- a/app/components/personal_details_review_component.html.erb
+++ b/app/components/personal_details_review_component.html.erb
@@ -1,7 +1,7 @@
 <% if @personal_details_form.valid? %>
   <%= render(SummaryCardComponent, rows: rows, editable: @editable) %>
 <% elsif @editable %>
-  <%= render(SectionMissingBannerComponent, section: :personal_details, section_path: candidate_interface_personal_details_edit_path) %>
+  <%= render(SectionMissingBannerComponent, section: :personal_details, section_path: candidate_interface_personal_details_edit_path, error: @missing_error) %>
 <% else %>
   <p class="govuk-body">No personal details entered.</p>
 <% end %>

--- a/app/components/personal_details_review_component.rb
+++ b/app/components/personal_details_review_component.rb
@@ -1,12 +1,13 @@
 class PersonalDetailsReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, missing_error: false)
     @application_form = application_form
     @personal_details_form = CandidateInterface::PersonalDetailsForm.build_from_application(
       application_form,
     )
     @editable = editable
+    @missing_error = missing_error
   end
 
   def rows

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -14,5 +14,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :references, section_path: candidate_interface_referees_path, text: t('review_application.references.incomplete', minimum_references: minimum_references)) %>
+  <%= render(SectionMissingBannerComponent, section: :references, section_path: candidate_interface_referees_path, text: t('review_application.references.incomplete', minimum_references: minimum_references), error: @missing_error) %>
 <% end %>

--- a/app/components/referees_review_component.rb
+++ b/app/components/referees_review_component.rb
@@ -1,11 +1,12 @@
 class RefereesReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
     @application_form = application_form
     @editable = editable
     @heading_level = heading_level
     @show_incomplete = show_incomplete
+    @missing_error = missing_error
   end
 
   def referee_rows(work)

--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-banner app-banner--info app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
+<div class="app-banner<% if @error %> app-banner--warning<% end %> app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
     <p class="govuk-body"><%= @text %></p>
     <%= link_to @section_path, class: 'govuk-link' do %>

--- a/app/components/section_missing_banner_component.rb
+++ b/app/components/section_missing_banner_component.rb
@@ -1,10 +1,11 @@
 class SectionMissingBannerComponent < ActionView::Component::Base
   validates :section, :section_path, presence: true
 
-  def initialize(section:, section_path:, text: t("review_application.#{section}.incomplete"))
+  def initialize(section:, section_path:, text: t("review_application.#{section}.incomplete"), error: false)
     @section = section
     @section_path = section_path
     @text = text
+    @error = error
   end
 
   attr_reader :section, :section_path, :text

--- a/app/components/subject_knowledge_review_component.html.erb
+++ b/app/components/subject_knowledge_review_component.html.erb
@@ -1,5 +1,5 @@
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :subject_knowledge, section_path: candidate_interface_subject_knowledge_edit_path) %>
+  <%= render(SectionMissingBannerComponent, section: :subject_knowledge, section_path: candidate_interface_subject_knowledge_edit_path, error: @missing_error) %>
 <% else %>
   <%= render(SummaryCardComponent, rows: subject_knowledge_form_rows, editable: @editable) %>
 <% end %>

--- a/app/components/subject_knowledge_review_component.rb
+++ b/app/components/subject_knowledge_review_component.rb
@@ -1,12 +1,13 @@
 class SubjectKnowledgeReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, missing_error: false)
     @application_form = application_form
     @subject_knowledge_form = CandidateInterface::SubjectKnowledgeForm.build_from_application(
       @application_form,
     )
     @editable = editable
+    @missing_error = missing_error
   end
 
   def subject_knowledge_form_rows

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :volunteering, section_path: candidate_interface_volunteering_experience_path) %>
+  <%= render(SectionMissingBannerComponent, section: :volunteering, section_path: candidate_interface_volunteering_experience_path, error: @missing_error) %>
 <% elsif @application_form.application_volunteering_experiences.empty? %>
   <section class="app-summary-card govuk-!-margin-bottom-6">
     <%= render(SummaryCardHeaderComponent, title: t('application_form.volunteering.no_experience.summary_card_title')) %>

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -1,7 +1,7 @@
 class VolunteeringReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
     @application_form = application_form
     @volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_all_from_application(
       @application_form,
@@ -9,6 +9,7 @@ class VolunteeringReviewComponent < ActionView::Component::Base
     @editable = editable
     @heading_level = heading_level
     @show_incomplete = show_incomplete
+    @missing_error = missing_error
   end
 
   def volunteering_role_rows(volunteering_role)

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -22,5 +22,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :work_experience, section_path: candidate_interface_work_history_length_path) %>
+  <%= render(SectionMissingBannerComponent, section: :work_experience, section_path: candidate_interface_work_history_length_path, error: @missing_error) %>
 <% end %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -1,11 +1,12 @@
 class WorkHistoryReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false)
+  def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
     @application_form = application_form
     @editable = editable
     @heading_level = heading_level
     @show_incomplete = show_incomplete
+    @missing_error = missing_error
   end
 
   def work_experience_rows(work)

--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -33,6 +33,12 @@
 
 .app-banner--warning {
   border-color: govuk-colour("red");
+
+  &.app-banner--missing-section {
+    .app-banner__message p {
+      color: govuk-colour("red");
+    }
+  }
 }
 
 .app-banner__message {

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,53 +1,55 @@
+<% missing_error = @errors && @errors.any? %>
+
 <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
 
-<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true) %>
+<%= render(CourseChoicesReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 
 <h3 class="govuk-heading-m">Personal details</h3>
 
-<%= render(PersonalDetailsReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(PersonalDetailsReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
 
 <h3 class="govuk-heading-m">Contact details</h3>
 
-<%= render(ContactDetailsReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(ContactDetailsReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 
-<%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable) %>
+<%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
 
-<%= render(VolunteeringReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true) %>
+<%= render(VolunteeringReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
 <h3 class="govuk-heading-m">Degree(s)</h3>
 
-<%= render(DegreesReviewComponent, application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true) %>
+<%= render(DegreesReviewComponent, application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error) %>
 
 <h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
 
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4) %>
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error) %>
 
 <h3 class="govuk-heading-m">English GCSE or equivalent</h3>
 
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4) %>
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error) %>
 
 <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
 
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4) %>
+<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error) %>
 
 <h3 class="govuk-heading-m">Other relevant qualifications</h3>
 
-<%= render(OtherQualificationsReviewComponent, application_form: application_form, editable: editable, heading_level: 4) %>
+<%= render(OtherQualificationsReviewComponent, application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
 
-<%= render(BecomingATeacherReviewComponent, application_form: application_form, editable: editable) %>
-<%= render(SubjectKnowledgeReviewComponent, application_form: application_form, editable: editable) %>
-<%= render(InterviewPreferencesReviewComponent, application_form: application_form, editable: editable) %>
+<%= render(BecomingATeacherReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
+<%= render(SubjectKnowledgeReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
+<%= render(InterviewPreferencesReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 
-<%= render(RefereesReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true) %>
+<%= render(RefereesReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error) %>


### PR DESCRIPTION
### Context

If you try to submit an application with incomplete sections, we list all the uncompleted sections at the top of the page in an error summary _and_ use red banners instead of a blue ones to highlight incomplete sections. This PR does that last bit.  

### Changes proposed in this pull request

<img width="1000" alt="Screenshot 2019-11-29 at 18 03 09" src="https://user-images.githubusercontent.com/813383/69884939-b78b1900-12d2-11ea-94a8-8e8680ff31c2.png">

### Guidance to review

I got this working, but my solution seems overly longwinded. Maybe that’s just a symptom of our current review components, which could share more of the same code? Not sure… I’ve probably missed something totally obvious here!

### Link to Trello card

[536 - Review page error states should be red](https://trello.com/c/xYKmsTeC/)
