### PR TITLE
Override currently signed in user when signing in with a different user

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class SignInController < CandidateInterfaceController
     skip_before_action :authenticate_candidate!
-    before_action :redirect_to_application_if_signed_in
+    before_action :redirect_to_application_if_signed_in, except: :authenticate
 
     def new
       @candidate = Candidate.new
@@ -18,6 +18,16 @@ module CandidateInterface
         render 'candidate_interface/shared/check_your_email'
       else
         render :new
+      end
+    end
+
+    def authenticate
+      user = FindCandidateByToken.call(raw_token: params[:token])
+      if user
+        sign_in(user, scope: :candidate)
+        redirect_to candidate_interface_application_form_path
+      else
+        redirect_to action: :new
       end
     end
 

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -1,6 +1,6 @@
 class AuthenticationMailer < ApplicationMailer
   def sign_up_email(to:, token:)
-    @magic_link = "#{candidate_interface_application_form_url}?token=#{token}"
+    @magic_link = "#{candidate_interface_authenticate_url}?token=#{token}"
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: to,
@@ -8,7 +8,7 @@ class AuthenticationMailer < ApplicationMailer
   end
 
   def sign_in_email(to:, token:)
-    @magic_link = "#{candidate_interface_application_form_url}?token=#{token}"
+    @magic_link = "#{candidate_interface_authenticate_url}?token=#{token}"
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: to,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,8 @@ Rails.application.routes.draw do
     get '/sign-in', to: 'sign_in#new', as: :sign_in
     post '/sign-in', to: 'sign_in#create'
 
+    get '/authenticate', to: 'sign_in#authenticate', as: :authenticate
+
     get '/apply', to: 'apply_from_find#show', as: :apply_from_find
 
     scope '/application' do

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     end
 
     it 'sends an email with a magic link' do
-      expect(mail.body.encoded).to include("http://localhost:3000/candidate/application?token=#{token}")
+      expect(mail.body.encoded).to include("http://localhost:3000/candidate/authenticate?token=#{token}")
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     end
 
     it 'sends an email with a magic link' do
-      expect(mail.body.encoded).to include("http://localhost:3000/candidate/application?token=#{token}")
+      expect(mail.body.encoded).to include("http://localhost:3000/candidate/authenticate?token=#{token}")
     end
   end
 

--- a/spec/system/candidate_interface/candidate_account_multiple_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_multiple_sign_in_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate account' do
+  scenario 'Two candidates on the same machine sign in one after the other' do
+    given_the_pilot_is_open
+
+    given_i_am_the_first_candidate
+    then_i_can_sign_up_and_sign_out(@first_email)
+
+    given_i_am_the_second_candidate
+    then_i_can_sign_up_and_sign_out(@second_email)
+
+    when_i_click_the_link_in_the_email_for(@first_email)
+    then_i_am_signed_in_with(@first_email)
+
+    when_i_click_the_link_in_the_email_for(@second_email)
+    then_i_am_signed_in_with(@second_email)
+  end
+
+  def then_i_can_sign_up_and_sign_out(email)
+    when_i_visit_the_signup_page
+    and_i_accept_the_ts_and_cs
+    and_i_submit_my_email_address(email)
+    then_i_receive_an_email_with_a_signup_link(email)
+
+    given_i_store_the_received_email_link_for(email)
+
+    when_i_click_the_link_in_the_email_for(email)
+    then_i_am_signed_in_with(email)
+
+    when_i_click_the_sign_out_button
+    then_i_should_be_signed_out
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def given_i_am_the_first_candidate
+    @first_email = "first-#{SecureRandom.hex}@example.com"
+  end
+
+  def given_i_am_the_second_candidate
+    @second_email = "second-#{SecureRandom.hex}@example.com"
+  end
+
+  def when_i_visit_the_signup_page
+    visit '/'
+
+    click_on t('application_form.begin_button')
+
+    find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
+    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
+
+    click_on 'Continue'
+  end
+
+  def and_i_accept_the_ts_and_cs
+    check t('authentication.sign_up.accept_terms_checkbox')
+  end
+
+  def and_i_submit_my_email_address(email)
+    fill_in t('authentication.sign_up.email_address.label'), with: email
+    click_on t('authentication.sign_up.button_continue')
+  end
+
+  def then_i_receive_an_email_with_a_signup_link(email)
+    open_email(email)
+    expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
+  end
+
+  def given_i_store_the_received_email_link_for(email)
+    @email_link_for ||= {}
+    @email_link_for[email] = current_email.find_css('a').first
+  end
+
+  def when_i_click_the_link_in_the_email_for(email)
+    @email_link_for[email].click
+  end
+
+  def then_i_am_signed_in_with(email)
+    within 'header' do
+      expect(page).to have_content email
+    end
+  end
+
+  def when_i_click_the_sign_out_button
+    click_link 'Sign out'
+  end
+
+  def then_i_should_be_signed_out
+    expect(page).not_to have_selector :link_or_button, 'Sign out'
+    expect(page).to have_current_path(candidate_interface_start_path)
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
@@ -81,6 +81,6 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#interview-preferences-completed', text: 'Completed')
+    expect(page).to have_css('#interview-preferences-badge-id', text: 'Completed')
   end
 end


### PR DESCRIPTION
### Context

When two users sign in on the same computer, we should override the current session when a new token comes in and is valid.

### Changes proposed in this pull request

Adds a new `/authenticate` route that will purposefully check if the token is valid and if it is, sign in the user using the new token. This route will be sent in the sign in email moving forward.

Backwards compatibility with the old URLs is maintained by not removing the previous callbacks.

### Guidance to review

The test illustrates the scenario that this is addressing.

### Link to Trello card

[552 - Clicking on confirm email link does not sign you out of the previously signed in account](https://trello.com/c/ZJFXK7Tt)