### PR TITLE
Fix flakey vendor application spec

### DIFF
--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -186,6 +186,12 @@ RSpec.feature 'Vendor receives the application' do
         },
       },
     }
-    expect(@api_response['data'].first.deep_symbolize_keys).to eq expected_attributes
+    received_attributes = @api_response['data'].first.deep_symbolize_keys
+
+    # The order of these is non-deterministic which makes this test flakey
+    expected_attributes[:attributes][:qualifications][:gcses].sort_by! { |gcse| gcse[:subject] }
+    received_attributes[:attributes][:qualifications][:gcses].sort_by! { |gcse| gcse[:subject] }
+
+    expect(received_attributes).to eq expected_attributes
   end
 end


### PR DESCRIPTION
### Context

The GCSEs are not in a consistent order. We could also sort them on the presenter, but that does not feel necessary.