### PR TITLE
Show declined by date on Application dashboard.

### DIFF
--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -13,8 +13,7 @@
   </h2>
 
   <p class="govuk-body">
-  <!-- TODO: Update hardcoded date with decline by default date -->
-    You have 12 days (until 7 December 2019) to respond to any offers. If you
+    You have <%= decline_by_default_remaining_days %> days (until <%= decline_by_default_date %>) to respond to any offers. If you
     don’t respond, your applications will be automatically withdrawn.
   </p>
 <% elsif any_offers? %>

--- a/app/components/application_complete_content_component.rb
+++ b/app/components/application_complete_content_component.rb
@@ -8,22 +8,11 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
     @dates = ApplicationDates.new(@application_form)
   end
 
-  def any_accepted_offer?
-    @application_form.application_choices.map.any?(&:pending_conditions?)
-  end
+  delegate :any_accepted_offer?,
+           :all_provider_decisions_made?,
+           :any_awaiting_provider_decision?,
+           :any_offers?, to: :application_form
 
-  def all_provider_decisions_made?
-    @application_form.application_choices.any? &&
-      @application_form.application_choices.where(status: %w[awaiting_references application_complete awaiting_provider_decision]).empty?
-  end
-
-  def any_awaiting_provider_decision?
-    @application_form.application_choices.map.any?(&:awaiting_provider_decision?)
-  end
-
-  def any_offers?
-    @application_form.application_choices.map.any?(&:offer?)
-  end
 
   def editable?
     @dates.form_open_to_editing?

--- a/app/components/application_complete_content_component.rb
+++ b/app/components/application_complete_content_component.rb
@@ -13,10 +13,8 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
   end
 
   def all_provider_decisions_made?
-    # TODO: Update with correct logic when decline by default is added
-    @application_form.application_choices.map.all? do |course_choice|
-      course_choice.offer? || course_choice.rejected?
-    end
+    @application_form.application_choices.any? &&
+      @application_form.application_choices.where(status: %w[awaiting_references application_complete awaiting_provider_decision]).empty?
   end
 
   def any_awaiting_provider_decision?
@@ -29,6 +27,16 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
 
   def editable?
     @dates.form_open_to_editing?
+  end
+
+  def decline_by_default_remaining_days
+    distance_in_days = (@dates.decline_by_default_at.to_date - Date.current).to_i
+
+    [0, distance_in_days].max
+  end
+
+  def decline_by_default_date
+    @dates.decline_by_default_at.strftime('%-e %B %Y')
   end
 
 private

--- a/app/models/application_dates.rb
+++ b/app/models/application_dates.rb
@@ -11,6 +11,10 @@ class ApplicationDates
     @application_form.application_choices.first&.reject_by_default_at
   end
 
+  def decline_by_default_at
+    @application_form.first_not_declined_application_choice.decline_by_default_at
+  end
+
   def edit_by
     5.business_days.after(submitted_at).end_of_day
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -54,5 +54,21 @@ class ApplicationForm < ApplicationRecord
     qualification_in_subject(:gcse, :science)
   end
 
+  def any_accepted_offer?
+    application_choices.map.any?(&:pending_conditions?)
+  end
+
+  def all_provider_decisions_made?
+    application_choices.any? && application_choices.where(status: %w[awaiting_references application_complete awaiting_provider_decision]).empty?
+  end
+
+  def any_awaiting_provider_decision?
+    application_choices.map.any?(&:awaiting_provider_decision?)
+  end
+
+  def any_offers?
+    application_choices.map.any?(&:offer?)
+  end
+
   audited
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -36,6 +36,12 @@ class ApplicationForm < ApplicationRecord
       .first
   end
 
+  def first_not_declined_application_choice
+    application_choices
+      .where.not(decline_by_default_at: nil)
+      .first
+  end
+
   def maths_gcse
     qualification_in_subject(:gcse, :maths)
   end

--- a/spec/components/application_complete_content_component_spec.rb
+++ b/spec/components/application_complete_content_component_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ApplicationCompleteContentComponent do
   let(:submitted_at) { Time.zone.local(2019, 10, 22, 12, 0, 0) }
-  let(:first_january2019) { Time.zone.local(2020, 1, 1, 12, 0, 0) }
+  let(:first_january_2020) { Time.zone.local(2020, 1, 1, 12, 0, 0) }
 
   around do |example|
     Timecop.freeze(submitted_at) do
@@ -70,7 +70,7 @@ RSpec.describe ApplicationCompleteContentComponent do
 
       expect(render_result.text).to include('All your training providers have now reached a decision')
       # TODO: Update hardcoded date with decline by default date
-      expect(render_result.text).to include('You have 12 days (until 7 December 2019) to respond to any offers.')
+      expect(render_result.text).to include('You have 14 days (until 5 November 2019) to respond to any offers.')
     end
 
     it 'renders with all providers have made a decision content if an offer and rejected' do
@@ -81,7 +81,7 @@ RSpec.describe ApplicationCompleteContentComponent do
 
       # TODO: Update hardcoded date with decline by default date
       expect(render_result.text).to include('All your training providers have now reached a decision')
-      expect(render_result.text).to include('You have 12 days (until 7 December 2019) to respond to any offers.')
+      expect(render_result.text).to include('You have 14 days (until 5 November 2019) to respond to any offers.')
     end
   end
 
@@ -100,7 +100,8 @@ RSpec.describe ApplicationCompleteContentComponent do
     application_dates = instance_double(
       ApplicationDates,
       form_open_to_editing?: false,
-      reject_by_default_at: first_january2019,
+      reject_by_default_at: first_january_2020,
+      decline_by_default_at: 10.business_days.after(submitted_at),
     )
     allow(ApplicationDates).to receive(:new).and_return(application_dates)
   end
@@ -112,7 +113,7 @@ RSpec.describe ApplicationCompleteContentComponent do
       days_remaining_to_edit: 5,
       edit_by: Time.zone.local(2019, 10, 29, 12, 0, 0),
       submitted_at: Time.zone.local(2019, 10, 22, 12, 0, 0),
-      reject_by_default_at: first_january2019,
+      reject_by_default_at: first_january_2020,
     )
     allow(ApplicationDates).to receive(:new).and_return(application_dates)
   end
@@ -125,7 +126,7 @@ RSpec.describe ApplicationCompleteContentComponent do
         :application_choice,
         application_form: application_form,
         status: status,
-        reject_by_default_at: first_january2019,
+        reject_by_default_at: first_january_2020,
       )
     end
 

--- a/spec/models/application_dates_spec.rb
+++ b/spec/models/application_dates_spec.rb
@@ -49,6 +49,16 @@ RSpec.describe ApplicationDates, type: :model do
     end
   end
 
+  describe '#declined_by_default_at' do
+    let(:choices) { application_form.application_choices }
+
+    it 'returns correct declined_by_default_at' do
+      choices.update_all(status: :offer, decline_by_default_at: 10.business_days.after(submitted_at))
+
+      expect(application_dates.decline_by_default_at).to eq(10.business_days.after(submitted_at))
+    end
+  end
+
   describe '#form_open_to_editing?' do
     it 'returns true if the form is still open to editing' do
       Timecop.travel(submitted_at) do

--- a/spec/system/candidate_interface/candidate_viewing_an_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_an_offer_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Candidate views an offer' do
       offer: { 'conditions' => ['Fitness to Teach check', 'Be cool'] },
       course_option: course_option,
       application_form: application_form,
+      decline_by_default_at: application_form.submitted_at + 10.days,
     )
   end
 


### PR DESCRIPTION
### Context
This PR implements the Default By Default date, on the UI side.

### Changes proposed in this pull request
See the screenshot.

## Note about the 'ApplicationCompleteContentComponent' class 
I believe the Components class, should contain only code coupled with the front end,
but we all are really not observing this practice, 
as you can see in many `Components` classes we access the DB, with queries or making complex computation,

This makes testing the Components pretty complex, and create duplication.

I'd suggest refactoring this, maybe moving the queries in the appropriate model (that's a pretty easy first step, and maybe later to move again the queries in a Repositories module)

What do you think?

### Link to Trello card

https://trello.com/c/dQcEJNYP/547-update-the-application-dashboard-to-show-calculated-dbd-date