### PR TITLE
Fix email validation within candidate_interface/sign_up_form

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -8,7 +8,7 @@ module CandidateInterface
     end
 
     def create
-      @candidate = Candidate.find_or_initialize_by(email_address: candidate_params[:email_address])
+      @candidate = Candidate.for_email candidate_params[:email_address]
 
       if @candidate.persisted?
         MagicLinkSignIn.call(candidate: @candidate)

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -5,18 +5,17 @@ module CandidateInterface
     before_action :show_pilot_holding_page_if_not_open
 
     def new
-      @sign_up_form = CandidateInterface::SignUpForm.build_from_candidate(Candidate.new)
+      @sign_up_form = CandidateInterface::SignUpForm.new
     end
 
     def create
       @sign_up_form = CandidateInterface::SignUpForm.new(candidate_sign_up_form_params)
-      @candidate = Candidate.find_or_initialize_by(email_address: @sign_up_form.email_address)
 
-      if @candidate.persisted?
-        MagicLinkSignIn.call(candidate: @candidate)
+      if @sign_up_form.existing_candidate?
+        MagicLinkSignIn.call(candidate: @sign_up_form.candidate)
         render 'candidate_interface/shared/check_your_email'
-      elsif @sign_up_form.save(@candidate)
-        MagicLinkSignUp.call(candidate: @candidate)
+      elsif @sign_up_form.save
+        MagicLinkSignUp.call(candidate: @sign_up_form.candidate)
         render 'candidate_interface/shared/check_your_email'
       else
         render :new

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -2,13 +2,27 @@ class Candidate < ApplicationRecord
   # Only Devise's :timeoutable module is enabled to handle session expiry
   # Custom Warden strategy is used instead see app/warden/magic_link_token.rb
   devise :timeoutable
-  validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
-  validates :email_address, email_address: true
+
+  before_validation :downcase_email
+  validates :email_address, presence: true,
+                            uniqueness: { case_sensitive: false },
+                            length: { maximum: 250 },
+                            email_address: true
 
   has_many :application_forms
+
+  def self.for_email(email)
+    find_or_initialize_by(email_address: email.downcase) if email
+  end
 
   def current_application
     application_form = application_forms.first_or_create!
     application_form
+  end
+
+private
+
+  def downcase_email
+    email_address.try(:downcase!)
   end
 end

--- a/app/models/candidate_interface/sign_up_form.rb
+++ b/app/models/candidate_interface/sign_up_form.rb
@@ -1,30 +1,35 @@
 module CandidateInterface
   class SignUpForm
     include ActiveModel::Model
+    attr_accessor :email_address, :accept_ts_and_cs, :candidate
 
-    attr_accessor :email_address, :accept_ts_and_cs
     validates :email_address, :accept_ts_and_cs, presence: true
-    validates :email_address, length: { maximum: 250 }
-    validates :email_address, email_address: true
+    validate :candidate_email_address_is_valid
 
+    def initialize(params = {})
+      @email_address = params[:email_address]
+      @accept_ts_and_cs = params[:accept_ts_and_cs]
+      @candidate = Candidate.for_email @email_address
+    end
 
-    def save(candidate)
-      unless candidate.valid?
+    def existing_candidate?
+      candidate.persisted?
+    end
+
+    def save
+      return false if existing_candidate? || !valid?
+
+      candidate.save
+    end
+
+  private
+
+    def candidate_email_address_is_valid
+      if candidate && candidate.invalid?
         candidate.errors[:email_address].each do |error|
           errors.add(:email_address, error)
         end
       end
-
-      # need the explicit empty? check on errors as we're
-      # delegating email address validation to the candidate
-      # and just copying the messages
-      return false unless valid? && errors.empty?
-
-      candidate.update!(email_address: email_address)
-    end
-
-    def self.build_from_candidate(candidate)
-      new(email_address: candidate.email_address)
     end
   end
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -3,7 +3,7 @@ class Reference < ApplicationRecord
   validates :email_address, presence: true,
                             email_address: true,
                             length: { maximum: 100 },
-                            uniqueness: { scope: :application_form_id }
+                            uniqueness: { case_sensitive: false, scope: :application_form_id }
   validate :email_address_not_own
   validates :relationship, presence: true, word_count: { maximum: 50 }
   validates_presence_of :application_form_id

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Candidate, type: :model do
   describe 'a valid candidate' do
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
-    it { is_expected.to validate_uniqueness_of :email_address }
+    it { is_expected.to validate_uniqueness_of(:email_address).case_insensitive }
+    it { is_expected.to allow_value('user@example.com').for(:email_address) }
+    it { is_expected.not_to allow_value('foo').for(:email_address) }
     it { is_expected.not_to allow_value(Faker::Lorem.characters(number: 251)).for(:email_address) }
   end
 

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -40,6 +40,14 @@ RSpec.feature 'Candidate account' do
 
     when_i_signed_in_more_than_a_week_ago
     then_i_should_be_signed_out
+
+    when_i_click_the_signin_link
+    and_i_submit_my_email_address_in_uppercase
+    then_i_receive_an_email_with_a_signin_link
+
+    when_i_visit_the_signup_page
+    and_i_submit_my_email_address_in_uppercase
+    then_i_receive_an_email_with_a_signin_link
   end
 
   def given_the_pilot_is_open
@@ -69,9 +77,13 @@ RSpec.feature 'Candidate account' do
     check t('authentication.sign_up.accept_terms_checkbox')
   end
 
-  def and_i_submit_my_email_address
-    fill_in t('authentication.sign_up.email_address.label'), with: @email
+  def and_i_submit_my_email_address(email = @email)
+    fill_in t('authentication.sign_up.email_address.label'), with: email
     click_on t('authentication.sign_up.button_continue')
+  end
+
+  def and_i_submit_my_email_address_in_uppercase
+    and_i_submit_my_email_address(@email.upcase)
   end
 
   def then_i_receive_an_email_with_a_signup_link


### PR DESCRIPTION
### Context

We introduced case-insensitive email_address validation in the model but the SignUpForm was doing its own email_address validation and the logic wasn't in sync.

### Changes proposed in this pull request

Refactor SignUpForm so that all email_address validation happens within the model.

### Guidance to review

Run the tests! Read the code. Try to reproduce the bug.

### Link to Trello card

[595 - Can't sign up/in with uppercase version of existing email](https://trello.com/c/Kq1fmTFm)

### Env vars

No new env vars.
