### PR TITLE
Decide how personal statement is represented in API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -14,6 +14,7 @@ module VendorApi
           updated_at: application_choice.updated_at.iso8601,
           submitted_at: application_form.submitted_at.iso8601,
           personal_statement: personal_statement,
+          interview_preferences: application_form.interview_preferences,
           candidate: {
             first_name: application_form.first_name,
             last_name: application_form.last_name,

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -326,7 +326,7 @@ components:
           example: "2019-06-13T10:44:31Z"
         personal_statement:
           type: string
-          description: The candidate’s personal statement
+          description: The candidate’s personal statement, combined from the "Becoming a Teacher" and "Subject Knowledge" fields in the application form
           example: "Since retiring from the Police Service in 2007..."
         interview_preferences:
           type: string

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -286,6 +286,7 @@ components:
         - course
         - offer
         - personal_statement
+        - interview_preferences
         - qualifications
         - references
         - rejection
@@ -327,6 +328,10 @@ components:
           type: string
           description: The candidate’s personal statement
           example: "Since retiring from the Police Service in 2007..."
+        interview_preferences:
+          type: string
+          description: The candidate’s interview preferences
+          example: "I can’t come to interview on Thursdays"
         candidate:
           $ref: "#/components/schemas/Candidate"
         contact_details:

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -235,7 +235,7 @@ module CandidateHelper
   end
 
   def candidate_fills_in_becoming_a_teacher
-    fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I WANT I WANT I WANT I WANT'
+    fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I believe I would be a first-rate teacher'
     click_button t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
     # Confirmation page
     click_link t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
@@ -249,7 +249,7 @@ module CandidateHelper
   end
 
   def candidate_fills_in_interview_preferences
-    fill_in t('application_form.personal_statement.interview_preferences.label'), with: 'NOT WEDNESDAY'
+    fill_in t('application_form.personal_statement.interview_preferences.label'), with: 'Not on a Wednesday'
     click_button t('application_form.personal_statement.interview_preferences.complete_form_button')
     # Confirmation page
     click_link t('application_form.personal_statement.interview_preferences.complete_form_button')

--- a/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
@@ -112,7 +112,7 @@ RSpec.feature 'Candidate reviews the answers' do
   end
 
   def and_i_can_see_my_becoming_a_teacher_info
-    expect(page).to have_content 'I WANT I WANT I WANT I WANT'
+    expect(page).to have_content 'I believe I would be a first-rate teacher'
   end
 
   def and_i_can_see_my_subject_knowlegde_info
@@ -120,7 +120,7 @@ RSpec.feature 'Candidate reviews the answers' do
   end
 
   def and_i_can_see_my_interview_preferences
-    expect(page).to have_content 'NOT WEDNESDAY'
+    expect(page).to have_content 'Not on a Wednesday'
   end
 
   def and_i_can_see_my_referees

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -152,9 +152,9 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     expect(page).to have_content 'Classroom Volunteer'
     expect(page).to have_content 'BA Doge'
     expect(page).to have_content 'A-Level Believing in the Heart of the Cards'
-    expect(page).to have_content 'I WANT I WANT I WANT I WANT'
+    expect(page).to have_content 'I believe I would be a first-rate teacher'
     expect(page).to have_content 'Everything'
-    expect(page).to have_content 'NOT WEDNESDAY'
+    expect(page).to have_content 'Not on a Wednesday'
     expect(page).to have_content 'Terri Tudor'
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Vendor receives the application' do
       id: @provider.application_choices.first.id.to_s,
       type: 'application',
       attributes: {
-        personal_statement: "Why do you want to become a teacher?: I WANT I WANT I WANT I WANT \n What is your subject knowledge?: Everything",
+        personal_statement: "Why do you want to become a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
         hesa_itt_data: {
           disability: '',
           ethnicity: '',

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -54,6 +54,7 @@ RSpec.feature 'Vendor receives the application' do
       type: 'application',
       attributes: {
         personal_statement: "Why do you want to become a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
+        interview_preferences: 'Not on a Wednesday',
         hesa_itt_data: {
           disability: '',
           ethnicity: '',


### PR DESCRIPTION
### Context

- The personal statement field in the API appears as two fields in the Candidate form.
- We have nowhere in the API response to represent interview_preferences

### Changes proposed in this pull request

- Add interview_preferences to the API response
- Leave personal_statement as it is but add a line to the docs. Reasoning: it is easier to add fields than to remove them, and personal_statement is a battle-tested name for this information (unlike `becoming_a_teacher` and `subject_knowledge`)

### Link to Trello card

https://trello.com/c/cO93YzNL/1297-personal-statement-collected-as-multiple-fields-in-the-candidate-form-returned-as-a-single-field-in-the-api-whats-correct-for-th

### Env vars

N/A
