### PR TITLE
Use Rails 6 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,8 @@ Bundler.require(*Rails.groups)
 module ApplyForPostgraduateTeacherTraining
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
+    config.autoloader = :classic
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Changing to `load_defaults 6.0` fixes this common deprecation warning in our test suite, for example:

```
DEPRECATION WARNING: Sending mail with DeliveryJob and
Parameterized::DeliveryJob is deprecated and will be removed in Rails
6.1. Please use MailDeliveryJob instead. (called from call at
/Users/duncan/projects/bat-apply/apply-for-postgraduate-teacher-training/app/services/magic_link_sign_up.rb:4)
```

However, moving to 6.0 also brings in the new zeitwerk autoloader. This is on the face of it better and faster, but it is fussier about the capitalisation of autoloaded classes. Because one of these class names (VendorApi) is present as a type field in the database, I've not tackled this here and stuck to the :classic autoloader for now.

Here is the list of the defaults we've adopted by bumping this value to 6.0:

```
config.action_view.default_enforce_utf8: false
config.action_dispatch.use_cookies_with_metadata: true
config.action_dispatch.return_only_media_type_on_content_type: false
config.action_mailer.delivery_job: "ActionMailer::MailDeliveryJob"
config.active_job.return_false_on_aborted_enqueue: true
config.active_storage.queues.analysis: :active_storage_analysis
config.active_storage.queues.purge: :active_storage_purge
config.active_storage.replace_on_assign_to_many: true
config.active_record.collection_cache_versioning: true
```

See also: https://medium.com/@dylansreile/rails-6-0-new-framework-defaults-what-they-do-and-how-to-safely-uncomment-them-586146f371e8