### PR TITLE
Remove n+1 queries using bullet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,4 +90,5 @@ group :development, :test do
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'bullet'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'clockwork-test'
+  gem 'deepsort'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     bindex (0.8.1)
     brakeman (4.7.2)
     builder (3.2.3)
+    bullet (6.0.2)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     business_time (0.9.3)
       activesupport (>= 3.2.0)
       tzinfo
@@ -456,6 +459,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
+    uniform_notifier (1.13.0)
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
@@ -495,6 +499,7 @@ DEPENDENCIES
   actionview-component
   audited
   brakeman
+  bullet
   business_time
   capybara (>= 3.24)
   capybara-email

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,6 +134,7 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    deepsort (0.4.2)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -508,6 +509,7 @@ DEPENDENCIES
   clockwork-test
   cucumber-rails
   database_cleaner
+  deepsort
   devise
   dotenv-rails
   erb_lint

--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -1,4 +1,4 @@
-<% @application_form.references.each do |referee| %>
+<% @application_form.references.includes(:application_form).each do |referee| %>
   <%= render(SummaryCardComponent, rows: referee_rows(referee), editable: @editable) do %>
     <%= render(SummaryCardHeaderComponent, title: t('application_form.referees.nth_referee')[referee.ordinal], heading_level: @heading_level) do %>
       <% if @editable %>

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -10,7 +10,6 @@ module SupportInterface
              :submitted?,
              :updated_at,
              :candidate,
-             :application_choices,
              to: :application_form
 
     delegate :email_address, to: :candidate
@@ -94,6 +93,10 @@ module SupportInterface
           value: support_reference,
         }
       end
+    end
+
+    def application_choices
+      application_form.application_choices.includes(:course, :provider)
     end
 
     attr_reader :application_form

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -51,12 +51,14 @@ module CandidateInterface
     def set_referee
       @referee = current_candidate.current_application
                                     .references
+                                    .includes(:application_form)
                                     .find(params[:id])
     end
 
     def set_referees
       @referees = current_candidate.current_application
                                     .references
+                                    .includes(:application_form)
     end
 
     def referee_params

--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -1,18 +1,16 @@
 module SupportInterface
   class ApplicationFormsController < SupportInterfaceController
     def index
-      @application_forms = ApplicationForm.includes(:application_choices).sort_by(&:updated_at).reverse
+      @application_forms = ApplicationForm.includes(:candidate, :references).sort_by(&:updated_at).reverse
     end
 
     def show
       @application_form = ApplicationForm
-        .includes(:application_choices)
         .find(params[:application_form_id])
     end
 
     def audit
       @application_form = ApplicationForm
-        .includes(:application_choices)
         .find(params[:application_form_id])
     end
   end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -4,10 +4,18 @@ class GetApplicationChoicesForProvider
   def self.call(provider:)
     raise MissingProvider unless provider.present?
 
-    ApplicationChoice.includes(:course)
+    includes = [
+      :course,
+      :application_form,
+      :provider,
+      :site,
+      application_form: %i[candidate references application_work_experiences application_volunteering_experiences],
+    ]
+
+    ApplicationChoice.includes(*includes)
       .where('courses.provider_id' => provider)
-      .or(ApplicationChoice.includes(:course)
-      .where('courses.accrediting_provider_id' => provider))
+      .or(ApplicationChoice.includes(*includes)
+        .where('courses.accrediting_provider_id' => provider))
       .where('status NOT IN (?)', STATES_NOT_VISIBLE_TO_PROVIDER)
   end
 end

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -23,7 +23,7 @@ class ReceiveReference
         .update!(feedback: @feedback)
 
       if @application_form.references_complete?
-        @application_form.application_choices.each do |application_choice|
+        @application_form.application_choices.includes(:course_option).each do |application_choice|
           ApplicationStateChange.new(application_choice).references_complete!
         end
       end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    'Cache-Control' => "public, max-age=#{1.hour.to_i}",
   }
 
   # Show full error reports and disable caching.
@@ -37,7 +37,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   config.action_mailer.default_options = {
-    from: 'mail@example.com'
+    from: 'mail@example.com',
   }
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
@@ -46,4 +46,13 @@ Rails.application.configure do
 
   # Forces jobs that are normally queued to Sidekiq to run immediately
   config.active_job.queue_adapter = :inline
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.unused_eager_loading_enable = false
+    Bullet.counter_cache_enable = false
+    Bullet.add_whitelist type: :n_plus_one_query, class_name: 'Audited::Audit', association: :user
+
+    Bullet.raise = true # raise an error if n+1 query occurs
+  end
 end

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ReceiveReference do
     )
     action.save
 
-    expect(application_form).to be_references_complete
+    expect(application_form.reload).to be_references_complete
     expect(application_form.application_choices).to all(be_application_complete)
   end
 

--- a/spec/support/bullet.rb
+++ b/spec/support/bullet.rb
@@ -1,0 +1,11 @@
+RSpec.configure do |config|
+  if Bullet.enable?
+    config.before do
+      Bullet.start_request
+    end
+
+    config.after do
+      Bullet.end_request
+    end
+  end
+end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -187,18 +187,9 @@ RSpec.feature 'Vendor receives the application' do
         },
       },
     }
+
     received_attributes = @api_response['data'].first.deep_symbolize_keys
 
-    # The order of these is non-deterministic which makes this test flakey
-    expected_attributes[:attributes][:qualifications][:gcses].sort_by! { |gcse| gcse[:subject] }
-    received_attributes[:attributes][:qualifications][:gcses].sort_by! { |gcse| gcse[:subject] }
-
-    expected_attributes[:attributes][:references].sort_by! { |ref| ref[:email] }
-    received_attributes[:attributes][:references].sort_by! { |ref| ref[:email] }
-
-    received_attributes.keys.each do |k|
-      expect(received_attributes[k]).to eq expected_attributes[k]
-    end
-    # expect(received_attributes).to eq expected_attributes
+    expect(received_attributes.deep_sort).to eq expected_attributes.deep_sort
   end
 end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -193,6 +193,12 @@ RSpec.feature 'Vendor receives the application' do
     expected_attributes[:attributes][:qualifications][:gcses].sort_by! { |gcse| gcse[:subject] }
     received_attributes[:attributes][:qualifications][:gcses].sort_by! { |gcse| gcse[:subject] }
 
-    expect(received_attributes).to eq expected_attributes
+    expected_attributes[:attributes][:references].sort_by! { |ref| ref[:email] }
+    received_attributes[:attributes][:references].sort_by! { |ref| ref[:email] }
+
+    received_attributes.keys.each do |k|
+      expect(received_attributes[k]).to eq expected_attributes[k]
+    end
+    # expect(received_attributes).to eq expected_attributes
   end
 end


### PR DESCRIPTION
## Context

Load testing revealed a very heavy n+1 query behind the Vendor API. Nix it and all of its kind using `bullet`

## Changes proposed

Add `bullet`. The build will now fail if we introduce n+1 queries.

https://trello.com/c/e11QWmbi/1351-vendor-api-application-index-is-very-slow