### PR TITLE
Put the Support Interface behind DfE Sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ GenerateTestData.new(10, Provider.find_by(code: '1N1')).generate
 
 ## <a name="dfe-sign-in"></a>DfE Sign-in
 
-The Provider interface at `/provider` is protected by DfE's SSO provider DfE
-Sign-in.
+The Provider interface at `/provider` and Support interface at
+`/support` are both protected by DfE's SSO provider DfE Sign-in.
 
 ### Environments
 

--- a/app/components/dfe_sign_in_button_component.html.erb
+++ b/app/components/dfe_sign_in_button_component.html.erb
@@ -1,5 +1,1 @@
-<% if DfESignIn.bypass? %>
-  <%= button_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
-<% else %>
-  <%= button_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
-<% end %>
+<%= button_to title, path, class: 'govuk-button' %>

--- a/app/components/dfe_sign_in_button_component.html.erb
+++ b/app/components/dfe_sign_in_button_component.html.erb
@@ -1,0 +1,5 @@
+<% if DfESignIn.bypass? %>
+  <%= button_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
+<% else %>
+  <%= button_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
+<% end %>

--- a/app/components/dfe_sign_in_button_component.rb
+++ b/app/components/dfe_sign_in_button_component.rb
@@ -1,0 +1,16 @@
+class DfESignInButtonComponent < ActionView::Component::Base
+  include ViewHelper
+  attr_accessor :bypass
+
+  def initialize(bypass:)
+    self.bypass = bypass
+  end
+
+  def title
+    bypass ? 'Sign in using DfE Sign-in (bypass)' : 'Sign in using DfE Sign-in'
+  end
+
+  def path
+    bypass ? '/auth/developer' : '/auth/dfe'
+  end
+end

--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -1,0 +1,26 @@
+class DfESignInController < ActionController::Base
+  protect_from_forgery except: :bypass_callback
+
+  def callback
+    dfe_sign_in_session = DfESignIn.parse_auth_hash(request.env['omniauth.auth'])
+    DfESignInUser.begin_session!(session, dfe_sign_in_session)
+
+    redirect_to session.delete('post_dfe_sign_in_path') || default_authenticated_path
+  end
+
+  alias :bypass_callback :callback
+
+private
+
+  def default_authenticated_path
+    if authorized_for_support_interface?
+      support_interface_path
+    else
+      provider_interface_path
+    end
+  end
+
+  def authorized_for_support_interface?
+    SupportUser.load_from_session(session)&.authorized?
+  end
+end

--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -21,6 +21,6 @@ private
   end
 
   def authorized_for_support_interface?
-    SupportUser.load_from_session(session)&.authorized?
+    SupportUser.load_from_session(session)
   end
 end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -31,7 +31,10 @@ module ProviderInterface
     end
 
     def authenticate_provider_user!
-      redirect_to provider_interface_sign_in_path unless current_provider_user
+      return if current_provider_user
+
+      session['post_dfe_sign_in_path'] = request.path
+      redirect_to provider_interface_sign_in_path
     end
   end
 end

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -20,7 +20,7 @@ module ProviderInterface
     end
 
     def authorized_for_support_interface?
-      SupportUser.load_from_session(session)&.authorized?
+      SupportUser.load_from_session(session)
     end
   end
 end

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -7,13 +7,15 @@ module ProviderInterface
 
     def callback
       dfe_sign_in_session = DfESignIn.parse_auth_hash(request.env['omniauth.auth'])
-      ProviderUser.begin_session!(session, dfe_sign_in_session)
+      DfESignInUser.begin_session!(session, dfe_sign_in_session)
 
-      redirect_to provider_interface_path
+      # TODO: What if the given user doesn't have permission to visit
+      # the provider interface?
+      redirect_to session['post_dfe_sign_in_path'] || provider_interface_path
     end
 
     def destroy
-      ProviderUser.end_session!(session)
+      DfESignInUser.end_session!(session)
 
       redirect_to action: :new
     end

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -11,7 +11,7 @@ module ProviderInterface
 
       # TODO: What if the given user doesn't have permission to visit
       # the provider interface?
-      redirect_to session['post_dfe_sign_in_path'] || provider_interface_path
+      redirect_to session.delete('post_dfe_sign_in_path') || provider_interface_path
     end
 
     def destroy

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -2,7 +2,9 @@ module SupportInterface
   class SessionsController < SupportInterfaceController
     skip_before_action :authenticate_support_user!
 
-    def new; end
+    def new
+      session['post_dfe_sign_in_path'] ||= support_interface_path
+    end
 
     def destroy
       SupportUser.end_session!(session)

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -1,26 +1,13 @@
 module SupportInterface
   class SessionsController < SupportInterfaceController
     skip_before_action :authenticate_support_user!
-    protect_from_forgery except: :bypass_callback
 
     def new; end
-
-    def callback
-      # TODO: Work out whether this conflicts with provider sign-in (is
-      # there a use case for having both sign-ins at once even if only
-      # for developers doing testing?)
-      dfe_sign_in_session = DfESignIn.parse_auth_hash(request.env['omniauth.auth'])
-      SupportUser.begin_session!(session, dfe_sign_in_session)
-
-      redirect_to support_interface_path
-    end
 
     def destroy
       SupportUser.end_session!(session)
 
       redirect_to action: :new
     end
-
-    alias :bypass_callback :callback
   end
 end

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -7,7 +7,7 @@ module SupportInterface
     end
 
     def destroy
-      SupportUser.end_session!(session)
+      DfESignInUser.end_session!(session)
 
       redirect_to action: :new
     end

--- a/app/controllers/support_interface/sessions_controller.rb
+++ b/app/controllers/support_interface/sessions_controller.rb
@@ -1,0 +1,26 @@
+module SupportInterface
+  class SessionsController < SupportInterfaceController
+    skip_before_action :authenticate_support_user!
+    protect_from_forgery except: :bypass_callback
+
+    def new; end
+
+    def callback
+      # TODO: Work out whether this conflicts with provider sign-in (is
+      # there a use case for having both sign-ins at once even if only
+      # for developers doing testing?)
+      dfe_sign_in_session = DfESignIn.parse_auth_hash(request.env['omniauth.auth'])
+      SupportUser.begin_session!(session, dfe_sign_in_session)
+
+      redirect_to support_interface_path
+    end
+
+    def destroy
+      SupportUser.end_session!(session)
+
+      redirect_to action: :new
+    end
+
+    alias :bypass_callback :callback
+  end
+end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -24,7 +24,7 @@ module SupportInterface
     end
 
     def dfe_sign_in_user
-      ProviderUser.load_from_session(session)
+      DfESignInUser.load_from_session(session)
     end
 
     def authenticate_support_user!

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -24,7 +24,10 @@ module SupportInterface
     end
 
     def authenticate_support_user!
-      redirect_to support_interface_sign_in_path unless current_support_user
+      return if current_support_user
+
+      session['post_dfe_sign_in_path'] = request.path
+      redirect_to support_interface_sign_in_path
     end
   end
 end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -5,7 +5,7 @@ module SupportInterface
     layout 'support_layout'
     before_action :authenticate_support_user!
 
-    helper_method :current_support_user
+    helper_method :current_support_user, :dfe_sign_in_user
 
   private
 
@@ -20,13 +20,19 @@ module SupportInterface
     end
 
     def current_support_user
-      SupportUser.load_from_session(session)
+      @current_support_user ||= SupportUser.load_from_session(session)
+    end
+
+    def dfe_sign_in_user
+      ProviderUser.load_from_session(session)
     end
 
     def authenticate_support_user!
-      return if current_support_user&.authorized?
+      return if current_support_user
 
-      if current_support_user && !current_support_user.authorized?
+      session['post_dfe_sign_in_path'] = request.path
+
+      if !current_support_user && dfe_sign_in_user
         render(
           template: 'support_interface/unauthorized',
           status: 403,

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -3,7 +3,9 @@ module SupportInterface
     include LogQueryParams
 
     layout 'support_layout'
-    before_action :protect_with_basic_auth
+    before_action :authenticate_support_user!
+
+    helper_method :current_support_user
 
   private
 
@@ -15,6 +17,14 @@ module SupportInterface
 
     def render_404
       render 'errors/not_found', status: :not_found
+    end
+
+    def current_support_user
+      SupportUser.load_from_session(session)
+    end
+
+    def authenticate_support_user!
+      redirect_to support_interface_sign_in_path unless current_support_user
     end
   end
 end

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -24,7 +24,15 @@ module SupportInterface
     end
 
     def authenticate_support_user!
-      return if current_support_user
+      return if current_support_user&.authorized?
+
+      if current_support_user && !current_support_user.authorized?
+        render(
+          template: 'support_interface/unauthorized',
+          status: 403,
+        )
+        return
+      end
 
       session['post_dfe_sign_in_path'] = request.path
       redirect_to support_interface_sign_in_path

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -14,6 +14,8 @@ class DfESignInUser
   end
 
   def self.load_from_session(session)
+    return nil unless session['dfe_sign_in_user']
+
     if session['dfe_sign_in_user']
       new(
         email_address: session['dfe_sign_in_user']['email_address'],

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -14,10 +14,10 @@ class DfESignInUser
   end
 
   def self.load_from_session(session)
-    if session['dfe_user']
+    if session['dfe_sign_in_user']
       new(
-        email_address: session['dfe_user']['email_address'],
-        dfe_sign_in_uid: session['dfe_user']['dfe_sign_in_uid'],
+        email_address: session['dfe_sign_in_user']['email_address'],
+        dfe_sign_in_uid: session['dfe_sign_in_user']['dfe_sign_in_uid'],
       )
     end
   end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,0 +1,28 @@
+class DfESignInUser
+  attr_reader :email_address, :dfe_sign_in_uid
+
+  def self.begin_session!(session, dfe_sign_in_session)
+    session['dfe_user'] = {
+      'email_address' => dfe_sign_in_session.email_address,
+      'dfe_sign_in_uid' => dfe_sign_in_session.uid,
+    }
+  end
+
+  def self.load_from_session(session)
+    if session['dfe_user']
+      new(
+        email_address: session['dfe_user']['email_address'],
+        dfe_sign_in_uid: session['dfe_user']['dfe_sign_in_uid'],
+      )
+    end
+  end
+
+  def self.end_session!(session)
+    session.delete('dfe_user')
+  end
+
+  def initialize(email_address:, dfe_sign_in_uid:)
+    @email_address = email_address
+    @dfe_sign_in_uid = dfe_sign_in_uid
+  end
+end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,8 +1,13 @@
 class DfESignInUser
   attr_reader :email_address, :dfe_sign_in_uid
 
+  def initialize(email_address:, dfe_sign_in_uid:)
+    @email_address = email_address
+    @dfe_sign_in_uid = dfe_sign_in_uid
+  end
+
   def self.begin_session!(session, dfe_sign_in_session)
-    session['dfe_user'] = {
+    session['dfe_sign_in_user'] = {
       'email_address' => dfe_sign_in_session.email_address,
       'dfe_sign_in_uid' => dfe_sign_in_session.uid,
     }
@@ -18,11 +23,6 @@ class DfESignInUser
   end
 
   def self.end_session!(session)
-    session.delete('dfe_user')
-  end
-
-  def initialize(email_address:, dfe_sign_in_uid:)
-    @email_address = email_address
-    @dfe_sign_in_uid = dfe_sign_in_uid
+    session.delete('dfe_sign_in_user')
   end
 end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,31 +1,4 @@
-class ProviderUser
-  attr_reader :email_address, :dfe_sign_in_uid
-
-  def self.begin_session!(session, dfe_sign_in_session)
-    session['provider_user'] = {
-      'email_address' => dfe_sign_in_session.email_address,
-      'dfe_sign_in_uid' => dfe_sign_in_session.uid,
-    }
-  end
-
-  def self.load_from_session(session)
-    if session['provider_user']
-      new(
-        email_address: session['provider_user']['email_address'],
-        dfe_sign_in_uid: session['provider_user']['dfe_sign_in_uid'],
-      )
-    end
-  end
-
-  def self.end_session!(session)
-    session.delete('provider_user')
-  end
-
-  def initialize(email_address:, dfe_sign_in_uid:)
-    @email_address = email_address
-    @dfe_sign_in_uid = dfe_sign_in_uid
-  end
-
+class ProviderUser < DfESignInUser
   def provider
     provider_code = Rails.application.config.provider_permissions
       .select { |_code, permitted_uids| permitted_uids.include? dfe_sign_in_uid }

--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -1,4 +1,10 @@
 class SupportUser < ActiveRecord::Base
   validates :dfe_sign_in_uid, presence: true
   validates :email_address, presence: true
+
+  def self.load_from_session(session)
+    return nil unless session['dfe_sign_in_user']
+
+    SupportUser.find_by(dfe_sign_in_uid: session['dfe_sign_in_user']['dfe_sign_in_uid'])
+  end
 end

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -6,4 +6,13 @@
   <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
   <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
   <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
+  <% if current_support_user %>
+    <li class="govuk-header__navigation-item">
+      <b><%= current_support_user.email_address %></b>
+    </li>
+
+    <li class="govuk-header__navigation-item">
+      <%= link_to 'Sign out', support_interface_sign_out_path, class: 'govuk-header__link' %>
+    </li>
+  <% end %>
 </ul>

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -1,17 +1,17 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
   <% if current_support_user %>
-    <% if current_support_user.authorized? %>
-      <%= nav_link 'Applications', support_interface_applications_path, active: %w[application_forms import_references] %>
-      <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
-      <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
-      <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
-      <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
-      <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
-      <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
-    <% end %>
+    <%= nav_link 'Applications', support_interface_applications_path, active: %w[application_forms import_references] %>
+    <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
+    <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
+    <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
+    <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
+    <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
+    <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
+  <% end %>
 
+  <% if dfe_sign_in_user %>
     <li class="govuk-header__navigation-item">
-      <b><%= current_support_user.email_address %></b>
+      <b><%= dfe_sign_in_user.email_address %></b>
     </li>
 
     <li class="govuk-header__navigation-item">

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -1,12 +1,12 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
-  <%= nav_link 'Applications', support_interface_applications_path, active: %w[application_forms import_references] %>
-  <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
-  <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
-  <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
-  <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
-  <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
-  <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
   <% if current_support_user %>
+    <%= nav_link 'Applications', support_interface_applications_path, active: %w[application_forms import_references] %>
+    <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
+    <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
+    <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
+    <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
+    <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
+    <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
     <li class="govuk-header__navigation-item">
       <b><%= current_support_user.email_address %></b>
     </li>

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -1,12 +1,15 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
   <% if current_support_user %>
-    <%= nav_link 'Applications', support_interface_applications_path, active: %w[application_forms import_references] %>
-    <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
-    <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
-    <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
-    <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
-    <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
-    <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
+    <% if current_support_user.authorized? %>
+      <%= nav_link 'Applications', support_interface_applications_path, active: %w[application_forms import_references] %>
+      <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
+      <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
+      <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
+      <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
+      <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
+      <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
+    <% end %>
+
     <li class="govuk-header__navigation-item">
       <b><%= current_support_user.email_address %></b>
     </li>

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -1,5 +1,1 @@
-<% if DfESignIn.bypass? %>
-  <%= button_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
-<% else %>
-  <%= button_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
-<% end %>
+<%= render(DfESignInButtonComponent, bypass: DfESignIn.bypass?) %>

--- a/app/views/support_interface/sessions/new.html.erb
+++ b/app/views/support_interface/sessions/new.html.erb
@@ -1,5 +1,1 @@
-<% if DfESignIn.bypass? %>
-  <%= button_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
-<% else %>
-  <%= button_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
-<% end %>
+<%= render(DfESignInButtonComponent, bypass: DfESignIn.bypass?) %>

--- a/app/views/support_interface/sessions/new.html.erb
+++ b/app/views/support_interface/sessions/new.html.erb
@@ -1,0 +1,5 @@
+<% if DfESignIn.bypass? %>
+  <%= button_to 'Sign in using DfE Sign-in (bypass)', '/auth/developer', class: 'govuk-button' %>
+<% else %>
+  <%= button_to 'Sign in using DfE Sign-in', '/auth/dfe', class: 'govuk-button' %>
+<% end %>

--- a/app/views/support_interface/unauthorized.html.erb
+++ b/app/views/support_interface/unauthorized.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, t('page_titles.application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Your account is not authorized
+    </h1>
+    <p class="govuk-body">
+      You’re seeing this page because you’ve signed in
+      to the <%= t('service_name.apply') %> service but your account
+      is not authorized to view the support interface.
+    </p>
+
+    <p class="govuk-body">
+      If you work with us and you think your account should be authorized,
+      contact <%= bat_contact_mail_to %>.
+    </p>
+  </div>
+</div>

--- a/app/views/support_interface/unauthorized.html.erb
+++ b/app/views/support_interface/unauthorized.html.erb
@@ -8,7 +8,7 @@
     <p class="govuk-body">
       You’re seeing this page because you’ve signed in
       to the <%= t('service_name.apply') %> service but your account
-      is not authorized to view the support interface.
+      is not authorized to view this page
     </p>
 
     <p class="govuk-body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -289,6 +289,9 @@ Rails.application.routes.draw do
 
     post '/impersonate-candidate/:candidate_id' => 'impersonation#impersonate_candidate', as: :impersonate_candidate
 
+    get '/sign-in' => 'sessions#new'
+    get '/sign-out' => 'sessions#destroy'
+
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes
     require 'sidekiq/web'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -251,8 +251,8 @@ Rails.application.routes.draw do
     get '/sign-out' => 'sessions#destroy'
   end
 
-  get '/auth/dfe/callback' => 'provider_interface/sessions#callback'
-  post '/auth/developer/callback' => 'provider_interface/sessions#bypass_callback'
+  get '/auth/dfe/callback' => 'dfe_sign_in#callback'
+  post '/auth/developer/callback' => 'dfe_sign_in#bypass_callback'
 
   namespace :support_interface, path: '/support' do
     get '/' => redirect('/support/applications')

--- a/spec/components/dfe_sign_in_button_component_spec.rb
+++ b/spec/components/dfe_sign_in_button_component_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe DfESignInButtonComponent do
+  before do
+    view_helper = instance_double(ViewHelper)
+    allow(view_helper).to receive(:respond_by_date).and_return('1 January 2020')
+  end
+
+  context 'when bypass is set' do
+    it 'renders with button with link to the development route' do
+      render_result = render_inline(described_class, bypass: true)
+
+      expect(render_result.css('form').attr('action').value).to eq '/auth/developer'
+      expect(render_result.css('input').attr('value').value).to eq 'Sign in using DfE Sign-in (bypass)'
+    end
+  end
+
+  context 'when bypass is NOT set' do
+    it 'renders with button with link to the development route' do
+      render_result = render_inline(described_class, bypass: false)
+
+      expect(render_result.css('form').attr('action').value).to eq '/auth/dfe'
+      expect(render_result.css('input').attr('value').value).to eq 'Sign in using DfE Sign-in'
+    end
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/requests/support_interface/comments_spec.rb
+++ b/spec/requests/support_interface/comments_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe 'Support interface - Application Comments', type: :request, with_
     )
   end
 
-  def set_provider_permission
+  def set_support_user_permission
     allow(SupportUser).to receive(:load_from_session).and_return(support_user)
     allow(support_user).to receive(:authorized?).and_return(true)
   end
 
   before do
-    set_provider_permission
+    set_support_user_permission
   end
 
   it 'creates application comments in the audit trail' do

--- a/spec/requests/support_interface/comments_spec.rb
+++ b/spec/requests/support_interface/comments_spec.rb
@@ -5,14 +5,16 @@ RSpec.describe 'Support interface - Application Comments', type: :request, with_
     create :application_form
   end
 
-  def set_provider_permission
-    allow(SupportUser).to receive(:load_from_session)
-      .and_return(
-        SupportUser.new(
-          email_address: 'alice@example.com',
-          dfe_sign_in_uid: 'ABC',
-        ),
+  def support_user
+    @support_user ||= SupportUser.new(
+      email_address: 'alice@example.com',
+      dfe_sign_in_uid: 'ABC',
     )
+  end
+
+  def set_provider_permission
+    allow(SupportUser).to receive(:load_from_session).and_return(support_user)
+    allow(support_user).to receive(:authorized?).and_return(true)
   end
 
   before do

--- a/spec/requests/support_interface/comments_spec.rb
+++ b/spec/requests/support_interface/comments_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe 'Support interface - Application Comments', type: :request, with_
 
   def set_support_user_permission
     allow(SupportUser).to receive(:load_from_session).and_return(support_user)
-    allow(support_user).to receive(:authorized?).and_return(true)
   end
 
   before do

--- a/spec/requests/support_interface/comments_spec.rb
+++ b/spec/requests/support_interface/comments_spec.rb
@@ -5,14 +5,18 @@ RSpec.describe 'Support interface - Application Comments', type: :request, with_
     create :application_form
   end
 
-  def auth_header
-    {
-      'HTTP_AUTHORIZATION' =>
-        ActionController::HttpAuthentication::Basic.encode_credentials(
-          ENV.fetch('SUPPORT_USERNAME'),
-          ENV.fetch('SUPPORT_PASSWORD'),
+  def set_provider_permission
+    allow(SupportUser).to receive(:load_from_session)
+      .and_return(
+        SupportUser.new(
+          email_address: 'alice@example.com',
+          dfe_sign_in_uid: 'ABC',
         ),
-    }
+    )
+  end
+
+  before do
+    set_provider_permission
   end
 
   it 'creates application comments in the audit trail' do
@@ -22,7 +26,6 @@ RSpec.describe 'Support interface - Application Comments', type: :request, with_
       post(
         support_interface_application_form_comments_path(application_form_id: application_form.id),
         params: { support_interface_application_comment_form: { comment: 'foo' } },
-        headers: auth_header,
       )
     }.to(change { application_form.reload.audits.count }.by(1))
   end
@@ -34,7 +37,6 @@ RSpec.describe 'Support interface - Application Comments', type: :request, with_
       post(
         support_interface_application_form_comments_path(application_form_id: application_form.id),
         params: { support_interface_application_comment_form: { comment: '' } },
-        headers: auth_header,
       )
     }.not_to(change { application_form.reload.audits.count })
   end

--- a/spec/requests/support_interface/not_authorized_spec.rb
+++ b/spec/requests/support_interface/not_authorized_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'GET /support/applications' do
           ),
       )
 
-      # do not grant the user permission to view a provider's applications
+      # do not grant the DfE Sign-in user permission to view the support interface
     end
 
     it 'returns 403 with the account-creation-in-progress page' do

--- a/spec/requests/support_interface/not_authorized_spec.rb
+++ b/spec/requests/support_interface/not_authorized_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /support/applications' do
+  context 'when the DfE Sign-in account is not authorized' do
+    before do
+      allow(SupportUser).to receive(:load_from_session)
+        .and_return(
+          SupportUser.new(
+            email_address: 'email@example.com',
+            dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+          ),
+      )
+
+      # do not grant the user permission to view a provider's applications
+    end
+
+    it 'returns 403 with the account-creation-in-progress page' do
+      get '/support/applications'
+
+      expect(response).to have_http_status 403
+      expect(response.body).to include('Your account is not authorized')
+    end
+  end
+end

--- a/spec/requests/support_interface/not_authorized_spec.rb
+++ b/spec/requests/support_interface/not_authorized_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'GET /support/applications' do
   context 'when the DfE Sign-in account is not authorized' do
     before do
       allow(SupportUser).to receive(:load_from_session).and_return(nil)
-      allow(ProviderUser).to receive(:load_from_session)
+      allow(DfESignInUser).to receive(:load_from_session)
         .and_return(
           ProviderUser.new(
             email_address: 'email@example.com',

--- a/spec/requests/support_interface/not_authorized_spec.rb
+++ b/spec/requests/support_interface/not_authorized_spec.rb
@@ -3,9 +3,10 @@ require 'rails_helper'
 RSpec.describe 'GET /support/applications' do
   context 'when the DfE Sign-in account is not authorized' do
     before do
-      allow(SupportUser).to receive(:load_from_session)
+      allow(SupportUser).to receive(:load_from_session).and_return(nil)
+      allow(ProviderUser).to receive(:load_from_session)
         .and_return(
-          SupportUser.new(
+          ProviderUser.new(
             email_address: 'email@example.com',
             dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
           ),

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -5,8 +5,19 @@ module DfESignInHelpers
     )
   end
 
+  def support_user_exists_in_dfe_sign_in(email_address: 'email@apply-support.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
+      fake_dfe_sign_in_auth_hash(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid),
+    )
+  end
+
   def provider_signs_in_using_dfe_sign_in
     visit provider_interface_path
+    click_button 'Sign in using DfE Sign-in'
+  end
+
+  def support_user_signs_in_using_dfe_sign_in
+    visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end
 

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -17,6 +17,11 @@ module DfESignInHelpers
     click_button 'Sign in using DfE Sign-in'
   end
 
+  def sign_in_as_support_user
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
+    support_user_signs_in_using_dfe_sign_in
+  end
+
   def dfe_sign_in_uid_has_permission_to_view_applications_for_provider(dfe_sign_in_uid = 'DFE_SIGN_IN_UID', code = 'ABC')
     allow(Rails.application.config).to receive(:provider_permissions)
       .and_return(code => [dfe_sign_in_uid])

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -1,5 +1,5 @@
 module DfESignInHelpers
-  def user_exists_in_dfe_sign_in(email_address: 'email@apply-support.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  def user_exists_in_dfe_sign_in(email_address: 'email@provider.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       fake_dfe_sign_in_auth_hash(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid),
     )

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -55,10 +55,13 @@ module DfESignInHelpers
 
   def support_user_exists_in_dfe_sign_in(email_address: 'email@apply-support.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
     user_exists_in_dfe_sign_in(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid)
-    user_is_a_support_user(dfe_sign_in_uid: dfe_sign_in_uid)
+    user_is_a_support_user(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid)
   end
 
-  def user_is_a_support_user(dfe_sign_in_uid:)
-    SupportUser.find_or_create_by!(dfe_sign_in_uid: dfe_sign_in_uid)
+  def user_is_a_support_user(email_address:, dfe_sign_in_uid:)
+    SupportUser.find_or_create_by!(
+      dfe_sign_in_uid: dfe_sign_in_uid,
+      email_address:  email_address,
+    )
   end
 end

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -1,15 +1,11 @@
 module DfESignInHelpers
-  def provider_exists_in_dfe_sign_in(email_address: 'email@provider.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  def user_exists_in_dfe_sign_in(email_address: 'email@apply-support.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
       fake_dfe_sign_in_auth_hash(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid),
     )
   end
 
-  def support_user_exists_in_dfe_sign_in(email_address: 'email@apply-support.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
-    OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
-      fake_dfe_sign_in_auth_hash(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid),
-    )
-  end
+  alias :provider_exists_in_dfe_sign_in :user_exists_in_dfe_sign_in
 
   def provider_signs_in_using_dfe_sign_in
     visit provider_interface_path

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -52,4 +52,13 @@ module DfESignInHelpers
       },
     }
   end
+
+  def support_user_exists_in_dfe_sign_in(email_address: 'email@apply-support.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    user_exists_in_dfe_sign_in(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid)
+    user_is_a_support_user(dfe_sign_in_uid: dfe_sign_in_uid)
+  end
+
+  def user_is_a_support_user(dfe_sign_in_uid:)
+    SupportUser.find_or_create_by!(dfe_sign_in_uid: dfe_sign_in_uid)
+  end
 end

--- a/spec/system/basic_auth_spec.rb
+++ b/spec/system/basic_auth_spec.rb
@@ -36,30 +36,4 @@ RSpec.describe 'Require basic authentication', type: :request do
       expect(response).to have_http_status(200)
     end
   end
-
-  context 'support_interface' do
-    it 'requests without basic auth get 401' do
-      ClimateControl.modify SUPPORT_USERNAME: 'foo', SUPPORT_PASSWORD: 'bar' do
-        get support_interface_applications_path
-      end
-
-      expect(response).to have_http_status(401)
-    end
-
-    it 'requests with invalid basic auth get 401' do
-      ClimateControl.modify SUPPORT_USERNAME: 'foo', SUPPORT_PASSWORD: 'bar' do
-        get support_interface_applications_path, headers: basic_auth_headers('wrong', 'auth')
-      end
-
-      expect(response).to have_http_status(401)
-    end
-
-    it 'requests with valid basic auth get 200' do
-      ClimateControl.modify SUPPORT_USERNAME: 'foo', SUPPORT_PASSWORD: 'bar' do
-        get support_interface_applications_path, headers: basic_auth_headers('foo', 'bar')
-      end
-
-      expect(response).to have_http_status(200)
-    end
-  end
 end

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Add comments to the application history', with_audited: true do
+  include DfESignInHelpers
+
   around do |example|
     Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
       example.run
@@ -21,7 +23,9 @@ RSpec.feature 'Add comments to the application history', with_audited: true do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_is_an_application_in_the_system_logged_by_a_candidate

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -23,9 +23,7 @@ RSpec.feature 'Add comments to the application history', with_audited: true do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_is_an_application_in_the_system_logged_by_a_candidate

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Add comments to the application history', with_audited: true do
   end
 
   def given_i_am_a_support_user
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/api_tokens_spec.rb
+++ b/spec/system/support_interface/api_tokens_spec.rb
@@ -15,9 +15,7 @@ RSpec.feature 'Manage API tokens' do
   end
 
   def given_i_am_signed_in
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def when_i_visit_the_tokens_page

--- a/spec/system/support_interface/api_tokens_spec.rb
+++ b/spec/system/support_interface/api_tokens_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Manage API tokens' do
+  include DfESignInHelpers
+
   scenario 'Support creates a token' do
     given_i_am_signed_in
     and_providers_exist
@@ -13,7 +15,9 @@ RSpec.feature 'Manage API tokens' do
   end
 
   def given_i_am_signed_in
-    page.driver.browser.authorize('test', 'test')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def when_i_visit_the_tokens_page

--- a/spec/system/support_interface/api_tokens_spec.rb
+++ b/spec/system/support_interface/api_tokens_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'Manage API tokens' do
   end
 
   def given_i_am_signed_in
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'See application history', with_audited: true do
+  include DfESignInHelpers
+
   around do |example|
     Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
       example.run
@@ -20,7 +22,9 @@ RSpec.feature 'See application history', with_audited: true do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    provider_exists_in_dfe_sign_in(email_address: 'user@provider.com')
+    visit provider_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_is_an_application_in_the_system_logged_by_a_candidate

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'See application history', with_audited: true do
   end
 
   def given_i_am_a_support_user
-    provider_exists_in_dfe_sign_in(email_address: 'user@provider.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit provider_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -22,9 +22,7 @@ RSpec.feature 'See application history', with_audited: true do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit provider_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_is_an_application_in_the_system_logged_by_a_candidate

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'A provider authenticates via DfE Sign-in' do
+  include DfESignInHelpers
+
+  scenario 'signing in successfully' do
+    given_i_have_a_dfe_sign_in_account
+
+    when_i_visit_the_support_interface
+    and_i_sign_in_via_dfe_sign_in
+
+    then_i_should_be_redirected_to_the_support_home_page
+    and_i_should_see_my_email_address
+
+    when_i_click_sign_out
+    then_i_should_see_the_login_page_again
+  end
+
+  def given_i_have_a_dfe_sign_in_account
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+  end
+
+  def when_i_visit_the_support_interface
+    visit support_interface_path
+  end
+
+  def and_i_sign_in_via_dfe_sign_in
+    click_button 'Sign in using DfE Sign-in'
+  end
+
+  def then_i_should_be_redirected_to_the_support_home_page; end
+
+  def and_i_should_see_my_email_address
+    expect(page).to have_content('user@apply-support.com')
+  end
+
+  def when_i_click_sign_out
+    click_link 'Sign out'
+  end
+
+  def then_i_should_see_the_login_page_again
+    expect(page).to have_button('Sign in using DfE Sign-in')
+  end
+end

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -21,14 +21,16 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
   end
 
   def when_i_visit_the_support_interface
-    visit support_interface_path
+    visit support_interface_applications_path
   end
 
   def and_i_sign_in_via_dfe_sign_in
     click_button 'Sign in using DfE Sign-in'
   end
 
-  def then_i_should_be_redirected_to_the_support_home_page; end
+  def then_i_should_be_redirected_to_the_support_home_page
+    expect(page).to have_current_path support_interface_applications_path
+  end
 
   def and_i_should_see_my_email_address
     expect(page).to have_content('user@apply-support.com')

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'A provider authenticates via DfE Sign-in' do
+RSpec.describe 'A support user authenticates via DfE Sign-in' do
   include DfESignInHelpers
 
   scenario 'signing in successfully' do
@@ -17,7 +17,7 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
   end
 
   def given_i_have_a_dfe_sign_in_account
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
   end
 
   def when_i_visit_the_support_interface

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
     when_i_visit_the_support_interface
     then_i_should_be_redirected_to_login_page
+    and_i_should_not_see_support_menu
 
     when_i_sign_in_via_dfe_sign_in
 
@@ -28,6 +29,9 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
   def then_i_should_be_redirected_to_login_page
     expect(page).to have_current_path support_interface_sign_in_path
+  end
+
+  def and_i_should_not_see_support_menu
     expect(page).not_to have_link 'Applications'
     expect(page).not_to have_link 'APITokens'
     expect(page).not_to have_link 'Vendors'

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
     given_i_have_a_dfe_sign_in_account
 
     when_i_visit_the_support_interface
-    and_i_sign_in_via_dfe_sign_in
+    then_i_should_be_redirected_to_login_page
+
+    when_i_sign_in_via_dfe_sign_in
 
     then_i_should_be_redirected_to_the_support_home_page
     and_i_should_see_my_email_address
@@ -24,7 +26,14 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
     visit support_interface_applications_path
   end
 
-  def and_i_sign_in_via_dfe_sign_in
+  def then_i_should_be_redirected_to_login_page
+    expect(page).to have_current_path support_interface_sign_in_path
+    expect(page).not_to have_link 'Applications'
+    expect(page).not_to have_link 'APITokens'
+    expect(page).not_to have_link 'Vendors'
+  end
+
+  def when_i_sign_in_via_dfe_sign_in
     click_button 'Sign in using DfE Sign-in'
   end
 

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Feature flags' do
+  include DfESignInHelpers
+
   scenario 'Manage features' do
     given_i_am_a_support_user
     and_there_is_a_feature_flag_set_up
@@ -16,7 +18,9 @@ RSpec.feature 'Feature flags' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_is_a_feature_flag_set_up

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Feature flags' do
   end
 
   def given_i_am_a_support_user
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -18,9 +18,7 @@ RSpec.feature 'Feature flags' do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_is_a_feature_flag_set_up

--- a/spec/system/support_interface/import_references_spec.rb
+++ b/spec/system/support_interface/import_references_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'csv'
 
 RSpec.feature 'Import references' do
+  include DfESignInHelpers
+
   scenario 'Support agent imports a CSV' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
@@ -25,7 +27,9 @@ RSpec.feature 'Import references' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_are_applications_in_the_system

--- a/spec/system/support_interface/import_references_spec.rb
+++ b/spec/system/support_interface/import_references_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Import references' do
   end
 
   def given_i_am_a_support_user
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/import_references_spec.rb
+++ b/spec/system/support_interface/import_references_spec.rb
@@ -27,9 +27,7 @@ RSpec.feature 'Import references' do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_are_applications_in_the_system

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Managing support users' do
+  include DfESignInHelpers
+
   scenario 'creating a new support user' do
     given_i_am_a_support_user
 
@@ -15,7 +17,7 @@ RSpec.feature 'Managing support users' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    sign_in_as_support_user
   end
 
   def and_a_support_user_exists_in_the_database

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -23,9 +23,7 @@ RSpec.feature 'See providers' do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def when_i_visit_the_providers_page

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.feature 'See providers' do
+  include DfESignInHelpers
   include FindAPIHelper
 
   scenario 'User visits providers page' do
@@ -22,7 +23,9 @@ RSpec.feature 'See providers' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def when_i_visit_the_providers_page

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'See providers' do
   end
 
   def given_i_am_a_support_user
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -11,9 +11,7 @@ RSpec.feature 'See applications' do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_are_applications_in_the_system

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'See applications' do
   end
 
   def given_i_am_a_support_user
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'See applications' do
+  include DfESignInHelpers
+
   scenario 'Support agent visits the list of applications' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
@@ -9,7 +11,9 @@ RSpec.feature 'See applications' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_are_applications_in_the_system

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'See an application' do
   end
 
   def given_i_am_a_support_user
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -25,9 +25,7 @@ RSpec.feature 'See an application' do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_are_applications_in_the_system

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'See an application' do
+  include DfESignInHelpers
+
   scenario 'Support agent visits application page' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
@@ -23,7 +25,9 @@ RSpec.feature 'See an application' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_are_applications_in_the_system

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature 'Service performance' do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_are_candidates_in_the_system

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'Service performance' do
   end
 
   def given_i_am_a_support_user
-    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
     visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Service performance' do
+  include DfESignInHelpers
+
   scenario 'View service statistics' do
     given_i_am_a_support_user
     and_there_are_candidates_in_the_system
@@ -10,7 +12,9 @@ RSpec.feature 'Service performance' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    provider_exists_in_dfe_sign_in(email_address: 'user@provider.com')
+    visit provider_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_are_candidates_in_the_system

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -12,8 +12,8 @@ RSpec.feature 'Service performance' do
   end
 
   def given_i_am_a_support_user
-    provider_exists_in_dfe_sign_in(email_address: 'user@provider.com')
-    visit provider_interface_path
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com')
+    visit support_interface_path
     click_button 'Sign in using DfE Sign-in'
   end
 

--- a/spec/system/support_interface/sign_in_as_candidate_spec.rb
+++ b/spec/system/support_interface/sign_in_as_candidate_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Sign in as candidate' do
+  include DfESignInHelpers
+
   scenario 'Support user signs in as a candidate' do
     given_i_am_a_support_user
     and_there_is_an_application
@@ -10,7 +12,9 @@ RSpec.feature 'Sign in as candidate' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
+    visit support_interface_path
+    click_button 'Sign in using DfE Sign-in'
   end
 
   def and_there_is_an_application

--- a/spec/system/support_interface/sign_in_as_candidate_spec.rb
+++ b/spec/system/support_interface/sign_in_as_candidate_spec.rb
@@ -12,9 +12,7 @@ RSpec.feature 'Sign in as candidate' do
   end
 
   def given_i_am_a_support_user
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
-    visit support_interface_path
-    click_button 'Sign in using DfE Sign-in'
+    sign_in_as_support_user
   end
 
   def and_there_is_an_application

--- a/spec/system/support_interface/tasks_spec.rb
+++ b/spec/system/support_interface/tasks_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Tasks' do
+  include DfESignInHelpers
+
   scenario 'Support user performs a task' do
     given_i_am_a_support_user
 
@@ -10,7 +12,7 @@ RSpec.feature 'Tasks' do
   end
 
   def given_i_am_a_support_user
-    page.driver.browser.authorize('test', 'test')
+    sign_in_as_support_user
   end
 
   def when_i_visit_the_support_tasks_page

--- a/spec/system/support_interface/unauthorized_spec.rb
+++ b/spec/system/support_interface/unauthorized_spec.rb
@@ -14,9 +14,6 @@ RSpec.describe 'A support user authenticates via DfE Sign-in but is not authoriz
     then_i_should_be_see_the_not_authorized_page
     and_i_should_see_my_email_address
     and_i_should_not_see_support_menu
-
-    when_i_click_sign_out
-    then_i_should_see_the_login_page_again
   end
 
   def given_i_have_a_dfe_sign_in_account
@@ -47,13 +44,5 @@ RSpec.describe 'A support user authenticates via DfE Sign-in but is not authoriz
 
   def and_i_should_see_my_email_address
     expect(page).to have_content('user@apply-support.com')
-  end
-
-  def when_i_click_sign_out
-    click_link 'Sign out'
-  end
-
-  def then_i_should_see_the_login_page_again
-    expect(page).to have_button('Sign in using DfE Sign-in')
   end
 end

--- a/spec/system/support_interface/unauthorized_spec.rb
+++ b/spec/system/support_interface/unauthorized_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'A support user authenticates via DfE Sign-in' do
+RSpec.describe 'A support user authenticates via DfE Sign-in but is not authorized to access the support interface' do
   include DfESignInHelpers
 
-  scenario 'signing in successfully' do
+  scenario 'signing in unsuccessfully (without authorization)' do
     given_i_have_a_dfe_sign_in_account
 
     when_i_visit_the_support_interface
@@ -11,15 +11,16 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
     when_i_sign_in_via_dfe_sign_in
 
-    then_i_should_be_redirected_to_the_support_home_page
+    then_i_should_be_see_the_not_authorized_page
     and_i_should_see_my_email_address
+    and_i_should_not_see_support_menu
 
     when_i_click_sign_out
     then_i_should_see_the_login_page_again
   end
 
   def given_i_have_a_dfe_sign_in_account
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
   end
 
   def when_i_visit_the_support_interface
@@ -28,6 +29,9 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
   def then_i_should_be_redirected_to_login_page
     expect(page).to have_current_path support_interface_sign_in_path
+  end
+
+  def and_i_should_not_see_support_menu
     expect(page).not_to have_link 'Applications'
     expect(page).not_to have_link 'APITokens'
     expect(page).not_to have_link 'Vendors'
@@ -37,8 +41,8 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
     click_button 'Sign in using DfE Sign-in'
   end
 
-  def then_i_should_be_redirected_to_the_support_home_page
-    expect(page).to have_current_path support_interface_applications_path
+  def then_i_should_be_see_the_not_authorized_page
+    expect(page).to have_content 'Your account is not authorized'
   end
 
   def and_i_should_see_my_email_address


### PR DESCRIPTION
DO NOT MERGE UNTIL WE HAVE SET UP DfE Sign-in SUPPORT USERS ON QA/STAGING/PRODUCTION

### Context

Currently the support interface is authenticated with basic auth. This is not very secure and means that we cannot grant access to individuals or audit their activity.

### Changes proposed in this pull request

- [x] Authenticate users of the support interface with DfE Sign-in. Users can log in with one DfE Sign-in account that could have access to the provider interface, support interface or both.
- [x] Authorise users of the support interface by looking up their email address on a list stored in the database. For authenticated users that are not authorized we render a new 'Not authorized' template (because the one for providers isn't appropriate). (Copy needs to be reviewed).
- [x] Change the DfE Sign-in callback action so that it can serve both interfaces. To do this we now store the 'target' path that the unauthenticated user originally attempted to access in the user session and redirect them here following a successful login. Previously they were redirected to a hard-coded path in the provider interface.
- [x] Handle the situation in which the user went straight to the login page for the support or provider interface (without setting the target path session variable).
- [x] Ensure that we still handle the situation in which a provider can log in but has not yet been granted access.
- [x] Add a rake task to create a support user (or just update it's email address if it already exists). Usage: `bundle exec rails "create_support_user[alice, alice@example.com]"` where `alice` is the DfE Sign-in UID and `alice@example.com` is the email address.
- [x] Update README?
- [ ] Work out a list of email addresses that require access and configure these before we deploy to production. (We can add these using the rake task above or direct DB access).

![dfe-sign-in](https://user-images.githubusercontent.com/450843/70142572-752a5900-1691-11ea-8491-b0a844998615.gif)

### Guidance to review

- Are there any loopholes that would allow users to access the support interface unauthenticated or without the correct authorisation?
- Are the tests covering everything they should? e.g. failed login as well as success
- What are the challenges with rolling this out other than having to configure the list of users that should have access? Based on what we discussed at the incident review this should have been broken up somehow and/or feature flagged. Not sure how that would work exactly.
- Content review for the 'Not authorized' page

### Link to Trello card

[1307 - Put support behind DfE Sign-in](https://trello.com/c/DVh2NV9f/1307-put-support-behind-dfe-sign-in)

### Env vars

- no new env vars
