### PR TITLE
make FeatureFlag connect to hardcoded Redis db in test mode

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
+REDIS_URL=redis://localhost:6379/9
 FIND_BASE_URL=http://find-test/api/v3/
 SUPPORT_USERNAME=test
 SUPPORT_PASSWORD=test

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,15 +1,7 @@
 require 'workers/audit_trail_attribution_middleware'
 
-redis_url = ENV.fetch('REDIS_URL') rescue 'redis://localhost:6379/1'
-redis_url = redis_url.gsub(/\/\d+$/, '/9') if Rails.env.test? # hardcode db to isolate test data
-
 Sidekiq.configure_server do |config|
-  config.redis = { url: redis_url }
   config.server_middleware do |chain|
     chain.add Workers::AuditTrailAttributionMiddleware
   end
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = { url: redis_url }
 end


### PR DESCRIPTION
### Context

A previous PR introduced hardcoding the Redis database in Rails test environment so that any Sidekiq tasks generated in the tests do not pollute the local development environment.

### Changes proposed in this pull request

This makes rspec tests also connect to a different Redis database.

### Link to Trello card

[591 - Local development with feature flags affected by Redis shared environment](https://trello.com/c/xYFYzeuY)

### Env vars

 No new env vars
