### PR TITLE
Show application choices in the support interface

### DIFF
--- a/app/components/support_interface/application_status_tag_component.html.erb
+++ b/app/components/support_interface/application_status_tag_component.html.erb
@@ -1,0 +1,1 @@
+<%= render TagComponent, text: text, type: type %>

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -1,0 +1,36 @@
+# TODO: dedupe with the ProviderInterface counterpart
+module SupportInterface
+  class ApplicationStatusTagComponent < ActionView::Component::Base
+    validates :application_choice, presence: true
+    delegate :status, to: :application_choice
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def text
+      I18n.t!("support_application_states.#{status}")
+    end
+
+    def type
+      case status
+      when 'awaiting_provider_decision'
+        :primary_unfilled
+      when 'offer'
+        :info_unfilled
+      when 'rejected'
+        :danger
+      when 'pending_conditions'
+        :info
+      when 'declined'
+        :warning
+      else
+        ''
+      end
+    end
+
+  private
+
+    attr_reader :application_choice
+  end
+end

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -24,7 +24,6 @@ module SupportInterface
         support_reference_row,
         email_row,
         phone_number_row,
-        choices_row,
         submitted_row,
         last_updated_row,
       ].compact
@@ -53,19 +52,6 @@ module SupportInterface
         {
           key: 'Phone number',
           value: phone_number,
-        }
-      end
-    end
-
-    def choices_row
-      if application_choices.any?
-        {
-          key: 'Course choices',
-          value: application_choices.map do |a|
-            href = "https://find-postgraduate-teacher-training.education.gov.uk/course/#{a.course.provider.code}/#{a.course.code}"
-            text = "#{a.course.name_and_code} at #{a.course.provider.name_and_code}"
-            govuk_link_to(text, href)
-          end,
         }
       end
     end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -23,6 +23,17 @@
   <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), class: 'govuk-button' %>
 <% end %>
 
+<% @application_form.application_choices.includes(:course, :provider, :site).each do |application_choice| %>
+  <h2 class="govuk-heading-l govuk-!-margin-top-8"><%= application_choice.course.name_and_code %></h2>
+  <%= render SummaryListComponent, rows: [
+    { key: 'Course', value: application_choice.course.name_and_code },
+    { key: 'Provider', value: application_choice.provider.name_and_code },
+    { key: 'Location', value: application_choice.site.name_and_code },
+    { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent, application_choice: application_choice) },
+    { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s },
+  ] %>
+<% end %>
+
 <% @application_form.references.each_with_index do |reference, i| %>
   <h2 class="govuk-heading-l govuk-!-margin-top-8"><%= (i + 1).ordinalize %> reference</h2>
 

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -24,8 +24,8 @@ en:
     unsubmitted: Not submitted yet
     withdrawn: Candidate withdrawn
   support_application_states:
-    application_complete: New
-    awaiting_provider_decision: Awaiting provider decision
+    application_complete: Waiting to be sent
+    awaiting_provider_decision: Awaiting decision
     awaiting_references: Awaiting references
     declined: Candidate declined
     enrolled: Candidate enrolled


### PR DESCRIPTION
### Context

We currently don't show the state of application choices in the support interface. We need this to know what to do about an application.

### Changes proposed in this pull request

- Support users can see the state of application choices on the show page 

### Guidance to review



### Link to Trello card

https://trello.com/c/aDeICHGP