### PR TITLE
Generate better test applications

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,7 @@ Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
     - 'spec/**/*'
+    - app/services/generate_test_applications.rb
 
 RSpec/ExampleLength:
   Enabled: false

--- a/app/services/generate_test_applications.rb
+++ b/app/services/generate_test_applications.rb
@@ -1,0 +1,90 @@
+class GenerateTestApplications
+  def generate
+    raise 'You can\'t generate test data in production' if HostingEnvironment.production?
+
+    Reference.delete_all
+    ApplicationChoice.delete_all
+    ApplicationForm.delete_all
+
+    100.times do |i|
+      create_an_application(i)
+    end
+  end
+
+private
+
+  def create_an_application(application_index)
+    first_name = Faker::Name.unique.first_name
+    last_name = Faker::Name.unique.last_name
+    candidate = FactoryBot.create(
+      :candidate,
+      email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
+    )
+
+    Audited.audit_class.as_user(candidate) do
+      application_form = FactoryBot.create(
+        :completed_application_form,
+        application_choices_count: 0,
+        submitted_at: nil,
+        candidate: candidate,
+        first_name: first_name,
+        last_name: last_name,
+      )
+
+      [1, 2, 3].sample.times do
+        FactoryBot.create(
+          :application_choice,
+          status: 'unsubmitted',
+          course_option: CourseOption.all.sample,
+          application_form: application_form,
+          personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
+        )
+      end
+
+      return if application_index > 90
+
+      # The application is submitted by the candidate
+      SubmitApplication.new(application_form).call
+
+      return if application_index > 80
+
+      # References come in
+      application_form.references.each do |reference|
+        ReceiveReference.new(
+          application_form: application_form,
+          referee_email: reference.email_address,
+          feedback: 'You are awesome',
+        ).save
+      end
+
+      return if application_index > 70
+
+      application_form.application_choices.each do |application_choice|
+        # This is only supposed to happen after 7 days, but SendApplicationToProvider
+        # doesn't check the `edit_by` date of the ApplicationChoice
+        SendApplicationToProvider.new(application_choice: application_choice).call
+      end
+
+      return if application_index > 60
+
+      # Now the providers need to make a decision
+
+      # First one gets an offer
+      MakeAnOffer.new(application_choice: application_form.application_choices[0], offer_conditions: []).save
+
+      return if application_index > 50
+
+      if (second = application_form.application_choices[1])
+        RejectApplication.new(application_choice: second, rejection_reason: 'Some').save
+      end
+
+      return if application_index > 40
+
+      if (third = application_form.application_choices[2])
+        RejectApplication.new(application_choice: third, rejection_reason: 'Some').save
+      end
+
+      # TODO: accept/decline/withdraw
+    end
+  end
+end

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -1,3 +1,9 @@
+desc 'Delete and create test data, including courses and options'
 task generate_test_data: :environment do
   GenerateTestData.new(100).generate
+end
+
+desc 'Generate test applications for existing providers'
+task generate_test_applications: :environment do
+  GenerateTestApplications.new.generate
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -28,14 +28,19 @@ FactoryBot.define do
       address_line4 { '' }
       country { 'UK' }
       postcode { Faker::Address.postcode }
-      degrees_completed { [true, false].sample }
-      other_qualifications_completed { [true, false].sample }
       becoming_a_teacher { Faker::Lorem.paragraph_by_chars(number: 500) }
       subject_knowledge { Faker::Lorem.paragraph_by_chars(number: 300) }
       interview_preferences { Faker::Lorem.paragraph_by_chars(number: 100) }
       work_history_explanation { Faker::Lorem.paragraph_by_chars(number: 600) }
       work_history_breaks { Faker::Lorem.paragraph_by_chars(number: 400) }
       volunteering_experience { [true, false, nil].sample }
+
+      # Checkboxes to mark a section as complete
+      course_choices_completed { true }
+      degrees_completed { true }
+      other_qualifications_completed { true }
+      volunteering_completed { true }
+      work_history_completed { true }
 
       transient do
         application_choices_count { 3 }
@@ -57,10 +62,14 @@ FactoryBot.define do
       end
 
       after(:build) do |application_form, evaluator|
+        create(:application_qualification, application_form: application_form, subject: 'maths', level: 'gcse', qualification_type: 'GCSE')
+        create(:application_qualification, application_form: application_form, subject: 'english', level: 'gcse', qualification_type: 'GCSE')
+        create(:application_qualification, application_form: application_form, subject: 'science', level: 'gcse', qualification_type: 'GCSE')
+
+
         create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'awaiting_references')
         create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)
         create_list(:application_volunteering_experience, evaluator.volunteering_experiences_count, application_form: application_form)
-        create_list(:application_qualification, evaluator.qualifications_count, application_form: application_form)
         create_list(:reference, evaluator.references_count, evaluator.references_state, application_form: application_form)
         # The application_form validates the length of this collection when
         # it is created, which is BEFORE we create the references here.

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#volunteering_path' do
     it 'returns the experience path if volunteering experience is not set' do
-      application_form = build(:completed_application_form, volunteering_experience: nil, volunteering_experiences_count: 0)
+      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: nil, volunteering_experiences_count: 0)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
@@ -236,7 +236,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
 
     it 'returns the review path if no volunteering experience' do
-      application_form = build(:completed_application_form, volunteering_experience: false, volunteering_experiences_count: 0)
+      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: false, volunteering_experiences_count: 0)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter.volunteering_path).to eq(
@@ -245,7 +245,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
 
     it 'returns the review path if volunteering experience' do
-      application_form = build(:completed_application_form, volunteering_experience: true, volunteering_experiences_count: 1)
+      application_form = build(:completed_application_form, volunteering_completed: false, volunteering_experience: true, volunteering_experiences_count: 1)
 
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 


### PR DESCRIPTION
### Context

We need more test data to facilitate manual testing. This generates applications in various states.

### Changes proposed in this pull request

This adds a rake task to generate test applications.

We do this by using FactoryBot to generate a fully filled-in application, and progressing a number of them through successive states. This means we'll end up with 10 applications in each "stage". There's space left at the bottom for accepting and withdrawing applications.

It's a separate task from `GenerateTestData`, since it only generates the applications and doesn't touch providers, courses and sites. I suspect that we'll replace the existing test data task with this, but I'm not sure how it's going to work out.

It doesn't have tests because they would be slow, and this is a development-only thing for now.

In a follow up PR we'll consider how to run this on test environments.

### Guidance to review

Run it locally. Note that you can't really see any difference in the support interface, we'll need https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/772 for that.

### Link to Trello card

https://trello.com/c/49yLJZEW/1353-improve-how-we-do-manual-testing