### PR TITLE
Revert "Downcase candidate email_address before saving/comparing"

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -2,9 +2,7 @@ class Candidate < ApplicationRecord
   # Only Devise's :timeoutable module is enabled to handle session expiry
   # Custom Warden strategy is used instead see app/warden/magic_link_token.rb
   devise :timeoutable
-
-  before_validation :downcase_email
-  validates :email_address, presence: true, uniqueness: { case_sensitive: false }, length: { maximum: 250 }
+  validates :email_address, presence: true, uniqueness: true, length: { maximum: 250 }
   validates :email_address, email_address: true
 
   has_many :application_forms
@@ -12,11 +10,5 @@ class Candidate < ApplicationRecord
   def current_application
     application_form = application_forms.first_or_create!
     application_form
-  end
-
-private
-
-  def downcase_email
-    email_address.try(:downcase!)
   end
 end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Candidate, type: :model do
   describe 'a valid candidate' do
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
-    it { is_expected.to validate_uniqueness_of(:email_address).case_insensitive }
+    it { is_expected.to validate_uniqueness_of :email_address }
     it { is_expected.not_to allow_value(Faker::Lorem.characters(number: 251)).for(:email_address) }
   end
 


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-postgraduate-teacher-training#753

We need something more involved to implement this functionality, so it seems best to revert this at this stage and come back with a follow-up PR.