### PR TITLE
Add conditional showing of Science GCSE on Your application page

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
       return redirect_to candidate_interface_application_form_path if params[:token]
 
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+      @application_form = current_application
     end
 
     def review

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -70,5 +70,13 @@ class ApplicationForm < ApplicationRecord
     application_choices.map.any?(&:offer?)
   end
 
+  def science_gcse_needed?
+    return true unless FeatureFlag.active?('conditional_science_gcse')
+
+    application_choices.any? do |application_choice|
+      application_choice.course_option.course.primary_course?
+    end
+  end
+
   audited
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,7 @@
 class FeatureFlag
   FEATURES = %w[
     pilot_open
+    conditional_science_gcse
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -50,9 +50,11 @@
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent, text: 'English GCSE or equivalent', completed: @application_form_presenter.english_gcse_completed?, path: @application_form_presenter.english_gcse_completed? ? candidate_interface_gcse_review_path(subject: :english) : candidate_interface_gcse_details_edit_type_path(subject: :english)) %>
       </li>
-      <li class="app-task-list__item">
-        <%= render(TaskListItemComponent, text: 'Science GCSE or equivalent', completed: @application_form_presenter.science_gcse_completed?, path: @application_form_presenter.science_gcse_completed? ? candidate_interface_gcse_review_path(subject: :science) : candidate_interface_gcse_details_edit_type_path(subject: :science)) %>
-      </li>
+      <% if @application_form.science_gcse_needed? %>
+        <li class="app-task-list__item">
+          <%= render(TaskListItemComponent, text: 'Science GCSE or equivalent', completed: @application_form_presenter.science_gcse_completed?, path: @application_form_presenter.science_gcse_completed? ? candidate_interface_gcse_review_path(subject: :science) : candidate_interface_gcse_details_edit_type_path(subject: :science)) %>
+        </li>
+      <% end %>
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent, text: t('page_titles.other_qualification'), completed: @application_form_presenter.other_qualifications_completed?, path: @application_form_presenter.other_qualification_path, show_incomplete: false) %>
       </li>

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -32,4 +32,56 @@ RSpec.describe ApplicationForm do
       expect(application_choices.map(&:updated_at)).not_to include(original_time)
     end
   end
+
+  describe '#science_gcse_needed?' do
+    before { FeatureFlag.activate('conditional_science_gcse') }
+
+    context 'when a candidate has no course choices' do
+      it 'returns false' do
+        application_form = build_stubbed(:application_form)
+
+        expect(application_form.science_gcse_needed?).to eq(false)
+      end
+    end
+
+    context 'when a candidate has a course choice that is primary' do
+      it 'returns true' do
+        application_form = application_form_with_course_option_for_provider_with(level: 'primary')
+
+        expect(application_form.science_gcse_needed?).to eq(true)
+      end
+    end
+
+    context 'when a candidate has a course choice that is secondary' do
+      it 'returns false' do
+        application_form = application_form_with_course_option_for_provider_with(level: 'secondary')
+
+        expect(application_form.science_gcse_needed?).to eq(false)
+      end
+    end
+
+    context 'when a candidate has a course choice that is further education' do
+      it 'returns false' do
+        application_form = application_form_with_course_option_for_provider_with(level: 'further_education')
+
+        expect(application_form.science_gcse_needed?).to eq(false)
+      end
+    end
+
+    def application_form_with_course_option_for_provider_with(level:)
+      provider = build(:provider)
+      course = create(:course, level: level, provider: provider)
+      site = create(:site, provider: provider)
+      course_option = create(:course_option, course: course, site: site)
+      application_form = create(:application_form)
+
+      create(
+        :application_choice,
+        application_form: application_form,
+        course_option: course_option,
+      )
+
+      application_form
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate viewing Science GCSE' do
+  include CandidateHelper
+
+  scenario 'Candidate views a Science GCSE only when a primary course is chosen' do
+    given_i_am_signed_in
+    when_i_visit_the_site
+    then_i_see_science_gcse
+
+    given_conditional_science_gcse_feature_flag_is_on
+    when_i_visit_the_site
+    then_i_dont_see_science_gcse
+
+    given_courses_exist
+    when_i_add_a_primary_course
+    then_i_see_science_gcse
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def then_i_see_science_gcse
+    expect(page).to have_content('Science GCSE or equivalent')
+  end
+
+  def given_conditional_science_gcse_feature_flag_is_on
+    FeatureFlag.activate('conditional_science_gcse')
+  end
+
+  def then_i_dont_see_science_gcse
+    expect(page).not_to have_content('Science GCSE or equivalent')
+  end
+
+  def when_i_add_a_primary_course
+    click_link 'Course choices'
+    candidate_fills_in_course_choices
+  end
+end


### PR DESCRIPTION
### Context

A candidate is only required to have a Science GCSE if the level of the course they have chosen is a primary one. Currently, we always show the Science GCSE section on the `Your application` page but this should be conditional on the courses chosen.

### Changes proposed in this pull request

This PR adds the showing of Science GCSE on the `Your application` page by adding a method called `science_gcse_needed?` to `ApplicationForm`. This returns `true` if any of courses chosen are primary and `false` for any other level.

We've also added in a feature flag called `conditional_science_gcse` as we'll need to always show the Science GCSE until we add conditional validation when reviewing and submitting an application in our next PR.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/69864394-bfc56300-1296-11ea-9c61-8cad62dd490a.png)

### Guidance to review

Upcoming PRs will look at not showing it in the application review and not validating it at submission.

### Link to Trello card

[401 - Primary course conditional](https://trello.com/c/cTiIxGpC/401-primary-course-conditional)
