### PR TITLE
Point support contacts to BaT team, not GiT

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -9,10 +9,10 @@ module ViewHelper
     link_to(body, url, class: 'govuk-back-link')
   end
 
-  def bat_contact_mail_to(name = nil, html_options: {})
+  def bat_contact_mail_to(name = 'becomingateacher<wbr>@digital.education.gov.uk', html_options: {})
     html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
 
-    mail_to('becomingateacher@digital.education.gov.uk', name, html_options)
+    mail_to('becomingateacher@digital.education.gov.uk', name.html_safe, html_options)
   end
 
   def govuk_button_link_to(body, url, html_options = {})

--- a/app/views/candidate_interface/shared/_need_help.html.erb
+++ b/app/views/candidate_interface/shared/_need_help.html.erb
@@ -1,7 +1,6 @@
 <aside class="app-related" role="complementary">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="help-title">Need help?</h2>
-
   <p class="govuk-body-s">
-    Call <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk' %> on Freephone 0800 389 2500 or chat to an adviser using their <%= govuk_link_to 'online chat service', 'https://getintoteaching.education.gov.uk/lp/live-chat' %> between 8am and 8pm, Monday to Friday
+    Email us and we can give you personalised&nbsp;support:<br><%= bat_contact_mail_to %>
   </p>
 </aside>

--- a/app/views/layouts/_candidate_footer.html.erb
+++ b/app/views/layouts/_candidate_footer.html.erb
@@ -1,7 +1,7 @@
 <h2 class="govuk-heading-m">Need help?</h2>
-<div class="govuk-footer__meta-custom">
-  Call <%= link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk', class: 'govuk-footer__link' %> on Freephone 0800 389 2500 or chat to an adviser using their <%= link_to 'online chat service', 'https://getintoteaching.education.gov.uk/lp/live-chat', class: 'govuk-footer__link' %> between 8am and 8pm, Monday to Friday
-</div>
+<p class="govuk-footer__meta-custom">
+  Email us on <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %> and we can give you personalised&nbsp;support.
+</p>
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.accessibility'), candidate_interface_accessibility_path, class: 'govuk-footer__link' %>

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ViewHelper, type: :helper do
     it 'returns an anchor tag with href="mailto:" and the govuk-link class' do
       anchor_tag = helper.bat_contact_mail_to
 
-      expect(anchor_tag).to eq('<a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>')
+      expect(anchor_tag).to eq('<a class="govuk-link" href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher<wbr>@digital.education.gov.uk</a>')
     end
 
     it 'returns an anchor tag with the name' do
@@ -51,7 +51,7 @@ RSpec.describe ViewHelper, type: :helper do
     it 'returns an anchor tag with additional HTML options' do
       anchor_tag = helper.bat_contact_mail_to(html_options: { subject: 'Support and guidance', class: 'govuk-link--no-visited-state' })
 
-      expect(anchor_tag).to eq('<a class="govuk-link govuk-link--no-visited-state" href="mailto:becomingateacher@digital.education.gov.uk?subject=Support%20and%20guidance">becomingateacher@digital.education.gov.uk</a>')
+      expect(anchor_tag).to eq('<a class="govuk-link govuk-link--no-visited-state" href="mailto:becomingateacher@digital.education.gov.uk?subject=Support%20and%20guidance">becomingateacher<wbr>@digital.education.gov.uk</a>')
     end
   end
 


### PR DESCRIPTION
### Context

We now want to point candidates to our internal support channel, rather than Get into Teaching.

Also updates the `bat_contact_mail_to` helper to include a suggested word break before the @ symbol in our long email address. 

### Changes proposed in this pull request

<img width="580" alt="Screenshot 2019-12-03 at 12 56 51" src="https://user-images.githubusercontent.com/813383/70052998-704fa180-15cc-11ea-81ab-f4c5b845b2c0.png">

<img width="330" alt="Screenshot 2019-12-03 at 12 57 02" src="https://user-images.githubusercontent.com/813383/70053005-72b1fb80-15cc-11ea-8673-b3381cfaf35b.png">

### Link to Trello card

[597 - Change support banner on service](https://trello.com/c/mnZv6qiH/)
