### PR TITLE
Remove "Guidance" from terms of use.

### DIFF
--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -21,12 +21,12 @@
       <p class="govuk-body">We use it to process your application, build a better service and improve teacher recruitment and retention.</p>
       <p class="govuk-body govuk-!-margin-bottom-6">Take a look at our <%= govuk_link_to 'privacy policy', candidate_interface_privacy_policy_path %> before starting your application to check you understand how we use your data.</p>
 
-      <%= f.govuk_check_boxes_fieldset :accept_ts_and_cs, legend: { text: 'Guidance and terms of use' } do %>
-        <p class="govuk-body">Our <%= govuk_link_to 'Guidance and terms of use', candidate_interface_terms_path %> contain useful information about:</p>
+      <%= f.govuk_check_boxes_fieldset :accept_ts_and_cs, legend: { text: 'Terms of use' } do %>
+        <p class="govuk-body">Our <%= govuk_link_to 'terms of use', candidate_interface_terms_path %> contain information about:</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>how the application process works</li>
-          <li>contacting us if you need help</li>
-          <li>how we check you’re safe to work with children</li>
+          <li>the application process</li>
+          <li>contacting us</li>
+          <li>checking you’re safe to work with children</li>
         </ul>
 
         <%= f.govuk_check_box :accept_ts_and_cs, true, multiple: false, link_errors: true, label: { text: t('authentication.sign_up.accept_terms_checkbox') } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,7 +21,7 @@ en:
     review_application: Review your application
     accessibility: Accessibility statement
     privacy_policy: How we look after your personal data
-    terms_candidate: Guidance and terms of use for candidates
+    terms_candidate: Terms of use for candidates
     terms_provider: Terms of use for teacher training providers
     cookies_candidate: Cookies
     cookies_provider: Cookies


### PR DESCRIPTION
Avoid legal questions around combining terms and guidance.

While the terms of use are user friendly, and give a good overview of what you can and can’t do, they are terms and not guidance. 

Where guidance is needed, the service is already doing this in context. If we do need an overview, it probably shouldn't be bundled with the terms.

[Slack message](https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1574356545238400?thread_ts=1574353437.232700&cid=CAHBLU6ET) for further context.

This undoes #641 which I think was merged too early.

![Screen Shot 2019-12-03 at 13 46 24](https://user-images.githubusercontent.com/319055/70056416-55346000-15d3-11ea-9f86-7f520c530e4f.png)

