### PR TITLE
Set log level to `:info` in live environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,6 +60,8 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Logging configuration
+  config.log_level = :info
+
   if ENV['LOGSTASH_ENABLE'] == 'true'
     LogstashLogging.enable(config)
   else


### PR DESCRIPTION
### Changes proposed in this pull request

I think we're currently logging at `:debug` level in live environments, which means email contents are logged, and we don't want that.  

### Guidance to review

Does this make sense? It's a guess that this would work, since our logging setup is complicated.

### Link to Trello card

https://trello.com/c/m6FtsxEs