### PR TITLE
Use aria for simpler complete section links

### DIFF
--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,8 +1,6 @@
 <div class="app-banner<% if @error %> app-banner--warning<% end %> app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
-    <p class="govuk-body"><%= @text %></p>
-    <%= link_to @section_path, class: 'govuk-link' do %>
-      Complete <span class="govuk-visually-hidden"><%= t("review_application.#{section}.complete_section_visually_hidden") %></span> section
-    <% end %>
+    <p class="govuk-body" id="<%= "missing-#{section}" %>"><%= @text %></p>
+    <%= link_to t('review_application.complete_section'), @section_path, class: 'govuk-link', aria: { describedby: "missing-#{section}" } %>
   </div>
 </div>

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -2,43 +2,31 @@ en:
   review_application:
     title: Review your application
     heading: Review your application
+    complete_section: Complete section
     button_continue: Continue
     becoming_a_teacher:
       incomplete: Tell us why you want to be a teacher
-      complete_section_visually_hidden: tell us why you want to be a teacher
     contact_details:
       incomplete: Contact details not entered
-      complete_section_visually_hidden: contact details
     course_choices:
       incomplete: Course choices are not marked as completed
-      complete_section_visually_hidden: course choices
     degrees:
       incomplete: Degree(s) are not marked as completed
-      complete_section_visually_hidden: degree(s)
     maths_gcse:
       incomplete: Maths GCSE or equivalent not entered
-      complete_section_visually_hidden: Maths GCSE or equivalent
     english_gcse:
       incomplete: English GCSE or equivalent not entered
-      complete_section_visually_hidden: English GCSE or equivalent
     science_gcse:
       incomplete: Science GCSE or equivalent not entered
-      complete_section_visually_hidden: Science GCSE or equivalent
     interview_preferences:
       incomplete: Tell us your interview preferences
-      complete_section_visually_hidden: interview preferences
     personal_details:
       incomplete: Personal details not entered
-      complete_section_visually_hidden: personal details
     references:
       incomplete: Add %{minimum_references} referees to your application
-      complete_section_visually_hidden: references
     subject_knowledge:
       incomplete: Tell us about your knowledge about the subject you want to teach
-      complete_section_visually_hidden: subject knowledge
     volunteering:
       incomplete: Volunteering with children and young people is not marked as completed
-      complete_section_visually_hidden: volunteering with children and young people
     work_experience:
       incomplete: Work history is not marked as completed
-      complete_section_visually_hidden: work history

--- a/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
@@ -145,15 +145,17 @@ RSpec.feature 'Candidate reviews the answers' do
   end
 
   def then_i_should_see_an_incomplete_banner_for(section)
-    expect(page).to have_content "Complete #{t("review_application.#{section}.complete_section_visually_hidden")} section"
+    expect(page).to have_selector "[aria-describedby='missing-#{section}']"
   end
 
   def when_i_click_to_complete_section_for(section)
-    click_link "Complete #{t("review_application.#{section}.complete_section_visually_hidden")} section"
+    within "#missing-#{section}-error" do
+      click_link "Complete section"
+    end
   end
 
   def then_i_should_not_see_an_incomplete_banner_for(section)
-    expect(page).not_to have_content "Complete #{t("review_application.#{section}.complete_section_visually_hidden")} section"
+    expect(page).not_to have_selector "[aria-describedby='missing-#{section}']"
   end
 
   def then_i_should_be_able_to_complete_section_for(section)

--- a/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature 'Candidate reviews the answers' do
 
   def when_i_click_to_complete_section_for(section)
     within "#missing-#{section}-error" do
-      click_link "Complete section"
+      click_link 'Complete section'
     end
   end
 


### PR DESCRIPTION
### Context

We can use `aria-describedby` to simplify how we annotate ‘Complete section’ links, reducing code, localisable strings and code duplication. Nice spot, @adamsilver!
