### PR TITLE
Add CUSTOM_HOSTNAME to Sidekiq

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -665,6 +665,10 @@
                                 "secureValue": "[parameters('secretKeyBase')]"
                             },
                             {
+                                "name": "CUSTOM_HOSTNAME",
+                                "value": "[parameters('customHostName')]"
+                            },
+                            {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
                             },
@@ -715,6 +719,18 @@
                             {
                                 "name": "SERVICE_TYPE",
                                 "value": "worker"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_CLIENT_ID",
+                                "value": "[parameters('dfeSignInClientId')]"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_SECRET",
+                                "value": "[parameters('dfeSignInSecret')]"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_ISSUER",
+                                "value": "[parameters('dfeSignInIssuer')]"
                             },
                             {
                                 "name": "REDIS_URL",
@@ -789,6 +805,10 @@
                                 "secureValue": "[parameters('secretKeyBase')]"
                             },
                             {
+                                "name": "CUSTOM_HOSTNAME",
+                                "value": "[parameters('customHostName')]"
+                            },
+                            {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
                             },
@@ -839,6 +859,18 @@
                             {
                                 "name": "SERVICE_TYPE",
                                 "value": "clock"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_CLIENT_ID",
+                                "value": "[parameters('dfeSignInClientId')]"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_SECRET",
+                                "value": "[parameters('dfeSignInSecret')]"
+                            },
+                            {
+                                "name": "DFE_SIGN_IN_ISSUER",
+                                "value": "[parameters('dfeSignInIssuer')]"
                             },
                             {
                                 "name": "REDIS_URL",

--- a/spec/azure/configuration_spec.rb
+++ b/spec/azure/configuration_spec.rb
@@ -5,6 +5,26 @@ RSpec.describe 'Configuration' do
     it 'is valid JSON' do
       JSON.parse(File.read('azure/template.json'))
     end
+
+    it 'includes the app-service variables in clockwork and sidekiq processes' do
+      app_settings = resource('app-service').dig('properties', 'parameters', 'appServiceAppSettings', 'value').map { |v| v['name'] }
+      worker_settings = resource('container-instances-worker').dig('properties', 'parameters', 'environmentVariables', 'value').map { |v| v['name'] }
+      clock_settings = resource('container-instances-clock').dig('properties', 'parameters', 'environmentVariables', 'value').map { |v| v['name'] }
+
+      settings_that_are_okay_to_differ = %w[APPINSIGHTS_INSTRUMENTATIONKEY
+                                            BASIC_AUTH_PASSWORD BASIC_AUTH_USERNAME RAILS_SERVE_STATIC_FILES
+                                            WEBSITES_CONTAINER_START_TIME_LIMIT
+                                            WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION
+                                            WEBSITE_SWAP_WARMUP_PING_PATH WEBSITE_SWAP_WARMUP_PING_STATUSES]
+
+      expect(worker_settings).to match_array(app_settings - settings_that_are_okay_to_differ)
+      expect(clock_settings).to match_array(app_settings - settings_that_are_okay_to_differ)
+    end
+
+    def resource(process)
+      thing = JSON.parse(File.read('azure/template.json'))
+      thing['resources'].find { |resource| resource['name'] == process }
+    end
   end
 
   describe 'azure-pipelines.yml' do


### PR DESCRIPTION
We're currently seeing weird things on live environments where the hostname is the internal azure one (`s106x61`). This is because `CUSTOM_HOSTNAME` isn't set in the Sidekiq worker process.

- This fixes the issue in the ARM template
- And adds a test that it doesn't happen again

https://trello.com/c/v4tAgboi/1356-fix-domain-linked-to-from-emails