### PR TITLE
Remove Science GCSE validation when not required

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -23,7 +23,7 @@ module CandidateInterface
         [:degrees, degrees_completed?],
         [:maths_gcse, maths_gcse_completed?],
         [:english_gcse, english_gcse_completed?],
-        [:science_gcse, science_gcse_completed?],
+        ([:science_gcse, science_gcse_completed?] if @application_form.science_gcse_needed?),
         # "Other qualifications" is intentionally omitted, since it's optional
 
         # "Personal statement and interview" section
@@ -33,7 +33,7 @@ module CandidateInterface
 
         # "References" section
         [:references, all_referees_provided_by_candidate?],
-      ]
+      ].compact
     end
 
     def section_errors

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -36,9 +36,11 @@
 
 <%= render(GcseQualificationReviewComponent, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error) %>
 
-<h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
+<% if @application_form.science_gcse_needed? %>
+  <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
 
-<%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error) %>
+  <%= render(GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error) %>
+<% end %>
 
 <h3 class="govuk-heading-m">Other relevant qualifications</h3>
 

--- a/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
@@ -8,13 +8,29 @@ RSpec.feature 'Candidate viewing Science GCSE' do
     when_i_visit_the_site
     then_i_see_science_gcse
 
+    when_i_click_on_check_your_answers
+    then_i_see_science_gcse_is_missing_below_the_section
+
     given_conditional_science_gcse_feature_flag_is_on
     when_i_visit_the_site
     then_i_dont_see_science_gcse
 
+    when_i_click_on_check_your_answers
+    then_i_dont_see_science_gcse_is_missing_below_the_section
+
+    when_i_submit_my_application
+    then_i_dont_see_a_science_gcse_validation_error
+
     given_courses_exist
+    and_i_am_on_your_application_page
     when_i_add_a_primary_course
     then_i_see_science_gcse
+
+    when_i_click_on_check_your_answers
+    then_i_see_science_gcse_is_missing_below_the_section
+
+    when_i_submit_my_application
+    then_i_see_a_science_gcse_validation_error
   end
 
   def given_i_am_signed_in
@@ -29,6 +45,16 @@ RSpec.feature 'Candidate viewing Science GCSE' do
     expect(page).to have_content('Science GCSE or equivalent')
   end
 
+  def when_i_click_on_check_your_answers
+    click_link 'Check your answers before submitting'
+  end
+
+  def then_i_see_science_gcse_is_missing_below_the_section
+    within('#missing-science_gcse-error') do
+      expect(page).to have_content(t('review_application.science_gcse.incomplete'))
+    end
+  end
+
   def given_conditional_science_gcse_feature_flag_is_on
     FeatureFlag.activate('conditional_science_gcse')
   end
@@ -37,8 +63,38 @@ RSpec.feature 'Candidate viewing Science GCSE' do
     expect(page).not_to have_content('Science GCSE or equivalent')
   end
 
+  def then_i_dont_see_science_gcse_is_missing_below_the_section
+    expect(page).not_to have_content(t('review_application.science_gcse.incomplete'))
+  end
+
+  def when_i_submit_my_application
+    click_link 'Continue'
+  end
+
+  def then_i_dont_see_a_science_gcse_validation_error
+    within('.govuk-error-summary') do
+      expect(page).not_to have_content(t('review_application.science_gcse.incomplete'))
+    end
+  end
+
+  def and_i_am_on_your_application_page
+    visit candidate_interface_application_form_path
+  end
+
   def when_i_add_a_primary_course
     click_link 'Course choices'
     candidate_fills_in_course_choices
+  end
+
+  def then_i_see_science_gcse_is_missing_below_the_section
+    within '#missing-science_gcse-error' do
+      expect(page).to have_content(t('review_application.science_gcse.incomplete'))
+    end
+  end
+
+  def then_i_see_a_science_gcse_validation_error
+    within('.govuk-error-summary') do
+      expect(page).to have_content(t('review_application.science_gcse.incomplete'))
+    end
   end
 end


### PR DESCRIPTION
### Context

When no primary courses are selected we don't want to display and validate the presence of Science GCSE.

In a previous PR #775, we added conditional showing of the Science GCSE on the `Your application` page. But didn't remove the validation on it when submitting.

### Changes proposed in this pull request

This PR removes the Science GCSE validation errors when a primary course has not been selected.

### Guidance to review

You'll need to activate the `conditional_science_gcse` feature flag within support to test. Would recommend adding a course choice that is primary and then checking if the Science GCSE shows up when review your application. Then doing the opposite, so adding a course choice that is not primary.

### Link to Trello card

[401 - Primary course conditional](https://trello.com/c/cTiIxGpC/401-primary-course-conditional)
