### PR TITLE
Remove return redirect from application_form#show

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -3,8 +3,6 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted, only: %i[show review]
 
     def show
-      return redirect_to candidate_interface_application_form_path if params[:token]
-
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
     end
 

--- a/spec/requests/candidate_interface/authentication_spec.rb
+++ b/spec/requests/candidate_interface/authentication_spec.rb
@@ -24,13 +24,4 @@ RSpec.describe 'Authentication for candidates', type: :request do
     # TODO: add a better check once we have implemented error messages
     expect(response).to have_http_status(302)
   end
-
-  it 'authenticates and redirects to itself to remove the token from URL' do
-    magic_link_token = MagicLinkToken.new
-    create(:candidate, magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
-
-    get candidate_interface_application_form_url(token: magic_link_token.raw)
-
-    expect(response).to redirect_to(candidate_interface_application_form_path)
-  end
 end


### PR DESCRIPTION
### Context

Now that we authenticate on a separate route, we don't need to remove the token param on the `application_form#show` route.

### Changes proposed in this pull request

Remove some redundant code.

### Guidance to review

Just a minor refactor, there should not be a need to test this.

### Link to Trello card

[552 - Clicking on confirm email link does not sign you out of the previously signed in account](https://trello.com/c/ZJFXK7Tt/552-clicking-on-confirm-email-link-does-not-sign-you-out-of-the-previously-signed-in-account)