### PR TITLE
Do not log SQL in production

### DIFF
--- a/config/initializers/active_record_logger.rb
+++ b/config/initializers/active_record_logger.rb
@@ -1,0 +1,1 @@
+ActiveRecord::Base.logger.level = Logger::INFO if Rails.env.production?


### PR DESCRIPTION
### Context

Our logs from various environments seem to include SQL statements. This can expose email addresses, as well as magic link tokens etc.

### Changes proposed in this pull request

Change to log_level of ActiveRecord::Base to prevent this.

### Guidance to review

You can remove the ```if Rails.env.production?``` guard and switch ```LOGSTASH_ENABLE=true``` in development to see that SQL is being suppressed (e.g. when signing-in).

### Link to Trello card

[616 - We should not log emails when candidates sign in](https://trello.com/c/GywLfyEE)
