### PR TITLE
Prevent email addresses in the logs through ActionMailer/Sidekiq

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -1,17 +1,17 @@
 class AuthenticationMailer < ApplicationMailer
-  def sign_up_email(to:, token:)
+  def sign_up_email(candidate:, token:)
     @magic_link = "#{candidate_interface_authenticate_url}?token=#{token}"
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: to,
+              to: candidate.email_address,
               subject: t('authentication.sign_up.email.subject'))
   end
 
-  def sign_in_email(to:, token:)
+  def sign_in_email(candidate:, token:)
     @magic_link = "#{candidate_interface_authenticate_url}?token=#{token}"
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: to,
+              to: candidate.email_address,
               subject: t('authentication.sign_in.email.subject'))
   end
 

--- a/app/services/magic_link_sign_in.rb
+++ b/app/services/magic_link_sign_in.rb
@@ -1,7 +1,7 @@
 class MagicLinkSignIn
   def self.call(candidate:)
     magic_link_token = MagicLinkToken.new
-    AuthenticationMailer.sign_in_email(to: candidate.email_address, token: magic_link_token.raw).deliver_later
+    AuthenticationMailer.sign_in_email(candidate: candidate, token: magic_link_token.raw).deliver_later
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
   end
 end

--- a/app/services/magic_link_sign_up.rb
+++ b/app/services/magic_link_sign_up.rb
@@ -1,7 +1,7 @@
 class MagicLinkSignUp
   def self.call(candidate:)
     magic_link_token = MagicLinkToken.new
-    AuthenticationMailer.sign_up_email(to: candidate.email_address, token: magic_link_token.raw).deliver_later
+    AuthenticationMailer.sign_up_email(candidate: candidate, token: magic_link_token.raw).deliver_later
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.now)
     StateChangeNotifier.call(:magic_link_sign_up, candidate: candidate)
   end

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -3,9 +3,11 @@ require 'rails_helper'
 RSpec.describe AuthenticationMailer, type: :mailer do
   subject(:mailer) { described_class }
 
+  let(:candidate) { create(:candidate, email_address: 'test@example.com') }
+
   describe '.sign_up_email' do
     let(:token) { 'blub' }
-    let(:mail) { mailer.sign_up_email(to: 'test@example.com', token: token) }
+    let(:mail) { mailer.sign_up_email(candidate: candidate, token: token) }
 
     before { mail.deliver_later }
 
@@ -24,7 +26,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
 
   describe 'the candidate receives the sign in email containing the magic link' do
     let(:token) { 'blub' }
-    let(:mail) { mailer.sign_in_email(to: 'test@example.com', token: token) }
+    let(:mail) { mailer.sign_in_email(candidate: candidate, token: token) }
 
     before { mail.deliver_later }
 


### PR DESCRIPTION
### Context

Now that ActionMailer emails are sent in background jobs, there are log statements exposing email addresses at the time of enqueuing and at the time of executing the job.

![image](https://user-images.githubusercontent.com/107591/70095688-4ffc0300-161d-11ea-8c47-4ee4869abac7.png)

### Changes proposed in this pull request

Pass ```candidate``` to the relevant mailers, rather than ```to```, which is an email address. Rails now will create a GID for the Candidate model, not serialise the object.

### Guidance to review

Set  ```LOGSTASH_ENABLE=true```, run rails/sidekiq/clockwork locally and follow some sign-in/sign-up flows.

### Link to Trello card

[616 - We should not log emails when candidates sign in](https://trello.com/c/GywLfyEE)
