### PR TITLE
Fix name of `accept_and_decline_via_ui` flag

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :set_application_choice
 
     def offer
-      if FeatureFlag.active?('accept_and_withdraw_via_ui')
+      if FeatureFlag.active?('accept_and_decline_via_ui')
         @respond_to_offer = CandidateInterface::RespondToOfferForm.new
       else
         render :offer_via_support

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,7 +1,7 @@
 class FeatureFlag
   FEATURES = %w[
     pilot_open
-    accept_and_withdraw_via_ui
+    accept_and_decline_via_ui
     conditional_science_gcse
   ].freeze
 

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
   end
 
   def given_the_accept_and_decline_feature_is_on
-    FeatureFlag.activate('accept_and_withdraw_via_ui')
+    FeatureFlag.activate('accept_and_decline_via_ui')
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_declines_offer_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Candidate declines an offer', sidekiq: true do
   end
 
   def given_the_accept_and_decline_feature_is_on
-    FeatureFlag.activate('accept_and_withdraw_via_ui')
+    FeatureFlag.activate('accept_and_decline_via_ui')
   end
 
   def given_i_am_signed_in


### PR DESCRIPTION
This was a typo. This is safe to deploy because it’s not been enabled on production.