### PR TITLE
Expose a "process state" in the support UI

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -27,6 +27,7 @@ module SupportInterface
         choices_row,
         submitted_row,
         last_updated_row,
+        state_row,
       ].compact
     end
 
@@ -93,6 +94,20 @@ module SupportInterface
           value: support_reference,
         }
       end
+    end
+
+    def state_row
+      {
+        key: 'State',
+        value: formatted_status,
+      }
+    end
+
+    def formatted_status
+      process_state = ProcessState.new(application_form).state
+      name = I18n.t!("process_states.#{process_state}.name")
+      desc = I18n.t!("process_states.#{process_state}.description")
+      "#{name} - #{desc}"
     end
 
     def application_choices

--- a/app/components/support_interface/applications_table_component.html.erb
+++ b/app/components/support_interface/applications_table_component.html.erb
@@ -4,6 +4,7 @@
       <th scope="col" class="govuk-table__header">Application</th>
       <th scope="col" class="govuk-table__header">Reference 1</th>
       <th scope="col" class="govuk-table__header">Reference 2</th>
+      <th scope="col" class="govuk-table__header">Status</th>
       <th scope="col" class="govuk-table__header">Last updated</th>
     </tr>
   </thead>
@@ -16,6 +17,7 @@
         </td>
         <td class="govuk-table__cell"><%= table_row[:first_reference_status] %></td>
         <td class="govuk-table__cell"><%= table_row[:second_reference_status] %></td>
+        <td class="govuk-table__cell"><%= t "process_states.#{table_row[:process_state]}.name" %></td>
         <td class="govuk-table__cell"><%= table_row[:updated_at] %></td>
       </tr>
     <% end %>

--- a/app/components/support_interface/applications_table_component.rb
+++ b/app/components/support_interface/applications_table_component.rb
@@ -17,6 +17,7 @@ module SupportInterface
           first_reference_status: reference_status(application_form.references[0], submitted),
           second_reference_status: reference_status(application_form.references[1], submitted),
           updated_at: application_form.updated_at.strftime('%e %b %Y at %l:%M%P'),
+          process_state: ProcessState.new(application_form).state,
         }
       end
     end

--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ApplicationFormsController < SupportInterfaceController
     def index
-      @application_forms = ApplicationForm.includes(:candidate, :references).sort_by(&:updated_at).reverse
+      @application_forms = ApplicationForm.includes(:candidate, :references, :application_choices).sort_by(&:updated_at).reverse
     end
 
     def show

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -1,0 +1,51 @@
+# ProcessState is an *experimental* thing that infers the state from
+# the state of application choices. Do not rely on this for business logic.
+class ProcessState
+  def initialize(application_form)
+    @application_form = application_form
+  end
+
+  def state
+    if application_choices.empty?
+      :unsubmitted
+    elsif all_states_are?('unsubmitted')
+      :unsubmitted
+    elsif all_states_are?('awaiting_references')
+      :awaiting_references
+    elsif all_states_are?('application_complete')
+      :waiting_to_be_sent
+    elsif any_state_is?('awaiting_provider_decision')
+      :awaiting_provider_decisions
+    elsif any_state_is?('offer')
+      # Offer, but no awaiting means we're waiting on the candidate
+      :awaiting_candidate_response
+    elsif any_state_is?('enrolled')
+      :enrolled
+    elsif any_state_is?('recruited')
+      :recruited
+    elsif any_state_is?('pending_conditions')
+      :pending_conditions
+    elsif all_states_are?('withdrawn', 'rejected', 'declined')
+      :ended_without_success
+    else
+      :unknown_state
+    end
+  end
+
+private
+
+  attr_reader :application_form
+  delegate :application_choices, to: :application_form
+
+  def states
+    @states ||= application_choices.map(&:status)
+  end
+
+  def all_states_are?(*in_states)
+    states.uniq == in_states
+  end
+
+  def any_state_is?(state)
+    states.include?(state)
+  end
+end

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -1,4 +1,35 @@
 en:
+  process_states:
+    unsubmitted:
+      name: Unsubmitted
+      description: Candidate hasn’t submitted the form yet
+    awaiting_references:
+      name: Awaiting references
+      description: Candidate has submitted the form. We’ve asked their references for feedback, and are still waiting on one or more of those.
+    waiting_to_be_sent:
+      name: Waiting to be sent
+      description: All of the references have come in, but we haven’t sent the applications to the provider yet
+    awaiting_provider_decisions:
+      name: Awaiting decisions from providers
+      description: We’ve sent the applications to the providers, but we haven’t heard back from all of them
+    awaiting_candidate_response:
+      name: Awaiting decision from candidate
+      description: All providers have responded and it’s now up to the candidate to make a decision
+    pending_conditions:
+      name: Pending conditions
+      description: The candidate has accepted an offer. The provider now has to confirm to us that the candidate has met the conditions in the offer.
+    recruited:
+      name: Recruited
+      description: The candidate has been recruited, but hasn’t enrolled yet.
+    enrolled:
+      name: Enrolled
+      description: The candidate has enrolled in the course.
+    ended_without_success:
+      name: Ended without success
+      description: All of the candidate’s applications have been withdrawn, rejected or declined.
+    unknown_state:
+      name: 'Unknown!'
+      description: This application is a state that we don’t recognise. Please report this to a developer.
   candidate_application_states:
     application_complete: Submitted
     awaiting_provider_decision: Pending

--- a/spec/services/process_state_spec.rb
+++ b/spec/services/process_state_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe ProcessState do
+  describe '#state' do
+    it 'returns unsubmitted without choices' do
+      application_form = build_stubbed(:application_form)
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:unsubmitted)
+    end
+
+    it 'returns unsubmitted with unsubmitted choices' do
+      application_form = build_stubbed(:application_form, application_choices: build_list(:application_choice, 2, status: 'unsubmitted'))
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:unsubmitted)
+    end
+
+    it 'returns awaiting_references when awaiting references' do
+      application_form = build_stubbed(:application_form, application_choices: build_list(:application_choice, 2, status: 'awaiting_references'))
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:awaiting_references)
+    end
+
+    it 'returns waiting_to_be_sent when awaiting application complete' do
+      application_form = build_stubbed(:application_form, application_choices: build_list(:application_choice, 2, status: 'application_complete'))
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:waiting_to_be_sent)
+    end
+
+    it 'returns awaiting when not all providers have made a decision' do
+      application_form = create(:application_form)
+      create(:application_choice, application_form: application_form, status: 'awaiting_provider_decision')
+      create(:application_choice, application_form: application_form, status: 'offer')
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:awaiting_provider_decisions)
+    end
+
+    it 'is waiting on candidate when there is an offer' do
+      application_form = create(:application_form)
+      create(:application_choice, application_form: application_form, status: 'offer')
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:awaiting_candidate_response)
+    end
+
+    it 'is pending conditions when the candidate has accepted' do
+      application_form = create(:application_form)
+      create(:application_choice, application_form: application_form, status: 'pending_conditions')
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:pending_conditions)
+    end
+
+    it 'is recruited when the candidate has been recruited' do
+      application_form = create(:application_form)
+      create(:application_choice, application_form: application_form, status: 'recruited')
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:recruited)
+    end
+
+    it 'is enrolled when the candidate has been enrolled' do
+      application_form = create(:application_form)
+      create(:application_choice, application_form: application_form, status: 'enrolled')
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:enrolled)
+    end
+
+    it 'is all_withdrawn when the candidate has withdrawn from all' do
+      application_form = create(:application_form)
+      create(:application_choice, application_form: application_form, status: 'withdrawn')
+      create(:application_choice, application_form: application_form, status: 'rejected')
+      create(:application_choice, application_form: application_form, status: 'declined')
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:ended_without_success)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We need to know what state an application is in, in the support UI. In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/772 it became clear that we need some sort of "application form state", "compound state", or "process state".

If this makes sense, we may be able to re-use this in other parts of the application to determine the overall state of the application.

### Changes proposed in this pull request

This adds the state to the support section.

<img width="1101" alt="Screenshot 2019-12-04 at 13 56 23" src="https://user-images.githubusercontent.com/233676/70148361-ed971700-169d-11ea-9f7e-9f99fb93da6f.png">
<img width="1277" alt="Screenshot 2019-12-04 at 13 56 40" src="https://user-images.githubusercontent.com/233676/70148363-ed971700-169d-11ea-883d-ee1e850e29a3.png">


### Guidance to review

- Do the states make sense?
- Do the explanations make sense?

### Link to Trello card

https://trello.com/c/aDeICHGP