### PR TITLE
Ensure CUSTOM_HOSTNAME environment variable is always set.

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -536,7 +536,7 @@
                             },
                             {
                                 "name": "CUSTOM_HOSTNAME",
-                                "value": "[parameters('customHostName')]"
+                                "value": "[if(greater(length(parameters('customHostName')), 0), parameters('customHostName'), split(parameters('authorisedHosts'), ',')[0])]"
                             },
                             {
                                 "name": "SENTRY_DSN",
@@ -666,7 +666,7 @@
                             },
                             {
                                 "name": "CUSTOM_HOSTNAME",
-                                "value": "[parameters('customHostName')]"
+                                "value": "[if(greater(length(parameters('customHostName')), 0), parameters('customHostName'), split(parameters('authorisedHosts'), ',')[0])]"
                             },
                             {
                                 "name": "SENTRY_DSN",
@@ -806,7 +806,7 @@
                             },
                             {
                                 "name": "CUSTOM_HOSTNAME",
-                                "value": "[parameters('customHostName')]"
+                                "value": "[if(greater(length(parameters('customHostName')), 0), parameters('customHostName'), split(parameters('authorisedHosts'), ',')[0])]"
                             },
                             {
                                 "name": "SENTRY_DSN",


### PR DESCRIPTION
### Context

At the present time the `CUSTOM_HOSTNAME` environment variable is empty if a gov.uk domain and SSL certificate does not exist.

### Changes proposed in this pull request

Revised the ARM template to set `CUSTOM_HOSTNAME` to the azurewebsites.net domain where a gov.uk domain is not configured.

### Guidance to review

Probably worth someone with more knowledge of the app than me checking that everything is working as expected in the devops subscription where this new configuration is currently deployed.

https://s106d02-apply-as.azurewebsites.net

### Link to Trello card

N/A

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
