### PR TITLE
Reload application_choices when sending them to providers

### DIFF
--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -3,7 +3,7 @@ class SendApplicationToProvider
   attr_accessor :application_choice
 
   def initialize(application_choice:)
-    self.application_choice = application_choice
+    self.application_choice = application_choice.reload
   end
 
   def call


### PR DESCRIPTION
Without this change, running rake generate_test_data will fail because the application choice received by this service is `application_complete` in the database but `awaiting_references` in memory.

I've added a card to the Tech Debt backlog to investigate, because this happens a lot in our codebase.

https://trello.com/c/lQpwnQH2/372-find-out-why-we-need-to-reload-so-much-when-were-working-with-references