### PR TITLE
Limit the number of FactoryBot creations

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -147,13 +147,14 @@ FactoryBot.define do
   end
 
   factory :application_choice do
-    # application_forms come with 3 application_choices out of the box. if we're making
-    # an application_choice on its own, suppress these to avoid surprises
-    association :application_form, factory: %i[completed_application_form without_application_choices]
-
+    application_form
     course_option
     status { ApplicationStateChange.valid_states.sample }
     personal_statement { 'hello' }
+
+    factory :submitted_application_choice do
+      association :application_form, factory: %i[completed_application_form without_application_choices with_completed_references]
+    end
 
     trait :awaiting_provider_decision do
       association :application_form, factory: %i[completed_application_form without_application_choices with_completed_references]

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -43,10 +43,9 @@ FactoryBot.define do
       work_history_completed { true }
 
       transient do
-        application_choices_count { 3 }
+        application_choices_count { 1 }
         work_experiences_count { 1 }
         volunteering_experiences_count { 1 }
-        qualifications_count { 4 }
         references_count { 2 }
         references_state { :unsubmitted }
       end
@@ -65,7 +64,6 @@ FactoryBot.define do
         create(:application_qualification, application_form: application_form, subject: 'maths', level: 'gcse', qualification_type: 'GCSE')
         create(:application_qualification, application_form: application_form, subject: 'english', level: 'gcse', qualification_type: 'GCSE')
         create(:application_qualification, application_form: application_form, subject: 'science', level: 'gcse', qualification_type: 'GCSE')
-
 
         create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'awaiting_references')
         create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe ApplicationForm do
 
     it 'can view audit records for ApplicationForm and its associated ApplicationChoices' do
       application_form = create :completed_application_form
-      expect(application_form.own_and_associated_audits.count).to eq 6
-      application_form.application_choices.first.update!(personal_statement: 'hello again')
-      expect(application_form.own_and_associated_audits.count).to eq 7
+
+      expect {
+        application_form.application_choices.first.update!(personal_statement: 'hello again')
+      }.to change { application_form.own_and_associated_audits.count }.by(1)
     end
   end
 

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
   it 'returns applications of the authenticated provider' do
     create_list(
-      :application_choice,
+      :submitted_application_choice,
       2,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
       status: 'awaiting_provider_decision',
@@ -16,7 +16,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     alternate_provider = create(:provider, code: 'DIFFERENT')
 
     create_list(
-      :application_choice,
+      :submitted_application_choice,
       1,
       course_option: course_option_for_provider(provider: alternate_provider),
       status: 'awaiting_provider_decision',
@@ -64,14 +64,14 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
 
   it 'returns applications that are in a viewable state' do
     create_list(
-      :application_choice,
+      :submitted_application_choice,
       2,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
       status: :awaiting_provider_decision,
     )
 
     create_list(
-      :application_choice,
+      :submitted_application_choice,
       3,
       course_option: course_option_for_provider(provider: currently_authenticated_provider),
       status: :unsubmitted,

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe SetDeclineByDefault do
   describe '#call' do
-    let(:application_form) { create(:completed_application_form) }
+    let(:application_form) { create(:completed_application_form, application_choices_count: 3) }
     let(:choices) { application_form.application_choices }
     let(:time_limit_calculator) { instance_double('TimeLimitCalculator', call: 10) }
     let(:now) { Time.zone.local(2019, 11, 26, 12, 0, 0) }

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -46,7 +46,7 @@ module VendorApiSpecHelpers
 
   def create_application_choice_for_currently_authenticated_provider(attributes = {})
     create(
-      :application_choice,
+      :submitted_application_choice,
       { course_option: course_option_for_provider(provider: currently_authenticated_provider) }.merge(attributes),
     )
   end

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -7,10 +7,12 @@ RSpec.feature 'Provider responds to application' do
   let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
 
   let(:application_awaiting_provider_decision) do
-    create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
   end
 
-  let(:application_rejected) { create(:application_choice, status: 'rejected', course_option: course_option) }
+  let(:application_rejected) do
+    create(:submitted_application_choice, status: 'rejected', course_option: course_option)
+  end
 
   scenario 'Provider can respond to an application currently awaiting_provider_decision' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -55,14 +55,14 @@ RSpec.feature 'See applications' do
   def and_my_organisation_has_applications
     course_option = course_option_for_provider_code(provider_code: 'ABC')
 
-    @my_provider_choice1  = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
-    @my_provider_choice2  = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    @my_provider_choice1  = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    @my_provider_choice2  = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
   end
 
   def and_another_organisation_has_applications
     other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
 
-    @other_provider_choice = create(:application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
+    @other_provider_choice = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
   end
 
   def and_i_visit_the_provider_page


### PR DESCRIPTION
### Context

This speeds up the test run by limiting the number of database records we create.

### Changes proposed in this pull request

See commits for details. On my machine, this shaves of ~5 seconds from the test run.

### Link to Trello card

https://trello.com/c/OEjmIn3C