### PR TITLE
Use a hardcoded string when testing Google Form URL encoding

### DIFF
--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RefereeMailer, type: :mailer do
       create(
         :completed_application_form,
         first_name: 'Harry',
-        last_name: 'Potter',
+        last_name: "O'Potter",
         application_choices_count: 0,
         application_choices: [
           first_application_choice,
@@ -48,8 +48,7 @@ RSpec.describe RefereeMailer, type: :mailer do
     end
 
     it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
-      expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
-      expect(mail.body.encoded).to include("=#{reference.name.gsub(' ', '%20')}")
+      expect(mail.body.encoded).to include('Harry%20O%27Potter')
     end
 
     context 'an email containing a +' do


### PR DESCRIPTION
Specs flaked in CI when the factory-generated candidate_name had an
apostrophe in it.

- use a string for the assertion so this can't happen
- add an apostrophe to show that other chars are also encoded

☘️ 

Original spec failure in CI: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=33761&view=logs&j=32f3c9c7-a610-55d2-616a-efba1ecc24a2&t=85c1dfa3-8bc2-5353-acab-1c1a0e7b38db