### PR TITLE
Allow support users to create test applications 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,7 +27,7 @@ Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
     - 'spec/**/*'
-    - app/services/generate_test_applications.rb
+    - app/workers/generate_test_applications.rb
 
 RSpec/ExampleLength:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'lograge'
 gem 'logstash-logger'
 gem 'logstash-event'
 gem 'request_store_rails'
+gem 'request_store-sidekiq'
 
 # Background processing
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,9 @@ GEM
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
+    request_store-sidekiq (0.1.0)
+      request_store (>= 1.3)
+      sidekiq (>= 3.0)
     request_store_rails (2.0.0)
       concurrent-ruby (~> 1.0)
     responders (3.0.0)
@@ -540,6 +543,7 @@ DEPENDENCIES
   rails (~> 6.0)
   rails-erd
   redcarpet
+  request_store-sidekiq
   request_store_rails
   rollout
   rspec-rails

--- a/app/components/support_interface/applications_table_component.html.erb
+++ b/app/components/support_interface/applications_table_component.html.erb
@@ -2,8 +2,6 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Application</th>
-      <th scope="col" class="govuk-table__header">Reference 1</th>
-      <th scope="col" class="govuk-table__header">Reference 2</th>
       <th scope="col" class="govuk-table__header">Status</th>
       <th scope="col" class="govuk-table__header">Last updated</th>
     </tr>
@@ -15,8 +13,6 @@
         <td class="govuk-table__cell">
           <%= table_row[:application_link] %>
         </td>
-        <td class="govuk-table__cell"><%= table_row[:first_reference_status] %></td>
-        <td class="govuk-table__cell"><%= table_row[:second_reference_status] %></td>
         <td class="govuk-table__cell"><%= t "process_states.#{table_row[:process_state]}.name" %></td>
         <td class="govuk-table__cell"><%= table_row[:updated_at] %></td>
       </tr>

--- a/app/components/support_interface/applications_table_component.rb
+++ b/app/components/support_interface/applications_table_component.rb
@@ -8,14 +8,11 @@ module SupportInterface
 
     def table_rows
       application_forms.map do |application_form|
-        submitted = application_form.submitted?
         email_address = application_form.candidate.email_address
 
         {
           application_form_id: application_form.id,
           application_link: govuk_link_to(email_address, support_interface_application_form_path(application_form)),
-          first_reference_status: reference_status(application_form.references[0], submitted),
-          second_reference_status: reference_status(application_form.references[1], submitted),
           updated_at: application_form.updated_at.strftime('%e %b %Y at %l:%M%P'),
           process_state: ProcessState.new(application_form).state,
         }
@@ -25,11 +22,5 @@ module SupportInterface
   private
 
     attr_reader :application_forms
-
-    def reference_status(reference, submitted)
-      return 'Not requested yet' unless reference && submitted
-
-      reference.complete? ? 'Received' : 'Awaiting response'
-    end
   end
 end

--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ApplicationFormsController < SupportInterfaceController
     def index
-      @application_forms = ApplicationForm.includes(:candidate, :references, :application_choices).sort_by(&:updated_at).reverse
+      @application_forms = ApplicationForm.includes(:candidate, :application_choices).sort_by(&:updated_at).reverse
     end
 
     def show

--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -1,0 +1,16 @@
+module SupportInterface
+  class TasksController < SupportInterfaceController
+    def index; end
+
+    def run
+      case params.fetch(:task)
+      when 'generate_test_applications'
+        GenerateTestApplications.perform_async
+        flash[:success] = 'Scheduled job to generate test applications - this might take a while!'
+        redirect_to support_interface_tasks_path
+      else
+        render_404
+      end
+    end
+  end
+end

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -36,6 +36,12 @@ class StateChangeNotifier
     else
       raise 'StateChangeNotifier: unsupported state transition event'
     end
+
+    if RequestStore.store[:disable_slack_messages]
+      Rails.logger.info "Sending Slack messages disabled (message: `#{text}`)"
+      return
+    end
+
     SlackNotificationWorker.perform_async(text, url)
   end
 end

--- a/app/services/generate_test_applications.rb
+++ b/app/services/generate_test_applications.rb
@@ -2,11 +2,7 @@ class GenerateTestApplications
   def generate
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
-    Reference.delete_all
-    ApplicationChoice.delete_all
-    ApplicationForm.delete_all
-
-    100.times do |i|
+    (1..11).each do |i|
       create_an_application(i)
     end
   end
@@ -41,12 +37,12 @@ private
         )
       end
 
-      return if application_index > 90
+      return if application_index == 1
 
       # The application is submitted by the candidate
       SubmitApplication.new(application_form).call
 
-      return if application_index > 80
+      return if application_index == 2
 
       # References come in
       application_form.references.each do |reference|
@@ -57,7 +53,9 @@ private
         ).save
       end
 
-      return if application_index > 70
+      return if application_index == 3
+
+      application_form.reload
 
       application_form.application_choices.each do |application_choice|
         # This is only supposed to happen after 7 days, but SendApplicationToProvider
@@ -65,26 +63,45 @@ private
         SendApplicationToProvider.new(application_choice: application_choice).call
       end
 
-      return if application_index > 60
+      return if application_index == 4
 
-      # Now the providers need to make a decision
+      main_application_choice = application_form.application_choices[0]
 
       # First one gets an offer
-      MakeAnOffer.new(application_choice: application_form.application_choices[0], offer_conditions: ['Complete DBS']).save
+      MakeAnOffer.new(application_choice: main_application_choice, offer_conditions: ['Complete DBS']).save
 
-      return if application_index > 50
+      return if application_index == 5
 
       if (second = application_form.application_choices[1])
         RejectApplication.new(application_choice: second, rejection_reason: 'Some').save
       end
 
-      return if application_index > 40
+      return if application_index == 6
 
       if (third = application_form.application_choices[2])
         RejectApplication.new(application_choice: third, rejection_reason: 'Some').save
       end
 
-      # TODO: accept/decline/withdraw
+      if application_index == 7
+        DeclineOffer.new(application_choice: main_application_choice).save!
+        return
+      end
+
+      AcceptOffer.new(application_choice: main_application_choice).save!
+
+      return if application_index == 9
+
+      ConfirmOfferConditions.new(application_choice: main_application_choice).save
+
+      if application_index == 10
+        ConfirmEnrolment.new(application_choice: main_application_choice).save
+        return
+      end
+
+      if application_index == 11
+        # TODO replace after https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/784 is merged
+        ApplicationStateChange.new(main_application_choice).withdraw!
+      end
     end
   end
 end

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -25,7 +25,7 @@ class ProcessState
       :recruited
     elsif any_state_is?('pending_conditions')
       :pending_conditions
-    elsif all_states_are?('withdrawn', 'rejected', 'declined')
+    elsif (states.uniq - %w[withdrawn rejected declined]).empty?
       :ended_without_success
     else
       :unknown_state

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -5,4 +5,5 @@
   <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
   <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
   <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
+  <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
 </ul>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, 'Tasks' %>
+
+<% unless HostingEnvironment.production? %>
+  <div>
+    <h2 class='govuk-heading-m'>Test applications</h2>
+    <div class='govuk-body'>
+      This will generate ~10 mostly-random test applications in all of the states.
+    </div>
+    <%= button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button' %>
+  </div>
+<% end %>

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -1,5 +1,7 @@
 class GenerateTestApplications
-  def generate
+  include Sidekiq::Worker
+
+  def perform
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
     (1..11).each do |i|

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -4,12 +4,20 @@ class GenerateTestApplications
   def perform
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
-    (1..11).each do |i|
-      create_an_application(i)
+    without_slack_message_sending do
+      (1..11).each do |i|
+        create_an_application(i)
+      end
     end
   end
 
 private
+
+  def without_slack_message_sending
+    RequestStore.store[:disable_slack_messages] = true
+    yield
+    RequestStore.store[:disable_slack_messages] = false
+  end
 
   def create_an_application(application_index)
     first_name = Faker::Name.unique.first_name

--- a/config/initializers/mail_interceptors.rb
+++ b/config/initializers/mail_interceptors.rb
@@ -1,0 +1,5 @@
+require 'test_email_interceptor'
+
+if Rails.env.production?
+  ActionMailer::Base.register_interceptor(TestEmailInterceptor)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -276,6 +276,9 @@ Rails.application.routes.draw do
 
     get '/performance' => 'performance#index', as: :performance
 
+    get '/tasks' => 'tasks#index', as: :tasks
+    post '/tasks/:task' => 'tasks#run', as: :run_task
+
     post '/impersonate-candidate/:candidate_id' => 'impersonation#impersonate_candidate', as: :impersonate_candidate
 
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -5,5 +5,5 @@ end
 
 desc 'Generate test applications for existing providers'
 task generate_test_applications: :environment do
-  GenerateTestApplications.new.generate
+  GenerateTestApplications.new.perform
 end

--- a/lib/test_email_interceptor.rb
+++ b/lib/test_email_interceptor.rb
@@ -1,0 +1,8 @@
+class TestEmailInterceptor
+  def self.delivering_email(message)
+    if message.to.any? { |email| email.end_with?('@example.com') }
+      Rails.logger.info "Skipping email to #{message.to} ('#{message.subject}')"
+      message.perform_deliveries = false
+    end
+  end
+end

--- a/spec/lib/test_email_interceptor_spec.rb
+++ b/spec/lib/test_email_interceptor_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe TestEmailInterceptor do
+  it 'intercepts example emails' do
+    message = Mail::Message.new(to: ['test@example.com'])
+
+    described_class.delivering_email(message)
+
+    expect(message.perform_deliveries).to be false
+  end
+
+  it 'will let other emails be delivered' do
+    message = Mail::Message.new(to: ['test@no-example.com'])
+
+    described_class.delivering_email(message)
+
+    expect(message.perform_deliveries).to be true
+  end
+end

--- a/spec/services/process_state_spec.rb
+++ b/spec/services/process_state_spec.rb
@@ -80,10 +80,19 @@ RSpec.describe ProcessState do
       expect(state).to be(:enrolled)
     end
 
-    it 'is all_withdrawn when the candidate has withdrawn from all' do
+    it 'is "ended without success" when the candidate has no succesfull applications' do
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'withdrawn')
       create(:application_choice, application_form: application_form, status: 'rejected')
+      create(:application_choice, application_form: application_form, status: 'declined')
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:ended_without_success)
+    end
+
+    it 'is "ended without success" when the candidate has no succesful applications' do
+      application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'declined')
 
       state = ProcessState.new(application_form).state

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -4,10 +4,8 @@ RSpec.feature 'See applications' do
   scenario 'Support agent visits the list of applications' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
-    and_an_application_has_received_a_reference
     and_i_visit_the_support_page
     then_i_should_see_the_applications
-    and_i_should_see_their_reference_statuses
   end
 
   def given_i_am_a_support_user
@@ -20,15 +18,6 @@ RSpec.feature 'See applications' do
     @application_with_reference = create(:completed_application_form)
   end
 
-  def and_an_application_has_received_a_reference
-    action = ReceiveReference.new(
-      application_form: @application_with_reference,
-      referee_email: @application_with_reference.reload.references.first.email_address,
-      feedback: Faker::Lorem.paragraphs(number: 2),
-    )
-    action.save
-  end
-
   def and_i_visit_the_support_page
     visit support_interface_path
   end
@@ -37,20 +26,5 @@ RSpec.feature 'See applications' do
     expect(page).to have_content @completed_application.candidate.email_address
     expect(page).to have_content @application_with_reference.candidate.email_address
     expect(page).to have_content @unsubmitted_application.candidate.email_address
-  end
-
-  def and_i_should_see_their_reference_statuses
-    within "[data-qa='application-form-#{@application_with_reference.id}']" do
-      expect(page).to have_content 'Received'
-      expect(page).to have_content 'Awaiting response'
-    end
-
-    within "[data-qa='application-form-#{@completed_application.id}']" do
-      expect(page).to have_content('Awaiting response', count: 2)
-    end
-
-    within "[data-qa='application-form-#{@unsubmitted_application.id}']" do
-      expect(page).to have_content('Not requested yet', count: 2)
-    end
   end
 end

--- a/spec/system/support_interface/tasks_spec.rb
+++ b/spec/system/support_interface/tasks_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.feature 'Tasks' do
+  scenario 'Support user performs a task' do
+    given_i_am_a_support_user
+
+    when_i_visit_the_support_tasks_page
+    and_i_click_on_generate_test_applications
+    then_i_see_that_the_job_has_been_scheduled
+  end
+
+  def given_i_am_a_support_user
+    page.driver.browser.authorize('test', 'test')
+  end
+
+  def when_i_visit_the_support_tasks_page
+    visit support_interface_tasks_path
+  end
+
+  def and_i_click_on_generate_test_applications
+    click_button 'Generate test application'
+  end
+
+  def then_i_see_that_the_job_has_been_scheduled
+    expect(page).to have_content 'Scheduled job to generate test applications'
+  end
+end


### PR DESCRIPTION
### Context

We need better manual testing because we're now building features that are later in the application process. To avoid us having to repetitively create applications in the UI, this adds a button to the support section that creates an application in each known state. 

### Changes proposed in this pull request

- Add a button to create test applications
- Improve how we generate the test applications
- Update the support layout so it's clear what state the application is in
- Don't send emails to addresses that end in `@example.com` - this will prevent us from spamming Notify
- Similarly, prevent Slack messages from being sent when generating test applications

### Guidance to review

Test it out locally. Review per commit!

### Link to Trello card

https://trello.com/c/49yLJZEW/1353-improve-how-we-do-manual-testing