### PR TITLE
Disable auditing in test

### DIFF
--- a/spec/components/support_interface/audit_trail_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_component_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SupportInterface::AuditTrailComponent do
+RSpec.describe SupportInterface::AuditTrailComponent, with_audited: true do
   def candidate
     @candidate ||= create :candidate, email_address: 'bob@example.com'
   end

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ApplicationChoice, type: :model do
     end
   end
 
-  describe 'auditing' do
+  describe 'auditing', with_audited: true do
     it 'creates audit entries' do
       application_choice = create :application_choice
       expect(application_choice.audits.count).to eq 1

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationForm do
-  describe 'auditing' do
+  describe 'auditing', with_audited: true do
     it 'records an audit entry when creating a new ApplicationForm' do
       application_form = create :application_form
       expect(application_form.audits.count).to eq 1

--- a/spec/models/reference_spec.rb
+++ b/spec/models/reference_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Reference, type: :model do
     end
   end
 
-  describe 'auditing' do
+  describe 'auditing', with_audited: true do
     let(:application_form) { create(:application_form) }
 
     it { is_expected.to be_audited.associated_with :application_form }

--- a/spec/models/support_interface/application_comment_form_spec.rb
+++ b/spec/models/support_interface/application_comment_form_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SupportInterface::ApplicationCommentForm, type: :model do
+RSpec.describe SupportInterface::ApplicationCommentForm, type: :model, with_audited: true do
   let(:form_data) do
     {
       comment: Faker::Lorem.paragraph_by_chars(number: 200),

--- a/spec/requests/candidate_interface/audit_trail_spec.rb
+++ b/spec/requests/candidate_interface/audit_trail_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Candidate interface - audit trail', type: :request do
+RSpec.describe 'Candidate interface - audit trail', type: :request, with_audited: true do
   def create_candidate(magic_link_token)
     create(
       :candidate,

--- a/spec/requests/provider_interface/audit_trail_spec.rb
+++ b/spec/requests/provider_interface/audit_trail_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Provider interface - audit trail', type: :request do
+RSpec.describe 'Provider interface - audit trail', type: :request, with_audited: true do
   def create_application
     create(
       :application_choice,

--- a/spec/requests/support_interface/comments_spec.rb
+++ b/spec/requests/support_interface/comments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Support interface - Application Comments', type: :request do
+RSpec.describe 'Support interface - Application Comments', type: :request, with_audited: true do
   def create_application_form
     create :application_form
   end

--- a/spec/requests/vendor_api/audit_trail_spec.rb
+++ b/spec/requests/vendor_api/audit_trail_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - audit trail', type: :request do
+RSpec.describe 'Vendor API - audit trail', type: :request, with_audited: true do
   include VendorApiSpecHelpers
   include CourseOptionHelpers
 

--- a/spec/support/audited.rb
+++ b/spec/support/audited.rb
@@ -1,0 +1,9 @@
+Audited.auditing_enabled = false
+
+RSpec.configure do |config|
+  config.around(:each, with_audited: true) do |example|
+    Audited.auditing_enabled = true
+    example.run
+    Audited.auditing_enabled = false
+  end
+end

--- a/spec/system/support_interface/add_audit_comment_spec.rb
+++ b/spec/system/support_interface/add_audit_comment_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Add comments to the application history' do
+RSpec.feature 'Add comments to the application history', with_audited: true do
   around do |example|
     Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
       example.run

--- a/spec/system/support_interface/audit_trail_spec.rb
+++ b/spec/system/support_interface/audit_trail_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'See application history' do
+RSpec.feature 'See application history', with_audited: true do
   around do |example|
     Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
       example.run


### PR DESCRIPTION
### Context

Disabling audit trail, except where necessary, saves a lot of database inserts.

### Changes proposed in this pull request

Don't enabled auditable unless the test is tagged `with_auditable: true`.

#### Before (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/798)

Finished in 1 minute 58.01 seconds (files took 6.58 seconds to load)

#### After

Finished in 2 minutes 1 second (files took 7.11 seconds to load)

![](https://media.giphy.com/media/CPskAi4C6WLHa/source.gif)

https://trello.com/c/OEjmIn3C/327-the-tests-are-becoming-slow-high