### PR TITLE
fix n+1 queries in Vendor API applications index…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,11 +83,13 @@ group :test do
   gem 'database_cleaner'
   gem 'clockwork-test'
   gem 'deepsort'
+  gem 'rspec-benchmark'
 end
 
 group :development, :test do
   gem 'brakeman'
   gem 'rspec-rails'
+  gem 'db-query-matchers'
   gem 'dotenv-rails'
   gem 'pry'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
       activerecord (>= 4.2, < 6.1)
     backports (3.15.0)
     bcrypt (3.1.13)
+    benchmark-malloc (0.1.0)
+    benchmark-perf (0.5.0)
+    benchmark-trend (0.3.0)
     better_html (1.0.14)
       actionview (>= 4.0)
       activesupport (>= 4.0)
@@ -134,6 +137,9 @@ GEM
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
     database_cleaner (1.7.0)
+    db-query-matchers (0.10.0)
+      activesupport (>= 4.0, < 7)
+      rspec (~> 3.0)
     deepsort (0.4.2)
     devise (4.7.1)
       bcrypt (~> 3.0)
@@ -381,6 +387,11 @@ GEM
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
+    rspec-benchmark (0.5.1)
+      benchmark-malloc (~> 0.1.0)
+      benchmark-perf (~> 0.5.0)
+      benchmark-trend (~> 0.3.0)
+      rspec (>= 3.0.0, < 4.0.0)
     rspec-core (3.9.0)
       rspec-support (~> 3.9.0)
     rspec-expectations (3.9.0)
@@ -512,6 +523,7 @@ DEPENDENCIES
   clockwork-test
   cucumber-rails
   database_cleaner
+  db-query-matchers
   deepsort
   devise
   dotenv-rails
@@ -546,6 +558,7 @@ DEPENDENCIES
   request_store-sidekiq
   request_store_rails
   rollout
+  rspec-benchmark
   rspec-rails
   rspec_junit_formatter
   rubocop-rspec

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -125,10 +125,19 @@ module VendorApi
 
     def qualifications
       {
-        gcses: application_form.application_qualifications.gcses.map do |gcse| qualification_to_hash(gcse) end,
-        degrees: application_form.application_qualifications.degrees.map do |degree| qualification_to_hash(degree) end,
-        other_qualifications: application_form.application_qualifications.other.map do |other| qualification_to_hash(other) end,
+        gcses: qualifications_of_level('gcse').map { |q| qualification_to_hash(q) },
+        degrees: qualifications_of_level('degree').map { |q| qualification_to_hash(q) },
+        other_qualifications: qualifications_of_level('other').map { |q| qualification_to_hash(q) },
       }
+    end
+
+    def qualifications_of_level(level)
+      # NOTE: we do it this way so that it uses the already-included relation
+      # rather than triggering separate queries, as it does if we use the scopes
+      # .gcses .degrees etc
+      application_form.application_qualifications.select do |q|
+        q.level == level
+      end
     end
 
     def qualification_to_hash(qualification)

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -9,7 +9,7 @@ class GetApplicationChoicesForProvider
       :application_form,
       :provider,
       :site,
-      application_form: %i[candidate references application_work_experiences application_volunteering_experiences],
+      application_form: %i[candidate references application_work_experiences application_volunteering_experiences application_qualifications],
     ]
 
     ApplicationChoice.includes(*includes)

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -1,7 +1,13 @@
 begin
   require 'rspec/core/rake_task'
+
+  performance_test_pattern = 'spec/performance/**/*.rb'
+  RSpec::Core::RakeTask.new(:spec_without_performance) do |t|
+    t.rspec_opts = "--exclude-pattern #{performance_test_pattern}"
+  end
+
   RSpec::Core::RakeTask.new(:spec_with_profile) do |t|
-    t.rspec_opts = '--profile'
+    t.rspec_opts = "--profile --exclude-pattern #{performance_test_pattern}"
   end
 
   integration_test_pattern = 'spec/{system,requests}/**/*_spec.rb'
@@ -11,7 +17,7 @@ begin
   end
 
   RSpec::Core::RakeTask.new(:unit_tests) do |t|
-    t.rspec_opts = "--exclude-pattern #{integration_test_pattern}"
+    t.rspec_opts = "--exclude-pattern #{integration_test_pattern} --exclude-pattern #{performance_test_pattern}"
   end
 rescue LoadError
   nil
@@ -40,4 +46,4 @@ desc 'Run all acceptance tests'
 task acceptance_tests: %i[rspec_acceptance_tests cucumber]
 
 desc 'Run all the tests'
-task run_tests: %i[linting spec brakeman]
+task run_tests: %i[linting spec_without_performance brakeman]

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -11,13 +11,16 @@ begin
   end
 
   integration_test_pattern = 'spec/{system,requests}/**/*_spec.rb'
-
   RSpec::Core::RakeTask.new(:rspec_acceptance_tests) do |t|
     t.rspec_opts = "--pattern #{integration_test_pattern}"
   end
 
   RSpec::Core::RakeTask.new(:unit_tests) do |t|
-    t.rspec_opts = "--exclude-pattern #{integration_test_pattern} --exclude-pattern #{performance_test_pattern}"
+    t.rspec_opts = "--exclude-pattern '#{integration_test_pattern},#{performance_test_pattern}'"
+  end
+
+  RSpec::Core::RakeTask.new(:performance_tests) do |t|
+    t.rspec_opts = "--profile --pattern #{performance_test_pattern}"
   end
 rescue LoadError
   nil

--- a/spec/performance/requests/vendor_api/applications_controller_spec.rb
+++ b/spec/performance/requests/vendor_api/applications_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe VendorApi::ApplicationsController, type: :request do
+  context 'given two providers with 100 applications in various states' do
+    let(:current_provider) { create(:provider, code: 'BAT') }
+    let(:other_provider) { create(:provider, code: 'DIFFERENT') }
+    let(:api_token) { VendorApiToken.create_with_random_token!(provider: current_provider) }
+
+    before do
+      GenerateTestData.new(100, current_provider).generate
+    end
+
+    describe 'calling the index for all results in the last 2 years' do
+      let(:calling_the_index) {
+        get '/api/v1/applications.json', params: { since: 2.years.ago.to_date },
+                                         headers: { 'Authorization' => "Token #{api_token}" }
+      }
+
+      it 'returns a 200 status' do
+        calling_the_index
+        expect(response.code).to eq('200')
+      end
+
+      it 'runs in less than 0.5s' do
+        expect { calling_the_index }.to perform_under(0.5).sec
+      end
+    end
+  end
+end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1,16 +1,32 @@
 require 'rails_helper'
 
 RSpec.describe VendorApi::SingleApplicationPresenter do
+  let(:application_form) do
+    create(:completed_application_form) do |form|
+      form.first_nationality = 'British'
+      form.second_nationality = 'American'
+    end
+  end
+  let(:application_choice) do
+    create(:application_choice, application_form: application_form)
+  end
+
   describe '#candidate' do
     it 'returns nationality in the correct format' do
-      application_form = create(:completed_application_form) do |form|
-        form.first_nationality = 'British'
-        form.second_nationality = 'American'
-      end
-      application_choice = create(:application_choice, application_form: application_form)
       single_application_presenter = VendorApi::SingleApplicationPresenter.new(application_choice)
 
       expect(single_application_presenter.as_json[:attributes][:candidate][:nationality]).to eq(%w[GB US])
+    end
+  end
+
+  describe '#as_json' do
+    context 'given a relation that includes application_qualifications' do
+      let(:given_relation) { GetApplicationChoicesForProvider.call(provider: application_choice.provider) }
+      let!(:presenter) { VendorApi::SingleApplicationPresenter.new(given_relation.first) }
+
+      it 'does not trigger any additional queries' do
+        expect { presenter.as_json }.not_to make_database_queries
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,5 +106,4 @@ RSpec.configure do |config|
   # particularly slow.
   # config.profile_examples = 10
   config.include RSpec::Benchmark::Matchers
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,8 @@ SimpleCov.start 'rails'
 require 'sidekiq/testing'
 require 'clockwork/test'
 require 'audited-rspec'
+require 'rspec-benchmark'
+
 ENV['SERVICE_TYPE'] = 'test' # this is used for logging
 ENV['STATE_CHANGE_SLACK_URL'] = nil # ensure tests send no Slack notifications
 
@@ -103,4 +105,6 @@ RSpec.configure do |config|
   # end of the spec run, to help surface which specs are running
   # particularly slow.
   # config.profile_examples = 10
+  config.include RSpec::Benchmark::Matchers
+
 end


### PR DESCRIPTION
… and add performance tests to prove it

### Context

There is still an N+1 Query problem in the Vendor API's applications index, leading to very slow response times on Azure infrastructure.

### Changes proposed in this pull request

Remove the n+1 queries by including the `application_qualifications` relation in the main query, and replacing the references to `application_qualifications.gcses` etc with array select methods on the whole application_qualifications collection. 

This tests much faster on my localhost. Using apache bench with 50 requests against localhost, I get:

Before:

<img width="316" alt="Screen Shot 2019-12-05 at 17 30 26" src="https://user-images.githubusercontent.com/134501/70258933-0cbca400-1785-11ea-9b66-690b2c8d66ec.png">

After:
<img width="309" alt="Screen Shot 2019-12-05 at 17 31 54" src="https://user-images.githubusercontent.com/134501/70258982-278f1880-1785-11ea-8fff-c5a7d543e7f3.png">



### Guidance to review

...needs to be properly load-tested on staging

### Link to Trello card

[API performance: GET /applications still takes 3 seconds to return](https://trello.com/c/EhNeWrgv/1363-api-performance-get-applications-still-takes-3-seconds-to-return)

### Env vars

(none)