### PR TITLE
Skip site choice page when there is only one option

### DIFF
--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -16,6 +16,11 @@ module CandidateInterface
       end
     end
 
+    def single_site?
+      course_id = Course.find_by(code: code)
+      CourseOption.where(course_id: course_id).one?
+    end
+
   private
 
     def provider

--- a/spec/models/candidate_interface/pick_course_form_spec.rb
+++ b/spec/models/candidate_interface/pick_course_form_spec.rb
@@ -14,4 +14,24 @@ RSpec.describe CandidateInterface::PickCourseForm do
       expect(form.available_courses.map(&:name)).to eql(['Course you can apply to'])
     end
   end
+
+  describe '#single_site?' do
+    let(:provider) { create(:provider, name: 'Royal Academy of Dance', code: 'R55') }
+    let(:course) { create(:course, provider: provider, exposed_in_find: true, open_on_apply: true) }
+    let(:site) { create(:site, provider: provider) }
+    let(:pick_course_form) { CandidateInterface::PickCourseForm.new(provider_code: provider.code, code: course.code) }
+
+    before { create(:course_option, site: site, course: course) }
+
+    it 'returns true when there is one site for a course' do
+      expect(pick_course_form).to be_single_site
+    end
+
+    it 'returns false when there are more than one site for a course' do
+      another_site = create(:site, provider: provider)
+      create(:course_option, site: another_site, course: course)
+
+      expect(pick_course_form).not_to be_single_site
+    end
+  end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -95,9 +95,6 @@ module CandidateHelper
     choose 'Primary (2XT2)'
     click_button 'Continue'
 
-    choose 'Main site'
-    click_button 'Continue'
-
     check t('application_form.courses.complete.completed_checkbox')
     click_button 'Continue'
   end


### PR DESCRIPTION
### Context
We don't want to show the site choice page when there is only one option available. 

### Changes proposed in this pull request
This PR adds a `single_site?` method so we know when only one site option available for a course
When a course has a single site it selects the site for the user and redirects to the review page.

### Guidance to review
Try adding the `Dance` course provided by the `Royal Academy of Dance` as it has a single site. You should not be able to see the site choice page.

### Link to Trello card

[438 - Remove location choice page when there is only one option](https://trello.com/c/N9qXVSK9/438-remove-location-choice-page-when-there-is-only-one-option)