### PR TITLE
Extend the cucumber spec around references

### DIFF
--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -49,7 +49,7 @@ When(/^the candidate submits the application$/) do
 end
 
 When('{int} referees complete the references') do |number_of_complete_references|
-  references = @application_choice.application_form.reload.references[0...number_of_complete_references.to_i]
+  references = @application_choice.application_form.reload.references.first(number_of_complete_references)
   references.each do |reference|
     steps %{When "#{reference.email_address}" provides a reference}
   end

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -31,8 +31,28 @@ Given('its RBD time is set to {string}') do |time_string|
   @application_choice.update(reject_by_default_at: DateTime.parse(time_string))
 end
 
+Given("the time is {int} working days after the form's submission") do |number_of_working_days|
+  new_time = number_of_working_days.business_days.since(@application_choice.application_form.submitted_at)
+  Timecop.freeze(new_time)
+end
+
+Given('the candidate submits a complete application') do
+  steps %{
+    When an application choice has "unsubmitted" status
+    And the candidate has specified "bob@example.com" and "alice@example.com" as referees
+    And the candidate submits the application
+  }
+end
+
 When(/^the candidate submits the application$/) do
   SubmitApplication.new(@application_choice.application_form).call
+end
+
+When('{int} referees complete the references') do |number_of_complete_references|
+  references = @application_choice.application_form.reload.references[0...number_of_complete_references.to_i]
+  references.each do |reference|
+    steps %{When "#{reference.email_address}" provides a reference}
+  end
 end
 
 Then(/^the reject by default time is "(.*?)"$/) do |time|

--- a/features/submitting_references.feature
+++ b/features/submitting_references.feature
@@ -4,7 +4,7 @@ Feature: references
 
   Swapping out referees
   =====================
-  If a referee don't provide a reference within a certain period of time, a candidate is allowed to swap out that referee for another one. Candidates can't remove or swap out references once they've been submitted by the referees.
+   If a referee doesn't provide a reference within a certain period of time, a candidate is allowed to swap out that referee for another one. Candidates can't remove or swap out references once they've been submitted by the referees.
 
   Cooling-off period
   ==================

--- a/features/submitting_references.feature
+++ b/features/submitting_references.feature
@@ -2,33 +2,31 @@
 Feature: references
   Candidates need two references as part of their application. When filling in the application form, they provide two sets of contact details and DfE then prompts the referees for feedback once the candidate has submitted the form.
 
+  Swapping out referees
+  =====================
   If a referee don't provide a reference within a certain period of time, a candidate is allowed to swap out that referee for another one. Candidates can't remove or swap out references once they've been submitted by the referees.
 
+  Cooling-off period
+  ==================
   Providers don't see the application form until the references have both come back and 5 working days have elapsed since application submission.
 
+  Apply 2
+  =======
   At Apply 2, the references are carried over from Apply 1.
 
-  Scenario: an application isn't complete until it's received two references
-    Given an application choice has "unsubmitted" status
-    And the candidate has specified "j.moriarty@uni.ac.uk" and 's.skinner@springfield-elementary.edu' as referees
-    And the candidate submits the application
-    Then the new application choice status is "awaiting_references"
-    When "j.moriarty@uni.ac.uk" provides a reference
-    Then the new application choice status is "awaiting_references"
-    When "s.skinner@springfield-elementary.edu" provides a reference
-    Then the new application choice status is "application_complete"
+  Scenario Outline: an application is sent to a provider after it's received two references and 5 working days elapse after submission
+    Given the candidate submits a complete application
+    When <number of complete references> referees complete the references
+    And the time is <working days since submission> working days after the form's submission
+    And the daily application cron job has run
+    Then the new application choice status is "<status?>"
 
-  Scenario: an application is sent to a provider after it's received two references and 5 working days elapse after submission
-    Given an application choice has "unsubmitted" status
-    And the candidate has specified "j.moriarty@uni.ac.uk" and 's.skinner@springfield-elementary.edu' as referees
-    And the date is "2019-11-04"
-    And the candidate submits the application
-    And "j.moriarty@uni.ac.uk" provides a reference
-    And "s.skinner@springfield-elementary.edu" provides a reference
-    Then the new application choice status is "application_complete"
-    When the date is "2019-11-11"
-    And the daily application cron job has run
-    Then the new application choice status is "application_complete"
-    When the date is "2019-11-12"
-    And the daily application cron job has run
-    Then the new application choice status is "awaiting_provider_decision"
+    Examples:
+      | working days since submission | number of complete references | status?                    | notes                                          |
+      | 0                             | 0                             | awaiting references        | too few references                             |
+      | 6                             | 0                             | awaiting references        | too few references                             |
+      | 6                             | 1                             | awaiting references        | too few references                             |
+      | 0                             | 2                             | application complete       | in cooling-off period                          |
+      | 4                             | 2                             | application complete       | in cooling-off period                          |
+      | 5                             | 2                             | application complete       | cooling-off period lasts to the end of the day |
+      | 6                             | 2                             | awaiting provider decision | cooling-off period elapsed, enough references  |


### PR DESCRIPTION
### Context

To improve the documentation around the business rules.

### Changes proposed in this pull request

- Add a bit more structure to the free-text bit of the spec
- The two existing scenarios are generalised using a scenario table. This change
also adds coverage for some cases that weren't covered by the original scenarios.
