### PR TITLE
Rebuild the API docs as part of this site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'clockwork'
 # For outgoing http requests
 gem 'http'
 
+gem 'openapi3_parser', '0.5.2'
+gem 'rouge'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
       clockwork
       timecop
     coderay (1.1.2)
+    commonmarker (0.20.1)
+      ruby-enum (~> 0.5)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crack (0.4.3)
@@ -293,6 +295,8 @@ GEM
       addressable (~> 2.5)
       omniauth (~> 1.9)
       openid_connect (~> 1.1)
+    openapi3_parser (0.5.2)
+      commonmarker (~> 0.17)
     openid_connect (1.1.8)
       activemodel
       attr_required (>= 1.0.0)
@@ -383,6 +387,7 @@ GEM
       railties (>= 5.0)
     rollout (2.4.5)
       redis (~> 4.0)
+    rouge (3.13.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -423,6 +428,8 @@ GEM
       rubocop (>= 0.72.0)
     rubocop-rspec (1.37.0)
       rubocop (>= 0.68.1)
+    ruby-enum (0.7.2)
+      i18n
     ruby-graphviz (1.2.4)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
@@ -547,6 +554,7 @@ DEPENDENCIES
   omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect
+  openapi3_parser (= 0.5.2)
   pg (~> 1.1.4)
   pry
   pry-byebug
@@ -558,6 +566,7 @@ DEPENDENCIES
   request_store-sidekiq
   request_store_rails
   rollout
+  rouge
   rspec-benchmark
   rspec-rails
   rspec_junit_formatter

--- a/app/controllers/api_docs/api_docs_controller.rb
+++ b/app/controllers/api_docs/api_docs_controller.rb
@@ -1,0 +1,6 @@
+module ApiDocs
+  class ApiDocsController < ActionController::Base
+    include LogQueryParams
+    layout 'application'
+  end
+end

--- a/app/controllers/api_docs/pages_controller.rb
+++ b/app/controllers/api_docs/pages_controller.rb
@@ -1,0 +1,27 @@
+module ApiDocs
+  class PagesController < ApiDocsController
+    def home
+      render_content_page :home
+    end
+
+    def usage
+      render_content_page :usage
+    end
+
+    def help
+      render_content_page :help
+    end
+
+    def release_notes
+      render_content_page :release_notes
+    end
+
+  private
+
+    def render_content_page(page_name)
+      @converted_markdown = Govuk::MarkdownRenderer.render(File.read("app/views/api_docs/pages/#{page_name}.md")).html_safe
+      @page_name = page_name
+      render 'rendered_markdown_template'
+    end
+  end
+end

--- a/app/controllers/api_docs/reference_controller.rb
+++ b/app/controllers/api_docs/reference_controller.rb
@@ -1,0 +1,7 @@
+module ApiDocs
+  class ReferenceController < ApiDocsController
+    def reference
+      @document = Openapi3Parser.load_file('config/vendor-api-0.8.0.yml')
+    end
+  end
+end

--- a/app/controllers/vendor_api/openapi_controller.rb
+++ b/app/controllers/vendor_api/openapi_controller.rb
@@ -1,0 +1,9 @@
+module VendorApi
+  class OpenapiController < VendorApiController
+    skip_before_action :require_valid_api_token!
+
+    def spec
+      render text: File.read('config/vendor-api-0.8.0.yml'), content_type: 'text/yaml'
+    end
+  end
+end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -65,7 +65,7 @@ module VendorApi
     end
 
     def current_provider
-      @current_provider ||= @current_vendor_api_token.provider
+      @current_provider ||= @current_vendor_api_token&.provider
     end
 
     # controller-specific additional info to include in logstash logs

--- a/app/frontend/styles/_syntax-highlighting.scss
+++ b/app/frontend/styles/_syntax-highlighting.scss
@@ -1,0 +1,230 @@
+// A Base16 palette
+// https://github.com/chriskempson/base16
+
+$code-00: scale-color(govuk-colour("light-grey"), $lightness:50%); /* Default Background */
+$code-01: #f5f5f5; /* Lighter Background (Unused) */
+$code-02: #bfc1c3; /* Selection Background */
+$code-03: darken( $govuk-secondary-text-colour, 2%);; /* Comments, Invisibles, Line Highlighting */
+$code-04: #e8e8e8; /* Dark Foreground (Unused) */
+$code-05:  $govuk-text-colour; /* Default Foreground, Caret, Delimiters, Operators */
+$code-06: #ffffff; /* Light Foreground (Unused) */
+$code-07: #ffffff; /* Light Background (Unused) */
+
+$code-08: #B26749; /* Variables, XML Tags, Markup Link Text, Markup Lists */
+$code-09: #0E7754; /* Integers, Boolean, Constants, XML Attributes, Markup Link Url */
+$code-0A: #4C4077; /* Classes, Markup Bold, Search Text Background */
+$code-0B: $govuk-brand-colour; /* Strings, Inherited Class, Markup Code */
+$code-0C: $govuk-brand-colour; /* Support, Regular Expressions, Escape Characters, Markup Quotes */
+$code-0D: #4C4077; /* Functions, Methods, Attribute IDs, Headings */
+$code-0E: #a71d5d; /* Keywords, Storage, Selector, Markup Italic */
+$code-0F: #C92424; /* Deprecated, Opening/Closing Embedded Language Tags e.g. <?php ?> (Unused) */
+
+$code-insert-bg: #DEF8CA;
+$code-delete-bg: #FADDDD;
+
+.app-json-code-sample {
+  background: $code-00;
+  color: $code-05;
+  padding:3px 5px;
+  border-radius:1px;
+  font-family:monaco, Consolas, "Lucida Console", monospace;
+  font-size:15px;
+  color:#a71d5d;
+  overflow-wrap:break-word;
+  word-wrap:break-word;
+  -ms-word-break:break-all;
+  word-break:break-all;
+  word-break:break-word
+
+  /* Map Rouge / Pygments Tokens to work with 'Base 16' themes */
+
+
+  /**
+   * Comments
+   */
+
+  .c,       /* Comment */
+  .cm,      /* Comment.Multiline */
+  .cp,      /* Comment.Preproc */
+  .c1,      /* Comment.Single */
+  .cs {     /* Comment.Special */
+    color: $code-03;
+  }
+
+  /**
+   * Keywords
+   */
+
+  .k,       /* Keyword */
+  .kc,      /* Keyword.Constant */
+  .kd,      /* Keyword.Declaration */
+  .kp,      /* Keyword.Pseudo */
+  .kr {     /* Keyword.Reserved */
+    color: $code-0E;
+  }
+
+  .kn {     /* Keyword.Namespace */
+    color: $code-0C;
+  }
+
+  .kt {     /* Keyword.Type */
+    color: $code-0A;
+  }
+
+  /**
+   * Operators
+   */
+
+  .o,       /* Operator */
+  .ow {     /* Operator.Word */
+    color: $code-0C
+  }
+
+  /**
+   * Names
+   */
+
+  .n,       /* Name */
+  .nb,      /* Name.Builtin */
+  .bp,      /* Name.Builtin.Pseudo */
+  .ni,      /* Name.Entity */
+  .nl,      /* Name.Label */
+  .py {     /* Name.Property */
+    // Default styling
+  }
+
+  .nc,      /* Name.Class */
+  .nn {     /* Name.Namespace */
+    color: $code-0A;
+  }
+
+  .na,      /* Name.Attribute */
+  .nf {     /* Name.Function */
+    color: $code-0D;
+  }
+
+  .nv,      /* Name.Variable */
+  .no,      /* Name.Constant */
+  .vc,      /* Name.Variable.Class */
+  .vg,      /* Name.Variable.Global */
+  .vi {     /* Name.Variable.Instance */
+    color: $code-08;
+  }
+
+  .nd {     /* Name.Decorator */
+    color: $code-0C;
+  }
+
+  .nt,      /* Name.Tag */
+  .nx {     /* Name.Other */
+    color: $code-09;
+  }
+
+  .ne {     /* Name.Exception */
+    color: $code-0F;
+  }
+
+  /**
+   * Literals
+   */
+
+  .l  {     /* Literal */
+    color: $code-09;
+  }
+
+  .ld {     /* Literal.Date */
+    color: $code-0B;
+  }
+
+  .m,       /* Literal.Number */
+  .mf,      /* Literal.Number.Float */
+  .mh,      /* Literal.Number.Hex */
+  .mi,      /* Literal.Number.Integer */
+  .il,      /* Literal.Number.Integer.Long */
+  .mo {     /* Literal.Number.Oct */
+    color: $code-09;
+  }
+
+  .s,       /* Literal.String */
+  .sb,      /* Literal.String.Backtick */
+  .s2,      /* Literal.String.Double */
+  .sh {     /* Literal.String.Heredoc */
+    color: $code-0B;
+  }
+
+  .sx,      /* Literal.String.Other */
+  .sr,      /* Literal.String.Regex */
+  .s1,      /* Literal.String.Single */
+  .ss {     /* Literal.String.Symbol */
+    color: $code-0B;
+  }
+
+  .se,      /* Literal.String.Escape */
+  .si {     /* Literal.String.Interpol */
+    color: $code-09;
+  }
+
+  .sd {     /* Literal.String.Doc */
+    color: $code-03
+  }
+
+  .sc {     /* Literal.String.Char */
+    // Default styling
+  }
+
+  /**
+   * Diffs
+   */
+
+  .gi {     /* Generic.Inserted */
+    background-color: $code-insert-bg;
+  }
+
+  .gd {     /* Generic.Deleted */
+    background-color: $code-delete-bg;
+  }
+
+  /**
+   * Misc
+   */
+
+  .p {      /* Punctuation */
+    // Default styling
+  }
+
+  .w {      /* Text.Whitespace */
+    // Default styling
+  }
+
+  .hll {    /* Highlight */
+    background-color: $code-02;
+  }
+
+  .err,     /* Error */
+  .gr,      /* Generic.Error */
+  .gt {     /* Generic.Traceback */
+    color: $code-0F;
+  }
+
+  .gs {     /* Generic.Strong */
+    font-weight: bold;
+  }
+
+  .ge {     /* Generic.Emph */
+    font-style: italic;
+  }
+
+  .gh {     /* Generic.Heading */
+    font-weight: bold;
+  }
+
+  .gu {     /* Generic.Subheading */
+    color: $code-0A;
+    font-weight: bold;
+  }
+
+  .gp {     /* Generic.Prompt */
+    color: $code-03;
+    font-weight: bold
+  }
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -21,3 +21,4 @@ $govuk-image-url-function: frontend-image-url;
 @import "_summary-card";
 @import "_tag";
 @import "_task-list";
+@import "_syntax-highlighting";

--- a/app/helpers/api_docs_helper.rb
+++ b/app/helpers/api_docs_helper.rb
@@ -1,0 +1,13 @@
+module ApiDocsHelper
+  def json_code_sample(code)
+    source = JSON.pretty_generate(code)
+    formatter = Rouge::Formatters::HTML.new
+    lexer = Rouge::Lexers::JSON.new
+
+    tag.pre class: 'app-json-code-sample' do
+      tag.code do
+        formatter.format(lexer.lex(source)).html_safe
+      end
+    end
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,7 +1,8 @@
 module NavigationHelper
-  def nav_link(text, url, active:)
+  def nav_link(text, url, active: [], active_action: [])
     item_class = 'govuk-header__navigation-item'
     item_class += ' govuk-header__navigation-item--active' if controller.controller_name.in?(Array.wrap(active))
+    item_class += ' govuk-header__navigation-item--active' if controller.action_name.in?(Array.wrap(active_action))
 
     tag.li class: item_class do
       link_to text, url, class: 'govuk-header__link'

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -1,0 +1,70 @@
+module ApiDocs
+  class ApiOperation
+    attr_reader :path_name, :operation
+
+    def initialize(http_verb:, path_name:, operation:)
+      @http_verb = http_verb
+      @path_name = path_name
+      @operation = operation
+    end
+
+    def http_verb
+      @http_verb.upcase
+    end
+
+    def request_body
+      return unless operation.request_body
+
+      RequestBody.new(operation.request_body)
+    end
+
+    delegate :summary,
+             :description,
+             :parameters,
+             to: :operation
+
+    def responses
+      operation.responses.map { |code, response| Response.new(code, response) }
+    end
+  end
+
+  class Response
+    attr_reader :code, :response
+
+    delegate :description, :content, to: :response
+
+    def initialize(code, response)
+      @code = code
+      @response = response
+    end
+
+    def example
+      return unless response.content['application/json']
+
+      response.content['application/json']['example'] || ApiDocs::SchemaExample.new(schema).as_json
+    end
+
+    def schema
+      response.content['application/json'].schema
+    end
+
+    def schema_name
+      location = schema.node_context.source_location.to_s
+      location.gsub(/#\/components\/schemas\//, '')
+    end
+  end
+
+  class RequestBody
+    attr_reader :request_body
+    delegate :description, to: :request_body
+
+    def initialize(request_body)
+      @request_body = request_body
+    end
+
+    def example
+      request_body.content['application/json']['example'] ||
+        ApiDocs::SchemaExample.new(request_body.content['application/json'].schema).as_json
+    end
+  end
+end

--- a/app/presenters/api_docs/schema.rb
+++ b/app/presenters/api_docs/schema.rb
@@ -1,0 +1,59 @@
+module ApiDocs
+  class Schema
+    attr_reader :name, :schema
+    delegate :description, :required, to: :schema
+
+    def initialize(name:, schema:)
+      @name = name
+      @schema = schema
+    end
+
+    def properties
+      props = []
+
+      if schema['allOf']
+        schema['allOf'].each do |schema_nested|
+          schema_nested.properties.each do |property|
+            props << property
+          end
+        end
+      end
+
+      schema.properties.each do |property|
+        props << property
+      end
+
+      props.map { |property_name, property_attributes| Property.new(self, property_name, property_attributes) }
+    end
+
+    class Property
+      attr_reader :schema, :name, :example, :attributes
+      delegate :type, to: :attributes
+
+      def initialize(schema, name, attributes)
+        @schema = schema
+        @name = name
+        @attributes = attributes
+      end
+
+      def required?
+        name.in?(schema.required.to_a)
+      end
+
+      def subschema
+        linked_schema = attributes
+
+        # If property is an array, check the items property for a reference.
+        if type == 'array'
+          linked_schema = attributes['items']
+        end
+
+        return unless linked_schema.node_context.referenced_by.to_s.include?('#/components/schemas') &&
+          !linked_schema.node_context.source_location.to_s.include?('/properties/')
+
+        location = linked_schema.node_context.source_location.to_s
+        location.gsub(/#\/components\/schemas\//, '')
+      end
+    end
+  end
+end

--- a/app/presenters/api_docs/schema_example.rb
+++ b/app/presenters/api_docs/schema_example.rb
@@ -1,0 +1,88 @@
+module ApiDocs
+  class SchemaExample
+    attr_reader :main_schema
+
+    def initialize(main_schema)
+      @main_schema = main_schema
+    end
+
+    def as_json
+      generate_example_from_schema(main_schema)
+    end
+
+  private
+
+    def generate_example_from_schema(schema_data)
+      properties = {}
+
+      schema_data.properties.each do |key, property|
+        properties[key] = property
+      end
+
+      properties.merge!(get_all_of_hash(schema_data))
+
+      example_data = {}
+
+      properties.each do |property_key, property|
+        example_data[property_key] = generate_example_value_for_property(property)
+      end
+
+      example_data
+    end
+
+    def generate_example_value_for_property(property)
+      if property.example
+        property.example
+      elsif property.type == 'object'
+        if property.items
+          generate_example_from_schema(property.items)
+        elsif property.properties
+          generate_example_from_schema(property)
+        else
+          {}
+        end
+      elsif property.type == 'array'
+        if property.items
+          [generate_example_value_for_property(property.items)]
+        else
+          []
+        end
+      else
+        # If all else fails, just show the type
+        property.type
+      end
+    end
+
+    def get_all_of_array(schema)
+      properties = []
+
+      if schema['allOf']
+        schema['allOf'].each do |schema_nested|
+          schema_nested.properties.each do |property|
+            if property.is_a?(Array)
+              property = property[1]
+            end
+
+            properties << property
+          end
+        end
+      end
+
+      properties
+    end
+
+    def get_all_of_hash(schema)
+      properties = {}
+
+      if schema['allOf']
+        schema['allOf'].each do |schema_nested|
+          schema_nested.properties.each do |key, property|
+            properties[key] = property
+          end
+        end
+      end
+
+      properties
+    end
+  end
+end

--- a/app/views/api_docs/pages/help.md
+++ b/app/views/api_docs/pages/help.md
@@ -1,0 +1,3 @@
+If you have any questions or suggestions [contact us](mailto:becomingateacher@digital.education.gov.uk) at <becomingateacher@digital.education.gov.uk>.
+
+We’ll try to get back to you within two working days.

--- a/app/views/api_docs/pages/home.md
+++ b/app/views/api_docs/pages/home.md
@@ -1,0 +1,78 @@
+This is API documentation for the Department for Education (DfE)’s new "Apply for teacher training" service.
+
+Apply will replace the online UCAS application form for postgraduate
+teacher training. All vendors of student record systems (SRS) and some
+training providers will need to make changes to integrate with Apply.
+
+The API is a work in progress. We are publishing draft documentation so that:
+
+- providers and vendors have all the information they need to plan a transition to the new service
+- the Apply team can better understand providers’ and vendors’ needs for the API
+
+## What this API is for
+
+Once a candidate has submitted their application via the Apply service, the
+application will become available over the API.
+
+Providers can then use the API for:
+
+- [Retrieving applications](/reference/#get-applications)
+- [Making an offer to a candidate](/reference/#post-applications-application-id-offer)
+- Confirming a candidate [has met conditions](/reference/#post-applications-application-id-confirm-conditions-met), or [has been enrolled](/reference/#post-applications-application-id-confirm-enrolment)
+- [Rejecting unsuccessful applications](/reference/#post-applications-application-id-reject)
+
+To get an idea of how the API works, we recommend you [review the example usage scenarios](/usage-scenarios).
+
+## Codes and reference data
+
+Before each application cycle, UCAS provides vendors with reference data defining how certain values appear in API responses.
+
+DfE Apply will avoid prioprietary codes wherever possible, preferring existing data formats such as ISO-certified standards or HESA codes.
+
+Codes appear in three contexts:
+
+- All dates in the API specification are intended to be [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) compliant
+- Nationality is expressed as an [ISO 3166](https://www.iso.org/iso-3166-country-codes.html) country code
+- Demographic data required for HESA reporting uses [HESA codes for the 2019/20 Initial Teacher Training return](https://www.hesa.ac.uk/collection/c19053/e/ittschms). When the HESA codes for the next cycle are released, we will update the documentation to reflect these.
+
+## How do I connect to this API?
+
+### Authentication and authorisation
+
+The data held by the Apply service is confidential and only available
+to candidates themselves and staff from the training provider to
+which applications are made. Therefore authentication will be required
+for all API interactions.
+
+To set up an authenticated connection between the student record
+system and DfE Apply, users will need to provide an API key to
+the SRS. To get an API key, the user will need to sign in to the DfE
+Apply web interface using DfE Sign-in, the Single Sign-on provider
+used on the existing _Publish teacher training courses_ service, part
+of [Find postgraduate teacher training](https://find-postgraduate-teacher-training.education.gov.uk). For each
+provider supported by your SRS, one user needs to generate this
+key. It is up to SRS vendors to provide a way for users to add the API
+key to their SRS system.
+
+The API key will expire after 6 months. One month in advance of
+expiry, DfE Apply will email the user who generated the key so that
+they know to come back and generate a new one. To prevent a hard
+cut-over between keys, once a new key is created the old key will
+continue to work until it expires.
+
+### Versioning
+
+The version of the API is specified in the URL `/api/v{n}/`. For example: `/api/v1/`, `/api/v2/`, `/api/v3/`, ...
+
+When the API changes in a way that is backwards-incompatible, a new version number of the API will be published.
+
+When a new version, for example `/api/v2`, is published, both the previous **v1** and the current **v2** versions will be supported.
+
+We, however, only support one version back, so if the **v3** is published, the **v1** will be discontinued.
+
+When non-breaking changes are made to the API, this will not result in a version bump.
+
+Information about deprecations (for instance attributes/endpoints that will be modified/removed) will be included in the API
+response through a "Warning" header.
+
+We will update our [release notes](/release-notes) with all breaking and non-breaking changes.

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,0 +1,100 @@
+### Unreleased Changes
+- Add Development, Test and Vendor Sandbox enviroment details to [api info](/reference/#api-info) page.
+- Add [/test-data/regenerate](/reference/#post-test-data-regenerate) endpoint.
+- Add [single application](/reference/#singleapplicationresponse) and [multiple applications](/reference/#multipleapplicationsresponse) response schemas.
+- Add `422` error response to `POST` endpoints including:
+    - [offer](/reference/#post-applications-application-id-offer)
+    - [confirm enrolment](/reference/#post-applications-application-id-confirm-enrolment)
+    - [confirm conditions met](/reference/#post-applications-application-id-confirm-conditions-met)
+    - [reject](/reference/#post-applications-application-id-reject)
+
+### Release 0.4.0 - 26 September 2019
+
+Changes to the data:
+
+- Change the structure of an [application](/reference#get-applications):
+  - add `type` field
+  - add `attributes` field and move `status`, `submitted_at`, `updated_at`, `personal_statement`
+    `candidate`, `contact_details`, `course`, `qualifications`, `work_experiences`
+    `references`, `offer`, `withdrawal` and `rejection` fields into it
+- Remove date from [reject](/reference/#post-applications-application-id-reject) endpoint
+- Limit [candidates](/reference/#candidate) to only 2 nationalities
+- Rename the `org` field on [work experience](/reference/#workexperience) to `organisation_name`
+- Rename the `type` field on [qualification](/reference/#qualification) to `qualification_type`
+- Rename the `type` field on [reference](/reference/#reference) to `reference_type`
+- Add HESA ITT data to the [application](/reference#get-applications). Available only once a student is enrolled
+
+Changes to functionality:
+
+- Change the successful response for all endpoints to be within a `data` object
+- Change the successful response for making an offer, confirming candidate
+  enrolment, confirming offer conditions are met and rejecting an application
+  endpoints to be the application
+- Change the HTTP response code for making an offer, confirming candidate enrolment,
+  confirming offer conditions are met and rejecting an application endpoints to `200`
+- Support a `provider_ucas_code` parameter when [retrieving many applications](/retrieve-many-applications)
+- Require a `meta` key in POST request bodies, holding `attribution` and `timestamp` metadata
+
+Additional changes:
+
+- Clarify the endpoint for rejecting an application in [usage scenarios](/usage-scenarios)
+- Clarify the timestamp format for retrieving applications in [usage scenarios](/usage-scenarios)
+- Clarify maximum length of strings in Schemas
+- Add description of the [API versioning](/#versioning)
+- Add error responses to OpenAPI spec for all endpoints
+- Add [instructions](/reference/#use-the-swagger-editor) for importing our OpenAPI specification in the Swagger Editor
+- Add `provider_code` param to retrieving many applications in [usage scenarios](/usage-scenarios)
+- Update responses for [making an offer](/reference/#post-applications-application-id-offer),
+  [confirming candidate enrolment](/reference/#post-applications-application-id-confirm-enrolment),
+  [confirming offer conditions are met](/reference/#post-applications-application-id-confirm-conditions-met)
+  and [rejecting an application](/reference/#post-applications-application-id-reject) endpoints in [usage scenarios](/usage-scenarios)
+- Clarify the steps between making an offer and confirming that offer conditions are met in [usage scenarios](/usage-scenarios)
+
+### Release 0.3 - 16 September 2019
+
+Changes to the data:
+
+- Remove first and last name from Candidate in favour of full name
+- Remove id from Candidate
+- Remove disability information from Candidate, as this is not collected via the application form
+- Remove functionality to amend an offer
+- Rename the rejection endpoint
+- Update Contact Details resource to split address into separate fields
+- Remove description from course resource
+- Add first name, last name and date of birth for Candidate
+
+### Release 0.2 - 11 September 2019
+
+Changes to functionality:
+
+- Add documentation on the proposed way of authenticating users
+- Limit the number of offer conditions to 20
+- Remove functionality to amend an offer (you can reuse the make an offer endpoint)
+- Remove functionality to confirm a placement for a candidate
+- Remove functionality to schedule interviews for a candidate
+
+Changes to the data:
+
+- Remove first and last name from Candidate in favour of full name
+- Remove id from Candidate
+- Remove disability information from Candidate, as this is not collected via the application form
+- Rename the rejection endpoint
+- Update Contact Details resource to split address into separate fields
+- Applications now have a 10 character identifier
+- The `course` attribute of an application now refers to a single course instead of multiple
+- References have a "content" attribute containing the referee's contribution
+- Qualifications have an "equivalency_details" attribute for overseas awards
+- Withdrawals and Rejections now have timestamps instead of dates
+- Withdrawal reason has become optional
+
+Additional changes:
+
+- Clarify that strings have a 255 character limit, unless otherwise specified
+- Clarify that only candidates can withdraw an application
+- Clarify that we're using [ISO 3166 for country codes](/#codes-and-reference-data), not ISO 3611
+- Clarify how to make an unconditional and conditional offer
+- Clarify that offer conditions are optional
+
+### Release 0.1 - 4 July 2019
+
+Initial release of the API documentation.

--- a/app/views/api_docs/pages/rendered_markdown_template.html.erb
+++ b/app/views/api_docs/pages/rendered_markdown_template.html.erb
@@ -1,0 +1,11 @@
+<%= content_for :title, t("page_titles.api_docs.#{@page_name}") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("page_titles.api_docs.#{@page_name}") %></h1>
+
+    <div class="app-styled-content">
+      <%= @converted_markdown %>
+    </div>
+  </div>
+</div>

--- a/app/views/api_docs/pages/usage.md
+++ b/app/views/api_docs/pages/usage.md
@@ -1,0 +1,85 @@
+The scenarios on this page show example request URLs and payloads clients can
+use to take actions via this API. The examples are only concerned with business
+logic and are missing details necessary for real-world usage. For example,
+authentication is completely left out.
+
+At the beginning of each scenario, a candidate has completed an application for initial teacher training via the Apply service and that application is available via the API.
+
+The provider has authenticated to your system and begins their work by retrieving all the applications since a given date. Your system issues the following request on their behalf:
+
+```
+GET /applications?since=2018-10-01T10:00:00Z&provider_code=2FR
+```
+
+This returns a list of [Application](/reference/#application)s.
+
+The following examples all refer to a single application id, `11fc0d3b2f`, which
+we assume belongs to one of the applications in that list.
+
+## A successful application
+
+### 1. Provider retrieves the application
+
+Get the application data.
+
+```
+GET /applications/11fc0d3b2f
+```
+
+This returns an [application](/reference/#application).
+
+_See [retrieve an application](/reference/#get-applications-application-id) endpoint._
+
+### 2. The provider makes an offer
+
+The provider would like to offer the candidate a conditional place.
+
+```
+POST /applications/11fc0d3b2f/offer
+```
+
+With a [request body containing conditions](/reference/#request-body).
+
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [make an offer](/reference/#post-applications-application-id-offer) endpoint._
+
+### 3. Confirm that the conditions are met
+
+When the candidate has accepted this offer the application status changes to `meeting_conditions`.
+
+Once you know the conditions are met, make the following request.
+
+```
+POST /applications/11fc0d3b2f/confirm-conditions-met
+```
+
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [confirm offer conditions are met](/reference/#post-applications-application-id-confirm-conditions-met) endpoint._
+
+### 4. Confirm candidate enrolment
+
+Once the candidate has enrolled, make the following request.
+
+```
+POST /applications/11fc0d3b2f/confirm-enrolment
+```
+
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [confirm candidate enrolment](/reference/#post-applications-application-id-confirm-enrolment) endpoint._
+
+## Rejecting an application
+
+### 1. The provider reviews the form and rejects the candidate without an interview
+
+```
+POST /applications/11fc0d3b2f/reject
+```
+
+With a [request body containing a reason](/reference/#post-applications-application-id-reject-request-body).
+
+This returns an [application](/reference/#application) with an updated `status`.
+
+_See [reject an application](/reference/#post-applications-application-id-reject) endpoint._

--- a/app/views/api_docs/reference/_operation.html.erb
+++ b/app/views/api_docs/reference/_operation.html.erb
@@ -1,0 +1,86 @@
+<h3 class='govuk-heading-l'><code><%= operation.http_verb %> <%= operation.path_name %></code></h3>
+
+<div class="govuk-body-l">
+  <%= operation.summary %>
+</div>
+
+<div class="govuk-body">
+  <%= operation.description %>
+</div>
+
+<% if operation.parameters.any? %>
+  <h4 class='govuk-heading-s'>Parameters</h4>
+
+  <table class='govuk-table'>
+    <thead class='govuk-table__head'>
+      <tr class='govuk-table__row'>
+        <th scope='col' class='govuk-table__header'>Parameter</th>
+        <th scope='col' class='govuk-table__header'>In</th>
+        <th scope='col' class='govuk-table__header'>Type</th>
+        <th scope='col' class='govuk-table__header'>Required</th>
+        <th scope='col' class='govuk-table__header'>Description</th>
+      </tr>
+    </thead>
+    <tbody class='govuk-table__body'>
+      <% operation.parameters.each do |parameter| %>
+        <tr class='govuk-table__row'>
+          <td scope='row' class='govuk-table__header'><%= parameter.name %></td>
+          <td class='govuk-table__cell'><%= parameter.in %></td>
+          <td class='govuk-table__cell'><%= parameter.schema.type %></td>
+          <td class='govuk-table__cell'><%= parameter.required? %></td>
+          <td class='govuk-table__cell'><p><%= parameter.description %></p>
+            <% if parameter.schema.enum %>
+              <p>Allowed items:</p>
+
+              <ul>
+                <% parameter.schema.enum.each do |item| %>
+                  <li><%= item %></li>
+                <% end %>
+              </ul>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<% unless operation.request_body.nil? %>
+  <h4 class='govuk-heading-s'>Request body</h4>
+
+  <div class="govuk-body">
+    <%= operation.request_body.description %>
+  </div>
+
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Example request body
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <%= json_code_sample(operation.request_body.example) %>
+    </div>
+  </details>
+<% end %>
+
+<% if operation.responses.any? %>
+  <h4 class='govuk-heading-s'>Possible reponses</h4>
+
+  <% operation.responses.each do |response| %>
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          HTTP <%= response.code %> - <%= response.description %>
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        This request will return a <%= govuk_link_to response.schema_name, "#schema-#{response.schema_name.parameterize}" %> object.
+
+        <% if response.example %>
+          <%= json_code_sample(response.example) %>
+        <% end %>
+      </div>
+    </details>
+  <% end %>
+<% end %>

--- a/app/views/api_docs/reference/_schema.html.erb
+++ b/app/views/api_docs/reference/_schema.html.erb
@@ -1,0 +1,47 @@
+<h3 class='govuk-heading-m' id='schema-<%= schema.name.parameterize %>'><%= schema.name %></h3>
+
+<p class='govuk-body'>
+  <%= schema.description %>
+</p>
+
+<% if schema.properties.any? %>
+  <table class='govuk-body' style='width:100%'>
+    <thead class='govuk-table__head'>
+      <tr class='govuk-table__row'>
+        <th scope='col' class='govuk-table__header'>Name</th>
+        <th scope='col' class='govuk-table__header'>Type</th>
+        <th scope='col' class='govuk-table__header'>Example</th>
+        <th scope='col' class='govuk-table__header'>Description</th>
+      </tr>
+    </thead>
+
+    <tbody class='govuk-table__body'>
+      <% schema.properties.each do |property| %>
+        <tr class='govuk-table__row'>
+          <td scope='row' class='govuk-table__header'>
+            <%= property.name %><%= property.required? ? "<abbr title='This field will always be present in the response'>*</abbr>".html_safe : "" %>
+          </td>
+
+          <td class='govuk-table__cell'>
+            <%= property.type %>
+            <%= property.subschema ? govuk_link_to("(#{property.subschema})", "#schema-#{property.subschema.parameterize}") : nil %>
+          </td>
+
+          <td class='govuk-table__cell'>
+            <%= property.example %>
+          </td>
+
+          <td class='govuk-table__cell'>
+            <%= property.attributes.description %>
+
+            <% if property.type == 'string' && property.attributes.max_length.present? %>
+              <p>(limited to <%= property.attributes.max_length %> characters)</p>
+            <% elsif property.type == 'array' && property.attributes.max_items.present? %>
+              <p>(limited to <%= property.attributes.max_items %> elements)</p>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/reference/reference.html.erb
@@ -1,0 +1,42 @@
+<h1 class="govuk-heading-xl"><%= t("page_titles.api_docs.reference") %></h1>
+
+<h2 class='govuk-heading-l'>Developing on the API</h2>
+
+<p class='govuk-body'>
+  Our API is described using the <%= govuk_link_to 'OpenAPI specification', 'https://swagger.io/docs/specification/about' %>, so you can use the <%= govuk_link_to 'Swagger Editor', 'https://swagger.io/tools/swagger-editor' %> to experiment with the API.
+</p>
+
+<div class="govuk-form-group">
+  <label class="govuk-label" for="open-api-url">
+    Copy the specification URL:
+  </label>
+
+  <input class="govuk-input" id="open-api-url" readonly="readonly" name="open-api-url" type="text" value="<%= vendor_api_spec_url %>">
+</div>
+
+<p class="govuk-body">
+  You can use the following servers:
+</p>
+
+<ul class='govuk-list govuk-list--bullet'>
+  <% @document.servers.each do |server| %>
+    <li><%= server.description %>: <%= govuk_link_to server.url, server.url %></li>
+  <% end %>
+</ul>
+
+<h2 class='govuk-heading-l'>Endpoints</h2>
+
+<% @document.paths.each do |path_name, path| %>
+  <% %w[get put post delete patch].map do |http_verb| %>
+    <% operation = path.node_data[http_verb]
+    next unless operation
+    %>
+    <%= render 'operation', operation: ApiDocs::ApiOperation.new(http_verb: http_verb, path_name: path_name, operation: operation) %>
+  <% end %>
+<% end %>
+
+<h2 class='govuk-heading-l'>Schemas</h2>
+
+<% @document.components.schemas.each do |schema_name, schema| %>
+  <%= render 'schema', schema: ApiDocs::Schema.new(name: schema_name, schema: schema) %>
+<% end %>

--- a/app/views/layouts/_api_docs_header.html.erb
+++ b/app/views/layouts/_api_docs_header.html.erb
@@ -1,0 +1,7 @@
+<ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+  <%= nav_link 'Home', api_docs_home_path, active_action: %w[home] %>
+  <%= nav_link t('page_titles.api_docs.usage'), api_docs_usage_path, active_action: %w[usage] %>
+  <%= nav_link t('page_titles.api_docs.reference'), api_docs_reference_path, active_action: %w[reference] %>
+  <%= nav_link t('page_titles.api_docs.release_notes'), api_docs_release_notes_path, active_action: %w[release_notes] %>
+  <%= nav_link t('page_titles.api_docs.help'), api_docs_help_path, active_action: %w[help] %>
+</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,6 +73,8 @@
             <%= render 'layouts/support_header' %>
           <% when 'provider_interface' %>
             <%= render 'layouts/provider_header' %>
+          <% when 'api_docs' %>
+            <%= render 'layouts/api_docs_header' %>
           <% end %>
         </div>
       </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,12 @@ en:
       - Second referee
     providers: Training providers available through Apply for teacher training
     view_and_respond_to_offer: Details of offer
+    api_docs:
+      home:  Apply for teacher training
+      usage: Usage scenarios
+      reference: API reference
+      help: Get help
+      release_notes: Release notes
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -216,6 +216,8 @@ Rails.application.routes.draw do
 
     post '/test-data/regenerate' => 'test_data#regenerate'
 
+    get '/spec.yml' => 'openapi#spec', as: :spec
+
     get '/ping', to: 'ping#ping'
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,6 +295,14 @@ Rails.application.routes.draw do
     mount Sidekiq::Web, at: 'sidekiq'
   end
 
+  namespace :api_docs, path: '/api-docs' do
+    get '/' => 'pages#home', as: :home
+    get '/usage-scenarios' => 'pages#usage', as: :usage
+    get '/reference' => 'reference#reference', as: :reference
+    get '/release-notes' => 'pages#release_notes', as: :release_notes
+    get '/help' => 'pages#help', as: :help
+  end
+
   get '/check', to: 'healthcheck#show'
 
   scope via: :all do

--- a/spec/presenters/api_docs/schema_example_spec.rb
+++ b/spec/presenters/api_docs/schema_example_spec.rb
@@ -1,0 +1,98 @@
+require 'rails_helper'
+
+RSpec.describe ApiDocs::SchemaExample do
+  describe '#as_json' do
+    it 'generates an example for an empty schema' do
+      example = generate_example({})
+
+      expect(example).to eql({})
+    end
+
+    it 'generates examples for an object with strings' do
+      example = generate_example(
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+      )
+
+      expect(example).to eql(
+        'name' => 'string',
+      )
+    end
+
+    it 'generates examples for an object with integers' do
+      example = generate_example(
+        properties: {
+          id: {
+            type: 'integer',
+            format: 'int64',
+          },
+        },
+      )
+
+      expect(example).to eql(
+        'id' => 'integer',
+      )
+    end
+
+    it 'generates examples for an object with an object' do
+      example = generate_example(
+        properties: {
+          some_other_thing: {
+            type: 'object',
+          },
+        },
+      )
+
+      expect(example).to eql(
+        'some_other_thing' => {},
+      )
+    end
+
+    it 'generates examples for an object with an array' do
+      example = generate_example(
+        properties: {
+          array_of_integers: {
+            type: 'array',
+            items: {
+              type: 'integer',
+            },
+          },
+          array_of_strings: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+        },
+      )
+
+      expect(example).to eql(
+        'array_of_integers' => %w[integer],
+        'array_of_strings' => %w[string],
+      )
+    end
+
+    def generate_example(schema)
+      document = Openapi3Parser.load(
+        openapi: '3.0.0',
+        info: {
+          title: 'Test schema',
+          version: '1.0.0',
+        },
+        paths: {
+
+        },
+        components: {
+          schemas: {
+            SomeSchema: schema,
+          },
+        },
+      )
+
+      ApiDocs::SchemaExample.new(document.components.schemas.first.last).as_json
+    end
+  end
+end

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
     end
   end
   let(:application_choice) do
-    create(:application_choice, application_form: application_form)
+    create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
   end
 
   describe '#candidate' do

--- a/spec/system/api_docs/api_docs_spec.rb
+++ b/spec/system/api_docs/api_docs_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.feature 'API docs' do
+  scenario 'User browses through the API docs' do
+    given_i_am_a_vendor
+    i_can_browse_the_api_docs
+  end
+
+  def given_i_am_a_vendor
+    # No authentication necessary
+  end
+
+  def i_can_browse_the_api_docs
+    visit api_docs_home_path
+    expect(page).to have_content 'This is API documentation'
+
+    click_link 'Usage scenarios'
+    expect(page).to have_content 'The scenarios on this page'
+
+    click_link 'API reference'
+    expect(page).to have_content 'Developing on the API'
+
+    click_link 'Release notes'
+    expect(page).to have_content 'Unreleased Changes'
+
+    click_link 'Get help'
+    expect(page).to have_content 'If you have any questions or'
+  end
+end


### PR DESCRIPTION
### Context

The API docs are currently in another repo, and hosted on the PaaS.

We'd like to move it in this repo:

- To avoid drift between the openapi specs
- Offer a consistent UI
- Reduce technical overhead (we'll have a single repo)
- Get good testing and deployment for free 
- Unified analytics
- A nice domain name

### Changes proposed in this pull request

This PR:

- Moves all of the content into a "API docs" section in this site
- Rewrites the API reference to be easier to read and iterate 

### Guidance to review

Look at it locally!

### Link to Trello card

https://trello.com/c/KENwAoIR/1357-merge-tech-docs-into-main-application