### PR TITLE
Fix Page not found when "Another course"

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -61,10 +61,10 @@ module CandidateInterface
         application_form: current_application,
       )
 
-      if !@pick_course.valid?
-        render :options_for_course
-      elsif @pick_course.other?
+      if @pick_course.other?
         redirect_to candidate_interface_course_choices_on_ucas_path
+      elsif !@pick_course.valid?
+        render :options_for_course
       elsif @pick_course.single_site?
         course_id = Course.find_by(code: course_code)
         course_option = CourseOption.where(course_id: course_id).first

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -32,6 +32,10 @@ RSpec.feature 'Selecting a course' do
     when_i_click_on_add_another_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_another_provider
+    and_i_choose_another_course
+    then_i_see_the_not_ready_for_you_yet_page
+
+    when_i_click_back
     and_i_choose_another_course_with_only_one_site
     then_i_review_my_second_course_choice
 
@@ -125,6 +129,11 @@ RSpec.feature 'Selecting a course' do
     click_button 'Continue'
   end
 
+  def and_i_choose_another_course
+    choose 'Another course'
+    click_button 'Continue'
+  end
+
   def then_i_see_the_address
     expect(page).to have_content('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, lEEDS, LS27 0LZ')
   end
@@ -183,6 +192,13 @@ RSpec.feature 'Selecting a course' do
     click_button 'Continue'
   end
 
+  def when_i_click_back
+    # TODO: the back link goes back to the '/candidate/application/courses/provider' instead of going back to the specific provider.
+    # Fix this and use click_link 'Back'
+
+    visit '/candidate/application/courses/provider/R55/courses'
+  end
+
   def and_i_delete_one_of_my_course_choice
     first(:link, t('application_form.courses.delete')).click
   end
@@ -193,5 +209,9 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_no_longer_see_my_course_choice
     expect(page).not_to have_content('Primary (2XT2)')
+  end
+
+  def then_i_see_the_not_ready_for_you_yet_page
+    expect(page).to have_content('We’re sorry, but we’re not ready for you yet')
   end
 end


### PR DESCRIPTION
### Context
This PR fixes the `Page not found` error when selecting a second-course choice and choosing `Another course`

### Changes proposed in this pull request

The error is raised because 

`@pick_course.valid?` was checked in case of course code equal to `"other"`

My quick fix proposal is just inverting the order of the conditionals.

## NOTE
This bug suggests that the controller action `pick_course` is quite brittle and a refactor is much recommended.

If you have any comments on how to refactor this let me know, I am happy to review this code on Monday. 

### Trello

https://trello.com/c/KbNZQgry/629-redirects-to-page-not-found-when-selecting-a-second-course-choice-and-choosing-another-course
