### PR TITLE
Add audit trail attribution for support users

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -22,7 +22,7 @@ module SupportInterface
       elsif audit.user_type == 'VendorApiUser'
         "#{audit.user.email_address} (Vendor API)"
       elsif audit.user_type == 'SupportUser'
-        "#{audit.user.email_address} (Support User)"
+        "#{audit.user.email_address} (Support user)"
       elsif audit.username.present?
         audit.username
       else

--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -21,6 +21,8 @@ module SupportInterface
         "#{audit.user.email_address} (Candidate)"
       elsif audit.user_type == 'VendorApiUser'
         "#{audit.user.email_address} (Vendor API)"
+      elsif audit.user_type == 'SupportUser'
+        "#{audit.user.email_address} (Support User)"
       elsif audit.username.present?
         audit.username
       else

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -7,6 +7,16 @@ module SupportInterface
 
     helper_method :current_support_user, :dfe_sign_in_user
 
+    def current_support_user
+      SupportUser.load_from_session(session)
+    end
+
+    def dfe_sign_in_user
+      DfESignInUser.load_from_session(session)
+    end
+
+    alias :audit_user :current_support_user
+
   private
 
     def protect_with_basic_auth
@@ -17,14 +27,6 @@ module SupportInterface
 
     def render_404
       render 'errors/not_found', status: :not_found
-    end
-
-    def current_support_user
-      @current_support_user ||= SupportUser.load_from_session(session)
-    end
-
-    def dfe_sign_in_user
-      DfESignInUser.load_from_session(session)
     end
 
     def authenticate_support_user!

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -7,4 +7,13 @@ class ProviderUser < DfESignInUser
 
     Provider.find_by(code: provider_code)
   end
+
+  def self.load_from_session(session)
+    return nil unless session['dfe_sign_in_user']
+
+    ProviderUser.new(
+      email_address: session['dfe_sign_in_user']['email_address'],
+      dfe_sign_in_uid: session['dfe_sign_in_user']['dfe_sign_in_uid'],
+    )
+  end
 end

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     @provider_user ||= ProviderUser.new(email_address: 'jim@example.com', dfe_sign_in_uid: 'abc')
   end
 
+  def support_user
+    @support_user ||= SupportUser.new(email_address: 'alice@support.com', dfe_sign_in_uid: 'alice')
+  end
+
   def audit
     @audit ||= Audited::Audit.new(
       user: candidate,
@@ -51,6 +55,14 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('Comment on Application Form')
     expect(render_result.text).to include('some comment')
     expect(render_result.text).to include('alice@example.com (Vendor API)')
+  end
+
+  it 'renders an update on application form audit record with a Support User' do
+    audit.user = support_user
+    audit.action = 'update'
+    expect(render_result.text).to include('1 October 2019 12:10')
+    expect(render_result.text).to include('Update Application Form')
+    expect(render_result.text).to include('alice@support.com (Support User)')
   end
 
   it 'renders an update application form audit record with the username (rather than a persistent model)' do

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     audit.action = 'update'
     expect(render_result.text).to include('1 October 2019 12:10')
     expect(render_result.text).to include('Update Application Form')
-    expect(render_result.text).to include('alice@support.com (Support User)')
+    expect(render_result.text).to include('alice@support.com (Support user)')
   end
 
   it 'renders an update application form audit record with the username (rather than a persistent model)' do


### PR DESCRIPTION
### Context

We have switched the Support Interface from basic auth over to DfE Sign-in. This means that we know who the 'current user' is in the Support Interface so we can properly attribute changes made there now.

### Changes proposed in this pull request

- [x] Link audit trail records to instances of `SupportUser` for all changes made via the Support Interface.
- [x] Label such audit trail records with the email of the support user on the application history page.

![image](https://user-images.githubusercontent.com/450843/70339141-3689cf80-1846-11ea-9a89-ab94c9a49631.png)


### Guidance to review

- Are the tests adequate?
- Do the labels in application history make sense?

### Link to Trello card

[1347 - Add attribution to support users for auditing](https://trello.com/c/Fbwpa49B/1347-add-attribution-to-support-users-for-auditing)

### Env vars

- [x] No new env vars
