### PR TITLE
Order the course choices by creation

### DIFF
--- a/app/components/course_choices_review_component.rb
+++ b/app/components/course_choices_review_component.rb
@@ -3,7 +3,7 @@ class CourseChoicesReviewComponent < ActionView::Component::Base
 
   def initialize(application_form:, editable: true, heading_level: 2, show_status: false, show_incomplete: false, missing_error: false)
     @application_form = application_form
-    @course_choices = @application_form.application_choices.includes(:course, :site, :provider)
+    @course_choices = @application_form.application_choices.includes(:course, :site, :provider).order(id: :asc)
     @editable = editable
     @heading_level = heading_level
     @show_status = show_status


### PR DESCRIPTION
This fixes intermittently failing spec by making sure the order of application choices is predictable. This is relied upon in:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/e40148714bbc28f7c2de596db10dd7d2f13ded18/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb#L187

Tested by reversing the order with `id: :desc`, which makes the test fail consistently.