### PR TITLE
Add new providers and alphabetically reorder for readability

### DIFF
--- a/config/providers_to_sync.yml
+++ b/config/providers_to_sync.yml
@@ -1,8 +1,14 @@
 development: &default
   codes:
-    - R55
-    - 1N1
-    - S31
+    - 1HQ  # Alliance of Leading Learning
+    - 24L  # Ashton on Mersey SCITT
+    - 1N1  # Gorse SCITT
+    - 254  # Nottinghamshire Torch SCITT
+    - 2LR  # Oriel High School
+    - R55  # Royal Academy of Dance
+    - L06  # Shotton Hall SCITT
+    - S31  # Somerset SCITT Consortium
+    - 12K  # Trent Valley Teaching School Alliance
 
 production:
   <<: *default


### PR DESCRIPTION
### Context

We have some new providers wanting to join the service.

### Changes proposed in this pull request

This PR adds the following:

- Alliance of Leading Learning
- Ashton on Mersey SCITT
- Nottinghamshire Torch SCITT
- Oriel High School
- Shotton Hall SCITT
- Somerset SCITT Consortium
- Trent Valley Teaching School Alliance

to `providers_to_sync.yml` and just alphabetically reorders them with the name of the provider beside for readability.

### Guidance to review

Nothing in particular.

### Link to Trello card

[617 - Add December providers to support console](https://trello.com/c/XFn2UPjD/617-add-december-providers-to-support-console)
