### PR TITLE
Add phone number length validation

### DIFF
--- a/app/models/candidate_interface/contact_details_form.rb
+++ b/app/models/candidate_interface/contact_details_form.rb
@@ -10,7 +10,7 @@ module CandidateInterface
     validates :address_line1, :address_line2, :address_line3, :address_line4,
               length: { maximum: 50 }, on: :address
 
-    validates :phone_number, phone_number: true, on: :base
+    validates :phone_number, length: { maximum: 50 }, phone_number: true, on: :base
 
     validates :postcode, postcode: true, on: :address
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -366,6 +366,7 @@ en:
             phone_number:
               blank: Enter your phone number
               invalid: Enter a real phone number
+              too_long: Phone number must be %{count} characters or fewer
             address_line1:
               blank: Enter your building and street
               too_long: Building and street must be %{count} characters or fewer

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -365,7 +365,7 @@ en:
           attributes:
             phone_number:
               blank: Enter your phone number
-              invalid: Enter a real phone number
+              invalid: Enter a phone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192
               too_long: Phone number must be %{count} characters or fewer
             address_line1:
               blank: Enter your building and street

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -474,7 +474,7 @@ components:
         phone_number:
           type: string
           description: The candidate’s phone number
-          maxLength: 18
+          maxLength: 50
           example: "07944386555"
     Course:
       type: object

--- a/spec/models/candidate_interface/contact_details_form_spec.rb
+++ b/spec/models/candidate_interface/contact_details_form_spec.rb
@@ -73,5 +73,6 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
 
     it { is_expected.to allow_value('07700 900 982').for(:phone_number).on(:base) }
     it { is_expected.not_to allow_value('07700 WUT WUT').for(:phone_number).on(:base) }
+    it { is_expected.to validate_length_of(:phone_number).is_at_most(50).on(:base) }
   end
 end


### PR DESCRIPTION
### Context

We don't validate the total length of the phone number in the candidate form, but we specify a maximum length on the API.

### Changes proposed in this pull request

- Update API to 50 char limit based on https://docs.google.com/spreadsheets/d/1m6K7kF8_bwCZ4uMBFNTVQy5_CSoEFxaMYc2MiEOyvMQ/edit#gid=0
- 18 is too short - consider international numbers with spaces for formatting and a possible extension number
- Add limit to model and custom error message

https://trello.com/c/G5Urzd52/570-match-phone-number-validation-in-candidate-form-to-the-one-in-the-api-specification
