### PR TITLE
Once a work break explanation is entered, say "Change" not "Enter"

### DIFF
--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -31,11 +31,13 @@ class WorkHistoryReviewComponent < ActionView::Component::Base
   end
 
   def break_in_work_history_rows
+    action_label = t("application_form.work_history.break.#{@application_form.work_history_breaks ? 'change' : 'enter'}_label")
+
     [
       {
         key: t('application_form.work_history.break.label'),
         value: @application_form.work_history_breaks,
-        action: t('application_form.work_history.break.enter_label'),
+        action: action_label,
         action_path: Rails.application.routes.url_helpers.candidate_interface_work_history_breaks_path,
       },
     ]

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -105,6 +105,7 @@ en:
       break:
         label: Tell us about any breaks in your work history
         enter_label: Enter explanation
+        change_label: Change explanation
         button: Continue
       review:
         completed_checkbox: I have completed this section

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe WorkHistoryReviewComponent do
           expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
             Rails.application.routes.url_helpers.candidate_interface_work_history_breaks_path,
           )
-          expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.enter_label'))
+          expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
         end
       end
     end


### PR DESCRIPTION
Update the action label on the work break review page.

https://trello.com/c/PGqWa3hE/530-review-application-work-history