### PR TITLE
UI to add support users to the database

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ A service for candidates to apply for initial teacher training.
 | Sandbox | [sandbox.apply-for-teacher-training.education.gov.uk](https://sandbox.apply-for-teacher-training.education.gov.uk) | Demo environment for software vendors who integrate with our API |
 | QA | [qa.apply-for-teacher-training.education.gov.uk](https://qa.apply-for-teacher-training.education.gov.uk) | For internal use by DfE for testing. Automatically deployed from master |
 
+When setting up a new environment, check you have followed [the instructions
+for doing so](#deploy-env-setup).
+
 ## Table of Contents
 
 * [Dependencies](#dependencies)
 * [Prerequisites for development](#dev-prerequisites)
 * [Setting up the development environment](#dev-env-setup)
+* [Setting up new deployment environments](#deploy-env-setup)
 * [Docker workflow](#docker-workflow)
 * [Releases](#releases)
 * [DfE Sign-in](#dfe-sign-in)
@@ -32,6 +36,7 @@ A service for candidates to apply for initial teacher training.
   * [Environment Variables](#documentation-env-vars)
   * [Pipeline Variables](#documentation-pipeline-vars)
   * [Database Restore](#documentation-db-restore)
+  * [Connecting to live databases](#documentation-db-connect)
 
 ## <a name="dependencies"></a>Dependencies
 
@@ -69,6 +74,28 @@ running and then run Sidekiq. The simplest way to do that is with
 `docker-compose` (see below) or `foreman`. e.g.
 
     $ foreman start
+
+
+
+## <a name="deploy-env-setup"></a>Setting up new deployment environments
+
+New deployment environments are configured by Azure specialists via the Azure YAML and JSON files.
+
+Once a fresh environment is deployed, it is necessary to enable feature flags
+and perhaps grant access to support and provider users.
+
+To do this it's necessary to have a Support user set up, but support users are
+created via the support UI, which is only accessible to Support users!
+
+It is possible to grant access directly by updating the database of the environment
+in question.
+
+1. Connect to the database following the [instructions for connecting to a production database]('/docs/connecting-to-databases.md')
+2. Issue the following query, which writes your email address (EMAIL) and DfE Sign-in uid (UID) into the support_users table.
+
+```
+INSERT INTO support_users (email_address, dfe_sign_in_uid, created_at, updated_at) VALUES ('EMAIL', 'UID', current_timestamp, current_timestamp);
+```
 
 ## <a name="docker-workflow"></a>Docker Workflow
 
@@ -278,3 +305,7 @@ The `TEST-NAMEn` should be short, unique and descriptive and contain no spaces. 
 ### <a name="documentation-db-restore"></a>Database Restore
 
 👉 [See the database restore guide](/docs/database-restore.md)
+
+### <a name="documentation-db-connect"></a>Connecting to live databases
+
+👉 [See instructions for connection to production database](/docs/connecting-to-databases.md)

--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class SupportUsersController < SupportInterfaceController
+    def index
+      @support_users = SupportUser.all
+    end
+  end
+end

--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -3,5 +3,26 @@ module SupportInterface
     def index
       @support_users = SupportUser.all
     end
+
+    def new
+      @support_user = SupportUser.new
+    end
+
+    def create
+      @support_user = SupportUser.new(support_user_params)
+
+      if @support_user.save
+        flash[:success] = 'Support user created'
+        redirect_to support_interface_support_users_path
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def support_user_params
+      params.require(:support_user).permit(:email_address, :dfe_sign_in_uid)
+    end
   end
 end

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -6,4 +6,5 @@
   <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
   <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
   <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
+  <%= nav_link 'Support users', support_interface_support_users_path, active: 'users' %>
 </ul>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, 'Support users' %>
 
-<%# <%= button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button' %>
+<%= link_to 'Add support user', new_support_interface_support_user_path, class: 'govuk-button' %>
 
 <table class='govuk-table'>
   <thead class='govuk-table__head'>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -1,0 +1,25 @@
+<% content_for :title, 'Support users' %>
+
+<%# <%= button_to 'Generate test applications', support_interface_run_task_path('generate_test_applications'), class: 'govuk-button' %>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Email</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>DfE Sign-in UID</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @support_users.each do |support_user| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'>
+          <%= support_user.email_address %>
+        </td>
+        <td class='govuk-table__cell'>
+          <%= support_user.dfe_sign_in_uid %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/support_users/new.html.erb
+++ b/app/views/support_interface/support_users/new.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @support_user, url: support_interface_support_users_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class='govuk-heading-xl'>Add support user</h1>
+
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
+      <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID' } %>
+
+      <%= f.govuk_submit 'Add support user' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,12 @@ en:
             relationship:
               blank: Tell us about the referee’s relationship to you and how long they’ve known you
               too_many_words: Relationship to referee must be %{count} words or fewer
+        support_user:
+          attributes:
+            email_address:
+              blank: Email address can’t be blank
+            dfe_sign_in_uid:
+              blank: DfE Sign-in UID can’t be blank
   errors:
     messages:
       too_many_words: Must be %{count} words or fewer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,7 +282,7 @@ Rails.application.routes.draw do
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task
 
-    get '/support_users' => 'support_users#index', as: :users
+    resources :support_users, only: %i[index new create]
 
     post '/impersonate-candidate/:candidate_id' => 'impersonation#impersonate_candidate', as: :impersonate_candidate
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,8 @@ Rails.application.routes.draw do
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task
 
+    get '/support_users' => 'support_users#index', as: :users
+
     post '/impersonate-candidate/:candidate_id' => 'impersonation#impersonate_candidate', as: :impersonate_candidate
 
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes

--- a/docs/connecting-to-databases.md
+++ b/docs/connecting-to-databases.md
@@ -1,0 +1,52 @@
+# Apply for Postgraduate Teacher Training - Production database access
+
+## Purpose
+
+This document describes how to connect to databases in Microsoft Azure, including production.
+
+## Prerequisites
+
+To get the database password for a production environment you will need [elevated PIM permissions](/docs/pim-guide.md).
+For development and test environments no elevation is necessary.
+
+## Instructions
+
+### Get a connection string
+
+1. Figure out the Azure identifier for the database you wish to connect to. This is a string
+on the model of `s106{ENV}-apply-psql` where ENV is a value like `d01` for QA or `p01` for prod.
+1. Visit that resource’s page in Azure by searching for it.
+1. When you get there, click on "Connection security" on the left hand side and add your IP to the whitelist
+by clicking "Add client IP", labelling your IP with a sensible value, and clicking "Save". A notification
+will pop up after a few seconds to show the operation is complete.
+1. Get the `psql` connection string — the CLI command which will open a console on the
+database instance — by clicking "Connection strings" on the left. This
+string will have two placeholder values: `database_name` and `your_password`.
+
+### Populate the connection string credentials
+
+1. Obtain the database_name and database_password values by visiting the app service
+corresponding to the database. To find out the identifier for the app service substitute `psql` for `as` in the
+resource identifier. e.g. for production (database `s106p01-apply-psql`) you need to visit `s106p01-apply-as`.
+Be careful not to visit "Application Insights" instead of "App Service" — they share an identifier.
+1. From the app service page, visit "Configuration" to view the environment variables in that app service.
+1. Click on the `DB_DATABASE` and `DB_PASSWORD` keys to obtain the values for the placeholders in the connection string.
+
+### Use and cleanup
+
+Replace the placeholders in the connection string and run it to connect to the database from your local machine.
+
+Once you're finished, visit the database (`*-psql`) in Azure again and remove your client IP from the whitelist.
+
+### Troubleshooting
+
+If you see the following message on trying to connect, you may have a version conflict
+between your local copy of `psql` and the `postgres` version running in Azure (9.6 at time of writing).
+
+```
+psql: error: could not connect to server: server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+```
+
+Check your `psql` version using `psql --version`.

--- a/docs/database-restore.md
+++ b/docs/database-restore.md
@@ -1,4 +1,4 @@
-# Apply for Postgraduate Teacher Training - Manual Deployment
+# Apply for Postgraduate Teacher Training - Database restoration
 
 ## Purpose
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,7 +41,7 @@ Do whatever it takes to test what you've just deployed. Be sure to keep an eye o
 Wait until the deploy finishes and, if necessary, test on production.
 
 [Check the production monitoring dashboard in
-Azure](https://portal.azure.com/#@platform.education.gov.uk/dashboard/arm/subscriptions/67722207-6a10-4c7d-b4bc-c72caa76ef12/resourcegroups/s106p01-apply/providers/microsoft.portal/dashboards/a38bba8f-4bdc-4c57-801c-0fd018f72b82-dashboard)
+Azure](https://portal.azure.com/#@platform.education.gov.uk/dashboard/arm/subscriptions/67722207-6a10-4c7d-b4bc-c72caa76ef12/resourceGroups/s106p01-apply/providers/Microsoft.Portal/dashboards/s106p01-apply-dashboard)
 before declaring the deploy finished.
 
 ## 7. Move deploy cards to done
@@ -74,5 +74,3 @@ You should then shut down the staging slot, which now contains the faulty
 version of the code. Do this by repeating the above process to find the staging
 slot resource, and — after double checking that it is the *staging* slot
 — clicking "stop".
-
-

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing support users' do
+  scenario 'creating a new support user' do
+    given_i_am_a_support_user
+    and_a_support_user_exists_in_the_database
+
+    when_i_visit_the_support_console
+    and_i_click_the_manange_support_users_link
+
+    then_i_should_see_the_list_of_support_users
+  end
+
+  def given_i_am_a_support_user
+    page.driver.browser.authorize('test', 'test')
+  end
+
+  def and_a_support_user_exists_in_the_database
+    create(:support_user, email_address: 'person@education.gov.uk')
+  end
+
+  def when_i_visit_the_support_console
+    visit '/support'
+  end
+
+  def and_i_click_the_manange_support_users_link
+    click_link 'Support users'
+  end
+
+  def then_i_should_see_the_list_of_support_users
+    expect(page).to have_content('Support users')
+  end
+end

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -3,12 +3,15 @@ require 'rails_helper'
 RSpec.feature 'Managing support users' do
   scenario 'creating a new support user' do
     given_i_am_a_support_user
-    and_a_support_user_exists_in_the_database
 
     when_i_visit_the_support_console
     and_i_click_the_manange_support_users_link
+    and_i_click_the_add_user_link
+    and_i_enter_the_users_email_and_dsi_uid
+    and_i_click_add_user
 
     then_i_should_see_the_list_of_support_users
+    and_i_should_see_the_user_i_created
   end
 
   def given_i_am_a_support_user
@@ -16,18 +19,35 @@ RSpec.feature 'Managing support users' do
   end
 
   def and_a_support_user_exists_in_the_database
-    create(:support_user, email_address: 'person@education.gov.uk')
+    create(:support_user, email_address: 'person@example.com')
   end
 
   def when_i_visit_the_support_console
-    visit '/support'
+    visit support_interface_path
   end
 
   def and_i_click_the_manange_support_users_link
     click_link 'Support users'
   end
 
+  def and_i_enter_the_users_email_and_dsi_uid
+    fill_in 'support_user[email_address]', with: 'harrison@example.com'
+    fill_in 'support_user[dfe_sign_in_uid]', with: '12345-ABCDE'
+  end
+
+  def and_i_click_the_add_user_link
+    click_link 'Add support user'
+  end
+
+  def and_i_click_add_user
+    click_button 'Add support user'
+  end
+
   def then_i_should_see_the_list_of_support_users
-    expect(page).to have_content('Support users')
+    expect(page).to have_title('Support users')
+  end
+
+  def and_i_should_see_the_user_i_created
+    expect(page).to have_content('harrison@example.com')
   end
 end


### PR DESCRIPTION
### Context

To support #770, create a UI to add support users to the db

- we should not merge #770 until this is merged and we have created at least one support user, as without a user in the database it will be impossible to log into support once basic auth is turned off

### Changes proposed in this pull request

CRUD for `SupportUsers` in the support interface.

- We don't support deletion as we haven't discussed how this will work
- at the moment all support users will be able to create other users, which is a bit 😬, but we can revisit

### Link to Trello card

https://trello.com/c/Yk89F38A/1371-ui-to-add-support-users-to-the-database

![out](https://user-images.githubusercontent.com/642279/70440282-c10e4100-1a89-11ea-818f-eeec13f16970.gif)

