### PR TITLE
Minor API fixes

### DIFF
--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -23,8 +23,7 @@ module VendorApi
     end
 
     def since_param
-      since = params.fetch(:since)
-      Time.iso8601(since)
+      params.fetch(:since).to_datetime
     rescue ArgumentError
       raise InvalidParameter.new('Parameter is invalid (should be ISO8601): since')
     end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -25,7 +25,7 @@ module VendorApi
     def since_param
       params.fetch(:since).to_datetime
     rescue ArgumentError
-      raise InvalidParameter.new('Parameter is invalid (should be ISO8601): since')
+      raise ParameterInvalid.new('Parameter is invalid (should be ISO8601): since')
     end
   end
 end

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -2,7 +2,7 @@ module VendorApi
   class ApplicationsController < VendorApiController
     def index
       application_choices = get_application_choices_for_provider_since(
-        since: params.fetch(:since),
+        since: since_param,
       )
 
       render json: { data: MultipleApplicationsPresenter.new(application_choices).as_json }
@@ -19,7 +19,14 @@ module VendorApi
 
     def get_application_choices_for_provider_since(since:)
       GetApplicationChoicesForProvider.call(provider: current_provider)
-        .where('application_choices.updated_at > ?', since.to_datetime)
+        .where('application_choices.updated_at > ?', since)
+    end
+
+    def since_param
+      since = params.fetch(:since)
+      Time.iso8601(since)
+    rescue ArgumentError
+      raise InvalidParameter.new('Parameter is invalid (should be ISO8601): since')
     end
   end
 end

--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -2,8 +2,11 @@ module VendorApi
   class TestDataController < VendorApiController
     before_action :check_this_is_a_test_environment
 
+    MAX_COUNT = 100
+    DEFAULT_COUNT = 100
+
     def regenerate
-      GenerateTestData.new([params[:count].to_i, 100].min, current_provider).generate
+      GenerateTestData.new(count_param, current_provider).generate
       render json: { data: { message: 'OK, regenerated the test data' } }
     end
 
@@ -13,6 +16,10 @@ module VendorApi
       if HostingEnvironment.production?
         render status: 400, json: { data: { message: 'Sorry, you can only generate test data in test environments' } }
       end
+    end
+
+    def count_param
+      [(params[:count] || DEFAULT_COUNT).to_i, MAX_COUNT].min
     end
   end
 end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -5,6 +5,7 @@ module VendorApi
 
     rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
+    rescue_from InvalidParameter, with: :invalid_parameter
 
     before_action :set_cors_headers
     before_action :require_valid_api_token!
@@ -37,6 +38,10 @@ module VendorApi
 
     def parameter_missing(e)
       render json: { errors: [{ error: 'ParameterMissing', message: e }] }, status: 422
+    end
+
+    def invalid_parameter(e)
+      render json: { errors: [{ error: 'InvalidParameter', message: e }] }, status: 422
     end
 
     def set_cors_headers

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -5,7 +5,7 @@ module VendorApi
 
     rescue_from ActiveRecord::RecordNotFound, with: :application_not_found
     rescue_from ActionController::ParameterMissing, with: :parameter_missing
-    rescue_from InvalidParameter, with: :invalid_parameter
+    rescue_from ParameterInvalid, with: :parameter_invalid
 
     before_action :set_cors_headers
     before_action :require_valid_api_token!
@@ -40,8 +40,8 @@ module VendorApi
       render json: { errors: [{ error: 'ParameterMissing', message: e }] }, status: 422
     end
 
-    def invalid_parameter(e)
-      render json: { errors: [{ error: 'InvalidParameter', message: e }] }, status: 422
+    def parameter_invalid(e)
+      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: 422
     end
 
     def set_cors_headers

--- a/app/lib/invalid_parameter.rb
+++ b/app/lib/invalid_parameter.rb
@@ -1,0 +1,2 @@
+class InvalidParameter < RuntimeError; end
+

--- a/app/lib/invalid_parameter.rb
+++ b/app/lib/invalid_parameter.rb
@@ -1,1 +1,0 @@
-class InvalidParameter < RuntimeError; end

--- a/app/lib/invalid_parameter.rb
+++ b/app/lib/invalid_parameter.rb
@@ -1,2 +1,1 @@
 class InvalidParameter < RuntimeError; end
-

--- a/app/lib/parameter_invalid.rb
+++ b/app/lib/parameter_invalid.rb
@@ -1,0 +1,1 @@
+class ParameterInvalid < RuntimeError; end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,6 +4,8 @@ class Site < ApplicationRecord
   validates :code, presence: true
   validates :name, presence: true
 
+  CODE_LENGTH = 1
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/services/confirm_enrolment.rb
+++ b/app/services/confirm_enrolment.rb
@@ -7,8 +7,11 @@ class ConfirmEnrolment
 
   def save
     ApplicationStateChange.new(@application_choice).confirm_enrolment!
-  rescue Workflow::NoTransitionAllowed => e
-    errors.add(:state, e.message)
+  rescue Workflow::NoTransitionAllowed
+    errors.add(
+      :base,
+      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+    )
     false
   end
 end

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -7,8 +7,11 @@ class ConfirmOfferConditions
 
   def save
     ApplicationStateChange.new(@application_choice).confirm_conditions_met!
-  rescue Workflow::NoTransitionAllowed => e
-    errors.add(:state, e.message)
+  rescue Workflow::NoTransitionAllowed
+    errors.add(
+      :base,
+      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+    )
     false
   end
 end

--- a/app/services/generate_test_data.rb
+++ b/app/services/generate_test_data.rb
@@ -65,6 +65,8 @@ private
   end
 
   def random_site
+    return Site.where(provider: provider).sample if Site.where(provider: provider).count > 10
+
     FactoryBot.create(
       :site,
       provider: provider,

--- a/app/services/generate_test_data.rb
+++ b/app/services/generate_test_data.rb
@@ -60,7 +60,7 @@ private
     FactoryBot.create(
       :course,
       provider: provider,
-      code: random_code(Course, provider),
+      code: random_code(Course, provider, Course::CODE_LENGTH),
     )
   end
 
@@ -68,7 +68,7 @@ private
     FactoryBot.create(
       :site,
       provider: provider,
-      code: random_code(Site, provider),
+      code: random_code(Site, provider, Site::CODE_LENGTH),
     )
   end
 
@@ -78,9 +78,9 @@ private
     end
   end
 
-  def random_code(klass, provider)
+  def random_code(klass, provider, code_length)
     loop do
-      code = Faker::Alphanumeric.alphanumeric(number: Course::CODE_LENGTH).upcase
+      code = Faker::Alphanumeric.alphanumeric(number: code_length).upcase
       return code if klass.find_by(code: code, provider: provider).nil?
     end
   end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -24,8 +24,11 @@ class MakeAnOffer
 
     SetDeclineByDefault.new(application_form: application_choice.application_form).call
     StateChangeNotifier.call(:make_an_offer, application_choice: application_choice)
-  rescue Workflow::NoTransitionAllowed => e
-    errors.add(:state, e.message)
+  rescue Workflow::NoTransitionAllowed
+    errors.add(
+      :base,
+      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+    )
     false
   end
 

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -29,8 +29,11 @@ class ReceiveReference
       end
     end
     true
-  rescue Workflow::NoTransitionAllowed => e
-    errors.add(:state, e.message)
+  rescue Workflow::NoTransitionAllowed
+    errors.add(
+      :base,
+      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+    )
     false
   end
 

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -23,8 +23,11 @@ class RejectApplication
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
-  rescue Workflow::NoTransitionAllowed => e
-    errors.add(:state, e.message)
+  rescue Workflow::NoTransitionAllowed
+    errors.add(
+      :base,
+      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
+    )
     false
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -122,6 +122,10 @@ en:
               blank: Email address can’t be blank
             dfe_sign_in_uid:
               blank: DfE Sign-in UID can’t be blank
+        application_choice:
+          attributes:
+            status:
+              invalid_transition: The application is not ready for that action
   errors:
     messages:
       too_many_words: Must be %{count} words or fewer

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -451,7 +451,7 @@ components:
           type: string
           description: The candidate’s address line 3
           maxLength: 50
-          example: Cheshire
+          example: Greater Manchester
         address_line4:
           type: string
           description: The candidate’s address line 4

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -440,17 +440,17 @@ components:
           type: string
           description: The candidate’s address line 1
           maxLength: 50
-          example: "45"
+          example: "45 Dialstone Lane"
         address_line2:
           type: string
           description: The candidate’s address line 2
           maxLength: 50
-          example: Dialstone Lane
+          example: Stockport
         address_line3:
           type: string
           description: The candidate’s address line 3
           maxLength: 50
-          example: Stockport
+          example: Cheshire
         address_line4:
           type: string
           description: The candidate’s address line 4

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -23,6 +23,7 @@ paths:
           description: Include only applications changed or created on or since a date and time. Times should be in ISO 8601 format.
           in: query
           required: true
+          example: "2019-12-06T12:00:00Z"
           schema:
             type: string
             format: date-time

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -495,14 +495,17 @@ components:
           type: string
           description: The provider’s UCAS code
           example: 2FR
+          maxLength: 3
         course_ucas_code:
           type: string
           description: The course’s UCAS code
           example: 3CVK
+          maxLength: 4
         site_ucas_code:
           type: string
           description: The site’s UCAS code
           example: K
+          maxLength: 1
     Offer:
       type: object
       additionalProperties: false

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -111,7 +111,7 @@ FactoryBot.define do
   factory :site do
     provider
 
-    code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
+    code { Faker::Alphanumeric.unique.alphanumeric(number: 1).upcase }
     name { Faker::Educator.secondary_school }
     address_line1 { Faker::Address.street_address }
     address_line2 { Faker::Address.city }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,4 +68,6 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 
   config.include ActionView::Component::TestHelpers
+
+  config.before { Faker::UniqueGenerator.clear }
 end

--- a/spec/requests/vendor_api/get_multiple_applications_spec.rb
+++ b/spec/requests/vendor_api/get_multiple_applications_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: 'awaiting_provider_decision',
     )
 
-    get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
+    get_api_request "/api/v1/applications?since=#{CGI.escape((Time.now - 1.days).iso8601)}"
     expect(parsed_response['data'].size).to be(2)
   end
 
@@ -37,7 +37,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: 'awaiting_provider_decision',
     )
 
-    get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
+    get_api_request "/api/v1/applications?since=#{CGI.escape((Time.now - 1.days).iso8601)}"
 
     expect(parsed_response['data'].size).to be(1)
   end
@@ -47,7 +47,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: 'awaiting_provider_decision',
     )
 
-    get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
+    get_api_request "/api/v1/applications?since=#{CGI.escape((Time.now - 1.days).iso8601)}"
 
     expect(parsed_response).to be_valid_against_openapi_schema('MultipleApplicationsResponse')
   end
@@ -60,6 +60,16 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
     expect(parsed_response).to be_valid_against_openapi_schema('ParameterMissingResponse')
 
     expect(error_response['message']).to eql('param is missing or the value is empty: since')
+  end
+
+  it 'returns HTTP status 422 given an unparseable `since` date value' do
+    get_api_request '/api/v1/applications?since=bad-date'
+
+    expect(response).to have_http_status(422)
+
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+
+    expect(error_response['message']).to eql('Parameter is invalid (should be ISO8601): since')
   end
 
   it 'returns applications that are in a viewable state' do
@@ -77,7 +87,7 @@ RSpec.describe 'Vendor API - GET /api/v1/applications', type: :request do
       status: :unsubmitted,
     )
 
-    get_api_request "/api/v1/applications?since=#{(Time.now - 1.days).iso8601}"
+    get_api_request "/api/v1/applications?since=#{CGI.escape((Time.now - 1.days).iso8601)}"
 
     expect(parsed_response['data'].size).to be(2)
   end

--- a/spec/requests/vendor_api/post_conditions_met_spec.rb
+++ b/spec/requests/vendor_api/post_conditions_met_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-conditio
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(error_response['message']).to eq 'The application is not ready for that action'
   end
 
   it 'returns not found error when the application was not found' do

--- a/spec/requests/vendor_api/post_confirm_enrolment_spec.rb
+++ b/spec/requests/vendor_api/post_confirm_enrolment_spec.rb
@@ -33,5 +33,6 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/confirm-enrolmen
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(error_response['message']).to eq 'The application is not ready for that action'
   end
 end

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(error_response['message']).to eq 'The application is not ready for that action'
   end
 
   it 'returns an error when given invalid conditions' do

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -30,11 +30,17 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
   it 'returns an error when trying to transition to an invalid state' do
     application_choice = create_application_choice_for_currently_authenticated_provider(status: 'rejected')
+    request_body = {
+      "data": {
+        "reason": 'Does not meet minimum GCSE requirements',
+      },
+    }
 
-    post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: {}
+    post_api_request "/api/v1/applications/#{application_choice.id}/reject", params: request_body
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+    expect(error_response['message']).to eq 'The application is not ready for that action'
   end
 
   it 'returns an error when a proper reason is not provided' do

--- a/spec/requests/vendor_api/post_test_data_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/regenerate', type: :request 
     expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
   end
 
+  it 'generates test data with default count of 100' do
+    generate_test_data = instance_double(GenerateTestData, generate: nil)
+    allow(GenerateTestData).to receive(:new).and_return(generate_test_data)
+    post_api_request '/api/v1/test-data/regenerate'
+
+    expect(GenerateTestData).to have_received(:new).with(100, anything)
+    expect(parsed_response).to be_valid_against_openapi_schema('OkResponse')
+  end
+
   it 'does not generate test data in production' do
     ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
       post_api_request '/api/v1/test-data/regenerate?count=3'


### PR DESCRIPTION
### Context

A number of issues were raised after manual testing by @fofr . This PR addresses some of the bug fixes (doc fixed to follow)

### Changes proposed in this pull request

- [X] Course codes should be 4 chars, not 3 - `maxLength` added to OpenAPI spec and values adjusted in test data generator
- [X] Site code should be single char, not 3 - `maxLength` added to OpenAPI spec and values adjusted in test data generator. Requires a bit more care in how we generate 'random' codes as they need to be unique.
- [X] Address line 1 not a good example (it’s “45”) - Moved the street name into line 1 and added a county for line 3 (though not sure Stockport is technically in a county)
- [X] Catch the error when an invalid date is provided for ?since= (we 500 rn) - added validation to ensure this error is caught and causes status 422
- [X] Provide a sensible default value for test-data/regenerate (0 is current and it wipes everything, docs say 100 by default) - happens because `nil.to_i -> 0` so have made a small change to ensure default is 100.
- [X] API: Formatting on state errors is bad (mispunctuated, reveals implementation details) - Trapping the invalid transition exception and returning a more bland error message `The application is not ready for that action` - please shout if you have better wording

### Guidance to review

- Commit by commit
- Is there a better way to specify fixed length attributes? (OpenAPI only seems to let you specify a `maxLength`)
- Is there a better wording for the error message above?

### Link to Trello card

[1176 - Minor API fixes following user testing with Paul H](https://trello.com/c/MVlw347D/1176-minor-api-fixes-following-user-testing-with-paul-h)

### Env vars

- [x] No env vars