### PR TITLE
Add back training with a disability section with a feature flag

### DIFF
--- a/app/components/training_with_a_disability_review_component.html.erb
+++ b/app/components/training_with_a_disability_review_component.html.erb
@@ -1,1 +1,5 @@
-<%= render(SummaryCardComponent, rows: training_with_a_disability_form_rows, editable: @editable) %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent, section: :training_with_a_disability, section_path: candidate_interface_training_with_a_disability_edit_path, error: @missing_error) %>
+<% else %>
+  <%= render(SummaryCardComponent, rows: training_with_a_disability_form_rows, editable: @editable) %>
+<% end %>

--- a/app/components/training_with_a_disability_review_component.html.erb
+++ b/app/components/training_with_a_disability_review_component.html.erb
@@ -1,1 +1,1 @@
-<%= render(SummaryCardComponent, rows: training_with_a_disability_form_rows) %>
+<%= render(SummaryCardComponent, rows: training_with_a_disability_form_rows, editable: @editable) %>

--- a/app/components/training_with_a_disability_review_component.html.erb
+++ b/app/components/training_with_a_disability_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(SummaryCardComponent, rows: training_with_a_disability_form_rows) %>

--- a/app/components/training_with_a_disability_review_component.rb
+++ b/app/components/training_with_a_disability_review_component.rb
@@ -37,7 +37,7 @@ private
   def boolean_display_value(value)
     key = if value.nil?
             'not_specified'
-          elsif value
+          elsif value == 'yes'
             'yes'
           else
             'no'

--- a/app/components/training_with_a_disability_review_component.rb
+++ b/app/components/training_with_a_disability_review_component.rb
@@ -1,0 +1,47 @@
+class TrainingWithADisabilityReviewComponent < ActionView::Component::Base
+  validates :application_form, presence: true
+
+  def initialize(application_form:)
+    @application_form = application_form
+    @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(
+      @application_form,
+    )
+  end
+
+  def training_with_a_disability_form_rows
+    [disclose_disability_row, disability_disclosure_row]
+  end
+
+private
+
+  attr_reader :application_form
+
+  def disclose_disability_row
+    {
+      key: t('application_form.training_with_a_disability.disclose_disability.label'),
+      value: boolean_display_value(@training_with_a_disability_form.disclose_disability),
+      action: t('application_form.training_with_a_disability.disclose_disability.change_action'),
+      change_path: Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path,
+    }
+  end
+
+  def disability_disclosure_row
+    {
+      key: t('application_form.training_with_a_disability.disability_disclosure.label'),
+      value: @training_with_a_disability_form.disability_disclosure,
+      action: t('application_form.training_with_a_disability.disability_disclosure.change_action'),
+      change_path: Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path,
+    }
+  end
+
+  def boolean_display_value(value)
+    key = if value.nil?
+            'not_specified'
+          elsif value
+            'yes'
+          else
+            'no'
+          end
+    t(key, scope: %i[application_form training_with_a_disability disclose_disability])
+  end
+end

--- a/app/components/training_with_a_disability_review_component.rb
+++ b/app/components/training_with_a_disability_review_component.rb
@@ -1,11 +1,12 @@
 class TrainingWithADisabilityReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:)
+  def initialize(application_form:, editable: true)
     @application_form = application_form
     @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(
       @application_form,
     )
+    @editable = editable
   end
 
   def training_with_a_disability_form_rows

--- a/app/components/training_with_a_disability_review_component.rb
+++ b/app/components/training_with_a_disability_review_component.rb
@@ -1,12 +1,13 @@
 class TrainingWithADisabilityReviewComponent < ActionView::Component::Base
   validates :application_form, presence: true
 
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, missing_error: false)
     @application_form = application_form
     @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(
       @application_form,
     )
     @editable = editable
+    @missing_error = missing_error
   end
 
   def training_with_a_disability_form_rows
@@ -14,6 +15,10 @@ class TrainingWithADisabilityReviewComponent < ActionView::Component::Base
       disclose_disability_row,
       (disability_disclosure_row if @training_with_a_disability_form.disclose_disability == 'yes'),
     ].compact
+  end
+
+  def show_missing_banner?
+    !@training_with_a_disability_form.valid? && @editable
   end
 
 private

--- a/app/components/training_with_a_disability_review_component.rb
+++ b/app/components/training_with_a_disability_review_component.rb
@@ -9,7 +9,10 @@ class TrainingWithADisabilityReviewComponent < ActionView::Component::Base
   end
 
   def training_with_a_disability_form_rows
-    [disclose_disability_row, disability_disclosure_row]
+    [
+      disclose_disability_row,
+      (disability_disclosure_row if @training_with_a_disability_form.disclose_disability == 'yes'),
+    ].compact
   end
 
 private

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -1,0 +1,35 @@
+module CandidateInterface
+  class TrainingWithADisabilityController < CandidateInterfaceController
+    def edit
+      @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(
+        current_application,
+      )
+    end
+
+    def update
+      @training_with_a_disability_form = TrainingWithADisabilityForm.new(training_with_a_disability_params)
+
+      if @training_with_a_disability_form.save(current_application)
+        @application_form = current_application
+        render :show
+      else
+        render :edit
+      end
+    end
+
+    def show
+      @application_form = current_application
+      @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(
+        current_application,
+      )
+    end
+
+  private
+
+    def training_with_a_disability_params
+      params.require(:candidate_interface_training_with_a_disability_form).permit(
+        :disclose_disability, :disability_disclosure
+      )
+    end
+  end
+end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -1,5 +1,7 @@
 module CandidateInterface
   class TrainingWithADisabilityController < CandidateInterfaceController
+    before_action :redirect_to_application_form_if_feature_flag_deactivated
+
     def edit
       @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(
         current_application,
@@ -11,7 +13,7 @@ module CandidateInterface
 
       if @training_with_a_disability_form.save(current_application)
         @application_form = current_application
-        render :show
+        redirect_to candidate_interface_training_with_a_disability_show_path
       else
         render :edit
       end
@@ -30,6 +32,10 @@ module CandidateInterface
       params.require(:candidate_interface_training_with_a_disability_form).permit(
         :disclose_disability, :disability_disclosure
       )
+    end
+
+    def redirect_to_application_form_if_feature_flag_deactivated
+      redirect_to candidate_interface_application_form_path unless FeatureFlag.active?('training_with_a_disability')
     end
   end
 end

--- a/app/models/candidate_interface/training_with_a_disability_form.rb
+++ b/app/models/candidate_interface/training_with_a_disability_form.rb
@@ -1,0 +1,47 @@
+module CandidateInterface
+  class TrainingWithADisabilityForm
+    include ActiveModel::Model
+
+    attr_accessor :disclose_disability, :disability_disclosure
+
+    validates_inclusion_of :disclose_disability, in: %w[yes no]
+
+    def self.build_from_application(application_form)
+      new(
+        disclose_disability: boolean_to_word(application_form.disclose_disability),
+        disability_disclosure: application_form.disability_disclosure,
+      )
+    end
+
+    def save(application_form)
+      return false unless valid?
+
+      # explicitly null-out the text field if the user said 'No'
+      # so that we don't need to add the boolean field to the API:
+      # it just returns null for the text field if they said No
+      self.disability_disclosure = nil if self.disclose_disability.to_s == 'no'
+
+      application_form.update!(
+        disclose_disability: yes_no_to_boolean(self.disclose_disability),
+        disability_disclosure: self.disability_disclosure,
+      )
+    end
+
+    def self.boolean_to_word(boolean)
+      return nil if boolean.nil?
+
+      boolean ? 'yes' : 'no'
+    end
+
+  private
+
+    def yes_no_to_boolean(value)
+      if value == 'yes'
+        true
+      elsif value == 'no'
+        false
+      end
+      # nil by default
+    end
+  end
+end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -16,6 +16,7 @@ module CandidateInterface
         # "About you" section
         [:personal_details, personal_details_completed?],
         [:contact_details, contact_details_completed?],
+        ([:training_with_a_disability, training_with_a_disability_completed?] if FeatureFlag.active?('training_with_a_disability')),
         [:work_experience, work_experience_completed?],
         [:volunteering, volunteering_completed?],
 

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -136,6 +136,12 @@ module CandidateInterface
       CandidateInterface::InterviewPreferencesForm.build_from_application(@application_form).valid?
     end
 
+    def training_with_a_disability_completed?
+      @application_form.disclose_disability == false || \
+        (@application_form.disclose_disability == true && \
+          @application_form.disability_disclosure.present?)
+    end
+
     def course_choices_completed?
       @application_form.course_choices_completed
     end

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -24,7 +24,7 @@ module VendorApi
             english_main_language: application_form.english_main_language,
             english_language_qualifications: application_form.english_language_details,
             other_languages: application_form.other_language_details,
-            disability_disclosure: 'I have difficulty climbing stairs',
+            disability_disclosure: application_form.disability_disclosure,
           },
           contact_details: {
             phone_number: application_form.phone_number,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,6 +4,7 @@ class FeatureFlag
     accept_and_decline_via_ui
     conditional_science_gcse
     candidate_withdrawals
+    training_with_a_disability
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -16,7 +16,7 @@
 
 <h3 class="govuk-heading-m">Training with a disability</h3>
 
-<%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form, editable: editable) %>
+<%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form, editable: editable, missing_error: missing_error) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -14,9 +14,11 @@
 
 <%= render(ContactDetailsReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
 
-<h3 class="govuk-heading-m">Training with a disability</h3>
+<% if FeatureFlag.active?('training_with_a_disability') %>
+  <h3 class="govuk-heading-m">Training with a disability</h3>
 
-<%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form, editable: editable, missing_error: missing_error) %>
+  <%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form, editable: editable, missing_error: missing_error) %>
+<% end %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -16,7 +16,7 @@
 
 <h3 class="govuk-heading-m">Training with a disability</h3>
 
-<%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form) %>
+<%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form, editable: editable) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -14,6 +14,10 @@
 
 <%= render(ContactDetailsReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
 
+<h3 class="govuk-heading-m">Training with a disability</h3>
+
+<%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form) %>
+
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 
 <%= render(WorkHistoryReviewComponent, application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error) %>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -35,9 +35,11 @@
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent, text: t('page_titles.volunteering.short'), completed: @application_form_presenter.volunteering_completed?, path: @application_form_presenter.volunteering_path) %>
       </li>
-      <li class="app-task-list__item">
-        <%= render(TaskListItemComponent, text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path) %>
-      </li>
+        <% if FeatureFlag.active?('training_with_a_disability') %>
+          <li class="app-task-list__item">
+            <%= render(TaskListItemComponent, text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path) %>
+          </li>
+        <% end %>
     </ul>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -35,6 +35,9 @@
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent, text: t('page_titles.volunteering.short'), completed: @application_form_presenter.volunteering_completed?, path: @application_form_presenter.volunteering_path) %>
       </li>
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent, text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path) %>
+      </li>
     </ul>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.training_with_a_disability'), @training_with_a_disability_form.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @training_with_a_disability_form, url: candidate_interface_training_with_a_disability_update_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl govuk-!-margin-bottom-8">
+          <h1 class="govuk-fieldset__heading">
+            <%= t('page_titles.training_with_a_disability') %>
+          </h1>
+        </legend>
+
+        <p class="govuk-body">It’s a personal choice if you want to inform your training provider of your disability.</p>
+        <p class="govuk-body">The advantage of disclosure is that it enables support and reasonable adjustments to be put in place. In addition, specialist equipment, extra funding and support, can help you achieve your ambition of becoming a teacher.</p>
+        <p class="govuk-body"><%= govuk_link_to 'The Equality Act 2010', 'https://www.gov.uk/guidance/equality-act-2010-guidance' %> and Special Educational Needs and Disability Act 2001, require teacher training providers to ensure they are not discriminating against applicants with disabilities or special educational needs (SEN).</p>
+
+        <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { size: 'm', text: t('application_form.training_with_a_disability.disclose_disability.label') } do %>
+          <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') } do %>
+            <%= f.govuk_text_area :disability_disclosure, rows: 24, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label') }, max_words: 400 %>
+          <% end %>
+
+          <%= f.govuk_radio_button :disclose_disability, 'no', label: { text: t('application_form.training_with_a_disability.disclose_disability.no') } %>
+
+        <% end %>
+
+        <%= f.govuk_submit t('application_form.training_with_a_disability.complete_form_button') %>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -1,0 +1,10 @@
+<% content_for :title, t('page_titles.training_with_a_disability') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.training_with_a_disability') %>
+</h1>
+
+<%= render(TrainingWithADisabilityReviewComponent, application_form: @application_form) %>
+
+<%= govuk_button_link_to t('application_form.training_with_a_disability.review.button'), candidate_interface_application_form_path %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -225,6 +225,19 @@ en:
         change_action: interview preferences
         label: Interview preferences
         complete_form_button: Continue
+    training_with_a_disability:
+      complete_form_button: Continue
+      disclose_disability:
+        change_action: whether you want to disclose a disability
+        label: Do you want to disclose a disability?
+        'yes': "Yes"
+        'no': "No"
+        not_specified: Not entered
+      disability_disclosure:
+        label: Tell us about your disability
+        change_action: what you want to tell us about your disability
+      review:
+        button: Continue
     volunteering:
       experience:
         label: Do you have experience volunteering with young people or in school?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,7 @@ en:
     becoming_a_teacher: Why do you want to be a teacher?
     subject_knowledge: What do you know about the subject you want to teach?
     interview_preferences: Interview preferences
+    training_with_a_disability: Training with a disability
     volunteering:
       short: Volunteering with children and young people
       long: "Children and young people: volunteering and experience in school"

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -26,6 +26,8 @@ en:
       incomplete: Add %{minimum_references} referees to your application
     subject_knowledge:
       incomplete: Tell us about your knowledge about the subject you want to teach
+    training_with_a_disability:
+      incomplete: Training with a disability not entered
     volunteering:
       incomplete: Volunteering with children and young people is not marked as completed
     work_experience:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,12 @@ Rails.application.routes.draw do
         get '/interview-preferences/review' => 'personal_statement/interview_preferences#show', as: :interview_preferences_show
       end
 
+      scope '/training-with-a-disability' do
+        get '/' => 'training_with_a_disability#edit', as: :training_with_a_disability_edit
+        post '/review' => 'training_with_a_disability#update', as: :training_with_a_disability_update
+        get '/review' => 'training_with_a_disability#show', as: :training_with_a_disability_show
+      end
+
       scope '/contact-details' do
         get '/' => 'contact_details/base#edit', as: :contact_details_edit_base
         post '/' => 'contact_details/base#update', as: :contact_details_update_base

--- a/spec/components/training_with_a_disability_review_component_spec.rb
+++ b/spec/components/training_with_a_disability_review_component_spec.rb
@@ -50,4 +50,20 @@ RSpec.describe TrainingWithADisabilityReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).not_to include(t('application_form.training_with_a_disability.disability_disclosure.label'))
     end
   end
+
+  context 'when disability disclosure is not editable' do
+    let(:application_form) do
+      build_stubbed(
+        :application_form,
+        disclose_disability: false,
+        disability_disclosure: nil,
+      )
+    end
+
+    it 'renders component without an edit link' do
+      result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form, editable: false)
+
+      expect(result.css('.app-summary-list__actions').text).not_to include('Change')
+    end
+  end
 end

--- a/spec/components/training_with_a_disability_review_component_spec.rb
+++ b/spec/components/training_with_a_disability_review_component_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe TrainingWithADisabilityReviewComponent do
+  let(:application_form) do
+    build_stubbed(
+      :application_form,
+      disclose_disability: true,
+      disability_disclosure: 'I have difficulty climbing stairs',
+    )
+  end
+
+  it 'renders component with correct values for a disclose_disability' do
+    result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
+
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disclose_disability.label'))
+    expect(result.css('.govuk-summary-list__value').text).to include('Yes')
+    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disclose_disability.change_action')}")
+  end
+
+  it 'renders component with correct values for an disability_disclosure' do
+    result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
+
+    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.label'))
+    expect(result.css('.govuk-summary-list__value').to_html).to include('I have difficulty climbing stairs')
+    expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
+    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disability_disclosure.change_action')}")
+  end
+end

--- a/spec/components/training_with_a_disability_review_component_spec.rb
+++ b/spec/components/training_with_a_disability_review_component_spec.rb
@@ -43,5 +43,11 @@ RSpec.describe TrainingWithADisabilityReviewComponent do
 
       expect(result.css('.govuk-summary-list__value').text).to include('No')
     end
+
+    it 'renders component without disability disclosure' do
+      result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
+
+      expect(result.css('.govuk-summary-list__key').text).not_to include(t('application_form.training_with_a_disability.disability_disclosure.label'))
+    end
   end
 end

--- a/spec/components/training_with_a_disability_review_component_spec.rb
+++ b/spec/components/training_with_a_disability_review_component_spec.rb
@@ -1,29 +1,47 @@
 require 'rails_helper'
 
 RSpec.describe TrainingWithADisabilityReviewComponent do
-  let(:application_form) do
-    build_stubbed(
-      :application_form,
-      disclose_disability: true,
-      disability_disclosure: 'I have difficulty climbing stairs',
-    )
+  context 'when a candidate discloses a disability' do
+    let(:application_form) do
+      build_stubbed(
+        :application_form,
+        disclose_disability: true,
+        disability_disclosure: 'I have difficulty climbing stairs',
+      )
+    end
+
+    it 'renders component with correct values for a disclose_disability' do
+      result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disclose_disability.label'))
+      expect(result.css('.govuk-summary-list__value').text).to include('Yes')
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
+      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disclose_disability.change_action')}")
+    end
+
+    it 'renders component with correct values for an disability_disclosure' do
+      result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
+
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.label'))
+      expect(result.css('.govuk-summary-list__value').to_html).to include('I have difficulty climbing stairs')
+      expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
+      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disability_disclosure.change_action')}")
+    end
   end
 
-  it 'renders component with correct values for a disclose_disability' do
-    result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
+  context 'when a candidate does not disclose a disability' do
+    let(:application_form) do
+      build_stubbed(
+        :application_form,
+        disclose_disability: false,
+        disability_disclosure: nil,
+      )
+    end
 
-    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disclose_disability.label'))
-    expect(result.css('.govuk-summary-list__value').text).to include('Yes')
-    expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
-    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disclose_disability.change_action')}")
-  end
+    it 'renders component with correct values for a disclose_disability' do
+      result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
 
-  it 'renders component with correct values for an disability_disclosure' do
-    result = render_inline(TrainingWithADisabilityReviewComponent, application_form: application_form)
-
-    expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.label'))
-    expect(result.css('.govuk-summary-list__value').to_html).to include('I have difficulty climbing stairs')
-    expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
-    expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disability_disclosure.change_action')}")
+      expect(result.css('.govuk-summary-list__value').text).to include('No')
+    end
   end
 end

--- a/spec/models/candidate_interface/training_with_a_disability_form_spec.rb
+++ b/spec/models/candidate_interface/training_with_a_disability_form_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::TrainingWithADisabilityForm, type: :model do
+  describe '.build_from_application' do
+    it 'creates an object based on the provided ApplicationForm' do
+      data = {
+        disclose_disability: true,
+        disability_disclosure: 'I have difficulty climbing stairs',
+      }
+      application_form = build_stubbed(:application_form, data)
+      disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(application_form)
+
+      expect(disability_form).to have_attributes(
+        disclose_disability: 'yes',
+        disability_disclosure: 'I have difficulty climbing stairs',
+      )
+    end
+  end
+
+  describe '#save' do
+    let(:application_form) { build(:application_form) }
+    let(:disability_form) do
+      CandidateInterface::TrainingWithADisabilityForm.new(form_data)
+    end
+
+    context 'when not valid' do
+      let(:form_data) do
+        {}
+      end
+
+      it 'returns false' do
+        expect(disability_form.save(ApplicationForm.new)).to eq(false)
+      end
+    end
+
+    context 'when valid and the user wants to disclose a disability' do
+      let(:form_data) do
+        {
+          disclose_disability: 'yes',
+          disability_disclosure: 'I have a hearing impairment',
+        }
+      end
+
+      it 'updates the provided ApplicationForm' do
+        expect(disability_form.save(application_form)).to eq(true)
+        expect(application_form).to have_attributes(
+          disclose_disability: true,
+          disability_disclosure: 'I have a hearing impairment',
+        )
+      end
+    end
+
+    context 'when valid and the user does not want to disclose a disability' do
+      let(:form_data) do
+        {
+          disclose_disability: 'no',
+          disability_disclosure: 'I have a hearing impairment',
+        }
+      end
+
+      before do
+        allow(application_form).to receive(:update!).and_return true
+      end
+
+      it 'nulls-out the existing disability_disclosure' do
+        disability_form.save(application_form)
+
+        expect(application_form).to have_received(:update!).with(
+          disability_disclosure: nil,
+          disclose_disability: false,
+        )
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_inclusion_of(:disclose_disability).in_array %w[yes no] }
+  end
+end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -125,6 +125,57 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#training_with_a_disability_completed?' do
+    let(:application_form) do
+      FactoryBot.build(:completed_application_form)
+    end
+    let(:presenter) do
+      CandidateInterface::ApplicationFormPresenter.new(application_form)
+    end
+
+    context 'when the candidate has not selected Yes or No to the disclosure question' do
+      before do
+        application_form.disclose_disability = nil
+      end
+
+      it 'returns false' do
+        expect(presenter.training_with_a_disability_completed?).to eq(false)
+      end
+    end
+
+    context 'when the candidate says Yes to disclosure but has not filled in the text field' do
+      before do
+        application_form.disclose_disability = true
+        application_form.disability_disclosure = ''
+      end
+
+      it 'returns false' do
+        expect(presenter.training_with_a_disability_completed?).to eq(false)
+      end
+    end
+
+    context 'when the candidate says Yes to disclosure and has filled in the text field' do
+      before do
+        application_form.disclose_disability = true
+        application_form.disability_disclosure = 'I have difficulty climbing stairs'
+      end
+
+      it 'returns true' do
+        expect(presenter.training_with_a_disability_completed?).to eq(true)
+      end
+    end
+
+    context 'when the candidate has selected No to the disclosure question' do
+      before do
+        application_form.disclose_disability = false
+      end
+
+      it 'returns true' do
+        expect(presenter.training_with_a_disability_completed?).to eq(true)
+      end
+    end
+  end
+
   describe '#volunteering_completed?' do
     it 'returns true if volunteering section is completed' do
       application_form = build(:application_form, volunteering_completed: true)

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -3,6 +3,7 @@ module CandidateHelper
     course_choices
     personal_details
     contact_details
+    training_with_a_disability
     work_experience
     volunteering
     degrees

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -40,6 +40,11 @@ module CandidateHelper
     click_link t('page_titles.volunteering.short')
     candidate_fills_in_volunteering_role
 
+    click_link t('page_titles.training_with_a_disability')
+    candidate_fills_in_disability_info
+    click_button t('application_form.training_with_a_disability.complete_form_button')
+    click_link t('application_form.training_with_a_disability.review.button')
+
     click_link t('page_titles.degree')
     candidate_fills_in_their_degree
 
@@ -158,6 +163,11 @@ module CandidateHelper
     click_button t('application_form.other_qualification.base.button')
     check t('application_form.other_qualification.review.completed_checkbox')
     click_button t('application_form.other_qualification.review.button')
+  end
+
+  def candidate_fills_in_disability_info
+    choose t('application_form.training_with_a_disability.disclose_disability.yes')
+    fill_in t('application_form.training_with_a_disability.disability_disclosure.label'), with: 'I have difficulty climbing stairs'
   end
 
   def candidate_fills_in_work_experience

--- a/spec/system/candidate_interface/candidate_entering_disability_info.rb
+++ b/spec/system/candidate_interface/candidate_entering_disability_info.rb
@@ -6,7 +6,28 @@ RSpec.feature 'Entering their disability information' do
   scenario 'Candidate submits their disability information' do
     given_i_am_signed_in
     and_i_visit_the_site
+    and_the_training_with_a_disability_feature_flag_is_off
+    then_i_dont_see_training_with_a_disability
 
+    when_i_click_on_check_your_answers
+    then_i_dont_see_training_with_a_disability_is_missing_below_the_section
+
+    when_i_submit_my_application
+    then_i_dont_see_a_training_with_a_disability_validation_error
+
+    when_i_visit_training_with_a_disability_section
+    then_i_see_the_application_form
+
+    given_training_with_a_disability_feature_flag_is_on
+    and_i_visit_the_site
+
+    when_i_click_on_check_your_answers
+    then_i_see_training_with_a_disability_is_missing_below_the_section
+
+    when_i_submit_my_application
+    then_i_see_a_training_with_a_disability_validation_error
+
+    when_i_visit_the_site
     when_i_click_on_training_with_a_disability
     and_i_fill_in_my_disability_information
     and_i_submit_the_form
@@ -31,6 +52,60 @@ RSpec.feature 'Entering their disability information' do
 
   def and_i_visit_the_site
     visit candidate_interface_application_form_path
+  end
+
+  def and_the_training_with_a_disability_feature_flag_is_off
+    FeatureFlag.deactivate('training_with_a_disability')
+  end
+
+  def then_i_dont_see_training_with_a_disability
+    expect(page).not_to have_content(t('page_titles.training_with_a_disability'))
+  end
+
+  def when_i_click_on_check_your_answers
+    click_link 'Check your answers before submitting'
+  end
+
+  def then_i_dont_see_training_with_a_disability_is_missing_below_the_section
+    expect(page).not_to have_content(t('review_application.training_with_a_disability.incomplete'))
+  end
+
+  def when_i_submit_my_application
+    click_link 'Continue'
+  end
+
+  def then_i_dont_see_a_training_with_a_disability_validation_error
+    within('.govuk-error-summary') do
+      expect(page).not_to have_content(t('review_application.training_with_a_disability.incomplete'))
+    end
+  end
+
+  def when_i_visit_training_with_a_disability_section
+    visit candidate_interface_training_with_a_disability_show_path
+  end
+
+  def then_i_see_the_application_form
+    expect(page).to have_content(t('page_titles.application_form'))
+  end
+
+  def given_training_with_a_disability_feature_flag_is_on
+    FeatureFlag.activate('training_with_a_disability')
+  end
+
+  def then_i_see_training_with_a_disability_is_missing_below_the_section
+    within('#missing-training_with_a_disability-error') do
+      expect(page).to have_content(t('review_application.training_with_a_disability.incomplete'))
+    end
+  end
+
+  def then_i_see_a_training_with_a_disability_validation_error
+    within('.govuk-error-summary') do
+      expect(page).to have_content(t('review_application.training_with_a_disability.incomplete'))
+    end
+  end
+
+  def when_i_visit_the_site
+    and_i_visit_the_site
   end
 
   def when_i_click_on_training_with_a_disability
@@ -75,6 +150,6 @@ RSpec.feature 'Entering their disability information' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#training-with-a-disability-completed', text: 'Completed')
+    expect(page).to have_css('#training-with-a-disability-badge-id', text: 'Completed')
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_disability_info.rb
+++ b/spec/system/candidate_interface/candidate_entering_disability_info.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their disability information' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their disability information' do
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_training_with_a_disability
+    and_i_fill_in_my_disability_information
+    and_i_submit_the_form
+    then_i_can_check_my_answers
+
+    when_i_click_to_change_my_answer
+    and_i_select_no
+    and_i_submit_the_form
+    then_i_can_check_my_revised_answers
+
+    when_i_submit_my_details
+    then_i_should_see_the_form
+    and_that_the_section_is_completed
+
+    when_i_click_on_training_with_a_disability
+    then_i_can_check_my_revised_answers
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_training_with_a_disability
+    click_link t('page_titles.training_with_a_disability')
+  end
+
+  def and_i_fill_in_my_disability_information
+    scope = 'application_form.training_with_a_disability'
+    choose t('disclose_disability.yes', scope: scope)
+    fill_in t('disability_disclosure.label', scope: scope), with: 'I have difficulty climbing stairs'
+  end
+
+  def and_i_submit_the_form
+    click_button t('application_form.training_with_a_disability.complete_form_button')
+  end
+
+  def then_i_can_check_my_answers
+    expect(page).to have_content 'Yes'
+    expect(page).to have_content 'I have difficulty climbing stairs'
+  end
+
+  def when_i_click_to_change_my_answer
+    first('.govuk-summary-list__actions').click_link 'Change'
+  end
+
+  def and_i_select_no
+    scope = 'application_form.training_with_a_disability'
+    choose t('disclose_disability.no', scope: scope)
+  end
+
+  def then_i_can_check_my_revised_answers
+    expect(page).to have_content 'No'
+    expect(page).not_to have_content 'I have difficulty climbing stairs'
+  end
+
+  def when_i_submit_my_details
+    click_link 'Continue'
+  end
+
+  def then_i_should_see_the_form
+    expect(page).to have_content(t('page_titles.training_with_a_disability'))
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#training-with-a-disability-completed', text: 'Completed')
+  end
+end

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   scenario 'sees everything missing from the current state' do
     given_i_am_signed_in
+    and_the_training_with_a_disability_feature_flag_is_on
 
     when_i_visit_the_review_application_page
     then_i_should_be_able_to_click_through_and_complete_each_section
@@ -15,6 +16,10 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_training_with_a_disability_feature_flag_is_on
+    FeatureFlag.activate('training_with_a_disability')
   end
 
   def when_i_visit_the_review_application_page

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
 
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in
+    and_the_training_with_a_disability_feature_flag_is_on
 
     when_i_have_completed_my_application
     and_i_review_my_application
@@ -13,6 +14,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     and_i_can_see_my_course_choices
     and_i_can_see_my_personal_details
     and_i_can_see_my_contact_details
+    and_i_can_see_my_disability_disclosure
     and_i_can_see_my_volunteering_roles
     and_i_can_see_my_degree
     and_i_can_see_my_gcses
@@ -57,6 +59,10 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     create_and_sign_in_candidate
   end
 
+  def and_the_training_with_a_disability_feature_flag_is_on
+    FeatureFlag.activate('training_with_a_disability')
+  end
+
   def when_i_have_completed_my_application
     candidate_completes_application_form
   end
@@ -97,6 +103,11 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     expect(page).to have_content '42 Much Wow Street'
     expect(page).to have_content 'London'
     expect(page).to have_content 'SW1P 3BT'
+  end
+
+  def and_i_can_see_my_disability_disclosure
+    expect(page).to have_content 'Yes'
+    expect(page).to have_content 'I have difficulty climbing stairs'
   end
 
   def and_i_can_see_my_volunteering_roles

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -16,6 +16,7 @@ RSpec.feature 'Vendor receives the application' do
   end
 
   def given_a_candidate_has_submitted_their_application
+    FeatureFlag.activate('training_with_a_disability')
     candidate_completes_application_form
     candidate_submits_application
   end


### PR DESCRIPTION
### Context

We want to add back the `Training with a disability` section but just for staging.

- PR for when we added the section https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/480
- PR for when we removed the section https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/526

### Changes proposed in this pull request

This PR reverts the commit which removed the `Training with a disability` section (see https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/18667997de21cc789192d42bc74e9b60572f402a) and then:

- fixes showing `Yes` when a `No` was selected for `Do you want to disclose a disability?`
- updates the `TrainingWithADisabilityReviewComponent` to have `editable` and `missing_error` parameters
- adds a `training_with_a_disability` feature flag

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/70460638-bb772200-1aae-11ea-9879-6c3c523efc96.png)

### Guidance to review

- Best to go through commit by commit.
- Please test the feature flag by activating it in support

As I'm away tomorrow, feel free to hop onto this branch for any updates and merge this in without me.

### Link to Trello card

[645 - Add 'training with a disability' into staging](https://trello.com/c/0Y1cUtJb/645-add-training-with-a-disability-into-staging)
