### PR TITLE
Remove "ucas" from thing-codes and allow more sites to exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,8 +218,8 @@ by invoking `bin/webpack`. If all is well, there is a chance that
 ## <a name="documentation"></a>Documentation
 
 ### <a name="documentation-nomenclature"></a>Nomenclature
-- **Course** consists of a UCAS provider code and a UCAS course code. In our system, this is represented by the `ucas_provider_code` and `ucas_course_code` on the `ApplicationChoice` model
-- **Course Choice** is the course plus a training location code, in our system represented by `ucas_provider_code`, `ucas_course_code`, `ucas_location_code`
+- **Course** consists of a UCAS provider code and a UCAS course code. In our system, this is represented by the `provider_code` and `course_code` on the `ApplicationChoice` model
+- **Course Choice** is the course plus a training location code, in our system represented by `provider_code`, `course_code`, `location_code`
 
 ### <a name="documentation-domain-model"></a>Domain Model
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -4,7 +4,7 @@ class Site < ApplicationRecord
   validates :code, presence: true
   validates :name, presence: true
 
-  CODE_LENGTH = 1
+  CODE_LENGTH = 5
 
   def name_and_code
     "#{name} (#{code})"

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -78,9 +78,9 @@ module VendorApi
     def course
       {
         start_date: application_choice.course.start_date,
-        provider_ucas_code: application_choice.provider.code,
-        site_ucas_code: application_choice.site.code,
-        course_ucas_code: application_choice.course.code,
+        provider_code: application_choice.provider.code,
+        site_code: application_choice.site.code,
+        course_code: application_choice.course.code,
       }
     end
 

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -482,28 +482,28 @@ components:
       additionalProperties: false
       required:
         - start_date
-        - provider_ucas_code
-        - course_ucas_code
-        - site_ucas_code
+        - provider_code
+        - course_code
+        - site_code
       properties:
         start_date:
           type: string
           format: date
           description: The course’s start date
           example: "2020-09-10"
-        provider_ucas_code:
+        provider_code:
           type: string
-          description: The provider’s UCAS code
+          description: The provider’s code
           example: 2FR
           maxLength: 3
-        course_ucas_code:
+        course_code:
           type: string
-          description: The course’s UCAS code
+          description: The course’s code
           example: 3CVK
           maxLength: 4
-        site_ucas_code:
+        site_code:
           type: string
-          description: The site’s UCAS code
+          description: The site’s code
           example: K
           maxLength: 1
     Offer:

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -505,7 +505,7 @@ components:
           type: string
           description: The site’s code
           example: K
-          maxLength: 1
+          maxLength: 5
     Offer:
       type: object
       additionalProperties: false

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -74,9 +74,9 @@ RSpec.feature 'Vendor receives the application' do
         },
         course: {
           start_date: '2020-09-01', # TODO: Necessary?
-          provider_ucas_code: '1N1',
-          site_ucas_code: '-',
-          course_ucas_code: '2XT2',
+          provider_code: '1N1',
+          site_code: '-',
+          course_code: '2XT2',
         },
         candidate: {
           first_name: 'Lando',


### PR DESCRIPTION
### Context

We call provider/course/site codes "ucas_provider_code", "ucas_site_code", etc - this is incorrect because they are now minted and managed by the DfE Find service, and not by UCAS anymore. 

This also means that we don't have to enforce the 1-character code for the site, which limits the number of sites per provider to 36. This limit has been hit already by some providers.

Discussed and 🔨 decided with @fofr, @misaka and @benilovj.

### Changes proposed in this pull request

- Remove `ucas_` from attribute names in the API
- Up the limit for sites to 5. This is so that we easily can differentiate them from other codes (1 char for an old-style site code, 3 for a provider, 4 for course, 5 for new-style sites).

### Guidance to review

Nothing in particular.

### Link to Trello card

https://trello.com/c/yKbdofEs/1376-remove-ucas-from-thing-codes-and-allow-more-sites-to-exist