### PR TITLE
Prevent candidates from being able to visit the withdraw and offer page for a course choice when in the incorrect state

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -3,6 +3,8 @@ module CandidateInterface
     before_action :set_application_choice
 
     def offer
+      redirect_to candidate_interface_application_form_path unless @application_choice.offer?
+
       if FeatureFlag.active?('accept_and_decline_via_ui')
         @respond_to_offer = CandidateInterface::RespondToOfferForm.new
       else
@@ -41,10 +43,10 @@ module CandidateInterface
     end
 
     def withdraw
-      if ApplicationStateChange.new(@application_choice).can_withdraw? 
+      if ApplicationStateChange.new(@application_choice).can_withdraw?
         render :withdraw
       else
-        redirect_to candidate_interface_application_form_path 
+        redirect_to candidate_interface_application_form_path
       end
     end
 

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -40,7 +40,13 @@ module CandidateInterface
       redirect_to candidate_interface_application_complete_path
     end
 
-    def withdraw; end
+    def withdraw
+      if ApplicationStateChange.new(@application_choice).can_withdraw? 
+        render :withdraw
+      else
+        redirect_to candidate_interface_application_form_path 
+      end
+    end
 
     def confirm_withdraw
       raise unless FeatureFlag.active?('candidate_withdrawals')

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class DecisionsController < CandidateInterfaceController
     before_action :set_application_choice
+    before_action :check_that_candidate_can_decline, only: %i[decline confirm_decline]
 
     def offer
       redirect_to candidate_interface_application_form_path unless @application_choice.offer?
@@ -64,6 +65,12 @@ module CandidateInterface
 
     def set_application_choice
       @application_choice = current_candidate.current_application.application_choices.find(params[:id])
+    end
+
+    def check_that_candidate_can_decline
+      unless ApplicationStateChange.new(@application_choice).can_decline?
+        render_404
+      end
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -21,8 +21,7 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
     and_i_see_that_i_accepted_the_offer
     and_i_see_that_i_declined_the_other_offer
 
-    when_i_have_another_application_without_offer
-    and_i_visit_the_offer_page
+    when_i_visit_the_offer_page_of_the_declined_offer
     then_i_see_the_applcation_dashboard
   end
 
@@ -105,17 +104,8 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
     end
   end
 
-  def when_i_have_another_application_without_offer
-    @application_choice_without_offer = create(
-      :application_choice,
-      :awaiting_provider_decision,
-      course_option: @course_option,
-      application_form: @application_form,
-    )
-  end
-
-  def and_i_visit_the_offer_page
-    visit candidate_interface_offer_path(id: @application_choice_without_offer.id)
+  def when_i_visit_the_offer_page_of_the_declined_offer
+    visit candidate_interface_offer_path(id: @other_application_choice.id)
   end
 
   def then_i_see_the_applcation_dashboard

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -20,6 +20,10 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
     then_a_slack_notification_is_sent
     and_i_see_that_i_accepted_the_offer
     and_i_see_that_i_declined_the_other_offer
+
+    when_i_have_another_application_without_offer
+    and_i_visit_the_offer_page
+    then_i_see_the_applcation_dashboard
   end
 
   def given_the_accept_and_decline_feature_is_on
@@ -99,5 +103,22 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
     within ".qa-application-choice-#{@other_application_choice.id}" do
       expect(page).to have_content 'Declined'
     end
+  end
+
+  def when_i_have_another_application_without_offer
+    @application_choice_without_offer = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: @course_option,
+      application_form: @application_form,
+    )
+  end
+
+  def and_i_visit_the_offer_page
+    visit candidate_interface_offer_path(id: @application_choice_without_offer.id)
+  end
+
+  def then_i_see_the_applcation_dashboard
+    expect(page).to have_content('Application dashboard')
   end
 end

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -23,8 +23,7 @@ RSpec.feature 'A candidate withdraws her application' do
     then_my_application_should_be_withdrawn
     and_a_slack_notification_is_sent
 
-    given_i_have_an_application_with_offer
-    when_i_visit_the_withdraw_page
+    when_i_try_to_visit_the_withdraw_page
     then_i_can_not_see_the_withdaw_page
     and_i_am_redirected_to_the_applcation_dashboard
   end
@@ -62,11 +61,7 @@ RSpec.feature 'A candidate withdraws her application' do
     expect_slack_message_with_text 'has withdrawn their application'
   end
 
-  def given_i_have_an_application_with_offer
-    MakeAnOffer.new(application_choice: @application_choice).save
-  end
-
-  def when_i_visit_the_withdraw_page
+  def when_i_try_to_visit_the_withdraw_page
     visit candidate_interface_withdraw_path(id: @application_choice.id)
   end
 

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -22,6 +22,11 @@ RSpec.feature 'A candidate withdraws her application' do
     when_i_click_to_confirm_withdrawal
     then_my_application_should_be_withdrawn
     and_a_slack_notification_is_sent
+
+    given_i_have_an_application_with_offer
+    when_i_visit_the_withdraw_page
+    then_i_can_not_see_the_withdaw_page
+    and_i_am_redirected_to_the_applcation_dashboard
   end
 
   def given_i_am_signed_in_as_a_candidate
@@ -55,5 +60,21 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def and_a_slack_notification_is_sent
     expect_slack_message_with_text 'has withdrawn their application'
+  end
+
+  def given_i_have_an_application_with_offer
+    MakeAnOffer.new(application_choice: @application_choice).save
+  end
+
+  def when_i_visit_the_withdraw_page
+    visit candidate_interface_withdraw_path(id: @application_choice.id)
+  end
+
+  def then_i_can_not_see_the_withdaw_page
+    expect(page).not_to have_content('Confirm you would like to withdraw your application to study')
+  end
+
+  def and_i_am_redirected_to_the_applcation_dashboard
+    expect(page).to have_content('Application dashboard')
   end
 end


### PR DESCRIPTION
### Context
We want to prevent candidates from being able to visit the withdraw and offer page when their application is not withdrawable or does not have an offer. 

### Changes proposed in this pull request
This PR adds conditions to the `DecisionsController` to check whether the `current_application_choice` has an `offer?` or `can_withdraw?` and redirects to the `application dashboard` in case the application choice is in an incorrect state.

### Guidance to review
Try to submit a new application and visit the `candidate/application/choice/:id/offer` page, you should not be able to see the offer page, but the application dashboard. Add an offer to the application and visit the `candidate/application/choice/:id/withdraw` page, you should see the application dashboard. 

### Link to Trello card

[509 - Prevent candidates from being able to visit the withdraw and offer page for a course choice when in the incorrect state](https://trello.com/c/OSNrqiuI/509-prevent-candidates-from-being-able-to-visit-the-withdraw-and-offer-page-for-a-course-choice-when-in-the-incorrect-state)

