### PR TITLE
Expose the support users Signin UID

### DIFF
--- a/app/views/support_interface/unauthorized.html.erb
+++ b/app/views/support_interface/unauthorized.html.erb
@@ -13,7 +13,9 @@
 
     <p class="govuk-body">
       If you work with us and you think your account should be authorized,
-      contact <%= bat_contact_mail_to %>.
+      contact <%= bat_contact_mail_to %> and tell them your DfE Signin ID:
+
+      <code><%= dfe_sign_in_user.dfe_sign_in_uid %></code>
     </p>
   </div>
 </div>


### PR DESCRIPTION
This allows us to more easily add people, because it’s fairly difficult to get someones DfE Signin UID at the moment.

https://trello.com/c/DVh2NV9f/1307-put-support-behind-dfe-sign-in