### PR TITLE
Prevent candidates from being able to visit the decline and accept page for a course choice when in the incorrect state

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -2,10 +2,11 @@ module CandidateInterface
   class DecisionsController < CandidateInterfaceController
     before_action :set_application_choice
     before_action :check_that_candidate_can_decline, only: %i[decline confirm_decline]
+    before_action :check_that_candidate_can_accept, only: %i[accept confirm_accept]
+    before_action :check_that_candidate_can_withdraw, only: %i[withdraw confirm_withdraw]
+    before_action :check_that_candidate_has_an_offer, only: %i[offer respond_to_offer]
 
     def offer
-      redirect_to candidate_interface_application_form_path unless @application_choice.offer?
-
       if FeatureFlag.active?('accept_and_decline_via_ui')
         @respond_to_offer = CandidateInterface::RespondToOfferForm.new
       else
@@ -43,13 +44,7 @@ module CandidateInterface
       redirect_to candidate_interface_application_complete_path
     end
 
-    def withdraw
-      if ApplicationStateChange.new(@application_choice).can_withdraw?
-        render :withdraw
-      else
-        redirect_to candidate_interface_application_form_path
-      end
-    end
+    def withdraw; end
 
     def confirm_withdraw
       raise unless FeatureFlag.active?('candidate_withdrawals')
@@ -71,6 +66,22 @@ module CandidateInterface
       unless ApplicationStateChange.new(@application_choice).can_decline?
         render_404
       end
+    end
+
+    def check_that_candidate_can_accept
+      unless ApplicationStateChange.new(@application_choice).can_accept?
+        render_404
+      end
+    end
+
+    def check_that_candidate_can_withdraw
+      unless ApplicationStateChange.new(@application_choice).can_withdraw?
+        render_404
+      end
+    end
+
+    def check_that_candidate_has_an_offer
+      render_404 unless @application_choice.offer?
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -22,7 +22,13 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
     and_i_see_that_i_declined_the_other_offer
 
     when_i_visit_the_offer_page_of_the_declined_offer
-    then_i_see_the_applcation_dashboard
+    then_i_see_the_page_not_found
+
+    when_i_visit_the_accept_page_of_the_declined_offer
+    then_i_see_the_page_not_found
+
+    when_i_visit_the_decline_page_of_the_accepted_offer
+    then_i_see_the_page_not_found
   end
 
   def given_the_accept_and_decline_feature_is_on
@@ -105,10 +111,18 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
   end
 
   def when_i_visit_the_offer_page_of_the_declined_offer
-    visit candidate_interface_offer_path(id: @other_application_choice.id)
+    visit candidate_interface_offer_path(@other_application_choice.id)
   end
 
-  def then_i_see_the_applcation_dashboard
-    expect(page).to have_content('Application dashboard')
+  def when_i_visit_the_accept_page_of_the_declined_offer
+    visit candidate_interface_accept_offer_path(@other_application_choice.id)
+  end
+
+  def then_i_see_the_page_not_found
+    expect(page).to have_content('Page not found')
+  end
+
+  def when_i_visit_the_decline_page_of_the_accepted_offer
+    visit candidate_interface_decline_offer_path(@application_choice.id)
   end
 end

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -24,8 +24,7 @@ RSpec.feature 'A candidate withdraws her application' do
     and_a_slack_notification_is_sent
 
     when_i_try_to_visit_the_withdraw_page
-    then_i_can_not_see_the_withdaw_page
-    and_i_am_redirected_to_the_applcation_dashboard
+    then_i_see_the_page_not_found
   end
 
   def given_i_am_signed_in_as_a_candidate
@@ -65,11 +64,7 @@ RSpec.feature 'A candidate withdraws her application' do
     visit candidate_interface_withdraw_path(id: @application_choice.id)
   end
 
-  def then_i_can_not_see_the_withdaw_page
-    expect(page).not_to have_content('Confirm you would like to withdraw your application to study')
-  end
-
-  def and_i_am_redirected_to_the_applcation_dashboard
-    expect(page).to have_content('Application dashboard')
+  def then_i_see_the_page_not_found
+    expect(page).to have_content('Page not found')
   end
 end


### PR DESCRIPTION
## Context 
There are a few cases that were not covered in the acceptance criteria on [509 - Prevent candidates from being able to visit the withdraw and offer page...](https://trello.com/c/OSNrqiuI/509-prevent-candidates-from-being-able-to-visit-the-withdraw-and-offer-page-for-a-course-choice-when-in-the-incorrect-state)
We don't want to allow candidates to visit the accept/decline offer path when the course choice is in an incorrect state. In these cases, we want to show a 404 page.

### Changes proposed in this pull request
This PR adds `before_action` to the `DecisionsController` to check whether the `application choice` is in the correct state for the visited page. Also addressed the refactoring suggestions and typos pointed out by @tijmenb in the previous PR https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/836

### Guidance to review
Try to visit the `/candidate/application/choice/:id/offer/accept` or `/candidate/application/choice/:id/offer/decline` when the application does not have an offer, you should see a 404 page.

### Link to Trello card

[509 - Prevent candidates from being able to visit the withdraw and offer page for a course choice when in the incorrect state](https://trello.com/c/OSNrqiuI/509-prevent-candidates-from-being-able-to-visit-the-withdraw-and-offer-page-for-a-course-choice-when-in-the-incorrect-state)