### PR TITLE
Make DfE environment usage simpler

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,23 @@ The Provider interface at `/provider` and Support interface at
 
 ### Environments
 
-Apply environment | DfE Sign-in environment
----- | ------
-Development | Test (https://signin-test-oidc-as.azurewebsites.net) [Manage](https://signin-test-mng-as.azurewebsites.net/)
-QA | Test (as above)
-Pentest | Test (as above)
-Staging | Pre-prod (https://pp-oidc.signin.education.gov.uk) [Manage](https://signin-pp-mng-as.azurewebsites.net)
-Sandbox | Pre-prod (as above)
-Production | Prod (https://oidc.signin.education.gov.uk) [Manage](https://manage.signin.education.gov.uk)
+In development, QA, and pentest we use the **Test** environment of DfE Signin:
+
+[Manage console (test)](https://signin-test-mng-as.azurewebsites.net/)
+
+```sh
+# .env
+DFE_SIGN_IN_ISSUER=https://signin-test-oidc-as.azurewebsites.net
+```
+
+In staging, production and sandbox we use the **Production** environment of DfE Signin:
+
+[Manage console (production)](https://manage.signin.education.gov.uk)
+
+```sh
+# .env
+DFE_SIGN_IN_ISSUER=https://oidc.signin.education.gov.uk
+```
 
 ### Local development
 


### PR DESCRIPTION
### Context

The DfE Signin dance is complicated by the different environments we use.

### Changes proposed in this pull request

Remove usage of the pre-prod environment. Staging and Sandbox now use production. 

### Link to Trello card

https://trello.com/c/DVh2NV9f/1307-put-support-behind-dfe-sign-in