### PR TITLE
Remove Back link on Ucas page, and update wording.

### DIFF
--- a/app/views/candidate_interface/course_choices/ucas.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas.html.erb
@@ -7,7 +7,7 @@
       <%= t('page_titles.not_eligible_yet') %>
     </h1>
 
-    <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers.</p>
+    <p class="govuk-body"><%= service_name %> is still in development, so for now, we have to limit candidate numbers and the range of courses on offer.</p>
     <p class="govuk-body govuk-!-font-weight-bold">You can apply for all teacher training courses and providers using UCAS.</p>
     <p class="govuk-body">You’ll need to register with UCAS before you can apply.</p>
     <p class="govuk-body"><%= govuk_button_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %></p>


### PR DESCRIPTION
### Context

The Ucas page content is not suitable for users that want to apply to a non-opted in course ("other course").

### Changes proposed in this pull request

- Update the wording.

- Since the "back" link should be dynamic because that page is accessed from different paths, remove the link for now.


### Link to Trello card

https://trello.com/c/GkvNXpDd/646-change-content-for-page-users-are-sent-to-when-they-want-to-apply-to-a-non-opted-in-course
