### PR TITLE
Include Candidate ID in API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -16,6 +16,7 @@ module VendorApi
           personal_statement: personal_statement,
           interview_preferences: application_form.interview_preferences,
           candidate: {
+            id: "C#{application_form.candidate.id}",
             first_name: application_form.first_name,
             last_name: application_form.last_name,
             date_of_birth: application_form.date_of_birth,

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -370,6 +370,7 @@ components:
       type: object
       additionalProperties: false
       required:
+        - id
         - first_name
         - last_name
         - date_of_birth
@@ -380,6 +381,11 @@ components:
         - other_languages
         - disability_disclosure
       properties:
+        id:
+          type: string
+          description: The candidate’s ID in the Apply system
+          maxLength: 20
+          example: "C5432"
         first_name:
           type: string
           description: The candidate’s first name

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -79,6 +79,7 @@ RSpec.feature 'Vendor receives the application' do
           course_code: '2XT2',
         },
         candidate: {
+          id: "C#{@current_candidate.id}",
           first_name: 'Lando',
           last_name: 'Calrissian',
           date_of_birth: '1937-04-06',


### PR DESCRIPTION
### Context

This allows providers/vendors to better able to match the candidates they received from us against existing records in their DB.

We noted an ID in our system is not guaranteed to be stable, but it's still useful if it does happen to match data in their system. If it doesn't then they can continue to match on other values (name, email etc)

The ID is a string starting with “C”. This allows us to quickly see that it’s a (C)andidate identifier, and prevents downstream services from relying on it as an integer.

### Changes proposed in this pull request

Add the candidate ID to the API response.

### Guidance to review

N/A.

### Link to Trello card

https://trello.com/c/KcV7T4zD