### PR TITLE
Add more context to Sentry errors and logs

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -26,6 +26,10 @@ module CandidateInterface
     def add_identity_to_log(candidate_id = current_candidate&.id)
       RequestLocals.store[:identity] = { candidate_id: candidate_id }
       Raven.user_context(candidate_id: candidate_id)
+
+      return unless current_candidate
+
+      Raven.extra_context(application_support_url: support_interface_application_form_url(current_application))
     end
 
     def current_application

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -23,9 +23,9 @@ module CandidateInterface
       render 'candidate_interface/shared/pilot_holding_page'
     end
 
-    # controller-specific additional info to include in logstash logs
     def add_identity_to_log(candidate_id = current_candidate&.id)
       RequestLocals.store[:identity] = { candidate_id: candidate_id }
+      Raven.user_context(candidate_id: candidate_id)
     end
 
     def current_application

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -4,6 +4,7 @@ module SupportInterface
 
     layout 'support_layout'
     before_action :authenticate_support_user!
+    before_action :add_identity_to_log
 
     helper_method :current_support_user, :dfe_sign_in_user
 
@@ -44,6 +45,13 @@ module SupportInterface
 
       session['post_dfe_sign_in_path'] = request.path
       redirect_to support_interface_sign_in_path
+    end
+
+    def add_identity_to_log
+      return unless current_support_user
+
+      RequestLocals.store[:identity] = { support_user_id: current_support_user.id }
+      Raven.user_context(support_user_id: current_support_user.id)
     end
   end
 end

--- a/app/controllers/vendor_api/vendor_api_controller.rb
+++ b/app/controllers/vendor_api/vendor_api_controller.rb
@@ -75,10 +75,13 @@ module VendorApi
 
     # controller-specific additional info to include in logstash logs
     def add_identity_to_log
-      RequestLocals.store[:identity] = {
+      user_info = {
         vendor_api_token_id: @current_vendor_api_token&.id,
         provider_id: current_provider&.id,
       }
+
+      RequestLocals.store[:identity] = user_info
+      Raven.user_context(user_info)
     end
 
     def validate_metadata!

--- a/spec/requests/provider_interface/account_creation_in_progress_spec.rb
+++ b/spec/requests/provider_interface/account_creation_in_progress_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe 'GET /provider/applications' do
     end
 
     it 'reports the error to Sentry, appending the Sign-in UID' do
-      allow(Raven).to receive(:extra_context)
+      allow(Raven).to receive(:user_context)
       allow(Raven).to receive(:capture_exception)
 
       get '/provider/applications'
 
-      expect(Raven).to have_received(:extra_context), with: { dfe_sign_in_uid: 'DFE_SIGN_IN_UID' }
+      expect(Raven).to have_received(:user_context).with(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
       expect(Raven).to have_received(:capture_exception)
     end
   end


### PR DESCRIPTION
### Context

When diagnosing errors, it's useful to know the user that saw an error in Sentry.

### Changes proposed in this pull request

This:

- Adds the candidate user ID to Sentry's user context
- Adds a link to the current application in the extra context 
- Adds the current provider user DfE Signin ID to the logs and to Sentry
- Adds the current support user to logs and Sentry
- Adds the current token/vendor to Sentry in the API

### Guidance to review

Look at this error:

https://sentry.io/organizations/dfe-bat/issues/1382294765

<img width="910" alt="Screenshot 2019-12-11 at 08 42 00" src="https://user-images.githubusercontent.com/233676/70605699-e36f9e00-1bf2-11ea-9c2c-01d8cae2be7a.png">


### Link to Trello card

https://trello.com/c/xrAxayCB/1375-deal-with-pentest-outcomes
