### PR TITLE
Fail tests when linting fails

### DIFF
--- a/app/views/api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/reference/reference.html.erb
@@ -28,7 +28,7 @@
   </li>
 </ol>
 
-<hr class='govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6' />
+<hr class='govuk-section-break govuk-section-break--visible govuk-!-margin-top-6 govuk-!-margin-bottom-6'>
 
 <h2 class='govuk-heading-l' id='developing'>Developing on the API</h2>
 

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -34,12 +34,12 @@ end
 
 desc 'Run rubocop'
 task :rubocop do
-  system 'bundle exec rubocop --parallel'
+  sh 'bundle exec rubocop --parallel'
 end
 
 desc 'Lint all *.erb* files in app/views using erblint'
 task :erblint do
-  system 'erblint app/views'
+  sh 'erblint app/views'
 end
 
 desc 'Run all the linters'


### PR DESCRIPTION
`system` just returns false if the command fails, which means rake doesn’t return a non-zero exit code, and GitHub CI will be green.

`sh` correctly triggers the rake task to fail.

Fixes an `erblint` issue too that was helpful in testing this:

```sh
$ be rake linting
bundle exec rubocop --parallel
Inspecting 583 files
........................................................................

583 files inspected, no offenses detected
erblint app/views
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.5-compliant syntax, but you are running 2.6.3.
warning: please see
https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Linting 129 files with 14 linters...

Tag `hr` is a void element, it must end with `>` and not `/>`.
In file: app/views/api_docs/reference/reference.html.erb:31

1 error(s) were found in ERB files
rake aborted!
Command failed with status (1): [erblint app/views...]
/Users/tijmen/dfe/apply-for-postgraduate-teacher-training/lib/tasks/test
ing.rake:42:in `block in <top (required)>'
/Users/tijmen/.rbenv/versions/2.6.3/bin/bundle:23:in `load'
/Users/tijmen/.rbenv/versions/2.6.3/bin/bundle:23:in `<main>'
Tasks: TOP => linting => erblint
(See full trace by running task with --trace)

$ echo $?
1
```

