### PR TITLE
Parameterise app service instance size and count

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -5,6 +5,9 @@ parameters:
   environment:
   resourceEnvironmentName:
   serviceName:
+  appServicePlanTier: 'Standard'
+  appServicePlanSize: '2'
+  appServicePlanInstances: 1
   redisCacheSKU: 'Basic'
   redisCacheFamily: 'C'
   redisCacheCapacity: 1
@@ -86,6 +89,9 @@ jobs:
                 -keyVaultName "${{parameters.keyVaultName}}"
                 -keyVaultResourceGroup "${{parameters.keyVaultResourceGroup}}"
                 -customHostName "${{parameters.customHostName}}"
+                -appServicePlanTier "${{parameters.appServicePlanTier}}"
+                -appServicePlanSize "${{parameters.appServicePlanSize}}"
+                -appServicePlanInstances "${{parameters.appServicePlanInstances}}"
                 -redisCacheSKU ${{parameters.redisCacheSKU}}
                 -redisCacheFamily ${{parameters.redisCacheFamily}}
                 -redisCacheCapacity ${{parameters.redisCacheCapacity}}

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -54,6 +54,8 @@ stages:
       environment: 'staging'
       resourceEnvironmentName: 't01'
       serviceName: 'apply'
+      appServicePlanTier: 'PremiumV2'
+      appServicePlanInstances: 2
       redisCacheSKU: 'Premium'
       redisCacheFamily: 'P'
       containerImageReference: '$(imageName):$(build.buildNumber)'
@@ -202,6 +204,8 @@ stages:
       environment: 'production'
       resourceEnvironmentName: 'p01'
       serviceName: 'apply'
+      appServicePlanTier: 'PremiumV2'
+      appServicePlanInstances: 2
       redisCacheSKU: 'Premium'
       redisCacheFamily: 'P'
       containerImageReference: '$(imageName):$(build.buildNumber)'

--- a/azure/template.json
+++ b/azure/template.json
@@ -39,6 +39,24 @@
                 "description": "Environment for the rails app."
             }
         },
+        "appServicePlanTier": {
+            "type": "string",
+            "metadata": {
+                "description": "The App Service Plan tier."
+            }
+        },
+        "appServicePlanSize": {
+            "type": "string",
+            "metadata": {
+                "description": "The App Serivce Plan instance size."
+            }
+        },
+        "appServicePlanInstances": {
+            "type": "int",
+            "metadata": {
+                "description": "The number of instance of the web app Docker image to run in parallel."
+            }
+        },
         "redisCacheSKU": {
             "type": "string",
             "metadata": {
@@ -399,10 +417,13 @@
                         "value": "[variables('appServicePlanName')]"
                     },
                     "appServicePlanTier": {
-                        "value": "Standard"
+                        "value": "[parameters('appServicePlanTier')]"
                     },
                     "appServicePlanSize": {
-                        "value": "2"
+                        "value": "[parameters('appServicePlanSize')]"
+                    },
+                    "appServicePlanInstances": {
+                        "value": "[parameters('appServicePlanInstances')]"
                     }
                 }
             }


### PR DESCRIPTION
### Context

The current ARM templates are set up such that all app service instances are configured the same across all six of our environments. This configuration is currently a single Standard S2 tier instance. Performance testing has revealed that the production and staging instances of the app service need to be scaled up and out independently of the other instances.

### Changes proposed in this pull request

- Draw out the instance tier, size and count parameters from the app service plan building blocks template into our ARM template so that they can be set independently on each environment.
- Set production and staging environments to use two PremiumV2 P2v2 instances.
- All other environments are configured to retain the existing default; a single Standard S2 instance.

### Guidance to review

Nothing specific.

### Link to Trello card

[1379 Upgrade staging production web infrastructure to premium tier 2x instances](https://trello.com/c/LelfyhxF/1379-upgrade-staging-production-web-infrastructure-to-premium-tier-2xinstances)

### Env vars

- [ ] If this PR introduces new environment variables, they have been added to all necessary parts of the Azure config based on the [documentation in the README](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
