### PR TITLE
Put the Sidekiq Admin interface behind DfE Sign-in

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -294,13 +294,10 @@ Rails.application.routes.draw do
 
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes
     require 'sidekiq/web'
+    require 'support_user_constraint'
 
-    Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV.fetch('SUPPORT_USERNAME'))) &
-        ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV.fetch('SUPPORT_PASSWORD')))
-    end
-
-    mount Sidekiq::Web, at: 'sidekiq'
+    mount Sidekiq::Web => '/sidekiq', constraints: SupportUserConstraint.new
+    get '/sidekiq', to: redirect('/support/sign-in'), status: 302
   end
 
   namespace :api_docs, path: '/api-docs' do

--- a/lib/support_user_constraint.rb
+++ b/lib/support_user_constraint.rb
@@ -1,0 +1,11 @@
+class SupportUserConstraint
+  def matches?(request)
+    current_support_user(request).present?
+  end
+
+private
+
+  def current_support_user(request)
+    SupportUser.load_from_session(request.session)
+  end
+end

--- a/spec/system/support_interface/sidekiq_admin_spec.rb
+++ b/spec/system/support_interface/sidekiq_admin_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.feature 'Sidekiq Admin' do
+  include DfESignInHelpers
+
+  scenario 'View the Sidekiq Admin interface' do
+    when_i_visit_the_sidekiq_interface
+    then_i_should_be_redirected_to_login_page
+
+    when_i_sign_in_via_dfe_sign_in
+    then_i_visit_the_sidekiq_interface
+
+    then_i_should_see_the_sidekiq_admin_interface
+  end
+
+  def when_i_visit_the_sidekiq_interface
+    visit support_interface_sidekiq_path
+  end
+
+  def then_i_should_be_redirected_to_login_page
+    expect(page).to have_current_path support_interface_sign_in_path
+  end
+
+  def when_i_sign_in_via_dfe_sign_in
+    sign_in_as_support_user
+  end
+
+  def then_i_visit_the_sidekiq_interface
+    visit support_interface_sidekiq_path
+  end
+
+  def then_i_should_see_the_sidekiq_admin_interface
+    expect(page).to have_content 'Sidekiq'
+    expect(page).to have_current_path support_interface_sidekiq_path
+  end
+end


### PR DESCRIPTION
### Context

We recently put the Support Interface behind DfE Sign-in. This left the Sidekiq Admin interface (`/support/sidekiq`) still behind basic auth. We want to have this interface controlled by the same authentication/authorisation rules as the Support Interface (i.e. if only if you are logged into Support you have access to Sidekiq admin).

### Changes proposed in this pull request

- [x] Add a route constraint that controls access to the routes mounted by the Sidekiq Rails engine.
- [x] Add a fallback route that redirects unauthenticated requests to `/support/sidekiq` to the login page.
- [x] System spec to check authentication

### Guidance to review

- Are there any loopholes?

### Link to Trello card

[1381 - Put Sidekiq admin behind DfE Sign-in](https://trello.com/c/YuG0N9K3/1381-put-sidekiq-admin-behind-dfe-sign-in)

### Env vars

- [x] No new env vars
