### PR TITLE
Prevent client errors from getting to Sentry

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -7,6 +7,14 @@ class ErrorsController < ApplicationController
     render 'unprocessable_entity.html', status: :unprocessable_entity
   end
 
+  def not_acceptable
+    respond_to do |format|
+      format.any do
+        head 406, content_type: 'text/html'
+      end
+    end
+  end
+
   def internal_server_error
     render status: :internal_server_error
   end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -2,6 +2,7 @@ Raven.configure do |config|
   config.current_environment = HostingEnvironment.environment_name
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.excluded_exceptions += [
+    'ActionController::BadRequest',
     'ActionController::UnknownHttpMethod',
     'ActionDispatch::Http::Parameters::ParseError',
   ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,6 +312,7 @@ Rails.application.routes.draw do
 
   scope via: :all do
     match '/404', to: 'errors#not_found'
+    match '/406', to: 'errors#not_acceptable'
     match '/422', to: 'errors#unprocessable_entity'
     match '/500', to: 'errors#internal_server_error'
   end


### PR DESCRIPTION
### Context

During the pentests we're seeing some exceptions in Sentry. Most of these we should ignore, because they're client errors that aren't actionable. 

### Changes proposed in this pull request

This solves 2 classes of errors, which should cover most of the recent ones:

https://sentry.io/organizations/dfe-bat/issues/?project=1765973

### Guidance to review

Per commit.

### Link to Trello card

https://trello.com/c/xrAxayCB/1375-deal-with-pentest-outcomes