### PR TITLE
hardcode study_mode in application API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -82,6 +82,7 @@ module VendorApi
         provider_code: application_choice.provider.code,
         site_code: application_choice.site.code,
         course_code: application_choice.course.code,
+        study_mode: 'full_time',
       }
     end
 

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -515,6 +515,10 @@ components:
           description: The site’s code
           example: K
           maxLength: 5
+        study_mode:
+          type: string
+          description: Can be 'full_time' or 'part_time'
+          example: full_time
     Offer:
       type: object
       additionalProperties: false

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -493,6 +493,7 @@ components:
         - provider_code
         - course_code
         - site_code
+        - study_mode
       properties:
         start_date:
           type: string

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
     end
   end
 
+  describe '#course' do
+    let(:single_application_presenter) {
+      VendorApi::SingleApplicationPresenter.new(application_choice)
+    }
+    let(:course) { single_application_presenter.as_json[:attributes][:course] }
+
+    it 'includes study_mode' do
+      expect(course[:study_mode]).not_to be_nil
+    end
+  end
+
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
       let(:given_relation) { GetApplicationChoicesForProvider.call(provider: application_choice.provider) }

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -19,17 +19,6 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
     end
   end
 
-  describe '#course' do
-    let(:single_application_presenter) {
-      VendorApi::SingleApplicationPresenter.new(application_choice)
-    }
-    let(:course) { single_application_presenter.as_json[:attributes][:course] }
-
-    it 'includes study_mode' do
-      expect(course[:study_mode]).not_to be_nil
-    end
-  end
-
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
       let(:given_relation) { GetApplicationChoicesForProvider.call(provider: application_choice.provider) }

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -77,6 +77,7 @@ RSpec.feature 'Vendor receives the application' do
           provider_code: '1N1',
           site_code: '-',
           course_code: '2XT2',
+          study_mode: 'full_time',
         },
         candidate: {
           id: "C#{@current_candidate.id}",


### PR DESCRIPTION
### Context

We'll be adding a ```study_mode``` attribute to CourseOption. More details here:
https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/851

This PR just hardcodes the value in the API responses until the full solution is built.

### Changes proposed in this pull request

Add a ```study_mode``` attribute to the ```course``` section of applications, as returned by the API.

### Guidance to review

Run ```rspec spec/presenters/vendor_api/single_application_presenter_spec.rb```.

### Link to Trello card

[1345 - API: add fake full or part time to course selection](https://trello.com/c/qx0OfPLx)
