### PR TITLE
Add release notes to the API docs

### DIFF
--- a/app/controllers/api_docs/openapi_controller.rb
+++ b/app/controllers/api_docs/openapi_controller.rb
@@ -1,7 +1,5 @@
-module VendorApi
-  class OpenapiController < VendorApiController
-    skip_before_action :require_valid_api_token!
-
+module ApiDocs
+  class OpenapiController < ApiDocsController
     def spec
       render plain: File.read('config/vendor-api-v1.yml'), content_type: 'text/yaml'
     end

--- a/app/controllers/api_docs/pages_controller.rb
+++ b/app/controllers/api_docs/pages_controller.rb
@@ -16,6 +16,10 @@ module ApiDocs
       render_content_page :release_notes
     end
 
+    def alpha_release_notes
+      render_content_page :alpha_release_notes
+    end
+
   private
 
     def render_content_page(page_name)

--- a/app/controllers/vendor_api/openapi_controller.rb
+++ b/app/controllers/vendor_api/openapi_controller.rb
@@ -3,7 +3,7 @@ module VendorApi
     skip_before_action :require_valid_api_token!
 
     def spec
-      render text: File.read('config/vendor-api-v1.yml'), content_type: 'text/yaml'
+      render plain: File.read('config/vendor-api-v1.yml'), content_type: 'text/yaml'
     end
   end
 end

--- a/app/controllers/vendor_api/openapi_controller.rb
+++ b/app/controllers/vendor_api/openapi_controller.rb
@@ -3,7 +3,7 @@ module VendorApi
     skip_before_action :require_valid_api_token!
 
     def spec
-      render text: File.read('config/vendor-api-0.8.0.yml'), content_type: 'text/yaml'
+      render text: File.read('config/vendor-api-v1.yml'), content_type: 'text/yaml'
     end
   end
 end

--- a/app/presenters/api_docs/api_operation.rb
+++ b/app/presenters/api_docs/api_operation.rb
@@ -49,6 +49,8 @@ module ApiDocs
     end
 
     def schema
+      return unless response.content['application/json']
+
       response.content['application/json'].schema
     end
 

--- a/app/presenters/api_docs/api_reference.rb
+++ b/app/presenters/api_docs/api_reference.rb
@@ -4,7 +4,7 @@ module ApiDocs
     delegate :servers, to: :document
 
     def initialize
-      @document = Openapi3Parser.load_file('config/vendor-api-0.8.0.yml')
+      @document = Openapi3Parser.load_file('config/vendor-api-v1.yml')
     end
 
     def operations

--- a/app/views/api_docs/pages/alpha_release_notes.md
+++ b/app/views/api_docs/pages/alpha_release_notes.md
@@ -14,6 +14,7 @@ Changes to the docs:
 New attributes:
 
 - `Candidate` now has an `id`. This is a version of our internal identifier, and could be used to match previous candidate records.
+- `Course` now has a `study_mode` attribute that shows whether the candidate wants to study full time or part time. 
 
 Removed attributes:
 

--- a/app/views/api_docs/pages/alpha_release_notes.md
+++ b/app/views/api_docs/pages/alpha_release_notes.md
@@ -1,0 +1,159 @@
+These are the release notes for the API while still in alpha.
+
+See the [current release notes](/api-docs/release-notes) for the release notes
+once v1 is live.
+
+### Alpha release - 11 December 2019
+
+Changes to the docs:
+
+- We've added more examples and descriptions to the attributes
+- The OpenAPI spec is now accessible via the API itself
+- Move the documentation to https://www.apply-for-teacher-training.education.gov.uk/api-docs
+
+New attributes:
+
+- `Candidate` now has an `id`. This is a version of our internal identifier, and could be used to match previous candidate records.
+
+Removed attributes:
+
+- Referee `phone_number` and `confirms_safe_to_work_with_children` have been removed
+- We've removed the `date` from `Rejection` object
+
+Updated attributes:
+
+- Updated the application `status` enum to contain all statuses that could appear
+- We've renamed `provider_ucas_code` to `provider_code`, `course_ucas_code` to `course_code` and `site_ucas_code` to `site_code`. The `site_code` will also be able to have more characters.
+
+### Alpha release - 29 October 2019
+
+Changes to the data:
+
+- Application statuses: remove `declined` and add `unsubmitted`
+- Remove `provider_ucas_code` URL param on GET requests (only applications for
+  the currently authenticated provider will be returned)
+- Add `futher_information` key to `ApplicationAttributes`
+- Rename `work_experiences` array to `work_experience` object in
+  `ApplicationAttributes` and add properties `jobs` and `volunteering`
+- Change `qualifications` key to an object with with properties `gcses`,
+  `degrees` and `other`
+- Change `Qualification` schema, grouping `place_of_study`,
+  `awarding_body_country` and `awarding_body_name` in a single string
+  `institution_details`.
+- Add `english_main_language`, `english_language_qualifications`,
+  `other_languages` and `disability_disclosure` to `Candidate` schema
+- Rename `location_ucas_code` to `site_ucas_code`
+- Change `WorkExperience` schema, adding `working_with_children` boolean and
+  `commitment` (part/full time) and increasing the length of the `description`
+  field
+- Change `Reference` schema, adding `confirms_safe_to_work_with_children` and
+  `phone_number`, renaming `content` to `reference` and removing
+  `reference_type` and `reason_for_character_reference`
+
+Changes to functionality:
+
+- Add [/test-data/regenerate](/api-docs/reference/#post-test-data-regenerate) endpoint.
+- Add [single application](/api-docs/reference/#singleapplicationresponse-object) and [multiple
+  applications](/api-docs/reference/#multipleapplicationsresponse-object) response schemas.
+- Add `422` error response to `POST` endpoints including:
+    - [offer](/api-docs/reference/#post-applications-application_id-offer)
+    - [confirm enrolment](/api-docs/reference/#post-applications-application_id-confirm-enrolment)
+    - [confirm conditions met](/api-docs/reference/#post-applications-application_id-confirm-conditions-met)
+    - [reject](/api-docs/reference/#post-applications-application_id-reject)
+
+Additional changes:
+
+- Add [limits](/api-docs/reference/#rate-limits) section to give details around api rate limiting.
+- Add Development and Vendor Sandbox enviroment details to [api info](/api-docs/reference/#api-info) page.
+- Add Authentication and Metadata sections to the API Reference
+
+### Alpha release - 26 September 2019
+
+Changes to the data:
+
+- Change the structure of an [application](/api-docs/reference#get-applications):
+  - add `type` field
+  - add `attributes` field and move `status`, `submitted_at`, `updated_at`, `personal_statement`
+    `candidate`, `contact_details`, `course`, `qualifications`, `work_experiences`
+    `references`, `offer`, `withdrawal` and `rejection` fields into it
+- Remove date from [reject](/api-docs/reference/#post-applications-application_id-reject) endpoint
+- Limit [candidates](/api-docs/reference/#candidate-object) to only 2 nationalities
+- Rename the `org` field on [work experience](/api-docs/reference/#workexperience-object) to `organisation_name`
+- Rename the `type` field on [qualification](/api-docs/reference/#qualification-object) to `qualification_type`
+- Rename the `type` field on [reference](/api-docs/reference/#reference-object) to `reference_type`
+- Add HESA ITT data to the [application](/api-docs/reference#get-applications). Available only once a student is enrolled
+
+Changes to functionality:
+
+- Change the successful response for all endpoints to be within a `data` object
+- Change the successful response for making an offer, confirming candidate
+  enrolment, confirming offer conditions are met and rejecting an application
+  endpoints to be the application
+- Change the HTTP response code for making an offer, confirming candidate enrolment,
+  confirming offer conditions are met and rejecting an application endpoints to `200`
+- Support a `provider_ucas_code` parameter when [retrieving many applications](/api-docs/reference#retrieve-many-applications)
+- Require a `meta` key in POST request bodies, holding `attribution` and `timestamp` metadata
+
+Additional changes:
+
+- Clarify the endpoint for rejecting an application in [usage scenarios](/api-docs/usage-scenarios)
+- Clarify the timestamp format for retrieving applications in [usage scenarios](/api-docs/usage-scenarios)
+- Clarify maximum length of strings in Schemas
+- Add description of the [API versioning](/#versioning)
+- Add error responses to OpenAPI spec for all endpoints
+- Add [instructions](/api-docs/reference/#use-the-swagger-editor) for importing our OpenAPI specification in the Swagger Editor
+- Add `provider_code` param to retrieving many applications in [usage scenarios](/api-docs/usage-scenarios)
+- Update responses for [making an offer](/api-docs/reference/#post-applications-application_id-offer),
+  [confirming candidate enrolment](/api-docs/reference/#post-applications-application_id-confirm-enrolment),
+  [confirming offer conditions are met](/api-docs/reference/#post-applications-application_id-confirm-conditions-met)
+  and [rejecting an application](/api-docs/reference/#post-applications-application_id-reject) endpoints in [usage scenarios](/api-docs/usage-scenarios)
+- Clarify the steps between making an offer and confirming that offer conditions are met in [usage scenarios](/api-docs/usage-scenarios)
+
+### Alpha release - 16 September 2019
+
+Changes to the data:
+
+- Remove first and last name from Candidate in favour of full name
+- Remove id from Candidate
+- Remove disability information from Candidate, as this is not collected via the application form
+- Remove functionality to amend an offer
+- Rename the rejection endpoint
+- Update Contact Details resource to split address into separate fields
+- Remove description from course resource
+- Add first name, last name and date of birth for Candidate
+
+### Alpha release - 11 September 2019
+
+Changes to functionality:
+
+- Add documentation on the proposed way of authenticating users
+- Limit the number of offer conditions to 20
+- Remove functionality to amend an offer (you can reuse the make an offer endpoint)
+- Remove functionality to confirm a placement for a candidate
+- Remove functionality to schedule interviews for a candidate
+
+Changes to the data:
+
+- Remove first and last name from Candidate in favour of full name
+- Remove id from Candidate
+- Remove disability information from Candidate, as this is not collected via the application form
+- Rename the rejection endpoint
+- Update Contact Details resource to split address into separate fields
+- Applications now have a 10 character identifier
+- The `course` attribute of an application now refers to a single course instead of multiple
+- References have a "content" attribute containing the referee's contribution
+- Qualifications have an "equivalency_details" attribute for overseas awards
+- Withdrawals and Rejections now have timestamps instead of dates
+- Withdrawal reason has become optional
+
+Additional changes:
+
+- Clarify that strings have a 255 character limit, unless otherwise specified
+- Clarify that only candidates can withdraw an application
+- Clarify that we're using [ISO 3166 for country codes](/#codes-and-reference-data), not ISO 3611
+- Clarify how to make an unconditional and conditional offer
+- Clarify that offer conditions are optional
+
+### Alpha release - 4 July 2019
+
+Initial release of the API documentation.

--- a/app/views/api_docs/pages/alpha_release_notes.md
+++ b/app/views/api_docs/pages/alpha_release_notes.md
@@ -8,7 +8,6 @@ once v1 is live.
 Changes to the docs:
 
 - We've added more examples and descriptions to the attributes
-- The OpenAPI spec is now accessible via the API itself
 - Move the documentation to https://www.apply-for-teacher-training.education.gov.uk/api-docs
 
 New attributes:

--- a/app/views/api_docs/pages/alpha_release_notes.md
+++ b/app/views/api_docs/pages/alpha_release_notes.md
@@ -14,7 +14,7 @@ Changes to the docs:
 New attributes:
 
 - `Candidate` now has an `id`. This is a version of our internal identifier, and could be used to match previous candidate records.
-- `Course` now has a `study_mode` attribute that shows whether the candidate wants to study full time or part time. 
+- `Course` now has a `study_mode` attribute that shows whether the candidate wants to study full time or part time.
 
 Removed attributes:
 
@@ -151,7 +151,7 @@ Additional changes:
 
 - Clarify that strings have a 255 character limit, unless otherwise specified
 - Clarify that only candidates can withdraw an application
-- Clarify that we're using [ISO 3166 for country codes](/#codes-and-reference-data), not ISO 3611
+- Clarify that we're using [ISO 3166 for country codes](/api-docs/#codes-and-reference-data), not ISO 3611
 - Clarify how to make an unconditional and conditional offer
 - Clarify that offer conditions are optional
 

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,1 +1,5 @@
-## Unreleased Changes
+We are currently working towards the release of v1 of the API on December 17th. Once v1 is
+published, this page will contain the changes that have been made to the API and docs.
+
+You can [follow the alpha release notes](/api-docs/alpha-release-notes) to keep
+track of changes that we're making on the basis of feedback.  

--- a/app/views/api_docs/reference/reference.html.erb
+++ b/app/views/api_docs/reference/reference.html.erb
@@ -33,7 +33,7 @@
 <h2 class='govuk-heading-l' id='developing'>Developing on the API</h2>
 
 <p class='govuk-body'>
-  The OpenAPI spec from which this documentation is generated is <%= govuk_link_to 'available in YAML format', vendor_api_spec_url %>.
+  The OpenAPI spec from which this documentation is generated is <%= govuk_link_to 'available in YAML format', api_docs_spec_url %>.
 </p>
 
 <h3 class='govuk-heading-m'>Environments</h3>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
       reference: API reference
       help: Get help
       release_notes: Release notes
+      alpha_release_notes: Alpha release notes
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,6 +305,7 @@ Rails.application.routes.draw do
     get '/usage-scenarios' => 'pages#usage', as: :usage
     get '/reference' => 'reference#reference', as: :reference
     get '/release-notes' => 'pages#release_notes', as: :release_notes
+    get '/alpha-release-notes' => 'pages#alpha_release_notes'
     get '/help' => 'pages#help', as: :help
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -222,8 +222,6 @@ Rails.application.routes.draw do
 
     post '/test-data/regenerate' => 'test_data#regenerate'
 
-    get '/spec.yml' => 'openapi#spec', as: :spec
-
     get '/ping', to: 'ping#ping'
   end
 
@@ -307,6 +305,7 @@ Rails.application.routes.draw do
     get '/release-notes' => 'pages#release_notes', as: :release_notes
     get '/alpha-release-notes' => 'pages#alpha_release_notes'
     get '/help' => 'pages#help', as: :help
+    get '/spec.yml' => 'openapi#spec', as: :spec
   end
 
   get '/check', to: 'healthcheck#show'

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.8.0
+  version: "v1"
   title: Apply API
   contact:
     name: DfE

--- a/spec/lib/openapi_spec.rb
+++ b/spec/lib/openapi_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'OpenAPI spec' do
-  document = Openapi3Parser.load_file('config/vendor-api-0.8.0.yml')
+  document = Openapi3Parser.load_file('config/vendor-api-v1.yml')
 
   it 'is a valid OpenAPI spec' do
     expect(document).to be_valid, document.errors.to_a.inspect

--- a/spec/presenters/api_docs/api_schema_spec.rb
+++ b/spec/presenters/api_docs/api_schema_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ApiDocs::ApiSchema do
   describe '#object_schema_name' do
     let :schema do
-      @document = Openapi3Parser.load_file('config/vendor-api-0.8.0.yml')
+      @document = Openapi3Parser.load_file('config/vendor-api-v1.yml')
       schema_name, raw_schema = @document.components.schemas.find { |schema_name, _schema| schema_name == 'ApplicationAttributes' }
       ApiDocs::ApiSchema.new(name: schema_name, schema: raw_schema)
     end

--- a/spec/requests/api_docs/get_spec_spec.rb
+++ b/spec/requests/api_docs/get_spec_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe 'Vendor API - GET /api/v1/spec.yml', type: :request do
+RSpec.describe 'API Docs - GET /api-docs/spec.yml', type: :request do
   it 'returns the spec in YAML format' do
-    get '/api/v1/spec.yml'
+    get '/api-docs/spec.yml'
 
     expect(response).to have_http_status(200)
     expect(response.body).to match 'openapi: 3.0.0'

--- a/spec/requests/vendor_api/get_spec_spec.rb
+++ b/spec/requests/vendor_api/get_spec_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendor API - GET /api/v1/spec.yml', type: :request do
+  it 'returns the spec in YAML format' do
+    get '/api/v1/spec.yml'
+
+    expect(response).to have_http_status(200)
+    expect(response.body).to match 'openapi: 3.0.0'
+  end
+end

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ApplicationStateChange do
 
   describe '.states_visible_to_provider' do
     it 'has corresponding entries in the OpenAPI spec' do
-      valid_states_in_openapi = YAML.load_file('config/vendor-api-0.8.0.yml')['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
+      valid_states_in_openapi = YAML.load_file('config/vendor-api-v1.yml')['components']['schemas']['ApplicationAttributes']['properties']['status']['enum']
 
       expect(ApplicationStateChange.states_visible_to_provider)
         .to match_array(valid_states_in_openapi.map(&:to_sym))

--- a/spec/support/vendor_api/vendor_api_spec_helpers.rb
+++ b/spec/support/vendor_api/vendor_api_spec_helpers.rb
@@ -61,7 +61,7 @@ module VendorApiSpecHelpers
 
   RSpec::Matchers.define :be_valid_against_openapi_schema do |schema_name|
     match do |item|
-      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.8.0.yml"))
+      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-v1.yml"))
 
       JSONSchemaValidator.new(
         spec.as_json_schema(schema_name),
@@ -70,7 +70,7 @@ module VendorApiSpecHelpers
     end
 
     failure_message do |item|
-      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-0.8.0.yml"))
+      spec = OpenApi3Specification.new(YAML.load_file("#{Rails.root}/config/vendor-api-v1.yml"))
 
       JSONSchemaValidator.new(
         spec.as_json_schema(schema_name),

--- a/spec/system/api_docs/api_docs_spec.rb
+++ b/spec/system/api_docs/api_docs_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'API docs' do
     expect(page).to have_content 'Developing on the API'
 
     click_link 'Release notes'
-    expect(page).to have_content 'Unreleased Changes'
+    expect(page).to have_content 'We are currently working towards the release of v1'
 
     click_link 'Get help'
     expect(page).to have_content 'If you have any questions or'


### PR DESCRIPTION
### Context

This adds the release notes for the API.

### Changes proposed in this pull request

This proposes some changes to how we do change noting.

While we're still in the pre-v1 phase, the release notes added to a separate "Alpha release notes" page. This is to signify that it's a different type of change - it doesn't break, since no one has been building on it.

I've also removed all references to sub-versions like "0.8.0". This is just confusing, because it implies we can "release" a version like that (we can't, since we deploy continously).  

### Guidance to review

Does it make sense?

### Link to Trello card

https://trello.com/c/KENwAoIR/1357-merge-tech-docs-into-main-application