### PR TITLE
Specify lengths for all API fields

### DIFF
--- a/app/models/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_type_form.rb
@@ -11,9 +11,12 @@ module CandidateInterface
     validates :subject, :level, :qualification_type, presence: true
 
     validates :other_uk_qualification_type, presence: true, if: -> { qualification_type == OTHER_UK_QUALIFICATION_TYPE }
-    validates :other_uk_qualification_type, length: { maximum: 100 }
+    validates :qualification_type, length: { maximum: 255 }
+    validates :other_uk_qualification_type, length: { maximum: 255 }
 
     validates :missing_explanation, word_count: { maximum: 200 }
+
+    validates :subject, length: { maximum: 255 }
 
     def save_base(application_form)
       return false unless valid?

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -14,7 +14,7 @@ module CandidateInterface
               presence: true
 
     validates :first_name, :last_name,
-              length: { maximum: 100 }
+              length: { maximum: 60 }
 
     validate :date_of_birth_valid
     validate :date_of_birth_not_in_future

--- a/app/models/candidate_interface/sign_up_form.rb
+++ b/app/models/candidate_interface/sign_up_form.rb
@@ -4,6 +4,8 @@ module CandidateInterface
     attr_accessor :email_address, :accept_ts_and_cs, :candidate
 
     validates :email_address, :accept_ts_and_cs, presence: true
+    validates :email_address, length: { maximum: 100 }
+
     validate :candidate_email_address_is_valid
 
     def initialize(params = {})

--- a/app/models/candidate_interface/training_with_a_disability_form.rb
+++ b/app/models/candidate_interface/training_with_a_disability_form.rb
@@ -6,6 +6,10 @@ module CandidateInterface
 
     validates_inclusion_of :disclose_disability, in: %w[yes no]
 
+    validates :disability_disclosure,
+              word_count: { maximum: 400 },
+              allow_blank: true
+
     def self.build_from_application(application_form)
       new(
         disclose_disability: boolean_to_word(application_form.disclose_disability),

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -7,6 +7,7 @@ en:
             email_address:
               blank: Enter your email address
               invalid: Enter an email address in the correct format, like name@example.com
+              too_long: Email address must be %{count} characters or fewer
             accept_ts_and_cs:
               blank: You must agree to the terms of use
   authentication:

--- a/config/vendor-api-0.8.0.yml
+++ b/config/vendor-api-0.8.0.yml
@@ -327,10 +327,12 @@ components:
           example: "2019-06-13T10:44:31Z"
         personal_statement:
           type: string
+          maxLength: 6144  # 600 words
           description: The candidate’s personal statement, combined from the "Becoming a Teacher" and "Subject Knowledge" fields in the application form
           example: "Since retiring from the Police Service in 2007..."
         interview_preferences:
           type: string
+          maxLength: 2048  # 200 words
           description: The candidate’s interview preferences
           example: "I can’t come to interview on Thursdays"
         candidate:
@@ -363,6 +365,7 @@ components:
           $ref: "#/components/schemas/HESAITTData"
         further_information:
           type: string
+          maxLength: 3072  # 300 words
           nullable: true
           description: "Other personal or professional issues relevant to the application which are not covered in the form"
           example: "I am expecting to be called for jury service in the next 12 months"
@@ -411,6 +414,7 @@ components:
           description: One or more ISO 3166 country codes
         uk_residency_status:
           type: string
+          maxLength: 256
           description: "The candidate’s UK residency status, e.g. Citizen"
           example: UK Citizen
         english_main_language:
@@ -419,16 +423,19 @@ components:
           example: true
         english_language_qualifications:
           type: string
+          maxLength: 2048  # 200 words
           nullable: true
           description: About this candidate's English language qualifications, if English is not their main language
           example: "I have a degree in English Language and Literature from the University of Munich"
         other_languages:
           type: string
+          maxLength: 2048  # 200 words
           nullable: true
           description: Details of the candidate's fluency in other languages
           example: "I am bilingual in Finnish and English"
         disability_disclosure:
           type: string
+          maxLength: 4096  # 400 words
           nullable: true
           description: Voluntary disclosure of disabliity or SEN so providers can provide appropriate support
           example: "I am dyslexic"
@@ -472,6 +479,7 @@ components:
           example: SK2 6AA
         country:
           type: string
+          maxLength: 2
           description: The candidate’s country - ISO 3166 country code
           pattern: "^[A-Z]{2}$"
           example: GB
@@ -544,6 +552,7 @@ components:
       properties:
         qualification_type:
           type: string
+          maxLength: 255
           description: The qualification awarded
           example: BA
         subject:
@@ -553,10 +562,12 @@ components:
           example: History and Politics
         grade:
           type: string
+          maxLength: 255
           description: The grade awarded
           example: "2:1"
         award_year:
           type: string
+          maxLength: 4
           description: The year the award was made
           example: "1992"
         institution_details:
@@ -589,7 +600,7 @@ components:
         name:
           type: string
           description: The referee’s name
-          maxLength: 255
+          maxLength: 200
           example: Julia Wild
         email:
           type: string
@@ -599,11 +610,12 @@ components:
         relationship:
           type: string
           description: The referee’s relationship to the candidate
-          maxLength: 255
+          maxLength: 512  # 0.5k — 50 words
           example: Julia was my mentor at Cheadle Hulme High
         reference:
           type: string
           description: "The reference content provided by the referee."
+          maxLength: 3072  # 3k — 300 words
           example: Boris is committed to the profession of teaching...
     Rejection:
       type: object
@@ -687,7 +699,7 @@ components:
         organisation_name:
           type: string
           description: The organisation worked for
-          maxLength: 255
+          maxLength: 60
           example: Cheadle Hulme High School
         start_date:
           type: string
@@ -703,12 +715,12 @@ components:
         role:
           type: string
           description: The position held by the candidate
-          maxLength: 255
+          maxLength: 60
           example: Whole School Literacy Specialist
         description:
           type: string
           description: A written description of the work involved
-          maxLength: 4096
+          maxLength: 1536  # 1.5k — 150 words
           example: "I lead, develop and enhance the literacy teaching practice of others..."
         working_with_children:
           type: boolean
@@ -793,14 +805,17 @@ components:
         full_name:
           type: string
           description: The full name of the user who made this update
+          maxLength: 120
           example: "Jane Smith"
         email:
           type: string
           description: The email address of the user who made this update
+          maxLength: 100
           example: "jane.smith@example.com"
         user_id:
           type: string
           description: The ID of the user in the Student Record System, used for disambiguation
+          maxLength: 100
           example: "12345"
     MetaData:
       type: object
@@ -824,12 +839,10 @@ components:
         error:
           type: string
           description: Name of the current error
-          maxLength: 255
           example: "Unauthorized"
         message:
           type: string
           description: Description of the current error
-          maxLength: 255
           example: Please provide a valid authentication token
       required:
         - error

--- a/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_type_form_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe CandidateInterface::GcseQualificationTypeForm, type: :model do
     it { is_expected.to validate_presence_of(:level) }
     it { is_expected.to validate_presence_of(:subject) }
     it { is_expected.to validate_presence_of(:qualification_type) }
+
+    it { is_expected.to validate_length_of(:other_uk_qualification_type).is_at_most(255) }
+    it { is_expected.to validate_length_of(:qualification_type).is_at_most(255) }
+    it { is_expected.to validate_length_of(:subject).is_at_most(255) }
   end
 
   describe '#save_base' do

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -121,8 +121,8 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
     it { is_expected.to validate_presence_of(:first_nationality) }
     it { is_expected.to validate_presence_of(:english_main_language) }
 
-    it { is_expected.to validate_length_of(:first_name).is_at_most(100) }
-    it { is_expected.to validate_length_of(:last_name).is_at_most(100) }
+    it { is_expected.to validate_length_of(:first_name).is_at_most(60) }
+    it { is_expected.to validate_length_of(:last_name).is_at_most(60) }
 
     it 'validates nationalities against the NATIONALITY_DEMONYMS list' do
       details_with_invalid_nationality = CandidateInterface::PersonalDetailsForm.new(

--- a/spec/models/candidate_interface/sign_up_form_spec.rb
+++ b/spec/models/candidate_interface/sign_up_form_spec.rb
@@ -48,5 +48,6 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
   describe 'validations' do
     it { is_expected.to validate_presence_of(:accept_ts_and_cs) }
     it { is_expected.to validate_presence_of(:email_address) }
+    it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
   end
 end

--- a/spec/models/candidate_interface/training_with_a_disability_form_spec.rb
+++ b/spec/models/candidate_interface/training_with_a_disability_form_spec.rb
@@ -75,5 +75,11 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityForm, type: :model do
 
   describe 'validations' do
     it { is_expected.to validate_inclusion_of(:disclose_disability).in_array %w[yes no] }
+
+    valid_text = Faker::Lorem.sentence(word_count: 400)
+    invalid_text = Faker::Lorem.sentence(word_count: 401)
+
+    it { is_expected.to allow_value(valid_text).for(:disability_disclosure) }
+    it { is_expected.not_to allow_value(invalid_text).for(:disability_disclosure) }
   end
 end


### PR DESCRIPTION
We should now have `maxLength` for all relevant string attrs in the API. See commits for details.

https://trello.com/c/kxJsbCJE/1359-make-sure-we-specify-lengths