### PR TITLE
Sort providers alphabetically in the providers page

### DIFF
--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -23,6 +23,7 @@ module CandidateInterface
         .visible_to_candidates
         .includes(:provider)
         .group_by { |c| c.provider.name }
+        .sort_by { |provider_name, _| provider_name }
     end
   end
 end


### PR DESCRIPTION
### Context

https://www.apply-for-teacher-training.education.gov.uk/candidate/providers

I refreshed this page on production and got a different ordering, which made me think something changed.

### Changes proposed in this pull request

Adds a `sort_by`.

### Guidance to review

I looked but couldn't find system tests for this; if there already are, happy to add some tests.