### PR TITLE
Spike into implementing Apply 2

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -8,6 +8,11 @@ module CandidateInterface
       @application_form = current_application
     end
 
+    def apply_2
+      DuplicateApplication.new(current_application).duplicate
+      redirect_to candidate_interface_application_form_path
+    end
+
     def review
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
       @application_form = current_application

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -20,7 +20,8 @@ class Candidate < ApplicationRecord
   end
 
   def current_application
-    application_form = application_forms.first_or_create!
+    application_form = application_forms.last
+    application_form ||= application_forms.create!
     application_form
   end
 

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -33,9 +33,15 @@ module CandidateInterface
     end
 
     def candidate_can_only_apply_to_3_courses
-      return if application_form.application_choices.count <= 2
+      if application_form.apply_1?
+        return if application_form.application_choices.count <= 2
 
-      errors[:base] << 'You can only apply for up to 3 courses'
+        errors[:base] << 'You can only apply for up to 3 courses'
+      else
+        return if application_form.application_choices.count == 0
+
+        errors[:base] << 'You can only apply to 1 course'
+      end
     end
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -8,6 +8,14 @@ module CandidateInterface
       "Last saved on #{@application_form.updated_at.to_s(:govuk_date_and_time)}"
     end
 
+    def apply_1?
+      @application_form.apply_1?
+    end
+
+    def apply_2?
+      @application_form.apply_2?
+    end
+
     def sections_with_completion
       [
         # "Courses" section

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -1,0 +1,43 @@
+class DuplicateApplication
+  attr_reader :original_application_form
+
+  def initialize(original_application_form)
+    @original_application_form = original_application_form
+  end
+
+  def duplicate
+    attrs = original_application_form.attributes.except(*
+      %w[id created_at updated_at submitted_at course_choices_completed phase]
+    ).merge(
+      phase: 'apply_2'
+    )
+
+    new_application_form = ApplicationForm.create!(attrs)
+
+    original_application_form.application_work_experiences.each do |w|
+      new_application_form.application_work_experiences.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    original_application_form.application_volunteering_experiences.each do |w|
+      new_application_form.application_volunteering_experiences.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    original_application_form.application_qualifications.each do |w|
+      new_application_form.application_qualifications.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    original_application_form.references.each do |w|
+      new_application_form.references.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    true
+  end
+end

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -9,6 +9,14 @@
   Application submitted on <%= submitted_at_date %>. <%= govuk_link_to 'View application', candidate_interface_application_review_submitted_path %>
 </p>
 
+<% if ProcessState.new(@application_form).state == :ended_without_success %>
+  <p class="govuk-body">
+    Too bad, so sad. But you can go into Apply 2:
+
+    <%= button_to 'Go into Apply 2', candidate_interface_apply_2_path, class: 'govuk-button' %>
+  </p>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render(CandidateInterface::ApplicationCompleteContentComponent.new(application_form: @application_form)) %>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -22,7 +22,11 @@
       <%= t('page_titles.course_choices') %>
     </h2>
     <% unless @application_form_presenter.application_choices_added? %>
-      <p class="govuk-body"><%= t('application_form.courses.intro') %></p>
+      <% if @application_form_presenter.apply_1? %>
+        <p class="govuk-body"><%= t('application_form.courses.intro') %></p>
+      <% else %>
+        <p class="govuk-body">You can choose 1 course</p>
+      <% end %>
     <% end %>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">

--- a/app/views/candidate_interface/course_choices/_guidance.html.erb
+++ b/app/views/candidate_interface/course_choices/_guidance.html.erb
@@ -1,4 +1,3 @@
-<p class="govuk-body">You can apply for up to 3 courses at this stage of your application.</p>
 <p class="govuk-body">Not all courses and training providers are signed up to this service. If you choose a course that isn’t signed up to <%= service_name %>, you’ll be directed to UCAS to continue your application.</p>
 <p class="govuk-body">You can preview <%= govuk_link_to 'courses currently available', candidate_interface_providers_path %> on <%= service_name %>.</p>
 <p class="govuk-body">Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>

--- a/app/views/candidate_interface/course_choices/review.html.erb
+++ b/app/views/candidate_interface/course_choices/review.html.erb
@@ -13,7 +13,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @course_choices.count.present? %>
-        <% if @course_choices.count.between?(1, 2) %>
+        <% if @application_form.apply_1? && @course_choices.count.between?(1, 2) %>
           <h2 class="govuk-heading-m">Do you want to add another course?</h2>
           <%= render 'guidance' %>
           <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   namespace :candidate_interface, path: '/candidate' do
     get '/' => 'start_page#show', as: :start
 
+    post '/apply-2' => 'application_form#apply_2', as: :apply_2
+
     get '/accessibility', to: 'content#accessibility'
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/cookies', to: 'content#cookies_candidate', as: :cookies


### PR DESCRIPTION
### Context

We need to implement "Apply 2". This is when the first application was unsuccesful, and the candidate can now apply to 1 course at the time.

Things that we want from this system:

- [x] Candidates don't have to fill in stuff they've previously filled in
- [x] Candidates can change everything about their applications
- [x] Number of concurrent applications is limited to 1
- [ ] Guidance changes
- [ ] It's exposed in the API
- [ ] It doesn't mess with our reporting
- [ ] The code is easy to follow
- [ ] Users can't edit references

### Changes proposed in this pull request

Spikey code. The flow looks like this:

1. When the application is unsuccessful, the user gets a button to "try again"
2. This button duplicates the application, minus the choices
3. The user can then edit the application and make 1 new choice
4. Application is submitted as normal

![thing](https://user-images.githubusercontent.com/233676/70711471-8ef31e00-1cd9-11ea-9bee-f481904dbb8e.gif)

### Guidance to review

Can we think of other ways of implementing this?

### Link to Trello card

https://trello.com/c/GJb6DGs8