### PR TITLE
Do not assert on autogenerated ID in spec

### DIFF
--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -82,7 +82,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
 
       expect(qualifications).to include(
         have_attributes(
-          id: 1,
           qualification_type: 'BTEC',
           subject: 'Being a Superhero',
           institution_name: 'School of Heroes',


### PR DESCRIPTION
We don't decide what IDs things get, postgres does. This caused
intermittent spec failures.

There are plenty of other specs that explicitly set IDs. These may start
flaking too, but unlike this spec, they start to break once the explicit
ID is removed, eg /spec/components/volunteering_review_component_spec.rb:71
