### PR TITLE
Add Referee page, with authentication token

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -2,11 +2,37 @@ module RefereeInterface
   class ReferenceController < ActionController::Base
     layout 'application'
 
-    def comments
+    def feedback
       reference = Reference.find_by(token: params[:token])
 
       if reference.present?
+        @reference_form = RefereeInterface::ReferenceForm.build_from_reference(reference)
         @application = reference.application_form
+      else
+        render_404
+      end
+    end
+
+    def submit_feedback
+      reference = Reference.find_by(token: params[:token])
+      reference.feedback = params[:reference][:comments]
+      @application = reference.application_form
+
+      @reference_form = RefereeInterface::ReferenceForm.build_from_reference(reference)
+
+      if @reference_form.save(reference)
+        redirect_to referee_interface_confirmation_path
+      else
+        render :feedback
+      end
+    end
+
+    def finish; end
+
+    def confirmation
+      @reference = Reference.find_by(token: params[:token])
+      if @reference.present?
+        render :confirmation
       else
         render_404
       end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -3,8 +3,6 @@ module RefereeInterface
     layout 'application'
 
     def feedback
-      reference = Reference.find_by(token: params[:token])
-
       if reference.present?
         @reference_form = RefereeInterface::ReferenceForm.build_from_reference(reference)
         @application = reference.application_form
@@ -14,7 +12,6 @@ module RefereeInterface
     end
 
     def submit_feedback
-      reference = Reference.find_by(token: params[:token])
       reference.feedback = params[:reference][:comments]
       @application = reference.application_form
 
@@ -30,9 +27,18 @@ module RefereeInterface
     def finish; end
 
     def confirmation
-      @reference = Reference.find_by(token: params[:token])
-      if @reference.present?
+      if reference.present?
         render :confirmation
+      else
+        render_404
+      end
+    end
+
+    def decline
+      if reference.present?
+        @application = reference.application_form
+        #TODO: add logic to record this and notify candidate
+        render :decline
       else
         render_404
       end
@@ -42,6 +48,10 @@ module RefereeInterface
 
     def render_404
       render 'errors/not_found', status: :not_found
+    end
+
+    def reference
+      @reference ||= Reference.find_by(token: params[:token])
     end
   end
 end

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -1,0 +1,21 @@
+module RefereeInterface
+  class ReferenceController < ActionController::Base
+    layout 'application'
+
+    def comments
+      reference = Reference.find_by(token: params[:token])
+
+      if reference.present?
+        @application = reference.application_form
+      else
+        render_404
+      end
+    end
+
+  private
+
+    def render_404
+      render 'errors/not_found', status: :not_found
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,4 +36,8 @@ module ApplicationHelper
   def current_namespace
     params[:controller].split('/').first
   end
+
+  def full_name(application_form)
+    "#{application_form.first_name} #{application_form.last_name}"
+  end
 end

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -6,6 +6,7 @@ class RefereeMailer < ApplicationMailer
 
     if FeatureFlag.active?('reference_form')
       @reference_link = referee_interface_reference_feedback_url(token: reference.token)
+      @decline_reference_link = referee_interface_decline_feedback_url(token: reference.token)
       template_name = :reference_request_email
     else
       @reference_link = google_form_url_for(@candidate_name, @reference)

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -5,8 +5,7 @@ class RefereeMailer < ApplicationMailer
     @candidate_name = "#{application_form.first_name} #{application_form.last_name}"
 
     if FeatureFlag.active?('reference_form')
-      # reference.token.nil? ? reference.token = '1234567890' : reference.token
-      @reference_link = referee_interface_reference_comments_url(token: reference.token)
+      @reference_link = referee_interface_reference_feedback_url(token: reference.token)
       template_name = :reference_request_email
     else
       @reference_link = google_form_url_for(@candidate_name, @reference)

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -4,7 +4,7 @@ class RefereeMailer < ApplicationMailer
     @reference = reference
     @candidate_name = "#{application_form.first_name} #{application_form.last_name}"
 
-    @reference_link = candidate_interface_reference_comments_url(token: '1234567890')
+    @reference_link = referee_interface_reference_comments_url(token: reference.token)
 
     # TODO: add feature flag to switch between reference_link and google_form_link
     # google_form_url_for(@candidate_name, @reference)

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -3,7 +3,11 @@ class RefereeMailer < ApplicationMailer
     @application_form = application_form
     @reference = reference
     @candidate_name = "#{application_form.first_name} #{application_form.last_name}"
-    @google_form_url = google_form_url_for(@candidate_name, @reference)
+
+    @reference_link = candidate_interface_reference_comments_url(token: '1234567890')
+
+    # TODO: add feature flag to switch between reference_link and google_form_link
+    # google_form_url_for(@candidate_name, @reference)
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -4,14 +4,19 @@ class RefereeMailer < ApplicationMailer
     @reference = reference
     @candidate_name = "#{application_form.first_name} #{application_form.last_name}"
 
-    @reference_link = referee_interface_reference_comments_url(token: reference.token)
-
-    # TODO: add feature flag to switch between reference_link and google_form_link
-    # google_form_url_for(@candidate_name, @reference)
+    if FeatureFlag.active?('reference_form')
+      # reference.token.nil? ? reference.token = '1234567890' : reference.token
+      @reference_link = referee_interface_reference_comments_url(token: reference.token)
+      template_name = :reference_request_email
+    else
+      @reference_link = google_form_url_for(@candidate_name, @reference)
+      template_name = :reference_request_by_google_form_email
+    end
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,
-              subject: t('reference_request.subject.initial', candidate_name: @candidate_name))
+              subject: t('reference_request.subject.initial', candidate_name: @candidate_name),
+              template_name: template_name)
   end
 
   def reference_request_chaser_email(application_form, reference)

--- a/app/models/referee_interface/reference_form.rb
+++ b/app/models/referee_interface/reference_form.rb
@@ -1,0 +1,24 @@
+module RefereeInterface
+  class ReferenceForm
+    include ActiveModel::Model
+
+    attr_accessor :feedback
+
+    validates :feedback,
+              word_count: { maximum: 300 },
+              presence: true
+
+    def self.build_from_reference(reference)
+      new(
+        feedback: reference.feedback,
+      )
+    end
+
+    def save(reference)
+      return false unless valid?
+
+      reference.update!(feedback: feedback)
+      true
+    end
+  end
+end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -29,4 +29,9 @@ class Reference < ApplicationRecord
 
     errors.add(:email_address, :own) if email_address == candidate_email_address
   end
+
+  def update_token
+    raw_token, _encrypted_token = Devise.token_generator.generate(Reference, :token)
+    update(token: raw_token)
+  end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,6 +5,7 @@ class FeatureFlag
     conditional_science_gcse
     candidate_withdrawals
     training_with_a_disability
+    reference_form
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -21,7 +21,9 @@ class SubmitApplication
 private
 
   def send_reference_request_email_to_referees(application_form)
-    application_form.references.each do |reference|
+    application_form.references.includes(:application_form).each do |reference|
+      reference.update_token
+
       RefereeMailer.reference_request_email(application_form, reference).deliver_later
     end
   end
@@ -30,11 +32,6 @@ private
     application_choices.each do |application_choice|
       application_choice.edit_by = ApplicationDates.new(application_form).edit_by
       ApplicationStateChange.new(application_choice).submit!
-    end
-
-    application_form.references.includes(:application_form).each do |ref|
-      raw_token, _encrypted_token = Devise.token_generator.generate(Reference, :token)
-      ref.update(token: raw_token)
     end
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -32,10 +32,9 @@ private
       ApplicationStateChange.new(application_choice).submit!
     end
 
-    @application_form.reload.references.each do |reference|
+    application_form.references.includes(:application_form).each do |ref|
       _raw_token, encrypted_token = Devise.token_generator.generate(Reference, :token)
-
-      reference.update(token: encrypted_token)
+      ref.update(token: encrypted_token)
     end
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -33,8 +33,8 @@ private
     end
 
     application_form.references.includes(:application_form).each do |ref|
-      _raw_token, encrypted_token = Devise.token_generator.generate(Reference, :token)
-      ref.update(token: encrypted_token)
+      raw_token, _encrypted_token = Devise.token_generator.generate(Reference, :token)
+      ref.update(token: raw_token)
     end
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -31,5 +31,11 @@ private
       application_choice.edit_by = ApplicationDates.new(application_form).edit_by
       ApplicationStateChange.new(application_choice).submit!
     end
+
+    @application_form.reload.references.each do |reference|
+      _raw_token, encrypted_token = Devise.token_generator.generate(Reference, :token)
+
+      reference.update(token: encrypted_token)
+    end
   end
 end

--- a/app/views/referee_interface/reference/comments.html.erb
+++ b/app/views/referee_interface/reference/comments.html.erb
@@ -1,0 +1,62 @@
+<% content_for :title, t('page_titles.application') %>
+
+<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+
+<form action="/reference/confirmation" method="post">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">Tell us about <%= @application.first_name + ' ' + @application.last_name%></h1>
+
+        <p class="govuk-body">Try to cover the following, but don’t worry if there are areas you can’t comment on:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+          <li>
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
+            <p class="govuk-body">For example, does the candidate care about the wellbeing of children? Are they emotionally resilient and do they work well with others?</p>
+          </li>
+          <li>
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Subject knowledge</h2>
+            <p class="govuk-body">Is the candidate passionate and informed about their teaching subject?</p>
+          </li>
+          <li>
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
+            <p class="govuk-body">For example, does the candidate think critically and have good numeracy and literacy skills?</p>
+          </li>
+          <li>
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
+            <p class="govuk-body">What abilities would the candidate bring to teaching, for example, communication, creativity, project management?</p>
+          </li>
+          <li>
+            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
+            <p class="govuk-body">For example, can the candidate meet deadlines and manage their time?</p>
+          </li>
+        </ul>
+
+
+
+        <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="300">
+
+
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-label--m govuk-!-margin-top-6" for="reference-comments">
+              Your reference
+            </label>
+
+
+            <textarea class="govuk-textarea govuk-js-character-count" id="reference-comments" name="reference[comments]" rows="15" aria-describedby="reference-comments-info"></textarea><span id="reference-comments-info" class="govuk-hint govuk-character-count__message" aria-live="polite">You have 300 words remaining</span>
+          </div>
+
+
+        </div>
+
+        <button class="govuk-button" data-module="govuk-button">
+          Submit reference
+        </button>
+
+
+      </div>
+
+    </div>
+  </form>
+
+</main>

--- a/app/views/referee_interface/reference/comments.html.erb
+++ b/app/views/referee_interface/reference/comments.html.erb
@@ -6,7 +6,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Tell us about <%= @application.first_name + ' ' + @application.last_name%></h1>
+    <h1 class="govuk-heading-xl">Tell us about <%= @application.first_name + ' ' + @application.last_name %></h1>
 
         <p class="govuk-body">Try to cover the following, but don’t worry if there are areas you can’t comment on:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
@@ -32,30 +32,19 @@
           </li>
         </ul>
 
-
-
         <div class="govuk-character-count" data-module="govuk-character-count" data-maxwords="300">
-
-
           <div class="govuk-form-group">
             <label class="govuk-label govuk-label--m govuk-!-margin-top-6" for="reference-comments">
               Your reference
             </label>
-
-
             <textarea class="govuk-textarea govuk-js-character-count" id="reference-comments" name="reference[comments]" rows="15" aria-describedby="reference-comments-info"></textarea><span id="reference-comments-info" class="govuk-hint govuk-character-count__message" aria-live="polite">You have 300 words remaining</span>
           </div>
-
-
         </div>
 
         <button class="govuk-button" data-module="govuk-button">
           Submit reference
         </button>
-
-
       </div>
-
     </div>
   </form>
 

--- a/app/views/referee_interface/reference/confirmation.html.erb
+++ b/app/views/referee_interface/reference/confirmation.html.erb
@@ -1,0 +1,11 @@
+<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+
+  <%= form_with model: @reference, url: referee_interface_reference_finish_path, method: :get do |f| %>
+  <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
+      <h1 class="govuk-panel__title">
+        Your reference for <%= full_name(@reference.application_form) %> has been&nbsp;submitted
+      </h1>
+    </div>
+    <%= f.govuk_submit 'Finish' %>
+  <% end %>
+</main>

--- a/app/views/referee_interface/reference/decline.html.erb
+++ b/app/views/referee_interface/reference/decline.html.erb
@@ -1,0 +1,7 @@
+<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+    <h1 class="govuk-heading-xl">You’ve declined to give a reference</h1>
+    <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">We will tell <%= full_name(@application) %> and ask them for a new referee</h2>
+    <p class="govuk-body">If you declined in error, please email us at  <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p></div>
+</main>

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -2,11 +2,12 @@
 
 <main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
 
-<form action="/reference/confirmation" method="post">
-  <div class="govuk-grid-row">
+  <%= form_with model: @reference_form, url: referee_interface_submit_feedback_path, method: :patch do |f| %>
+    <%= f.govuk_error_summary %>
+    <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-xl">Tell us about <%= @application.first_name + ' ' + @application.last_name %></h1>
+    <h1 class="govuk-heading-xl">Tell us about <%= full_name(@application) %></h1>
 
         <p class="govuk-body">Try to cover the following, but don’t worry if there are areas you can’t comment on:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
@@ -41,11 +42,8 @@
           </div>
         </div>
 
-        <button class="govuk-button" data-module="govuk-button">
-          Submit reference
-        </button>
+      <%= f.govuk_submit 'Submit reference' %>
       </div>
     </div>
-  </form>
-
+  <% end %>
 </main>

--- a/app/views/referee_interface/reference/finish.html.erb
+++ b/app/views/referee_interface/reference/finish.html.erb
@@ -1,0 +1,7 @@
+<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+  <h1 class="govuk-heading-xl">Thank you</h1>
+    <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Our user research team will contact you shortly</h2>
+    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p></div>
+</main>

--- a/app/views/referee_mailer/reference_request_by_google_form_email.text.erb
+++ b/app/views/referee_mailer/reference_request_by_google_form_email.text.erb
@@ -1,0 +1,21 @@
+Dear <%= @reference.name %>,
+
+# Give a reference for <%= @candidate_name %>
+
+<%= @candidate_name %> put us in touch with you to get a reference for their teacher training application. They applied to:
+
+<% @application_form.application_choices.each do |application_choice| %>
+* <%= application_choice.provider.name %> - <%= application_choice.course.name %>
+<% end %>
+
+Please use the link below to give a complete reference as soon as possible.
+
+<%= @reference_link %>
+
+If we don’t hear from you within 5 working days we’ll send you a reminder.
+
+If you won’t give <%= @candidate_name %> a reference, please let us know as soon as possible by emailing: [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+
+# Your data
+
+We’ll only use your data to process the candidate’s application, unless you agree to be contacted by us about your experience of giving a reference. We’ll ask about this before you submit any information.

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -6,10 +6,6 @@ Please use the link below to give a reference as soon as possible
 
 <%= @reference_link %>
 
-If you won’t give <%= @candidate_name %> a reference, please let us know by clicking the link below:
-
-[The link]
-
 # Your data
 
 We’ll only use your data to process the candidate’s application, unless you agree to be contacted by us about your experience of giving a reference. We’ll ask about this before you submit any information.

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -1,20 +1,14 @@
 Dear <%= @reference.name %>,
 
-# Give a reference for <%= @candidate_name %>
+<%= @candidate_name %> put us in touch with you to get a reference for their teacher training application.
 
-<%= @candidate_name %> put us in touch with you to get a reference for their teacher training application. They applied to:
-
-<% @application_form.application_choices.each do |application_choice| %>
-* <%= application_choice.provider.name %> - <%= application_choice.course.name %>
-<% end %>
-
-Please use the link below to give a complete reference as soon as possible.
+Please use the link below to give a reference as soon as possible
 
 <%= @reference_link %>
 
-If we don’t hear from you within 5 working days we’ll send you a reminder.
+If you won’t give <%= @candidate_name %> a reference, please let us know by clicking the link below:
 
-If you won’t give <%= @candidate_name %> a reference, please let us know as soon as possible by emailing: [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+[The link]
 
 # Your data
 

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -10,7 +10,7 @@ Dear <%= @reference.name %>,
 
 Please use the link below to give a complete reference as soon as possible.
 
-<%= @google_form_url %>
+<%= @reference_link %>
 
 If we don’t hear from you within 5 working days we’ll send you a reminder.
 

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -6,6 +6,10 @@ Please use the link below to give a reference as soon as possible
 
 <%= @reference_link %>
 
+If you won’t give <%= @candidate_name %> a reference, please let us know by clicking the link below:
+
+<%= @decline_reference_link %>
+
 # Your data
 
 We’ll only use your data to process the candidate’s application, unless you agree to be contacted by us about your experience of giving a reference. We’ll ask about this before you submit any information.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   config.action_mailer.default_options = {
     from: 'mail@example.com',
   }
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: 'www.example.com', port: 3000 }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -520,3 +520,7 @@ en:
           attributes:
             comment:
               blank: Enter a comment
+        referee_interface/reference_form:
+          attributes:
+            feedback:
+              blank: Enter your reference

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -211,8 +211,11 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :referee_interface, path: '/referee' do
-    get 'comments/:token' => 'reference#comments', as: :reference_comments
+  namespace :referee_interface, path: '/reference' do
+    get '/finish' => 'reference#finish', as: :reference_finish
+    get '/:token/confirmation' => 'reference#confirmation', as: :confirmation
+    get '/:token' => 'reference#feedback', as: :reference_feedback
+    patch '/:token/confirmation' => 'reference#submit_feedback', as: :submit_feedback
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -214,6 +214,7 @@ Rails.application.routes.draw do
   namespace :referee_interface, path: '/reference' do
     get '/finish' => 'reference#finish', as: :reference_finish
     get '/:token/confirmation' => 'reference#confirmation', as: :confirmation
+    get '/:token/decline' => 'reference#decline', as: :decline_feedback
     get '/:token' => 'reference#feedback', as: :reference_feedback
     patch '/:token/confirmation' => 'reference#submit_feedback', as: :submit_feedback
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,6 +208,8 @@ Rails.application.routes.draw do
         get '/delete/:id' => 'referees#confirm_destroy', as: :confirm_destroy_referee
         delete '/delete/:id' => 'referees#destroy', as: :destroy_referee
       end
+
+      get 'reference/:token' => 'reference#comments', as: :reference_comments
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -208,9 +208,11 @@ Rails.application.routes.draw do
         get '/delete/:id' => 'referees#confirm_destroy', as: :confirm_destroy_referee
         delete '/delete/:id' => 'referees#destroy', as: :destroy_referee
       end
-
-      get 'reference/:token' => 'reference#comments', as: :reference_comments
     end
+  end
+
+  namespace :referee_interface, path: '/referee' do
+    get 'comments/:token' => 'reference#comments', as: :reference_comments
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/db/migrate/20191211142511_add_token_to_reference.rb
+++ b/db/migrate/20191211142511_add_token_to_reference.rb
@@ -1,0 +1,5 @@
+class AddTokenToReference < ActiveRecord::Migration[6.0]
+  def change
+    add_column :references, :token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -193,6 +193,7 @@ ActiveRecord::Schema.define(version: 2019_12_16_104559) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "name"
     t.string "relationship"
+    t.string "token"
     t.index ["application_form_id", "email_address"], name: "index_references_on_application_form_id_and_email_address", unique: true
     t.index ["application_form_id"], name: "index_references_on_application_form_id"
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -191,6 +191,7 @@ FactoryBot.define do
     email_address { "#{SecureRandom.hex(5)}@example.com" }
     name { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
     relationship { Faker::Lorem.paragraph(sentence_count: 3) }
+    token { SecureRandom.hex(8) }
 
     trait :unsubmitted do
       feedback { nil }

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     end
 
     it 'sends an email with a magic link' do
-      expect(mail.body.encoded).to include("http://localhost:3000/candidate/authenticate?token=#{token}")
+      expect(mail.body.encoded).to include("http://www.example.com:3000/candidate/authenticate?token=#{token}")
     end
   end
 
@@ -39,7 +39,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     end
 
     it 'sends an email with a magic link' do
-      expect(mail.body.encoded).to include("http://localhost:3000/candidate/authenticate?token=#{token}")
+      expect(mail.body.encoded).to include("http://www.example.com:3000/candidate/authenticate?token=#{token}")
     end
   end
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -24,25 +24,28 @@ RSpec.describe RefereeMailer, type: :mailer do
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
     let(:mail) { mailer.reference_request_email(application_form, reference) }
 
-    before { mail.deliver_now }
+    before do
+      FeatureFlag.activate('reference_form')
+      mail.deliver_now
+    end
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('reference_request.subject.initial', candidate_name: candidate_name))
     end
 
     it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include("Give a reference for #{candidate_name}")
+      expect(mail.body.encoded).to include("Dear #{reference.name}")
     end
 
-    it 'sends an email with the correct courses listed' do
-      expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
-      expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
-      expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
-    end
+    # it 'sends an email with the correct courses listed' do
+    #   expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
+    #   expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
+    #   expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
+    # end
 
     it 'sends an email with a link to the reference page' do
       body = mail.body.encoded
-      expect(body).to include(candidate_interface_reference_comments_url(token: '1234567890'))
+      expect(body).to include(referee_interface_reference_comments_url(token: reference.token))
     end
   end
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -40,23 +40,9 @@ RSpec.describe RefereeMailer, type: :mailer do
       expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
     end
 
-    it 'sends an email with a link to a prefilled Google form' do
+    it 'sends an email with a link to the reference page' do
       body = mail.body.encoded
-      expect(body).to include(t('reference_request.google_form_url'))
-      expect(body).to include("=#{reference.id}")
-      expect(body).to include("=#{CGI.escape(reference.email_address)}")
-    end
-
-    it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
-      expect(mail.body.encoded).to include('Harry%20O%27Potter')
-    end
-
-    context 'an email containing a +' do
-      let(:reference) { build(:reference, email_address: 'email+email@email.com') }
-
-      it 'does not strip the plus from the email address' do
-        expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
-      end
+      expect(body).to include(candidate_interface_reference_comments_url(token: '1234567890'))
     end
   end
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe RefereeMailer, type: :mailer do
 
     it 'sends an email with a link to the reference page' do
       body = mail.body.encoded
-      expect(body).to include(referee_interface_reference_comments_url(token: reference.token))
+      expect(body).to include(referee_interface_reference_feedback_url(token: reference.token))
     end
   end
 

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -32,5 +32,19 @@ RSpec.describe SubmitApplication do
       SubmitApplication.new(application_form).call
       expect(SlackNotificationWorker).to have_received(:perform_async).once # per application_form, not application_choices
     end
+
+    context 'when application has references' do
+      before do
+        create(:reference, application_form: application_form)
+        create(:reference, application_form: application_form)
+      end
+
+      it 'generates a magic link token for the referee' do
+        SubmitApplication.new(application_form).call
+
+        expect(application_form.reload.references.first.token).not_to be_empty
+        expect(application_form.reload.references.second.token).not_to be_empty
+      end
+    end
   end
 end

--- a/spec/system/candidate_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/candidate_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee submits a reference for a candidate', sidekiq: true do
+  include CandidateHelper
+
+  scenario 'Candidate with a completed application' do
+    FeatureFlag.activate('training_with_a_disability')
+
+    given_a_candidate_completed_an_application
+    # and_selected_me_as_a_referee
+    when_the_candidate_submits_the_application
+    then_i_receive_an_email_with_a_magic_link
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+  end
+
+  def then_i_receive_an_email_with_a_magic_link
+    open_email('terri@example.com')
+
+    current_email.click_link candidate_interface_reference_comments_url(token: '1234567890')
+  end
+end

--- a/spec/system/candidate_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/candidate_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Referee submits a reference for a candidate', sidekiq: true do
 
   scenario 'Candidate with a completed application' do
     FeatureFlag.activate('training_with_a_disability')
+    FeatureFlag.activate('reference_form')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -14,6 +14,9 @@ RSpec.feature 'Referee submits a reference for a candidate', sidekiq: true do
     when_i_try_to_access_the_reference_page_with_invalid_token
     then_i_see_page_not_found
 
+    when_i_click_the_decline_the_link_within_the_email
+    then_i_see_the_decline_page
+
     when_i_click_on_the_link_within_the_email
     then_i_see_the_reference_comment_page
 
@@ -44,6 +47,15 @@ RSpec.feature 'Referee submits a reference for a candidate', sidekiq: true do
 
   def then_i_see_page_not_found
     expect(page).to have_content('Page not found')
+  end
+
+  def when_i_click_the_decline_the_link_within_the_email
+    current_email.click_link referee_interface_decline_feedback_url(token: referee_token)
+  end
+
+  def then_i_see_the_decline_page
+    expect(page).to have_content('You’ve declined to give a reference')
+    expect(page).to have_content("We will tell #{@application.first_name} #{@application.last_name}")
   end
 
   def when_i_click_on_the_link_within_the_email

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -16,6 +16,13 @@ RSpec.feature 'Referee submits a reference for a candidate', sidekiq: true do
 
     when_i_click_on_the_link_within_the_email
     then_i_see_the_reference_comment_page
+
+    when_i_fill_in_the_reference_field
+    and_i_click_the_submit_button
+    then_i_see_the_success_page
+
+    when_i_click_finish_button
+    then_i_see_the_thank_you_page
   end
 
   def given_a_candidate_completed_an_application
@@ -28,11 +35,11 @@ RSpec.feature 'Referee submits a reference for a candidate', sidekiq: true do
 
   def then_i_receive_an_email_with_a_magic_link
     open_email('terri@example.com')
-    expect(current_email).to have_content(referee_interface_reference_comments_url(token: referee_token))
+    expect(current_email).to have_content(referee_interface_reference_feedback_url(token: referee_token))
   end
 
   def when_i_try_to_access_the_reference_page_with_invalid_token
-    visit referee_interface_reference_comments_url(token: 'invalid-token')
+    visit referee_interface_reference_feedback_url(token: 'invalid-token')
   end
 
   def then_i_see_page_not_found
@@ -40,11 +47,31 @@ RSpec.feature 'Referee submits a reference for a candidate', sidekiq: true do
   end
 
   def when_i_click_on_the_link_within_the_email
-    current_email.click_link referee_interface_reference_comments_url(token: referee_token)
+    current_email.click_link referee_interface_reference_feedback_url(token: referee_token)
   end
 
   def then_i_see_the_reference_comment_page
     expect(page).to have_content("Tell us about #{@application.first_name} #{@application.last_name}")
+  end
+
+  def when_i_fill_in_the_reference_field
+    fill_in 'Your reference', with: 'This is a reference for the candidate.'
+  end
+
+  def and_i_click_the_submit_button
+    click_button 'Submit reference'
+  end
+
+  def when_i_click_finish_button
+    click_button 'Finish'
+  end
+
+  def then_i_see_the_success_page
+    expect(page).to have_content("Your reference for #{@application.first_name} #{@application.last_name}")
+  end
+
+  def then_i_see_the_thank_you_page
+    expect(page).to have_content('Thank you')
   end
 
 private


### PR DESCRIPTION
## Context

This PR is the first slice of replacing the google form to a Referee page. This includes:

- Create the token for the referee (stored on Reference model)
- Create a new page to allow the referee to enter the comments https://apply-beta-prototype.herokuapp.com/reference/comments
- Include the token in the email and check the token is correct when trying to access the reference view

## Changes proposed in this pull request

- new Token on `Reference` model
- update email with new Token
- Add new view/controller in a new namespace
- Added new feature Flag `reference_form`

## Guidance to review
Tests are a good starting point

## Link to Trello card

https://trello.com/c/RrlqYDMz/585-referee-can-provide-a-reference-via-dfe-apply-service-%F0%9F%8F%88
