### PR TITLE
Fix the support applications view to match controller

### DIFF
--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -24,9 +24,9 @@
 <% end %>
 
 <% if @application_form.candidate.hide_in_reporting? %>
-  <%= button_to 'Show in reporting', support_interface_show_candidate_path(@application_form.candidate), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Show in reporting', support_interface_show_candidate_path(@application_form), class: 'govuk-button govuk-button--secondary' %>
 <% else %>
-  <%= button_to 'Hide in reporting', support_interface_hide_candidate_path(@application_form.candidate), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Hide in reporting', support_interface_hide_candidate_path(@application_form), class: 'govuk-button govuk-button--secondary' %>
 <% end %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Course choices</h2>


### PR DESCRIPTION
The controller and routes are expecting the application form ID, not the candidate ID.

## Context

A bug-fix to #871. Feature currently not working on QA because of a mismatch between the URL being generated by the view and what the route/controller is expecting.

This worked locally because the IDs happened to coincide.

## Changes proposed in this pull request

Align view and controller.

## Things to consider

Do we need a system test for this?