### PR TITLE
Add `Application#reject_by_default_at` to Vendor API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -15,6 +15,7 @@ module VendorApi
           submitted_at: application_form.submitted_at.iso8601,
           personal_statement: personal_statement,
           interview_preferences: application_form.interview_preferences,
+          reject_by_default_at: application_choice.reject_by_default_at&.iso8601,
           candidate: {
             id: "C#{application_form.candidate.id}",
             first_name: application_form.first_name,

--- a/app/views/api_docs/pages/alpha_release_notes.md
+++ b/app/views/api_docs/pages/alpha_release_notes.md
@@ -9,6 +9,9 @@ New attributes:
 
 - `Course` now has a `recruitment_cycle_year` integer attribute to
     indicate which recruitment year the Course belongs to, e.g. 2020.
+- `Application` now has a `reject_by_default_at` string attribute to
+    indicate when an application is (or was) due to be rejected by
+    default, e.g. "2019-06-13T23:59:59Z"
 
 Removed attributes:
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -297,6 +297,7 @@ components:
         - status
         - submitted_at
         - updated_at
+        - reject_by_default_at
         - withdrawal
         - hesa_itt_data
         - further_information
@@ -325,6 +326,12 @@ components:
           format: date-time
           description: ISO 8601 date of last change, with time and timezone
           example: "2019-06-13T10:44:31Z"
+        reject_by_default_at:
+          type: string
+          format: date-time
+          nullable: true
+          description: ISO 8601 date when the application is due to be rejected by default
+          example: "2019-06-13T23:59:59Z"
         personal_statement:
           type: string
           maxLength: 6144  # 600 words

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -162,6 +162,7 @@ RSpec.feature 'Vendor receives the application' do
         status: 'awaiting_provider_decision',
         submitted_at: @application.submitted_at.iso8601,
         updated_at: @application.application_choices.first.updated_at.iso8601,
+        reject_by_default_at: @application.application_choices.first.reject_by_default_at.iso8601,
         withdrawal: nil,
         further_information: '',
         work_experience: {


### PR DESCRIPTION
## Context

The `reject_by_default_at` datetime is important to Providers because it defines a deadline for them to make a decision about an application. Therefore it makes sense to return it 

## Changes proposed in this pull request

- [X] Add `reject_by_default_at` to presenter that serializes Applications
- [X] Update release notes
- [X] Update API spec

## Guidance to review

- Do the schema changes make sense? And release notes?
- Missing tests?

## Link to Trello card

https://trello.com/c/T5SH02qE/1385-should-we-include-rejectbydefaultdate-in-api-responses

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
