### PR TITLE
Ensure that qualifications and experiences are audited

### DIFF
--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -11,6 +11,8 @@ class ApplicationQualification < ApplicationRecord
     other: 'other',
   }
 
+  audited associated_with: :application_form
+
   def missing_qualification?
     qualification_type == 'missing'
   end

--- a/app/models/application_volunteering_experience.rb
+++ b/app/models/application_volunteering_experience.rb
@@ -1,3 +1,5 @@
 class ApplicationVolunteeringExperience < ApplicationExperience
   belongs_to :application_form
+
+  audited associated_with: :application_form
 end

--- a/app/models/application_work_experience.rb
+++ b/app/models/application_work_experience.rb
@@ -7,4 +7,6 @@ class ApplicationWorkExperience < ApplicationExperience
     full_time: 'Full-time',
     part_time: 'Part-time',
   }
+
+  audited associated_with: :application_form
 end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -30,4 +30,20 @@ RSpec.describe ApplicationQualification, type: :model do
         .to raise_error ArgumentError, "'invalid_level' is not a valid level"
     end
   end
+
+  describe 'auditing', with_audited: true do
+    it 'creates audit entries' do
+      application_form = create :application_form
+      application_qualification = create :application_qualification, application_form: application_form
+      expect(application_qualification.audits.count).to eq 1
+      application_qualification.update!(subject: 'Rocket Surgery')
+      expect(application_qualification.audits.count).to eq 2
+    end
+
+    it 'creates an associated object in each audit record' do
+      application_form = create :application_form
+      application_qualification = create :application_qualification, application_form: application_form
+      expect(application_qualification.audits.last.associated).to eq application_qualification.application_form
+    end
+  end
 end

--- a/spec/models/application_qualification_spec.rb
+++ b/spec/models/application_qualification_spec.rb
@@ -36,8 +36,9 @@ RSpec.describe ApplicationQualification, type: :model do
       application_form = create :application_form
       application_qualification = create :application_qualification, application_form: application_form
       expect(application_qualification.audits.count).to eq 1
-      application_qualification.update!(subject: 'Rocket Surgery')
-      expect(application_qualification.audits.count).to eq 2
+      expect {
+        application_qualification.update!(subject: 'Rocket Surgery')
+      }.to change { application_qualification.audits.count }.by(1)
     end
 
     it 'creates an associated object in each audit record' do

--- a/spec/models/application_volunteering_experience_spec.rb
+++ b/spec/models/application_volunteering_experience_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe ApplicationVolunteeringExperience, type: :model do
       application_form = create :application_form
       application_volunteering_experience = create :application_volunteering_experience, application_form: application_form
       expect(application_volunteering_experience.audits.count).to eq 1
-      application_volunteering_experience.update!(role: 'Rocket Surgeon')
-      expect(application_volunteering_experience.audits.count).to eq 2
+      expect {
+        application_volunteering_experience.update!(role: 'Rocket Surgeon')
+      }.to change { application_volunteering_experience.audits.count }.by(1)
     end
 
     it 'creates an associated object in each audit record' do

--- a/spec/models/application_volunteering_experience_spec.rb
+++ b/spec/models/application_volunteering_experience_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationVolunteeringExperience, type: :model do
+  describe 'auditing', with_audited: true do
+    it 'creates audit entries' do
+      application_form = create :application_form
+      application_volunteering_experience = create :application_volunteering_experience, application_form: application_form
+      expect(application_volunteering_experience.audits.count).to eq 1
+      application_volunteering_experience.update!(role: 'Rocket Surgeon')
+      expect(application_volunteering_experience.audits.count).to eq 2
+    end
+
+    it 'creates an associated object in each audit record' do
+      application_form = create :application_form
+      application_volunteering_experience = create :application_volunteering_experience, application_form: application_form
+      expect(application_volunteering_experience.audits.last.associated).to eq application_volunteering_experience.application_form
+    end
+  end
+end

--- a/spec/models/application_work_experience_spec.rb
+++ b/spec/models/application_work_experience_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationWorkExperience, type: :model do
+  describe 'auditing', with_audited: true do
+    it 'creates audit entries' do
+      application_form = create :application_form
+      application_work_experience = create :application_work_experience, application_form: application_form
+      expect(application_work_experience.audits.count).to eq 1
+      application_work_experience.update!(role: 'Rocket Surgeon')
+      expect(application_work_experience.audits.count).to eq 2
+    end
+
+    it 'creates an associated object in each audit record' do
+      application_form = create :application_form
+      application_work_experience = create :application_work_experience, application_form: application_form
+      expect(application_work_experience.audits.last.associated).to eq application_work_experience.application_form
+    end
+  end
+end

--- a/spec/models/application_work_experience_spec.rb
+++ b/spec/models/application_work_experience_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe ApplicationWorkExperience, type: :model do
     it 'creates audit entries' do
       application_form = create :application_form
       application_work_experience = create :application_work_experience, application_form: application_form
-      expect(application_work_experience.audits.count).to eq 1
-      application_work_experience.update!(role: 'Rocket Surgeon')
-      expect(application_work_experience.audits.count).to eq 2
+      expect(application_work_experience.audits.count).to be 1
+      expect {
+        application_work_experience.update!(role: 'Rocket Surgeon')
+      }.to change { application_work_experience.audits.count }.by(1)
     end
 
     it 'creates an associated object in each audit record' do


### PR DESCRIPTION
## Context

We need to see activity in the audit trail (History page in the Support Interface) for applications and all of the child objects. This includes volunteering experiences, work experience and qualifications.

## Changes proposed in this pull request

Tag the relevant models with the `audited` method so that they are all related to their parent application form.

![image](https://user-images.githubusercontent.com/450843/70808162-03e85580-1db7-11ea-834c-01031dc7ca41.png)


## Guidance to review

- Are tests sufficient? I've added a few model specs that are somewhat repetitive - they only really ensure that we don't mess up the configuration for these three models in future.

Has been tested manually in my dev env.

## Link to Trello card

https://trello.com/c/IN5xB5qu/1390-qualifications-work-history-and-volunteering-roles-arent-showing-up-in-the-audit-trail

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
