### PR TITLE
Fixed deployment bug for deployments that use SSL certs

### DIFF
--- a/azure/containers.json
+++ b/azure/containers.json
@@ -58,8 +58,16 @@
         },
         "customHostName": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "The top level common domain for the service, e.g. apply-for-teacher-training.education.gov.uk."
+            }
+        },
+        "certificateThumbprint": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SSL certificate thumbprint value."
             }
         },
         "containerInstanceNamePrefix": {
@@ -117,7 +125,7 @@
                         "value": "[parameters('customHostName')]"
                     },
                     "certificateThumbprint": {
-                        "value": "[if(greater(length(parameters('customHostName')), 0), reference('app-service-certificate', '2018-11-01').outputs.certificateThumbprint.value, '')]"
+                        "value": "[parameters('certificateThumbprint')]"
                     },
                     "runtimeStack": {
                         "value": "[variables('appServiceRuntimeStack')]"

--- a/azure/template.json
+++ b/azure/template.json
@@ -492,6 +492,9 @@
                     "customHostName": {
                         "value": "[parameters('customHostName')]"
                     },
+                    "certificateThumbprint": {
+                        "value": "[if(greater(length(parameters('customHostName')), 0), reference('app-service-certificate', '2018-11-01').outputs.certificateThumbprint.value, '')]"
+                    },
                     "containerInstanceNamePrefix": {
                         "value": "[parameters('containerInstanceNamePrefix')]"
                     },


### PR DESCRIPTION
## Context

An earlier change to simplify the environment variables overlooked the scenario where SSL certs are used in the environment during testing

## Changes proposed in this pull request

Moved the reference to the app service thumbprint out of the nested template the to the parent template where the reference can work. This value is then passed into the nested template directly as a parameter, rather than being referenced within the nested template which can't work.

## Guidance to review

Tested successfully in this pipeline run: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=35254&view=results
The QA branch uses SSL, while DevOps doesn't, proving the change can hand both scenarios.

## Link to Trello card

N/A - Bugfix

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
