### PR TITLE
Fix bug where users can sign in with an expired token

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -23,10 +23,11 @@ module CandidateInterface
     end
 
     def authenticate
-      user = FindCandidateByToken.call(raw_token: params[:token])
-      if user
-        sign_in(user, scope: :candidate)
-        add_identity_to_log user.id
+      candidate = FindCandidateByToken.call(raw_token: params[:token])
+
+      if candidate
+        sign_in(candidate, scope: :candidate)
+        add_identity_to_log candidate.id
         redirect_to candidate_interface_application_form_path
       else
         redirect_to action: :new

--- a/app/services/find_candidate_by_token.rb
+++ b/app/services/find_candidate_by_token.rb
@@ -1,6 +1,16 @@
 class FindCandidateByToken
+  MAX_TOKEN_DURATION = 1.hour
+
   def self.call(raw_token:)
     token = MagicLinkToken.from_raw(raw_token)
-    Candidate.find_by(magic_link_token: token)
+    candidate = Candidate.find_by(magic_link_token: token)
+
+    candidate if self.token_not_expired?(candidate)
+  end
+
+  def self.token_not_expired?(candidate)
+    return false if candidate.nil?
+
+    Time.now < (candidate.magic_link_token_sent_at + MAX_TOKEN_DURATION)
   end
 end

--- a/app/warden/magic_link_strategy.rb
+++ b/app/warden/magic_link_strategy.rb
@@ -1,6 +1,4 @@
 class MagicLinkStrategy < Warden::Strategies::Base
-  MAX_TOKEN_DURATION = 1.hour
-
   def valid?
     params[:token].present?
   end
@@ -8,16 +6,10 @@ class MagicLinkStrategy < Warden::Strategies::Base
   def authenticate!
     candidate = FindCandidateByToken.call(raw_token: params[:token])
 
-    if candidate.present? && token_not_expired?(candidate)
+    if candidate.present?
       success!(candidate)
     else
       fail!
     end
-  end
-
-private
-
-  def token_not_expired?(candidate)
-    Time.now < (candidate.magic_link_token_sent_at + MAX_TOKEN_DURATION)
   end
 end

--- a/spec/system/candidate_interface/candidate_account_multiple_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_multiple_sign_in_spec.rb
@@ -15,6 +15,9 @@ RSpec.feature 'Candidate account' do
 
     when_i_click_the_link_in_the_email_for(@second_email)
     then_i_am_signed_in_with(@second_email)
+
+    when_i_click_the_link_in_the_email_after_an_hour_for(@first_email)
+    then_i_am_signed_in_with(@second_email)
   end
 
   def then_i_can_sign_up_and_sign_out(email)
@@ -76,6 +79,12 @@ RSpec.feature 'Candidate account' do
 
   def when_i_click_the_link_in_the_email_for(email)
     @email_link_for[email].click
+  end
+
+  def when_i_click_the_link_in_the_email_after_an_hour_for(email)
+    Timecop.travel(Time.now + 1.hour + 1.second) do
+      @email_link_for[email].click
+    end
   end
 
   def then_i_am_signed_in_with(email)


### PR DESCRIPTION
## Context

If an existing session is in place, we follow a different code path which does not check for the `token_not_expired?` method. This allows users to sign in using an expired token.

## Changes proposed in this pull request

Hoist the `token_not_expired?` logic inside `FindCandidateByToken` so it's consistently applied wherever it's used.

## Guidance to review

Start by understanding the test; the rest of the implementation can be updated as needed, it feels clunky to me but I decided to open it for others to comment anyway.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)