### PR TITLE
Add button to open all courses through support

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -12,5 +12,14 @@ module SupportInterface
       SyncFromFind.perform_async
       redirect_to action: 'index'
     end
+
+    def open_all_courses
+      @provider = Provider.find(params[:provider_id])
+
+      @provider.courses.update_all(open_on_apply: true)
+
+      flash[:success] = 'Successfully updated all courses'
+      redirect_to support_interface_provider_path(@provider)
+    end
   end
 end

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -2,6 +2,18 @@
 
 <h2 class='govuk-heading-l'><%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.visible_to_candidates.size %> on DfE Apply)</h2>
 
+<% if @provider.courses.any? %>
+  <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>
+    <h3 class="govuk-heading-m">
+      Open all courses
+    </h3>
+
+    <p class="govuk-body">This will toggle every course on this provider to be available through Apply.</p>
+
+    <%= f.govuk_submit "Open #{pluralize(@provider.courses.size, 'course')}" %>
+  <% end %>
+<% end %>
+
 <table class='govuk-table'>
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ Rails.application.routes.draw do
     get '/providers' => 'providers#index', as: :providers
     post '/providers/sync' => 'providers#sync'
     get '/providers/:provider_id' => 'providers#show', as: :provider
+    post '/providers/:provider_id' => 'providers#open_all_courses'
 
     get '/courses/:course_id' => 'courses#show', as: :course
     post '/courses/:course_id' => 'courses#update'

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -24,6 +24,11 @@ RSpec.feature 'See providers' do
     when_i_visit_the_providers_page
     when_i_click_on_a_provider
     then_i_see_the_updated_providers_courses_and_sites
+
+    when_i_visit_the_providers_page
+    when_i_click_on_a_different_provider
+    and_i_choose_to_open_all_courses
+    then_all_courses_should_be_open_on_apply
   end
 
   def given_i_am_a_support_user
@@ -113,6 +118,18 @@ RSpec.feature 'See providers' do
 
   def then_i_see_the_updated_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
+    expect(page).to have_content '1 course (1 on DfE Apply)'
+  end
+
+  def when_i_click_on_a_different_provider
+    click_link 'Gorse SCITT'
+  end
+
+  def and_i_choose_to_open_all_courses
+    click_button 'Open 1 course'
+  end
+
+  def then_all_courses_should_be_open_on_apply
     expect(page).to have_content '1 course (1 on DfE Apply)'
   end
 end


### PR DESCRIPTION
## Context

Saves me having to submit ~100 forms ever again!

## Changes proposed in this pull request

![Screenshot 2019-12-13 at 17 14 24](https://user-images.githubusercontent.com/1650875/70818634-1ae57280-1dcc-11ea-858d-a1603ca1a0b3.png)

Click, and:

![Screenshot 2019-12-13 at 17 14 28](https://user-images.githubusercontent.com/1650875/70818637-1b7e0900-1dcc-11ea-8b35-4be7c40a88b9.png)

https://trello.com/c/poinLtZ3/1395-add-button-to-enable-all-courses-through-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)