### PR TITLE
Update model validations to allow start date to be equal to end date

### DIFF
--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -95,7 +95,7 @@ module CandidateInterface
     end
 
     def start_date_before_end_date
-      errors.add(:start_date, :before) unless start_date < end_date
+      errors.add(:start_date, :before) unless start_date <= end_date
     end
 
     def end_date_before_current_year_and_month

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -96,7 +96,7 @@ module CandidateInterface
     end
 
     def start_date_before_end_date
-      errors.add(:start_date, :before) unless start_date < end_date
+      errors.add(:start_date, :before) unless start_date <= end_date
     end
 
     def end_date_before_current_year_and_month

--- a/spec/models/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_role_form_spec.rb
@@ -166,6 +166,17 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
           ["Start date #{t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.start_date.before')}"],
         )
       end
+
+      it 'is valid if the date is equal to the end date' do
+        volunteering_role = CandidateInterface::VolunteeringRoleForm.new(
+          start_date_month: '5', start_date_year: '2017',
+          end_date_month: '5', end_date_year: '2017'
+        )
+
+        volunteering_role.validate
+
+        expect(volunteering_role.errors.full_messages_for(:start_date)).to be_empty
+      end
     end
 
     describe 'end date' do

--- a/spec/models/candidate_interface/work_experience_form_spec.rb
+++ b/spec/models/candidate_interface/work_experience_form_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
           ["Start date #{t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.start_date.before')}"],
         )
       end
+
+      it 'is valid if the date is equal to the end date' do
+        work_experience = CandidateInterface::WorkExperienceForm.new(
+          start_date_month: '5', start_date_year: '2018',
+          end_date_month: '5', end_date_year: '2018'
+        )
+
+        work_experience.validate
+
+        expect(work_experience.errors.full_messages_for(:start_date)).to be_empty
+      end
     end
 
     describe 'end date' do


### PR DESCRIPTION
## Context

Bug Fix. 

When a candidate enters a work or volunteering experience that is less than one month long (the start date is equal to end date) the validations fail and the candidate is told that the end date needs to be after the start date.

## Changes proposed in this pull request

Updated work experience and volunteering experience form model validations to allow a candidate to have a start date month/year be equal to end date month/year.
This allow candidates to enter experiences that lasted a month or shorter.

### Before

Work experience
<img width="1195" alt="Screenshot 2019-12-16 at 11 08 19" src="https://user-images.githubusercontent.com/47318392/70902436-ae998780-1ff4-11ea-9ac1-64679b60aca9.png">

Volunteering 
<img width="1208" alt="Screenshot 2019-12-16 at 11 08 53" src="https://user-images.githubusercontent.com/47318392/70902424-a6414c80-1ff4-11ea-9de9-96cc3a212b9b.png">

### After

Work experience
<img width="1198" alt="Screenshot 2019-12-16 at 11 07 10" src="https://user-images.githubusercontent.com/47318392/70902466-c1ac5780-1ff4-11ea-8f9f-44af04687ce0.png">

Volunteering 
<img width="1219" alt="Screenshot 2019-12-16 at 11 06 34" src="https://user-images.githubusercontent.com/47318392/70902472-c53fde80-1ff4-11ea-8119-3ad92e5e2c82.png">

## Guidance to review

Run specs to ensure that a candidate can enter a work_experience/volunteering start date (month/year) that is equal to the end date (month/year). 

## Link to Trello card

https://trello.com/c/YQu0SA3y/656-user-isnt-able-to-use-the-same-month-for-start-and-end-month-in-the-work-history-and-volunteering-sections

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
