### PR TITLE
Update interview preferences to a question

### DIFF
--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -12,7 +12,7 @@ module CandidateInterface
       @interview_preferences_form = InterviewPreferencesForm.new(interview_preferences_params)
 
       if @interview_preferences_form.save(current_application)
-        render :show
+        redirect_to candidate_interface_interview_preferences_show_path
       else
         render :edit
       end
@@ -26,7 +26,7 @@ module CandidateInterface
 
     def interview_preferences_params
       params.require(:candidate_interface_interview_preferences_form).permit(
-        :interview_preferences,
+        :any_preferences, :interview_preferences
       )
         .transform_values(&:strip)
     end

--- a/app/models/candidate_interface/interview_preferences_form.rb
+++ b/app/models/candidate_interface/interview_preferences_form.rb
@@ -2,24 +2,45 @@ module CandidateInterface
   class InterviewPreferencesForm
     include ActiveModel::Model
 
-    attr_accessor :interview_preferences
+    DEFAULT_NO_VALUE = I18n.t('application_form.personal_statement.interview_preferences.no_value')
 
-    validates :interview_preferences,
-              word_count: { maximum: 200 },
-              presence: true
+    attr_accessor :any_preferences, :interview_preferences
 
-    def self.build_from_application(application_form)
-      new(
-        interview_preferences: application_form.interview_preferences,
-      )
+    validates :any_preferences, presence: true
+    validates :interview_preferences, presence: true, if: :any_preferences?
+    validates :interview_preferences, word_count: { maximum: 200 }
+
+    class << self
+      def build_from_application(application_form)
+        new(
+          any_preferences: interview_preferences_to_any_preferences(application_form.interview_preferences),
+          interview_preferences: application_form.interview_preferences,
+        )
+      end
+
+      def interview_preferences_to_any_preferences(preferences)
+        if preferences.nil?
+          nil
+        elsif preferences == DEFAULT_NO_VALUE
+          'no'
+        else
+          'yes'
+        end
+      end
     end
 
     def save(application_form)
       return false unless valid?
 
       application_form.update(
-        interview_preferences: interview_preferences,
+        interview_preferences: any_preferences? ? interview_preferences : DEFAULT_NO_VALUE,
       )
+    end
+
+  private
+
+    def any_preferences?
+      any_preferences == 'yes'
     end
   end
 end

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -6,16 +6,24 @@
     <%= form_with model: @interview_preferences_form, url: candidate_interface_interview_preferences_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.label'), tag: 'h1', size: 'xl' }, rows: 8, max_words: 200 do %>
-        <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>any disability, health or personal issue you feel is relevant</li>
-          <li>special arrangements or assistance you may need</li>
-          <li>dates you are unavailable for interview</li>
-        </ul>
+      <h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>
+
+      <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>any disability, health or personal issue you feel is relevant</li>
+        <li>special arrangements or assistance you may need</li>
+        <li>dates you are unavailable for interview</li>
+      </ul>
+
+      <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>
+        <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
+          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label') }, rows: 8, max_words: 200 %>
+        <% end %>
+
+        <%= f.govuk_radio_button :any_preferences, 'no', label: { text: 'No' } %>
       <% end %>
 
-      <%= f.govuk_submit 'Continue' %>
+      <%= f.govuk_submit t('application_form.personal_statement.interview_preferences.complete_form_button') %>
     <% end %>
   </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -224,8 +224,10 @@ en:
       interview_preferences:
         key: Interview preferences
         change_action: interview preferences
-        label: Interview preferences
-        complete_form_button: Continue
+        label: Do you have any preferences for your interview?
+        complete_form_button: Save and continue
+        yes_label: What are your interview preferences?
+        no_value: None
     training_with_a_disability:
       complete_form_button: Continue
       disclose_disability:
@@ -365,8 +367,10 @@ en:
               too_many_words: Your subject knowledge must be %{count} words or fewer
         candidate_interface/interview_preferences_form:
           attributes:
+            any_preferences:
+              blank: Choose if you have any interview preferences
             interview_preferences:
-              blank: Enter your interview preferences. If you do not have any, enter 'none'
+              blank: Enter your interview preferences
               too_many_words: Your interview preferences must be %{count} words or fewer
         candidate_interface/further_information_form:
           attributes:

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -273,10 +273,11 @@ module CandidateHelper
   end
 
   def candidate_fills_in_interview_preferences
-    fill_in t('application_form.personal_statement.interview_preferences.label'), with: 'Not on a Wednesday'
+    choose 'Yes'
+    fill_in t('application_form.personal_statement.interview_preferences.yes_label'), with: 'Not on a Wednesday'
     click_button t('application_form.personal_statement.interview_preferences.complete_form_button')
     # Confirmation page
-    click_link t('application_form.personal_statement.interview_preferences.complete_form_button')
+    click_link 'Continue'
   end
 
   def current_candidate

--- a/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
@@ -11,12 +11,12 @@ RSpec.feature 'Entering interview preferences' do
     and_i_submit_the_form
     then_i_should_see_validation_errors
 
-    when_i_fill_in_an_answer
+    when_i_choose_yes_and_enter_my_preferences
     and_i_submit_the_form
     then_i_can_check_my_answers
 
     when_i_click_to_change_my_answer
-    and_i_fill_in_a_different_answer
+    and_i_choose_no
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
@@ -48,9 +48,11 @@ RSpec.feature 'Entering interview preferences' do
     first('.govuk-summary-list__actions').click_link 'Change'
   end
 
-  def when_i_fill_in_an_answer
+  def when_i_choose_yes_and_enter_my_preferences
     scope = 'application_form.personal_statement'
-    fill_in t('interview_preferences.label', scope: scope), with: 'Hello world'
+
+    choose 'Yes'
+    fill_in t('interview_preferences.yes_label', scope: scope), with: 'Hello world'
   end
 
   def then_i_can_check_my_answers
@@ -59,17 +61,16 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def then_i_should_see_validation_errors
-    expect(page).to have_content t('activemodel.errors.models.candidate_interface/interview_preferences_form.attributes.interview_preferences.blank')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/interview_preferences_form.attributes.any_preferences.blank')
   end
 
-  def and_i_fill_in_a_different_answer
-    scope = 'application_form.personal_statement'
-    fill_in t('interview_preferences.label', scope: scope), with: 'Hello world again'
+  def and_i_choose_no
+    choose 'No'
   end
 
   def then_i_can_check_my_revised_answers
     expect(page).to have_content t('page_titles.interview_preferences')
-    expect(page).to have_content 'Hello world again'
+    expect(page).to have_content t('application_form.personal_statement.interview_preferences.no_value')
   end
 
   def when_i_submit_my_interview_preferences


### PR DESCRIPTION
## Context

We want to change the design of the interview preferences page from a text area to radio buttons with a text area.

## Changes proposed in this pull request

This PR updates the interview preferences to question by:

- updating the view to use radio buttons instead of a single text area
- adding `any_preferences` to `CandidateInterface::InterviewPreferencesForm` which does some mapping using `interview_preferences` to know if we should select a radio button and which one to select (none, `Yes`, `No`)
- updates validation so that if no radio buttons are selected or `Yes` is selected by nothing is entered in the text area, then an error is thrown

## Screenshots

**Before**

![image](https://user-images.githubusercontent.com/42817036/70903391-b35f3b00-1ff6-11ea-94a5-27c4b4ccaf02.png)

**After**

![image](https://user-images.githubusercontent.com/42817036/70902567-0932e380-1ff5-11ea-87b8-e3ea12b73b46.png)

![image](https://user-images.githubusercontent.com/42817036/70902601-19e35980-1ff5-11ea-8a2e-e784c455412e.png)

![image](https://user-images.githubusercontent.com/42817036/70902636-2cf62980-1ff5-11ea-88cf-9fbe4afdf7a9.png)

**When `No` is selected**

![image](https://user-images.githubusercontent.com/42817036/70902647-341d3780-1ff5-11ea-9eee-d210ca016dca.png)

## Guidance to review

Would like feedback on:

- naming of the added `any_preferences` attribute
- the default value for `interview_preferences` if `No` is selected

## Link to Trello card

https://trello.com/c/htjXI6yz/465-update-interview-preferences-to-a-question

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)