### PR TITLE
Implement Withdrawal in the API

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -48,7 +48,7 @@ module VendorApi
           },
           offer: application_choice.offer,
           rejection: get_rejection,
-          withdrawal: nil,
+          withdrawal: withdrawal,
           hesa_itt_data: {
             sex: '2',
             disability: '00',
@@ -69,6 +69,15 @@ module VendorApi
           reason: application_choice.rejection_reason,
         }
       end
+    end
+
+    def withdrawal
+      return unless application_choice.withdrawn?
+
+      {
+        reason: nil, # Candidates aren't able to provide a withdrawal reason yet
+        date: application_choice.withdrawn_at.iso8601,
+      }
     end
 
     def nationalities

--- a/app/views/api_docs/pages/alpha_release_notes.md
+++ b/app/views/api_docs/pages/alpha_release_notes.md
@@ -3,6 +3,10 @@ These are the release notes for the API while still in alpha.
 See the [current release notes](/api-docs/release-notes) for the release notes
 once v1 is live.
 
+### Alpha release - 18 December 2019
+
+- Clarify that when an appliction is withdrawn, the `reason` can be null.
+
 ### Alpha release - 13 December 2019
 
 New attributes:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -323,7 +323,7 @@ components:
             The phase of this application. In the first phase, "Apply 1", the
             candidate can choose up to 3 courses. If all of those choices are rejected,
             declined, or withdrawn, the user can go into "Apply 2". This means
-            they can choose 1 course at a time. 
+            they can choose 1 course at a time.
           enum:
             - apply_1
             - apply_2
@@ -662,6 +662,7 @@ components:
           type: string
           description: Optional. The candidate’s reason for withdrawing
           maxLength: 255
+          nullable: true
           example: Candidate is unwell
         date:
           type: string

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
+# To avoid this test becoming too large, only use this spec to test complex
+# logic in the presenter. For anything that is passed straight from the database
+# to the API, make sure that spec/system/vendor_api/vendor_receives_application_spec.rb is updated.
 RSpec.describe VendorApi::SingleApplicationPresenter do
   describe 'attributes.candidate.nationality' do
     it 'returns nationality in the correct format' do
@@ -10,6 +13,18 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
 
       expect(response.to_json).to be_valid_against_openapi_schema('Application')
       expect(response[:attributes][:candidate][:nationality]).to eq(%w[GB US])
+    end
+  end
+
+  describe 'attributes.withdrawal' do
+    it 'returns a withdrawal object' do
+      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'British', second_nationality: 'American')
+      application_choice = create(:application_choice, status: 'withdrawn', application_form: application_form, withdrawn_at: '2019-01-01')
+
+      response = VendorApi::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.to_json).to be_valid_against_openapi_schema('Application')
+      expect(response[:attributes][:withdrawal]).to eq(reason: nil, date: '2019-01-01T00:00:00+00:00')
     end
   end
 

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -1,26 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe VendorApi::SingleApplicationPresenter do
-  let(:application_form) do
-    create(:completed_application_form) do |form|
-      form.first_nationality = 'British'
-      form.second_nationality = 'American'
-    end
-  end
-  let(:application_choice) do
-    create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
-  end
-
-  describe '#candidate' do
+  describe 'attributes.candidate.nationality' do
     it 'returns nationality in the correct format' do
-      single_application_presenter = VendorApi::SingleApplicationPresenter.new(application_choice)
+      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'British', second_nationality: 'American')
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
 
-      expect(single_application_presenter.as_json[:attributes][:candidate][:nationality]).to eq(%w[GB US])
+      response = VendorApi::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.to_json).to be_valid_against_openapi_schema('Application')
+      expect(response[:attributes][:candidate][:nationality]).to eq(%w[GB US])
     end
   end
 
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
+      let(:application_choice) do
+        create(:application_choice, status: 'awaiting_provider_decision', application_form: create(:completed_application_form))
+      end
+
       let(:given_relation) { GetApplicationChoicesForProvider.call(provider: application_choice.provider) }
       let!(:presenter) { VendorApi::SingleApplicationPresenter.new(given_relation.first) }
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
+# This is an end-to-end test for the API response. To test complex logic in
+# the presenter, see spec/presenters/vendor_api/single_application_presenter_spec.rb.
 RSpec.feature 'Vendor receives the application' do
   include CandidateHelper
 


### PR DESCRIPTION
## Context

When an application is withdrawn, this adds the proper Withdrawal object to the API response. Because the `reason` isn’t collected yet from the candidate it’s made optional.

## Changes proposed in this pull request

See commits.

## Guidance to review

Is this the right way to test this?

## Link to Trello card

https://trello.com/c/ANmz8pDt/1397-add-withdraw-to-api-output

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
