### PR TITLE
Tweak spacing and dumb quote on candidate dashboard

### DIFF
--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -4,7 +4,7 @@
   </h2>
 
   <p class="govuk-body">
-    We've sent you an email to confirm this. Your training provider will be in
+    We’ve sent you an email to confirm this. Your training provider will be in
     touch with you direct to explain what happens next.
   </p>
 <% elsif all_choices_withdrawn? %>

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -15,7 +15,7 @@
 
     <hr class="govuk-section-break govuk-section-break--m">
 
-    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-4">References</h2>
+    <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">References</h2>
 
     <p class="govuk-body">We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.</p>
 


### PR DESCRIPTION
## Changes proposed in this pull request

* Increase margin above ‘References’ heading on dashboard (to match that used in prototype)
* Replace dumb quote in `We've`