### PR TITLE
Fix process state logic for certain states

### DIFF
--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -10,9 +10,9 @@ class ProcessState
       :unsubmitted
     elsif all_states_are?('unsubmitted')
       :unsubmitted
-    elsif all_states_are?('awaiting_references')
+    elsif any_state_is?('awaiting_references')
       :awaiting_references
-    elsif all_states_are?('application_complete')
+    elsif any_state_is?('application_complete')
       :waiting_to_be_sent
     elsif any_state_is?('awaiting_provider_decision')
       :awaiting_provider_decisions

--- a/spec/services/process_state_spec.rb
+++ b/spec/services/process_state_spec.rb
@@ -18,8 +18,18 @@ RSpec.describe ProcessState do
       expect(state).to be(:unsubmitted)
     end
 
-    it 'returns awaiting_references when awaiting references' do
+    it 'returns awaiting_references when awaiting references for all choices' do
       application_form = build_stubbed(:application_form, application_choices: build_list(:application_choice, 2, status: 'awaiting_references'))
+
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:awaiting_references)
+    end
+
+    it 'returns awaiting_references when awaiting references for any choice' do
+      application_form = create(:application_form)
+      create(:application_choice, application_form: application_form, status: 'awaiting_provider_decision')
+      create(:application_choice, application_form: application_form, status: 'awaiting_references')
 
       state = ProcessState.new(application_form).state
 


### PR DESCRIPTION
## Context

When initially building the process state logic, I thought that an application could only have all of its states the same in certain states.

I didn’t consider cases where the candidate has withdrawn from a course choice.

## Changes proposed in this pull request

Display `awaiting_references` if _any_ of the choices is in `awaiting_references`, and the same for `application_complete`.

## Guidance to review

Check the logic.

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
