### PR TITLE
Add chase email for referee and candidate

### DIFF
--- a/app/components/reference_with_feedback_component.html.erb
+++ b/app/components/reference_with_feedback_component.html.erb
@@ -1,3 +1,13 @@
 <div data-qa="reference">
-  <%= render SummaryListComponent, rows: rows %>
+  <%= render SummaryCardComponent, rows: rows do %>
+    <% if @show_chase_reference %>
+      <%= render(SummaryCardHeaderComponent, title: @title) do %>
+          <div class='app-summary-card__actions'>
+            <%= link_to support_interface_chase_reference_path(@reference), class: 'govuk-link' do %>
+              <%= t('application_form.referees.chase') %>
+            <% end %>
+          </div>
+      <% end %>
+    <% end %>
+  <% end %>
 </div>

--- a/app/components/reference_with_feedback_component.rb
+++ b/app/components/reference_with_feedback_component.rb
@@ -7,8 +7,10 @@ class ReferenceWithFeedbackComponent < ActionView::Component::Base
            :relationship,
            to: :reference
 
-  def initialize(reference:)
+  def initialize(reference:, title: '', show_chase_reference: false)
     @reference = reference
+    @title = title
+    @show_chase_reference = show_chase_reference
   end
 
   def rows
@@ -52,5 +54,5 @@ private
     end
   end
 
-  attr_reader :reference
+  attr_reader :reference, :title, :show_chase_reference
 end

--- a/app/controllers/support_interface/chase_reference_controller.rb
+++ b/app/controllers/support_interface/chase_reference_controller.rb
@@ -10,6 +10,7 @@ module SupportInterface
       @application_form = @reference.application_form
 
       RefereeMailer.reference_request_chaser_email(@application_form, @reference).deliver
+      CandidateMailer.reference_chaser_email(@application_form, @reference).deliver
 
       flash[:success] = t('application_form.referees.chase_success')
 

--- a/app/controllers/support_interface/chase_reference_controller.rb
+++ b/app/controllers/support_interface/chase_reference_controller.rb
@@ -9,8 +9,7 @@ module SupportInterface
       @reference = Reference.find(params[:reference_id])
       @application_form = @reference.application_form
 
-      RefereeMailer.reference_request_chaser_email(@application_form, @reference).deliver
-      CandidateMailer.reference_chaser_email(@application_form, @reference).deliver
+      SendChaseEmailToRefereeAndCandidate.call(application_form: @application_form, reference: @reference)
 
       flash[:success] = t('application_form.referees.chase_success')
 

--- a/app/controllers/support_interface/chase_reference_controller.rb
+++ b/app/controllers/support_interface/chase_reference_controller.rb
@@ -1,0 +1,19 @@
+module SupportInterface
+  class ChaseReferenceController < SupportInterfaceController
+    def show
+      @reference = Reference.find(params[:reference_id])
+      @application_form = @reference.application_form
+    end
+
+    def chase
+      @reference = Reference.find(params[:reference_id])
+      @application_form = @reference.application_form
+
+      RefereeMailer.reference_request_chaser_email(@application_form, @reference).deliver
+
+      flash[:success] = t('application_form.referees.chase_success')
+
+      redirect_to support_interface_application_form_path(@application_form)
+    end
+  end
+end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -19,4 +19,14 @@ class CandidateMailer < ApplicationMailer
               to: application_form.candidate.email_address,
               subject: t('application_under_consideration.email.subject'))
   end
+
+  def reference_chaser_email(application_form, reference)
+    @candidate_name = application_form.first_name
+    @referee_name = reference.name
+    @referee_email = reference.email_address
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: application_form.candidate.email_address,
+              subject: t('candidate_reference.subject.chaser', referee_name: @referee_name))
+  end
 end

--- a/app/services/send_chase_email_to_referee_and_candidate.rb
+++ b/app/services/send_chase_email_to_referee_and_candidate.rb
@@ -1,0 +1,15 @@
+class SendChaseEmailToRefereeAndCandidate
+  def self.call(application_form:, reference:)
+    RefereeMailer.reference_request_chaser_email(application_form, reference).deliver
+    CandidateMailer.reference_chaser_email(application_form, reference).deliver
+
+    audit_comment = I18n.t(
+      'application_form.referees.audit_comment',
+      referee_email: reference.email_address,
+      candidate_email: application_form.candidate.email_address,
+    )
+
+    application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
+    application_comment.save(application_form)
+  end
+end

--- a/app/views/candidate_mailer/reference_chaser_email.text.erb
+++ b/app/views/candidate_mailer/reference_chaser_email.text.erb
@@ -1,0 +1,15 @@
+Dear <%= @candidate_name %>,
+
+# Get in contact with <%= @referee_name %>
+
+We haven’t heard back from your referee yet.
+
+Ask the referee to check their email and give a reference as soon as possible.
+
+You gave us this address for the referee: <%= @referee_email %>
+
+We need to hear from <%= @referee_name %> within 5 working days.
+
+If this email address is wrong please get in touch with us with us at:
+
+[becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -44,8 +44,7 @@
 <% end %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">References</h2>
-<% @application_form.references.each_with_index do |reference, i| %>
-  <h2 class="govuk-heading-m"><%= (i + 1).ordinalize %> reference</h2>
 
-  <%= render ReferenceWithFeedbackComponent, reference: reference %>
+<% @application_form.references.each_with_index do |reference, i| %>
+  <%= render ReferenceWithFeedbackComponent, reference: reference, title: "#{(i + 1).ordinalize} reference", show_chase_reference: true %>
 <% end %>

--- a/app/views/support_interface/chase_reference/show.html.erb
+++ b/app/views/support_interface/chase_reference/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, t('application_form.referees.confirm_chase') %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form), 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @reference, url: support_interface_chase_reference_path(@reference), method: :post do |f| %>
+      <%= f.submit t('application_form.referees.chase_button'), class: 'govuk-button', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', support_interface_application_form_path(@application_form) %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/chase_reference/show.html.erb
+++ b/app/views/support_interface/chase_reference/show.html.erb
@@ -4,6 +4,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @reference, url: support_interface_chase_reference_path(@reference), method: :post do |f| %>
+      <p class="govuk-body">We will send:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>a reminder email to the referee</li>
+        <li>an email to the candidate telling them we are still waiting for this reference</li>
+      </ul>
+
       <%= f.submit t('application_form.referees.chase_button'), class: 'govuk-button', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -304,6 +304,10 @@ en:
         - (should never appear)
         - First referee
         - Second referee
+      chase: Chase referee
+      confirm_chase: Are you sure you want to send an email to chase the referee?
+      chase_button: Yes - send the email
+      chase_success: Email sent to candidate and referee
   activemodel:
     errors:
       models:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -308,6 +308,7 @@ en:
       confirm_chase: Are you sure you want to send emails to chase the referee?
       chase_button: Yes - send the email
       chase_success: Email sent to candidate and referee
+      audit_comment: "Chase emails have been sent to the referee (%{referee_email}) and candidate (%{candidate_email})."
   activemodel:
     errors:
       models:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -305,7 +305,7 @@ en:
         - First referee
         - Second referee
       chase: Chase referee
-      confirm_chase: Are you sure you want to send an email to chase the referee?
+      confirm_chase: Are you sure you want to send emails to chase the referee?
       chase_button: Yes - send the email
       chase_success: Email sent to candidate and referee
   activemodel:

--- a/config/locales/chaser_emails.yml
+++ b/config/locales/chaser_emails.yml
@@ -8,3 +8,6 @@ en:
     reference_id_entry: entry.1515340886
     candidate_name_entry: entry.1696393181
     referee_name_entry: entry.994572146
+  candidate_reference:
+    subject:
+      chaser: "%{referee_name} hasn’t given a reference yet"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -268,6 +268,9 @@ Rails.application.routes.draw do
     post '/candidates/:candidate_id/show' => 'candidates#show_in_reporting', as: :show_candidate
     post '/candidates/:candidate_id/impersonate' => 'candidates#impersonate', as: :impersonate_candidate
 
+    get '/chase-reference/:reference_id' => 'chase_reference#show', as: :chase_reference
+    post '/chase-reference/:reference_id' => 'chase_reference#chase'
+
     get '/tokens' => 'api_tokens#index', as: :api_tokens
     post '/tokens' => 'api_tokens#create'
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -20,4 +20,24 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect(mail.body.encoded).to include('SUPPORT-REFERENCE')
     end
   end
+
+  describe 'Send reference chaser email' do
+    let(:application_form) { create(:completed_application_form) }
+    let(:reference) { application_form.references.first }
+    let(:mail) { mailer.reference_chaser_email(application_form, reference) }
+
+    before { mail.deliver_later }
+
+    it 'sends an email with the correct subject' do
+      expect(mail.subject).to include(t('candidate_reference.subject.chaser', referee_name: reference.name))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(mail.body.encoded).to include("Dear #{application_form.first_name}")
+    end
+
+    it 'sends an email containing the referee email' do
+      expect(mail.body.encoded).to include(reference.email_address)
+    end
+  end
 end

--- a/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
+++ b/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature 'Send chase email to referee' do
+RSpec.feature 'Send chase email to referee and candidate' do
   include DfESignInHelpers
 
-  scenario 'Support agent sends a chase email to a referee' do
+  scenario 'Support agent sends a chase email to a referee and candidate' do
     given_i_am_a_support_user
     and_there_is_an_application_awaiting_references
     and_i_visit_the_support_page
@@ -15,7 +15,8 @@ RSpec.feature 'Send chase email to referee' do
     then_i_see_a_confirmation_page
 
     when_i_click_to_confirm_sending_the_chase_email
-    then_i_see_the_email_is_successfully_sent
+    then_i_see_the_referee_email_is_successfully_sent
+    and_i_see_the_candidate_email_is_successfully_sent
     and_i_am_sent_back_to_the_application_form_with_a_flash
   end
 
@@ -51,11 +52,17 @@ RSpec.feature 'Send chase email to referee' do
     click_button t('application_form.referees.chase_button')
   end
 
-  def then_i_see_the_email_is_successfully_sent
+  def then_i_see_the_referee_email_is_successfully_sent
     candidate_name = "#{@application_awaiting_references.first_name} #{@application_awaiting_references.last_name}"
     open_email(@application_awaiting_references.references.first.email_address)
 
     expect(current_email.subject).to have_content(t('reference_request.subject.chaser', candidate_name: candidate_name))
+  end
+
+  def and_i_see_the_candidate_email_is_successfully_sent
+    open_email(@application_awaiting_references.candidate.email_address)
+
+    expect(current_email.subject).to have_content(t('candidate_reference.subject.chaser', referee_name: @application_awaiting_references.references.first.name))
   end
 
   def and_i_am_sent_back_to_the_application_form_with_a_flash

--- a/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
+++ b/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Send chase email to referee and candidate' do
+RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
   include DfESignInHelpers
 
   scenario 'Support agent sends a chase email to a referee and candidate' do
@@ -18,6 +18,9 @@ RSpec.feature 'Send chase email to referee and candidate' do
     then_i_see_the_referee_email_is_successfully_sent
     and_i_see_the_candidate_email_is_successfully_sent
     and_i_am_sent_back_to_the_application_form_with_a_flash
+
+    when_i_click_on_the_history_for_the_application
+    then_i_see_a_comment_stating_chase_emails_have_been_sent
   end
 
   def given_i_am_a_support_user
@@ -67,5 +70,19 @@ RSpec.feature 'Send chase email to referee and candidate' do
 
   def and_i_am_sent_back_to_the_application_form_with_a_flash
     expect(page).to have_content(t('application_form.referees.chase_success'))
+  end
+
+  def when_i_click_on_the_history_for_the_application
+    click_link 'History'
+  end
+
+  def then_i_see_a_comment_stating_chase_emails_have_been_sent
+    referee_email = @application_awaiting_references.references.first.email_address
+    candidate_email = @application_awaiting_references.candidate.email_address
+
+    within('tbody tr:eq(1)') do
+      expect(page).to have_content 'Comment on Application Form'
+      expect(page).to have_content t('application_form.referees.audit_comment', referee_email: referee_email, candidate_email: candidate_email)
+    end
   end
 end

--- a/spec/system/support_interface/send_chase_email_to_referee_spec.rb
+++ b/spec/system/support_interface/send_chase_email_to_referee_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.feature 'Send chase email to referee' do
+  include DfESignInHelpers
+
+  scenario 'Support agent sends a chase email to a referee' do
+    given_i_am_a_support_user
+    and_there_is_an_application_awaiting_references
+    and_i_visit_the_support_page
+
+    when_i_click_on_the_application_awaiting_references
+    then_i_should_be_on_the_view_application_page
+
+    when_i_click_on_chase_reference
+    then_i_see_a_confirmation_page
+
+    when_i_click_to_confirm_sending_the_chase_email
+    then_i_see_the_email_is_successfully_sent
+    and_i_am_sent_back_to_the_application_form_with_a_flash
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application_awaiting_references
+    @application_awaiting_references = create(:completed_application_form)
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_the_application_awaiting_references
+    click_on @application_awaiting_references.candidate.email_address
+  end
+
+  def then_i_should_be_on_the_view_application_page
+    expect(page).to have_content @application_awaiting_references.candidate.email_address
+  end
+
+  def when_i_click_on_chase_reference
+    first(:link, t('application_form.referees.chase')).click
+  end
+
+  def then_i_see_a_confirmation_page
+    expect(page).to have_content(t('application_form.referees.confirm_chase'))
+  end
+
+  def when_i_click_to_confirm_sending_the_chase_email
+    click_button t('application_form.referees.chase_button')
+  end
+
+  def then_i_see_the_email_is_successfully_sent
+    candidate_name = "#{@application_awaiting_references.first_name} #{@application_awaiting_references.last_name}"
+    open_email(@application_awaiting_references.references.first.email_address)
+
+    expect(current_email.subject).to have_content(t('reference_request.subject.chaser', candidate_name: candidate_name))
+  end
+
+  def and_i_am_sent_back_to_the_application_form_with_a_flash
+    expect(page).to have_content(t('application_form.referees.chase_success'))
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to manually send chase emails to a referee and a candidate to notify them that we haven't received a reference from them.

## Changes proposed in this pull request

This PR adds the ability to send chase emails to a referee and candidate from the Support Interface by:

- updating the `ReferenceWithFeedbackComponent` with an optional `Chase reference` link
- adding a candidate chase email

**To do:**

- [x] add an audit comment so we know when chase emails have been sent out

## Screenshots (Updated 17 Dec, 10:20)

![image](https://user-images.githubusercontent.com/42817036/70986980-eb2db780-20b6-11ea-9eab-f20d5fb94116.png)

![image](https://user-images.githubusercontent.com/42817036/70987007-fb459700-20b6-11ea-860d-7ed1e7dabb2b.png)

![image](https://user-images.githubusercontent.com/42817036/70929193-685f1b00-202a-11ea-8606-93cf7009e905.png)

![image](https://user-images.githubusercontent.com/42817036/70987060-11ebee00-20b7-11ea-88a8-c311b56529b0.png)

## Guidance to review

Would like feedback on:

- the design from @adamsilver 

## Link to Trello card

https://trello.com/c/2ckyIKa6/516-wire-up-support-console-so-that-it-can-send-manual-emails

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
