### PR TITLE
Support interface candidate list improvements

### DIFF
--- a/app/components/support_interface/candidates_table_component.html.erb
+++ b/app/components/support_interface/candidates_table_component.html.erb
@@ -2,6 +2,7 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Candidate</th>
+      <th scope="col" class="govuk-table__header">Status of latest application</th>
       <th scope="col" class="govuk-table__header">Last updated</th>
     </tr>
   </thead>
@@ -12,6 +13,7 @@
         <td class="govuk-table__cell">
           <%= table_row[:candidate_link] %>
         </td>
+        <td class="govuk-table__cell"><%= t "process_states.#{table_row[:process_state]}.name" %></td>
         <td class="govuk-table__cell"><%= table_row[:updated_at] %></td>
       </tr>
     <% end %>

--- a/app/components/support_interface/candidates_table_component.rb
+++ b/app/components/support_interface/candidates_table_component.rb
@@ -10,6 +10,7 @@ module SupportInterface
       candidates.map do |candidate|
         {
           candidate_id: candidate.id,
+          process_state: ProcessState.new(candidate.last_updated_application).state,
           candidate_link: govuk_link_to(candidate.email_address, support_interface_candidate_path(candidate)),
           updated_at: candidate.updated_at.strftime('%e %b %Y at %l:%M%P'),
         }

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -12,6 +12,9 @@ module SupportInterface
     def show
       @candidate = Candidate.find(params[:candidate_id])
       @application_forms = @candidate.application_forms.order('updated_at desc')
+      if @application_forms.size == 1
+        redirect_to support_interface_application_form_path(@application_forms.first)
+      end
     end
 
     def hide_in_reporting

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -11,6 +11,7 @@ module SupportInterface
 
     def show
       @candidate = Candidate.find(params[:candidate_id])
+      @application_forms = @candidate.application_forms.order('updated_at desc')
     end
 
     def hide_in_reporting

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -4,8 +4,9 @@ module SupportInterface
 
     def index
       @candidates = Candidate
-        .includes(:application_forms)
-        .order('candidates.updated_at desc')
+        .includes(application_forms: :application_choices)
+        .sort_by { |candidate| (candidate.application_forms.collect(&:updated_at) + [candidate.updated_at]).max }
+        .reverse
     end
 
     def show

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -12,7 +12,7 @@ class StateChangeNotifier
     case event
     when :magic_link_sign_up
       text = "New sign-up [candidate_id: #{candidate.id}]"
-      url = helpers.support_interface_applications_url
+      url = helpers.support_interface_candidate_url(candidate)
     when :submit_application
       text = "#{application_form.first_name} has just submitted their application"
       url = helpers.support_interface_application_form_url(application_form)

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -20,6 +20,10 @@ class Candidate < ApplicationRecord
     application_form
   end
 
+  def last_updated_application
+    application_forms.max_by(&:updated_at)
+  end
+
 private
 
   def downcase_email

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -6,7 +6,9 @@ class ProcessState
   end
 
   def state
-    if application_choices.empty?
+    if application_form.nil?
+      :never_signed_in
+    elsif application_choices.empty?
       :unsubmitted
     elsif all_states_are?('unsubmitted')
       :unsubmitted

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -1,6 +1,6 @@
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
   <% if current_support_user %>
-    <%= nav_link 'Applications', support_interface_applications_path, active: %w[application_forms import_references] %>
+    <%= nav_link 'Candidates', support_interface_candidates_path, active: %w[candidates import_references] %>
     <%= nav_link 'API Tokens', support_interface_tokens_path, active: 'api_tokens' %>
     <%= nav_link 'Providers', support_interface_providers_path, active: 'providers' %>
     <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>

--- a/app/views/support_interface/candidates/index.html.erb
+++ b/app/views/support_interface/candidates/index.html.erb
@@ -1,3 +1,7 @@
 <% content_for :title, 'Candidates' %>
 
+<p class='govuk-body'>
+  You can import references from the <%= govuk_link_to 'applications list', support_interface_applications_path %>.
+</p>
+
 <%= render SupportInterface::CandidatesTableComponent, candidates: @candidates %>

--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -13,3 +13,8 @@
 <% else %>
   <%= button_to 'Hide in reporting', support_interface_hide_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary' %>
 <% end %>
+
+<% unless @application_forms.empty? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">Candidate’s applications</h2>
+  <%= render SupportInterface::ApplicationsTableComponent, application_forms: @application_forms %>
+<% end %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -1,5 +1,8 @@
 en:
   process_states:
+    never_signed_in:
+      name: Never signed in
+      description: Candidate has signed up but never signed into the service
     unsubmitted:
       name: Unsubmitted
       description: Candidate hasn’t submitted the form yet

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -254,7 +254,7 @@ Rails.application.routes.draw do
   post '/auth/developer/callback' => 'dfe_sign_in#bypass_callback'
 
   namespace :support_interface, path: '/support' do
-    get '/' => redirect('/support/applications')
+    get '/' => redirect('/support/candidates')
 
     get '/applications' => 'application_forms#index'
     get '/applications/:application_form_id' => 'application_forms#show', as: :application_form

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe StateChangeNotifier do
       end
 
       it 'links the notification to support interface' do
-        arg2 = helpers.support_interface_applications_url
+        arg2 = helpers.support_interface_candidate_url(candidate)
         expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
       end
     end

--- a/spec/services/process_state_spec.rb
+++ b/spec/services/process_state_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 RSpec.describe ProcessState do
   describe '#state' do
+    it 'returns never_signed_in without an application' do
+      state = ProcessState.new(nil).state
+
+      expect(state).to be(:never_signed_in)
+    end
+
     it 'returns unsubmitted without choices' do
       application_form = build_stubbed(:application_form)
 

--- a/spec/system/support_interface/import_references_spec.rb
+++ b/spec/system/support_interface/import_references_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Import references' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
     and_i_visit_the_support_page
+    and_i_follow_the_link_to_applications
 
     when_i_click_on_import_references
     then_i_should_see_an_import_references_form
@@ -36,6 +37,10 @@ RSpec.feature 'Import references' do
 
   def and_i_visit_the_support_page
     visit support_interface_path
+  end
+
+  def and_i_follow_the_link_to_applications
+    click_link 'applications list'
   end
 
   def when_i_click_on_import_references

--- a/spec/system/support_interface/see_candidates_spec.rb
+++ b/spec/system/support_interface/see_candidates_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'See candidates' do
   include DfESignInHelpers
 
-  scenario 'Support agent visits the list of candidates' do
+  scenario 'Support agent visits the list of candidates and selects one who has never signed in' do
     given_i_am_a_support_user
     and_there_are_candidates_in_the_system
     and_i_visit_the_support_candidate_page
@@ -11,6 +11,10 @@ RSpec.feature 'See candidates' do
 
     when_i_click_on_a_candidate_with_no_applications
     then_i_see_the_candidate_details
+
+    and_i_visit_the_support_candidate_page
+    when_i_click_on_a_candidate_with_one_application
+    then_i_should_see_a_summary_of_the_application
   end
 
   def given_i_am_a_support_user
@@ -40,5 +44,16 @@ RSpec.feature 'See candidates' do
 
   def then_i_see_the_candidate_details
     expect(page).to have_title(@candidate_who_has_signed_up_but_not_signed_in.id)
+  end
+
+  def when_i_click_on_a_candidate_with_one_application
+    click_link @candidate_with_a_submitted_application.email_address
+  end
+
+  def then_i_should_see_a_summary_of_the_application
+    application = @candidate_with_a_submitted_application.application_forms.first
+    within '[data-qa="application-summary"]' do
+      expect(page).to have_content application.support_reference
+    end
   end
 end

--- a/spec/system/support_interface/see_candidates_spec.rb
+++ b/spec/system/support_interface/see_candidates_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'See candidates' do
     and_i_visit_the_support_candidate_page
     then_i_should_see_the_candidates
 
-    when_i_click_on_a_candidate
+    when_i_click_on_a_candidate_with_no_applications
     then_i_see_the_candidate_details
   end
 
@@ -34,7 +34,7 @@ RSpec.feature 'See candidates' do
     expect(page).to have_content @candidate_with_a_submitted_application.email_address
   end
 
-  def when_i_click_on_a_candidate
+  def when_i_click_on_a_candidate_with_no_applications
     click_link @candidate_who_has_signed_up_but_not_signed_in.email_address
   end
 

--- a/spec/system/support_interface/see_candidates_spec.rb
+++ b/spec/system/support_interface/see_candidates_spec.rb
@@ -27,7 +27,10 @@ RSpec.feature 'See candidates' do
   end
 
   def then_i_should_see_the_candidates
-    expect(page).to have_content @candidate_who_has_signed_up_but_not_signed_in.email_address
+    within("[data-qa='candidate-#{@candidate_who_has_signed_up_but_not_signed_in.id}']") do
+      expect(page).to have_content @candidate_who_has_signed_up_but_not_signed_in.email_address
+      expect(page).to have_content('Never signed in')
+    end
     expect(page).to have_content @candidate_with_a_submitted_application.email_address
   end
 


### PR DESCRIPTION
## Context

Usability improvements to the support interface.

## Changes proposed in this pull request

Within the support interface:

- Make the candidates view the default one (and not the application forms view)
- Replace the applications view with the candidates view in the support nav
- Surface the status of the latest application form on the candidates list, including the case when the candidate has never actually logged into the service
- When support agents click on a candidate with only one application, they are redirected to that application's page

![image](https://user-images.githubusercontent.com/23801/70988687-32697780-20ba-11ea-9e25-f4e6ba21d269.png)
