### PR TITLE
Add feature flag for editing of submitted applications

### DIFF
--- a/app/components/application_complete_content_component.html.erb
+++ b/app/components/application_complete_content_component.html.erb
@@ -51,6 +51,6 @@
       training location.
     </p>
 
-    <%= govuk_link_to 'Edit your application', candidate_interface_application_edit_path %>
+    <%= govuk_link_to t('application_complete.dashboard.edit_link'), candidate_interface_application_edit_path %>
   </div>
 <% end %>

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -11,7 +11,13 @@ module CandidateInterface
       @application_form = current_application
     end
 
-    def edit; end
+    def edit
+      if FeatureFlag.active?('edit_application')
+        render :edit
+      else
+        render :edit_by_support
+      end
+    end
 
     def complete
       @application_form = current_application

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,6 +6,7 @@ class FeatureFlag
     candidate_withdrawals
     training_with_a_disability
     provider_permissions_in_database
+    edit_application
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -5,6 +5,10 @@
   <%= t('page_titles.application_edit') %>
 </h1>
 
+<% if FeatureFlag.active?('edit_application')%>
+  <%= govuk_button_link_to 'Edit Application', candidate_interface_application_edit_path %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">You have 5 working days after submission to edit most sections of your application.</p>

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -15,6 +15,6 @@
     <p class="govuk-body">You can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
     <h2 class="govuk-heading-m">Contact details</h2>
     <p class="govuk-body">You can update your contact details at any point during the application process.</p>
-    <%= govuk_button_link_to 'Edit Application', candidate_interface_application_edit_path %>
+    <%= govuk_button_link_to t('application_complete.edit_page.edit_button'), candidate_interface_application_edit_path %>
   </div>
 </div>

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -5,22 +5,16 @@
   <%= t('page_titles.application_edit') %>
 </h1>
 
-<% if FeatureFlag.active?('edit_application')%>
-  <%= govuk_button_link_to 'Edit Application', candidate_interface_application_edit_path %>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">You have 5 working days after submission to edit most sections of your application.</p>
-    <p class="govuk-body">To edit, you’ll need to email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>, explaining which changes you’d like to make.</p>
-    <p class="govuk-body">We can only edit your application once.</p>
     <h2 class="govuk-heading-m">Course choice</h2>
-    <p class="govuk-body">We can change your choice of training provider, course or location within the 5 working day editing period.</p>
-    <p class="govuk-body">We can also delete a course choice.</p>
-    <p class="govuk-body">After this, you can email us asking to withdraw your application completely.</p>
+    <p class="govuk-body">You can change your choice of training provider, course or location within the 5 working day editing period.</p>
+    <p class="govuk-body">You can also delete a course choice.</p>
     <h2 class="govuk-heading-m">References</h2>
-    <p class="govuk-body">We can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
+    <p class="govuk-body">You can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
     <h2 class="govuk-heading-m">Contact details</h2>
-    <p class="govuk-body">You can update your contact details at any point during the application process. To do this, email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+    <p class="govuk-body">You can update your contact details at any point during the application process.</p>
+    <%= govuk_button_link_to 'Edit Application', candidate_interface_application_edit_path %>
   </div>
 </div>

--- a/app/views/candidate_interface/application_form/edit_by_support.html.erb
+++ b/app/views/candidate_interface/application_form/edit_by_support.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, t('page_titles.application_edit') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back to application dashboard') %>
+
+<h1 class="govuk-heading-xl govuk-heading-xl">
+  <%= t('page_titles.application_edit') %>
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">You have 5 working days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">To edit, you’ll need to email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>, explaining which changes you’d like to make.</p>
+    <p class="govuk-body">We can only edit your application once.</p>
+    <h2 class="govuk-heading-m">Course choice</h2>
+    <p class="govuk-body">We can change your choice of training provider, course or location within the 5 working day editing period.</p>
+    <p class="govuk-body">We can also delete a course choice.</p>
+    <p class="govuk-body">After this, you can email us asking to withdraw your application completely.</p>
+    <h2 class="govuk-heading-m">References</h2>
+    <p class="govuk-body">We can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
+    <h2 class="govuk-heading-m">Contact details</h2>
+    <p class="govuk-body">You can update your contact details at any point during the application process. To do this, email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+  </div>
+</div>

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -1,0 +1,6 @@
+en:
+  application_complete:
+    dashboard:
+      edit_link: Edit your application
+    edit_page:
+      edit_button: 'Edit Application'

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'A candidate edits their application' do
+  include CandidateHelper
+
+  scenario 'candidate selects to edit their application', sidekiq: true do
+    given_the_edit_application_feature_flag_is_on
+
+    given_i_am_signed_in_as_a_candidate
+    and_i_have_a_completed_application
+
+    when_i_visit_the_application_dashboard
+    and_i_click_the_edit_link
+    then_i_see_a_button_to_edit_my_application
+  end
+
+  def given_the_edit_application_feature_flag_is_on
+    FeatureFlag.activate('edit_application')
+  end
+
+  def given_i_am_signed_in_as_a_candidate
+    create_and_sign_in_candidate
+  end
+
+  def and_i_have_a_completed_application
+    form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate)
+    @application_choice = create(:application_choice, :ready_to_send_to_provider, application_form: form)
+  end
+
+  def when_i_visit_the_application_dashboard
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_the_edit_link
+    click_link 'Edit your application'
+  end
+
+  def then_i_see_a_button_to_edit_my_application
+    expect(page).to have_content('Edit Application')
+  end
+end

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -32,10 +32,10 @@ RSpec.feature 'A candidate edits their application' do
   end
 
   def and_i_click_the_edit_link
-    click_link 'Edit your application'
+    click_link t('application_complete.dashboard.edit_link')
   end
 
   def then_i_see_a_button_to_edit_my_application
-    expect(page).to have_link('Edit Application')
+    expect(page).to have_link(t('application_complete.edit_page.edit_button'))
   end
 end

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -36,6 +36,6 @@ RSpec.feature 'A candidate edits their application' do
   end
 
   def then_i_see_a_button_to_edit_my_application
-    expect(page).to have_content('Edit Application')
+    expect(page).to have_link('Edit Application')
   end
 end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -245,7 +245,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
   end
 
   def when_i_click_the_edit_application_link
-    click_link 'Edit your application'
+    click_link t('application_complete.dashboard.edit_link')
   end
 
   def then_i_see_edit_information_page


### PR DESCRIPTION
## Context

Currently if a candidate wants to edit their application after submission they need to email support.
This PR is the first in a series of PR that will aim to allow candidates to self serve when editing their submitted applications. 

## Changes proposed in this pull request

This PR aims to lay the groundwork for future PRs.
This PR includes:
- Add a feature flag for candidate self serve editing
- Move the current `application_form/edit` page view to `application_form/edit_by_support`.
- Add new view for `application_form/edit` that outlines self serve editing.
- Update application_form controller to check self serve edit feature flag and direct to correct page.
- Add system spec to test edit flow

## Guidance to review

- Would like some guidance on the new view content (currently I have just edited the current content)

## Link to Trello card

https://trello.com/c/IP7g0jBr/583-amending-an-application-after-submission

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
