### PR TITLE
UI for managing provider users

### DIFF
--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -1,0 +1,28 @@
+module SupportInterface
+  class ProviderUsersController < SupportInterfaceController
+    def index
+      @provider_users = ProviderUser.all
+    end
+
+    def new
+      @form = ProviderUserForm.new(available_providers: Provider.all)
+    end
+
+    def create
+      @form = ProviderUserForm.new(provider_user_params.merge(available_providers: Provider.all))
+
+      if @form.save
+        flash[:success] = 'Provider user created'
+        redirect_to support_interface_provider_users_path
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def provider_user_params
+      params.require(:support_interface_provider_user_form).permit(:email_address, :dfe_sign_in_uid, :provider_ids)
+    end
+  end
+end

--- a/app/controllers/support_interface/users_controller.rb
+++ b/app/controllers/support_interface/users_controller.rb
@@ -1,0 +1,3 @@
+module SupportInterface
+  class UsersController < SupportInterfaceController; end
+end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,7 +1,4 @@
 class ProviderUser < ActiveRecord::Base
-  validates :dfe_sign_in_uid, presence: true
-  validates :email_address, presence: true
-
   has_and_belongs_to_many :providers
 
   def provider

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -1,0 +1,21 @@
+module SupportInterface
+  class ProviderUserForm
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_accessor :email_address, :dfe_sign_in_uid, :provider_ids, :available_providers
+
+    validates_presence_of :email_address, :dfe_sign_in_uid
+    validates :provider_ids, presence: true
+
+    def save
+      return false unless valid?
+
+      ProviderUser.create!(
+        email_address: email_address,
+        dfe_sign_in_uid: dfe_sign_in_uid,
+        provider_ids: provider_ids,
+      )
+    end
+  end
+end

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -6,7 +6,7 @@
     <%= nav_link 'Features', support_interface_feature_flags_path, active: 'feature_flags' %>
     <%= nav_link 'Performance', support_interface_performance_path, active: 'performance' %>
     <%= nav_link 'Tasks', support_interface_tasks_path, active: 'tasks' %>
-    <%= nav_link 'Users', support_interface_support_users_path, active: 'users' %>
+    <%= nav_link 'Users', support_interface_users_path, active: 'users' %>
   <% end %>
 
   <% if dfe_sign_in_user %>

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, 'Provider users' %>
+
+<%= link_to 'Add provider user', new_support_interface_provider_user_path, class: 'govuk-button' %>
+
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', support_interface_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Provider users
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-third'>Email</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-third'>Providers</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-third'>DfE Sign-in UID</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @provider_users.each do |provider_user| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'>
+          <%= provider_user.email_address %>
+        </td>
+        <td class='govuk-table__cell'>
+        <% provider_user.providers.map do |p| %>
+          <%= link_to(p.name, support_interface_provider_path(p)) %>
+        <% end %>
+        <td class='govuk-table__cell'>
+          <%= provider_user.dfe_sign_in_uid %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -1,0 +1,32 @@
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', support_interface_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= link_to 'Provider users', support_interface_provider_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Add provider user
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: support_interface_provider_users_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class='govuk-heading-xl'>Add provider user</h1>
+
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
+      <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID' } %>
+
+      <%= f.govuk_collection_radio_buttons :provider_ids, @form.available_providers, :id, :name, legend: { text: 'Provider' } %>
+
+      <%= f.govuk_submit 'Add provider user' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -2,6 +2,19 @@
 
 <%= link_to 'Add support user', new_support_interface_support_user_path, class: 'govuk-button' %>
 
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', support_interface_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Support users
+      </li>
+    </ol>
+  </div>
+<% end %>
+
 <table class='govuk-table'>
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>

--- a/app/views/support_interface/support_users/new.html.erb
+++ b/app/views/support_interface/support_users/new.html.erb
@@ -1,3 +1,19 @@
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', support_interface_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= link_to 'Support users', support_interface_support_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Add support user
+      </li>
+    </ol>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @support_user, url: support_interface_support_users_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>

--- a/app/views/support_interface/users/index.html.erb
+++ b/app/views/support_interface/users/index.html.erb
@@ -9,5 +9,12 @@
     <p class="govuk-body">
       <%= link_to 'Manage support users', support_interface_support_users_path %>
     </p>
+
+    <h2 class="govuk-heading-l">
+      Provider users
+    </h2>
+    <p class="govuk-body">
+      <%= link_to 'Manage provider users', support_interface_provider_users_path %>
+    </p>
   </div>
 </div>

--- a/app/views/support_interface/users/index.html.erb
+++ b/app/views/support_interface/users/index.html.erb
@@ -1,0 +1,13 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Users
+    </h1>
+    <h2 class="govuk-heading-l">
+      Support users
+    </h2>
+    <p class="govuk-body">
+      <%= link_to 'Manage support users', support_interface_support_users_path %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,6 +93,16 @@ en:
         user_id: user_id
         email: email
         full_name: full_name
+    errors:
+      models:
+        support_interface/provider_user_form:
+          attributes:
+            email_address:
+              blank: Email address can’t be blank
+            dfe_sign_in_uid:
+              blank: DfE Sign-in UID can’t be blank
+            provider_ids:
+              blank: Please specify a provider
   activerecord:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,6 +295,7 @@ Rails.application.routes.draw do
       get '/' => 'users#index', as: :users
 
       resources :support_users, only: %i[index new create], path: :support
+      resources :provider_users, only: %i[index new create], path: :provider
     end
 
     get '/sign-in' => 'sessions#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -291,7 +291,11 @@ Rails.application.routes.draw do
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task
 
-    resources :support_users, only: %i[index new create]
+    scope '/users' do
+      get '/' => 'users#index', as: :users
+
+      resources :support_users, only: %i[index new create], path: :support
+    end
 
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider users' do
+  include DfESignInHelpers
+
+  scenario 'creating a new provider user' do
+    given_i_am_a_support_user
+    and_providers_exist
+
+    when_i_visit_the_support_console
+    and_i_click_the_users_link
+    and_i_click_the_manange_provider_users_link
+    and_i_click_the_add_user_link
+    and_i_enter_the_users_email_and_dsi_uid
+    and_i_select_a_provider
+    and_i_click_add_user
+
+    then_i_should_see_the_list_of_provider_users
+    and_i_should_see_the_user_i_created
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_providers_exist
+    create(:provider, name: 'Example provider')
+  end
+
+  def when_i_visit_the_support_console
+    visit support_interface_path
+  end
+
+  def and_i_click_the_users_link
+    click_link 'Users'
+  end
+
+  def and_i_click_the_manange_provider_users_link
+    click_link 'Manage provider users'
+  end
+
+  def and_i_enter_the_users_email_and_dsi_uid
+    fill_in 'support_interface_provider_user_form[email_address]', with: 'harrison@example.com'
+    fill_in 'support_interface_provider_user_form[dfe_sign_in_uid]', with: '12345-ABCDE'
+  end
+
+  def and_i_select_a_provider
+    choose 'Example provider'
+  end
+
+  def and_i_click_the_add_user_link
+    click_link 'Add provider user'
+  end
+
+  def and_i_click_add_user
+    click_button 'Add provider user'
+  end
+
+  def then_i_should_see_the_list_of_provider_users
+    expect(page).to have_title('Provider users')
+  end
+
+  def and_i_should_see_the_user_i_created
+    expect(page).to have_content('harrison@example.com')
+  end
+end

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Managing support users' do
     given_i_am_a_support_user
 
     when_i_visit_the_support_console
+    and_i_click_the_users_link
     and_i_click_the_manange_support_users_link
     and_i_click_the_add_user_link
     and_i_enter_the_users_email_and_dsi_uid
@@ -28,8 +29,12 @@ RSpec.feature 'Managing support users' do
     visit support_interface_path
   end
 
-  def and_i_click_the_manange_support_users_link
+  def and_i_click_the_users_link
     click_link 'Users'
+  end
+
+  def and_i_click_the_manange_support_users_link
+    click_link 'Manage support users'
   end
 
   def and_i_enter_the_users_email_and_dsi_uid

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -21,10 +21,6 @@ RSpec.feature 'Managing support users' do
     sign_in_as_support_user
   end
 
-  def and_a_support_user_exists_in_the_database
-    create(:support_user, email_address: 'person@example.com')
-  end
-
   def when_i_visit_the_support_console
     visit support_interface_path
   end


### PR DESCRIPTION
## Context

As we move provider users into the database, we need a way to manage them.

## Changes proposed in this pull request

Introduce a top-level "Users" page in the Support UI, branching to Provider users and Support users.

Add a form for creating new provider users. The form enforces that a provider user must have a provider, but this isn't a hard constraint on the model. This is so that we can easily revoke access in the future.

![out](https://user-images.githubusercontent.com/642279/70994853-fd175680-20c6-11ea-8d60-dccceee37842.gif)


## Guidance to review

Try it out!

If you set up a user, then switch on the "Provider permissions in database" feature flag, then you should be able to fake your way into that provider's account by providing their DSI UID on the DSI Bypass flow. e.g.

1. Enable `BYPASS_DFE_SIGN_IN`
1. In support, create a ProviderUser with DSI UID `TEST` and permissions on provider ABC
1. Enable the feature flag
1. Visit `providers/sign-in` and enter `TEST` as the UID
1. See that you can see applications for that provider.

Not implemented yet: **multiple providers**. Possible in the database but we haven't thought through the UI yet

## Link to Trello card

https://trello.com/c/f0LD8ZaP/1380-use-database-for-provider-users

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
