### PR TITLE
Revert "Add provider 10T to sync"

### DIFF
--- a/config/providers_to_sync.yml
+++ b/config/providers_to_sync.yml
@@ -11,7 +11,6 @@ development: &default
     - 12K  # Trent Valley Teaching School Alliance
     - D87  # Durham SCITT
     - N83  # North West Shares SCITT
-    - 10T  # The Academy at Shotton Hall
 
 production:
   <<: *default


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-postgraduate-teacher-training#898

This blew up in Sentry in QA: https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers/10T?include=sites%2Ccourses.sites

Reverting this while we investigate why.