### PR TITLE
Add provider 1OT to sync

### DIFF
--- a/config/providers_to_sync.yml
+++ b/config/providers_to_sync.yml
@@ -11,6 +11,7 @@ development: &default
     - 12K  # Trent Valley Teaching School Alliance
     - D87  # Durham SCITT
     - N83  # North West Shares SCITT
+    - 1OT  # The Academy at Shotton Hall
 
 production:
   <<: *default


### PR DESCRIPTION
This is in an accrediting relationship with L06. Previously added as `10T` which does not exist!

I have tested this locally.