### PR TITLE
Hide HESA ITT data from API responses unless status is enrolled

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -6,7 +6,7 @@ module VendorApi
     end
 
     def as_json
-      {
+      hash = {
         id: application_choice.id.to_s,
         type: 'application',
         attributes: {
@@ -49,14 +49,13 @@ module VendorApi
           offer: offer,
           rejection: get_rejection,
           withdrawal: withdrawal,
-          hesa_itt_data: {
-            sex: '2',
-            disability: '00',
-            ethnicity: '10',
-          },
           further_information: application_form.further_information,
         },
       }
+      if application_choice.status == 'enrolled'
+        hash[:attributes][:hesa_itt_data] = hesa_itt_data
+      end
+      hash
     end
 
   private
@@ -187,6 +186,14 @@ module VendorApi
       return nil if application_choice.offer.nil?
 
       application_choice.offer.merge(offered_course)
+    end
+
+    def hesa_itt_data
+      {
+        sex: '2',
+        disability: '00',
+        ethnicity: '10',
+      }
     end
   end
 end

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -331,7 +331,6 @@ components:
         - updated_at
         - reject_by_default_at
         - withdrawal
-        - hesa_itt_data
         - further_information
         - work_experience
       properties:

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -28,6 +28,25 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.hesa_itt_data' do
+    let(:application_choice) do
+      application_form = create(:completed_application_form, :with_completed_references)
+      create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+    end
+
+    it 'is hidden by default' do
+      response = VendorApi::SingleApplicationPresenter.new(application_choice).as_json
+      expect(response.dig(:attributes, :hesa_itt_data)).to be_nil
+    end
+
+    it 'becomes available once application status is \'enrolled\'' do
+      application_choice.update(status: 'enrolled')
+      response = VendorApi::SingleApplicationPresenter.new(application_choice).as_json
+      expect(response.dig(:attributes, :hesa_itt_data)).not_to be_nil
+      expect(response.to_json).to be_valid_against_openapi_schema('Application')
+    end
+  end
+
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
       let(:application_choice) do

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -58,11 +58,6 @@ RSpec.feature 'Vendor receives the application' do
       attributes: {
         personal_statement: "Why do you want to become a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
         interview_preferences: 'Not on a Wednesday',
-        hesa_itt_data: {
-          disability: '00',
-          ethnicity: '10',
-          sex: '2',
-        },
         offer: nil,
         contact_details: {
           phone_number: '07700 900 982',


### PR DESCRIPTION
## Context

The API docs state HESA ITT information "... will only be returned once the application status is enrolled."

[https://www.apply-for-teacher-training.education.gov.uk/api-docs/reference#hesaittdata-object](https://www.apply-for-teacher-training.education.gov.uk/api-docs/reference#hesaittdata-object)

This is not currently the case.

## Changes proposed in this pull request

Hide the HESA ITT section from API application data responses unless status == 'enrolled'.

## Guidance to review

See changes to ```config/vendor-api-v1.yml```.

```hesa_itt_data``` is now an optional field, but if it supplied it must contain ```sex```, ```disability``` and ```ethnicity```, as before.

## Link to Trello card

[Implement HESA ITT data appearing in API responses only when enrolled](https://trello.com/c/ZDPdiiO3)
