### PR TITLE
Show bigger numbers on performance page

### DIFF
--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -1,0 +1,21 @@
+.app-card {
+  background-color: govuk-colour("light-grey");
+  display: block;
+  padding: govuk-spacing(2);
+  text-decoration: none;
+  @include govuk-font($size: 19);
+
+  @include govuk-media-query($from: desktop) {
+    padding: govuk-spacing(4);
+  }
+}
+
+.app-card--blue {
+  background: govuk-colour("blue");
+  color: govuk-colour("white");
+}
+
+.app-card__count {
+  @include govuk-font($size: 80, $weight: bold);
+  display: block;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -21,5 +21,10 @@ $govuk-image-url-function: frontend-image-url;
 @import "_summary-card";
 @import "_tag";
 @import "_task-list";
-@import "_syntax-highlighting";
 @import "_contents-list";
+
+// Support
+@import "_card";
+
+// API docs
+@import "_syntax-highlighting";

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,40 +1,33 @@
 <% content_for :title, 'Service performance' %>
 
-<table class="govuk-table govuk-!-width-one-half">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-    </tr>
-  </thead>
-  <tbody class="govuk-table__body">
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Total sign ups<br>(excluding DfE users)</th>
-      <th scope="row" class="govuk-table__header" id="total-sign-ups">
-        <%= @statistics[:total_non_dfe_sign_ups] %>
-      </th>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Users who signed up but have not signed in</th>
-      <td class="govuk-table__cell">
-        <%= @statistics[:candidates_signed_up_but_not_signed_in] %>
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Users who have signed in but not entered data</th>
-      <td class="govuk-table__cell">
-        <%= @statistics[:candidates_signed_in_but_not_entered_data] %>
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Users with unsubmitted forms</th>
-      <td class="govuk-table__cell">
-        <%= @statistics[:candidates_with_unsubmitted_forms] %>
-      </td>
-    </tr>
-    <tr class="govuk-table__row">
-      <th scope="row" class="govuk-table__header">Users with submitted forms</th>
-      <td class="govuk-table__cell">
-        <%= @statistics[:candidates_with_submitted_forms] %>
-      </td>
-    </tr>
-  </tbody>
-</table>
+<div class="app-card app-card--blue govuk-!-margin-bottom-4">
+  <span class="app-card__count" id="total-sign-ups"><%= @statistics[:total_non_dfe_sign_ups] %></span>
+  <span>sign ups (excluding DfE users)</span>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-card">
+      <span class="app-card__count"><%= @statistics[:candidates_signed_up_but_not_signed_in] %></span>
+      <span><%= @statistics[:candidates_signed_up_but_not_signed_in] == 1 ? 'hasn’t' : 'haven’t' %> signed in</span>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-card">
+      <span class="app-card__count"><%= @statistics[:candidates_signed_in_but_not_entered_data] %></span>
+      <span><%= @statistics[:candidates_signed_in_but_not_entered_data] == 1 ? 'hasn’t' : 'haven’t' %> started</span>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-card">
+      <span class="app-card__count"><%= @statistics[:candidates_with_unsubmitted_forms] %></span>
+      <span>in progress</span>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-quarter">
+    <div class="app-card">
+      <span class="app-card__count"><%= @statistics[:candidates_with_submitted_forms] %></span>
+      <span>submitted</span>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Clearer numbers
- Simplify labels
- Show that the four metrics add up to the total count

## Before
![Screen Shot 2019-12-17 at 13 20 10](https://user-images.githubusercontent.com/319055/71001889-1d9add00-20d6-11ea-8d5f-0eb3b2d25643.png)

## After
![Screen Shot 2019-12-17 at 14 03 28](https://user-images.githubusercontent.com/319055/71001872-1378de80-20d6-11ea-8163-9622a88ce6c1.png)
