### PR TITLE
Point to internal support instead of GiT, add SLAs to footer

### DIFF
--- a/app/views/candidate_interface/shared/_need_help.html.erb
+++ b/app/views/candidate_interface/shared/_need_help.html.erb
@@ -1,6 +1,8 @@
 <aside class="app-related" role="complementary">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="help-title">Need help?</h2>
-  <p class="govuk-body-s">
-    Email us and we can give you personalised&nbsp;support:<br><%= bat_contact_mail_to %>
-  </p>
+  <ul class="govuk-list govuk-body-s">
+    <li>Email: <%= bat_contact_mail_to %></li>
+    <li>Monday to Friday (except public holidays)</li>
+    <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
+  </ul>
 </aside>

--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -46,8 +46,6 @@ Your training provider will aim to make a decision on whether to make an offer w
 
 # Need help with your teacher training application?
 
-Call [Get into Teaching](https://getintoteaching.education.gov.uk/) on Freephone 0800 389 2500 or chat to an adviser using their [online chat service](https://getintoteaching.education.gov.uk/lp/live-chat) between 8am and 8pm, Monday to Friday.
+Contact the team on [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
-# Give feedback or report a problem
-
-Please contact the team on [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We don’t provide support over the weekend.

--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -48,4 +48,4 @@ Your training provider will aim to make a decision on whether to make an offer w
 
 Contact the team on [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).
 
-We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We don’t provide support over the weekend.
+We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We don’t provide support over the weekend or on public holidays.

--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -54,4 +54,4 @@ Your name will also be checked against a DBS list of people who have been barred
 
 You can contact the team at <becomingateacher@digital.education.gov.uk>.
 
-We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We don’t provide support over the weekend.
+We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We don’t provide support over the weekend or on public holidays.

--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -52,6 +52,6 @@ Your name will also be checked against a DBS list of people who have been barred
 
 ## How you can contact us
 
-Contact [Get Into Teaching](https://getintoteaching.education.gov.uk/get-help-and-support) on Freephone 0800 389 2500, or [chat to an adviser using the online chat service](https://getintoteaching.education.gov.uk/lp/live-chat).
+You can contact the team at <becomingateacher@digital.education.gov.uk>.
 
-We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. Unfortunately, we can’t provide support over the weekend.
+We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We don’t provide support over the weekend.

--- a/app/views/layouts/_candidate_footer.html.erb
+++ b/app/views/layouts/_candidate_footer.html.erb
@@ -1,7 +1,10 @@
 <h2 class="govuk-heading-m">Need help?</h2>
-<p class="govuk-footer__meta-custom">
-  Email us on <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %> and we can give you personalised&nbsp;support.
-</p>
+<ul class="govuk-footer__meta-custom govuk-list">
+  <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
+  <li>Monday to Friday (except public holidays)</li>
+  <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
+</ul>
+
 <ul class="govuk-footer__inline-list">
   <li class="govuk-footer__inline-list-item">
     <%= link_to t('layout.accessibility'), candidate_interface_accessibility_path, class: 'govuk-footer__link' %>


### PR DESCRIPTION
## Context

Emails and terms and conditions still point candidates to contact Get into Teaching, rather than our internal support channel.

## Changes proposed in this pull request

Update application confirmation email content to link to BaT support email, not GiT:

<img width="590" alt="Screenshot 2019-12-17 at 16 59 44" src="https://user-images.githubusercontent.com/813383/71017599-ad4c8580-20ee-11ea-8d5c-aa90e3c6d4d8.png">

Update ‘Terms of use for candidates’ content to link to BaT support email, not GiT:

<img width="670" alt="Screenshot 2019-12-17 at 16 59 09" src="https://user-images.githubusercontent.com/813383/71017613-b2a9d000-20ee-11ea-8dc5-49db87be2678.png">

Using [Contact a department or service team](https://design-system.service.gov.uk/patterns/contact-a-department-or-service-team/) pattern, add support SLAs to BaT contact details in the candidate footer:

<img width="620" alt="Screenshot 2019-12-17 at 15 35 36" src="https://user-images.githubusercontent.com/813383/71010866-6194de80-20e4-11ea-8fea-209d3ae9cbb2.png">

Update sidebar on dashboard:

<img width="325" alt="Screenshot 2019-12-17 at 16 54 26" src="https://user-images.githubusercontent.com/813383/71017127-0b2c9d80-20ee-11ea-8b2c-aa84b446977f.png">
