### PR TITLE
Start renaming references to application references

### DIFF
--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -1,4 +1,4 @@
-<% @application_form.references.includes(:application_form).each do |referee| %>
+<% @application_form.application_references.includes(:application_form).each do |referee| %>
   <%= render(SummaryCardComponent, rows: referee_rows(referee), editable: @editable) do %>
     <%= render(SummaryCardHeaderComponent, title: t('application_form.referees.nth_referee')[referee.ordinal], heading_level: @heading_level) do %>
       <% if @editable %>

--- a/app/components/referees_review_component.rb
+++ b/app/components/referees_review_component.rb
@@ -23,7 +23,7 @@ class RefereesReviewComponent < ActionView::Component::Base
   end
 
   def show_missing_banner?
-    @show_incomplete && @application_form.references.count < minimum_references && @editable
+    @show_incomplete && @application_form.application_references.count < minimum_references && @editable
   end
 
 private

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -11,12 +11,12 @@ module CandidateInterface
     end
 
     def new
-      @referee = current_candidate.current_application.references.build
+      @referee = current_candidate.current_application.application_references.build
     end
 
     def create
       @referee = current_candidate.current_application
-                                  .references
+                                  .application_references
                                   .build(referee_params)
       if @referee.save
         redirect_to candidate_interface_review_referees_path
@@ -50,19 +50,19 @@ module CandidateInterface
 
     def set_referee
       @referee = current_candidate.current_application
-                                    .references
+                                    .application_references
                                     .includes(:application_form)
                                     .find(params[:id])
     end
 
     def set_referees
       @referees = current_candidate.current_application
-                                    .references
+                                    .application_references
                                     .includes(:application_form)
     end
 
     def referee_params
-      params.require(:reference).permit(
+      params.require(:application_reference).permit(
         :name,
         :email_address,
         :relationship,

--- a/app/controllers/support_interface/chase_reference_controller.rb
+++ b/app/controllers/support_interface/chase_reference_controller.rb
@@ -1,12 +1,12 @@
 module SupportInterface
   class ChaseReferenceController < SupportInterfaceController
     def show
-      @reference = Reference.find(params[:reference_id])
+      @reference = ApplicationReference.find(params[:reference_id])
       @application_form = @reference.application_form
     end
 
     def chase
-      @reference = Reference.find(params[:reference_id])
+      @reference = ApplicationReference.find(params[:reference_id])
       @application_form = @reference.application_form
 
       SendChaseEmailToRefereeAndCandidate.call(application_form: @application_form, reference: @reference)

--- a/app/mailers/previews/referee_mailer_preview.rb
+++ b/app/mailers/previews/referee_mailer_preview.rb
@@ -1,14 +1,14 @@
 class RefereeMailerPreview < ActionMailer::Preview
   def reference_request_email
     application_form = FactoryBot.build(:completed_application_form)
-    reference = application_form.references.reload.first
+    reference = application_form.application_references.reload.first
 
     RefereeMailer.reference_request_email(application_form, reference)
   end
 
   def reference_request_chaser_email
     application_form = FactoryBot.build(:completed_application_form)
-    reference = application_form.references.reload.first
+    reference = application_form.application_references.reload.first
 
     RefereeMailer.reference_request_chaser_email(application_form, reference)
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -8,10 +8,10 @@ class ApplicationForm < ApplicationRecord
   has_many :application_qualifications
   # explicit default order, so that we can preserve 'First' / 'Second' in the UI
   # as we're using numerical IDs with autonumber, 'id' is fine to achieve this
-  has_many :references, -> { order('id ASC') }
+  has_many :application_references, -> { order('id ASC') }
 
   MINIMUM_COMPLETE_REFERENCES = 2
-  validates_length_of :references, maximum: MINIMUM_COMPLETE_REFERENCES
+  validates_length_of :application_references, maximum: MINIMUM_COMPLETE_REFERENCES
 
   enum phase: {
     apply_1: 'apply_1',
@@ -26,8 +26,8 @@ class ApplicationForm < ApplicationRecord
     submitted_at.present?
   end
 
-  def references_complete?
-    references.completed.count == MINIMUM_COMPLETE_REFERENCES
+  def application_references_complete?
+    application_references.completed.count == MINIMUM_COMPLETE_REFERENCES
   end
 
   def awaiting_provider_decisions?

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -1,4 +1,6 @@
-class Reference < ApplicationRecord
+class ApplicationReference < ApplicationRecord
+  self.table_name = 'references'
+
   validates :name, presence: true, length: { minimum: 2, maximum: 200 }
   validates :email_address, presence: true,
                             email_address: true,
@@ -19,7 +21,7 @@ class Reference < ApplicationRecord
   end
 
   def ordinal
-    self.application_form.references.find_index(self).to_i + 1
+    self.application_form.application_references.find_index(self).to_i + 1
   end
 
   def email_address_not_own

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -156,7 +156,7 @@ module CandidateInterface
     end
 
     def all_referees_provided_by_candidate?
-      @application_form.references.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+      @application_form.application_references.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES
     end
 
   private

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class ApplicationChoicePresenter
-    delegate :application_qualifications, :references, to: :application_form
+    delegate :application_qualifications, :application_references, to: :application_form
     attr_reader :application_form
 
     def initialize(application_choice)
@@ -80,11 +80,11 @@ module ProviderInterface
     end
 
     def first_reference
-      references.first
+      application_references.first
     end
 
     def second_reference
-      references.second
+      application_references.second
     end
 
   private

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -122,7 +122,7 @@ module VendorApi
     end
 
     def references
-      application_form.references.map do |reference|
+      application_form.application_references.map do |reference|
         reference_to_hash(reference)
       end
     end

--- a/app/services/get_application_choices_for_provider.rb
+++ b/app/services/get_application_choices_for_provider.rb
@@ -8,7 +8,7 @@ class GetApplicationChoicesForProvider
       :application_form,
       :provider,
       :site,
-      application_form: %i[candidate references application_work_experiences application_volunteering_experiences application_qualifications],
+      application_form: %i[candidate application_references application_work_experiences application_volunteering_experiences application_qualifications],
       course: %i[provider],
       course_option: [{ course: %i[provider] }, :site],
     ]

--- a/app/services/import_references_from_csv.rb
+++ b/app/services/import_references_from_csv.rb
@@ -18,8 +18,8 @@ class ImportReferencesFromCsv
     referee_feedback = row[5]
     reference_id     = row[1]
 
-    reference = Reference.find(reference_id)
-    application_form = ApplicationForm.includes(:references).where(references: { id: reference_id }).first
+    reference = ApplicationReference.find(reference_id)
+    application_form = ApplicationForm.includes(:application_references).where(references: { id: reference_id }).first
 
     if reference.feedback?
       {

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -18,11 +18,11 @@ class ReceiveReference
 
     ActiveRecord::Base.transaction do
       @application_form
-        .references
+        .application_references
         .find { |reference| reference.email_address == @referee_email }
         .update!(feedback: @feedback)
 
-      if @application_form.references_complete?
+      if @application_form.application_references_complete?
         @application_form.application_choices.includes(:course_option).each do |application_choice|
           ApplicationStateChange.new(application_choice).references_complete!
         end
@@ -40,7 +40,7 @@ class ReceiveReference
 private
 
   def referee_must_exist_on_application_form
-    if @application_form.references.where(email_address: @referee_email).empty?
+    if @application_form.application_references.where(email_address: @referee_email).empty?
       errors.add(:referee_email, 'does not match any of the provided referees')
     end
   end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -21,7 +21,7 @@ class SubmitApplication
 private
 
   def send_reference_request_email_to_referees(application_form)
-    application_form.references.each do |reference|
+    application_form.application_references.each do |reference|
       RefereeMailer.reference_request_email(application_form, reference).deliver_later
     end
   end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -45,6 +45,6 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">References</h2>
 
-<% @application_form.references.each_with_index do |reference, i| %>
+<% @application_form.application_references.each_with_index do |reference, i| %>
   <%= render ReferenceWithFeedbackComponent, reference: reference, title: "#{(i + 1).ordinalize} reference", show_chase_reference: true %>
 <% end %>

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -9,7 +9,7 @@ class DetectInvariants
   def detect_application_choices_stuck_in_awaiting_references_state
     # Application choices with completed feedback, but still awaiting references
     choices_in_wrong_state = begin
-      ApplicationChoice.where(status: 'awaiting_references', application_form: ApplicationForm.includes(:references).select(&:references_complete?))
+      ApplicationChoice.where(status: 'awaiting_references', application_form: ApplicationForm.includes(:application_references).select(&:application_references_complete?))
     end
 
     if choices_in_wrong_state.any?

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -55,7 +55,7 @@ private
       return if application_index == 2
 
       # References come in
-      application_form.references.each do |reference|
+      application_form.application_references.each do |reference|
         ReceiveReference.new(
           application_form: application_form,
           referee_email: reference.email_address,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,7 +113,7 @@ en:
               taken: Email address is already in use
               too_long: Email address must be %{count} characters or fewer
               invalid: Enter an email address in the correct format, like name@example.com
-        reference:
+        application_reference:
           attributes:
             email_address:
               blank: Enter the referee’s email address

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -10,7 +10,7 @@ Given(/an application choice has "(.*)" status/) do |original_application_status
 end
 
 Given('the candidate has specified {string} and {string} as referees') do |referee1_email, referee2_email|
-  @application_choice.application_form.references.map(&:delete)
+  @application_choice.application_form.application_references.each(&:delete)
   FactoryBot.create(:reference, :unsubmitted,
                     email_address: referee1_email,
                     application_form: @application_choice.application_form)
@@ -49,7 +49,7 @@ When(/^the candidate submits the application$/) do
 end
 
 When('{int} referees complete the references') do |number_of_complete_references|
-  references = @application_choice.application_form.reload.references.first(number_of_complete_references)
+  references = @application_choice.application_form.reload.application_references.first(number_of_complete_references)
   references.each do |reference|
     steps %{When "#{reference.email_address}" provides a reference}
   end

--- a/spec/components/referees_review_component_spec.rb
+++ b/spec/components/referees_review_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RefereesReviewComponent do
 
   context 'when referees are editable' do
     it "renders component with correct values for a referee's name" do
-      first_referee = application_form.references.first
+      first_referee = application_form.application_references.first
       result = render_inline(RefereesReviewComponent, application_form: application_form)
 
       expect(result.css('.app-summary-card__title').text).to include('First referee')
@@ -16,7 +16,7 @@ RSpec.describe RefereesReviewComponent do
     end
 
     it "renders component with correct values for a referee's email address" do
-      first_referee = application_form.references.first
+      first_referee = application_form.application_references.first
       result = render_inline(RefereesReviewComponent, application_form: application_form)
 
       expect(result.css('.govuk-summary-list__key').text).to include('Email address')
@@ -24,7 +24,7 @@ RSpec.describe RefereesReviewComponent do
     end
 
     it 'renders component along with a delete link for each referee' do
-      referee_id = application_form.references.first.id
+      referee_id = application_form.application_references.first.id
       result = render_inline(RefereesReviewComponent, application_form: application_form)
 
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.referees.delete'))

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -74,9 +74,9 @@ FactoryBot.define do
         # This then *caches* the association on the  application_form, and means
         # you have to explicitly reload it to pick up the created references.
         # We do this here, so we only have to do it in one place, rather than
-        # everywhere we refer to application_form.references in tests.
+        # everywhere we refer to application_form.application_references in tests.
         # See https://github.com/thoughtbot/factory_bot/issues/549 for details.
-        application_form.references.reload
+        application_form.application_references.reload
       end
     end
   end
@@ -187,7 +187,7 @@ FactoryBot.define do
     hashed_token { '1234567890' }
   end
 
-  factory :reference do
+  factory :reference, class: 'ApplicationReference' do
     email_address { "#{SecureRandom.hex(5)}@example.com" }
     name { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
     relationship { Faker::Lorem.paragraph(sentence_count: 3) }

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   describe 'Send reference chaser email' do
     let(:application_form) { create(:completed_application_form) }
-    let(:reference) { application_form.references.first }
+    let(:reference) { application_form.application_references.first }
     let(:mail) { mailer.reference_chaser_email(application_form, reference) }
 
     before { mail.deliver_later }

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RefereeMailer, type: :mailer do
         ],
       )
     end
-    let(:reference) { application_form.references.first }
+    let(:reference) { application_form.application_references.first }
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
     let(:mail) { mailer.reference_request_email(application_form, reference) }
 
@@ -77,7 +77,7 @@ RSpec.describe RefereeMailer, type: :mailer do
         ],
       )
     end
-    let(:reference) { application_form.references.first }
+    let(:reference) { application_form.application_references.first }
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
     let(:mail) { mailer.reference_request_chaser_email(application_form, reference) }
 

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Reference, type: :model do
+RSpec.describe ApplicationReference, type: :model do
   subject { build(:reference) }
 
   describe 'a valid reference' do
@@ -19,7 +19,7 @@ RSpec.describe Reference, type: :model do
 
         expect(reference.valid?).to eq(false)
         expect(reference.errors.full_messages_for(:email_address)).to eq(
-          ["Email address #{t('activerecord.errors.models.reference.attributes.email_address.own')}"],
+          ["Email address #{t('activerecord.errors.models.application_reference.attributes.email_address.own')}"],
         )
       end
     end
@@ -61,7 +61,7 @@ RSpec.describe Reference, type: :model do
 
       before do
         create(:reference, application_form: application_form)
-        application_form.references << new_reference
+        application_form.application_references << new_reference
       end
 
       it 'sets the ordinal to 2' do
@@ -79,10 +79,10 @@ RSpec.describe Reference, type: :model do
     let!(:application_form) { create(:completed_application_form, references_count: 2) }
 
     describe 'the ordinal of the remaining references' do
-      let(:ordinals) { application_form.references.map(&:ordinal) }
+      let(:ordinals) { application_form.application_references.map(&:ordinal) }
 
       it 'still starts at 1' do
-        application_form.references.first.destroy
+        application_form.application_references.first.destroy
         expect(ordinals.first).to eq(1)
       end
     end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
     context 'when there are no referees' do
       before do
-        application_form.references.delete_all
+        application_form.application_references.delete_all
       end
 
       it 'returns false' do

--- a/spec/services/import_references_from_csv_spec.rb
+++ b/spec/services/import_references_from_csv_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ImportReferencesFromCsv do
       expect(outcome[:updated]).to be true
       expect(outcome[:errors]).to be_nil
 
-      expect(application_form.references.find_by!(email_address: 'ab@c.com').feedback).to eq('Feedback')
+      expect(application_form.application_references.find_by!(email_address: 'ab@c.com').feedback).to eq('Feedback')
       application_form.application_choices.each { |choice| expect(choice.status).to eq('awaiting_references') }
     end
 
@@ -32,9 +32,9 @@ RSpec.describe ImportReferencesFromCsv do
       csv_row[1] = second_reference.id
       ImportReferencesFromCsv.process_row(csv_row)
 
-      expect(application_form.references.find_by!(email_address: 'ab@c.com').feedback).to eq('Feedback')
-      expect(application_form.references.find_by!(email_address: 'xy@z.com').feedback).to eq('More feedback')
-      expect(application_form.reload).to be_references_complete
+      expect(application_form.application_references.find_by!(email_address: 'ab@c.com').feedback).to eq('Feedback')
+      expect(application_form.application_references.find_by!(email_address: 'xy@z.com').feedback).to eq('More feedback')
+      expect(application_form.reload).to be_application_references_complete
     end
 
     it 'does not change existing feedback' do
@@ -47,7 +47,7 @@ RSpec.describe ImportReferencesFromCsv do
       expect(outcome[:updated]).to be false
       expect(outcome[:errors]).to eq(['Reference already has feedback'])
 
-      expect(application_form.references.find_by!(email_address: 'ab@c.com').feedback).to eq('Feedback')
+      expect(application_form.application_references.find_by!(email_address: 'ab@c.com').feedback).to eq('Feedback')
     end
 
     it 'does not update if an application form is not found' do

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe ReceiveReference do
   it 'updates the reference on an application form with the provided text' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
-    application_form.references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
-    application_form.references << build(:reference, :unsubmitted, email_address: 'xy@z.com')
+    application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.application_references << build(:reference, :unsubmitted, email_address: 'xy@z.com')
 
     action = ReceiveReference.new(
       application_form: application_form,
@@ -16,15 +16,15 @@ RSpec.describe ReceiveReference do
     expect(action).to be_valid
     expect(action.save).to be true
 
-    expect(application_form.references.find_by!(email_address: 'xy@z.com').feedback).to eq('A reference')
-    expect(application_form.references.find_by!(email_address: 'ab@c.com').feedback).to be_nil
+    expect(application_form.application_references.find_by!(email_address: 'xy@z.com').feedback).to eq('A reference')
+    expect(application_form.application_references.find_by!(email_address: 'ab@c.com').feedback).to be_nil
   end
 
   it 'progresses the application choices to the "application complete" status once all references have been received' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
-    application_form.references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
-    application_form.references << build(:reference, :complete)
+    application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.application_references << build(:reference, :complete)
 
     action = ReceiveReference.new(
       application_form: application_form,
@@ -33,14 +33,14 @@ RSpec.describe ReceiveReference do
     )
     action.save
 
-    expect(application_form.reload).to be_references_complete
+    expect(application_form.reload).to be_application_references_complete
     expect(application_form.application_choices).to all(be_application_complete)
   end
 
   it 'does not progress the application choices to the "application complete" status without minimum number of references' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
-    application_form.references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
 
     action = ReceiveReference.new(
       application_form: application_form,
@@ -49,7 +49,7 @@ RSpec.describe ReceiveReference do
     )
     action.save
 
-    expect(application_form).not_to be_references_complete
+    expect(application_form).not_to be_application_references_complete
     expect(application_form.application_choices).to all(be_awaiting_references)
   end
 

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Candidate adding referees' do
   end
 
   def given_i_have_no_existing_references_on_the_form
-    expect(@current_candidate.application_forms.last.references.count).to eq(0)
+    expect(@current_candidate.application_forms.last.application_references.count).to eq(0)
   end
 
   def and_i_visit_the_application_form
@@ -70,7 +70,7 @@ RSpec.feature 'Candidate adding referees' do
   end
 
   def i_see_a_validation_error_on_relationship
-    expect(page).to have_content t('activerecord.errors.models.reference.attributes.relationship.blank')
+    expect(page).to have_content t('activerecord.errors.models.application_reference.attributes.relationship.blank')
   end
 
   def when_i_enter_a_relationship

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -201,7 +201,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
 
   def and_my_referees_receive_a_request_for_a_reference_by_email
     current_application = current_candidate.current_application
-    current_application.references.each do |reference|
+    current_application.application_references.each do |reference|
       open_email(reference.email_address)
       expect(current_email).to have_content "Give a reference for #{current_application.first_name}"
       expect(current_email).to have_content reference.name
@@ -221,7 +221,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     expect(page).to have_content t('page_titles.application_dashboard')
     expect(page).to have_content "Application submitted on #{this_day}"
     expect(page).to have_content 'Gorse SCITT'
-    expect(page).to have_content current_candidate.current_application.references.first.name
+    expect(page).to have_content current_candidate.current_application.application_references.first.name
     expect(page).to have_content 'Submitted'
   end
 

--- a/spec/system/support_interface/import_references_spec.rb
+++ b/spec/system/support_interface/import_references_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'Import references' do
     csv_file = Tempfile.new(['csv_file', '.csv'])
     CSV.open(csv_file, 'w') do |csv|
       @completed_applications.each do |application_form|
-        application_form.references.each do |reference|
+        application_form.application_references.each do |reference|
           csv << ['', reference.id, reference.email_address, reference.name, application_form.first_name, 'Imported feedback', 'I confirm']
         end
       end

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature 'See an application' do
   def and_an_application_has_received_a_reference
     action = ReceiveReference.new(
       application_form: @application_with_reference,
-      referee_email: @application_with_reference.reload.references.first.email_address,
+      referee_email: @application_with_reference.reload.application_references.first.email_address,
       feedback: 'This is my feedback',
     )
     action.save

--- a/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
+++ b/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
 
   def then_i_see_the_referee_email_is_successfully_sent
     candidate_name = "#{@application_awaiting_references.first_name} #{@application_awaiting_references.last_name}"
-    open_email(@application_awaiting_references.references.first.email_address)
+    open_email(@application_awaiting_references.application_references.first.email_address)
 
     expect(current_email.subject).to have_content(t('reference_request.subject.chaser', candidate_name: candidate_name))
   end
@@ -65,7 +65,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
   def and_i_see_the_candidate_email_is_successfully_sent
     open_email(@application_awaiting_references.candidate.email_address)
 
-    expect(current_email.subject).to have_content(t('candidate_reference.subject.chaser', referee_name: @application_awaiting_references.references.first.name))
+    expect(current_email.subject).to have_content(t('candidate_reference.subject.chaser', referee_name: @application_awaiting_references.application_references.first.name))
   end
 
   def and_i_am_sent_back_to_the_application_form_with_a_flash
@@ -77,7 +77,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
   end
 
   def then_i_see_a_comment_stating_chase_emails_have_been_sent
-    referee_email = @application_awaiting_references.references.first.email_address
+    referee_email = @application_awaiting_references.application_references.first.email_address
     candidate_email = @application_awaiting_references.candidate.email_address
 
     within('tbody tr:eq(1)') do

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -25,11 +25,11 @@ RSpec.feature 'Vendor receives the application' do
 
   def and_references_have_been_received
     ReceiveReference.new(application_form: @application,
-                         referee_email: @application.references.first.email_address,
+                         referee_email: @application.application_references.first.email_address,
                          feedback: 'My ideal person').save
 
     ReceiveReference.new(application_form: @application,
-                         referee_email: @application.references.last.email_address,
+                         referee_email: @application.application_references.last.email_address,
                          feedback: 'Lovable').save
   end
 


### PR DESCRIPTION
## Context

There’s a Rails method called `references` on associations:

https://apidock.com/rails/ActiveRecord/QueryMethods/references

Over the last months we’ve seen weird, unexplained, mysterious and peculiar behaviour where associations for references aren’t reloading. We’ve had to add a bunch of `reload` statements to the tests to make them pass.

It could very well be unrelated to the naming collisions - another culprit might be the default scope on references.

In any case, this renames the Reference model to ApplicationReference, which avoids the collision and make it consistent with the other models like ApplicationWorkExperience.

## Changes proposed in this pull request

This commit does the least possible. It doesn’t rename the database table, and doesn’t rename the factory.

## Guidance to review

Read through it.

## Link to Trello card

https://trello.com/c/lQpwnQH2/372-find-out-why-we-need-to-reload-so-much-when-were-working-with-references