### PR TITLE
Correct withdrawal content, behind feature flag where possible

### DIFF
--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -24,7 +24,11 @@ You can sign back in to change your name or contact details at any point up unti
 
 # Withdrawing your application
 
-You can withdraw your application to <%= 'course'.pluralize(@application_form.application_choices.count) %> at any point, even after you've accepted an offer. [Sign in to your account](<%= candidate_interface_sign_in_url %>) and click ‘withdraw’ next to the <%= 'course'.pluralize(@application_form.application_choices.count) %> you want to withdraw. We'll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
+<% if FeatureFlag.active?('candidate_withdrawals') %>
+  You can withdraw your application to <%= 'course'.pluralize(@application_form.application_choices.count) %> at any point, even after you’ve accepted an offer. [Sign in to your account](<%= candidate_interface_sign_in_url %>) and click ‘withdraw’ next to the <%= 'course'.pluralize(@application_form.application_choices.count) %> you want to withdraw. We’ll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
+<% else %>
+  You can withdraw your application to <%= 'course'.pluralize(@application_form.application_choices.count) %> at any point, even after you’ve accepted an offer. Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) if you want to withdraw and we’ll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
+<% end %>
 
 # References
 

--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -32,11 +32,7 @@ We’ll let your training provider(s) know about any amends.
 
 ### Withdrawing your application
 
-You can withdraw your application to your course(s) at any point, even after you’ve accepted an offer.
-
-Contact us at <becomingateacher@digital.education.gov.uk> if you need to do this.
-
-We’ll let your training provider(s) know.
+You can withdraw your application to your course(s) at any point, even after you’ve accepted an offer. [Sign in to your account](/candidate/sign-in) and click ‘withdraw’ next to the course(s) you want to withdraw. We’ll let your training provider(s) know.
 
 ### Declaring that what you’ve said is true
 


### PR DESCRIPTION
## Context

We describe how to withdraw in the email we send to candidates after submitting an email, and in our terms of use. As we make withdrawing automated, this content needs to reflect the correct functionality.

## Changes proposed in this pull request

Updates the post-submission email to use the `candidate_withdrawals` feature flag.

Feature flags can’t be used in markdown-powered content pages, so updated to describe the functionality given how the flag is currently set on production.

## Link to Trello card

https://trello.com/c/KXQsqRAx
