### PR TITLE
Fix intermittent spec failure

### DIFF
--- a/app/components/application_complete_content_component.rb
+++ b/app/components/application_complete_content_component.rb
@@ -28,6 +28,10 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
     @dates.decline_by_default_at.strftime('%-e %B %Y')
   end
 
+  def edit_by_date
+    @dates.edit_by.strftime('%-e %B %Y')
+  end
+
 private
 
   attr_reader :application_form

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -37,11 +37,6 @@ module ViewHelper
     dates.reject_by_default_at.strftime('%e %B %Y').strip if dates.reject_by_default_at
   end
 
-  def edit_by_date
-    dates = ApplicationDates.new(@application_form)
-    dates.edit_by.strftime('%e %B %Y').strip
-  end
-
   def formatted_days_remaining
     dates = ApplicationDates.new(@application_form)
     pluralize(dates.days_remaining_to_edit, 'day')

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -8,6 +8,9 @@ class TimeLimitConfig
     decline_by_default: [
       Rule.new(nil, nil, 10),
     ],
+    edit_by: [
+      Rule.new(nil, nil, 5),
+    ],
   }.freeze
 
   def self.limits_for(rule)

--- a/app/models/application_dates.rb
+++ b/app/models/application_dates.rb
@@ -16,14 +16,14 @@ class ApplicationDates
   end
 
   def edit_by
-    5.business_days.after(submitted_at).end_of_day
+    @application_form.application_choices.first&.edit_by
   end
 
   def days_remaining_to_edit
-    ((edit_by - Time.zone.now) / 1.day).floor
+    edit_by.present? && ((edit_by - Time.zone.now) / 1.day).floor
   end
 
   def form_open_to_editing?
-    days_remaining_to_edit >= 1
+    edit_by.present? && days_remaining_to_edit >= 1
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -28,7 +28,12 @@ private
 
   def submit_application
     application_choices.each do |application_choice|
-      application_choice.edit_by = ApplicationDates.new(application_form).edit_by
+      edit_by_days = TimeLimitCalculator.new(
+        rule: :edit_by,
+        effective_date: application_form.submitted_at,
+      ).call
+
+      application_choice.edit_by = edit_by_days.business_days.after(application_form.submitted_at).end_of_day
       ApplicationStateChange.new(application_choice).submit!
     end
   end

--- a/features/reject_by_default.feature
+++ b/features/reject_by_default.feature
@@ -11,6 +11,7 @@ Feature: Reject by default
 
   Background:
     Given a 3 working day time limit on "reject_by_default"
+    And a 5 working day time limit on "edit_by"
     And the date is "2019-01-01" # well before the application is sent to the provider
     And the candidate submits a complete application with reference feedback
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -84,7 +84,6 @@ RSpec.describe ViewHelper, type: :helper do
         ApplicationDates,
         submitted_at: Time.zone.local(2019, 10, 22, 12, 0, 0),
         reject_by_default_at: Time.zone.local(2019, 12, 17, 12, 0, 0),
-        edit_by: Time.zone.local(2019, 10, 29, 12, 0, 0),
         days_remaining_to_edit: 7,
         form_open_to_editing?: true,
       )
@@ -100,12 +99,6 @@ RSpec.describe ViewHelper, type: :helper do
     describe '#respond_by_date' do
       it 'renders with correct respond by date' do
         expect(helper.respond_by_date).to include('17 December 2019')
-      end
-    end
-
-    describe '#edit_by_date' do
-      it 'renders with correct edit by date' do
-        expect(helper.edit_by_date).to include('29 October 2019')
       end
     end
 

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -9,5 +9,9 @@ RSpec.describe TimeLimitConfig do
     it ':decline_by_default returns a default limit of 10 days' do
       expect(TimeLimitConfig.limits_for(:decline_by_default).first.limit).to eq(10)
     end
+
+    it ':edit_by returns a default limit of 5 days' do
+      expect(TimeLimitConfig.limits_for(:edit_by).first.limit).to eq(5)
+    end
   end
 end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SubmitApplication do
 
     it 'sets application_form.submitted_at' do
       Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
-        expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day
+        expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day # business days
         SubmitApplication.new(application_form).call
 
         expect(application_form.submitted_at).to eq Time.zone.now

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'A candidate edits their application' do
 
   def and_i_have_a_completed_application
     form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate)
-    @application_choice = create(:application_choice, :ready_to_send_to_provider, application_form: form)
+    @application_choice = create(:application_choice, status: :application_complete, edit_by: 1.day.from_now.end_of_day, application_form: form)
   end
 
   def when_i_visit_the_application_dashboard


### PR DESCRIPTION
## Context

We saw an intermittent spec failure at `spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb:6`. In this spec we used a factory which set `edit_by` on the `application_choice`. This value was ignored, though, and the view would calculate the editability of the application form depending on the original submission date.

## Changes proposed in this pull request

In fixing the view to look at the stored value of `edit_by`, tidy up the responsibilities of `ApplicationDates` and `TimeLimitCalculator`. The former gets useful dates off an `application_form` record. The latter figures out significant dates according to business rules.

Before this change `ApplicationDates` was doing some work that properly belonged in `TimeLimitCalculator`. Things are now a bit neater.

## Guidance to review

Commit by commit