### PR TITLE
Bypass DfE Signin when running in `development` hosting environment

### DIFF
--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -9,6 +9,6 @@ module DfESignIn
   end
 
   def self.bypass?
-    Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
+    !HostingEnvironment.production? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end
 end


### PR DESCRIPTION
## Context

This allows us to bypass DfE Signin even when the app is set to Rails.env.production? to debug other things.

## Changes proposed in this pull request

Change the call from`Rails.env.development?` to `!HostingEnrivonment.production?`.

## Guidance to review

Should be fine as we initialize `HOSTING_ENVIRONMENT` this in `.env.development` locally.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)