### PR TITLE
Heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,20 @@
   "scripts": {
     "postdeploy": "bundle exec rake db:migrate && bundle exec rake setup_local_dev_data"
   },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "hobby"
+    },
+    "clock": {
+      "quantity": 1,
+      "size": "hobby"
+    },
+    "worker": {
+      "quantity": 1,
+      "size": "hobby"
+    }
+  },
   "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {

--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
   "scripts": {
     "postdeploy": "bundle exec rake db:migrate && bundle exec rake setup_local_dev_data"
   },
+  "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {
       "url": "heroku/ruby"

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "apply-for-teacher-training",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:migrate && bundle exec rake setup_local_dev_data"
+  },
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}

--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -9,6 +9,6 @@ module DfESignIn
   end
 
   def self.bypass?
-    Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
+    ENV['HOSTING_ENVIRONMENT_NAME'] == 'development' && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -8,7 +8,8 @@ module HostingEnvironment
   end
 
   def self.authorised_hosts
-    ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
+    # ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
+    ["#{ENV['HEROKU_APP_NAME']}.herokuapp.com"]
   end
 
   def self.hostname


### PR DESCRIPTION
Experimenting with enabling pull request review apps on Heroku.

Issues found so far below.

### `AUTHORISED_HOSTS`

`AUTHORISED_HOSTS` needs to be set to the domain of the review app, which varies from PR to PR.

- [x] Possible workaround: change the logic that reads it to use `HEROKU_APP_NAME` if it's available.

### DfE Signin

DfE Signin has a whitelist which needs to contain the domain of the review app; again, this varies.

- [x] Possible workaround: use `BYPASS_DFE_SIGNIN_TRUE`.

### Notify

The app needs a defined `GOVUK_NOTIFY_API_KEY` to send emails on the candidate side and to successfully boot up. I've set this to a `team-and-whitelist` type key, but because review apps get deployed for every pull request, a bad actor could steal this (alongside the other environment variables) by sending us a PR with something that scrapes our vars.

- [ ] (Possible?) Workaround 1: restrict deploying review apps to PRs opened only by DfE members. 

- [ ] (Possible?) Workaround 2: don't define this this in the review app somehow but still have mailing functionality work in some way.
- [ ] Workaround 3: maybe because this is a `team-and-whitelist` key, it's not a big deal if someone can find it? Could also be a `dev` key.

### Provisioning Redis

Postgres is auto-provisioned as part of a review app, but Redis is not.

- [x] Workaround: This should be fixable by specifying an `app.json` to provision it as part of the deploy.

Later edit: I found this and it looks like what this needs:

```json
  "addons": [
    "heroku-postgresql:hobby-basic",
    "papertrail",
    "rediscloud"
  ]
```

### Postgres migrations and seed data

Heroku provisions new copies of Postgres and Redis when the review app is created. This is good, because it prevents data from leaking from the "production" Heroku instance. However, we need to run `rake db:migrate` and `rake setup_local_dev_data` to be able to effectively interact with the deployed app.

- [x] Workaround: Maybe this could be done as part of `app.json`.

Later edit: I found this and it looks like what this needs:

```json
  "scripts": {
    "postdeploy": "pg_dump $STAGING_DATABASE_URL | psql $DATABASE_URL && bundle exec rake db:migrate"
  },
```

### Sidekiq worker auto-boot

The app relies on a Sidekiq worker dyno, defined in the Procfile. Heroku creates this for a newly deployed review app, but does not boot it up automatically.

- [x] Workaround: This is probably because it's currently running in the free tier, or could require something in `app.json`.

Later edit: I found this and it looks like what this needs:

```json
  "formation": {
    "web": {
      "quantity": 1,
      "size": "hobby"
    },
    "worker": {
      "quantity": 1,
      "size": "hobby"
    },
    "clock": {
      "quantity": 1,
      "size": "hobby"
    }
  },
```