### PR TITLE
Stop Sidekiq::Web writing its own unsecure 'rack.session' cookie

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,3 +5,6 @@ Sidekiq.configure_server do |config|
     chain.add Workers::AuditTrailAttributionMiddleware
   end
 end
+
+require 'sidekiq/web'
+Sidekiq::Web.set :sessions, false


### PR DESCRIPTION
## Context

Logging in to support requires a DfE sign-in and access to Sidekiq::Web is controlled by the same cookie (main Rails session cookie, ```_apply_for_postgraduate_teacher_training_session```), which is set as a `secure` cookie.

However, Sidekiq::Web also sets a ```rack.session``` cookie, which is not ```secure```. Furthermore, it seems to overwrite the main Rails cookie every time it polls, dropping the ```secure``` flag (it happens after 5s on the main dashboard).

![image](https://user-images.githubusercontent.com/107591/71080714-9efd7880-2185-11ea-80d8-ab5d22256e89.png)

Sidekiq docs suggest:
 
> If, when using the Web UI, your sessions are being overwritten, you can disable Sidekiq's sessions completely with an initializer:
> 
> ```ruby
> require 'sidekiq/web'
> Sidekiq::Web.set :sessions, false
> ```
> 

## Changes proposed in this pull request

Stop Sidekiq::Web from writing its own session cookies and make it rely exclusively on the main app. This also reduces the risk of Sidekiq::Web interfering with csrf tokens and sessions in general.

## Guidance to review

Generate a self-signed certificate for localhost:

```openssl req -x509 -sha256 -nodes -newkey rsa:2048 -days 365 -keyout tmp/localhost.key -out tmp/localhost.crt```

Add the relevant bits from our production config to ```config/environments/development.rb```:
```ruby
  config.force_ssl = true
  config.ssl_options = { redirect: false, secure_cookies: true, hsts: false }
```
... and restart rails with:

```bundle exec rails s -b 'ssl://localhost:3000?key=tmp/localhost.key&cert=tmp/localhost.crt'```

Navigate to https://localhost:3000/support/sidekiq and observe cookies in your browser's Dev Tools. No `rack.session` cookie, and the main Rails session cookie stays `secure`.

![image](https://user-images.githubusercontent.com/107591/71079784-d23f0800-2183-11ea-9706-598e5c39d1a1.png)

## Link to Trello card

[Make the Sidekiq Web cookie `secure`](https://trello.com/c/Xxfqa5Lu)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
