### PR TITLE
Update Release notes to reflect 1.0 release

### DIFF
--- a/app/views/api_docs/pages/alpha_release_notes.md
+++ b/app/views/api_docs/pages/alpha_release_notes.md
@@ -1,11 +1,11 @@
-These are the release notes for the API while still in alpha.
+**These are archived release notes for the alpha API, which has now become version 1.0.**
 
-See the [current release notes](/api-docs/release-notes) for the release notes
-once v1 is live.
+Future release notes will be published on the [Release notes page](/api-docs/release-notes).
 
 ### Alpha release - 18 December 2019
 
-- Clarify that when an appliction is withdrawn, the `reason` can be null.
+- Clarify that when an application is withdrawn, the `reason` can be null.
+- Clarify that HESA ITT data is only available once a candidate is enrolled.
 
 ### Alpha release - 13 December 2019
 

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,5 @@
-We are currently working towards the release of v1 of the API on December 17th. Once v1 is published, this page will contain the changes that have been made to the API and docs.
+### v1.0 — 18th December 2019
 
-You can [follow the alpha release notes](/api-docs/alpha-release-notes) to keep track of changes that we’re making on the basis of feedback.
+Initial release of the API.
+
+For a log of pre-release changes, [see the alpha release notes](/api-docs/alpha-release-notes).

--- a/spec/system/api_docs/api_docs_spec.rb
+++ b/spec/system/api_docs/api_docs_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'API docs' do
     expect(page).to have_content 'Developing on the API'
 
     click_link 'Release notes'
-    expect(page).to have_content 'We are currently working towards the release of v1'
+    expect(page).to have_content 'For a log of pre-release changes, see the alpha release notes'
 
     click_link 'Get help'
     expect(page).to have_content 'If you have any questions or'


### PR DESCRIPTION
- update the alpha release notes with the change we made to HESA data
yesterday
- add a 1.0 entry to the proper release notes and remove the "We are
currently working towards" copy
- link to the release notes from the now-finished alpha release notes

https://trello.com/c/vK1kzqbp/1406-update-release-notes-for-api-v10