### PR TITLE
Enable Heroku review apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ setting `BYPASS_DFE_SIGN_IN=true` in your `.env` file. This replaces the login
 flow with a dialog allowing you to specify a DfE Sign-in UID and Email address
 for your current session.
 
+### Heroku
+
+When a new PR is opened, a review app is deployed via Heroku. This has a `HOSTING_ENVIRONMENT=development`, an empty database which gets seeded with local dev data, and a URL which is similar to `https://apply-for-teacher-training.herokuapp.com`. The Heroku configuration is in [`app.json`](app.json).
+
 ### Provider permissions
 
 We decide what to show providers based on their DfE Sign-in UID.

--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
   "scripts": {
     "postdeploy": "bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
   },
+  "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {
       "url": "heroku/ruby"

--- a/app.json
+++ b/app.json
@@ -3,6 +3,20 @@
   "scripts": {
     "postdeploy": "bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
   },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "hobby"
+    },
+    "clock": {
+      "quantity": 1,
+      "size": "hobby"
+    },
+    "worker": {
+      "quantity": 1,
+      "size": "hobby"
+    }
+  },
   "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,13 @@
 {
   "name": "apply-for-teacher-training",
   "scripts": {
-    "postdeploy": "bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
+    "postdeploy": "heroku config:set AUTHORISED_HOSTS=${HEROKU_APP_NAME}.herokuapp.com --app ${HEROKU_APP_NAME} && bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
+  },
+  "env": {
+    "AUTHORISED_HOSTS": {
+      "description": "The comma separated list of hosts this application should run on.",
+      "value": "apply-for-teacher-training.herokuapp.com"
+    }
   },
   "formation": {
     "web": {
@@ -21,6 +27,9 @@
   "buildpacks": [
     {
       "url": "heroku/ruby"
+    },
+    {
+      "url": "heroku-community/cli"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,11 @@
+{
+  "name": "apply-for-teacher-training",
+  "scripts": {
+    "postdeploy": "bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
+  },
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
+  ]
+}


### PR DESCRIPTION
## Context

Previously: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/915

This enables [Heroku PR review apps](https://devcenter.heroku.com/articles/github-integration-review-apps). Whenever someone opens a PR, a new Heroku application is spun up with a fresh database and workers. We can use this to review and test features!

👇 Check out the review app below this PR description! 👇 

The review application runs in `Rails.env.production?`, but is meant to be local dev-y feeling, so DFE Signin is bypassed and the database is seeded with dev data.

You can access the support section by using the default local dev support user: `dev-support` / `support@example.com`.

Candidate emails work if you have a DfE email and you're signed up with Notify.

## Changes proposed in this pull request

Add an `app.json` which is used by Heroku to provision the right addons, dynos, and run the setup task for migrations. Populate `AUTHORISED_HOSTS` using `HEROKU_APP_NAME`.

- [ ] Add some docs to the README about this

## Guidance to review

<details>
<summary>I thought maybe we need to worry about our environment variables being stolen.</summary>
<p>There is one issue with this setup, and it relates to the GOVUK Notify key. I've set this to a `team-and-whitelist` type key, but because review apps get deployed for every pull request, a bad actor could steal this (alongside the other environment variables) by sending us a PR with something that scrapes our vars. The other environment variables are not sensitive.</p>

<p>We would know if this happens, as opening a PR is a highly visible action. The key is also restricted such that it can't be used for too nefarious a purpose. So I don't think it's a high risk, but it would be nice to somehow restrict these apps only to GitHub organisation members.</p>
</details>

But nevermind:

> With automatic creation, Heroku creates a review app as soon as a pull request is opened on your app’s connected GitHub repo. For security and billing reasons, **Heroku does not automatically create review apps for pull requests to public repos that are sent from forks**. You can still create review apps for these pull requests manually.

https://devcenter.heroku.com/articles/github-integration-review-apps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
