### PR TITLE
Improve UX for unauthorised ProviderUsers

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -13,7 +13,7 @@ module ProviderInterface
       render template: 'provider_interface/account_creation_in_progress', status: :forbidden
     }
 
-    helper_method :current_provider_user
+    helper_method :current_provider_user, :dfe_sign_in_user
 
   private
 

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -31,8 +31,22 @@ module ProviderInterface
       ProviderUser.load_from_session(session)
     end
 
+    def dfe_sign_in_user
+      DfESignInUser.load_from_session(session)
+    end
+
     def authenticate_provider_user!
       return if current_provider_user
+
+      session['post_dfe_sign_in_path'] = request.path
+
+      if !current_provider_user && dfe_sign_in_user
+        render(
+          template: 'provider_interface/account_creation_in_progress',
+          status: :forbidden,
+        )
+        return
+      end
 
       session['post_dfe_sign_in_path'] = request.path
       redirect_to provider_interface_sign_in_path

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -20,12 +20,6 @@ module SupportInterface
 
   private
 
-    def protect_with_basic_auth
-      authenticate_or_request_with_http_basic do |username, password|
-        (username == ENV.fetch('SUPPORT_USERNAME')) && (password == ENV.fetch('SUPPORT_PASSWORD'))
-      end
-    end
-
     def render_404
       render 'errors/not_found', status: :not_found
     end

--- a/app/views/layouts/_provider_header.html.erb
+++ b/app/views/layouts/_provider_header.html.erb
@@ -8,4 +8,10 @@
       <%= link_to 'Sign out', provider_interface_sign_out_path, class: 'govuk-header__link' %>
     </li>
   </ul>
+<% elsif dfe_sign_in_user %>
+  <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+    <li class="govuk-header__navigation-item">
+      <%= link_to 'Sign out', provider_interface_sign_out_path, class: 'govuk-header__link' %>
+    </li>
+  </ul>
 <% end %>

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -22,7 +22,10 @@ RSpec.feature 'See applications' do
       given_i_am_a_provider_user_authenticated_with_dfe_sign_in
       and_my_organisation_has_applications
 
-      when_i_have_been_assigned_to_my_training_provider
+      when_i_visit_the_provider_page
+      then_i_should_see_the_account_creation_in_progress_page
+
+      when_my_apply_account_has_been_created
       and_i_visit_the_provider_page
       then_i_should_see_the_applications_from_my_organisation
 
@@ -30,12 +33,14 @@ RSpec.feature 'See applications' do
       then_i_should_be_on_the_application_view_page
     end
 
-    def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-      provider_user = provider_user_exists_in_apply_database
-      create(:provider, code: 'ABC', provider_users: [provider_user])
-
+    def given_i_am_a_provider_user_with_a_dfe_sign_in_account_but_no_apply_account
       provider_exists_in_dfe_sign_in
       provider_signs_in_using_dfe_sign_in
+    end
+
+    def when_my_apply_account_has_been_created
+      provider_user = provider_user_exists_in_apply_database
+      create(:provider, code: 'ABC', provider_users: [provider_user])
     end
   end
 
@@ -92,6 +97,8 @@ RSpec.feature 'See applications' do
   def and_i_visit_the_provider_page
     visit provider_interface_path
   end
+
+  alias :when_i_visit_the_provider_page :and_i_visit_the_provider_page
 
   def then_i_should_see_the_applications_from_my_organisation
     expect(page).to have_content @my_provider_choice1.application_form.first_name

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'See applications' do
 
       when_i_visit_the_provider_page
       then_i_should_see_the_account_creation_in_progress_page
+      and_i_should_see_a_sign_out_link
 
       when_my_apply_account_has_been_created
       and_i_visit_the_provider_page
@@ -52,6 +53,7 @@ RSpec.feature 'See applications' do
     and_i_have_not_been_assigned_to_my_training_provider # this is a manual process for now
     and_i_visit_the_provider_page
     then_i_should_see_the_account_creation_in_progress_page
+    and_i_should_see_a_sign_out_link
 
     when_i_have_been_assigned_to_my_training_provider
     and_i_visit_the_provider_page
@@ -75,6 +77,10 @@ RSpec.feature 'See applications' do
 
   def then_i_should_see_the_account_creation_in_progress_page
     expect(page).to have_content('Your account is not ready yet')
+  end
+
+  def and_i_should_see_a_sign_out_link
+    expect(page).to have_link('Sign out')
   end
 
   def when_i_have_been_assigned_to_my_training_provider


### PR DESCRIPTION
## Context

Following testing of provider permissions in the database, we noticed that if a provider tried to sign in but they didn't have a `ProviderUser` they would be kicked straight back to the sign-in screen without any explanation.

Instead, show them the "Your account is not ready yet" screen. The logic is copy-pasted from the `SupportInterfaceController` where we do exactly the same job, checking first for a valid Sign-in session and then for a valid `(Provider|Support)User`

While we're here, add a "Sign out" link to the top of that page so providers can try again with different credentials