### PR TITLE
Refactor DfE session code

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -2,8 +2,7 @@ class DfESignInController < ActionController::Base
   protect_from_forgery except: :bypass_callback
 
   def callback
-    dfe_sign_in_session = DfESignIn.parse_auth_hash(request.env['omniauth.auth'])
-    DfESignInUser.begin_session!(session, dfe_sign_in_session)
+    DfESignInUser.begin_session!(session, request.env['omniauth.auth'])
 
     redirect_to session.delete('post_dfe_sign_in_path') || default_authenticated_path
   end

--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -1,13 +1,4 @@
 module DfESignIn
-  DfESignInSession = Struct.new(:email_address, :uid)
-
-  def self.parse_auth_hash(openid_auth_hash)
-    DfESignInSession.new(
-      openid_auth_hash['info']['email'],
-      openid_auth_hash['uid'],
-    )
-  end
-
   def self.bypass?
     Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -6,22 +6,21 @@ class DfESignInUser
     @dfe_sign_in_uid = dfe_sign_in_uid
   end
 
-  def self.begin_session!(session, dfe_sign_in_session)
+  def self.begin_session!(session, omniauth_payload)
     session['dfe_sign_in_user'] = {
-      'email_address' => dfe_sign_in_session.email_address,
-      'dfe_sign_in_uid' => dfe_sign_in_session.uid,
+      'email_address' => omniauth_payload['info']['email'],
+      'dfe_sign_in_uid' => omniauth_payload['uid'],
     }
   end
 
   def self.load_from_session(session)
-    return nil unless session['dfe_sign_in_user']
+    dfe_sign_in_session = session['dfe_sign_in_user']
+    return unless dfe_sign_in_session
 
-    if session['dfe_sign_in_user']
-      new(
-        email_address: session['dfe_sign_in_user']['email_address'],
-        dfe_sign_in_uid: session['dfe_sign_in_user']['dfe_sign_in_uid'],
-      )
-    end
+    new(
+      email_address: dfe_sign_in_session['email_address'],
+      dfe_sign_in_uid: dfe_sign_in_session['dfe_sign_in_uid'],
+    )
   end
 
   def self.end_session!(session)

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -6,16 +6,17 @@ class ProviderUser < ActiveRecord::Base
   end
 
   def self.load_from_session(session)
-    return nil unless session['dfe_sign_in_user']
+    dfe_sign_in_user = DfESignInUser.load_from_session(session)
+    return unless dfe_sign_in_user
 
     if FeatureFlag.active?('provider_permissions_in_database')
       ProviderUser.find_by(
-        dfe_sign_in_uid: session['dfe_sign_in_user']['dfe_sign_in_uid'],
+        dfe_sign_in_uid: dfe_sign_in_user.dfe_sign_in_uid,
       )
     else
       LegacyProviderUser.new(
-        email_address: session['dfe_sign_in_user']['email_address'],
-        dfe_sign_in_uid: session['dfe_sign_in_user']['dfe_sign_in_uid'],
+        email_address: dfe_sign_in_user.email_address,
+        dfe_sign_in_uid: dfe_sign_in_user.dfe_sign_in_uid,
       )
     end
   end

--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -3,8 +3,9 @@ class SupportUser < ActiveRecord::Base
   validates :email_address, presence: true
 
   def self.load_from_session(session)
-    return nil unless session['dfe_sign_in_user']
+    dfe_sign_in_user = DfESignInUser.load_from_session(session)
+    return unless dfe_sign_in_user
 
-    SupportUser.find_by(dfe_sign_in_uid: session['dfe_sign_in_user']['dfe_sign_in_uid'])
+    SupportUser.find_by(dfe_sign_in_uid: dfe_sign_in_user.dfe_sign_in_uid)
   end
 end


### PR DESCRIPTION

## Context

This is a refactor to make it easier to implement session expiry.

## Changes proposed in this pull request

- Makes sure we only access the `session['dfe_sign_in_user’]` session via the DfESignInUser class
- Simplifies passing in the omniauth_hash
- Tidies up some other code

## Guidance to review



## Link to Trello card

https://trello.com/c/sJJMs0Rq/1402-investigate-session-timeouts

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
