### PR TITLE
Allow candidate to view 'Edit your application' page

### DIFF
--- a/app/components/application_complete_content_component.rb
+++ b/app/components/application_complete_content_component.rb
@@ -28,10 +28,6 @@ class ApplicationCompleteContentComponent < ActionView::Component::Base
     @dates.decline_by_default_at.strftime('%-e %B %Y')
   end
 
-  def edit_by_date
-    @dates.edit_by.strftime('%-e %B %Y')
-  end
-
 private
 
   attr_reader :application_form

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class ApplicationFormController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted, only: %i[show review]
+    before_action :redirect_to_dashboard_if_not_amendable, only: %i[show review]
 
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -10,7 +10,11 @@ module CandidateInterface
   private
 
     def redirect_to_dashboard_if_submitted
-      redirect_to candidate_interface_application_complete_path if current_application.submitted? && FeatureFlag.active?('edit_application') == false
+      if FeatureFlag.active?('edit_application')
+        redirect_to candidate_interface_application_complete_path if current_application.submitted? && current_application.within_amend_period? == false
+      else
+        redirect_to candidate_interface_application_complete_path if current_application.submitted?
+      end
     end
 
     def redirect_to_application_if_signed_in

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -10,7 +10,7 @@ module CandidateInterface
   private
 
     def redirect_to_dashboard_if_submitted
-      redirect_to candidate_interface_application_complete_path if current_application.submitted?
+      redirect_to candidate_interface_application_complete_path if current_application.submitted? && FeatureFlag.active?('edit_application') == false
     end
 
     def redirect_to_application_if_signed_in

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -9,11 +9,11 @@ module CandidateInterface
 
   private
 
-    def redirect_to_dashboard_if_submitted
+    def redirect_to_dashboard_if_not_amendable
       if FeatureFlag.active?('edit_application')
         redirect_to candidate_interface_application_complete_path if current_application.submitted? && current_application.within_amend_period? == false
-      else
-        redirect_to candidate_interface_application_complete_path if current_application.submitted?
+      elsif current_application.submitted?
+        redirect_to candidate_interface_application_complete_path
       end
     end
 

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class ContactDetails::AddressController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class ContactDetails::BaseController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class ContactDetails::ReviewController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @application_form = current_application

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class CourseChoicesController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
 
     def index

--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Degrees::BaseController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def new
       @degree = DegreeForm.new

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Degrees::ReviewController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @application_form = current_application

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Gcse::DetailsController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     before_action :set_subject
 

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Gcse::ReviewController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     before_action :set_subject
 

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Gcse::TypeController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
     before_action :set_subject
 
     # 1st step - Edit qualification type

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class OtherQualifications::BaseController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def new
       qualifications = OtherQualificationForm.build_all_from_application(current_application)

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class OtherQualifications::DestroyController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def confirm_destroy
       @qualification = OtherQualificationForm.build_from_application(

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class OtherQualifications::ReviewController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @application_form = current_application

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def edit
       @personal_details_form = PersonalDetailsForm.build_from_application(

--- a/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class PersonalStatement::BecomingATeacherController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def edit
       @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(

--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class PersonalStatement::InterviewPreferencesController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def edit
       @interview_preferences_form = InterviewPreferencesForm.build_from_application(

--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class PersonalStatement::SubjectKnowledgeController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def edit
       @subject_knowledge_form = SubjectKnowledgeForm.build_from_application(

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class RefereesController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
     before_action :set_referee, only: %i[edit update confirm_destroy destroy]
     before_action :set_referees, only: %i[index review]
 

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Volunteering::BaseController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def new
       @volunteering_role = VolunteeringRoleForm.new

--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Volunteering::DestroyController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def confirm_destroy
       @volunteering_role = VolunteeringRoleForm.build_from_application(current_application, current_volunteering_role_id)

--- a/app/controllers/candidate_interface/volunteering/experience_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/experience_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Volunteering::ExperienceController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @volunteering_experience_form = VolunteeringExperienceForm.new

--- a/app/controllers/candidate_interface/volunteering/review_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class Volunteering::ReviewController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @application_form = current_application

--- a/app/controllers/candidate_interface/work_history/breaks_controller.rb
+++ b/app/controllers/candidate_interface/work_history/breaks_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class WorkHistory::BreaksController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def edit
       @work_breaks_form = WorkBreaksForm.build_from_application(

--- a/app/controllers/candidate_interface/work_history/destroy_controller.rb
+++ b/app/controllers/candidate_interface/work_history/destroy_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class WorkHistory::DestroyController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def confirm_destroy
       @work_experience = current_application

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class WorkHistory::EditController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def new
       @work_experience_form = WorkExperienceForm.new

--- a/app/controllers/candidate_interface/work_history/explanation_controller.rb
+++ b/app/controllers/candidate_interface/work_history/explanation_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class WorkHistory::ExplanationController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @work_explanation_form = WorkExplanationForm.build_from_application(

--- a/app/controllers/candidate_interface/work_history/length_controller.rb
+++ b/app/controllers/candidate_interface/work_history/length_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class WorkHistory::LengthController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @work_details_form = WorkHistoryForm.new

--- a/app/controllers/candidate_interface/work_history/review_controller.rb
+++ b/app/controllers/candidate_interface/work_history/review_controller.rb
@@ -1,6 +1,6 @@
 module CandidateInterface
   class WorkHistory::ReviewController < CandidateInterfaceController
-    before_action :redirect_to_dashboard_if_submitted
+    before_action :redirect_to_dashboard_if_not_amendable
 
     def show
       @application_form = current_application

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -46,6 +46,11 @@ module ViewHelper
     "#{t('page_titles.error_prefix') if error}#{title}"
   end
 
+  def edit_by_date
+    dates = ApplicationDates.new(@application_form)
+    dates.edit_by.strftime('%e %B %Y').strip
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -92,5 +92,13 @@ class ApplicationForm < ApplicationRecord
     "#{first_name} #{last_name}"
   end
 
+  def amendable?
+    FeatureFlag.active?('edit_application') && submitted? && within_amend_period?
+  end
+
+  def within_amend_period?
+    application_choices.none?(&:edit_by_expired?)
+  end
+
   audited
 end

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -15,6 +15,6 @@
     <p class="govuk-body">You can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
     <h2 class="govuk-heading-m">Contact details</h2>
     <p class="govuk-body">You can update your contact details at any point during the application process.</p>
-    <%= govuk_button_link_to t('application_complete.edit_page.edit_button'), candidate_interface_application_edit_path %>
+    <%= govuk_button_link_to t('application_complete.edit_page.edit_button'), candidate_interface_application_form_path %>
   </div>
 </div>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -1,12 +1,23 @@
-<% content_for :title, t('page_titles.application_form') %>
+<% content_for :title, @application_form.amendable? ? t('page_titles.edit_application_form') : t('page_titles.application_form') %>
 
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
-  <%= t('page_titles.application_form') %>
+  <%= @application_form.amendable? ? t('page_titles.edit_application_form') : t('page_titles.application_form') %>
 </h1>
-<p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% if @application_form.amendable? %>
+      <div class="govuk-warning-text govuk-!-margin-top-6">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+            <%= t('application_complete.edit_page.warning_text', remaining_days: formatted_days_remaining, date: edit_by_date) %>
+        </strong>
+      </div>
+    <% else %>
+      <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
+    <% end %>
+
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
       <%= t('page_titles.course_choices') %>
     </h2>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -25,6 +25,6 @@
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
     <p class="govuk-body">You have 5 working days to make changes to a submitted application. We won't send your application to your training provider(s) until the 5 working days are up.</p>
-    <p class="govuk-body">To edit your application, return to your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_form_path %>.</p>
+    <p class="govuk-body">To edit your application, return to your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
   </div>
 </div>

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -4,3 +4,5 @@ en:
       edit_link: Edit your application
     edit_page:
       edit_button: 'Edit Application'
+      warning_text: >
+        You have %{remaining_days} (until %{date}) to edit your application

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,7 @@ en:
   page_titles:
     application: ''
     application_form: Your application
+    edit_application_form: Edit your application
     application_dashboard: Application dashboard
     application_edit: Editing your application
     eligibility: First, check you can use this service

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe ViewHelper, type: :helper do
         ApplicationDates,
         submitted_at: Time.zone.local(2019, 10, 22, 12, 0, 0),
         reject_by_default_at: Time.zone.local(2019, 12, 17, 12, 0, 0),
+        edit_by: Time.zone.local(2019, 10, 29, 12, 0, 0),
         days_remaining_to_edit: 7,
         form_open_to_editing?: true,
       )
@@ -99,6 +100,12 @@ RSpec.describe ViewHelper, type: :helper do
     describe '#respond_by_date' do
       it 'renders with correct respond by date' do
         expect(helper.respond_by_date).to include('17 December 2019')
+      end
+    end
+
+    describe '#edit_by_date' do
+      it 'renders with correct edit by date' do
+        expect(helper.edit_by_date).to include('29 October 2019')
       end
     end
 

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -21,6 +21,9 @@ RSpec.feature 'A candidate edits their application' do
     when_i_click_the_edit_button
     then_i_see_the_edit_application_page
     and_i_see_the_remaining_days_to_edit
+
+    when_the_amend_period_has_ended_and_i_visit_the_edit_application_page
+    then_i_see_the_application_dashboard
   end
 
   def given_the_edit_application_feature_flag_is_on
@@ -66,5 +69,15 @@ RSpec.feature 'A candidate edits their application' do
     )
 
     expect(page).to have_content(remaining_days_to_edit)
+  end
+
+  def when_the_amend_period_has_ended_and_i_visit_the_edit_application_page
+    Timecop.travel(Time.zone.local(2019, 12, 16) + 5.days) do
+      visit candidate_interface_application_form_path
+    end
+  end
+
+  def then_i_see_the_application_dashboard
+    expect(page).to have_content t('page_titles.application_dashboard')
   end
 end

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -3,32 +3,41 @@ require 'rails_helper'
 RSpec.feature 'A candidate edits their application' do
   include CandidateHelper
 
+  around do |example|
+    Timecop.freeze(Time.zone.local(2019, 12, 16)) do
+      example.run
+    end
+  end
+
   scenario 'candidate selects to edit their application', sidekiq: true do
     given_the_edit_application_feature_flag_is_on
-
-    given_i_am_signed_in_as_a_candidate
+    and_i_am_signed_in_as_a_candidate
     and_i_have_a_completed_application
 
     when_i_visit_the_application_dashboard
     and_i_click_the_edit_link
     then_i_see_a_button_to_edit_my_application
+
+    when_i_click_the_edit_button
+    then_i_see_the_edit_application_page
+    and_i_see_the_remaining_days_to_edit
   end
 
   def given_the_edit_application_feature_flag_is_on
     FeatureFlag.activate('edit_application')
   end
 
-  def given_i_am_signed_in_as_a_candidate
+  def and_i_am_signed_in_as_a_candidate
     create_and_sign_in_candidate
   end
 
   def and_i_have_a_completed_application
-    form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate)
-    @application_choice = create(:application_choice, status: :application_complete, edit_by: 1.day.from_now.end_of_day, application_form: form)
+    form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
+    create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: form)
   end
 
   def when_i_visit_the_application_dashboard
-    visit candidate_interface_application_form_path
+    visit candidate_interface_application_complete_path
   end
 
   def and_i_click_the_edit_link
@@ -37,5 +46,25 @@ RSpec.feature 'A candidate edits their application' do
 
   def then_i_see_a_button_to_edit_my_application
     expect(page).to have_link(t('application_complete.edit_page.edit_button'))
+  end
+
+  def when_i_click_the_edit_button
+    click_link t('application_complete.edit_page.edit_button')
+  end
+
+  def then_i_see_the_edit_application_page
+    within('.govuk-heading-xl') do
+      expect(page).to have_content(t('page_titles.edit_application_form'))
+    end
+  end
+
+  def and_i_see_the_remaining_days_to_edit
+    remaining_days_to_edit = t(
+      'application_complete.edit_page.warning_text',
+      remaining_days: '4 days',
+      date: '20 December 2019',
+    )
+
+    expect(page).to have_content(remaining_days_to_edit)
   end
 end

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -44,15 +44,6 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
 
     when_i_click_view_application
     then_i_can_see_my_submitted_application
-
-    when_i_attempt_to_edit_my_personal_details
-    then_i_can_see_my_application_dashboard
-
-    when_i_attempt_to_edit_my_contact_details
-    then_i_can_see_my_application_dashboard
-
-    when_i_click_the_edit_application_link
-    then_i_see_edit_information_page
   end
 
   def given_i_am_signed_in
@@ -65,14 +56,6 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
 
   def when_i_have_completed_my_application
     candidate_completes_application_form
-  end
-
-  def when_i_attempt_to_edit_my_personal_details
-    visit candidate_interface_personal_details_edit_path
-  end
-
-  def when_i_attempt_to_edit_my_contact_details
-    visit candidate_interface_contact_details_edit_base_path
   end
 
   def and_i_review_my_application
@@ -242,13 +225,5 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     expect(page).to have_content 'Everything'
     expect(page).to have_content 'Not on a Wednesday'
     expect(page).to have_content 'Terri Tudor'
-  end
-
-  def when_i_click_the_edit_application_link
-    click_link t('application_complete.dashboard.edit_link')
-  end
-
-  def then_i_see_edit_information_page
-    expect(page).to have_content t('page_titles.application_edit')
   end
 end


### PR DESCRIPTION
## Context

We want candidates to be able to edit their application within 5 days after submission themselves.

In PR #897, we added a feature flag to simply show a `Edit your application` button but it never led anywhere.

## Changes proposed in this pull request

This PR allows a candidate to click on the `Edit your application` button and takes then to the `Your application` page but with a makeover:

- `Your application` is now `Edit your application`
- `Last saved` text is removed
- a warning text is added to notify when they must resubmit their application

We've also ensured that when the amend period is over (i.e. the 5 days have passed), candidates are then always redirected to the `Application dashboard`.

As well as renamed `redirect_to_dashboard_if_submitted` to `redirect_to_if_not_amendable` because we are no longer **_just_** checking if an application is submitted, we also check if it's within the amend period.

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/71086766-90698e00-2192-11ea-9e33-48c98d211245.png)

## Guidance to review

Review commit by commit with the extended description as we've added explanation there.

In upcoming PRs, we'll be ensuring that:

- references can't be edited
- `Check your answers before submitting` is updated for resubmission
- course choices is updated to show `Delete choice` rather than `Withdraw`

## Link to Trello card

https://trello.com/c/IP7g0jBr/583-amending-an-application-after-submission

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
