### PR TITLE
Redirect to application form#show page without a completed application

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class ApplicationFormController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_not_amendable, only: %i[show review]
+    before_action :redirect_to_application_form_unless_submitted, only: %i[review_submitted complete submit_success]
 
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -17,6 +17,10 @@ module CandidateInterface
       end
     end
 
+    def redirect_to_application_form_unless_submitted
+      redirect_to candidate_interface_application_form_path unless current_application.submitted?
+    end
+
     def redirect_to_application_if_signed_in
       redirect_to candidate_interface_application_form_path if candidate_signed_in?
     end

--- a/spec/system/candidate_interface/candidate_viewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_application_spec.rb
@@ -7,6 +7,16 @@ RSpec.feature 'Viewing their new application' do
     given_i_am_signed_in
     when_i_visit_the_site
     then_i_should_see_that_i_have_made_no_choices
+
+    #while I have not submitted an application
+    when_i_visit_the_review_page
+    then_i_am_on_the_application_form_page
+
+    when_i_visit_the_complete_page
+    then_i_am_on_the_application_form_page
+
+    when_i_visit_the_submit_success_page
+    then_i_am_on_the_application_form_page
   end
 
   def given_i_am_signed_in
@@ -19,5 +29,21 @@ RSpec.feature 'Viewing their new application' do
 
   def then_i_should_see_that_i_have_made_no_choices
     expect(page).to have_content(t('application_form.courses.intro'))
+  end
+
+  def when_i_visit_the_review_page
+    visit candidate_interface_application_review_submitted_path
+  end
+
+  def when_i_visit_the_complete_page
+    visit candidate_interface_application_complete_path
+  end
+
+  def when_i_visit_the_submit_success_page
+    visit candidate_interface_application_submit_success_path
+  end
+
+  def then_i_am_on_the_application_form_page
+    then_i_should_see_that_i_have_made_no_choices
   end
 end


### PR DESCRIPTION
## Context
We want to show the application page when a candidate is directly accessing the review page and has not submitted an application.

## Changes proposed in this pull request
This PR adds a `before_action` to redirect to the `application_form#show` page when the application has not been submitted.
 
## Guidance to review
- Sign in with an account without a completed application (a new one works fine)
- go to `/candidate/application/review/submitted`
- go to `/candidate/application/complete`
- go to `/candidate/application/submit-success`

You should see the `application` page in each of these scenarios instead of the 500 error

## Link to Trello card
https://trello.com/c/mogFoeDa/564-500-error-when-accessing-candidate-application-review-submitted-directly-without-a-completed-application