### PR TITLE
Implement session expiry for provider & support

### DIFF
--- a/spec/models/df_e_sign_in_user_spec.rb
+++ b/spec/models/df_e_sign_in_user_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe DfESignInUser, type: :model do
+  describe '.load_from_session' do
+    it 'returns the DfE User when the user has signed in and has been recently active' do
+      session = { 'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now } }
+
+      user = DfESignInUser.load_from_session(session)
+
+      expect(user).not_to be_nil
+    end
+
+    it 'returns nil when the user has signed in and has not been recently active' do
+      session = { 'dfe_sign_in_user' => { 'last_active_at' => Time.zone.now - 1.day } }
+
+      user = DfESignInUser.load_from_session(session)
+
+      expect(user).to be_nil
+    end
+
+    it 'returns nil when the user has not signed in' do
+      session = { 'dfe_sign_in_user' => nil }
+
+      user = DfESignInUser.load_from_session(session)
+
+      expect(user).to be_nil
+    end
+
+    it 'returns nil when the user does not have a last active timestamp' do
+      session = { 'dfe_sign_in_user' => { 'last_active_at' => nil } }
+
+      user = DfESignInUser.load_from_session(session)
+
+      expect(user).to be_nil
+    end
+  end
+end

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
       and_i_sign_in_via_dfe_sign_in
 
       then_i_should_see_my_email_address
+
+      when_i_signed_in_more_than_a_2_hours_ago
+      then_i_should_see_the_login_page_again
     end
   end
 
@@ -64,5 +67,11 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
 
   def then_i_should_see_the_login_page_again
     expect(page).to have_button('Sign in using DfE Sign-in')
+  end
+
+  def when_i_signed_in_more_than_a_2_hours_ago
+    Timecop.travel(Time.zone.now + 2.hours + 1.second) do
+      visit provider_interface_path
+    end
   end
 end


### PR DESCRIPTION
## Context

When a user hasn’t been active for over 2 hours, we require them to sign in again. This is a recommendation from the pentesters.

## Changes proposed in this pull request

Implement an expiry mechanism. Special care has been taken for users who have a previous session without an last_active timestamp. Implementation was made easier by https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/924.

## Guidance to review

Read the code and test it out.

## Link to Trello card

https://trello.com/c/sJJMs0Rq

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
