### PR TITLE
Disallow editing references after application submission

### DIFF
--- a/app/components/task_list_item_component.html.erb
+++ b/app/components/task_list_item_component.html.erb
@@ -1,5 +1,9 @@
 <%= govuk_link_to text, path, class: 'app-task-list__task-name', 'aria-describedby': tag_id %>
-<% if completed %>
+<% if submitted %>
+  <strong class="govuk-tag app-tag app-tag--secondary" id=<%= tag_id %>>
+    Submitted
+  </strong>
+<% elsif completed %>
   <strong class="govuk-tag app-tag app-tag--complete" id=<%= tag_id %>>
     Completed
   </strong>

--- a/app/components/task_list_item_component.rb
+++ b/app/components/task_list_item_component.rb
@@ -3,11 +3,12 @@ class TaskListItemComponent < ActionView::Component::Base
 
   validates :path, presence: true
 
-  def initialize(completed:, path:, text:, show_incomplete: true)
+  def initialize(completed:, path:, text:, show_incomplete: true, submitted: false)
     @completed = completed
     @path = path
     @text = text
     @show_incomplete = show_incomplete
+    @submitted = submitted
   end
 
   def tag_id
@@ -16,5 +17,5 @@ class TaskListItemComponent < ActionView::Component::Base
 
 private
 
-  attr_reader :completed, :path, :text, :show_incomplete
+  attr_reader :completed, :path, :text, :show_incomplete, :submitted
 end

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class RefereesController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_not_amendable
+    before_action :redirect_to_review_referees_if_amendable, except: %i[index review]
     before_action :set_referee, only: %i[edit update confirm_destroy destroy]
     before_action :set_referees, only: %i[index review]
 
@@ -68,6 +69,10 @@ module CandidateInterface
         :relationship,
       )
         .transform_values(&:strip)
+    end
+
+    def redirect_to_review_referees_if_amendable
+      redirect_to candidate_interface_review_referees_path if current_application.amendable?
     end
   end
 end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -92,11 +92,16 @@
     </ul>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
+    <% if @application_form.amendable? %>
+      <p class="govuk-body"><%= t('application_complete.edit_page.references_uneditable') %></p>
+    <% end %>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">
-        <%= render(TaskListItemComponent, text: 'Referees', completed: @application_form_presenter.all_referees_provided_by_candidate?, path: candidate_interface_referees_path) %>
+        <% submitted = @application_form.amendable? ? true : false %>
+        <%= render(TaskListItemComponent, text: 'Referees', completed: @application_form_presenter.all_referees_provided_by_candidate?, path: candidate_interface_referees_path, submitted: submitted) %>
       </li>
     </ul>
+
     <% if @application_form.amendable? %>
       <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('application_complete.edit_page.resubmit_title') %></h2>
       <ul class="app-task-list govuk-!-margin-bottom-8">

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -5,7 +5,8 @@
   <%= t('page_titles.referees') %>
 </h1>
 
-<%= render(RefereesReviewComponent, application_form: @application_form) %>
+<% editable = @application_form.amendable? ? false : true %>
+<%= render(RefereesReviewComponent, application_form: @application_form, editable: editable) %>
 
 <%- if @referees.count < ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 <p>

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -8,3 +8,5 @@ en:
         You have %{remaining_days} (until %{date}) to edit your application
       resubmit_title: 'Go back to application dashboard'
       resubmit_button: 'Finish and go back to application dashboard'
+      references_uneditable:
+        You can’t change your choice of referees after you’ve submitted your application.

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -22,6 +22,15 @@ RSpec.feature 'A candidate edits their application' do
     then_i_see_the_edit_application_page
     and_i_see_the_remaining_days_to_edit
     and_i_see_the_submit_button_is_changed
+    and_i_see_i_cant_change_my_references
+    and_i_see_a_submitted_label_for_referees
+
+    when_i_click_on_referees
+    then_i_can_review_my_references
+    and_i_cannot_see_the_edit_or_delete_referee_links
+
+    when_i_visit_the_new_referee_page
+    then_i_see_the_review_referees_page
 
     when_the_amend_period_has_ended_and_i_visit_the_edit_application_page
     then_i_see_the_application_dashboard
@@ -36,8 +45,8 @@ RSpec.feature 'A candidate edits their application' do
   end
 
   def and_i_have_a_completed_application
-    form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
-    create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: form)
+    @form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
+    create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: @form)
   end
 
   def when_i_visit_the_application_dashboard
@@ -70,6 +79,39 @@ RSpec.feature 'A candidate edits their application' do
     )
 
     expect(page).to have_content(remaining_days_to_edit)
+  end
+
+  def and_i_see_i_cant_change_my_references
+    expect(page).to have_content(t('application_complete.edit_page.references_uneditable'))
+  end
+
+  def and_i_see_a_submitted_label_for_referees
+    within('#referees-badge-id') { expect(page).to have_content('Submitted') }
+  end
+
+  def when_i_click_on_referees
+    click_link 'Referees'
+  end
+
+  def then_i_can_review_my_references
+    first_referee = @form.application_references.first
+    second_referee = @form.application_references.second
+
+    expect(page).to have_content(first_referee.name)
+    expect(page).to have_content(second_referee.name)
+  end
+
+  def and_i_cannot_see_the_edit_or_delete_referee_links
+    expect(page).not_to have_content('Change')
+    expect(page).not_to have_content(t('application_form.referees.delete'))
+  end
+
+  def when_i_visit_the_new_referee_page
+    visit candidate_interface_new_referee_path
+  end
+
+  def then_i_see_the_review_referees_page
+    then_i_can_review_my_references
   end
 
   def when_the_amend_period_has_ended_and_i_visit_the_edit_application_page


### PR DESCRIPTION
## Context

Candidates shouldn't be allowed to edit their references when they are in the amendment period.

## Changes proposed in this pull request (Updated 19 Dec, 12:20)

~This PR updates the `Edit your application` page so it doesn't show the `References` section and the link. It also prevents a candidate from going to the page directly if their application is in the amendment period.~

This PR updates the `Edit your application` page so it adds additional content to notify the candidate that references aren't editable after application submission and changes the `Completed` label to `Submitted.

When a candidate clicks on the `Referees` link, they are taken to the review referees page but without the `Delete referee` and `Change` links.

It also prevents a candidate from going to the page directly if their application is in the amendment period by redirecting them to the review referees page.

## Screenshot (Updated 19 Dec, 12:20)

![image](https://user-images.githubusercontent.com/42817036/71173256-1ef51280-225a-11ea-98fe-74f60d735cde.png)

![image](https://user-images.githubusercontent.com/42817036/71161096-a46bc900-2240-11ea-832e-b2f45b15c76a.png)

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/IP7g0jBr/583-amending-an-application-after-submission

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
