### PR TITLE
Update resubmit button on application edit page

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -3,12 +3,14 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_not_amendable, only: %i[show review]
     before_action :redirect_to_application_form_unless_submitted, only: %i[review_submitted complete submit_success]
 
+
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
       @application_form = current_application
     end
 
     def review
+      redirect_to candidate_interface_application_complete_path if current_application.submitted?
       @application_form = current_application
     end
 

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -97,15 +97,25 @@
         <%= render(TaskListItemComponent, text: 'Referees', completed: @application_form_presenter.all_referees_provided_by_candidate?, path: candidate_interface_referees_path) %>
       </li>
     </ul>
-
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Review and submit</h2>
-    <ul class="app-task-list govuk-!-margin-bottom-8">
-      <li class="app-task-list__item">
-        <%= govuk_link_to 'Check your answers before submitting',
-                          candidate_interface_application_review_path,
-                          class: 'app-task-list__task-name' %>
-      </li>
-    </ul>
+    <% if @application_form.amendable? %>
+      <h2 class="govuk-heading-m govuk-!-font-size-27"><%= t('application_complete.edit_page.resubmit_title') %></h2>
+      <ul class="app-task-list govuk-!-margin-bottom-8">
+        <li class="app-task-list__item">
+          <%= govuk_link_to t('application_complete.edit_page.resubmit_button'),
+                            candidate_interface_application_complete_path,
+                            class: 'app-task-list__task-name' %>
+        </li>
+      </ul>
+    <% else %>
+      <h2 class="govuk-heading-m govuk-!-font-size-27">Review and submit</h2>
+      <ul class="app-task-list govuk-!-margin-bottom-8">
+        <li class="app-task-list__item">
+          <%= govuk_link_to 'Check your answers before submitting',
+                            candidate_interface_application_review_path,
+                            class: 'app-task-list__task-name' %>
+        </li>
+      </ul>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -6,3 +6,5 @@ en:
       edit_button: 'Edit Application'
       warning_text: >
         You have %{remaining_days} (until %{date}) to edit your application
+      resubmit_title: 'Go back to application dashboard'
+      resubmit_button: 'Finish and go back to application dashboard'

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'A candidate edits their application' do
     when_i_click_the_edit_button
     then_i_see_the_edit_application_page
     and_i_see_the_remaining_days_to_edit
+    and_i_see_the_submit_button_is_changed
 
     when_the_amend_period_has_ended_and_i_visit_the_edit_application_page
     then_i_see_the_application_dashboard
@@ -79,5 +80,10 @@ RSpec.feature 'A candidate edits their application' do
 
   def then_i_see_the_application_dashboard
     expect(page).to have_content t('page_titles.application_dashboard')
+  end
+
+  def and_i_see_the_submit_button_is_changed
+    expect(page).to have_content(t('application_complete.edit_page.resubmit_title'))
+    expect(page).to have_link(t('application_complete.edit_page.resubmit_button'))
   end
 end


### PR DESCRIPTION
## Context

When candidates go to edit their submitted application the submit button suggests that the application will be saved and submitted again then, this is not the case because editing the application after submission edits the application in place.
This PR aims to address this.

## Changes proposed in this pull request

This PR includes:
- Update the submit button on application edit page to return to application complete page when the application is amendable and being edited.
- Update system specs to include test to assert that the submit button has been changed for submitted applications.



## Guidance to review

- Would like guidance on the copy for the new `go back to dashboard button title and text`.
- Check specs to ensure that I haven't missed any edge cases when editing an application.

## Screenshots
Before
<img width="803" alt="Screenshot 2019-12-18 at 16 32 21" src="https://user-images.githubusercontent.com/47318392/71104707-1fd36900-21b4-11ea-880c-69c3953cbda2.png">

After
<img width="833" alt="Screenshot 2019-12-18 at 16 32 07" src="https://user-images.githubusercontent.com/47318392/71104715-2366f000-21b4-11ea-83d1-f4c92a699f3c.png">


## Link to Trello card

https://trello.com/c/IP7g0jBr/583-amending-an-application-after-submission

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
