### PR TITLE
Revert "Bypass DfE Signin when running in `development` hosting environment"

### DIFF
--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -1,5 +1,5 @@
 module DfESignIn
   def self.bypass?
-    !HostingEnvironment.production? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
+    Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end
 end


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-postgraduate-teacher-training#914

This change causes some tests to fails when running locally as support sign-in fails