### PR TITLE
Fix interview preferences pre-population of 'None' in text area

### DIFF
--- a/app/components/interview_preferences_review_component.rb
+++ b/app/components/interview_preferences_review_component.rb
@@ -23,9 +23,11 @@ private
   attr_reader :application_form
 
   def interview_preferences_form_row
+    preferences = @interview_preferences_form.interview_preferences.presence || t('application_form.personal_statement.interview_preferences.no_value')
+
     {
       key: t('application_form.personal_statement.interview_preferences.key'),
-      value: @interview_preferences_form.interview_preferences,
+      value: preferences,
       action: t('application_form.personal_statement.interview_preferences.change_action'),
       change_path: Rails.application.routes.url_helpers.candidate_interface_interview_preferences_edit_path,
     }

--- a/app/models/candidate_interface/interview_preferences_form.rb
+++ b/app/models/candidate_interface/interview_preferences_form.rb
@@ -2,8 +2,6 @@ module CandidateInterface
   class InterviewPreferencesForm
     include ActiveModel::Model
 
-    DEFAULT_NO_VALUE = I18n.t('application_form.personal_statement.interview_preferences.no_value')
-
     attr_accessor :any_preferences, :interview_preferences
 
     validates :any_preferences, presence: true
@@ -21,7 +19,7 @@ module CandidateInterface
       def interview_preferences_to_any_preferences(preferences)
         if preferences.nil?
           nil
-        elsif preferences == DEFAULT_NO_VALUE
+        elsif preferences == ''
           'no'
         else
           'yes'
@@ -33,7 +31,7 @@ module CandidateInterface
       return false unless valid?
 
       application_form.update(
-        interview_preferences: any_preferences? ? interview_preferences : DEFAULT_NO_VALUE,
+        interview_preferences: any_preferences? ? interview_preferences : '',
       )
     end
 

--- a/spec/components/interview_preferences_review_component_spec.rb
+++ b/spec/components/interview_preferences_review_component_spec.rb
@@ -1,14 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe InterviewPreferencesReviewComponent do
-  let(:application_form) { create(:completed_application_form) }
+  let(:application_form) { build_stubbed(:application_form, interview_preferences: Faker::Lorem.paragraph_by_chars(number: 100)) }
 
   context 'when interview preferences is editable' do
-    it 'renders SummaryCardComponent with valid becoming a teacher' do
+    it 'renders SummaryCardComponent with interview preferences' do
       result = render_inline(InterviewPreferencesReviewComponent, application_form: application_form)
 
       expect(result.text).to include(application_form.interview_preferences)
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.personal_statement.interview_preferences.change_action')}")
+    end
+
+    it 'renders with "None" if value of interview preferences is an empty string' do
+      application_form.interview_preferences = ''
+
+      result = render_inline(InterviewPreferencesReviewComponent, application_form: application_form)
+
+      expect(result.text).to include('None')
     end
   end
 

--- a/spec/models/candidate_interface/interview_preferences_form_spec.rb
+++ b/spec/models/candidate_interface/interview_preferences_form_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
       expect(interview_preferences).to have_attributes(form_data)
     end
 
-    it 'returns no for any preferences if the default no value is used' do
+    it 'returns no for any preferences if an empty string' do
       application_form = ApplicationForm.new(
-        interview_preferences: t('application_form.personal_statement.interview_preferences.no_value'),
+        interview_preferences: '',
       )
       interview_preferences = CandidateInterface::InterviewPreferencesForm.build_from_application(
         application_form,
@@ -60,7 +60,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
       expect(application_form).to have_attributes(data)
     end
 
-    it 'updates the provided ApplicationForm with the default no value if no is selected' do
+    it 'updates the provided ApplicationForm with an empty string if no is selected' do
       application_form = create(:application_form)
       interview_preferences = CandidateInterface::InterviewPreferencesForm.new(
         any_preferences: 'no',
@@ -69,7 +69,7 @@ RSpec.describe CandidateInterface::InterviewPreferencesForm, type: :model do
 
       expect(interview_preferences.save(application_form)).to eq(true)
       expect(application_form).to have_attributes(
-        interview_preferences: t('application_form.personal_statement.interview_preferences.no_value'),
+        interview_preferences: '',
       )
     end
   end


### PR DESCRIPTION
## Context

When product reviewing the changing the interview preferences section to a question, Matteo found that  when a candidate:

1. selects `No` for any interview preferences
2. clicks `Save and continue`
3. clicks `Change`
4. selects `Yes`

the text area is pre-populated with `None`.

## Changes proposed in this pull request

This PR updates the `CandidateInterface::InterviewPreferencesForm` to save an empty string if `No` is selected. Then in order to display `None` when a candidate reviews their interview preferences, `InterviewPreferencesReviewComponent` is updated to display `None` when the value of `interview_preferences` is an empty string.

## Before screenshots

![image](https://user-images.githubusercontent.com/42817036/71163462-075f5f00-2245-11ea-822a-1b45781827b1.png)

![image](https://user-images.githubusercontent.com/42817036/71163470-0cbca980-2245-11ea-8336-7cd445d7656e.png)

## After screenshots

![image](https://user-images.githubusercontent.com/42817036/71163506-252cc400-2245-11ea-89b9-7a4d85625a0e.png)

![image](https://user-images.githubusercontent.com/42817036/71163513-2827b480-2245-11ea-923f-340f7b1e2f4c.png)

## Guidance to review

Does this makes sense? Is there a better way to deal with this?

## Link to Trello card

https://trello.com/c/htjXI6yz/465-update-interview-preferences-to-a-question

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
