### PR TITLE
Add application dates to the provider UI

### DIFF
--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,0 +1,10 @@
+<div class="app-status-box">
+  <h2 class="govuk-heading-m">Status</h2>
+  <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: @application_choice %>
+
+  <% if @application_choice.status == 'awaiting_provider_decision' %>
+    <div class="govuk-!-margin-top-6">
+      <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice.id), class: 'govuk-!-margin-bottom-0' %>
+    </div>
+  <% end %>
+</div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -2,6 +2,35 @@
   <h2 class="govuk-heading-m">Status</h2>
   <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: application_choice %>
 
+  <dl class="app-definition-list govuk-!-margin-top-4">
+    <dt>Application submitted</dt>
+    <dd><%= submitted_at %></dd>
+
+    <% if application_choice.awaiting_provider_decision? %>
+      <dt>Respond to the applicant by</dt>
+      <dd><%= respond_by %></dd>
+    <% elsif application_choice.withdrawn? %>
+      <dt>Application withdrawn</dt>
+      <dd><%= withdrawn_at %></dd>
+    <% elsif application_choice.offer? %>
+      <dt>Needs to respond by</dt>
+      <dd><%= candidate_respond_by %></dd>
+    <% elsif application_choice.rejected? %>
+      <dt>Rejected at</dt>
+      <dd><%= rejected_at %></dd>
+    <% elsif application_choice.recruited? %>
+      <%# TODO once we have recruited_at %>
+    <% elsif application_choice.declined? %>
+      <%# TODO once we have declined_at set every time the change %>
+    <% elsif application_choice.pending_conditions? %>
+      <%# TODO once we have accepted_at %>
+    <% elsif application_choice.conditions_not_met? %>
+      <%# TODO once we have conditions_not_met_at %>
+    <% elsif application_choice.enrolled? %>
+      <%# TODO once we have enrolled_at %>
+    <% end %>
+  </dl>
+
   <% if application_choice.awaiting_provider_decision? %>
     <div class="govuk-!-margin-top-6">
       <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0' %>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,10 +1,10 @@
 <div class="app-status-box">
   <h2 class="govuk-heading-m">Status</h2>
-  <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: @application_choice %>
+  <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: application_choice %>
 
-  <% if @application_choice.status == 'awaiting_provider_decision' %>
+  <% if application_choice.awaiting_provider_decision? %>
     <div class="govuk-!-margin-top-6">
-      <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice.id), class: 'govuk-!-margin-bottom-0' %>
+      <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
     </div>
   <% end %>
 </div>

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -1,0 +1,9 @@
+module ProviderInterface
+  class StatusBoxComponent < ActionView::Component::Base
+    attr_reader :application_choice
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+  end
+end

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -1,9 +1,37 @@
 module ProviderInterface
   class StatusBoxComponent < ActionView::Component::Base
+    include ViewHelper
+
     attr_reader :application_choice
 
     def initialize(application_choice:)
       @application_choice = application_choice
+    end
+
+    def submitted_at
+      format_date application_choice.application_form.submitted_at
+    end
+
+    def respond_by
+      format_date application_choice.reject_by_default_at
+    end
+
+    def withdrawn_at
+      format_date application_choice.withdrawn_at
+    end
+
+    def candidate_respond_by
+      format_date application_choice.decline_by_default_at
+    end
+
+    def rejected_at
+      format_date application_choice.rejected_at
+    end
+
+  private
+
+    def format_date(date)
+      date.strftime('%-e %B %Y')
     end
   end
 end

--- a/app/frontend/styles/_definition-list.scss
+++ b/app/frontend/styles/_definition-list.scss
@@ -1,0 +1,21 @@
+.app-definition-list {
+  @include govuk-font($size: 19);
+  margin: 0;
+  margin-bottom: govuk-spacing(3);
+
+  dt {
+    font-weight: bold;
+  }
+
+  dd + dt {
+    margin-top: govuk-spacing(3);
+  }
+
+  dd + dd {
+    margin-top: govuk-spacing(1);
+  }
+
+  dd {
+    margin-left: 0;
+  }
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -22,6 +22,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "_tag";
 @import "_task-list";
 @import "_contents-list";
+@import "_definition-list";
 
 // Support
 @import "_card";

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class ApplicationChoicePresenter
     delegate :application_qualifications, :application_references, to: :application_form
-    attr_reader :application_form
+    attr_reader :application_form, :application_choice
 
     def initialize(application_choice)
       @application_choice = application_choice
@@ -86,9 +86,5 @@ module ProviderInterface
     def second_reference
       application_references.second
     end
-
-  private
-
-    attr_reader :application_choice
   end
 end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -24,15 +24,7 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <div class="app-status-box">
-      <h2 class="govuk-heading-m">Status</h2>
-      <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: @application_choice %>
-      <% if @application_choice.status == 'awaiting_provider_decision' %>
-        <div class="govuk-!-margin-top-6">
-          <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice.id), class: 'govuk-!-margin-bottom-0' %>
-        </div>
-      <% end %>
-    </div>
+    <%= render ProviderInterface::StatusBoxComponent, application_choice: @application_choice %>
   </div>
 </div>
 

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -24,7 +24,7 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <%= render ProviderInterface::StatusBoxComponent, application_choice: @application_choice %>
+    <%= render ProviderInterface::StatusBoxComponent, application_choice: @application_choice.application_choice %>
   </div>
 </div>
 

--- a/spec/components/provider_interface/status_box_component_spec.rb
+++ b/spec/components/provider_interface/status_box_component_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::StatusBoxComponent do
+  it 'outputs a date for applications in the awaiting_provider_decision state' do
+    application_choice = make_choice(status: 'awaiting_provider_decision', reject_by_default_at: Time.zone.now)
+
+    result = render_inline(described_class, application_choice: application_choice)
+
+    expect(result.text).to include('Respond to the applicant by')
+  end
+
+  it 'outputs a date for applications in the withdrawn state' do
+    application_choice = make_choice(status: 'withdrawn', withdrawn_at: Time.zone.now)
+
+    result = render_inline(described_class, application_choice: application_choice)
+
+    expect(result.text).to include('Application withdrawn')
+  end
+
+  it 'outputs a date for applications in the offer state' do
+    application_choice = make_choice(status: 'offer', decline_by_default_at: Time.zone.now)
+
+    result = render_inline(described_class, application_choice: application_choice)
+
+    expect(result.text).to include('Needs to respond by')
+  end
+
+  it 'outputs a date for applications in the rejected state' do
+    application_choice = make_choice(status: 'rejected', rejected_at: Time.zone.now)
+
+    result = render_inline(described_class, application_choice: application_choice)
+
+    expect(result.text).to include('Rejected at')
+  end
+
+  def make_choice(attrs)
+    application_form = create(:application_form, submitted_at: Time.zone.now)
+    create(:application_choice, { application_form: application_form }.merge(attrs))
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -151,6 +151,9 @@ FactoryBot.define do
     personal_statement { 'hello' }
 
     factory :submitted_application_choice do
+      status { 'awaiting_provider_decision' }
+      reject_by_default_at { Time.zone.now + 40.days }
+      reject_by_default_days { 40 }
       association :application_form, factory: %i[completed_application_form without_application_choices with_completed_references]
     end
 

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -11,7 +11,7 @@ RSpec.feature 'Provider responds to application' do
   end
 
   let(:application_rejected) do
-    create(:submitted_application_choice, status: 'rejected', course_option: course_option)
+    create(:submitted_application_choice, status: 'rejected', rejected_at: Time.zone.now, course_option: course_option)
   end
 
   scenario 'Provider can respond to an application currently awaiting_provider_decision' do

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'A Provider viewing an individual application' do
   def and_my_organisation_has_received_an_application
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     application_form = create(:application_form,
+                              submitted_at: Time.zone.now,
                               becoming_a_teacher: 'This is my personal statement',
                               subject_knowledge: 'This is my subject knowledge',
                               interview_preferences: 'Any date is fine',
@@ -72,8 +73,7 @@ RSpec.describe 'A Provider viewing an individual application' do
            relationship: 'Companion droid',
            feedback: 'The possibility of successfully navigating training is approximately three thousand seven hundred and twenty to one')
 
-    @application_choice = create(:application_choice,
-                                 status: 'awaiting_provider_decision',
+    @application_choice = create(:submitted_application_choice,
                                  course_option: course_option,
                                  application_form: application_form)
   end


### PR DESCRIPTION
## Context

We don't surface any dates in the provider UI yet. This implements them for 4 of the states, the other ones will be done once we actually track them in the system (like https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/948).

## Changes proposed in this pull request

### Design

<img width="339" alt="Screenshot 2019-12-19 at 14 07 57" src="https://user-images.githubusercontent.com/233676/71179977-28d24200-2269-11ea-8741-65ccb9c231eb.png">

### Before

<img width="331" alt="Screenshot 2019-12-19 at 14 08 16" src="https://user-images.githubusercontent.com/233676/71179991-3091e680-2269-11ea-9f8b-4e736786dab5.png">

### After

<img width="322" alt="Screenshot 2019-12-19 at 15 12 53" src="https://user-images.githubusercontent.com/233676/71184787-2d4f2880-2272-11ea-9941-48df27b9e93b.png">
<img width="314" alt="Screenshot 2019-12-19 at 15 13 03" src="https://user-images.githubusercontent.com/233676/71184788-2d4f2880-2272-11ea-8810-c81f458de4f4.png">
<img width="325" alt="Screenshot 2019-12-19 at 15 13 22" src="https://user-images.githubusercontent.com/233676/71184790-2de7bf00-2272-11ea-9930-a852d48a8d70.png">
<img width="323" alt="Screenshot 2019-12-19 at 15 13 30" src="https://user-images.githubusercontent.com/233676/71184791-2de7bf00-2272-11ea-8fce-74e64de3bac0.png">
<img width="318" alt="Screenshot 2019-12-19 at 15 13 37" src="https://user-images.githubusercontent.com/233676/71184792-2de7bf00-2272-11ea-8667-a9931c815678.png">



## Guidance to review

- I copied the CSS from the prototype. Is it any good?

## Link to Trello card

https://trello.com/c/Php2IR0H/1409-solve-incongruities-between-provider-and-candidate-interfaces

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
