### PR TITLE
Add arrow on nationality drop down

### DIFF
--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -17,9 +17,9 @@ const initNationalityAutocomplete = () => {
 
       accessibleAutocomplete.enhanceSelectElement({
         selectElement: nationalitySelect,
-        name: nationalitySelect.name
+        name: nationalitySelect.name,
+        showAllValues: true
       });
-
       nationalitySelect.name = "";
     });
   } catch (err) {

--- a/app/frontend/styles/_autocomplete.scss
+++ b/app/frontend/styles/_autocomplete.scss
@@ -16,3 +16,8 @@
     box-shadow: none;
   }
 }
+
+.autocomplete__dropdown-arrow-down {
+  pointer-events: none;
+  z-index: 0;
+}


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
During testing with DAC it became apparent that we need to enable users to view the options within drop-down menus. Currently, a user is only able to see options when they start typing. This can be improved with a select arrow to view all menu options.


## Changes proposed in this pull request
This PR adds a drop-down arrow to the nationality-autocomplete field
### Before
![image](https://user-images.githubusercontent.com/22743709/71181010-3a1c4e00-226b-11ea-983c-5b47a779fc84.png)
### After
<img width="690" alt="Screenshot 2019-12-19 at 14 08 28" src="https://user-images.githubusercontent.com/22743709/71180945-1e18ac80-226b-11ea-9b73-1736e728f50c.png">


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
I have added some css in the `autocomplete.scss` file as the arrow was hidden by other components. I would like to get some comments on this since it might be a bit hacky. 
Please note there is an open issue relating to this drop-down arrow https://github.com/alphagov/accessible-autocomplete/issues/202

## Link to Trello card
https://trello.com/c/o7MN6V7s/657-add-arrow-on-nationality-drop-down

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)