### PR TITLE
Run GitHub actions on merge commits

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,7 @@
 name: 'Apply CI'
+
 on:
-  push:
-    branches-ignore:
-      - 'master'
+  pull_request: {}
 
 jobs:
   unit_tests:


### PR DESCRIPTION
## Context

We want our tests to run on the merge commit between a branch and the latest state of the master branch. If we don't do this, bugs can slip through.

## Changes proposed in this pull request

Switch from running on `push` to running on `pull_request`.

## Guidance to review

From https://github.com/actions/checkout/issues/15 and https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
