### PR TITLE
Add conditional info above referees in RefereesReviewComponent

### DIFF
--- a/app/components/referees_review_component.html.erb
+++ b/app/components/referees_review_component.html.erb
@@ -1,3 +1,11 @@
+<p class="govuk-body">
+  <% if @application_form.submitted? %>
+    <%= t('application_form.referees.info.after_submission') %>
+  <% else %>
+    <%= t('application_form.referees.info.before_submission') %>
+  <% end %>
+</p>
+
 <% @application_form.application_references.includes(:application_form).each do |referee| %>
   <%= render(SummaryCardComponent, rows: referee_rows(referee), editable: @editable) do %>
     <%= render(SummaryCardHeaderComponent, title: t('application_form.referees.nth_referee')[referee.ordinal], heading_level: @heading_level) do %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -309,6 +309,9 @@ en:
       chase_button: Yes - send the email
       chase_success: Email sent to candidate and referee
       audit_comment: "Chase emails have been sent to the referee (%{referee_email}) and candidate (%{candidate_email})."
+      info:
+        before_submission: We’ll contact your referees after you submit your application. We’ll let you know if they don’t supply a reference.
+        after_submission: We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.
   activemodel:
     errors:
       models:

--- a/spec/components/referees_review_component_spec.rb
+++ b/spec/components/referees_review_component_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe RefereesReviewComponent do
-  let(:application_form) do
-    create(:completed_application_form, references_count: 2)
-  end
-
   context 'when referees are editable' do
+    let(:application_form) { create(:completed_application_form, references_count: 2) }
+
     it "renders component with correct values for a referee's name" do
       first_referee = application_form.application_references.first
       result = render_inline(RefereesReviewComponent, application_form: application_form)
@@ -35,11 +33,33 @@ RSpec.describe RefereesReviewComponent do
   end
 
   context 'when referees are not editable' do
+    let(:application_form) { create(:completed_application_form, references_count: 1) }
+
     it 'renders component without an edit link' do
       result = render_inline(RefereesReviewComponent, application_form: application_form, editable: false)
 
       expect(result.css('.app-summary-list__actions').text).not_to include('Change')
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.referees.delete'))
+    end
+  end
+
+  context 'when the application has not been submitted' do
+    it 'renders component with content about what happens with referee details provided' do
+      application_form = build_stubbed(:application_form, submitted_at: nil)
+
+      result = render_inline(RefereesReviewComponent, application_form: application_form)
+
+      expect(result.text).to include(t('application_form.referees.info.before_submission'))
+    end
+  end
+
+  context 'when the application has been submitted' do
+    it 'renders component with content about referees being contacted' do
+      application_form = build_stubbed(:application_form, submitted_at: Time.zone.now)
+
+      result = render_inline(RefereesReviewComponent, application_form: application_form)
+
+      expect(result.text).to include(t('application_form.referees.info.after_submission'))
     end
   end
 end


### PR DESCRIPTION
## Context

We're currently missing some content when a candidate reviews their referees.

## Changes proposed in this pull request

This PR adds information in the `RefereesReviewComponent`, with the content dependent on whether or not the application has been submitted.

## Screenshots

**Before submission**

![image](https://user-images.githubusercontent.com/42817036/71184353-8b2f4080-2271-11ea-94e9-6fa55d4c355b.png)

![image](https://user-images.githubusercontent.com/42817036/71184377-97b39900-2271-11ea-92db-f795945f33d5.png)

**After submission**

![image](https://user-images.githubusercontent.com/42817036/71184502-c2055680-2271-11ea-8182-a9c68686881a.png)

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/U8dN8C0M/677-show-content-about-what-happens-with-referee-details-provided

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
