### PR TITLE
Use PersonalDetailsComponent in support UI

### DIFF
--- a/app/components/personal_details_component.html.erb
+++ b/app/components/personal_details_component.html.erb
@@ -1,3 +1,3 @@
-<div data-qa="application-summary">
+<div data-qa="personal-details">
   <%= render SummaryListComponent, rows: rows %>
 </div>

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -1,3 +1,4 @@
+# Used by Support Interface and Provider Interface
 class PersonalDetailsComponent < ActionView::Component::Base
   MISSING = '<em>Not provided</em>'.html_safe
 

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -2,17 +2,11 @@ module SupportInterface
   class ApplicationSummaryComponent < ActionView::Component::Base
     include ViewHelper
 
-    delegate :first_name,
-             :last_name,
-             :phone_number,
-             :support_reference,
+    delegate :support_reference,
              :submitted_at,
              :submitted?,
              :updated_at,
-             :candidate,
              to: :application_form
-
-    delegate :email_address, to: :candidate
 
     def initialize(application_form:)
       @application_form = application_form
@@ -20,10 +14,7 @@ module SupportInterface
 
     def rows
       [
-        name_row,
         support_reference_row,
-        email_row,
-        phone_number_row,
         submitted_row,
         last_updated_row,
         state_row,
@@ -31,31 +22,6 @@ module SupportInterface
     end
 
   private
-
-    def name_row
-      if first_name
-        {
-          key: 'Name',
-          value: "#{first_name} #{last_name}",
-        }
-      end
-    end
-
-    def email_row
-      {
-        key: 'Email address',
-        value: mail_to(email_address, email_address, class: 'govuk-link'),
-      }
-    end
-
-    def phone_number_row
-      if phone_number
-        {
-          key: 'Phone number',
-          value: phone_number,
-        }
-      end
-    end
 
     def last_updated_row
       {
@@ -94,10 +60,6 @@ module SupportInterface
       name = I18n.t!("process_states.#{process_state}.name")
       desc = I18n.t!("process_states.#{process_state}.description")
       "#{name} – #{desc}"
-    end
-
-    def application_choices
-      application_form.application_choices.includes(:course, :provider)
     end
 
     attr_reader :application_form

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -19,6 +19,10 @@
 
 <%= render SupportInterface::ApplicationSummaryComponent, application_form: @application_form %>
 
+<h2 class="govuk-heading-l govuk-!-margin-top-8">Personal details</h2>
+
+<%= render PersonalDetailsComponent, application_form: @application_form %>
+
 <% unless HostingEnvironment.production? %>
   <%= button_to 'Sign in as this candidate', support_interface_impersonate_candidate_path(@application_form.candidate), class: 'govuk-button' %>
 <% end %>

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -58,13 +58,20 @@ RSpec.feature 'See an application' do
   def and_i_should_see_a_summary_of_the_completed_application
     within '[data-qa="application-summary"]' do
       [
+        @completed_application.support_reference,
+        'Submitted',
+        'Last updated',
+      ].each do |content|
+        expect(page).to have_content content
+      end
+    end
+
+    within '[data-qa="personal-details"]' do
+      [
         @completed_application.candidate.email_address,
         @completed_application.first_name,
         @completed_application.last_name,
         @completed_application.phone_number,
-        @completed_application.support_reference,
-        'Submitted',
-        'Last updated',
       ].each do |content|
         expect(page).to have_content content
       end
@@ -86,22 +93,9 @@ RSpec.feature 'See an application' do
   end
 
   def then_i_should_see_a_summary_of_the_unsubmitted_application
-    within '[data-qa="application-summary"]' do
-      [
-        @unsubmitted_application.candidate.email_address,
-        'Last updated',
-      ].each do |content|
-        expect(page).to have_content content
-      end
-
-      [
-        'Phone number',
-        'Name',
-        'Support reference',
-        'Submitted',
-      ].each do |content|
-        expect(page).not_to have_content content
-      end
+    within '[data-qa="personal-details"]' do
+      expect(page).to have_content 'Phone number Not provided'
+      expect(page).to have_content @unsubmitted_application.candidate.email_address
     end
   end
 


### PR DESCRIPTION
## Context

This uses the recently created PersonalDetailsComponent (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/942) to display the personal details of the user. It's part of a larger effort to make sure we display the correct data everywhere.

I'm pretty sure this will be redesigned, but I'm first trying to get all the components on the page.

## Changes proposed in this pull request

### Before

![image](https://user-images.githubusercontent.com/233676/71188679-54f5bf00-2279-11ea-8787-abc3b52c91bc.png)

### After 

![image](https://user-images.githubusercontent.com/233676/71188656-460f0c80-2279-11ea-9278-bc3e661b5a2a.png)


## Guidance to review

See it.

## Link to Trello card

https://trello.com/c/Php2IR0H/1409-solve-incongruities-between-provider-and-candidate-interfaces