### PR TITLE
Correct font size for meta content in footer

### DIFF
--- a/app/views/candidate_interface/shared/_need_help.html.erb
+++ b/app/views/candidate_interface/shared/_need_help.html.erb
@@ -1,6 +1,6 @@
 <aside class="app-related" role="complementary">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="help-title">Need help?</h2>
-  <ul class="govuk-list govuk-body-s">
+  <ul class="govuk-list govuk-!-font-size-16">
     <li>Email: <%= bat_contact_mail_to %></li>
     <li>Monday to Friday (except public holidays)</li>
     <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>

--- a/app/views/layouts/_candidate_footer.html.erb
+++ b/app/views/layouts/_candidate_footer.html.erb
@@ -1,5 +1,5 @@
 <h2 class="govuk-heading-m">Need help?</h2>
-<ul class="govuk-footer__meta-custom govuk-list">
+<ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
   <li>Email: <%= bat_contact_mail_to(html_options: { class: 'govuk-footer__link' }) %></li>
   <li>Monday to Friday (except public holidays)</li>
   <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>


### PR DESCRIPTION
## Context

Use correct font size (i.e., consistent with font size used across GOV.UK footers). Also use `govuk-!-font-size-16` instead of `govuk-body-s` for this content when shown in the sidebar, as more explicit and deliberate class name.

## Changes proposed in this pull request

Before:

<img width="640" alt="Screenshot 2019-12-19 at 16 08 14" src="https://user-images.githubusercontent.com/813383/71188925-d2b9ca80-2279-11ea-82a4-0efcf13be1da.png">

After:

<img width="640" alt="Screenshot 2019-12-19 at 16 08 00" src="https://user-images.githubusercontent.com/813383/71188936-d8afab80-2279-11ea-8b3a-1ffd9dff1244.png">
