### PR TITLE
Allow bypassing DfE Signin when running in production mode

### DIFF
--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -1,5 +1,5 @@
 module DfESignIn
   def self.bypass?
-    Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
+    HostingEnvironment.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -44,6 +44,10 @@ module HostingEnvironment
     ENV.fetch('HOSTING_ENVIRONMENT_NAME', 'unknown-environment')
   end
 
+  def self.development?
+    environment_name == 'development'
+  end
+
   def self.production?
     environment_name == 'production'
   end


### PR DESCRIPTION
But still check that the hosting environment is not one of our live ones.

Was previously https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/914 which caused issues with running tests locally.

This is needed to allow bypassing DSI on Heroku review apps, which do run in `Rails.env.production?`, but have autogenerated hostnames and as such can not be configured to work with DSI because they expect a static and whitelisted callback URL.