### PR TITLE
Add review environment for Heroku and bypass DSI

### DIFF
--- a/app/frontend/styles/_environments.scss
+++ b/app/frontend/styles/_environments.scss
@@ -1,5 +1,6 @@
 $app-colour-qa: govuk-colour("orange");
 $app-colour-sandbox: govuk-colour("bright-purple");
+$app-colour-review: govuk-colour("purple");
 $app-colour-staging: govuk-colour("red");
 $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 
@@ -17,6 +18,10 @@ $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 
 .app-header--sandbox .govuk-header__container {
   border-bottom-color: $app-colour-sandbox;
+}
+
+.app-header--review .govuk-header__container {
+  border-bottom-color: $app-colour-review;
 }
 
 .app-header--development .govuk-header__container,
@@ -38,6 +43,10 @@ $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 
 .app-environment-tag--sandbox {
   background-color: $app-colour-sandbox;
+}
+
+.app-environment-tag--review {
+  background-color: $app-colour-review;
 }
 
 .app-environment-tag--development,

--- a/app/frontend/styles/_environments.scss
+++ b/app/frontend/styles/_environments.scss
@@ -1,5 +1,5 @@
 $app-colour-qa: govuk-colour("orange");
-$app-colour-sandbox: govuk-colour("bright-purple");
+$app-colour-sandbox: govuk-colour("purple");
 $app-colour-review: govuk-colour("purple");
 $app-colour-staging: govuk-colour("red");
 $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");

--- a/app/lib/dfe_sign_in.rb
+++ b/app/lib/dfe_sign_in.rb
@@ -1,5 +1,5 @@
 module DfESignIn
   def self.bypass?
-    Rails.env.development? && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
+    (HostingEnvironment.review? || Rails.env.development?) && ENV['BYPASS_DFE_SIGN_IN'] == 'true'
   end
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -35,6 +35,8 @@ module HostingEnvironment
       'This is a internal environment used by DfE to test deploys'
     when 'development'
       'This is a development version of the Apply service'
+    when 'review'
+      'This is a review environment used to test a pull request'
     when 'unknown-environment'
       'This is a unknown version of the Apply service'
     end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -46,6 +46,10 @@ module HostingEnvironment
     ENV.fetch('HOSTING_ENVIRONMENT_NAME', 'unknown-environment')
   end
 
+  def self.review?
+    environment_name == 'review'
+  end
+
   def self.production?
     environment_name == 'production'
   end


### PR DESCRIPTION
## Context

Previously: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/954.

This allows us to bypass DSI on the Heroku review apps.

I chose to name it `review` instead of `heroku` so that it can be used even if we move away from Heroku.

## Changes proposed in this pull request

Add an environment and update the DSI bypass conditional.

## Guidance to review

:ship:

<img width="986" alt="Screenshot 2019-12-19 at 16 43 06" src="https://user-images.githubusercontent.com/1650875/71191593-a48ab980-227e-11ea-884e-a38df45cf9d5.png">


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)