### PR TITLE
Add e-mail format validations

### DIFF
--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -6,7 +6,7 @@ class Candidate < ApplicationRecord
   before_validation :downcase_email
   validates :email_address, presence: true,
                             uniqueness: { case_sensitive: false },
-                            length: { maximum: 250 },
+                            length: { maximum: 100 },
                             email_address: true
 
   has_many :application_forms

--- a/app/validators/email_address_validator.rb
+++ b/app/validators/email_address_validator.rb
@@ -1,6 +1,15 @@
 class EmailAddressValidator < ActiveModel::EachValidator
+  ALPHANUMERIC = 'a-zA-Z0-9àèìòùÀÈÌÒÙáéíóúýÁÉÍÓÚÝâêîôûÂÊÎÔÛãñõÃÑÕäëïöüÿÄËÏÖÜŸçÇßØøÅåÆæœ' + # Number and letters including accented characters
+    '\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\uFF00-\uFFEF\u4E00-\u9FAF\u2605-\u2606\u2190-\u2195\u203B'.freeze # Chinese/Japanese/Korean characters
+  EMAIL_REGEX = %r{\A[#{ALPHANUMERIC}.!\#$%&'*+\/=?^_`{|}~-] # Local part
+                  +@[#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-] # Domain name
+                  {0,61}[#{ALPHANUMERIC}])?(?:\. # Allow periods in domain name
+                  [#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-]{0,61}[#{ALPHANUMERIC}])?)*\.
+                  [#{ALPHANUMERIC}](?:[#{ALPHANUMERIC}-]{0,61} # # End of domain
+                  [#{ALPHANUMERIC}])\z}x.freeze
+
   def validate_each(record, attribute, value)
-    if value.blank? || !value.match?(/@/)
+    if value.blank? || !value.match?(EMAIL_REGEX)
       record.errors[attribute] << I18n.t('activerecord.errors.models.candidate.attributes.email_address.invalid')
     end
   end

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Candidate, type: :model do
 
   describe 'a valid candidate' do
     it { is_expected.to validate_presence_of :email_address }
-    it { is_expected.to validate_length_of(:email_address).is_at_most(250) }
+    it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
     it { is_expected.to validate_uniqueness_of(:email_address).case_insensitive }
     it { is_expected.to allow_value('user@example.com').for(:email_address) }
     it { is_expected.not_to allow_value('foo').for(:email_address) }

--- a/spec/validators/email_address_validator_spec.rb
+++ b/spec/validators/email_address_validator_spec.rb
@@ -9,19 +9,82 @@ RSpec.describe EmailAddressValidator do
     end
   end
 
+  context 'when an email address has a valid format' do
+    let(:model) { Validatable.new }
+    let(:valid_emails) do
+      [
+        'email@domain.com',
+        'email@domain.COM',
+        'firstname.lastname@domain.com',
+        'firstname.o\'lastname@domain.com',
+        'email@subdomain.domain.com',
+        'firstname+lastname@domain.com',
+        '1234567890@domain.com',
+        'email@domain-one.com',
+        '_______@domain.com',
+        'email@domain.name',
+        'email@domain.superlongtld',
+        'email@domain.co.jp',
+        'firstname-lastname@domain.com',
+        'info@german-financial-services.vermögensberatung',
+        'info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase',
+        'japanese-info@例え.テスト',
+    ]
+    end
+
+    it 'returns valid' do
+      valid_emails.each do |email|
+        model.email_address = email
+        model.validate(:no_context)
+        expect(model).to be_valid
+      end
+    end
+  end
+
   context 'when an email address is in an invalid format' do
     let(:model) { Validatable.new }
-
-    before do
-      model.email_address = 'foo'
-      model.validate(:no_context)
+    let(:invalid_emails) do
+      [
+      'email@[123.123.123.123]',
+      'plainaddress',
+      '@no-local-part.com',
+      'Outlook Contact <outlook-contact@domain.com>',
+      'no-at.domain.com',
+      'no-tld@domain',
+      ';beginning-semicolon@domain.co.uk',
+      'middle-semicolon@domain.co;uk',
+      'trailing-semicolon@domain.com;',
+      '"email+leading-quotes@domain.com',
+      'email+middle"-quotes@domain.com',
+      '"quoted-local-part"@domain.com',
+      '"quoted@domain.com"',
+      'lots-of-dots@domain..gov..uk',
+      'multiple@domains@domain.com',
+      'spaces in local@domain.com',
+      'spaces-in-domain@dom ain.com',
+      'underscores-in-domain@dom_ain.com',
+      'pipe-in-domain@example.com|gov.uk',
+      'comma,in-local@gov.uk',
+      'comma-in-domain@domain,gov.uk',
+      'pound-sign-in-local£@domain.com',
+      'local-with-’-apostrophe@domain.com',
+      'local-with-”-quotes@domain.com',
+      'domain-starts-with-a-dot@.domain.com',
+      'brackets(in)local@domain.com',
+    ]
     end
 
     it 'returns invalid' do
-      expect(model).not_to be_valid
+      invalid_emails.each do |email|
+        model.email_address = email
+        model.validate(:no_context)
+        expect(model).not_to be_valid
+      end
     end
 
     it 'returns the correct error message' do
+      model.email_address = 'foo'
+      model.validate(:no_context)
       expect(model.errors[:email_address]).to include(t('activerecord.errors.models.candidate.attributes.email_address.invalid'))
     end
   end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
At the moment we only specify that an email address must have @. This means a lot of other known errors are able to pass through undetected. This is an issue because a user won't realise they have submitted an invalid email address.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR updates the email format validation using a regular expression that allows emails that are allowed by Notify https://github.com/alphagov/notifications-utils/blob/31391091d2351e3e6bd306585e67007bcdb31911/tests/test_recipient_validation.py#L104-L152
- Update the maximum characters from 250 to 100. The max length in the [API docs](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/config/vendor-api-v1.yml#L539) is 100 chars, and iirc this is a hard constraint from vendors

- Update email validator regex according to reproduce [validation of Notify](https://github.com/alphagov/notifications-utils/blob/31391091d2351e3e6bd306585e67007bcdb31911/tests/test_recipient_validation.py#L104-L152)
## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I would suggest having a look at the unit tests and try to come up with other valid/invalid e-mails to check the right behaviour. Please note the validator allows `two-dots..in-local@domain.com`, please advise if this is acceptable or any further changes. 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/4lfXwREg/655-revisit-email-validation-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
