### PR TITLE
Frontend fixes for the reference form

### DIFF
--- a/app/views/referee_interface/reference/confirmation.html.erb
+++ b/app/views/referee_interface/reference/confirmation.html.erb
@@ -1,10 +1,7 @@
 <% content_for :title, t('page_titles.give_a_reference.confirmation') %>
-
-<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-  <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
-    <h1 class="govuk-panel__title">
-      Your reference for <%= @reference.application_form.full_name %> has been&nbsp;submitted
-    </h1>
-  </div>
-  <%= govuk_button_link_to 'Finish', referee_interface_reference_finish_path(token: @token_param) %>
-</main>
+<div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
+  <h1 class="govuk-panel__title">
+    Your reference for <%= @reference.application_form.full_name %> has been&nbsp;submitted
+  </h1>
+</div>
+<%= govuk_button_link_to 'Finish', referee_interface_reference_finish_path(token: @token_param) %>

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -41,7 +41,7 @@
           </li>
         </ul>
 
-        <%= f.govuk_text_area :feedback, label: { text: 'Your reference' }, max_words: 300, rows: 15 %>
+        <%= f.govuk_text_area :feedback, label: { text: 'Your reference', size: 'm' }, max_words: 300, rows: 15 %>
 
         <%= f.govuk_submit 'Submit reference' %>
       </div>

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -8,7 +8,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-xl">Give a teacher training reference for <%= @application.full_name %></h1>
 
-        <p class="govuk-body"><%= @application.full_name %>applied to the following courses:</p>
+        <p class="govuk-body"><%= @application.full_name %> applied to the following courses:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
           <% @application.application_choices.each do |application_choice| %>
             <li>

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -1,50 +1,47 @@
 <% content_for :title, "Give a teacher training reference for #{@application.full_name}" %>
 
-<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
+<%= form_with model: @reference_form, url: referee_interface_submit_feedback_path(token: @token_param), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Give a teacher training reference for <%= @application.full_name %></h1>
 
-  <%= form_with model: @reference_form, url: referee_interface_submit_feedback_path(token: @token_param), method: :patch do |f| %>
-    <%= f.govuk_error_summary %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Give a teacher training reference for <%= @application.full_name %></h1>
+      <p class="govuk-body"><%= @application.full_name %> applied to the following courses:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <% @application.application_choices.each do |application_choice| %>
+          <li>
+            <%= application_choice.course.name %> - <%= application_choice.site.name %>
+          </li>
+        <% end %>
+      </ul>
 
-        <p class="govuk-body"><%= @application.full_name %> applied to the following courses:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-          <% @application.application_choices.each do |application_choice| %>
-            <li>
-              <%= application_choice.course.name %> - <%= application_choice.site.name %>
-            </li>
-          <% end %>
-        </ul>
+      <p class="govuk-body">Try to cover the following, but don’t worry if there are areas you can’t comment on:</p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
+          <p class="govuk-body">For example, does the candidate care about the wellbeing of children? Are they emotionally resilient and do they work well with others?</p>
+        </li>
+        <li>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Subject knowledge</h2>
+          <p class="govuk-body">Is the candidate passionate and informed about their teaching subject?</p>
+        </li>
+        <li>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
+          <p class="govuk-body">For example, does the candidate think critically and have good numeracy and literacy skills?</p>
+        </li>
+        <li>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
+          <p class="govuk-body">What abilities would the candidate bring to teaching, for example, communication, creativity, project management?</p>
+        </li>
+        <li>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
+          <p class="govuk-body">For example, can the candidate meet deadlines and manage their time?</p>
+        </li>
+      </ul>
 
-        <p class="govuk-body">Try to cover the following, but don’t worry if there are areas you can’t comment on:</p>
-        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-          <li>
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
-            <p class="govuk-body">For example, does the candidate care about the wellbeing of children? Are they emotionally resilient and do they work well with others?</p>
-          </li>
-          <li>
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Subject knowledge</h2>
-            <p class="govuk-body">Is the candidate passionate and informed about their teaching subject?</p>
-          </li>
-          <li>
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
-            <p class="govuk-body">For example, does the candidate think critically and have good numeracy and literacy skills?</p>
-          </li>
-          <li>
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
-            <p class="govuk-body">What abilities would the candidate bring to teaching, for example, communication, creativity, project management?</p>
-          </li>
-          <li>
-            <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
-            <p class="govuk-body">For example, can the candidate meet deadlines and manage their time?</p>
-          </li>
-        </ul>
+      <%= f.govuk_text_area :feedback, label: { text: 'Your reference', size: 'm' }, max_words: 300, rows: 15 %>
 
-        <%= f.govuk_text_area :feedback, label: { text: 'Your reference', size: 'm' }, max_words: 300, rows: 15 %>
-
-        <%= f.govuk_submit 'Submit reference' %>
-      </div>
+      <%= f.govuk_submit 'Submit reference' %>
     </div>
-  <% end %>
-</main>
+  </div>
+<% end %>

--- a/app/views/referee_interface/reference/finish.html.erb
+++ b/app/views/referee_interface/reference/finish.html.erb
@@ -4,6 +4,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Our user research team will contact you shortly</h2>
-    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p></div>
+    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <%= bat_contact_mail_to %>.</p>
   </div>
 </div>

--- a/app/views/referee_interface/reference/finish.html.erb
+++ b/app/views/referee_interface/reference/finish.html.erb
@@ -1,11 +1,9 @@
 <% content_for :title, t('page_titles.give_a_reference.finish') %>
 
-<main class="govuk-main-wrapper govuk-main-wrapper--auto-spacing" id="main-content" role="main">
-  <h1 class="govuk-heading-xl">Thank you</h1>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h2 class="govuk-heading-m">Our user research team will contact you shortly</h2>
-      <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p></div>
-    </div>
+<h1 class="govuk-heading-xl">Thank you</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Our user research team will contact you shortly</h2>
+    <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <a href="mailto:becomingateacher@digital.education.gov.uk">becomingateacher@digital.education.gov.uk</a>.</p></div>
   </div>
-</main>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -532,4 +532,4 @@ en:
           attributes:
             feedback:
               blank: Enter your reference
-              word_count: Your reference must be %{count} words or fewer
+              too_many_words: Your reference must be %{count} words or fewer

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ReceiveReference do
 
       expect(action).not_to be_valid
 
-      expect(action.errors[:feedback]).to eq(['Must be 300 words or fewer'])
+      expect(action.errors[:feedback]).to eq(['Your reference must be 300 words or fewer'])
     end
 
     it 'validates that the referee email matches the references on the application form' do


### PR DESCRIPTION
## Context

- Fix typo with candidate name
- Use correct label size for Your reference
- Show correct error message when too many words
- Remove unnecessary main wrappers (fixes spacing too)
- Use helper for bat email link

Ignore whitespace to review.

![localhost_3000_reference](https://user-images.githubusercontent.com/319055/71258359-ddce3280-232d-11ea-8928-36eae035eae1.png)
