### PR TITLE
Fix incorrect path when signing in as candidate from Support

### DIFF
--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -48,7 +48,18 @@ module SupportInterface
       bypass_sign_in(candidate, scope: :candidate)
 
       flash[:success] = "You are now signed in as candidate #{candidate.email_address}"
-      redirect_to candidate_interface_application_form_path
+
+      candidate_application = candidate.application_forms.first
+
+      if FeatureFlag.active?('edit_application')
+        if !candidate_application.submitted? || candidate_application.amendable?
+          redirect_to candidate_interface_application_form_path
+        else
+          redirect_to candidate_interface_application_complete_path
+        end
+      else
+        redirect_to candidate_interface_application_form_path
+      end
     end
 
   private

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -71,6 +71,9 @@ private
         # This is only supposed to happen after 7 days, but SendApplicationToProvider
         # doesn't check the `edit_by` date of the ApplicationChoice
         SendApplicationToProvider.new(application_choice: application_choice).call
+
+        # This is so the application is no longer amendable
+        application_choice.update(edit_by: Time.zone.now)
       end
 
       return if application_index == 4

--- a/spec/system/support_interface/sign_in_as_candidate_spec.rb
+++ b/spec/system/support_interface/sign_in_as_candidate_spec.rb
@@ -3,24 +3,48 @@ require 'rails_helper'
 RSpec.feature 'Sign in as candidate' do
   include DfESignInHelpers
 
+  around do |example|
+    Timecop.freeze(Time.zone.local(2019, 12, 16)) do
+      example.run
+    end
+  end
+
   scenario 'Support user signs in as a candidate' do
     given_i_am_a_support_user
-    and_there_is_an_application
-    when_i_visit_the_application_form_page
+    and_the_edit_application_feature_flag_is_on
+    and_there_is_an_unsubmitted_application
+    when_i_visit_the_unsubmitted_application_form_page
     and_click_the_sign_in_button
     then_i_am_logged_in_as_the_candidate
+    and_i_see_the_your_application_page
+
+    given_there_is_an_amendable_application
+    when_i_visit_the_amendable_application_form_page
+    and_click_the_sign_in_button
+    then_i_am_logged_in_as_the_candidate
+    and_i_see_the_edit_application_page
+
+    given_there_is_an_awaiting_provider_decision_application
+    when_i_visit_the_awaiting_provider_decision_application_form_page
+    and_click_the_sign_in_button
+    then_i_am_logged_in_as_the_candidate
+    and_i_see_the_application_dashboard
   end
 
   def given_i_am_a_support_user
     sign_in_as_support_user
   end
 
-  def and_there_is_an_application
-    @application = create(:completed_application_form)
+  def and_the_edit_application_feature_flag_is_on
+    FeatureFlag.activate('edit_application')
   end
 
-  def when_i_visit_the_application_form_page
-    visit support_interface_application_form_path(@application)
+  def and_there_is_an_unsubmitted_application
+    @unsubmitted_application = create(:completed_application_form, submitted_at: nil)
+  end
+
+  def when_i_visit_the_unsubmitted_application_form_page
+    visit support_interface_application_form_path(@unsubmitted_application)
   end
 
   def and_click_the_sign_in_button
@@ -29,5 +53,41 @@ RSpec.feature 'Sign in as candidate' do
 
   def then_i_am_logged_in_as_the_candidate
     expect(page).to have_content 'You are now signed in as candidate'
+  end
+
+  def and_i_see_the_your_application_page
+    within('.govuk-heading-xl') do
+      expect(page).to have_content t('page_titles.application_form')
+    end
+  end
+
+  def given_there_is_an_amendable_application
+    @amendable_application = create(:completed_application_form, submitted_at: Time.zone.local(2019, 12, 16))
+    create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: @amendable_application)
+  end
+
+  def when_i_visit_the_amendable_application_form_page
+    visit support_interface_application_form_path(@amendable_application)
+  end
+
+  def and_i_see_the_edit_application_page
+    within('.govuk-heading-xl') do
+      expect(page).to have_content t('page_titles.edit_application_form')
+    end
+  end
+
+  def given_there_is_an_awaiting_provider_decision_application
+    @awaiting_provider_decision_application = create(:completed_application_form, submitted_at: Time.zone.local(2019, 12, 2))
+    create(:application_choice, status: :awaiting_provider_decision, edit_by: Time.zone.local(2019, 12, 9), application_form: @awaiting_provider_decision_application)
+  end
+
+  def when_i_visit_the_awaiting_provider_decision_application_form_page
+    visit support_interface_application_form_path(@awaiting_provider_decision_application)
+  end
+
+  def and_i_see_the_application_dashboard
+    within('.govuk-heading-xl') do
+      expect(page).to have_content t('page_titles.application_dashboard')
+    end
   end
 end


### PR DESCRIPTION
## Context

When signing in as a candidate that has an application that has passed the amend period (no longer editable) using the Support Interface, the support user is taken to the 'Edit your application' page instead they should be taken to the 'Application dashboard' page.

## Changes proposed in this pull request

This PR fixes this by wrapping the path around the `edit_application` feature flag and redirecting to the dashboard if it's not submitted or it's amendable.

However, an addition change was required in `GenerateTestApplications`. From the commit description:

>After an application has been submitted, a candidate has 5 working
days to edit their application. This is calculated at submission and
used to work out whether an application is in amend period.

>However, when we generate test applications we are able to skip this
period to send applications to a provider as the service we use
does not check the `edit_by` date.

>Therefore, it is necessary to update the `edit_by` to now, to
make it come up as no longer amendable.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/E7Rt3O3q/682-signing-into-a-completed-application-directs-you-to-edit-application-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
