### PR TITLE
Success message gets focused and document title prefix

### DIFF
--- a/app/components/flash_message_component.html.erb
+++ b/app/components/flash_message_component.html.erb
@@ -16,7 +16,7 @@
       </div>
     </div>
   <% elsif flash[:success] %>
-    <div class="app-banner app-banner--success" aria-labelledby="success-message">
+    <div class="app-banner app-banner--success" aria-labelledby="success-message" data-module="govuk-error-summary" tabindex="-1">
       <div class="app-banner__message">
         <h2 class="govuk-heading-m" id="success-message">
           <%= flash[:success] %>

--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -4,6 +4,12 @@
   @include govuk-responsive-margin(8, "bottom");
   border: $govuk-border-width solid govuk-colour("blue");
 
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // Ensure outline appears outside of the element
+    outline-offset: 0;
+  }
+
   &--missing-section {
     @include govuk-responsive-margin(4, "bottom");
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -46,6 +46,10 @@ module ViewHelper
     "#{t('page_titles.error_prefix') if error}#{title}"
   end
 
+  def title_with_success_prefix(title, success)
+    "#{t('page_titles.success_prefix') if success}#{title}"
+  end
+
   def edit_by_date
     dates = ApplicationDates.new(@application_form)
     dates.edit_by.strftime('%e %B %Y').strip

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, "Application ##{@application_form.id}" %>
+<% content_for :browser_title, title_with_success_prefix("Application ##{@application_form.id}", flash[:success].present?) %>
 <% content_for :title do %>
   <span class="govuk-caption-xl">Application #<%= @application_form.id %></span>
   <%= @application_form.candidate.email_address %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
     application_edit: Editing your application
     eligibility: First, check you can use this service
     error_prefix: 'Error: '
+    success_prefix: 'Success: '
     not_eligible_yet: We’re sorry, but we’re not ready for you yet
     submitted_application: Your submitted application
     sign_up: Create an account


### PR DESCRIPTION
## Context

Addresses ticket 683, the accessibility fail from DAC.

Before (not focused):
![image](https://user-images.githubusercontent.com/37163/71261344-06a5f600-2335-11ea-9a74-e9aff22c4b16.png)

After (focused):
![image](https://user-images.githubusercontent.com/37163/71261361-1291b800-2335-11ea-83d5-293bc483f856.png)
