### PR TITLE
Fix title for provider terms of use

### DIFF
--- a/app/views/provider_interface/content/rendered_markdown_template.html.erb
+++ b/app/views/provider_interface/content/rendered_markdown_template.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, @page_name %>
+<%= content_for :title, t("page_titles.#{@page_name}") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Before it would be ` terms_provider - Manage teacher training applications - GOV.UK`.