### PR TITLE
Fix application_choice factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -65,7 +65,12 @@ FactoryBot.define do
         create(:application_qualification, application_form: application_form, subject: 'english', level: 'gcse', qualification_type: 'GCSE')
         create(:application_qualification, application_form: application_form, subject: 'science', level: 'gcse', qualification_type: 'GCSE')
 
-        create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'awaiting_references')
+        edit_by = if application_form.submitted_at.nil?
+                    nil
+                  else
+                    5.business_days.after application_form.submitted_at
+                  end
+        create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'awaiting_references', edit_by: edit_by)
         create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)
         create_list(:application_volunteering_experience, evaluator.volunteering_experiences_count, application_form: application_form)
         create_list(:reference, evaluator.references_count, evaluator.references_state, application_form: application_form)


### PR DESCRIPTION
`ApplicationDates#edit_by` checks for `@application_form.application_choices.first&.edit_by`. When we provision a `completed_application_form`, even if `submitted_at` is set to something, `edit_by` is set to `nil` on the first choice. This does not match up to what should happen in the real app, which is a submitted application should always have `edit_by` defined on all of its choices.

Fixes master.