### PR TITLE
Added role=alert to match govuk error summary

### DIFF
--- a/app/components/flash_message_component.html.erb
+++ b/app/components/flash_message_component.html.erb
@@ -16,7 +16,7 @@
       </div>
     </div>
   <% elsif flash[:success] %>
-    <div class="app-banner app-banner--success" aria-labelledby="success-message" data-module="govuk-error-summary" tabindex="-1">
+    <div class="app-banner app-banner--success" aria-labelledby="success-message" data-module="govuk-error-summary" tabindex="-1" role="alert">
       <div class="app-banner__message">
         <h2 class="govuk-heading-m" id="success-message">
           <%= flash[:success] %>


### PR DESCRIPTION
## Context

Addresses feedback from previous work that makes sure the success message is accessible (by being read out in screen readers). 

## Changes proposed in this pull request

This gives the success message container `role="alert"` which matches the same code as the Error Summary component.

## Link to Trello card

https://trello.com/c/83AycElp/683-dac-fix-success-message-focus
