### PR TITLE
Make sure navigation works as expected on small/mobile screens

### DIFF
--- a/app/views/layouts/_api_docs_header.html.erb
+++ b/app/views/layouts/_api_docs_header.html.erb
@@ -1,3 +1,4 @@
+<button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
   <%= nav_link 'Home', api_docs_home_path, active_action: %w[home] %>
   <%= nav_link t('page_titles.api_docs.usage'), api_docs_usage_path, active_action: %w[usage] %>

--- a/app/views/layouts/_candidate_header.html.erb
+++ b/app/views/layouts/_candidate_header.html.erb
@@ -1,4 +1,5 @@
 <% if candidate_signed_in? %>
+  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
   <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
     <li class="govuk-header__navigation-item">
       <b><%= current_candidate.email_address %></b>

--- a/app/views/layouts/_provider_header.html.erb
+++ b/app/views/layouts/_provider_header.html.erb
@@ -1,4 +1,5 @@
 <% if current_provider_user %>
+  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
   <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
     <li class="govuk-header__navigation-item">
       <b><%= current_provider_user.email_address %></b>
@@ -9,6 +10,7 @@
     </li>
   </ul>
 <% elsif dfe_sign_in_user %>
+  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle"    aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
   <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
     <li class="govuk-header__navigation-item">
       <%= link_to 'Sign out', provider_interface_sign_out_path, class: 'govuk-header__link' %>

--- a/app/views/layouts/_provider_header.html.erb
+++ b/app/views/layouts/_provider_header.html.erb
@@ -10,7 +10,7 @@
     </li>
   </ul>
 <% elsif dfe_sign_in_user %>
-  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle"    aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
   <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
     <li class="govuk-header__navigation-item">
       <%= link_to 'Sign out', provider_interface_sign_out_path, class: 'govuk-header__link' %>

--- a/app/views/layouts/_support_header.html.erb
+++ b/app/views/layouts/_support_header.html.erb
@@ -1,3 +1,4 @@
+<button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
 <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
   <% if current_support_user %>
     <%= nav_link 'Candidates', support_interface_candidates_path, active: %w[candidates import_references] %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
 
-    <header class="govuk-header app-header--<%= HostingEnvironment.environment_name %>" role="banner" data-module="header">
+    <header class="govuk-header app-header--<%= HostingEnvironment.environment_name %>" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">
           <%= link_to service_link, class: 'govuk-header__link govuk-header__link--homepage' do %>


### PR DESCRIPTION
## Context

The navigation didn't work on mobile across support, candidate and provider and failed accessibility.

## Changes proposed in this pull request

Before: ![image](https://user-images.githubusercontent.com/37163/71354309-6a1d6700-2573-11ea-8765-05b07b49528d.png)

After: ![image](https://user-images.githubusercontent.com/37163/71354288-5ffb6880-2573-11ea-993d-88318a59bc01.png)

## Guidance to review

It would be good if we could turn the header and navigation into a component. For this commit I've had to scatter the same button across a number of templates.

## Link to Trello card

https://trello.com/c/Mq9xM59d/686-cant-access-navigation-on-mobile
