### PR TITLE
Limit Candidate ID to 10 chars in API responses

### DIFF
--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -437,7 +437,7 @@ components:
         id:
           type: string
           description: The candidate’s ID in the Apply system
-          maxLength: 20
+          maxLength: 10
           example: "C5432"
         first_name:
           type: string


### PR DESCRIPTION
This is now consistent with application_id

https://trello.com/c/HguXLQ33/1418-reduce-candidateid-limit-to-10-chars-consistent-with-applicationid