### PR TITLE
Disassociate long hint text from certain questions

### DIFF
--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
@@ -5,23 +5,27 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @becoming_a_teacher_form, url: candidate_interface_becoming_a_teacher_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), tag: 'h1', size: 'xl' }, rows: 20, max_words: 600 do %>
-        <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
-        <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
-        <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/' %> for help from a teacher training adviser.</p>
 
-        <p class="govuk-body govuk-!-font-weight-bold">You do not have to cover everything in this list, but suggested topics include:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>why you want to be a teacher</li>
-          <li>your passion for your subject and the age group you’ve chosen to teach</li>
-          <li>the welfare and education of children and/or young people</li>
-          <li>the demands and rewards of the profession</li>
-          <li>personal qualities that will make you a good teacher</li>
-          <li>your contribution to the life of the school outside the classroom  – for example, running extra-curricular activities and clubs</li>
-          <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
-        </ul>
-      <% end %>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.becoming_a_teacher') %>
+      </h1>
 
+      <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
+      <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
+      <p class="govuk-body">You can ask your training provider for examples written by successful applicants, or register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/' %> for help from a teacher training adviser.</p>
+
+      <p class="govuk-body govuk-!-font-weight-bold">You do not have to cover everything in this list, but suggested topics include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>why you want to be a teacher</li>
+        <li>your passion for your subject and the age group you’ve chosen to teach</li>
+        <li>the welfare and education of children and/or young people</li>
+        <li>the demands and rewards of the profession</li>
+        <li>personal qualities that will make you a good teacher</li>
+        <li>your contribution to the life of the school outside the classroom  – for example, running extra-curricular activities and clubs</li>
+        <li>if you have school experience or have worked as a volunteer with children or young people, give details of what this has taught you</li>
+      </ul>
+
+      <%= f.govuk_text_area :becoming_a_teacher, label: { text: t('application_form.personal_statement.becoming_a_teacher.label'), size: 'm' }, rows: 20, max_words: 600 %>
       <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/edit.html.erb
@@ -5,29 +5,32 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @subject_knowledge_form, url: candidate_interface_subject_knowledge_update_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), tag: 'h1', size: 'xl' }, rows: 20, max_words: 400 do %>
-        <% if @course_names.any? %>
-          <p class="govuk-body">
-            Give us detailed evidence for the knowledge and interest you bring to:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <% @course_names.each do |course_name| %>
-              <li><%= course_name %></li>
-            <% end %>
-          </ul>
-        <% else %>
-          <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to the subject(s) you’d like to teach.</p>
-        <% end %>
-        <p class="govuk-body">Evidence can include:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>the subject of your undergraduate degree</li>
-          <li>modules you studied as part of your degree</li>
-          <li>postgraduate degrees (for example, a Masters or PhD)</li>
-          <li>your A level subjects</li>
-          <li>expertise you’ve gained at work</li>
-        </ul>
-      <% end %>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.subject_knowledge') %>
+      </h1>
 
+      <% if @course_names.any? %>
+        <p class="govuk-body">
+          Give us detailed evidence for the knowledge and interest you bring to:
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% @course_names.each do |course_name| %>
+            <li><%= course_name %></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="govuk-body">Give us detailed evidence for the knowledge and interest you bring to the subject(s) you’d like to teach.</p>
+      <% end %>
+      <p class="govuk-body">Evidence can include:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the subject of your undergraduate degree</li>
+        <li>modules you studied as part of your degree</li>
+        <li>postgraduate degrees (for example, a Masters or PhD)</li>
+        <li>your A level subjects</li>
+        <li>expertise you’ve gained at work</li>
+      </ul>
+
+      <%= f.govuk_text_area :subject_knowledge, label: { text: t('application_form.personal_statement.subject_knowledge.label'), size: 'm' }, rows: 20, max_words: 400 %>
       <%= f.govuk_submit 'Continue' %>
     <% end %>
   </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -214,12 +214,12 @@ en:
     personal_statement:
       becoming_a_teacher:
         change_action: tell us why you want to be a teacher
-        label: Why do you want to be a teacher?
+        label: Tell us why you want to be a teacher
         complete_form_button: Continue
       subject_knowledge:
         key: Your knowledge about the subject you want to teach
         change_action:  evidence of subject knowledge
-        label: What do you know about the subject you want to teach?
+        label: Tell us what you know about the subject you want to teach
         complete_form_button: Continue
       interview_preferences:
         key: Interview preferences


### PR DESCRIPTION
## Context

The long guidance is read out in screeen readers every time it's focused. The advice from DAC is to put it above the field below a separate h1.

## Why do you want to be a teacher?

Before:
![image](https://user-images.githubusercontent.com/37163/71405307-f5a6fe80-262c-11ea-8f31-b71b9d85a72f.png)

After:
![image](https://user-images.githubusercontent.com/37163/71405397-3868d680-262d-11ea-9516-6666d5ec3423.png)

## Subject knowledge

Before: 
![image](https://user-images.githubusercontent.com/37163/71405336-0eafaf80-262d-11ea-9100-bbbcfa4d65a9.png)

After:
![image](https://user-images.githubusercontent.com/37163/71405369-21c27f80-262d-11ea-9a98-ee4ba32e6fa9.png)


## Link to Trello card

https://trello.com/c/fCwP6f9N/689-inappropriate-use-of-aria-why-do-you-want-to-be-a-teacher
