### PR TITLE
Error messages now match GDS standard on subject matter knowledgee wh…

### DIFF
--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -371,8 +371,8 @@ en:
         candidate_interface/subject_knowledge_form:
           attributes:
             subject_knowledge:
-              blank: Please enter your subject knowledge
-              too_many_words: Your subject knowledge must be %{count} words or fewer
+              blank: Enter what you know about the subject you want to teach
+              too_many_words: Your subject knowledge explanation must be %{count} words or fewer
         candidate_interface/interview_preferences_form:
           attributes:
             any_preferences:


### PR DESCRIPTION
## Context

The error message did read ‘Please enter subject knowledge’ which lacks clarity and uses pleasantries when it shouldn't.

## Changes proposed in this pull request

This PR changes the error messages to remove pleasantries

Before:
![image](https://user-images.githubusercontent.com/37163/71410247-699cd300-263c-11ea-8ec4-c827cafed4b1.png)

After:
![image](https://user-images.githubusercontent.com/37163/71410261-75889500-263c-11ea-9493-9181a13a54b7.png)

## Link to Trello card

https://trello.com/c/QrLZTnrd/690-error-handling-a11y-audit-subject-knowledge