### PR TITLE
Show the last time Provider Users signed in

### DIFF
--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -15,6 +15,11 @@
           <td class="govuk-table__cell"><%= row[:email_address] %></td>
           <td class="govuk-table__cell"><%= row[:links_to_providers].html_safe %></td>
           <td class="govuk-table__cell"><%= row[:dfe_sign_in_uid] %></td>
+          <% if row[:last_signed_in_at] %>
+            <td class="govuk-table__cell"><%= row[:last_signed_in_at] %></td>
+          <% else %>
+            <td class="govuk-table__cell"><em>Never signed in</em></td>
+          <%end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -1,0 +1,22 @@
+<% if table_rows.any? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header">Email address</th>
+        <th scope="col" class="govuk-table__header">Providers</th>
+        <th scope="col" class="govuk-table__header">DfE Sign-in UID</th>
+        <th scope="col" class="govuk-table__header">Last signed in at</th>
+      </tr>
+    </thead>
+
+    <tbody class="govuk-table__body">
+      <% table_rows.each do |row| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell"><%= row[:email_address] %></td>
+          <td class="govuk-table__cell"><%= row[:links_to_providers].html_safe %></td>
+          <td class="govuk-table__cell"><%= row[:dfe_sign_in_uid] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/components/support_interface/provider_users_table_component.rb
+++ b/app/components/support_interface/provider_users_table_component.rb
@@ -1,0 +1,31 @@
+module SupportInterface
+  class ProviderUsersTableComponent < ActionView::Component::Base
+    include ViewHelper
+
+    def initialize(provider_users:)
+      @provider_users = provider_users
+    end
+
+    def table_rows
+      provider_users.map do |provider_user|
+        {
+          email_address: provider_user.email_address,
+          links_to_providers: links_to_providers(provider_user),
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+        }
+      end
+    end
+
+    def links_to_providers(provider_user)
+      links = provider_user.providers.map do |p|
+        govuk_link_to(p.name, support_interface_provider_path(p))
+      end
+
+      links.join(', ')
+    end
+
+  private
+
+    attr_reader :provider_users
+  end
+end

--- a/app/components/support_interface/provider_users_table_component.rb
+++ b/app/components/support_interface/provider_users_table_component.rb
@@ -12,8 +12,13 @@ module SupportInterface
           email_address: provider_user.email_address,
           links_to_providers: links_to_providers(provider_user),
           dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          last_signed_in_at: last_signed_in_at(provider_user),
         }
       end
+    end
+
+    def last_signed_in_at(provider_user)
+      provider_user.last_signed_in_at&.to_s(:govuk_date_and_time)
     end
 
     def links_to_providers(provider_user)

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -15,31 +15,4 @@
   </div>
 <% end %>
 
-<% if @provider_users.any? %>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Email</th>
-        <th scope="col" class="govuk-table__header govuk-!-width-one-third">Providers</th>
-        <th scope="col" class="govuk-table__header govuk-!-width-one-third">DfE Sign-in UID</th>
-      </tr>
-    </thead>
-
-    <tbody class="govuk-table__body">
-      <% @provider_users.each do |provider_user| %>
-        <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <%= provider_user.email_address %>
-          </td>
-          <td class="govuk-table__cell">
-          <% provider_user.providers.map do |p| %>
-            <%= govuk_link_to(p.name, support_interface_provider_path(p)) %>
-          <% end %>
-          <td class="govuk-table__cell">
-            <%= provider_user.dfe_sign_in_uid %>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-<% end %>
+<%= render(SupportInterface::ProviderUsersTableComponent, provider_users: @provider_users) %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -4,4 +4,4 @@ Date::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
 Time::DATE_FORMATS[:month_and_year] = '%B %Y'
 Date::DATE_FORMATS[:month_and_year] = '%B %Y'
 
-Time::DATE_FORMATS[:govuk_date_and_time] = '%e %b %Y at %l:%M%P'
+Time::DATE_FORMATS[:govuk_date_and_time] = '%e %B %Y at %l:%M%P'

--- a/spec/components/support_interface/provider_users_table_component_spec.rb
+++ b/spec/components/support_interface/provider_users_table_component_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe SupportInterface::ProviderUsersTableComponent do
         create(:provider_user,
                email_address: 'provider@example.com',
                dfe_sign_in_uid: 'ABCDEF',
+               last_signed_in_at: DateTime.new(2019, 12, 1, 10, 45, 0),
                providers: [create(:provider, name: 'The Provider')]),
       ]
     end
@@ -21,6 +22,15 @@ RSpec.describe SupportInterface::ProviderUsersTableComponent do
       expect(rendered_component).to include('provider@example.com')
       expect(rendered_component).to include('ABCDEF')
       expect(rendered_component).to include('The Provider')
+      expect(rendered_component).to include('1 December 2019 at 10:45am')
+    end
+  end
+
+  context 'when the provider user has never signed in' do
+    let(:provider_users) { [create(:provider_user, last_signed_in_at: nil)] }
+
+    it 'shows that the user has never signed in' do
+      expect(rendered_component).to include('Never signed in')
     end
   end
 

--- a/spec/components/support_interface/provider_users_table_component_spec.rb
+++ b/spec/components/support_interface/provider_users_table_component_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ProviderUsersTableComponent do
+  subject(:rendered_component) do
+    render_inline(
+      SupportInterface::ProviderUsersTableComponent, provider_users: provider_users
+    ).text
+  end
+
+  context 'when the provider user has all fields present' do
+    let(:provider_users) do
+      [
+        create(:provider_user,
+               email_address: 'provider@example.com',
+               dfe_sign_in_uid: 'ABCDEF',
+               providers: [create(:provider, name: 'The Provider')]),
+      ]
+    end
+
+    it 'renders all the fields' do
+      expect(rendered_component).to include('provider@example.com')
+      expect(rendered_component).to include('ABCDEF')
+      expect(rendered_component).to include('The Provider')
+    end
+  end
+
+  context 'when there are no provider users' do
+    let(:provider_users) { [] }
+
+    it { is_expected.to be_blank }
+  end
+end


### PR DESCRIPTION
## Context

To help us understand how providers are using the service, we would like to display the date of their last sign-in in the support console.

## Changes proposed in this pull request

### Before

![Screenshot 2019-12-24 at 11 52 58](https://user-images.githubusercontent.com/642279/71412085-fbf4a500-2643-11ea-80d6-a57ce0b0d677.png)


### After

![Screenshot 2019-12-24 at 11 52 48](https://user-images.githubusercontent.com/642279/71412091-feef9580-2643-11ea-8a94-381a3ccc0694.png)

## Link to Trello card

https://trello.com/c/CeQmRrNB/1411-show-the-last-time-that-a-provider-user-signed-in

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
