### PR TITLE
Standardise date formats

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -26,7 +26,7 @@ module CandidateInterface
     end
 
     def decline_by_default_date
-      @dates.decline_by_default_at.strftime('%-e %B %Y')
+      @dates.decline_by_default_at.to_s(:govuk_date)
     end
 
   private

--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -62,7 +62,7 @@ private
   def date_of_birth_row
     {
       key: 'Date of birth',
-      value: application_form.date_of_birth ? application_form.date_of_birth.strftime('%e %B %Y') : MISSING,
+      value: application_form.date_of_birth ? application_form.date_of_birth.to_s(:govuk_date) : MISSING,
     }
   end
 

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -51,7 +51,7 @@ module ProviderInterface
   private
 
     def format_date(date)
-      date.strftime('%-e %B %Y')
+      date.to_s(:govuk_date)
     end
   end
 end

--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -26,7 +26,7 @@ module SupportInterface
     def last_updated_row
       {
         key: 'Last updated',
-        value: "#{updated_at.strftime('%e %b %Y at %l:%M%P')} (#{govuk_link_to('History', support_interface_application_form_audit_path(application_form))})".html_safe,
+        value: "#{updated_at.to_s(:govuk_date_and_time)} (#{govuk_link_to('History', support_interface_application_form_audit_path(application_form))})".html_safe,
       }
     end
 
@@ -34,7 +34,7 @@ module SupportInterface
       if submitted?
         {
           key: 'Submitted',
-          value: submitted_at.strftime('%e %b %Y at %l:%M%P'),
+          value: submitted_at.to_s(:govuk_date_and_time),
         }
       end
     end

--- a/app/components/support_interface/applications_table_component.rb
+++ b/app/components/support_interface/applications_table_component.rb
@@ -13,7 +13,7 @@ module SupportInterface
         {
           application_form_id: application_form.id,
           application_link: govuk_link_to(email_address, support_interface_application_form_path(application_form)),
-          updated_at: application_form.updated_at.strftime('%e %b %Y at %l:%M%P'),
+          updated_at: application_form.updated_at.to_s(:govuk_date_and_time),
           process_state: ProcessState.new(application_form).state,
         }
       end

--- a/app/components/support_interface/candidates_table_component.rb
+++ b/app/components/support_interface/candidates_table_component.rb
@@ -12,7 +12,7 @@ module SupportInterface
           candidate_id: candidate.id,
           process_state: ProcessState.new(candidate.last_updated_application).state,
           candidate_link: govuk_link_to(candidate.email_address, support_interface_candidate_path(candidate)),
-          updated_at: candidate.updated_at.strftime('%e %b %Y at %l:%M%P'),
+          updated_at: candidate.updated_at.to_s(:govuk_date_and_time),
         }
       end
     end

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -76,13 +76,13 @@ private
   end
 
   def formatted_start_date(volunteering_role)
-    volunteering_role.start_date.strftime('%B %Y')
+    volunteering_role.start_date.to_s(:month_and_year)
   end
 
   def formatted_end_date(volunteering_role)
     return 'Present' if volunteering_role.end_date.nil? || volunteering_role.end_date == DateTime.now
 
-    volunteering_role.end_date.strftime('%B %Y')
+    volunteering_role.end_date.to_s(:month_and_year)
   end
 
   def edit_path(volunteering_role)

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -93,12 +93,12 @@ private
   end
 
   def formatted_start_date(work)
-    work.start_date.strftime('%B %Y')
+    work.start_date.to_s(:month_and_year)
   end
 
   def formatted_end_date(work)
     return 'Present' if work.end_date.nil?
 
-    work.end_date.strftime('%B %Y')
+    work.end_date.to_s(:month_and_year)
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -29,12 +29,12 @@ module ViewHelper
 
   def submitted_at_date
     dates = ApplicationDates.new(@application_form)
-    dates.submitted_at.strftime('%e %B %Y').strip
+    dates.submitted_at.to_s(:govuk_date).strip
   end
 
   def respond_by_date
     dates = ApplicationDates.new(@application_form)
-    dates.reject_by_default_at.strftime('%e %B %Y').strip if dates.reject_by_default_at
+    dates.reject_by_default_at.to_s(:govuk_date).strip if dates.reject_by_default_at
   end
 
   def formatted_days_remaining
@@ -52,7 +52,7 @@ module ViewHelper
 
   def edit_by_date
     dates = ApplicationDates.new(@application_form)
-    dates.edit_by.strftime('%e %B %Y').strip
+    dates.edit_by.to_s(:govuk_date).strip
   end
 
 private

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -5,7 +5,7 @@ module CandidateInterface
     end
 
     def updated_at
-      "Last saved on #{@application_form.updated_at.strftime('%d %B %Y')} at #{@application_form.updated_at.strftime('%l:%M%P')}"
+      "Last saved on #{@application_form.updated_at.to_s(:govuk_date_and_time)}"
     end
 
     def sections_with_completion

--- a/app/presenters/candidate_interface/personal_details_review_presenter.rb
+++ b/app/presenters/candidate_interface/personal_details_review_presenter.rb
@@ -30,7 +30,7 @@ module CandidateInterface
     def date_of_birth_row
       {
         key: I18n.t('application_form.personal_details.date_of_birth.label'),
-        value: @form.date_of_birth.strftime('%e %B %Y'),
+        value: @form.date_of_birth.to_s(:govuk_date),
         action: ('date of birth' if @editable),
       }
     end

--- a/app/presenters/provider_interface/application_choice_presenter.rb
+++ b/app/presenters/provider_interface/application_choice_presenter.rb
@@ -48,7 +48,7 @@ module ProviderInterface
     end
 
     def updated_at
-      application_choice.updated_at.strftime('%e %b %Y %l:%M%P')
+      application_choice.updated_at.to_s(:govuk_date_and_time)
     end
 
     def to_param

--- a/app/views/candidate_mailer/application_under_consideration.text.erb
+++ b/app/views/candidate_mailer/application_under_consideration.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application.candidate_name %>,
 
 Your application is now with your teacher training <%= 'provider'.pluralize(@application.choice_count) %>.
 
-We’ve asked them to make a final decision before <%= @application.rbd_date.strftime('%-e %B %Y') %> (<%= @application.rbd_days %> working days).
+We’ve asked them to make a final decision before <%= @application.rbd_date.to_s(:govuk_date) %> (<%= @application.rbd_days %> working days).
 
 They’ll be in touch with you sooner if they want to arrange an interview.
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -42,7 +42,7 @@
       { key: 'Location', value: application_choice.site.name_and_code },
       { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent, application_choice: application_choice) },
     ] %>
-    <% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.strftime('%e %b %Y at %l:%M%P') } if application_choice.reject_by_default_at %>
+    <% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at %>
 
     <%= render SummaryCardComponent, rows: rows  do %>
       <%= render SummaryCardHeaderComponent, title: application_choice.course.name_and_code %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,3 +1,4 @@
 Time::DATE_FORMATS[:default] = '%-d %B %Y'
 Time::DATE_FORMATS[:month_and_year] = '%B %Y'
 Date::DATE_FORMATS[:month_and_year] = '%B %Y'
+Time::DATE_FORMATS[:govuk_date_and_time] = '%e %b %Y at %l:%M%P'

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,1 +1,3 @@
-Date::DATE_FORMATS[:default] = '%-d %B %Y'
+Time::DATE_FORMATS[:default] = '%-d %B %Y'
+Time::DATE_FORMATS[:month_and_year] = '%B %Y'
+Date::DATE_FORMATS[:month_and_year] = '%B %Y'

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,4 +1,7 @@
-Time::DATE_FORMATS[:default] = '%-d %B %Y'
+Time::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
+Date::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
+
 Time::DATE_FORMATS[:month_and_year] = '%B %Y'
 Date::DATE_FORMATS[:month_and_year] = '%B %Y'
+
 Time::DATE_FORMATS[:govuk_date_and_time] = '%e %b %Y at %l:%M%P'

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe WorkHistoryReviewComponent do
 
         application_form.application_work_experiences.each do |work|
           expect(result.text).to include(work.role)
-          expect(result.text).to include(work.start_date.strftime('%B %Y'))
+          expect(result.text).to include(work.start_date.to_s(:month_and_year))
           expect(result.css('.govuk-summary-list__actions').text).to include('Change')
           if work.working_with_children
             expect(result.text).to include(t('application_form.review.role_involved_working_with_children'))

--- a/spec/system/candidate_interface/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_submitting_application_spec.rb
@@ -200,7 +200,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
   end
 
   def then_i_can_see_my_application_dashboard
-    this_day = Time.zone.now.strftime('%-e %B %Y')
+    this_day = Time.zone.now.to_s(:govuk_date)
     expect(page).to have_content t('page_titles.application_dashboard')
     expect(page).to have_content "Application submitted on #{this_day}"
     expect(page).to have_content 'Gorse SCITT'
@@ -214,7 +214,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
 
   def then_i_can_see_my_submitted_application
     expect(page).to have_content t('page_titles.submitted_application')
-    expect(page).to have_content Time.zone.now.strftime('%-e %B %Y')
+    expect(page).to have_content Time.zone.now.to_s(:govuk_date)
     expect(page).to have_content 'Gorse SCITT'
     expect(page).to have_content 'Lando Calrissian'
     expect(page).to have_content '07700 900 982'


### PR DESCRIPTION
## Context

Came out of #980.

We have lots of `strftime` all over the app.

Rails has a way to define standard `strftime` formats for both Date and Time objects. This PR causes our code to use them.


## Changes proposed in this pull request

- declare `DATE_FORMAT`s for the three formats we use: `govuk_date` (eg 13 December 2019) `month_and_year` (eg December 2019) and `govuk_date_and_time` (eg 13 December 2019 at 10:46am)

## Guidance to review

Any stray unformatted dates anywhere?

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
