### PR TITLE
Fix nationality autocomplete confirm

### DIFF
--- a/app/frontend/packs/nationality-autocomplete.js
+++ b/app/frontend/packs/nationality-autocomplete.js
@@ -18,7 +18,8 @@ const initNationalityAutocomplete = () => {
       accessibleAutocomplete.enhanceSelectElement({
         selectElement: nationalitySelect,
         name: nationalitySelect.name,
-        showAllValues: true
+        showAllValues: true,
+        confirmOnBlur: false
       });
       nationalitySelect.name = "";
     });


### PR DESCRIPTION
## Context

Because now the autocomplete is set to `showAllValues`, if you click on it and don't select anything, the first option will be preselected. This can lead to users selecting something unintended and not noticing it.

## Changes proposed in this pull request

Disable `confirmOnBlur`.

## Guidance to review

Nothing in particular.

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)