### PR TITLE
Add defensive code for nil dates in StatusBoxComponent

### DIFF
--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -51,7 +51,7 @@ module ProviderInterface
   private
 
     def format_date(date)
-      date.to_s(:govuk_date)
+      date&.to_s(:govuk_date) || ''
     end
   end
 end

--- a/spec/components/provider_interface/status_box_component_spec.rb
+++ b/spec/components/provider_interface/status_box_component_spec.rb
@@ -66,7 +66,17 @@ RSpec.describe ProviderInterface::StatusBoxComponent do
   end
 
   it 'outputs a date for applications in the enrolled_at state' do
-    application_choice = make_choice(status: 'enrolled', enrolled_at: Time.zone.now)
+    now = Time.zone.now
+    application_choice = make_choice(status: 'enrolled', enrolled_at: now)
+
+    result = render_inline(described_class, application_choice: application_choice)
+
+    expect(result.text).to include('Enrolled at')
+    expect(result.text).to include(now.to_s(:govuk_date))
+  end
+
+  it 'handles nil `enrolled_at` date for applications in the enrolled_at state' do
+    application_choice = make_choice(status: 'enrolled', enrolled_at: nil)
 
     result = render_inline(described_class, application_choice: application_choice)
 


### PR DESCRIPTION
## Context

The provider interface application detail page can error if certain dates, such as `enrolled_at`, are `nil`. 

## Changes proposed in this pull request

Add some defensive code to the `StatusBoxComponent` to ensure that missing date values cannot cause errors.

## Guidance to review

`ApplicationChoice#enrolled_at` should in theory be present whenever the `status` value is `enrolled` however there is nothing to stop it being `nil` in either database constraints or model validations. You could take the view that `nil` values here are a symptom of a bigger issue but as far as I can see this has only happened in a development environment.

Setting the `ApplicationChoice#enrolled_at` value does seem to be correctly handled already by https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/app/services/confirm_enrolment.rb.

## Link to Trello card

https://trello.com/c/Q9V4eft5/1414-application-details-view-triggers-error-for-some-applications-with-a-missing-date

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
