### PR TITLE
Allow candidates to see courses not open on Apply

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -61,10 +61,10 @@ module CandidateInterface
         application_form: current_application,
       )
 
-      if @pick_course.other?
-        redirect_to candidate_interface_course_choices_on_ucas_path
-      elsif !@pick_course.valid?
+      if !@pick_course.valid?
         render :options_for_course
+      elsif !@pick_course.applyable?
+        redirect_to candidate_interface_course_choices_on_ucas_path
       elsif @pick_course.single_site?
         course_id = Course.find_by(code: course_code)
         course_option = CourseOption.where(course_id: course_id).first

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -6,13 +6,17 @@ module CandidateInterface
     validates :code, presence: true
     validate :user_cant_apply_to_same_course_twice
 
+    def applyable?
+      !other? && course.open_on_apply?
+    end
+
     def other?
       code == 'other'
     end
 
     def available_courses
       @available_courses ||= begin
-        provider.courses.visible_to_candidates.order(:name)
+        provider.courses.where(exposed_in_find: true).order(:name)
       end
     end
 

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -16,7 +16,7 @@ module CandidateInterface
 
     def available_courses
       @available_courses ||= begin
-        provider.courses.where(exposed_in_find: true).order(:name)
+        provider.courses.visible_to_candidates.order(:name)
       end
     end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,7 +7,7 @@ class Course < ApplicationRecord
   validates :level, presence: true
   validates :code, uniqueness: { scope: :provider_id }
 
-  scope :visible_to_candidates, -> { where(exposed_in_find: true, open_on_apply: true) }
+  scope :visible_to_candidates, -> { where(exposed_in_find: true) }
 
   CODE_LENGTH = 4
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,6 +8,7 @@ class Course < ApplicationRecord
   validates :code, uniqueness: { scope: :provider_id }
 
   scope :visible_to_candidates, -> { where(exposed_in_find: true) }
+  scope :applyable, -> { visible_to_candidates.where(open_on_apply: true) }
 
   CODE_LENGTH = 4
 

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -11,10 +11,6 @@
           <% @pick_course.available_courses.each_with_index do |course, i| %>
             <%= f.govuk_radio_button :code, course.code, label: { text: "#{course.name} (#{course.code})" }, link_errors: i.zero? %>
           <% end %>
-
-          <%= f.govuk_radio_divider %>
-
-          <%= f.govuk_radio_button :code, :other, label: { text: 'Another course' } %>
         </div>
       <% end %>
 

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -24,7 +24,7 @@
           <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
         </td>
         <td class='govuk-table__cell'>
-          <%= pluralize provider.courses.size, 'course' %> (<%= provider.courses.visible_to_candidates.size %> on DfE Apply)
+          <%= pluralize provider.courses.size, 'course' %> (<%= provider.courses.applyable.size %> on DfE Apply)
         </td>
         <td class='govuk-table__cell'>
           <%= provider.sites.size %>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @provider.name_and_code %>
 
-<h2 class='govuk-heading-l'><%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.visible_to_candidates.size %> on DfE Apply)</h2>
+<h2 class='govuk-heading-l'><%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.applyable.size %> on DfE Apply)</h2>
 
 <% if @provider.courses.any? %>
   <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>

--- a/spec/models/candidate_interface/pick_course_form_spec.rb
+++ b/spec/models/candidate_interface/pick_course_form_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickCourseForm do
   describe '#available_courses' do
-    it 'returns courses that candidates can apply to' do
+    it 'returns courses that candidates can choose from' do
       provider = create(:provider, name: 'School with courses')
       create(:course, exposed_in_find: false, open_on_apply: true, name: 'Course not shown in Find', provider: provider)
       create(:course, exposed_in_find: true, open_on_apply: false, name: 'Course not open on apply', provider: provider)
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
 
       form = CandidateInterface::PickCourseForm.new(provider_code: provider.code)
 
-      expect(form.available_courses.map(&:name)).to eql(['Course you can apply to'])
+      expect(form.available_courses.map(&:name)).to eql(['Course not open on apply', 'Course you can apply to'])
     end
   end
 

--- a/spec/models/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/models/candidate_interface/pick_provider_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateInterface::PickProviderForm do
   describe '#available_providers' do
     it 'returns providers with available courses' do
       create(:provider, name: 'School without courses')
-      create(:course, open_on_apply: false, exposed_in_find: true, provider: create(:provider, name: 'School with disabled courses'))
+      create(:course, open_on_apply: false, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
       create(:course, open_on_apply: true, exposed_in_find: true, provider: create(:provider, name: 'School with courses'))
 
       form = CandidateInterface::PickProviderForm.new({})

--- a/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def i_should_see_the_available_providers_and_courses
-    expect(page).not_to have_content 'Biology'
+    expect(page).to have_content 'Biology'
     expect(page).to have_content 'Potions'
   end
 end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -33,8 +33,10 @@ RSpec.feature 'Selecting a course not on Apply' do
   def and_there_are_course_options
     provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: provider)
-    course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true, open_on_apply: true)
-    create(:course_option, site: site, course: course, vacancy_status: 'B')
+    course1 = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true, open_on_apply: true)
+    course2 = create(:course, name: 'Secondary', code: 'X123', provider: provider, exposed_in_find: true, open_on_apply: false)
+    create(:course_option, site: site, course: course1, vacancy_status: 'B')
+    create(:course_option, site: site, course: course2, vacancy_status: 'B')
   end
 
   def and_i_click_on_course_choices
@@ -69,7 +71,7 @@ RSpec.feature 'Selecting a course not on Apply' do
   end
 
   def and_i_choose_another_course
-    choose 'Another course'
+    choose 'Secondary (X123)'
     click_button 'Continue'
   end
 end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -32,8 +32,6 @@ RSpec.feature 'Selecting a course' do
     when_i_click_on_add_another_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_another_provider
-
-    when_i_click_back
     and_i_choose_another_course_with_only_one_site
     then_i_review_my_second_course_choice
 

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -32,8 +32,6 @@ RSpec.feature 'Selecting a course' do
     when_i_click_on_add_another_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_another_provider
-    and_i_choose_another_course
-    then_i_see_the_not_ready_for_you_yet_page
 
     when_i_click_back
     and_i_choose_another_course_with_only_one_site
@@ -129,11 +127,6 @@ RSpec.feature 'Selecting a course' do
     click_button 'Continue'
   end
 
-  def and_i_choose_another_course
-    choose 'Another course'
-    click_button 'Continue'
-  end
-
   def then_i_see_the_address
     expect(page).to have_content('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, lEEDS, LS27 0LZ')
   end
@@ -209,9 +202,5 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_no_longer_see_my_course_choice
     expect(page).not_to have_content('Primary (2XT2)')
-  end
-
-  def then_i_see_the_not_ready_for_you_yet_page
-    expect(page).to have_content('We’re sorry, but we’re not ready for you yet')
   end
 end

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature 'See providers' do
 
   def then_i_see_the_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
-    expect(page).to have_content '1 course (0 on DfE Apply)'
+    expect(page).to have_content '1 course (1 on DfE Apply)'
   end
 
   def when_i_click_on_a_course

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature 'See providers' do
 
   def then_i_see_the_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
-    expect(page).to have_content '1 course (1 on DfE Apply)'
+    expect(page).to have_content '1 course (0 on DfE Apply)'
   end
 
   def when_i_click_on_a_course


### PR DESCRIPTION
## Context

If a candidate chooses one of these courses, they will be directed to the "Apply on UCAS" page. We also remove the "Another course" option which would take them to the same page.

This is a prerequisite to putting all the course options into an autocomplete component.

## Changes proposed in this pull request

Update the scope to look for courses which are just exposed in find, without `available_on_apply: true`. Remove the "Another course" option, and update relevant tests.

## Guidance to review

Does the naming of the new helpers make sense? Should we be concerned that the `courses.visible_to_candidates` scope is now incorrectly named, and should we update and use that instead?

Later edit: have pushed another commit that does this.

Later later edit: have also added an `applyable` scope.

## Link to Trello card

https://trello.com/c/uQaeQEm2/619-users-can-select-a-course-from-a-drop-down

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)