### PR TITLE
Allow users to choose a course from a select dropdown

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -27,6 +27,12 @@ module ViewHelper
     ] + NATIONALITIES.map { |_, nationality| OpenStruct.new(id: nationality, name: nationality) }
   end
 
+  def select_course_options(courses)
+    [
+      OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_course_form.attributes.code.blank')),
+    ] + courses.map { |course| OpenStruct.new(id: course.code, name: "#{course.name} (#{course.code})") }
+  end
+
   def submitted_at_date
     dates = ApplicationDates.new(@application_form)
     dates.submitted_at.to_s(:govuk_date).strip

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -7,11 +7,7 @@ module CandidateInterface
     validate :user_cant_apply_to_same_course_twice
 
     def applyable?
-      !other? && course.open_on_apply?
-    end
-
-    def other?
-      code == 'other'
+      course.open_on_apply?
     end
 
     def available_courses
@@ -32,7 +28,7 @@ module CandidateInterface
     end
 
     def user_cant_apply_to_same_course_twice
-      return unless code
+      return if code.blank?
 
       if application_form.application_choices.any? { |application_choice| application_choice.course == course }
         errors[:base] << 'You have already selected this course'

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -6,13 +6,11 @@
     <%= form_with model: @pick_course, url: candidate_interface_course_choices_course_path(provider_code: params[:provider_code]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
-        <div class="govuk-!-margin-top-6">
-          <% @pick_course.available_courses.each_with_index do |course, i| %>
-            <%= f.govuk_radio_button :code, course.code, label: { text: "#{course.name} (#{course.code})" }, link_errors: i.zero? %>
-          <% end %>
-        </div>
-      <% end %>
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.which_course') %>
+      </h1>
+
+      <%= f.govuk_collection_select :code, select_course_options(@pick_course.available_courses), :id, :name, label: { text: 'Enter course name and code' } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -98,7 +98,7 @@ module CandidateHelper
     choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
 
-    choose 'Primary (2XT2)'
+    select 'Primary (2XT2)'
     click_button 'Continue'
 
     check t('application_form.courses.complete.completed_checkbox')

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'A candidate edits their course choice after submission' do
     click_button 'Continue'
     choose 'Gorse SCITT (1N1)'
     click_button 'Continue'
-    choose 'Primary (2XT2)'
+    select 'Primary (2XT2)'
     click_button 'Continue'
     choose 'Main site'
     click_button 'Continue'

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Selecting a course not on Apply' do
   end
 
   def and_i_choose_another_course
-    choose 'Secondary (X123)'
+    select 'Secondary (X123)'
     click_button 'Continue'
   end
 end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -121,7 +121,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_a_course
-    choose 'Primary (2XT2)'
+    select 'Primary (2XT2)'
     click_button 'Continue'
   end
 
@@ -159,7 +159,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_another_course_with_only_one_site
-    choose 'Dance (W5X1)'
+    select 'Dance (W5X1)'
     click_button 'Continue'
   end
 


### PR DESCRIPTION
## Context

This is a prerequisite to allowing users to choose a course via autocomplete. If the autocomplete fails to initialise, it will fallback to this select element.

## Changes proposed in this pull request

Change the set of radio buttons to a select element, update relevant tests and helpers.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/uQaeQEm2/619-users-can-select-a-course-from-a-drop-down

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)