### PR TITLE
Fix error labels for condition fields when making an offer

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -21,7 +21,12 @@ module ProviderInterface
       @application_offer = MakeAnOffer.new(
         application_choice: @application_choice,
         standard_conditions: make_an_offer_params[:standard_conditions],
-        further_conditions: make_an_offer_params[:further_conditions],
+        further_conditions: make_an_offer_params.permit(
+          :further_conditions0,
+          :further_conditions1,
+          :further_conditions2,
+          :further_conditions3,
+        ).to_h,
       )
       render action: :new_offer if !@application_offer.valid?
     end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -18,13 +18,10 @@ module ProviderInterface
     end
 
     def confirm_offer
-      offer_conditions = [
-        make_an_offer_params[:standard_conditions],
-        make_an_offer_params[:further_conditions],
-      ].flatten.reject(&:blank?)
       @application_offer = MakeAnOffer.new(
         application_choice: @application_choice,
-        offer_conditions: offer_conditions,
+        standard_conditions: make_an_offer_params[:standard_conditions],
+        further_conditions: make_an_offer_params[:further_conditions],
       )
       render action: :new_offer if !@application_offer.valid?
     end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -1,5 +1,6 @@
 class MakeAnOffer
-  attr_accessor :offer_conditions
+  attr_accessor :standard_conditions
+  attr_accessor :further_conditions
 
   include ActiveModel::Validations
 
@@ -7,11 +8,12 @@ class MakeAnOffer
   MAX_CONDITION_LENGTH = 255
 
   validate :validate_course_data
-  validate :validate_offer_conditions
+  validate :validate_further_conditions
 
-  def initialize(application_choice:, offer_conditions: nil, course_data: nil)
+  def initialize(application_choice:, standard_conditions: nil, further_conditions: nil, course_data: nil)
     @application_choice = application_choice
-    @offer_conditions = offer_conditions
+    @standard_conditions = standard_conditions
+    @further_conditions = further_conditions
     @course_data = course_data
   end
 
@@ -20,7 +22,7 @@ class MakeAnOffer
 
     ApplicationStateChange.new(application_choice).make_offer!
     application_choice.offered_course_option = offered_course_option
-    application_choice.offer = { 'conditions' => (@offer_conditions || []) }
+    application_choice.offer = { 'conditions' => offer_conditions }
 
     application_choice.offered_at = Time.zone.now
     application_choice.save!
@@ -87,15 +89,22 @@ private
     errors.add(:offered_course, "does not belong to provider #{current_provider.code}, it belongs to #{provider.code}") if providers_dont_match
   end
 
-  def validate_offer_conditions
-    return if @offer_conditions.blank?
+  def validate_further_conditions
+    return if @further_conditions.blank?
 
-    unless @offer_conditions.is_a?(Array)
-      errors.add(:offer_conditions, 'must be an array')
+    unless @further_conditions.is_a?(Array)
+      errors.add(:further_conditions, 'must be an array')
       return
     end
 
-    errors.add(:offer_conditions, "has over #{MAX_CONDITIONS_COUNT} elements") if @offer_conditions.count > MAX_CONDITIONS_COUNT
-    errors.add(:offer_conditions, "has a condition over #{MAX_CONDITION_LENGTH} chars in length") if @offer_conditions.any? { |c| c.length > MAX_CONDITION_LENGTH }
+    errors.add(:further_conditions, "has over #{MAX_CONDITIONS_COUNT} elements") if @further_conditions.count > MAX_CONDITIONS_COUNT
+    errors.add(:further_conditions, "has a condition over #{MAX_CONDITION_LENGTH} chars in length") if @further_conditions.any? { |c| c.length > MAX_CONDITION_LENGTH }
+  end
+
+  def offer_conditions
+    [
+      standard_conditions,
+      further_conditions,
+    ].flatten.reject(&:blank?)
   end
 end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -117,7 +117,16 @@ private
     return if further_conditions.blank?
 
     further_conditions.each_with_index do |value, index|
-      errors.add("further_conditions#{index}", "must be #{MAX_CONDITION_LENGTH} characters or fewer") if value && value.length > MAX_CONDITION_LENGTH
+      if value && value.length > MAX_CONDITION_LENGTH
+        errors.add(
+          "further_conditions#{index}",
+          I18n.t(
+            'activemodel.errors.models.support_interface/new_offer_form.attributes.further_conditions.too_long',
+            name: I18n.t("activemodel.attributes.support_interface/new_offer.further_conditions#{index}"),
+            limit: MAX_CONDITION_LENGTH,
+          ),
+        )
+      end
     end
   end
 

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -12,11 +12,13 @@ class MakeAnOffer
 
   def initialize(
     application_choice:,
+    offer_conditions: nil,
     standard_conditions: nil,
     further_conditions: {},
     course_data: nil
   )
     @application_choice = application_choice
+    @offer_conditions = offer_conditions
     @standard_conditions = standard_conditions
     @course_data = course_data
     further_conditions.each { |key, value| self.send("#{key}=", value) }
@@ -43,7 +45,7 @@ class MakeAnOffer
   end
 
   def offer_conditions
-    [
+    @offer_conditions ||= [
       standard_conditions,
       further_conditions,
     ].flatten.reject(&:blank?)
@@ -106,7 +108,7 @@ private
 
     errors.add(:further_conditions, "has over #{MAX_CONDITIONS_COUNT} elements") if further_conditions.count > MAX_CONDITIONS_COUNT
     further_conditions.each_with_index do |value, index|
-      errors.add("further_conditions#{index}", "has a condition over #{MAX_CONDITION_LENGTH} chars in length") if value.length > MAX_CONDITION_LENGTH
+      errors.add("further_conditions#{index}", "has a condition over #{MAX_CONDITION_LENGTH} chars in length") if value && value.length > MAX_CONDITION_LENGTH
     end
   end
 

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -118,7 +118,7 @@ private
     return if further_conditions.blank?
 
     further_conditions.each_with_index do |value, index|
-      errors.add("further_conditions#{index}", "has a condition over #{MAX_CONDITION_LENGTH} chars in length") if value && value.length > MAX_CONDITION_LENGTH
+      errors.add("further_conditions#{index}", "must be #{MAX_CONDITION_LENGTH} characters or fewer") if value && value.length > MAX_CONDITION_LENGTH
     end
   end
 

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -8,7 +8,6 @@ class MakeAnOffer
   MAX_CONDITION_LENGTH = 255
 
   validate :validate_course_data
-  validate :validate_conditions_array
   validate :validate_conditions_max_length
   validate :validate_further_conditions
 
@@ -120,12 +119,6 @@ private
     further_conditions.each_with_index do |value, index|
       errors.add("further_conditions#{index}", "must be #{MAX_CONDITION_LENGTH} characters or fewer") if value && value.length > MAX_CONDITION_LENGTH
     end
-  end
-
-  def validate_conditions_array
-    return if offer_conditions.is_a?(Array)
-
-    errors.add(:offer_conditions, 'must be an array')
   end
 
   def validate_conditions_max_length

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -8,6 +8,8 @@ class MakeAnOffer
   MAX_CONDITION_LENGTH = 255
 
   validate :validate_course_data
+  validate :validate_conditions_array
+  validate :validate_conditions_max_length
   validate :validate_further_conditions
 
   def initialize(
@@ -61,6 +63,15 @@ private
     @course_option
   end
 
+  def further_conditions
+    [
+      further_conditions0,
+      further_conditions1,
+      further_conditions2,
+      further_conditions3,
+    ]
+  end
+
   def validate_course_data
     return if @course_data.nil?
 
@@ -106,18 +117,20 @@ private
   def validate_further_conditions
     return if further_conditions.blank?
 
-    errors.add(:further_conditions, "has over #{MAX_CONDITIONS_COUNT} elements") if further_conditions.count > MAX_CONDITIONS_COUNT
     further_conditions.each_with_index do |value, index|
       errors.add("further_conditions#{index}", "has a condition over #{MAX_CONDITION_LENGTH} chars in length") if value && value.length > MAX_CONDITION_LENGTH
     end
   end
 
-  def further_conditions
-    [
-      further_conditions0,
-      further_conditions1,
-      further_conditions2,
-      further_conditions3,
-    ]
+  def validate_conditions_array
+    return if offer_conditions.is_a?(Array)
+
+    errors.add(:offer_conditions, 'must be an array')
+  end
+
+  def validate_conditions_max_length
+    return if offer_conditions.is_a?(Array) && offer_conditions.count <= MAX_CONDITIONS_COUNT
+
+    errors.add(:offer_conditions, "has over #{MAX_CONDITIONS_COUNT} elements")
   end
 end

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -31,10 +31,10 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
         <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
-        <%= f.govuk_text_area :further_conditions0, label: { text: 'First condition', size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions1, label: { text: 'Second condition', size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions2, label: { text: 'Third condition', size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions3, label: { text: 'Further condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions0, id: :first_condition, label: { text: 'First condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions1, id: :second_condition, label: { text: 'Second condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions2, id: :third_condition, label: { text: 'Third condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions3, id: :further_condition, label: { text: 'Further condition', size: 's' }, rows: 3 %>
       </fieldset>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -31,10 +31,10 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
         <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
-        <%= f.govuk_text_area :further_conditions0, label: { text: 'First condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
-        <%= f.govuk_text_area :further_conditions1, label: { text: 'Second condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
-        <%= f.govuk_text_area :further_conditions2, label: { text: 'Third condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
-        <%= f.govuk_text_area :further_conditions3, label: { text: 'Further condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
+        <%= f.govuk_text_area :further_conditions0, label: { text: 'First condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions1, label: { text: 'Second condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions2, label: { text: 'Third condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions3, label: { text: 'Further condition', size: 's' }, rows: 3 %>
       </fieldset>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -31,10 +31,10 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
         <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
-        <%= f.govuk_text_area :further_conditions0, label: { text: 'First condition', size: 's' }, id: 'first_condition', rows: 3, multiple: false %>
-        <%= f.govuk_text_area :further_conditions1, label: { text: 'Second condition', size: 's' }, id: 'second_condition', rows: 3, multiple: false %>
-        <%= f.govuk_text_area :further_conditions2, label: { text: 'Third condition', size: 's' }, id: 'third_condition', rows: 3, multiple: false %>
-        <%= f.govuk_text_area :further_conditions3, label: { text: 'Further condition', size: 's' }, id: 'further_condition', rows: 3, multiple: false %>
+        <%= f.govuk_text_area :further_conditions0, label: { text: 'First condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
+        <%= f.govuk_text_area :further_conditions1, label: { text: 'Second condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
+        <%= f.govuk_text_area :further_conditions2, label: { text: 'Third condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
+        <%= f.govuk_text_area :further_conditions3, label: { text: 'Further condition', size: 's' }, rows: 3, max_chars: 255, threshold: 75 %>
       </fieldset>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -31,10 +31,10 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
         <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
-        <%= f.govuk_text_area :further_conditions0, id: :first_condition, label: { text: 'First condition', size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions1, id: :second_condition, label: { text: 'Second condition', size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions2, id: :third_condition, label: { text: 'Third condition', size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions3, id: :further_condition, label: { text: 'Further condition', size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions0, id: :first_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions0'), size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions1, id: :second_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions1'), size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions2, id: :third_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions2'), size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions3, id: :further_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions3'), size: 's' }, rows: 3 %>
       </fieldset>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -31,10 +31,10 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
         <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
-        <%= f.govuk_text_area :further_conditions, label: { text: 'First condition', size: 's' }, id: 'first_condition', rows: 3, multiple: true %>
-        <%= f.govuk_text_area :further_conditions, label: { text: 'Second condition', size: 's' }, id: 'second_condition', rows: 3, multiple: true %>
-        <%= f.govuk_text_area :further_conditions, label: { text: 'Third condition', size: 's' }, id: 'third_condition', rows: 3, multiple: true %>
-        <%= f.govuk_text_area :further_conditions, label: { text: 'Further condition', size: 's' }, id: 'further_condition', rows: 3, multiple: true %>
+        <%= f.govuk_text_area :further_conditions0, label: { text: 'First condition', size: 's' }, id: 'first_condition', rows: 3, multiple: false %>
+        <%= f.govuk_text_area :further_conditions1, label: { text: 'Second condition', size: 's' }, id: 'second_condition', rows: 3, multiple: false %>
+        <%= f.govuk_text_area :further_conditions2, label: { text: 'Third condition', size: 's' }, id: 'third_condition', rows: 3, multiple: false %>
+        <%= f.govuk_text_area :further_conditions3, label: { text: 'Further condition', size: 's' }, id: 'further_condition', rows: 3, multiple: false %>
       </fieldset>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,11 @@ en:
         user_id: user_id
         email: email
         full_name: full_name
+      support_interface/new_offer:
+        further_conditions0: First condition
+        further_conditions1: Second condition
+        further_conditions2: Third condition
+        further_conditions3: Further condition
     errors:
       models:
         support_interface/provider_user_form:
@@ -108,6 +113,10 @@ en:
               blank: DfE Sign-in UID can’t be blank
             provider_ids:
               blank: Please specify a provider
+        support_interface/new_offer_form:
+          attributes:
+            further_conditions:
+              too_long: "%{name} must be %{limit} characters or fewer"
   activerecord:
     errors:
       models:

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -237,7 +237,6 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eql 'Offer conditions must be an array'
   end
 
   it 'returns a not found error if the application can\'t be found' do

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe MakeAnOffer do
       expect(decision).not_to be_valid
     end
 
-    it 'limits the length of conditions to 255 characters' do
+    it 'limits the length of individual further_conditions to 255 characters' do
       decision = MakeAnOffer.new(
         application_choice: build_stubbed(:application_choice, status: :awaiting_provider_decision),
-        offer_conditions: ['a' * 256],
+        further_conditions: { further_conditions2: 'a' * 256 },
       )
 
       expect(decision).not_to be_valid

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -25,15 +25,6 @@ RSpec.describe MakeAnOffer do
       expect(decision).to be_valid
     end
 
-    it 'only accepts conditions as an array' do
-      decision = MakeAnOffer.new(
-        application_choice: build_stubbed(:application_choice, status: :awaiting_provider_decision),
-        offer_conditions: 'SPLAT',
-      )
-
-      expect(decision).not_to be_valid
-    end
-
     it 'limits the number of conditions to 20' do
       decision = MakeAnOffer.new(
         application_choice: build_stubbed(:application_choice, status: :awaiting_provider_decision),


### PR DESCRIPTION
## Context

Offers can include up to 4 'further conditions' selected by filling a text area as well as 2 'standard conditions' selected via a checkbox. The further conditions have a validation rule limiting input to 255 characters. If this is exceeded the client doesn't warn the user, the server then throws a validation error but doesn't render the error message next to the offending text area and discards the value that the user entered. We want to preserve the user input and render error messages in the right place.

## Changes proposed in this pull request

* Model each further condition attribute on the `MakeAnOffer` service class a named field rather than an array of non-blank values so that any errors can be mapped back to the form fields.
* Fixup the view to use the new named fields.
* Add a character counter component to each of the fields so that users get a visual warning when they approach or exceed the limit.

## Guidance to review

* Is there a simpler way to do this? I am not all that happy about having `further_conditions0` - `further_conditions3` referenced in so many places.
* Is there any more testing needed here?

## Link to Trello card

https://trello.com/c/SOODVP0D/1316-labels-arent-assigned-with-inputs-for-condition-fields-when-making-an-offer-errors-are-wrong

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
