### PR TITLE
Fix `Complete section` link for  work history on review application page

### DIFF
--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -22,5 +22,5 @@
 <% end %>
 
 <% if show_missing_banner? %>
-  <%= render(SectionMissingBannerComponent, section: :work_experience, section_path: candidate_interface_work_history_length_path, error: @missing_error) %>
+  <%= render(SectionMissingBannerComponent, section: :work_experience, section_path: CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path, error: @missing_error) %>
 <% end %>


### PR DESCRIPTION
## Context

When a candidate has filled in some work history but not said it's complete, the `Complete section` link on the `Review your application` page should take them to the work history review page but instead
takes you to the initial question.

## Changes proposed in this pull request

This PR updates the link used to instead use the `CandidateInterface::ApplicationFormPresenter.new(@application_form).work_experience_path` which works out what page to send the candidate to.

## Guidance to review

Wasn't sure if a spec was needed as there are specs for the presenter method used: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/0e4d44331594cfa6c8860d50d74df04ab694c11d/spec/presenters/candidate_interface/application_form_presenter_spec.rb#L250-L277

Recommendations?

## Link to Trello card

https://trello.com/c/3shAfbAR/550-when-youve-filled-in-work-history-but-not-said-its-complete-the-complete-section-link-should-take-you-to-the-review-but-it-takes

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
