### PR TITLE
Add title for responding to an offer as a provider

### DIFF
--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.provider.respond') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
 <span class="govuk-caption-xl">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,8 @@ en:
       help: Get help
       release_notes: Release notes
       alpha_release_notes: Alpha release notes
+    provider:
+      respond: Respond to application
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use


### PR DESCRIPTION
## Context

Add a page title to the page to meet a11y and usability standards. Came up in DAC.

## Guidance to review

Wanted to check that my provider ‘namespace’ is okay to section off titles for the provider app. 

## Link to Trello card

https://trello.com/c/ARnK0YPP/706-dac-page-59-add-custom-title-to-respond-to-application-provider-page