### PR TITLE
Availability alert automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,14 @@ By default the `/check` path of the azurewebsites.net URL is automatically monit
 
 The `TEST-NAMEn` should be short, unique and descriptive and contain no spaces. The `DOMAINn` should be the complete domain without the protocol specified (i.e drop the "http(s)://").
 
+To enable email alerting for the custom URLs you must update the `alertRecipientEmails` pipeline variable for each environment as required in the following format.
+
+`["NAME1:EMAIL1","NAME2:EMAIL2"]`
+
+`NAMEn` is the display name for the email recipient. At the present time this name cannot contain any spaces. `EMAILn` is the email address of the recipient.
+
+Email alerting is not configured for the `/check` domains using this approach, it only applies to any custom URLs added in the pipeline variables. If no email alerting is required, the `alertRecipientEmails` pipeline variable should be left empty or not set.
+
 ### <a name="documentation-db-restore"></a>Database Restore
 
 👉 [See the database restore guide](/docs/database-restore.md)

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -81,7 +81,8 @@ jobs:
               resourceGroupName: '$(resourceGroupName)'
               location: 'West Europe'
               csmFile: '$(Pipeline.Workspace)\arm_template\template.json'
-              overrideParameters: '-resourceEnvironmentName "${{parameters.resourceEnvironmentName}}"
+              overrideParameters: '-localBranchName "$(Build.SourceBranchName)"
+                -resourceEnvironmentName "${{parameters.resourceEnvironmentName}}"
                 -serviceName "${{parameters.serviceName}}"
                 -dockerHubUsername "${{parameters.dockerHubUsername}}"
                 -containerImageReference "${{parameters.containerImageReference}}"

--- a/azure/template.json
+++ b/azure/template.json
@@ -1,7 +1,14 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "localBranchName": {
+            "type": "string",
+            "defaultValue": "master",
+            "metadata": {
+                "description": "The name of the local branch for the code in use."
+            }
+        },
         "resourceEnvironmentName": {
             "type": "string",
             "metadata": {
@@ -332,7 +339,7 @@
     },
     "variables": {
         "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
-        "deploymentUrlBaseLocal": "https://raw.githubusercontent.com/DFE-Digital/apply-for-postgraduate-teacher-training/master/azure/",
+        "deploymentUrlBaseLocal": "[concat('https://raw.githubusercontent.com/DFE-Digital/apply-for-postgraduate-teacher-training/', parameters('localBranchName'),'/azure/')]",
         "resourceNamePrefix": "[toLower(concat('s106', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",
@@ -351,8 +358,16 @@
                     "url": "[concat('https://', split(variables('availabilityCheckHosts')[copyIndex('availabilityTests')], ':')[1])]",
                     "guid": "[guid(variables('availabilityCheckHosts')[copyIndex('availabilityTests')])]"
                 }
+            },
+            {
+                "name": "alertRecipientEmails",
+                "count": "[if(greater(length(parameters('alertRecipientEmails')), 0), length(parameters('alertRecipientEmails')), 1)]",
+                "input": {
+                    "displayName": "[if(greater(length(parameters('alertRecipientEmails')), 0), split(parameters('alertRecipientEmails')[copyIndex('alertRecipientEmails')], ':')[0], 'UNUSED')]",
+                    "emailAddress": "[if(greater(length(parameters('alertRecipientEmails')), 0), split(parameters('alertRecipientEmails')[copyIndex('alertRecipientEmails')], ':')[1], 'UNUSED')]"
+                }
             }
-	]
+        ]
     },
     "resources": [
         {
@@ -694,12 +709,97 @@
                     },
                     "attachedService": {
                         "value": "[variables('appServiceName')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "action-groups",
+            "condition": "[greater(length(parameters('alertRecipientEmails')), 0)]",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'action-group.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appInsightsName": {
+                        "value": "[variables('appServiceName')]"
+                    },
+                    "alertRecipientEmails": {
+                        "value": "[variables('alertRecipientEmails')]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "availability-tests",
+            "type": "Microsoft.Resources/deployments",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'availability-tests.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appInsightsName": {
+                        "value": "[variables('appServiceName')]"
                     },
                     "availabilityTests": {
                         "value": "[variables('availabilityTests')]"
                     }
                 }
-            }
+            },
+            "dependsOn": [
+                "app-insights"
+            ]
+        },
+        {
+            "apiVersion": "2017-05-10",
+            "name": "availability-test-alerts",
+            "condition": "[and(greater(length(parameters('customAvailabilityMonitors')), 0), greater(length(parameters('alertRecipientEmails')), 0))]",
+            "type": "Microsoft.Resources/deployments",
+            "copy": {
+                "name": "customAlerts",
+                "count": "[if(greater(length(parameters('customAvailabilityMonitors')), 0), length(parameters('customAvailabilityMonitors')), 1)]"
+            },
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[concat(variables('deploymentUrlBase'), 'availability-test-alert.json')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "appInsightsName": {
+                        "value": "[variables('appServiceName')]"
+                    },
+                    "appInsightsId": {
+                        "value": "[reference('app-insights').outputs.AppInsightsResourceId.value]"
+                    },
+                    "alertName": {
+                        "value": "[concat(variables('appServiceName'), '-at-alert-', split(parameters('customAvailabilityMonitors')[copyIndex('customAlerts')], ':')[0])]"
+                    },
+                    "actionGroupId": {
+                        "value": "[reference('action-groups', '2019-03-01').outputs.actionGroupResourceId.value]"
+                    },
+                    "alertDescriptionText": {
+                        "value": "[concat('Custom URL availability monitor alert for \"', split(parameters('customAvailabilityMonitors')[copyIndex('customAlerts')], ':')[0], '\".')]"
+                    },
+                    "alertSeverity": {
+                        "value": 1
+                    },
+                    "webTestId": {
+                        "value": "[resourceId('microsoft.insights/webtests', concat(variables('appServiceName'), '-at-', split(parameters('customAvailabilityMonitors')[copyIndex('customAlerts')], ':')[0]))]"
+                    }
+                }
+            },
+            "dependsOn": [
+                "availability-tests",
+                "action-groups"
+            ]
         },
         {
             "apiVersion": "2017-05-10",


### PR DESCRIPTION
## Context

Prior to the pilot launch email alerting was set up manually to ensure it was in place ready for the go-live. This PR adds the necessary changes to ensure email automation is set up automatically in the build pipeline.

## Changes proposed in this pull request

- Added action groups and and availability alert email template references (templates in building blocks) to the ARM template.
- Added `localBranchName` parameter to template to dynamically use the correct branch for nested templates.
- Added instruction for configuring the email recipients.

## Guidance to review

The DevOps build environment is running a fully deployed version of this code for testing.

## Link to Trello card

https://trello.com/c/WnnBnHPh/1391-automate-availability-monitoring-alerts

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
