### PR TITLE
Add survey emails for a candidate

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -35,6 +35,14 @@ class CandidateMailer < ApplicationMailer
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: application_form.candidate.email_address,
-              subject: t('survey_emails.subject'))
+              subject: t('survey_emails.subject.initial'))
+  end
+
+  def survey_chaser_email(application_form)
+    @candidate_name = application_form.first_name
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: application_form.candidate.email_address,
+              subject: t('survey_emails.subject.chaser'))
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -29,4 +29,12 @@ class CandidateMailer < ApplicationMailer
               to: application_form.candidate.email_address,
               subject: t('candidate_reference.subject.chaser', referee_name: @referee_name))
   end
+
+  def survey_email(application_form)
+    @candidate_name = application_form.first_name
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: application_form.candidate.email_address,
+              subject: t('survey_emails.subject'))
+  end
 end

--- a/app/views/candidate_mailer/survey_chaser_email.text.erb
+++ b/app/views/candidate_mailer/survey_chaser_email.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @candidate_name %>,
+
+We recently sent you an email about the new Apply for teacher training service. We invited you to take part in some research and offered to pay £100 in return for your time.
+
+We’re not sure if you saw the message because we didn’t hear back from you. If you don’t remember seeing the email, please check your junk folder in case it’s gone there.
+
+We’d love to hear what you think about the service. To take part in our research and claim the £100 incentive, go to <%= t('survey_emails.survey_link') %>
+
+Becoming a teacher team

--- a/app/views/candidate_mailer/survey_email.text.erb
+++ b/app/views/candidate_mailer/survey_email.text.erb
@@ -1,0 +1,19 @@
+Dear <%= @candidate_name %>,
+
+Thanks for submitting your teacher training application.
+
+As you’re one of the first users of our new service, we’d love to hear about your experience. We’re paying £100 to those willing to take part.
+
+This research will be in two stages:
+
+1) You fill in a short survey (most people complete it in under 5 minutes).
+
+2) Once you’ve completed the survey, we’ll follow up with a phone call to talk about your responses.
+
+To take part, go to <%= t('survey_emails.survey_link') %>
+
+Once you’re finished, we’ll contact you to confirm payment.
+
+If you have any questions about our service or our research, please get in touch by emailing [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+
+Becoming a teacher team

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -1,0 +1,4 @@
+en:
+  survey_emails:
+    subject: Get £100 for helping us improve our service
+    survey_link: https://forms.gle/QQqurrCs9YSpTfbc8

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -1,4 +1,6 @@
 en:
   survey_emails:
-    subject: Get £100 for helping us improve our service
+    subject:
+      initial: Get £100 for helping us improve our service
+      chaser: We’d love to hear from you about your teacher training application
     survey_link: https://forms.gle/QQqurrCs9YSpTfbc8

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -40,4 +40,27 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect(mail.body.encoded).to include(reference.email_address)
     end
   end
+
+  describe 'Send survey email' do
+    let(:candidate) { build_stubbed(:candidate) }
+    let(:application_form) { build_stubbed(:application_form, candidate: candidate) }
+
+    context 'when initial email' do
+      let(:mail) { mailer.survey_email(application_form) }
+
+      before { mail.deliver_later }
+
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('survey_emails.subject'))
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include("Dear #{application_form.first_name}")
+      end
+
+      it 'sends an email with the link to the survey' do
+        expect(mail.body.encoded).to include(t('survey_emails.survey_link'))
+      end
+    end
+  end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -51,7 +51,25 @@ RSpec.describe CandidateMailer, type: :mailer do
       before { mail.deliver_later }
 
       it 'sends an email with the correct subject' do
-        expect(mail.subject).to include(t('survey_emails.subject'))
+        expect(mail.subject).to include(t('survey_emails.subject.initial'))
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include("Dear #{application_form.first_name}")
+      end
+
+      it 'sends an email with the link to the survey' do
+        expect(mail.body.encoded).to include(t('survey_emails.survey_link'))
+      end
+    end
+
+    context 'when chaser email' do
+      let(:mail) { mailer.survey_chaser_email(application_form) }
+
+      before { mail.deliver_later }
+
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('survey_emails.subject.chaser'))
       end
 
       it 'sends an email with the correct heading' do


### PR DESCRIPTION
## Context

We want to be able to send surveys to candidates and referees in the first phase of the pilot (November/December) from the Support console.

## Changes proposed in this pull request

This PR is the first of many to come. It just adds in the two survey emails for candidates in the `CandidateMailer`: the initial one and the chase up email.

## Guidance to review

Are adding these to the `CandidateMailer` the right move? Or is it better to create a `SurveyMailer`? Was planning on adding the survey emails for a referee to the `RefereeMailer` but considering that the emails for a candidate and referee are very similar, I'm not too sure.

## Link to Trello card

https://trello.com/c/KpaTL5K5/543-survey-emails-to-referee-and-candidate-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
