### PR TITLE
Add title text when the provider confirms an offer

### DIFF
--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t('page_titles.application') %>
+<% content_for :title, t('page_titles.provider.confirm') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_offer_path(@application_choice.id)) %>
 
 <%= render(FlashMessageComponent, flash: flash) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -86,6 +86,7 @@ en:
       alpha_release_notes: Alpha release notes
     provider:
       respond: Respond to application
+      confirm: Confirm offer
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use


### PR DESCRIPTION
## Context

Failed the DAC audit

## Link to Trello card

https://trello.com/c/Q7H4sXsR/707-dac-page-60-add-custom-title-to-confirm-offer-provider-page