### PR TITLE
Allow candidates to view an incorrect date format

### DIFF
--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -70,15 +70,17 @@ module CandidateInterface
 
       if valid_year?(year) && Date.valid_date?(*date_args)
         Date.new(*date_args)
+      else
+        Struct.new(:day, :month, :year).new(day, month, year)
       end
     end
 
     def date_of_birth_valid
-      errors.add(:date_of_birth, :invalid) if date_of_birth.nil?
+      errors.add(:date_of_birth, :invalid) unless date_of_birth.is_a?(Date)
     end
 
     def date_of_birth_not_in_future
-      errors.add(:date_of_birth, :future) if date_of_birth.present? && date_of_birth > Date.today
+      errors.add(:date_of_birth, :future) if date_of_birth.is_a?(Date) && date_of_birth > Date.today
     end
 
     def english_main_language?

--- a/spec/models/candidate_interface/personal_details_form_spec.rb
+++ b/spec/models/candidate_interface/personal_details_form_spec.rb
@@ -96,16 +96,20 @@ RSpec.describe CandidateInterface::PersonalDetailsForm, type: :model do
   end
 
   describe '#date_of_birth' do
-    it 'returns nil for nil day/month/year' do
+    it 'return a nil for nil day/month/year' do
       personal_details = CandidateInterface::PersonalDetailsForm.new(day: nil, month: nil, year: nil)
 
-      expect(personal_details.date_of_birth).to eq(nil)
+      expect(personal_details.date_of_birth.day).to be_nil
+      expect(personal_details.date_of_birth.month).to be_nil
+      expect(personal_details.date_of_birth.year).to be_nil
     end
 
-    it 'returns nil for invalid day/month/year' do
+    it 'can return an invalid date object for invalid day/month/year' do
       personal_details = CandidateInterface::PersonalDetailsForm.new(day: 99, month: 99, year: 99)
 
-      expect(personal_details.date_of_birth).to eq(nil)
+      expect(personal_details.date_of_birth.day).to eq(99)
+      expect(personal_details.date_of_birth.month).to eq(99)
+      expect(personal_details.date_of_birth.year).to eq(99)
     end
 
     it 'returns a date for a valid day/month/year' do

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Entering their personal details' do
     and_i_fill_in_some_details_but_omit_some_required_details
     and_i_submit_the_form
     then_i_should_see_validation_errors
+    and_i_should_see_the_completed_fields
 
     when_i_fill_in_the_rest_of_my_details
     and_i_submit_the_form
@@ -45,10 +46,18 @@ RSpec.feature 'Entering their personal details' do
     scope = 'application_form.personal_details'
     fill_in t('first_name.label', scope: scope), with: 'Lando'
     fill_in t('last_name.label', scope: scope), with: 'Calrissian'
+    fill_in 'Month', with: '11'
   end
 
   def then_i_should_see_validation_errors
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/personal_details_form.attributes.date_of_birth.invalid')
+  end
+
+  def and_i_should_see_the_completed_fields
+    scope = 'application_form.personal_details'
+    expect(find_field(t('first_name.label', scope: scope)).value).to eq('Lando')
+    expect(find_field(t('last_name.label', scope: scope)).value).to eq('Calrissian')
+    expect(find_field('Month').value).to eq('11')
   end
 
   def when_i_fill_in_the_rest_of_my_details


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When a user doesn't complete the DOB field properly but does include text within the day/month/year field, it doesn't keep the data once the validation error message pops up. 

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds an else condition when to `PersonalDetailsForm#date_of_birth` method to return an Open struct when the date is invalid.

### Before
![image](https://user-images.githubusercontent.com/22743709/71674655-afac1200-2d73-11ea-8ee4-db41d8dd21cd.png)


### After
![image](https://user-images.githubusercontent.com/22743709/71674623-9905bb00-2d73-11ea-890d-51ceac8a4fdd.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Try to fill in the date_of_birth field with an invalid or partially completed date, you should be able to see the invalid date along with the errors

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/zzxq2zKG/444-personal-details-doesnt-retain-month-input-value

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
