### PR TITLE
Remove `foreman` from `Gemfile` to try to fix JSON constant warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,6 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'
   gem 'rails-erd'
-  gem 'foreman'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,6 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    foreman (0.86.0)
     formatador (0.2.5)
     gherkin (5.1.0)
     globalid (0.4.2)
@@ -529,7 +528,6 @@ DEPENDENCIES
   erb_lint
   factory_bot_rails
   faker
-  foreman
   govuk_design_system_formbuilder (= 1.1.0)
   guard-rspec
   holidays
@@ -578,4 +576,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   2.0.2
+   2.1.3


### PR DESCRIPTION
## Context

We are seeing lots of warnings when running the application locally like `Already initialized constant JSON::VERSION`. These are benign but very noisy.

## Changes proposed in this pull request

* Remove `foreman` from the `Gemfile` as recommended by the foreman author - https://github.com/ddollar/foreman#installation

## Guidance to review

I had trouble working out the root cause for this one. The `json` gem is installed both as part of the Ruby Standard library and as a regular gem (I did try reinstalling all gems and even reinstalling Ruby but nothing changed). Why both get loaded I'm not entirely sure. However I can only reproduce the issue when running `foreman` through `bundler` (which is probably wrong anyway), e.g.

    $ PORT=3000 bundle exec foreman start

If people are seeing the errors outside `foreman` then it's back to the drawing board.

## Link to Trello card

https://trello.com/c/QWyfidEr/1423-lots-of-json-gem-warnings-on-app-boot

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
