### PR TITLE
Add survey emails for referees

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -31,18 +31,23 @@ class CandidateMailer < ApplicationMailer
   end
 
   def survey_email(application_form)
-    @candidate_name = application_form.first_name
+    @name = application_form.first_name
+    @thank_you_message = t('survey_emails.thank_you.candidate')
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: application_form.candidate.email_address,
-              subject: t('survey_emails.subject.initial'))
+              subject: t('survey_emails.subject.initial'),
+              template_path: 'survey_emails',
+              template_name: 'initial')
   end
 
   def survey_chaser_email(application_form)
-    @candidate_name = application_form.first_name
+    @name = application_form.first_name
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: application_form.candidate.email_address,
-              subject: t('survey_emails.subject.chaser'))
+              subject: t('survey_emails.subject.chaser'),
+              template_path: 'survey_emails',
+              template_name: 'chaser')
   end
 end

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -30,6 +30,17 @@ class RefereeMailer < ApplicationMailer
               subject: t('reference_request.subject.chaser', candidate_name: @candidate_name))
   end
 
+  def survey_email(application_form, reference)
+    @name = reference.name
+    @thank_you_message = t('survey_emails.thank_you.referee', candidate_name: application_form.full_name)
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: reference.email_address,
+              subject: t('survey_emails.subject.initial'),
+              template_path: 'survey_emails',
+              template_name: 'initial')
+  end
+
 private
 
   def google_form_url_for(candidate_name, reference)

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -41,6 +41,16 @@ class RefereeMailer < ApplicationMailer
               template_name: 'initial')
   end
 
+  def survey_chaser_email(reference)
+    @name = reference.name
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: reference.email_address,
+              subject: t('survey_emails.subject.chaser'),
+              template_path: 'survey_emails',
+              template_name: 'chaser')
+  end
+
 private
 
   def google_form_url_for(candidate_name, reference)

--- a/app/views/survey_emails/chaser.text.erb
+++ b/app/views/survey_emails/chaser.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @candidate_name %>,
+Dear <%= @name %>,
 
 We recently sent you an email about the new Apply for teacher training service. We invited you to take part in some research and offered to pay £100 in return for your time.
 

--- a/app/views/survey_emails/initial.text.erb
+++ b/app/views/survey_emails/initial.text.erb
@@ -1,6 +1,6 @@
-Dear <%= @candidate_name %>,
+Dear <%= @name %>,
 
-Thanks for submitting your teacher training application.
+<%= @thank_you_message %>
 
 As you’re one of the first users of our new service, we’d love to hear about your experience. We’re paying £100 to those willing to take part.
 

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -6,3 +6,4 @@ en:
     survey_link: https://forms.gle/QQqurrCs9YSpTfbc8
     thank_you:
       candidate: Thanks for submitting your teacher training application.
+      referee: Thanks for submitting your reference for %{candidate_name}.

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -4,3 +4,5 @@ en:
       initial: Get £100 for helping us improve our service
       chaser: We’d love to hear from you about your teacher training application
     survey_link: https://forms.gle/QQqurrCs9YSpTfbc8
+    thank_you:
+      candidate: Thanks for submitting your teacher training application.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -42,8 +42,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe 'Send survey email' do
-    let(:candidate) { build_stubbed(:candidate) }
-    let(:application_form) { build_stubbed(:application_form, candidate: candidate) }
+    let(:application_form) { build_stubbed(:application_form) }
 
     context 'when initial email' do
       let(:mail) { mailer.survey_email(application_form) }
@@ -56,6 +55,10 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it 'sends an email with the correct heading' do
         expect(mail.body.encoded).to include("Dear #{application_form.first_name}")
+      end
+
+      it 'sends an email with the correct thank you message' do
+        expect(mail.body.encoded).to include(t('survey_emails.thank_you.candidate'))
       end
 
       it 'sends an email with the link to the survey' do

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -117,4 +117,42 @@ RSpec.describe RefereeMailer, type: :mailer do
       end
     end
   end
+
+  describe 'Send survey email' do
+    let(:reference) { build_stubbed(:reference) }
+    let(:application_form) do
+      build_stubbed(
+        :application_form,
+        first_name: 'Elliot',
+        last_name: 'Alderson',
+        application_references: [reference],
+      )
+    end
+
+    context 'when initial email' do
+      let(:mail) { mailer.survey_email(application_form, reference) }
+
+      before { mail.deliver_later }
+
+      it 'sends an email to the provided referee' do
+        expect(mail.to).to include(reference.email_address)
+      end
+
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('survey_emails.subject.initial'))
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include("Dear #{reference.name}")
+      end
+
+      it 'sends an email with the correct thank you message' do
+        expect(mail.body.encoded).to include(t('survey_emails.thank_you.referee', candidate_name: 'Elliot Alderson'))
+      end
+
+      it 'sends an email with the link to the survey' do
+        expect(mail.body.encoded).to include(t('survey_emails.survey_link'))
+      end
+    end
+  end
 end

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -154,5 +154,23 @@ RSpec.describe RefereeMailer, type: :mailer do
         expect(mail.body.encoded).to include(t('survey_emails.survey_link'))
       end
     end
+
+    context 'when chaser email' do
+      let(:mail) { mailer.survey_chaser_email(reference) }
+
+      before { mail.deliver_later }
+
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('survey_emails.subject.chaser'))
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include("Dear #{reference.name}")
+      end
+
+      it 'sends an email with the link to the survey' do
+        expect(mail.body.encoded).to include(t('survey_emails.survey_link'))
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

In #1001, the survey emails for candidates were added but not for the referees. 

## Changes proposed in this pull request

This PR adds the survey emails for referees. To do this some refactoring has been done around the `CandidateMailer`, most importantly the survey emails views have been moved out so that it's accessible to `RefereeMailer`. 

## Guidance to review

- Review commit by commit
- Could you do a sanity check that the only difference between the emails are the thank you sentence for the initial email and the name
- Not sure about the placement of the survey emails views. Currently top-level within the `views` directory... Thoughts?

![image](https://user-images.githubusercontent.com/42817036/71679443-85605180-2d7f-11ea-979c-e7897bf1ae8b.png)

## Link to Trello card

https://trello.com/c/KpaTL5K5/543-survey-emails-to-referee-and-candidate-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
