### PR TITLE
Fix Respond to Application form to show validation error when no selection made

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -2,13 +2,17 @@ module ProviderInterface
   class DecisionsController < ProviderInterfaceController
     before_action :set_application_choice_and_presenter
 
-    def respond; end
+    def respond
+      @pick_response_form = PickResponseForm.new
+    end
 
     def submit_response
-      decision = params[:application_choice][:decision] if params[:application_choice]
-      if decision == 'offer'
+      @pick_response_form = PickResponseForm.new(decision: params.dig(:provider_interface_pick_response_form, :decision))
+      render action: :respond if !@pick_response_form.valid?
+
+      if @pick_response_form.decision == 'offer'
         redirect_to action: :new_offer
-      elsif decision == 'reject'
+      elsif @pick_response_form.decision == 'reject'
         redirect_to action: :new_reject
       end
     end

--- a/app/models/provider_interface/pick_response_form.rb
+++ b/app/models/provider_interface/pick_response_form.rb
@@ -1,0 +1,8 @@
+module ProviderInterface
+  class PickResponseForm
+    include ActiveModel::Model
+
+    attr_accessor :decision
+    validates :decision, presence: true
+  end
+end

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -1,18 +1,18 @@
 <% content_for :title, t('page_titles.provider.respond') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
-<span class="govuk-caption-xl">
-  Application for <%= @application_choice.course.name_and_code %>
-</span>
-
-<h1 class="govuk-heading-xl">
-  Respond to application
-</h1>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @pick_response_form, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
+
+      <span class="govuk-caption-xl">
+        Application for <%= @application_choice.course.name_and_code %>
+      </span>
+
+      <h1 class="govuk-heading-xl">
+        Respond to application
+      </h1>
 
       <%- offer_text = 'Make an offer (including any conditions)' %>
       <%- reject_text = 'Reject application' %>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @application_choice, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
+    <%= form_with model: @pick_response_form, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <%- offer_text = 'Make an offer (including any conditions)' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,7 +123,7 @@ en:
         provider_interface/pick_response_form:
           attributes:
             decision:
-              blank: Select a response to send to the candidate
+              blank: Select if you want to make an offer or reject the application
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,10 @@ en:
           attributes:
             further_conditions:
               too_long: "%{name} must be %{limit} characters or fewer"
+        provider_interface/pick_response_form:
+          attributes:
+            decision:
+              blank: Select which response you are making
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,7 +123,7 @@ en:
         provider_interface/pick_response_form:
           attributes:
             decision:
-              blank: Select which response you are making
+              blank: Select a response to send to the candidate
   activerecord:
     errors:
       models:

--- a/spec/models/provider_interface/pick_response_form_spec.rb
+++ b/spec/models/provider_interface/pick_response_form_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::PickResponseForm do
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:decision).with_message('Select which response you are making') }
+    it { is_expected.to validate_presence_of(:decision).with_message('Select a response to send to the candidate') }
   end
 end

--- a/spec/models/provider_interface/pick_response_form_spec.rb
+++ b/spec/models/provider_interface/pick_response_form_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::PickResponseForm do
   describe 'validations' do
-    it { is_expected.to validate_presence_of :decision }
+    it { is_expected.to validate_presence_of(:decision).with_message('Select which response you are making') }
   end
 end

--- a/spec/models/provider_interface/pick_response_form_spec.rb
+++ b/spec/models/provider_interface/pick_response_form_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::PickResponseForm do
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:decision).with_message('Select a response to send to the candidate') }
+    it { is_expected.to validate_presence_of(:decision).with_message('Select if you want to make an offer or reject the application') }
   end
 end

--- a/spec/models/provider_interface/pick_response_form_spec.rb
+++ b/spec/models/provider_interface/pick_response_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::PickResponseForm do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :decision }
+  end
+end

--- a/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
+++ b/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
@@ -44,6 +44,6 @@ RSpec.feature 'Provider makes an offer' do
         @application_awaiting_provider_decision.id,
       ),
     )
-    expect(page).to have_content 'Select a response to send to the candidate'
+    expect(page).to have_content 'Select if you want to make an offer or reject the application'
   end
 end

--- a/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
+++ b/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes an offer' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider fails to select a response (offer/reject)' do
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_application_choices_exist_for_my_provider
+    and_i_am_permitted_to_see_applications_for_my_provider
+
+    when_i_respond_to_an_application
+    and_i_try_to_proceed_without_selecting_a_response
+    then_i_see_an_error_message_prompting_for_a_response
+  end
+
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_application_choices_exist_for_my_provider
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    @application_awaiting_provider_decision = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def when_i_respond_to_an_application
+    visit provider_interface_application_choice_respond_path(
+      @application_awaiting_provider_decision.id,
+    )
+  end
+
+  def and_i_try_to_proceed_without_selecting_a_response
+    click_on 'Continue'
+  end
+
+  def then_i_see_an_error_message_prompting_for_a_response
+    expect(page).to have_current_path(
+      provider_interface_application_choice_respond_path(
+        @application_awaiting_provider_decision.id,
+      ),
+    )
+    expect(page).to have_content 'Select which response you are making'
+  end
+end

--- a/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
+++ b/spec/system/provider_interface/provider_fails_to_select_response_spec.rb
@@ -44,6 +44,6 @@ RSpec.feature 'Provider makes an offer' do
         @application_awaiting_provider_decision.id,
       ),
     )
-    expect(page).to have_content 'Select which response you are making'
+    expect(page).to have_content 'Select a response to send to the candidate'
   end
 end


### PR DESCRIPTION
## Context

If a provider selects neither the 'make offer' or 'reject' options on the 'Respond to Application' form there is no feedback (the server just returns a 204 No Content response).

## Changes proposed in this pull request

* Add a `PickResponseForm` object that models the response and validates the presence of the `descision`.
* Wire the form up to the view.
* Add a new system spec.

![image](https://user-images.githubusercontent.com/450843/71717639-9907c880-2e10-11ea-886f-e4c5469d3bda.png)



## Guidance to review

* I added a custom message but I'm not sure about the copy for the message. (I looked at some similar forms in the candidate interface for inspiration).
* Is it tested properly? Is a system spec for the error case overkill?

## Link to Trello card

https://trello.com/c/oMyZmYOU/1424-not-selecting-a-response-doesnt-show-feedback

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
