### PR TITLE
Fix QA deployment

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -783,7 +783,7 @@
                         "value": "[concat(variables('appServiceName'), '-at-alert-', split(parameters('customAvailabilityMonitors')[copyIndex('customAlerts')], ':')[0])]"
                     },
                     "actionGroupId": {
-                        "value": "[reference('action-groups', '2019-03-01').outputs.actionGroupResourceId.value]"
+                        "value": "[if(greater(length(parameters('alertRecipientEmails')), 0), reference('action-groups', '2019-03-01').outputs.actionGroupResourceId.value, '')]"
                     },
                     "alertDescriptionText": {
                         "value": "[concat('Custom URL availability monitor alert for \"', split(parameters('customAvailabilityMonitors')[copyIndex('customAlerts')], ':')[0], '\".')]"


### PR DESCRIPTION
## Context

PR#1000 caused a failure of the deployment ARM template when merged yesterday. This issue was never observed and couldn't be reproduced in the DevOps environment.

Properties are being evaluated in the `availability-test-alerts` resource when the condition on the resource should prevent this. The resource conditions have been tested and match correctly between QA and DevOps, but QA is still attempting to parse the resource properties unnecessarily resulting in the failure observed. The DevOps environment is parsing correctly. Why this is happening is still unknown, but a workaround to prevent the error observed as been added. 

## Changes proposed in this pull request

An additional `if` has been placed around the offending property in the resource to prevent it being evaluated even when the condition should prevent the `availability-test-alerts` resource from deploying.

## Guidance to review

Successful deployments can be observed in the QA environment in the DevOps GUI showing the fix has worked.
https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary&repositoryFilter=37&branchFilter=7626

## Link to Trello card

N/A - Bugfix

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
