### PR TITLE
Update recruited and enrolled content on Application dashboard

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -2,6 +2,14 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.enrolled') %>
   </h2>
+<% elsif any_recruited? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= t('application_complete.dashboard.recruited') %>
+  </h2>
+
+  <p class="govuk-body">
+    Your training provider will be in touch with you direct to explain what happens next.
+  </p>
 <% elsif any_accepted_offer? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.accepted_offer') %>

--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -1,4 +1,8 @@
-<% if any_accepted_offer? %>
+<% if any_enrolled? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= t('application_complete.dashboard.enrolled') %>
+  </h2>
+<% elsif any_accepted_offer? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= t('application_complete.dashboard.accepted_offer') %>
   </h2>

--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -1,6 +1,6 @@
 <% if any_accepted_offer? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
-    You have accepted an offer
+    <%= t('application_complete.dashboard.accepted_offer') %>
   </h2>
 
   <p class="govuk-body">
@@ -9,11 +9,11 @@
   </p>
 <% elsif all_choices_withdrawn? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
-    You have withdrawn all your choices
+    <%= t('application_complete.dashboard.all_withdrawn') %>
   </h2>
 <% elsif all_provider_decisions_made? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
-    All your training providers have now reached a decision
+    <%= t('application_complete.dashboard.all_provider_decisions_made') %>
   </h2>
 
   <% if any_offers? %>
@@ -24,11 +24,11 @@
   <% end %>
 <% elsif any_offers? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
-    Some of your training providers haven’t reached a decision yet
+    <%= t('application_complete.dashboard.some_provider_decisions_made') %>
   </h2>
 
   <p class="govuk-body">
-    Training providers must respond by <%= respond_by_date %>.
+    <%= t('application_complete.dashboard.providers_respond_by', date: respond_by_date) %>
   </p>
 
   <p class="govuk-body">
@@ -38,7 +38,7 @@
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses you’ve applied to</h2>
 
   <p class="govuk-body">
-    Training providers must respond by <%= respond_by_date %>.
+    <%= t('application_complete.dashboard.providers_respond_by', date: respond_by_date) %>
   </p>
 <% elsif editable? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">Courses you’ve applied to</h2>

--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -14,6 +14,7 @@ module CandidateInterface
              :any_awaiting_provider_decision?,
              :all_choices_withdrawn?,
              :any_enrolled?,
+             :any_recruited?,
              :any_offers?, to: :application_form
 
     def editable?

--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -13,6 +13,7 @@ module CandidateInterface
              :all_provider_decisions_made?,
              :any_awaiting_provider_decision?,
              :all_choices_withdrawn?,
+             :any_enrolled?,
              :any_offers?, to: :application_form
 
     def editable?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -59,6 +59,10 @@ class ApplicationForm < ApplicationRecord
     qualification_in_subject(:gcse, :science)
   end
 
+  def any_enrolled?
+    application_choices.map.any?(&:enrolled?)
+  end
+
   def any_accepted_offer?
     application_choices.map.any?(&:pending_conditions?)
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -63,6 +63,10 @@ class ApplicationForm < ApplicationRecord
     application_choices.map.any?(&:enrolled?)
   end
 
+  def any_recruited?
+    application_choices.map.any?(&:recruited?)
+  end
+
   def any_accepted_offer?
     application_choices.map.any?(&:pending_conditions?)
   end

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -8,6 +8,7 @@ en:
       candidate_respond_by: You have %{remaining_days} days (until %{date}) to respond to any offers.
       all_withdrawn: You have withdrawn all your choices
       accepted_offer: You have accepted an offer
+      enrolled: You have been enrolled on your chosen course
     edit_page:
       edit_button: 'Edit Application'
       warning_text: >

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -8,6 +8,7 @@ en:
       candidate_respond_by: You have %{remaining_days} days (until %{date}) to respond to any offers.
       all_withdrawn: You have withdrawn all your choices
       accepted_offer: You have accepted an offer
+      recruited: You have met your conditions and are ready to be enrolled
       enrolled: You have been enrolled on your chosen course
     edit_page:
       edit_button: 'Edit Application'

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -2,6 +2,12 @@ en:
   application_complete:
     dashboard:
       edit_link: Edit your application
+      some_provider_decisions_made: Some of your training providers haven’t reached a decision yet
+      all_provider_decisions_made: All your training providers have now reached a decision
+      providers_respond_by: Training providers must respond by %{date}.
+      candidate_respond_by: You have %{remaining_days} days (until %{date}) to respond to any offers.
+      all_withdrawn: You have withdrawn all your choices
+      accepted_offer: You have accepted an offer
     edit_page:
       edit_button: 'Edit Application'
       warning_text: >

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -41,7 +41,7 @@ en:
     enrolled: Enrolled
     offer: Offer
     pending_conditions: Accepted
-    recruited: Recruited
+    recruited: Conditions met
     rejected: Rejected
     unsubmitted: Not submitted yet
     withdrawn: Withdrawn

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('Edit your application')
+      expect(render_result.text).to include(t('application_complete.dashboard.edit_link'))
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).not_to include('Edit your application')
+      expect(render_result.text).not_to include(t('application_complete.dashboard.edit_link'))
     end
   end
 
@@ -44,8 +44,8 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).not_to include('Edit your application')
-      expect(render_result.text).to include('Training providers must respond by 1 January 2020.')
+      expect(render_result.text).not_to include(t('application_complete.dashboard.edit_link'))
+      expect(render_result.text).to include(t('application_complete.dashboard.providers_respond_by', date: '1 January 2020'))
     end
   end
 
@@ -56,8 +56,8 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('Some of your training providers haven’t reached a decision yet')
-      expect(render_result.text).to include('Training providers must respond by 1 January 2020.')
+      expect(render_result.text).to include(t('application_complete.dashboard.some_provider_decisions_made'))
+      expect(render_result.text).to include(t('application_complete.dashboard.providers_respond_by', date: '1 January 2020'))
     end
   end
 
@@ -68,8 +68,8 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('All your training providers have now reached a decision')
-      expect(render_result.text).to include('You have 14 days (until 5 November 2019) to respond to any offers.')
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
+      expect(render_result.text).to include(t('application_complete.dashboard.candidate_respond_by', remaining_days: '14', date: '5 November 2019'))
     end
 
     it 'renders with all providers have made a decision content if an offer and rejected' do
@@ -78,8 +78,8 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('All your training providers have now reached a decision')
-      expect(render_result.text).to include('You have 14 days (until 5 November 2019) to respond to any offers.')
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
+      expect(render_result.text).to include(t('application_complete.dashboard.candidate_respond_by', remaining_days: '14', date: '5 November 2019'))
     end
 
     it 'renders when all offers have been withdrawn' do
@@ -89,7 +89,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('You have withdrawn all your choices')
+      expect(render_result.text).to include(t('application_complete.dashboard.all_withdrawn'))
     end
 
     it 'renders when one offer has been withdrawn and one offered' do
@@ -100,7 +100,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('All your training providers have now reached a decision')
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
     end
 
     it 'renders when the only offer has been rejected' do
@@ -110,7 +110,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('All your training providers have now reached a decision')
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
     end
   end
 
@@ -121,7 +121,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      expect(render_result.text).to include('You have accepted an offer')
+      expect(render_result.text).to include(t('application_complete.dashboard.accepted_offer'))
     end
   end
 

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -125,6 +125,17 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
   end
 
+  context 'when the application is recruited' do
+    it 'renders with recruited content' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[recruited declined])
+
+      render_result = render_inline(described_class, application_form: application_form)
+
+      expect(render_result.text).to include(t('application_complete.dashboard.recruited'))
+    end
+  end
+
   context 'when the application is enrolled' do
     it 'renders with enrolled content' do
       stub_application_dates_with_form_uneditable

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
       render_result = render_inline(described_class, application_form: application_form)
 
       expect(render_result.text).to include('All your training providers have now reached a decision')
-      # TODO: Update hardcoded date with decline by default date
       expect(render_result.text).to include('You have 14 days (until 5 November 2019) to respond to any offers.')
     end
 
@@ -79,7 +78,6 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class, application_form: application_form)
 
-      # TODO: Update hardcoded date with decline by default date
       expect(render_result.text).to include('All your training providers have now reached a decision')
       expect(render_result.text).to include('You have 14 days (until 5 November 2019) to respond to any offers.')
     end

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -125,6 +125,17 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
   end
 
+  context 'when the application is enrolled' do
+    it 'renders with enrolled content' do
+      stub_application_dates_with_form_uneditable
+      application_form = create_application_form_with_course_choices(statuses: %w[enrolled declined])
+
+      render_result = render_inline(described_class, application_form: application_form)
+
+      expect(render_result.text).to include(t('application_complete.dashboard.enrolled'))
+    end
+  end
+
   def stub_application_dates_with_form_uneditable
     application_dates = instance_double(
       ApplicationDates,


### PR DESCRIPTION
## Context

We should have more descriptive headings on the dashboard during `recruited` and `enrolled` states.

## Changes proposed in this pull request

This PR updates the content for when a candidate has a course choice that is recruited or enrolled. It also does some refactoring to use translations.

## Screenshots

**Before for enrolled**

![image](https://user-images.githubusercontent.com/42817036/71718889-8becd880-2e14-11ea-8f88-39c1c82926b5.png)

**After for enrolled**

![image](https://user-images.githubusercontent.com/42817036/71718940-a921a700-2e14-11ea-9091-148d1c39b14b.png)

**Before for recruited**

![image](https://user-images.githubusercontent.com/42817036/71719003-d66e5500-2e14-11ea-88b7-c1e56631a62a.png)

**After for enrolled**

![image](https://user-images.githubusercontent.com/42817036/71719022-ec7c1580-2e14-11ea-9d4a-8bca05c1d34b.png)

## Guidance to review

Review commit by commit as some refactoring done.

## Link to Trello card

https://trello.com/c/k1NjsuMR/671-update-recruited-and-enrolled-content-on-candidate-dashboard

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
