### PR TITLE
Add a custom error message for blank rejection feedback

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,10 @@ en:
           attributes:
             decision:
               blank: Select if you want to make an offer or reject the application
+        reject_application:
+          attributes:
+            rejection_reason:
+              blank: Enter feedback for the candidate
   activerecord:
     errors:
       models:

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eql "Rejection reason can't be blank"
+    expect(error_response['message']).to eql 'Rejection reason Enter feedback for the candidate'
   end
 
   it 'returns not found error when the application was not found' do


### PR DESCRIPTION
## Context

When the provider doesn't add feedback they just see a `can't be blank` error message. Needs to be descriptive.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/450843/71723703-8d72cc80-2e25-11ea-9d07-d2530b2d9285.png)

## Guidance to review

Is the copy correct and the error message in the right place?

## Link to Trello card

https://trello.com/c/7JcO0QxH/695-dac-page-20-add-error-text-for-blank-application-reject-reason

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
