### PR TITLE
Fix all date fields that does not retain incorrect input value

### DIFF
--- a/app/helpers/date_validation_helper.rb
+++ b/app/helpers/date_validation_helper.rb
@@ -1,0 +1,52 @@
+module DateValidationHelper
+  def valid_end_date_or_nil(year, month)
+    date_args = [year, month, 1].map(&:to_i)
+    if year.present? && Date.valid_date?(*date_args)
+      Date.new(*date_args)
+    elsif year.present? || month.present?
+      Struct.new(:day, :month, :year).new(1, month, year)
+    end
+  end
+
+  def valid_or_invalid_start_date(year, month)
+    date_args = [year, month, 1].map(&:to_i)
+    if year.present? && Date.valid_date?(*date_args)
+      Date.new(*date_args)
+    else
+      Struct.new(:day, :month, :year).new(1, month, year)
+    end
+  end
+
+  def end_date_blank?
+    end_date_year.blank? && end_date_month.blank?
+  end
+
+  def end_date_valid
+    errors.add(:end_date, :invalid) unless end_date.is_a?(Date)
+  end
+
+  def start_date_valid
+    errors.add(:start_date, :invalid) unless start_date.is_a?(Date)
+  end
+
+  def start_date_before_end_date
+    if start_date_and_end_date_valid?
+      errors.add(:start_date, :before) unless start_date <= end_date
+    end
+  end
+
+  def end_date_before_current_year_and_month
+    if end_date.year > Time.zone.today.year || \
+        end_date.year == Time.zone.today.year && end_date.month > Time.zone.today.month
+      errors.add(:end_date, :in_the_future)
+    end
+  end
+
+  def start_date_and_end_date_valid?
+    end_date.is_a?(Date) && start_date.is_a?(Date)
+  end
+
+  def end_date_valid?
+    end_date.is_a?(Date)
+  end
+end

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -68,18 +68,31 @@ module CandidateInterface
     end
 
     def start_date
-      valid_date_or_nil(start_date_year, start_date_month)
+      valid_or_invalid_start_date(start_date_year, start_date_month)
     end
 
     def end_date
-      valid_date_or_nil(end_date_year, end_date_month)
+      valid_end_date_or_nil(end_date_year, end_date_month)
     end
 
   private
 
-    def valid_date_or_nil(year, month)
+    def valid_end_date_or_nil(year, month)
       date_args = [year, month, 1].map(&:to_i)
-      Date.new(*date_args) if year.present? && Date.valid_date?(*date_args)
+      if year.present? && Date.valid_date?(*date_args)
+        Date.new(*date_args)
+      elsif year.present? || month.present?
+        Struct.new(:day, :month, :year).new(1, month, year)
+      end
+    end
+
+    def valid_or_invalid_start_date(year, month)
+      date_args = [year, month, 1].map(&:to_i)
+      if year.present? && Date.valid_date?(*date_args)
+        Date.new(*date_args)
+      else
+        Struct.new(:day, :month, :year).new(1, month, year)
+      end
     end
 
     def end_date_blank?
@@ -87,15 +100,17 @@ module CandidateInterface
     end
 
     def end_date_valid
-      errors.add(:end_date, :invalid) unless end_date
+      errors.add(:end_date, :invalid) unless end_date.is_a?(Date)
     end
 
     def start_date_valid
-      errors.add(:start_date, :invalid) unless start_date
+      errors.add(:start_date, :invalid) unless start_date.is_a?(Date)
     end
 
     def start_date_before_end_date
-      errors.add(:start_date, :before) unless start_date <= end_date
+      if start_date_and_end_date_valid?
+        errors.add(:start_date, :before) unless start_date <= end_date
+      end
     end
 
     def end_date_before_current_year_and_month
@@ -106,11 +121,11 @@ module CandidateInterface
     end
 
     def start_date_and_end_date_valid?
-      end_date && start_date
+      end_date.is_a?(Date) && start_date.is_a?(Date)
     end
 
     def end_date_valid?
-      end_date
+      end_date.is_a?(Date)
     end
 
     def map_attributes

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -4,6 +4,7 @@
 module CandidateInterface
   class VolunteeringRoleForm
     include ActiveModel::Model
+    include DateValidationHelper
 
     attr_accessor :id, :role, :organisation, :details, :working_with_children,
                   :start_date_day, :start_date_month, :start_date_year,
@@ -76,57 +77,6 @@ module CandidateInterface
     end
 
   private
-
-    def valid_end_date_or_nil(year, month)
-      date_args = [year, month, 1].map(&:to_i)
-      if year.present? && Date.valid_date?(*date_args)
-        Date.new(*date_args)
-      elsif year.present? || month.present?
-        Struct.new(:day, :month, :year).new(1, month, year)
-      end
-    end
-
-    def valid_or_invalid_start_date(year, month)
-      date_args = [year, month, 1].map(&:to_i)
-      if year.present? && Date.valid_date?(*date_args)
-        Date.new(*date_args)
-      else
-        Struct.new(:day, :month, :year).new(1, month, year)
-      end
-    end
-
-    def end_date_blank?
-      end_date_year.blank? && end_date_month.blank?
-    end
-
-    def end_date_valid
-      errors.add(:end_date, :invalid) unless end_date.is_a?(Date)
-    end
-
-    def start_date_valid
-      errors.add(:start_date, :invalid) unless start_date.is_a?(Date)
-    end
-
-    def start_date_before_end_date
-      if start_date_and_end_date_valid?
-        errors.add(:start_date, :before) unless start_date <= end_date
-      end
-    end
-
-    def end_date_before_current_year_and_month
-      if end_date.year > Date.today.year || \
-          end_date.year == Date.today.year && end_date.month > Date.today.month
-        errors.add(:end_date, :in_the_future)
-      end
-    end
-
-    def start_date_and_end_date_valid?
-      end_date.is_a?(Date) && start_date.is_a?(Date)
-    end
-
-    def end_date_valid?
-      end_date.is_a?(Date)
-    end
 
     def map_attributes
       {

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -69,18 +69,31 @@ module CandidateInterface
     end
 
     def start_date
-      valid_date_or_nil(start_date_year, start_date_month)
+      valid_or_invalid_start_date(start_date_year, start_date_month)
     end
 
     def end_date
-      valid_date_or_nil(end_date_year, end_date_month)
+      valid_end_date_or_nil(end_date_year, end_date_month)
     end
 
   private
 
-    def valid_date_or_nil(year, month)
+    def valid_end_date_or_nil(year, month)
       date_args = [year, month, 1].map(&:to_i)
-      Date.new(*date_args) if year.present? && Date.valid_date?(*date_args)
+      if year.present? && Date.valid_date?(*date_args)
+        Date.new(*date_args)
+      elsif year.present? || month.present?
+        Struct.new(:day, :month, :year).new(1, month, year)
+      end
+    end
+
+    def valid_or_invalid_start_date(year, month)
+      date_args = [year, month, 1].map(&:to_i)
+      if year.present? && Date.valid_date?(*date_args)
+        Date.new(*date_args)
+      else
+        Struct.new(:day, :month, :year).new(1, month, year)
+      end
     end
 
     def end_date_blank?
@@ -88,15 +101,17 @@ module CandidateInterface
     end
 
     def end_date_valid
-      errors.add(:end_date, :invalid) unless end_date
+      errors.add(:end_date, :invalid) unless end_date.is_a?(Date)
     end
 
     def start_date_valid
-      errors.add(:start_date, :invalid) unless start_date
+      errors.add(:start_date, :invalid) unless start_date.is_a?(Date)
     end
 
     def start_date_before_end_date
-      errors.add(:start_date, :before) unless start_date <= end_date
+      if start_date_and_end_date_valid?
+        errors.add(:start_date, :before) unless start_date <= end_date
+      end
     end
 
     def end_date_before_current_year_and_month
@@ -107,11 +122,11 @@ module CandidateInterface
     end
 
     def start_date_and_end_date_valid?
-      end_date && start_date
+      end_date.is_a?(Date) && start_date.is_a?(Date)
     end
 
     def end_date_valid?
-      end_date
+      end_date.is_a?(Date)
     end
   end
 end

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class WorkExperienceForm
     include ActiveModel::Model
+    include DateValidationHelper
 
     attr_accessor :role, :organisation, :details, :working_with_children,
                   :commitment,
@@ -74,59 +75,6 @@ module CandidateInterface
 
     def end_date
       valid_end_date_or_nil(end_date_year, end_date_month)
-    end
-
-  private
-
-    def valid_end_date_or_nil(year, month)
-      date_args = [year, month, 1].map(&:to_i)
-      if year.present? && Date.valid_date?(*date_args)
-        Date.new(*date_args)
-      elsif year.present? || month.present?
-        Struct.new(:day, :month, :year).new(1, month, year)
-      end
-    end
-
-    def valid_or_invalid_start_date(year, month)
-      date_args = [year, month, 1].map(&:to_i)
-      if year.present? && Date.valid_date?(*date_args)
-        Date.new(*date_args)
-      else
-        Struct.new(:day, :month, :year).new(1, month, year)
-      end
-    end
-
-    def end_date_blank?
-      end_date_year.blank? && end_date_month.blank?
-    end
-
-    def end_date_valid
-      errors.add(:end_date, :invalid) unless end_date.is_a?(Date)
-    end
-
-    def start_date_valid
-      errors.add(:start_date, :invalid) unless start_date.is_a?(Date)
-    end
-
-    def start_date_before_end_date
-      if start_date_and_end_date_valid?
-        errors.add(:start_date, :before) unless start_date <= end_date
-      end
-    end
-
-    def end_date_before_current_year_and_month
-      if end_date.year > Date.today.year || \
-          end_date.year == Date.today.year && end_date.month > Date.today.month
-        errors.add(:end_date, :in_the_future)
-      end
-    end
-
-    def start_date_and_end_date_valid?
-      end_date.is_a?(Date) && start_date.is_a?(Date)
-    end
-
-    def end_date_valid?
-      end_date.is_a?(Date)
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_volunteering_and_school_experience_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature 'Entering volunteering and school experience' do
     when_i_fill_in_some_of_my_role_but_omit_some_required_details
     and_i_submit_the_volunteering_role_form
     then_i_see_validation_errors_for_my_volunteering_role
+    and_i_see_the_incorrect_values
 
     when_i_fill_in_my_volunteering_role
     and_i_submit_the_volunteering_role_form
@@ -86,6 +87,13 @@ RSpec.feature 'Entering volunteering and school experience' do
   def when_i_fill_in_some_of_my_role_but_omit_some_required_details
     fill_in t('application_form.volunteering.role.label'), with: 'Classroom Volunteer'
     fill_in t('application_form.volunteering.organisation.label'), with: 'A Noice School'
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '33'
+    end
+
+    within('[data-qa="end-date"]') do
+      fill_in 'Year', with: '9999'
+    end
   end
 
   def and_i_submit_the_volunteering_role_form
@@ -94,6 +102,16 @@ RSpec.feature 'Entering volunteering and school experience' do
 
   def then_i_see_validation_errors_for_my_volunteering_role
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/volunteering_role_form.attributes.start_date.invalid')
+  end
+
+  def and_i_see_the_incorrect_values
+    within('[data-qa="start-date"]') do
+      expect(find_field('Month').value).to eq('33')
+    end
+
+    within('[data-qa="end-date"]') do
+      expect(find_field('Year').value).to eq('9999')
+    end
   end
 
   def when_i_fill_in_my_volunteering_role

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -16,6 +16,10 @@ RSpec.feature 'Entering their work history' do
     when_i_choose_more_than_5_years
     then_i_should_see_the_job_form
 
+    when_i_fill_in_the_job_form_with_incorrect_date_fields
+    then_i_should_see_date_validation_errors
+    and_i_should_see_the_incorrect_date_values
+
     when_i_fill_in_the_job_form
     then_i_should_see_my_completed_job
 
@@ -82,6 +86,33 @@ RSpec.feature 'Entering their work history' do
 
   def then_i_should_see_the_job_form
     expect(page).to have_content(t('page_titles.add_job'))
+  end
+
+  def when_i_fill_in_the_job_form_with_incorrect_date_fields
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '33'
+    end
+
+    within('[data-qa="end-date"]') do
+      fill_in 'Year', with: '9999'
+    end
+
+    click_button t('application_form.work_history.complete_form_button')
+  end
+
+  def then_i_should_see_date_validation_errors
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.start_date.invalid')
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/work_experience_form.attributes.end_date.invalid')
+  end
+
+  def and_i_should_see_the_incorrect_date_values
+    within('[data-qa="start-date"]') do
+      expect(find_field('Month').value).to eq('33')
+    end
+
+    within('[data-qa="end-date"]') do
+      expect(find_field('Year').value).to eq('9999')
+    end
   end
 
   def when_i_fill_in_the_job_form


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Wherever a `govuk_date_field` is used and an incomplete/incorrect date has entered the form does not show the incorrect day/month/year values. This can be confusing to candidates who entering an incorrect date but cannot see what was the invalid error.

## Changes proposed in this pull request
This PR updates the `volunteering form` and `work experience form` to save incorrect date inputs in a `Struct` that later can be displayed. 

### Before
![image](https://user-images.githubusercontent.com/22743709/71724175-3bcb4180-2e27-11ea-855a-4a70b772a8d8.png)

### After
![image](https://user-images.githubusercontent.com/22743709/71724164-2d7d2580-2e27-11ea-8323-d4965468c6a7.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Visit these pages and fill up the dates with incorrect input, you should be able to see the incorrect values after submission. I have introduced a `DateValidationHelper` to remove the duplication from `VolunteeringRoleForm` and `WorkExperienceForm`. 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/admBeoVk/713-date-fields-doesnt-retain-incorrect-incomplete-date-input-value
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
