### PR TITLE
Enhance courses select element into an autocomplete

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,6 +1,7 @@
 require.context("govuk-frontend/govuk/assets");
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
 import initNationalityAutocomplete from "./nationality-autocomplete";
+import initCoursesAutocomplete from "./courses-autocomplete";
 import cookieMessage from "./cookie-banner";
 
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
@@ -8,6 +9,7 @@ import "../styles/application.scss";
 govUKFrontendInitAll();
 
 initNationalityAutocomplete();
+initCoursesAutocomplete();
 
 var $cookieMessage = document.querySelector('[data-module="cookie-message"]');
 new cookieMessage($cookieMessage).init();

--- a/app/frontend/packs/courses-autocomplete.js
+++ b/app/frontend/packs/courses-autocomplete.js
@@ -1,0 +1,22 @@
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const initCoursesAutocomplete = () => {
+  try {
+    const coursesSelect = document.querySelector('#candidate-interface-pick-course-form-code-field');
+
+    if (!coursesSelect) return;
+
+    // Replace "Select a course" with empty string
+    coursesSelect.querySelector("[value='']").innerHTML = "";
+
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: coursesSelect,
+      showAllValues: true,
+      confirmOnBlur: false
+    });
+  } catch (err) {
+    console.error("Could not enhance courses select:", err);
+  }
+};
+
+export default initCoursesAutocomplete;

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -6,11 +6,7 @@
     <%= form_with model: @pick_course, url: candidate_interface_course_choices_course_path(provider_code: params[:provider_code]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        <%= t('page_titles.which_course') %>
-      </h1>
-
-      <%= f.govuk_collection_select :code, select_course_options(@pick_course.available_courses), :id, :name, label: { text: 'Enter course name and code' } %>
+      <%= f.govuk_collection_select :code, select_course_options(@pick_course.available_courses), :id, :name, label: { text: t('page_titles.which_course'), size: 'xl' } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>


### PR DESCRIPTION
## Context

This makes the `<select>` a no-JS fallback.

## Changes proposed in this pull request

Update the label and add the required JS.

## Guidance to review

Nothing in particular.

No-JS:

![Screenshot 2020-01-03 at 15 17 30](https://user-images.githubusercontent.com/1650875/71731377-78edfe80-2e3c-11ea-9dac-c5ff50543ae9.png)

Yes-JS:

![Screenshot 2020-01-03 at 15 17 41](https://user-images.githubusercontent.com/1650875/71731378-78edfe80-2e3c-11ea-8a79-34ed1f1706ab.png)


## Link to Trello card

https://trello.com/c/uQaeQEm2/619-users-can-select-a-course-from-a-drop-down

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)