### PR TITLE
Remove custom `id` from further condition textareas so that labels match

### DIFF
--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -31,10 +31,10 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>
         <p class="govuk-body">Outline any further conditions (for example, studying a subject knowledge enhancement course) and give deadlines for completing them.</p>
 
-        <%= f.govuk_text_area :further_conditions0, id: :first_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions0'), size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions1, id: :second_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions1'), size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions2, id: :third_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions2'), size: 's' }, rows: 3 %>
-        <%= f.govuk_text_area :further_conditions3, id: :further_condition, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions3'), size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions0, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions0'), size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions1, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions1'), size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions2, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions2'), size: 's' }, rows: 3 %>
+        <%= f.govuk_text_area :further_conditions3, label: { text: t('activemodel.attributes.support_interface/new_offer.further_conditions3'), size: 's' }, rows: 3 %>
       </fieldset>
 
       <%= f.govuk_submit 'Continue' %>

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_add_optional_further_conditions
-    fill_in('first_condition', with: 'A further condition')
+    fill_in('make_an_offer[further_conditions0]', with: 'A further condition')
   end
 
   def and_i_click_to_continue


### PR DESCRIPTION
## Context

The custom `id` causes a mismatch between the label (that we can't specify a custom
`id` for) and the textarea itself.

## Changes proposed in this pull request

No visible change, removing the `id` generates the following kind of HTML:

```
<div class="govuk-form-group">
  <label for="make-an-offer-further-conditions0-field" class="govuk-label govuk-label--s">First condition</label>
  <textarea id="make-an-offer-further-conditions0-field" class="govuk-textarea" rows="3" name="make_an_offer[further_conditions0]"></textarea>
</div>
```

## Guidance to review

The `id` value only seemed to be referred to in a system spec and we can use a name there instead. Any other reason why we needed the `id`?

## Link to Trello card

https://trello.com/c/BWbCBEVj/693-dac-page-15-add-form-labels-to-provider-offer-page-conditions

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
