### PR TITLE
Added CIP mandated resource tagging.

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -51,6 +51,11 @@ parameters:
   stateChangeSlackUrl:
   customAvailabilityMonitors: []
   alertRecipientEmails: []
+  commonResourceTags: '{
+    "Parent Business Service": "Teacher Services",
+    "Service Offering": "Become a Teacher"
+  }'
+
 
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
@@ -82,6 +87,7 @@ jobs:
               location: 'West Europe'
               csmFile: '$(Pipeline.Workspace)\arm_template\template.json'
               overrideParameters: '-localBranchName "$(Build.SourceBranchName)"
+                -commonResourceTags ${{parameters.commonResourceTags}}
                 -resourceEnvironmentName "${{parameters.resourceEnvironmentName}}"
                 -serviceName "${{parameters.serviceName}}"
                 -dockerHubUsername "${{parameters.dockerHubUsername}}"
@@ -145,13 +151,18 @@ jobs:
               Inline: |
                 Param(
                   [string] $resourceGroupName = "$(resourceGroupName)",
+                  [string] $commonResourceTags = '${{parameters.commonResourceTags}}',
                   [string] $environment = "${{parameters.environment}}"
                 )
 
-                Set-AzureRmResourceGroup -Name $resourceGroupName -Tag @{
+                $tags = @{
                   Version = "$(Build.SourceVersion)";
                   Environment = "$environment"
                 }
+
+                (ConvertFrom-Json $commonResourceTags).psobject.properties | Foreach { $tags[$_.Name] = $_.Value }
+
+                Set-AzureRmResourceGroup -Name $resourceGroupName -Tag $tags
 
 
           - task: AzureAppServiceManage@0

--- a/azure/containers.json
+++ b/azure/containers.json
@@ -8,6 +8,13 @@
                 "description": "BAT building block URL."
             }
         },
+        "commonResourceTags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "decsription": "A object containing the common tags that should be applied to all Azure resources."
+            }
+        },
         "serviceName": {
             "type": "string",
             "metadata": {
@@ -112,6 +119,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "appServiceName": {
                         "value": "[parameters('appServiceName')]"
                     },
@@ -147,6 +157,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "containerInstanceName": {
                         "value": "[concat(parameters('containerInstanceNamePrefix'), '-wkr')]"
                     },
@@ -182,6 +195,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "containerInstanceName": {
                         "value": "[concat(parameters('containerInstanceNamePrefix'), '-clk')]"
                     },

--- a/azure/template.json
+++ b/azure/template.json
@@ -9,6 +9,13 @@
                 "description": "The name of the local branch for the code in use."
             }
         },
+        "commonResourceTags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "decsription": "A object containing the common tags that should be applied to all Azure resources."
+            }
+        },
         "resourceEnvironmentName": {
             "type": "string",
             "metadata": {
@@ -381,6 +388,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "storageAccountName": {
                         "value": "[variables('storageAccountName')]"
                     }
@@ -398,6 +408,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "redisCacheName": {
                         "value": "[parameters('redisCacheName')]"
                     },
@@ -427,6 +440,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "appServicePlanName": {
                         "value": "[variables('appServicePlanName')]"
                     },
@@ -454,6 +470,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "keyVaultCertificateName": {
                         "value": "[variables('keyVaultCertificateName')]"
                     },
@@ -477,6 +496,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "commonResourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "deploymentUrlBase": {
                         "value": "[variables('deploymentUrlBase')]"
                     },
@@ -675,6 +697,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "appServiceName": {
                         "value": "[variables('appServiceName')]"
                     },
@@ -704,6 +729,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "appInsightsName": {
                         "value": "[variables('appServiceName')]"
                     },
@@ -725,6 +753,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "appInsightsName": {
                         "value": "[variables('appServiceName')]"
                     },
@@ -745,6 +776,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "appInsightsName": {
                         "value": "[variables('appServiceName')]"
                     },
@@ -773,6 +807,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "appInsightsName": {
                         "value": "[variables('appServiceName')]"
                     },
@@ -812,6 +849,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "postgresServerName": {
                         "value": "[variables('databaseServerName')]"
                     },
@@ -915,6 +955,9 @@
                     "contentVersion": "1.0.0.0"
                 },
                 "parameters": {
+                    "resourceTags": {
+                        "value": "[parameters('commonResourceTags')]"
+                    },
                     "resourceGroupName": {
                         "value": "[variables('resourceNamePrefix')]"
                     },


### PR DESCRIPTION
## Context

CIP requires that all resources within any given subscription in the CIP Azure Tenant must have the `Parent Business Service` and `Service Offering` present and correctly populated. 

## Changes proposed in this pull request

- Created a hard coded `commonResourceTags` parameter in the azure pipeline YAML files that will be used throughout all deployments on Apply.
- The two new tags are added/appended to all resources in the deployment via a new `resourceTag` parameter added to all building block templates in a previous change.
- The two new tags are also included in the resource group tags along with our current `Environment` and `Version` tags.

## Guidance to review

Successful deployments can be observed on DevOps environment: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary&repositoryFilter=37&branchFilter=7644

The new tags can be seen in place on any Azure resource in the DevOps environment in the Azure portal: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/289869cc-7183-46bd-8131-f673c5eb94ba/resourceGroups/s106d02-apply/overview

## Link to Trello card

https://trello.com/c/zvf1aaAL/1426-update-cip-resource-tags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
