### PR TITLE
Provider: change enrolled status text

### DIFF
--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -51,7 +51,7 @@ en:
     awaiting_provider_decision: New
     awaiting_references: Awaiting references
     declined: Declined
-    enrolled: Candidate enrolled
+    enrolled: Enrolled
     offer: Offer
     pending_conditions: Accepted
     recruited: Candidate recruited


### PR DESCRIPTION
## Context

To shorten the status and be more consistent with the other statuses

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/37163/71808032-9c938d80-3064-11ea-8f19-a56959454c42.png)

After:
![image](https://user-images.githubusercontent.com/37163/71807978-82f24600-3064-11ea-83c2-d89572c6f87e.png)

## Link to Trello card

https://trello.com/c/a5FSS54R/1428-change-candidate-enrolled-to-enrolled-tag