### PR TITLE
Refactor status tag class names

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -56,21 +56,19 @@ module CandidateInterface
     def status_row(course_choice)
       type =  case course_choice.status
               when 'awaiting_references', 'application_complete'
-                :secondary
+                :grey
               when 'awaiting_provider_decision'
-                :primary
+                :blue
               when 'offer'
-                :info_unfilled
+                :green
               when 'rejected'
-                :danger
+                :red
               when 'withdrawn'
-                :danger
+                :red
               when 'pending_conditions'
-                :info
+                :turquoise
               when 'declined'
-                :warning
-              else
-                ''
+                :orange
               end
       {
         key: 'Status',

--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -14,17 +14,17 @@ module ProviderInterface
     def type
       case status
       when 'awaiting_provider_decision'
-        :primary_unfilled
+        :purple
       when 'offer'
-        :info_unfilled
+        :green
       when 'rejected'
-        :danger
+        :red
       when 'pending_conditions'
-        :info
+        :turquoise
       when 'declined'
-        :warning
-      else
-        ''
+        :orange
+      when 'enrolled'
+        :blue
       end
     end
 

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -15,17 +15,17 @@ module SupportInterface
     def type
       case status
       when 'awaiting_provider_decision'
-        :primary_unfilled
+        :purple
       when 'offer'
-        :info_unfilled
+        :green
       when 'rejected'
-        :danger
+        :red
       when 'pending_conditions'
-        :info
+        :turquoise
       when 'declined'
-        :warning
-      else
-        ''
+        :orange
+      when 'enrolled'
+        :blue
       end
     end
 

--- a/app/components/tag_component.html.erb
+++ b/app/components/tag_component.html.erb
@@ -1,3 +1,3 @@
-<strong class="<%= @css_classes %>">
+<strong class="govuk-tag <%= @css_classes %>">
   <%= @text %>
 </strong>

--- a/app/components/tag_component.rb
+++ b/app/components/tag_component.rb
@@ -8,24 +8,7 @@ private
 
   attr_reader :text
 
-  def css_classes(type)
-    tag_css_class = case type
-                    when :danger
-                      'app-tag--danger'
-                    when :secondary
-                      'app-tag--secondary'
-                    when :info
-                      'app-tag--info'
-                    when :info_unfilled
-                      'app-tag--info-unfilled'
-                    when :warning
-                      'app-tag--warning'
-                    when :primary_unfilled
-                      'app-tag--primary-unfilled'
-                    else
-                      'app-tag--primary'
-                    end
-
-    "govuk-tag #{tag_css_class}"
+  def css_classes(colour)
+    colour ? "app-tag--#{colour}" : ''
   end
 end

--- a/app/components/task_list_item_component.html.erb
+++ b/app/components/task_list_item_component.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_link_to text, path, class: 'app-task-list__task-name', 'aria-describedby': tag_id %>
 <% if submitted %>
-  <strong class="govuk-tag app-tag app-tag--secondary" id=<%= tag_id %>>
+  <strong class="govuk-tag app-tag app-tag--grey" id=<%= tag_id %>>
     Submitted
   </strong>
 <% elsif completed %>
@@ -8,7 +8,7 @@
     Completed
   </strong>
 <% elsif show_incomplete %>
-  <strong class="govuk-tag app-tag app-tag--incomplete" id=<%= tag_id %>>
+  <strong class="govuk-tag app-tag app-tag--grey" id=<%= tag_id %>>
     Incomplete
   </strong>
 <% end %>

--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -1,35 +1,34 @@
-.app-tag--danger {
+.app-tag--red {
   color: govuk-shade(govuk-colour("red"), 20);
   background: govuk-tint(govuk-colour("red"), 80);
 }
 
-.app-tag--primary {
+.app-tag--blue {
   color: govuk-shade(govuk-colour("blue"), 30);
   background: govuk-tint(govuk-colour("blue"), 80);
 }
 
-.app-tag--primary-unfilled {
+.app-tag--purple {
   color: govuk-shade(govuk-colour("purple"), 20);
   background: govuk-tint(govuk-colour("purple"), 80);
 }
 
-.app-tag--secondary,
-.app-tag--incomplete {
+.app-tag--grey {
   color: govuk-shade(govuk-colour("dark-grey"), 30);
   background: govuk-tint(govuk-colour("dark-grey"), 90);
 }
 
-.app-tag--info {
+.app-tag--turquoise {
   color: govuk-shade(govuk-colour("turquoise"), 40);
   background: govuk-tint(govuk-colour("turquoise"), 70);
 }
 
-.app-tag--info-unfilled {
+.app-tag--green {
   color: govuk-shade(govuk-colour("green"), 20);
   background: govuk-tint(govuk-colour("green"), 80);
 }
 
-.app-tag--warning {
+.app-tag--orange {
   color: govuk-shade(govuk-colour("orange"), 55);
   background: govuk-tint(govuk-colour("orange"), 70);
 }


### PR DESCRIPTION
## Context

Changed class names to colours as they are used to mean different things in different contexts.

## Link to Trello card

https://trello.com/c/UfpbyXvb/1430-refactor-class-names-for-status-tags