### PR TITLE
Add ability to send survey email to candidate from Support

### DIFF
--- a/app/controllers/support_interface/survey_emails_controller.rb
+++ b/app/controllers/support_interface/survey_emails_controller.rb
@@ -7,6 +7,11 @@ module SupportInterface
     def deliver
       CandidateMailer.survey_email(@application_form).deliver
 
+      candidate_email = @application_form.candidate.email_address
+      audit_comment = I18n.t('survey_emails.send.audit_comment', candidate_email: candidate_email)
+      application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
+      application_comment.save(@application_form)
+
       flash[:success] = t('survey_emails.send.success')
 
       redirect_to support_interface_application_form_path(@application_form)

--- a/app/controllers/support_interface/survey_emails_controller.rb
+++ b/app/controllers/support_interface/survey_emails_controller.rb
@@ -1,0 +1,21 @@
+module SupportInterface
+  class SurveyEmailsController < SupportInterfaceController
+    before_action :set_application_form
+
+    def show; end
+
+    def deliver
+      CandidateMailer.survey_email(@application_form).deliver
+
+      flash[:success] = t('survey_emails.send.success')
+
+      redirect_to support_interface_application_form_path(@application_form)
+    end
+
+  private
+
+    def set_application_form
+      @application_form = ApplicationForm.find(params[:application_form_id])
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -57,3 +57,9 @@
     <%= render ReferenceWithFeedbackComponent, reference: reference, title: "#{(i + 1).ordinalize} reference", show_chase_reference: true %>
   <% end %>
 <% end %>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-8">Request feedback</h2>
+
+<p class="govuk-body">Ask the candidate to fill out a survey.</p>
+
+<%= govuk_button_link_to t('survey_emails.send.link'), support_interface_survey_emails_path(@application_form), class: 'govuk-button--secondary' %>

--- a/app/views/support_interface/survey_emails/show.html.erb
+++ b/app/views/support_interface/survey_emails/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, t('survey_emails.send.confirm', candidate_name: @application_form.full_name) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form), 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_form, url: support_interface_survey_emails_path(@application_form), method: :post do |f| %>
+      <%= f.submit t('survey_emails.send.button'), class: 'govuk-button', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', support_interface_application_form_path(@application_form) %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -12,3 +12,4 @@ en:
       confirm: Are you sure you want to send a survey email to %{candidate_name}?
       button: Yes - send the email
       success: Survey request sent to candidate
+      audit_comment: Survey email has been sent to candidate (%{candidate_email}).

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -7,3 +7,8 @@ en:
     thank_you:
       candidate: Thanks for submitting your teacher training application.
       referee: Thanks for submitting your reference for %{candidate_name}.
+    send:
+      link: Request feedback
+      confirm: Are you sure you want to send a survey email to %{candidate_name}?
+      button: Yes - send the email
+      success: Survey request sent to candidate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -278,6 +278,9 @@ Rails.application.routes.draw do
     get '/chase-reference/:reference_id' => 'chase_reference#show', as: :chase_reference
     post '/chase-reference/:reference_id' => 'chase_reference#chase'
 
+    get '/send-survey-email/:application_form_id' => 'survey_emails#show', as: :survey_emails
+    post '/send-survey-email/:application_form_id' => 'survey_emails#deliver'
+
     get '/tokens' => 'api_tokens#index', as: :api_tokens
     post '/tokens' => 'api_tokens#create'
 

--- a/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
+++ b/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
@@ -17,6 +17,9 @@ RSpec.feature 'Send survey email to candidate', with_audited: true do
     when_i_click_to_confirm_sending_the_survey_email
     then_i_see_the_survey_email_is_successfully_sent
     and_i_am_sent_back_to_the_application_form_with_a_flash
+
+    when_i_click_on_the_history_for_the_application
+    then_i_see_a_comment_stating_a_survey_emails_has_been_sent
   end
 
   def given_i_am_a_support_user
@@ -59,5 +62,18 @@ RSpec.feature 'Send survey email to candidate', with_audited: true do
 
   def and_i_am_sent_back_to_the_application_form_with_a_flash
     expect(page).to have_content(t('survey_emails.send.success'))
+  end
+
+  def when_i_click_on_the_history_for_the_application
+    click_link 'History'
+  end
+
+  def then_i_see_a_comment_stating_a_survey_emails_has_been_sent
+    candidate_email = @application.candidate.email_address
+
+    within('tbody tr:eq(1)') do
+      expect(page).to have_content 'Comment on Application Form'
+      expect(page).to have_content t('survey_emails.send.audit_comment', candidate_email: candidate_email)
+    end
   end
 end

--- a/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
+++ b/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.feature 'Send survey email to candidate', with_audited: true do
+  include DfESignInHelpers
+
+  scenario 'Support agent sends a survey email to a candidate' do
+    given_i_am_a_support_user
+    and_there_is_an_application
+    and_i_visit_the_support_page
+
+    when_i_click_on_the_application
+    then_i_should_be_on_the_view_application_page
+
+    when_i_click_on_request_feedback
+    then_i_see_a_confirmation_page
+
+    when_i_click_to_confirm_sending_the_survey_email
+    then_i_see_the_survey_email_is_successfully_sent
+    and_i_am_sent_back_to_the_application_form_with_a_flash
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application
+    @application = create(:completed_application_form, first_name: 'Darlene', last_name: 'Alderson')
+  end
+
+  def and_i_visit_the_support_page
+    visit support_interface_path
+  end
+
+  def when_i_click_on_the_application
+    click_on @application.candidate.email_address
+  end
+
+  def then_i_should_be_on_the_view_application_page
+    expect(page).to have_content @application.candidate.email_address
+  end
+
+  def when_i_click_on_request_feedback
+    click_link(t('survey_emails.send.link'))
+  end
+
+  def then_i_see_a_confirmation_page
+    expect(page).to have_content(t('survey_emails.send.confirm', candidate_name: 'Darlene Alderson'))
+  end
+
+  def when_i_click_to_confirm_sending_the_survey_email
+    click_button t('survey_emails.send.button')
+  end
+
+  def then_i_see_the_survey_email_is_successfully_sent
+    open_email(@application.candidate.email_address)
+
+    expect(current_email.subject).to have_content(t('survey_emails.subject.initial'))
+  end
+
+  def and_i_am_sent_back_to_the_application_form_with_a_flash
+    expect(page).to have_content(t('survey_emails.send.success'))
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to send surveys to candidates and referees in the first phase of the pilot (November/December) from the Support console.

In #1001 and #1005, the survey emails for a candidate and referee were added.

## Changes proposed in this pull request

This PR adds the ability to send a survey email to a **_candidate_** from Support by adding `Request feedback` section to the page we can view an application. The sending of an email is also audited.

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/71810472-61945880-306a-11ea-90e9-4e027c9f7122.png)

![image](https://user-images.githubusercontent.com/42817036/71810508-71ac3800-306a-11ea-92b3-1a4b7654a97e.png)

![image](https://user-images.githubusercontent.com/42817036/71810532-7ffa5400-306a-11ea-88ac-360a318bdade.png)

![image](https://user-images.githubusercontent.com/42817036/71810653-c18aff00-306a-11ea-9463-1097b28ce36e.png)

## Guidance to review

Sending to a referee is dependant on knowing whether or not they have consented to be sent a survey email which has not been added to the application yet.

Content and design has been checked with @adamsilver and @emmajhf.

## Link to Trello card

https://trello.com/c/KpaTL5K5/543-survey-emails-to-referee-and-candidate-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
