### PR TITLE
Show an accurate message for provider users who haven't signed in

### DIFF
--- a/app/components/support_interface/provider_users_table_component.html.erb
+++ b/app/components/support_interface/provider_users_table_component.html.erb
@@ -18,7 +18,11 @@
           <% if row[:last_signed_in_at] %>
             <td class="govuk-table__cell"><%= row[:last_signed_in_at] %></td>
           <% else %>
-            <td class="govuk-table__cell"><em>Never signed in</em></td>
+            <% if row[:created_at] < Date.new(2019, 12, 25) %>
+              <td class="govuk-table__cell"><em>Unknown (records began 24 December 2019)</em></td>
+            <% else %>
+              <td class="govuk-table__cell"><em>Never signed in</em></td>
+            <% end %>
           <%end %>
         </tr>
       <% end %>

--- a/app/components/support_interface/provider_users_table_component.rb
+++ b/app/components/support_interface/provider_users_table_component.rb
@@ -12,6 +12,7 @@ module SupportInterface
           email_address: provider_user.email_address,
           links_to_providers: links_to_providers(provider_user),
           dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          created_at: provider_user.created_at,
           last_signed_in_at: last_signed_in_at(provider_user),
         }
       end

--- a/spec/components/support_interface/provider_users_table_component_spec.rb
+++ b/spec/components/support_interface/provider_users_table_component_spec.rb
@@ -26,10 +26,18 @@ RSpec.describe SupportInterface::ProviderUsersTableComponent do
     end
   end
 
-  context 'when the provider user has never signed in' do
-    let(:provider_users) { [create(:provider_user, last_signed_in_at: nil)] }
+  context 'when the provider user has never signed in and was created before 24/12/2019' do
+    let(:provider_users) { [create(:provider_user, last_signed_in_at: nil, created_at: Date.new(2019, 12, 23))] }
 
-    it 'shows that the user has never signed in' do
+    it 'shows that we don’t know whether they’ve signed in or not (they’ve never signed in, or they signed in before records began on 24/12/2019)' do
+      expect(rendered_component).to include('Unknown (records began 24 December 2019)')
+    end
+  end
+
+  context 'when the provider user has never signed in and was created after 24/12/2019' do
+    let(:provider_users) { [create(:provider_user, last_signed_in_at: nil, created_at: Date.new(2019, 12, 25))] }
+
+    it 'shows that we don’t know whether they’ve signed in or not (they’ve never signed in, or they signed in before records began on 24/12/2019)' do
       expect(rendered_component).to include('Never signed in')
     end
   end


### PR DESCRIPTION
## Context

We currently show "Never signed in" on the list of provider users if we have no `last_signed_in_at` value for the provider. This is the case when a provider has not signed in since records began on 24/12/2019 at ~2:45pm (Azure deployment https://dev.azure.com/dfe-ssp/Become-A-Teacher/_build/results?buildId=36746&view=results).

This PR makes that message a bit more useful

- if they were created before sign-in records began on 24/12/2019, say we don't know
- if they were created after records began but haven't signed in, say
with certainty that they've never signed in

## Changes proposed in this pull request

Use the `created_at` date of the `ProviderUser` to decide which message to show in the event there's no `last_signed_in_at` date.

## Link to Trello card

https://trello.com/c/9olWppuF/1431-dont-incorrectly-say-a-provider-never-signed-in-if-they-could-have-signed-in-before-records-began

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
