### PR TITLE
Fix duplicate IDs on course site page

### DIFF
--- a/app/views/candidate_interface/course_choices/options_for_site.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_site.html.erb
@@ -6,12 +6,24 @@
     <%= form_with model: @pick_site, url: candidate_interface_course_choices_site_path(provider_code: params[:provider_code], course_code: params[:course_code]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location') } do %>
-        <div class="govuk-!-margin-top-6">
-          <% @pick_site.available_sites.each_with_index do |option, i| %>
-            <%= f.govuk_radio_button :course_option_id, option.id, label: { text: option.site.name }, link_errors: i.zero?, hint_text: option.site.full_address %>
-          <% end %>
-        </div>
+      <% sites = @pick_site.available_sites.map do |option|
+        OpenStruct.new(
+          id: option.id,
+          name: option.site.name,
+          description: option.site.full_address
+        )
+      end %>
+      <%=
+        f.govuk_collection_radio_buttons(
+          :course_option_id,
+          sites,
+          :id,
+          :name,
+          :description,
+          legend: { size: 'xl', text: t('page_titles.which_location') },
+        ) do
+      %>
+        <div class="govuk-!-margin-top-6"/>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>


### PR DESCRIPTION
HAVE RAISED AN ALTERNATIVE PR TO FIX THIS IN THE FORM BUILDER https://github.com/DFE-Digital/govuk_design_system_formbuilder. IF THAT GETS MERGED I CAN JUST CLOSE THIS PR.

## Context

The hint `span` element rendered on the candidate course site selection page are duplicates because they don't include anything unique to the individual radio buttons to which they relate. This was flagged as an issue in the DAC report.

## Changes proposed in this pull request

* Swapped out the `govuk_radio_buttons_fieldset` for `govuk_collection_radio_buttons` which seems to handle hint ids correctly (it includes the value of the radio button in the hint id).

After a bit of debugging it seems `govuk_radio_buttons_fieldset` allows you to create a hint for each radio button but it doesn't give you any control over the id of the hint element. This depends only on the name of the field not the value of the individual buttons because, for some reason, `FieldsetRadioButton` just doesn't pass the value to the hint element. `CollectionRadioButton` does pass the value and it appears to do everything else that we need though the markup varies (see below).

The only visible difference (that I can see) is that the radio button labels are now bold. There is actually an option to to make them bold, they are normally not bold by default but if you include a `hint_method` as we must do here that option is ignored and they are always bold (to make them stand out from the hint according to the docs). I guess we would need some CSS to keep the non-bold labels if that's important.

Before:

![image](https://user-images.githubusercontent.com/450843/71813926-d9668100-3072-11ea-84d5-a7998edacb32.png)

```
<div class="govuk-form-group">
  <fieldset class="govuk-fieldset">
    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
      <h1 class="govuk-fieldset__heading">Which location are you applying to?</h1>
    </legend>
    <div class="govuk-radios" data-module="govuk-radios">
      <div class="govuk-!-margin-top-6">
        <div class="govuk-radios__item">
          <input id="candidate-interface-pick-site-form-course-option-id-131-field" aria-describedby="candidate-interface-pick-site-form-course-option-id-131-hint" class="govuk-radios__input" type="radio" value="131" name="candidate_interface_pick_site_form[course_option_id]">
          <label for="candidate-interface-pick-site-form-course-option-id-131-field" class="govuk-label govuk-radios__label">Boston Spa School</label>
          <span class="govuk-hint govuk-radios__hint" id="candidate-interface-pick-site-form-course-option-id-hint">Clifford Moor Road, Boston Spa, West Yorkshire, LS23 6RW</span>
        </div>
      </div>
    </div>
  </fieldset>
</div>
```

After:

![image](https://user-images.githubusercontent.com/450843/71813953-f3a05f00-3072-11ea-9c70-ab5fbbad7879.png)

```
<div class="govuk-form-group">
  <fieldset class="govuk-fieldset">
    <h1 class="govuk-fieldset__heading">
      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">Which location are you applying to?</legend>
    </h1>
    <div id="candidate-interface-pick-site-form-course-option-id-supplemental">
      <div class="govuk-!-margin-top-6"></div>
      <div class="govuk-radios" data-module="govuk-radios">
        <div class="govuk-radios__item">
          <input id="candidate-interface-pick-site-form-course-option-id-131-field" aria-describedby="candidate-interface-pick-site-form-course-option-id-131-hint" class="govuk-radios__input" type="radio" value="131" name="candidate_interface_pick_site_form[course_option_id]">
          <label for="candidate-interface-pick-site-form-course-option-id-131-field" class="govuk-label govuk-label--s govuk-radios__label">Boston Spa School</label>
          <span class="govuk-hint govuk-radios__hint" id="candidate-interface-pick-site-form-course-option-id-131-hint">Clifford Moor Road, Boston Spa, West Yorkshire, LS23 6RW</span>
        </div>
      </div>
    </div>
  </fieldset>
</div>
```

## Guidance to review

* Are there any known downsides to swapping `govuk_radio_buttons_fieldset` for `govuk_collection_radio_buttons`?
* Are there any issues with the new markup?
* What's the best way to make the buttons non-bold?

## Link to Trello card

https://trello.com/c/LqbMmzbb/692-dac-page-13-fix-duplicate-ids-on-course-site-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
