### PR TITLE
Add provider_agreements table

### DIFF
--- a/db/migrate/20200106111239_create_provider_agreements.rb
+++ b/db/migrate/20200106111239_create_provider_agreements.rb
@@ -1,0 +1,11 @@
+class CreateProviderAgreements < ActiveRecord::Migration[6.0]
+  def change
+    create_table :provider_agreements do |t|
+      t.references :provider, null: false, foreign_key: true
+      t.references :provider_user, null: false, foreign_key: true
+      t.string :agreement_type
+      t.datetime :accepted_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_23_162115) do
+ActiveRecord::Schema.define(version: 2020_01_06_111239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -182,6 +182,17 @@ ActiveRecord::Schema.define(version: 2019_12_23_162115) do
     t.index ["provider_id"], name: "index_courses_on_provider_id"
   end
 
+  create_table "provider_agreements", force: :cascade do |t|
+    t.bigint "provider_id", null: false
+    t.bigint "provider_user_id", null: false
+    t.string "agreement_type"
+    t.datetime "accepted_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider_id"], name: "index_provider_agreements_on_provider_id"
+    t.index ["provider_user_id"], name: "index_provider_agreements_on_provider_user_id"
+  end
+
   create_table "provider_users", force: :cascade do |t|
     t.string "email_address", null: false
     t.string "dfe_sign_in_uid"
@@ -273,6 +284,8 @@ ActiveRecord::Schema.define(version: 2019_12_23_162115) do
   add_foreign_key "course_options", "courses", on_delete: :cascade
   add_foreign_key "course_options", "sites", on_delete: :cascade
   add_foreign_key "courses", "providers"
+  add_foreign_key "provider_agreements", "provider_users"
+  add_foreign_key "provider_agreements", "providers"
   add_foreign_key "references", "application_forms"
   add_foreign_key "sites", "providers"
   add_foreign_key "vendor_api_tokens", "providers", on_delete: :cascade


### PR DESCRIPTION
## Context

When a `ProviderUser` logs in, the relevant controller will check if any of their associated providers hasn't accepted the data sharing agreement. If this is the case, the controller will redirect the user to a data sharing agreement flow. Subsequent users for the same provider will not be redirected to this flow, provided the first user has completed the flow.

The data sharing agreement flow is triggered with this logic:

- The current user's list of associated providers is found
- We check if any of these providers have not accepted the data sharing agreement
- We trigger the data sharing agreement flow for the first of these providers
- Once the agreement has been accepted we redirect the user to the data sharing agreement flow for the next provider that requires it or the `provider_interface`.

Information about who has signed the data sharing agreement and when will be visible in the support interface.

## Changes proposed in this pull request

In the database, agreement acceptance will be stored in a new table, `provider_agreements`. The table includes `provider_id`, `provider_user_id`, `agreement_type` and `accepted_at` fields.

## Guidance to review

Just a database migration.

## Link to Trello card

[Data sharing agreement onto 'Manage'](https://trello.com/c/X6sXsnEm)