### PR TITLE
Provider user accepts data sharing agreement for provider

### DIFF
--- a/db/migrate/20200106111239_create_provider_agreements.rb
+++ b/db/migrate/20200106111239_create_provider_agreements.rb
@@ -1,0 +1,11 @@
+class CreateProviderAgreements < ActiveRecord::Migration[6.0]
+  def change
+    create_table :provider_agreements do |t|
+      t.references :provider, null: false, foreign_key: true
+      t.references :provider_user, null: false, foreign_key: true
+      t.string :agreement_type
+      t.datetime :accepted_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_23_162115) do
+ActiveRecord::Schema.define(version: 2020_01_06_111239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -182,6 +182,17 @@ ActiveRecord::Schema.define(version: 2019_12_23_162115) do
     t.index ["provider_id"], name: "index_courses_on_provider_id"
   end
 
+  create_table "provider_agreements", force: :cascade do |t|
+    t.bigint "provider_id", null: false
+    t.bigint "provider_user_id", null: false
+    t.string "agreement_type"
+    t.datetime "accepted_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider_id"], name: "index_provider_agreements_on_provider_id"
+    t.index ["provider_user_id"], name: "index_provider_agreements_on_provider_user_id"
+  end
+
   create_table "provider_users", force: :cascade do |t|
     t.string "email_address", null: false
     t.string "dfe_sign_in_uid"
@@ -273,6 +284,8 @@ ActiveRecord::Schema.define(version: 2019_12_23_162115) do
   add_foreign_key "course_options", "courses", on_delete: :cascade
   add_foreign_key "course_options", "sites", on_delete: :cascade
   add_foreign_key "courses", "providers"
+  add_foreign_key "provider_agreements", "provider_users"
+  add_foreign_key "provider_agreements", "providers"
   add_foreign_key "references", "application_forms"
   add_foreign_key "sites", "providers"
   add_foreign_key "vendor_api_tokens", "providers", on_delete: :cascade


### PR DESCRIPTION
### Context

Provider users must be able to sign the data sharing agreement when they first access the platform. This will assist/streamline the onboarding of SCITTs to the service.

This new flow in the app will replace the current DocuSign-based manual process. The data sharing agreement will be presented within the app and clicking on a simple checkbox will be all that's needed to accept the agreement. The identity of the person agreeing, as well as the timestamp of the acceptance, will be recorded in the database and exposed in the provider interface.

Requirements:

- Each ~~user~~ provider accepts the data sharing agreement only once
- The first user from each `Provider` must select they 'agree to the data sharing agreement'
- No-one linked to a particular provider can access the provider interface until the relevant data sharing agreement has been accepted.

The data sharing agreement will be presented to the user as a web page. The organisation name will need to appear in a couple of places in the form and will be automatically populated by the app. The provider may need access to the data sharing agreement at any point after it has been signed, so an appropriate route within the app will be provided.

Even though provider users go through DfE Sign-in, there is a ProviderUser model we can store values against. However, the relationship between `Provider` and `ProviderUser` is many-to-many and acceptance of the data sharing agreement must be enforced at the `Provider` level. For now, we'll assume any association between a `Provider` and and a `ProviderUser` gives this user the the authority to accept the data sharing agreement on the provider's behalf.

### Changes proposed in this pull request

When a `ProviderUser` logs in, the relevant controller will check if any of their associated providers hasn't accepted the data sharing agreement. If this is the case, the controller will redirect the user to a data sharing agreement flow. Subsequent users for the same provider will not be redirected to this flow, provided the first user has completed the flow.

The data sharing agreement flow is triggered with this logic:

- The current user's list of associated providers is found
- We check if any of these providers have not accepted the data sharing agreement
- We trigger the data sharing agreement flow for the first of these providers
- Once the agreement has been accepted we redirect the user to the data sharing agreement flow for the next provider that requires it or the `provider_interface`.

In the database, agreement acceptance will be stored in a new table, `provider_agreements`. The table includes `provider_id`, `provider_user_id`, `agreement_type` and `accepted_at` fields.

Information about who has signed the data sharing agreement and when is visible in the support interface.

### Guidance to review



### Link to Trello card

[Data sharing agreement onto 'Manage'](https://trello.com/c/X6sXsnEm)
