### PR TITLE
Make sure the full Notify error message is reported in Sentry

### DIFF
--- a/config/initializers/notify_extension.rb
+++ b/config/initializers/notify_extension.rb
@@ -1,0 +1,9 @@
+module Notifications
+  class Client
+    class RequestError < StandardError
+      def to_s
+        message
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

When processing an exception, Sentry reads `exception.to_s` for the description in Sentry.

https://github.com/getsentry/raven-ruby/blob/065cf973cb0ad3672d0d213e80b6e8a9a8e6f8cb/lib/raven/event.rb#L144

This is because by default, errors return the message when calling `to_s`:

```
> irb
irb(main):001:0> StandardError.new("Hi").to_s
=> "Hi"
```

However, the Notifications client doesn’t set the `@message` variable, but overrides the `message` method.

https://github.com/alphagov/notifications-ruby-client/blob/446923820d5133960d74eba6950f6c01168a3ea7/lib/notifications/client/request_error.rb#L17-L24

This means that Sentry will just report the exception name, but not the description.

```
> be rails c
Loading development environment (Rails 6.0.2.1)
[1] pry(main)>
Notifications::Client::BadRequestError.new(OpenStruct.new(code: "hey", body: {errors: [{error: "BadRequestError", message: "Can’t send to this recipient using a team-only API key"}] }.to_json )).to_s
=> "Notifications::Client::BadRequestError"
[2] pry(main)>
Notifications::Client::BadRequestError.new(OpenStruct.new(code: "hey", body: {errors: [{error: "BadRequestError", message: "Can’t send to this recipient using a team-only API key"}] }.to_json )).message 
=> "BadRequestError: Can’t send to this recipient using a team-only API key"
```

This causes the Sentry error to miss the full description, making it really hard to understand what error occurred.

<img width="1229" alt="Screenshot 2020-01-06 at 11 53 26" src="https://user-images.githubusercontent.com/233676/71816636-29494600-307b-11ea-8f88-a25b1fd0427b.png">

We’ve previously tried to solve this by rescuing mailer errors, but this didn’t work as intended
(https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/868).


## Changes proposed in this pull request

Add `to_s` as an alias. Once this fix has proven itself we’ll raise an upstream PR on the Notify library.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
