### PR TITLE
Update content for hide/show in reporting button

### DIFF
--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -20,7 +20,7 @@ module SupportInterface
     def hide_in_reporting
       candidate = Candidate.find(params[:candidate_id])
       candidate.update!(hide_in_reporting: true)
-      flash[:success] = 'Candidate will now be hidden in reporting'
+      flash[:success] = 'Candidate will now be excluded from service performance data'
       if params[:from_application_form_id]
         application_form_to_return_to = ApplicationForm.find(params[:from_application_form_id])
         redirect_to support_interface_application_form_path(application_form_to_return_to)
@@ -32,7 +32,7 @@ module SupportInterface
     def show_in_reporting
       candidate = Candidate.find(params[:candidate_id])
       candidate.update!(hide_in_reporting: false)
-      flash[:success] = 'Candidate will now be shown in reporting'
+      flash[:success] = 'Candidate will now be included in service performance data'
       if params[:from_application_form_id]
         application_form_to_return_to = ApplicationForm.find(params[:from_application_form_id])
         redirect_to support_interface_application_form_path(application_form_to_return_to)

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -28,9 +28,9 @@
 <% end %>
 
 <% if @application_form.candidate.hide_in_reporting? %>
-  <%= button_to 'Show in reporting', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary' %>
 <% else %>
-  <%= button_to 'Hide in reporting', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@application_form.candidate, from_application_form_id: @application_form.id), class: 'govuk-button govuk-button--secondary' %>
 <% end %>
 
 <% if @application_form.application_choices.any? %>

--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -9,9 +9,9 @@
 <% end %>
 
 <% if @candidate.hide_in_reporting? %>
-  <%= button_to 'Show in reporting', support_interface_show_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Include this candidate in service performance data', support_interface_show_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary' %>
 <% else %>
-  <%= button_to 'Hide in reporting', support_interface_hide_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary' %>
+  <%= button_to 'Exclude this candidate from service performance data', support_interface_hide_candidate_path(@candidate), class: 'govuk-button govuk-button--secondary' %>
 <% end %>
 
 <% unless @application_forms.empty? %>


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The ‘Hide in reporting’ and ‘Show in reporting’ buttons are not descriptive enough for all users, particularly screen reader users, to determine their function or purpose.

## Changes proposed in this pull request
This PR updates the content of ‘Hide in reporting’ and ‘Show in reporting’  and related status messages to clarify their function/purpose for screen reader users.
<!-- If there are UI changes, please include Before and After screenshots. -->

### Before
![image](https://user-images.githubusercontent.com/22743709/71817094-b3de7500-307c-11ea-8639-8bc787fed13b.png)

![image](https://user-images.githubusercontent.com/22743709/71817111-ba6cec80-307c-11ea-9159-ad5e29affe38.png)


### After 
![image](https://user-images.githubusercontent.com/22743709/71817052-914c5c00-307c-11ea-9a94-a8466590435d.png)

![image](https://user-images.githubusercontent.com/22743709/71817060-97dad380-307c-11ea-828c-7096bcb52f1f.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Visit the `candidates` on support console and select a candidate. Try to click on `Exclude this candidate from service performance data`, you should see the new content. 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/LIxkhgmi/696-dac-page-27-add-context-to-show-hide-in-reporting-button-in-support-application-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
