### PR TITLE
Skip CSRF checks for error controller

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def not_found
     render 'not_found.html', status: :not_found
   end


### PR DESCRIPTION
## Context

When a 500 error occurs on a POST request, I’m seeing CRSF errors in the logs:

```
app/controllers/candidate_interface/sign_up_controller.rb:12:in `create'
Processing by ErrorsController#internal_server_error as HTML
  Parameters: {"authenticity_token"=>"[FILTERED]",
"candidate_interface_sign_up_form"=>{"email_address"=>"[FILTERED]",
"accept_ts_and_cs"=>"true"}, "commit"=>"Continue"}
Can't verify CSRF token authenticity.
Completed 422 Unprocessable Entity in 1ms (ActiveRecord: 0.0ms |
Allocations: 499)

Error during failsafe response: ActionController::InvalidAuthenticityToken
```

This causes the error page to fall back to a text version:

<img width="960" alt="Screenshot 2020-01-06 at 12 06 21" src="https://user-images.githubusercontent.com/233676/71817378-9b228f00-307d-11ea-8d7b-54c51161ee1c.png">


## Changes proposed in this pull request

I’m not entirely sure why this is the case, but removing the CRSF token check fixes the issue.

<img width="1190" alt="Screenshot 2020-01-06 at 12 07 07" src="https://user-images.githubusercontent.com/233676/71817396-a5448d80-307d-11ea-83c2-787cf3c2ca44.png">

(The header will be fixed in a separate PR).

## Guidance to review

Trust.


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
