### PR TITLE
Fix headings hierarchy on provider offer page

### DIFF
--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -22,7 +22,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: 'Standard conditions', size: 'm' } do %>
+      <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: 'Standard conditions', size: 'm', tag: 'h2' } do %>
           <%= f.govuk_check_box :standard_conditions, 'Fitness to Teach check', label: { text: 'Fitness to Teach check' } %>
           <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check' } %>
       <% end %>


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The heading structure of the ‘Conditions of offer’ page is not logical because multiple level- one headings are present. This means that screen reader users may not be able to identify the structure and relation of content throughout the document. 

## Changes proposed in this pull request
This PR changes the heading level to the next logical level:
<!-- If there are UI changes, please include Before and After screenshots. -->
### Before
![image](https://user-images.githubusercontent.com/22743709/71828120-98359780-3099-11ea-9daf-28752ca4b7c2.png)

### After
![image](https://user-images.githubusercontent.com/22743709/71828181-bd2a0a80-3099-11ea-885a-c70a1b584044.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Link to Trello card
https://trello.com/c/n0wiBbfB/699-dac-page-41-change-headings-on-provider-offer-page-so-they-are-in-a-hierarchical-order
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
