### PR TITLE
Provider user accepts data sharing agreement for provider

### DIFF
--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -2,6 +2,7 @@ module ProviderInterface
   class ContentController < ProviderInterfaceController
     include ContentHelper
     skip_before_action :authenticate_provider_user!
+    skip_before_action :check_data_sharing_agreements
     layout 'application'
 
     helper_method :current_provider_user

--- a/app/controllers/provider_interface/provider_agreements_controller.rb
+++ b/app/controllers/provider_interface/provider_agreements_controller.rb
@@ -1,0 +1,42 @@
+module ProviderInterface
+  class ProviderAgreementsController < ProviderInterfaceController
+    skip_before_action :check_data_sharing_agreements
+
+    def new_data_sharing_agreement
+      @provider_agreement = GetPendingDataSharingAgreementsForProviderUser.call(provider_user: current_provider_user).first
+      if @provider_agreement
+        render :data_sharing_agreement
+      else
+        redirect_to provider_interface_path
+      end
+    end
+
+    def create_data_sharing_agreement
+      @provider_agreement = ProviderAgreement.new(provider_agreement_params.merge(provider_user: current_provider_user))
+      if @provider_agreement.save
+        redirect_to provider_interface_path
+      else
+        render :data_sharing_agreement
+      end
+    end
+
+    def show_data_sharing_agreement
+      @provider_agreement = ProviderAgreement.find_by_id params[:id]
+      if @provider_agreement
+        render :data_sharing_agreement
+      else
+        redirect_to provider_interface_path
+      end
+    end
+
+  private
+
+    def provider_agreement_params
+      params.require(:provider_agreement).permit(
+        :accept_agreement,
+        :agreement_type,
+        :provider_id,
+      )
+    end
+  end
+end

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -4,6 +4,7 @@ module ProviderInterface
     before_action :authenticate_provider_user!
     around_action :set_audit_username
     before_action :add_identity_to_log
+    before_action :check_data_sharing_agreements
 
     layout 'application'
 
@@ -57,6 +58,12 @@ module ProviderInterface
 
       RequestLocals.store[:identity] = { dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid }
       Raven.user_context(dfe_sign_in_uid: current_provider_user.dfe_sign_in_uid)
+    end
+
+    def check_data_sharing_agreements
+      if GetPendingDataSharingAgreementsForProviderUser.call(provider_user: current_provider_user).any?
+        redirect_to provider_interface_new_data_sharing_agreement_path
+      end
     end
   end
 end

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -1,6 +1,8 @@
 module ProviderInterface
   class SessionsController < ProviderInterfaceController
     skip_before_action :authenticate_provider_user!
+    skip_before_action :check_data_sharing_agreements
+
     def new; end
 
     def destroy

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class ProviderUsersController < SupportInterfaceController
     def index
-      @provider_users = ProviderUser.all
+      @provider_users = ProviderUser.includes(:providers).all
     end
 
     def new

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -6,6 +6,7 @@ module SupportInterface
 
     def show
       @provider = Provider.includes(:courses, :sites).find(params[:provider_id])
+      @provider_agreement = ProviderAgreement.data_sharing_agreements.for_provider(@provider).last
     end
 
     def sync

--- a/app/frontend/styles/_styled-content.scss
+++ b/app/frontend/styles/_styled-content.scss
@@ -11,6 +11,11 @@
     @extend %govuk-heading-s;
   }
 
+  h5 {
+    @extend %govuk-heading-s;
+    font-size: 0.99em;
+  }
+
   p,
   dl {
     @extend %govuk-body-m;

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,6 +5,7 @@ class Provider < ApplicationRecord
   has_many :application_choices, through: :course_options
 
   has_and_belongs_to_many :provider_users
+  has_many :provider_agreements
 
   def name_and_code
     "#{name} (#{code})"

--- a/app/models/provider_agreement.rb
+++ b/app/models/provider_agreement.rb
@@ -1,0 +1,26 @@
+class ProviderAgreement < ActiveRecord::Base
+  belongs_to :provider
+  belongs_to :provider_user
+  attr_accessor :accept_agreement
+
+  validates :accept_agreement, :agreement_type, :provider, :provider_user, presence: true
+  validate :provider_is_associated_with_the_user
+  before_create :set_accepted_at
+
+  scope :data_sharing_agreements, -> { where(agreement_type: :data_sharing_agreement) }
+  scope :for_provider, ->(specific_provider) { where(provider: specific_provider) }
+
+private
+
+  def provider_is_associated_with_the_user
+    if provider && provider_user
+      unless provider.provider_users.pluck(:id).include? provider_user.id
+        errors.add(:provider, 'Provider/user mismatch')
+      end
+    end
+  end
+
+  def set_accepted_at
+    self.accepted_at ||= Time.zone.now
+  end
+end

--- a/app/services/get_pending_data_sharing_agreements_for_provider_user.rb
+++ b/app/services/get_pending_data_sharing_agreements_for_provider_user.rb
@@ -1,0 +1,9 @@
+class GetPendingDataSharingAgreementsForProviderUser
+  def self.call(provider_user:)
+    providers = provider_user.providers
+    no_dsa = providers.where.not(id: ProviderAgreement.data_sharing_agreements.for_provider(providers).select(:provider_id))
+    no_dsa.map do |provider|
+      ProviderAgreement.new(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user)
+    end
+  end
+end

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -1,0 +1,427 @@
+<% page_name = 'data_sharing_agreement' %>
+<%= content_for :title, t("page_titles.#{page_name}") %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t("page_titles.#{page_name}") %></h1>
+
+    <div class="app-styled-content">
+
+      <p>between the Department of Education (DfE) and <em><%= @provider_agreement.provider.name %></em>, ‘the provider’.</p>
+
+      <h2>What we ask of you when you use and share data</h2>
+
+      <p>
+        Our data sharing agreement sets out how you should use and look after the data we share with you.
+        Please read the data sharing agreement below in full to check you can meet your responsibilities.
+        Once you have read it, please scroll to the bottom of the page to accept it.
+      </p>
+
+      <hr>
+
+      <h2>Data sharing agreement for Apply for teacher training</h2>
+
+      <p>
+        This agreement applies to personal data shared between the Department for Education (DfE) and
+        <em><%= @organisation_name %></em>,
+        ‘the provider’, as part of Apply for teacher training.
+      </p>
+
+      <h3 class="app-contents-list__title">What’s in this data sharing agreement?</h3>
+
+      <ol class="app-contents-list__list">
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <a class="app-contents-list__link" href="#section-1">Section 1: Introduction</a>
+          <p style="padding: 12px 0 0 10px;">
+            <a class="app-contents-list__link" href="#section-1-1">1.1 Background</a><br>
+          </p>
+        </li>
+
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <a class="app-contents-list__link" href="#section-2">
+            Section 2: What personal data DfE and the provider process/share and why
+          </a>
+          <p style="padding: 12px 0 0 10px;">
+            <a class="app-contents-list__link" href="#section-2-1">2.1 What data DfE and the provider will process/share</a><br>
+            <a class="app-contents-list__link" href="#section-2-2">2.2 What the provider can use personal data for</a><br>
+            <a class="app-contents-list__link" href="#section-2-3">2.3 What DfE can use personal data for</a>
+          </p>
+        </li>
+
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <a class="app-contents-list__link" href="#section-3">
+            Section 3: DfE’s legal basis for sharing/processing personal data
+          </a>
+          <p style="padding: 12px 0 0 10px;">
+            <a class="app-contents-list__link" href="#section-3-1">3.1 Lawful conditions for sharing/processing personal data</a><br>
+            <a class="app-contents-list__link" href="#section-3-2">3.2 The right to respect for private and family life</a><br>
+            <a class="app-contents-list__link" href="#section-3-3">3.3 Privacy notices</a>
+          </p>
+        </li>
+
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <a class="app-contents-list__link" href="#section-4">
+            Section 4: Data handling
+          </a>
+
+          <p style="padding: 12px 0 0 10px;">
+            <a class="app-contents-list__link" href="#section-4-1">4.1 Process and systems used for sharing data</a> <br>
+            <a class="app-contents-list__link" href="#section-4-2">4.2 Accuracy of the shared data</a><br>
+            <a class="app-contents-list__link" href="#section-4-3">4.3 Assurance of compliance</a><br>
+            <a class="app-contents-list__link" href="#section-4-4">4.4 Third party disclosure</a><br>
+            <a class="app-contents-list__link" href="#section-4-5">4.5 Handling subject access requests (SARs)</a><br>
+            <a class="app-contents-list__link" href="#section-4-6">4.6 Handling Freedom of Information Act Requests</a><br>
+            <a class="app-contents-list__link" href="#section-4-7">4.7 Data storage</a><br>
+            <a class="app-contents-list__link" href="#section-4-8">4.8 Retention schedule</a><br>
+            <a class="app-contents-list__link" href="#section-4-9">4.9 Destruction schedule</a>
+          </p>
+        </li>
+
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <a class="app-contents-list__link" href="#section-5">
+            Section 5: Security Breaches
+          </a>
+
+          <p style="padding: 12px 0 0 10px;">
+            <a class="app-contents-list__link" href="#section-5-1">5.1 Security incidents</a><br>
+            <a class="app-contents-list__link" href="#section-5-2">5.2 Consequences of security incident</a>
+          </p>
+        </li>
+
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <a class="app-contents-list__link" href="#section-6">
+            Section 6: Issues, disputes and resolution between participants
+          </a>
+
+          <p style="padding: 12px 0 0 10px;">
+            <a class="app-contents-list__link" href="#section-6-1">6.1 Resolving disputes</a>
+          </p>
+        </li>
+
+        <li class="app-contents-list__list-item app-contents-list__list-item--parent">
+          <a class="app-contents-list__link" href="#section-7">
+            Section 7: Termination
+          </a>
+
+          <p style="padding: 12px 0 0 10px;">
+            <a class="app-contents-list__link" href="#section-7-1">7.1 When to terminate this agreement</a>
+          </p>
+        </li>
+      </ol>
+
+      <div class="sections" style="padding-top: 10px;">
+
+        <section id="section-1">
+          <h3>Section 1: Introduction</h3>
+
+          <h4 id="section-1-1">Background</h4>
+
+          <h5>What is Apply for teacher training?</h5>
+          <p>
+            Apply for teacher training is a new service designed by the Department for Education (DfE).
+            It will replace UCAS Teacher Training as the new route into initial teacher training.
+            Apply for teacher training and the data processing activities described in this document operate under the Secretary of State for Education’s ministerial common law powers.
+          </p>
+
+          <h5>Why is DfE developing this service?</h5>
+          <p>
+            DfE research showed that teacher training candidates and training providers find the current application and selection process difficult.
+            DfE is trying to reduce the number of people dropping out of applying for teacher training by building a new application process.
+            Apply for teacher training will eventually share data with approximately 2,000 teacher training providers.
+            DfE is trialling the service with selected teacher training providers. The trial will help DfE improve the service and inform government policy relating to teacher retention and recruitment.
+          </p>
+
+          <h5>Why do we need this data sharing agreement?</h5>
+          <p>
+            To run this service, DfE and teacher training providers need to share personal data. This includes sharing the data of:
+          </p>
+          <ul>
+            <li>teacher training applicants</li>
+            <li>staff processing applications (within DfE/within the teacher training organisation)</li>
+            <li>candidates’ referees</li>
+          </ul>
+          <p>
+            This data sharing agreement sets out DfE’s and the provider’s responsibilities when looking after this personal data.
+          </p>
+        </section>
+
+        <section id="section-2">
+          <h3>Section 2: What personal data DfE and the provider process/share and why</h3>
+
+          <h4 id="section-2-1">What data DfE and the provider will process/share</h4>
+
+          <h5>Candidates</h5>
+          <p>
+            DfE and the provider will process and share some information about candidates including their:
+          </p>
+          <ul>
+            <li>name</li>
+            <li>address</li>
+            <li>date of birth</li>
+            <li>phone number</li>
+            <li>email address</li>
+            <li>any other personal/special category data that they choose to include in their application form (such as whether they’re disabled)</li>
+          </ul>
+          <p>
+            DfE will also get information from the provider about candidates, such as:
+          </p>
+          <ul>
+            <li>whether candidates were successful in their application (as well as the reasons why/why not)</li>
+            <li>whether candidates met their conditions (including passing an enhanced DBS check)</li>
+            <li>whether candidates enrolled</li>
+          </ul>
+
+          <h5>Referees</h5>
+          <p>
+            DfE and the provider will process and share some information about referees so that references can be processed. This includes their:
+          </p>
+          <ul>
+            <li>name</li>
+            <li>email address</li>
+            <li>relationship to the candidate</li>
+          </ul>
+
+          <h5>Staff</h5>
+          <p>
+            DfE and the provider may also share the names and contact details of relevant staff within DfE/within the teacher training organisation so that applications can be processed.
+            It is the provider’s responsibility to communicate this to relevant staff within their organisation.
+          </p>
+
+          <h4 id="section-2-2">What the provider can use personal data for</h4>
+
+          <p>
+            The provider can use data to process teacher training applications, in the ways outlined by this data sharing agreement.
+            Processing teacher training applications for the provider means:
+          </p>
+          <ul>
+            <li>getting in touch with a candidate about their application/the information they submitted - for example, to ask if a candidate needs reasonable adjustments to attend an interview</li>
+            <li>getting in touch with referees/candidates/relevant DfE staff if there has been a data security issue</li>
+            <li>making decisions on applications</li>
+            <li>getting statistics for internal use</li>
+            <li>contacting relevant staff at DfE if necessary to process an application</li>
+          </ul>
+
+          <h4 id="section-2-3">What DfE can use personal data for</h4>
+
+          <p>
+            DfE can use data to process teacher training applications, build a better teacher training application process and get insight to inform government policy.
+            This includes (but may not be limited to):
+          </p>
+          <ul>
+            <li>processing funding/bursary payments</li>
+            <li>analysing teacher training applications</li>
+            <li>analysing feedback from candidates and providers</li>
+            <li>getting in touch with candidates regarding their application</li>
+            <li>getting in touch with provider staff, candidates or referees if there has been a data security issue</li>
+            <li>getting in touch with relevant staff within the teacher training organisation if necessary to process an application</li>
+          </ul>
+          <p>
+            DfE will also share some of the data it collects through Apply for teacher training with UCAS. This is so that DfE can:
+          </p>
+          <ul>
+            <li>ensure candidates are using the two services according to DfE/UCAS policies, and contact candidates if they accept offers on both services</li>
+            <li>allow DfE/UCAS to see how many people are applying for teacher training across UCAS and Apply for teacher training, in order to carry out statistical analysis</li>
+          </ul>
+        </section>
+
+        <section id="section-3">
+          <h3>Section 3: DfE’s legal basis for sharing/processing personal data</h3>
+
+          <h4 id="section-3-1">Lawful conditions for sharing/processing personal data</h4>
+          <p>
+            Apply for teacher training and the data processing activities described in this document operate under the Secretary of State for Education’s Ministerial common law powers.
+            Apply for teacher training is in the public interest, as outlined under the following legislation:
+          </p>
+          <ul>
+            <li>Article 6(1)(e) and Article 9(2)(g) of the General Data Protection Regulation</li>
+            <li>Section 8 of the Data Protection Act 2018</li>
+          </ul>
+
+          <h4 id="section-3-2">The right to respect for private and family life</h4>
+          <p>
+            Participants will not be asked to share information related to their private or family lives.
+          </p>
+
+          <h4 id="section-3-3">Privacy notices</h4>
+          <p>
+            Please see the <a href="/provider/privacy-policy">Apply for teacher training privacy policy for candidates, referees and provider staff</a>.
+            DfE will make data subjects aware about how their data will be processed before data is collected through Apply for teacher training.
+            Please see DfE’s Personal Information Charter for more details on the organisation’s data storage and sharing policies.
+            By agreeing to this data sharing agreement, DfE and the provider confirm that their respective privacy policies explain the data sharing activities outlined in this agreement.
+            Privacy policies should outline the purposes of processing data, and the lawful basis for doing so.
+          </p>
+        </section>
+
+        <section id="section-4">
+          <h3>Section 4: Data handling</h3>
+
+          <h4 id="section-4-1">Process and systems used for sharing data</h4>
+          <p>
+            DfE and the provider are joint data controllers for the data collected through Apply for teacher training.<br><br>
+            DfE gives the provider access to the data through a digital service that allows providers to log in securely.<br><br>
+            Later on in the trial of the service, DfE will give relevant providers access to data through API systems which integrate with providers’ student record systems.<br><br>
+            DfE uses Zendesk, a customer relationship management system, to handle queries from providers. Zendesk uses various safeguards to look after data.<br><br>
+            DfE may also use G Suite to collect and share information, such as references, with the provider.<br><br>
+            DfE and the provider may also share some data through other channels, such as by phone or email.<br><br>
+            Refer to section on ‘Third party disclosure’ for more information on how DfE shares data.
+          </p>
+
+          <h4 id="section-4-2">Accuracy of the shared data</h4>
+          <p>
+            DfE undertakes to ensure that the data given to the provider accurately reflects the information given to DfE, though the format may be different.
+          </p>
+
+          <h4 id="section-4-3">Assurance of compliance</h4>
+          <p>
+            DfE’s Personal information charter explains the standards expected of DfE when holding personal information.
+            By signing this agreement, the provider confirms that:
+          </p>
+          <ul>
+            <li>their organisation is compliant with GDPR</li>
+            <li>data will be held in secure systems in line with data protection legislation</li>
+            <li>data will be held for only as long as needed for the purposes outlined in this agreement, and destroyed when no longer needed</li>
+            <li>they will comply with the security requirements for holding official data</li>
+            <li>it’s in the interest of both parties to comply with data protection legislation (to protect people’s rights and minimise data processing risks, such as reputational damage)</li>
+          </ul>
+
+          <h4 id="section-4-4">Third party disclosure</h4>
+          <p>
+            Within DfE, access to data will be restricted to teams that need it for processing applications, building a better teacher training application and getting insight to inform government policy.
+            DfE uses some third-party data processors, including Google Analytics, G Suite, Zendesk and Microsoft Azure.
+            Providers must follow guidance from the Information Commissioner's Office on appointing and using appropriate data processors.
+            It is the provider’s responsibility to ensure that data subjects know who processes data on their behalf and under what legal authority.
+            By signing this agreement, the provider confirms that:
+          </p>
+          <ul>
+            <li>their data sharing practices comply with data protection legislation</li>
+            <li>their data sharing practices minimise the risk of individuals being identified by unauthorised parties, using appropriate safeguards to look after shared data</li>
+            <li>they will only share data for the purposes outlined in this agreement</li>
+            <li>they hold data in strict confidence and have appropriate safeguards in place to protect data against unlawful or unauthorised processing</li>
+          </ul>
+
+          <h4 id="section-4-5">Handling subject access requests (SARs)</h4>
+            <p>
+              DfE will manage SAR requests regarding any information DfE holds.
+              DfE and the provider will contact each other immediately if they get a request for:
+            </p>
+            <ul>
+              <li>rectification of information (Article 16 of GDPR)</li>
+              <li>erasure of information (Article 17 of GDPR)</li>
+              <li>restriction to process information (Article 18 of GDPR)</li>
+            </ul>
+            <p>
+              For other types of SAR, the provider must notify DFE within 5 working days.
+              Data subjects wanting to make a SAR can email DfE at becomingateacher@digital.education.gov.uk.
+            </p>
+
+          <h4 id="section-4-6">Handling Freedom of Information Act Requests</h4>
+          <p>
+            DfE takes responsibility for responding to Freedom of Information Act Requests regarding Apply for teacher training data processing/sharing practices.
+            DfE will contact the provider if any support is needed to process a request.
+          </p>
+
+          <h4 id="section-4-7">Data storage</h4>
+          <p>
+            The provider must store shared data securely.
+            Data should be encrypted at rest, using modern, full disk encryption such as Windows BitLocker, or Linux/dm-crypt.
+            The data must be retained within the EEA, for example on cloud providers within Europe.
+            By signing this agreement, DfE and the provider agree to:
+          </p>
+          <ul>
+            <li>hold data in strict confidence</li>
+            <li>have appropriate safeguards in place to protect data against unlawful or unauthorised processing</li>
+          </ul>
+
+          <h4 id="section-4-8">Retention schedule </h4>
+          <p>
+            Personal data must be kept only as long as needed to carry out the activities outlined in this document.
+            DfE will keep data for 7 years.
+            The provider must set an appropriate time limit, in line with the General Data Protection Regulation, for retaining data before erasure or review.
+          </p>
+
+          <h4 id="section-4-9">Destruction schedule</h4>
+          <p>
+            The provider should destroy the data when it is no longer needed, or when the retention schedule has expired.
+            The provider should follow the NCSC guidance for secure sanitisation.
+          </p>
+        </section>
+
+        <section id="section-5">
+          <h3>Section 5: Security Breaches</h3>
+
+          <h4 id="section-5-1">Security incidents</h4>
+          <p>
+            DfE and the provider are responsible for notifying each other in writing in the event of loss or unauthorised disclosure of information within 24 hours of the event being discovered.
+            The designated points of contact will discuss and agree the next steps relating to the incident, taking specialist advice where appropriate.
+            Such arrangements will include (but will not be limited to):
+          </p>
+          <ul>
+            <li>containing the incident and mitigating any ongoing risk</li>
+            <li>recovering information</li>
+            <li>assessing whether the Information Commissioner should be notified or whether data protection officers or data subjects need to be notified</li>
+          </ul>
+          <p>
+            The arrangements may vary in each case, depending on the sensitivity of the information and the nature of the loss or unauthorised disclosure.
+            Where appropriate and if relevant to the incident, disciplinary misconduct action/criminal proceedings will be considered.
+          </p>
+
+          <h4 id="section-5-2">Consequences of security incident</h4>
+          <p>
+            Any security incident that occurs will not impact DfE’s ongoing cooperation with the provider.
+            In the event of a personal data breach (or where there is a reason to believe that an incident could arise) DfE and the provider will delay data transfers until the signatories of this agreement are satisfied that the cause/incident is resolved.
+            If the issue can’t be resolved or if it’s very serious, data sharing won’t start again until DfE and the provider are satisfied that the cause/incident is resolved.
+            The DfE contact would raise the incident with the DfE departmental security team and complete formal procedures in the event of a personal data breach.
+          </p>
+        </section>
+
+        <section id="section-6">
+          <h3>Section 6: Issues, disputes and resolution between participants</h3>
+
+          <h4 id="section-6-1">Resolving disputes</h4>
+          <p>
+            Any issues or disputes that arise as a result of the data sharing covered by this agreement must be directed to the relevant contact points at DfE and the provider.
+            DfE and the provider will be responsible for escalating the issue as necessary within their organisations.
+            Where a problem arises it should be reported as soon as possible.
+            Should the problem be of an urgent nature, it must be reported by phone immediately, and followed up in writing the same day.
+            If the problem is not of an urgent nature it can be reported in writing within 24 hours of the problem occurring.
+          </p>
+        </section>
+
+        <section id="section-6">
+          <h3>Section 7: Termination</h3>
+
+          <h4 id="section-7-1">When to terminate this agreement</h4>
+          <p>
+            Both participants to this DSA reserve the right to terminate this DSA with three months’ notice in the following circumstances:
+          </p>
+          <ul>
+            <li>by reason of cost, resources or other factors beyond the control of DfE or the provider</li>
+            <li>if any change occurs which, in the opinion of DfE and the provider, significantly impairs the value of the data sharing arrangement in meeting their objectives</li>
+          </ul>
+          <p>
+            In the event of a significant security breach or other serious breach of the terms of this DSA by either participant, the DSA will be terminated or suspended immediately without notice.
+          </p>
+        </section>
+      </div>
+
+      <% if !@provider_agreement.persisted? %>
+        <%= form_with model: @provider_agreement, url: provider_interface_create_data_sharing_agreement_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: false } do |f| %>
+          <%= f.govuk_error_summary %>
+          <%= f.hidden_field :agreement_type %>
+          <%= f.hidden_field :provider_id %>
+          <% declaration = "#{@provider_agreement.provider.name} agrees to comply with the data sharing practices outlined in this agreement" %>
+          <%= f.govuk_check_box :accept_agreement, true, multiple: false, link_errors: true, label: { text: declaration } %>
+          <%= f.govuk_submit 'Continue' %>
+        <% end %>
+      <% else %>
+        <div class="govuk-panel govuk-panel--confirmation">
+          <div class="govuk-panel__body">
+            <strong><%= @provider_agreement.provider.name %></strong>
+            agreed to comply with the data sharing practices outlined in this agreement on
+            <%= @provider_agreement.accepted_at.to_s(:govuk_date_and_time) %>.
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -5,6 +5,22 @@
 <% if @provider.courses.any? %>
   <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>
     <h3 class="govuk-heading-m">
+      Data Sharing Agreement
+    </h3>
+
+    <p class="govuk-body">
+      <% if @provider_agreement %>
+        Accepted by <strong>
+        <%= @provider_agreement.provider_user.email_address %>
+        </strong>
+        on
+        <%= @provider_agreement.accepted_at.to_s(:govuk_date) %>.
+      <% else %>
+        No data sharing agreement has been accepted yet.
+      <% end %>
+    </p>
+
+    <h3 class="govuk-heading-m">
       Open all courses
     </h3>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,7 @@ en:
     unprocessable_entity: Sorry, there is a problem with the service
     personal_details: Personal details
     review_application: Review your application
+    data_sharing_agreement: Data sharing agreement
     accessibility: Accessibility statement
     privacy_policy: How we look after your personal data
     terms_candidate: Terms of use for candidates
@@ -162,6 +163,10 @@ en:
           attributes:
             status:
               invalid_transition: The application is not ready for that action
+        provider_agreement:
+          attributes:
+            accept_agreement:
+              blank: You have to agree to these terms to use this service
   errors:
     messages:
       too_many_words: Must be %{count} words or fewer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,10 @@ Rails.application.routes.draw do
     get '/cookies', to: 'content#cookies_provider', as: :cookies
     get '/terms-of-use', to: 'content#terms_provider', as: :terms
 
+    get '/data-sharing-agreements/new', to: 'provider_agreements#new_data_sharing_agreement', as: :new_data_sharing_agreement
+    post '/data-sharing-agreements', to: 'provider_agreements#create_data_sharing_agreement', as: :create_data_sharing_agreement
+    get '/data-sharing-agreements/:id', to: 'provider_agreements#show_data_sharing_agreement', as: :show_data_sharing_agreement
+
     get '/applications' => 'application_choices#index'
     get '/applications/:application_choice_id' => 'application_choices#show', as: :application_choice
     get '/applications/:application_choice_id/respond' => 'decisions#respond', as: :application_choice_respond
@@ -255,7 +259,6 @@ Rails.application.routes.draw do
     post '/applications/:application_choice_id/reject' => 'decisions#create_reject', as: :application_choice_create_reject
     post '/applications/:application_choice_id/offer/confirm' => 'decisions#confirm_offer', as: :application_choice_confirm_offer
     post '/applications/:application_choice_id/offer' => 'decisions#create_offer', as: :application_choice_create_offer
-
 
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -146,6 +146,29 @@ FactoryBot.define do
     initialize_with { Provider.find_or_create_by code: code }
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     name { Faker::Educator.university }
+
+    transient do
+      provider_agreements_count { 1 }
+    end
+
+    trait :without_agreements do
+      provider_agreements_count { 0 }
+    end
+
+    after(:build) do |provider, evaluator|
+      create_list(:provider_agreement, evaluator.provider_agreements_count, provider: provider)
+    end
+  end
+
+  factory :provider_agreement do
+    association :provider, factory: %i[provider without_agreements]
+    provider_user
+    agreement_type { :data_sharing_agreement }
+    accept_agreement { true }
+
+    after(:build) do |_agreement, evaluator|
+      evaluator.provider.provider_users << evaluator.provider_user
+    end
   end
 
   factory :application_choice do

--- a/spec/models/provider_agreement_spec.rb
+++ b/spec/models/provider_agreement_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe ProviderAgreement, type: :model do
+  describe 'a valid provider_agreement' do
+    subject(:provider_agreement) { create(:provider_agreement) }
+
+    it { is_expected.to belong_to :provider }
+    it { is_expected.to belong_to :provider_user }
+    it { is_expected.to validate_presence_of :agreement_type }
+    it { is_expected.to validate_presence_of :accept_agreement }
+  end
+
+  describe 'provider/provider_user association' do
+    it 'is validated in the model' do
+      provider = create(:provider, :without_agreements)
+      provider_user = create(:provider_user)
+      agreement = ProviderAgreement.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
+      expect(agreement).not_to be_valid
+    end
+  end
+
+  describe ':accepted_at' do
+    it 'is set automatically on :create' do
+      provider = create(:provider, :without_agreements)
+      provider_user = create(:provider_user)
+      provider.provider_users << provider_user
+      agreement = ProviderAgreement.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
+      expect(agreement.accepted_at).not_to be_nil
+    end
+  end
+
+  describe '#data_sharing_agreements' do
+    it 'returns only data_sharing_agreements' do
+      create(:provider_agreement, agreement_type: :data_sharing_agreement)
+      create(:provider_agreement, agreement_type: :other_type)
+      expect(ProviderAgreement.count).to eq(2)
+      expect(ProviderAgreement.data_sharing_agreements.count).to eq(1)
+    end
+  end
+
+  describe '#for_provider' do
+    it 'returns agreements scoped to a provider' do
+      data_sharing_agreement = create(:provider_agreement, agreement_type: :data_sharing_agreement)
+      other_provider = create(:provider, :without_agreements, code: 'ZZZ', name: 'Other')
+      create(:provider_agreement, provider: other_provider)
+      expect(ProviderAgreement.count).to eq(2)
+      expect(ProviderAgreement.for_provider(data_sharing_agreement.provider).count).to eq(1)
+    end
+  end
+end

--- a/spec/services/get_pending_data_sharing_agreements_for_provider_user_spec.rb
+++ b/spec/services/get_pending_data_sharing_agreements_for_provider_user_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe GetPendingDataSharingAgreementsForProviderUser do
+  describe 'one user, one provider' do
+    let(:provider) { create(:provider, :without_agreements, code: 'ABC', name: 'Example provider') }
+    let(:provider_user) { create(:provider_user) }
+
+    before { provider.provider_users << provider_user }
+
+    it 'returns one unpersisted ProviderAgreement for this provider if no other agreements already exist' do
+      pending_agreements = GetPendingDataSharingAgreementsForProviderUser.call provider_user: provider_user
+      expect(pending_agreements.count).to eq(1)
+      expect(pending_agreements.first.provider.id).to eq(provider.id)
+      expect(pending_agreements.first).not_to be_persisted
+    end
+
+    it 'returns empty array if agreement for this provider already exists' do
+      ProviderAgreement.create(accept_agreement: true, agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user)
+      pending_agreements = GetPendingDataSharingAgreementsForProviderUser.call provider_user: provider_user
+      expect(pending_agreements.count).to eq(0)
+    end
+  end
+
+  describe 'one user, many providers' do
+    let(:provider1) { create(:provider, :without_agreements, code: 'ABC', name: 'Example provider 1') }
+    let(:provider2) { create(:provider, :without_agreements, code: 'CBA', name: 'Example provider 2') }
+    let(:provider_user) { create(:provider_user) }
+
+    before do
+      provider1.provider_users << provider_user
+      provider2.provider_users << provider_user
+    end
+
+    it 'returns provider agreements for all associated providers if no agreements exist' do
+      pending_agreements = GetPendingDataSharingAgreementsForProviderUser.call provider_user: provider_user
+      expect(pending_agreements.count).to eq(2)
+      expect(pending_agreements.first.provider.id).to eq(provider1.id)
+      expect(pending_agreements.second.provider.id).to eq(provider2.id)
+    end
+
+    it 'returns provider agreements only for providers that need one' do
+      ProviderAgreement.create(accept_agreement: true, agreement_type: :data_sharing_agreement, provider: provider2, provider_user: provider_user)
+      pending_agreements = GetPendingDataSharingAgreementsForProviderUser.call provider_user: provider_user
+      expect(pending_agreements.count).to eq(1)
+      expect(pending_agreements.first.provider.id).to eq(provider1.id)
+    end
+  end
+end

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -23,7 +23,7 @@ module DfESignInHelpers
   end
 
   def provider_user_exists_in_apply_database
-    provider = create(:provider, code: 'ABC')
+    provider = create(:provider, code: 'ABC', name: 'Example Provider')
     create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
   end
 

--- a/spec/system/provider_interface/provider_accepts_data_sharing_agreement.rb
+++ b/spec/system/provider_interface/provider_accepts_data_sharing_agreement.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.feature 'Accept data sharing agreement' do
+  include DfESignInHelpers
+
+  scenario 'Provider user cannot access provider_interface without a data sharing agreement in place' do
+    given_i_am_an_authorised_provider_user
+    and_no_data_sharing_agreement_for_my_provider_has_been_accepted
+    when_i_navigate_to_the_provider_interface
+    then_i_am_redirected_to_the_data_sharing_agreement_pages
+  end
+
+  scenario 'Provider user accepts the data sharing agreement' do
+    given_i_am_an_authorised_provider_user
+    and_no_data_sharing_agreement_for_my_provider_has_been_accepted
+    and_i_am_presented_with_a_data_sharing_agreement
+    when_i_agree_to_the_data_sharing_agreement
+    then_i_can_navigate_to_the_provider_interface
+  end
+
+  scenario 'Provider user agrees to multiple data sharing agreements' do
+    given_i_am_an_authorised_provider_user
+    and_no_data_sharing_agreements_for_any_of_my_providers_exist
+    when_i_navigate_to_the_provider_interface
+    then_i_am_redirected_to_the_data_sharing_agreement_pages
+    when_i_agree_to_the_data_sharing_agreement
+    then_i_am_redirected_to_the_data_sharing_agreement_pages
+    when_i_agree_to_the_data_sharing_agreement_again
+    then_i_can_navigate_to_the_provider_interface
+  end
+
+  def given_i_am_an_authorised_provider_user
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def and_no_data_sharing_agreement_for_my_provider_has_been_accepted
+    provider = Provider.find_by_code('ABC')
+    ProviderAgreement.data_sharing_agreements.for_provider(provider).destroy_all
+  end
+
+  def and_no_data_sharing_agreements_for_any_of_my_providers_exist
+    provider_user = ProviderUser.find_by_dfe_sign_in_uid 'DFE_SIGN_IN_UID'
+    provider1 = Provider.find_by_code('ABC')
+    provider2 = create(:provider, code: 'CBA', name: 'Another Provider')
+    provider2.provider_users << provider_user
+    ProviderAgreement.data_sharing_agreements.for_provider(provider1).destroy_all
+    ProviderAgreement.data_sharing_agreements.for_provider(provider2).destroy_all
+  end
+
+  def when_i_navigate_to_the_provider_interface
+    visit provider_interface_applications_path
+  end
+
+  def then_i_am_redirected_to_the_data_sharing_agreement_pages
+    expect(page).to have_current_path provider_interface_new_data_sharing_agreement_path
+  end
+
+  def and_i_am_presented_with_a_data_sharing_agreement
+    visit provider_interface_new_data_sharing_agreement_path
+  end
+
+  def when_i_agree_to_the_data_sharing_agreement
+    check 'Example Provider agrees to comply with the data sharing practices outlined in this agreement', allow_label_click: true
+    click_on 'Continue'
+  end
+
+  def when_i_agree_to_the_data_sharing_agreement_again
+    check 'Another Provider agrees to comply with the data sharing practices outlined in this agreement', allow_label_click: true
+    click_on 'Continue'
+  end
+
+  def then_i_can_navigate_to_the_provider_interface
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+end


### PR DESCRIPTION
### Context

Provider users must be able to sign the data sharing agreement when they first access the platform. This will assist/streamline the onboarding of SCITTs to the service.

This new flow in the app will replace the current DocuSign-based manual process. The data sharing agreement will be presented within the app and clicking on a simple checkbox will be all that's needed to accept the agreement. The identity of the person agreeing, as well as the timestamp of the acceptance, will be recorded in the database and exposed in the provider interface.

Requirements:

- Each ~~user~~ provider accepts the data sharing agreement only once
- The first user from each `Provider` must select they 'agree to the data sharing agreement'
- No-one linked to a particular provider can access the provider interface until the relevant data sharing agreement has been accepted.

The data sharing agreement will be presented to the user as a web page. The organisation name will need to appear in a couple of places in the form and will be automatically populated by the app.

Even though provider users go through DfE Sign-in, there is a ProviderUser model we can store values against. However, the relationship between `Provider` and `ProviderUser` is many-to-many and acceptance of the data sharing agreement must be enforced at the `Provider` level. For now, we'll assume any association between a `Provider` and and a `ProviderUser` gives this user the the authority to accept the data sharing agreement on the provider's behalf.

### Changes proposed in this pull request

When a `ProviderUser` logs in, the relevant controller will check if any of their associated providers hasn't accepted the data sharing agreement. If this is the case, the controller will redirect the user to a data sharing agreement flow. Subsequent users for the same provider will not be redirected to this flow, provided the first user has completed the flow.

The data sharing agreement flow is triggered with this logic:

- The current user's list of associated providers is found
- We check if any of these providers have not accepted the data sharing agreement
- We trigger the data sharing agreement flow for the first of these providers
- Once the agreement has been accepted we redirect the user to the data sharing agreement flow for the next provider that requires it or the `provider_interface`.

In the database, agreement acceptance will be stored in a new table, `provider_agreements`. The table includes `provider_id`, `provider_user_id`, `agreement_type` and `accepted_at` fields.

Information about who has signed the data sharing agreement and when is visible in the support interface.

### Guidance to review

#### Provider Interface

The provider user in this screen capture has been associated with two providers, none of which have a data sharing agreement in place. Therefore, they need to accept two data sharing agreements before given access to the applications interface.

![optimised](https://user-images.githubusercontent.com/107591/72064852-bcc98380-32d4-11ea-97e5-65aa0782603b.gif)

#### Support Interface

Without agreement:
![image](https://user-images.githubusercontent.com/107591/72061469-d7e4c500-32cd-11ea-8b50-3ac9512b9200.png)

With agreement:
![image](https://user-images.githubusercontent.com/107591/72061481-e16e2d00-32cd-11ea-928f-67951fc84172.png)

### Link to Trello card

[Data sharing agreement onto 'Manage'](https://trello.com/c/X6sXsnEm)
