### PR TITLE
Fix field length in API, add missing "breaks:" field to work experience

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -45,6 +45,7 @@ module VendorApi
           work_experience: {
             jobs: work_experience_jobs,
             volunteering: work_experience_volunteering,
+            breaks: application_form.work_history_breaks,
           },
           offer: offer,
           rejection: get_rejection,

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -45,7 +45,7 @@ module VendorApi
           work_experience: {
             jobs: work_experience_jobs,
             volunteering: work_experience_volunteering,
-            breaks: application_form.work_history_breaks,
+            work_history_break_explanation: application_form.work_history_breaks,
           },
           offer: offer,
           rejection: get_rejection,

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,5 +1,15 @@
+### 7th January 2020
+
+- Correct size of
+  [`personal_statement`](/api-docs/reference#applicationattributes-object)
+  field to 11624 chars
+- Introduce `work_history_break_explanation` field to
+  [`work_experience`](/api-docs/reference#workexperiences-object).  This
+  contains the candidate’s explanation for any breaks in work history.
+
 ### v1.0 — 18th December 2019
 
 Initial release of the API.
 
-For a log of pre-release changes, [see the alpha release notes](/api-docs/alpha-release-notes).
+For a log of pre-release changes, [see the alpha release
+notes](/api-docs/alpha-release-notes).

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -753,6 +753,7 @@ components:
       required:
         - jobs
         - volunteering
+        - breaks
       properties:
         jobs:
           type: array
@@ -764,6 +765,12 @@ components:
           description: The candidate’s experience as a volunteer
           items:
             $ref: "#/components/schemas/WorkExperience"
+        breaks:
+          type: string
+          nullable: true
+          description: The candidate’s explanation for any breaks in work history
+          maxLength: 4096 # 400 words
+          example: 'I spent time volunteering overseas...'
 
     WorkExperience:
       type: object

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -377,7 +377,7 @@ components:
           example: "2019-06-13T23:59:59Z"
         personal_statement:
           type: string
-          maxLength: 6144  # 600 words
+          maxLength: 11264  # 1000 words + 100 for our introductory text
           description: The candidate’s personal statement, combined from the "Becoming a Teacher" and "Subject Knowledge" fields in the application form
           example: "Since retiring from the Police Service in 2007..."
         interview_preferences:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -753,7 +753,7 @@ components:
       required:
         - jobs
         - volunteering
-        - breaks
+        - work_history_break_explanation
       properties:
         jobs:
           type: array
@@ -765,10 +765,10 @@ components:
           description: The candidate’s experience as a volunteer
           items:
             $ref: "#/components/schemas/WorkExperience"
-        breaks:
+        work_history_break_explanation:
           type: string
           nullable: true
-          description: The candidate’s explanation for any breaks in work history
+          description: The candidate’s explanation for any breaks in work history. Will be null if there aren't any breaks in the candidate’s work history. We define a break in work history as more than a month between 2 jobs.
           maxLength: 4096 # 400 words
           example: 'I spent time volunteering overseas...'
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -196,6 +196,11 @@ module CandidateHelper
     end
 
     click_button t('application_form.work_history.complete_form_button')
+
+    click_link t('application_form.work_history.break.enter_label')
+    fill_in 'candidate_interface_work_breaks_form[work_history_breaks]', with: 'I was unwell'
+    click_button t('application_form.work_history.break.button')
+
     check t('application_form.work_history.review.completed_checkbox')
     click_button t('application_form.work_history.review.button')
   end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -186,6 +186,7 @@ RSpec.feature 'Vendor receives the application' do
               description: 'I volunteered.',
             },
           ],
+          breaks: 'I was unwell',
         },
       },
     }

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -186,7 +186,7 @@ RSpec.feature 'Vendor receives the application' do
               description: 'I volunteered.',
             },
           ],
-          breaks: 'I was unwell',
+          work_history_break_explanation: 'I was unwell',
         },
       },
     }


### PR DESCRIPTION
## Context

When working through the API fields to check their lengths and validation criteria we noticed some inconsistencies:

- The personal statement field in the API has a 600 char limit. In fact this field is made out of the "Personal statement" and "Subject knowledge" sections of the form, so the total is in fact 1000 words. On top of that we add some text to explain that there are two sections munged into this field.
- The API does not include a reason for a break in work history
- The API does not include a reason for not having a Maths GCSE

## Changes proposed in this pull request

- increase the character count on `personal_statement`
- introduce a `breaks` field to `work_experience`

The Maths GCSE issue is left out as this information isn't currently in the Provider UI and we need to decide where it goes.

## Link to Trello card

https://trello.com/c/6vU8nJ7i/1433-personal-statement-field-has-wrong-length-in-api

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
