### PR TITLE
Mark optional standard conditions with ‘Optional’ in brackets

### DIFF
--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -23,8 +23,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: 'Standard conditions', size: 'm', tag: 'h2' } do %>
-          <%= f.govuk_check_box :standard_conditions, 'Fitness to Teach check', label: { text: 'Fitness to Teach check' } %>
-          <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check' } %>
+          <%= f.govuk_check_box :standard_conditions, 'Fitness to Teach check', label: { text: 'Fitness to Teach check (optional)' } %>
+          <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check (optional)' } %>
       <% end %>
 
       <fieldset class="govuk-fieldset">


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The checkboxes under ‘Standard conditions’ are optional; however, they are not denoted by the word ‘Optional’ in brackets included in the label.
When asking for optional information, consider marking the labels of optional fields with ‘(optional)’. Please refer to [Asking users questions](https://design-system.service.gov.uk/patterns/question-pages/) for more information about asking users for optional information.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds the word  ‘Optional’ in brackets for the standard conditions checkboxes

### Before
![image](https://user-images.githubusercontent.com/22743709/71831044-fa919680-309f-11ea-9289-042ba4b956ab.png)

### After
![image](https://user-images.githubusercontent.com/22743709/71831071-0a10df80-30a0-11ea-8168-7b8a4e894a01.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/hW5m9EFg/702-dac-page-50-add-optional-to-standard-conditions-in-provider-applications-offer-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
