### PR TITLE
Fall back to an empty header if no header is specified for the current namespace

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -73,6 +73,12 @@
                  service_name: service_name,
                  service_url: service_link,
                  navigation_items: NavigationItems.for_api_docs(controller)) %>
+    <% else %>
+      <%= render(HeaderComponent,
+                 classes: "app-header--#{HostingEnvironment.environment_name}",
+                 service_name: service_name,
+                 service_url: service_link,
+                 navigation_items: []) %>
     <% end %>
 
     <div class="govuk-width-container">


### PR DESCRIPTION
This is necessary under two circumstances:

1. We're in a namespace (eg `referee_interface`) without an entry in the switch statement edited here
2. We're in a controller without an effective namespace (`errors_controller`)

In either, fall back to a menuless header