### PR TITLE
Add `aria-describedby` for 'Change' links in work history

### DIFF
--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -4,7 +4,7 @@
       <dt class="govuk-summary-list__key">
         <%= row[:key] %>
       </dt>
-      <dd class="govuk-summary-list__value">
+      <dd <%= "id=#{row[:id]}" if row[:id] %> class="govuk-summary-list__value">
         <% if row[:value].is_a?(Array) %>
           <% row[:value].each do |value| %><%= value %><br><% end %>
         <% elsif row[:value].html_safe? %>
@@ -16,7 +16,7 @@
 
       <% if row[:change_path] %>
         <dd class="govuk-summary-list__actions">
-          <%= link_to row[:change_path], class: 'govuk-link' do %>
+          <%= link_to row[:change_path], class: 'govuk-link', aria: { 'describedby' => row[:aria_describedby] } do %>
             Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
           <% end %>
         </dd>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -58,10 +58,12 @@ private
 
   def job_row(work)
     {
+      id: generate_id(work_id: work.id, attribute: 'job'),
       key: 'Job',
       value: [work.role, work.organisation],
       action: 'job',
       change_path: candidate_interface_work_history_edit_path(work.id),
+      aria_describedby: generate_aria_describedby(work.id),
     }
   end
 
@@ -71,6 +73,7 @@ private
       value: work.commitment.dasherize.humanize,
       action: 'type',
       change_path: candidate_interface_work_history_edit_path(work.id),
+      aria_describedby: generate_aria_describedby(work.id),
     }
   end
 
@@ -80,15 +83,18 @@ private
       value: work.details,
       action: 'description',
       change_path: candidate_interface_work_history_edit_path(work.id),
+      aria_describedby: generate_aria_describedby(work.id),
     }
   end
 
   def dates_row(work)
     {
+      id: generate_id(work_id: work.id, attribute: 'dates'),
       key: 'Dates',
       value: "#{formatted_start_date(work)} - #{formatted_end_date(work)}",
       action: 'description',
       change_path: candidate_interface_work_history_edit_path(work.id),
+      aria_describedby: generate_aria_describedby(work.id),
     }
   end
 
@@ -100,5 +106,17 @@ private
     return 'Present' if work.end_date.nil?
 
     work.end_date.to_s(:month_and_year)
+  end
+
+  def generate_id(work_id:, attribute:)
+    "work-history-#{work_id}-#{attribute}"
+  end
+
+  def generate_aria_describedby(work_id)
+    [
+      generate_id(work_id: work_id, attribute: 'job'),
+      generate_id(work_id: work_id, attribute: 'dates'),
+    ]
+      .join(' ')
   end
 end

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -44,6 +44,35 @@ RSpec.describe WorkHistoryReviewComponent do
           end
         end
       end
+
+      it 'renders component with ids for job and dates rows' do
+        result = render_inline(described_class, application_form: application_form)
+
+        work_id = application_form.application_work_experiences.first.id
+
+        job_row_value = result.css('.govuk-summary-list__value')[0]
+        dates_row_value = result.css('.govuk-summary-list__value')[3]
+
+        expect(job_row_value.attr('id')).to include("work-history-#{work_id}-job")
+        expect(dates_row_value.attr('id')).to include("work-history-#{work_id}-dates")
+      end
+
+      it 'renders component with aria-describedby for each attribute row' do
+        result = render_inline(described_class, application_form: application_form)
+
+        work_id = application_form.application_work_experiences.first.id
+
+        change_links = [
+          result.css('.govuk-summary-list__actions a')[0],
+          result.css('.govuk-summary-list__actions a')[1],
+          result.css('.govuk-summary-list__actions a')[2],
+          result.css('.govuk-summary-list__actions a')[3],
+        ]
+
+        change_links.each do |change_link|
+          expect(change_link.attr('aria-describedby')).to include("work-history-#{work_id}-job work-history-#{work_id}-dates")
+        end
+      end
     end
 
     context 'when jobs are not editable' do


### PR DESCRIPTION
## Context

From our external accessibility audit it was noted that when we have `Change` links on review sections that consist of multiple entries, e.g. work history, they are not unique and descriptive which makes it difficult for screen readers users to identify the destination or purpose of the link out of context.

Following discussions, to improve the accessibility we decided that adding `aria-describedby` that includes a description of the job and the dates will uniquely identify and describe a job role. See https://ukgovernmentdfe.slack.com/archives/CPACU8GUF/p1578310497004300 for more detail.

As there are a number of other pages that have this issue, work history is the only one that is addressed so that a valid solution can be establish first. Further PRs will be made to fix the other pages.

## Changes proposed in this pull request

This PR adds `aria-describedby` for `Change` links in work history.  In order to do this `id`s needed to be created for the value cell of the 'Job' and 'Dates' row of an entry so that they can be referenced in the `aria-describedby`.

![image](https://user-images.githubusercontent.com/42817036/71833549-0fbcf400-30a5-11ea-8f9f-f0e957ac8de3.png)

## Guidance to review

The implementation of this feels weird. Feels like there's a better way to do this. Recommendations are more than welcome! Pliz and tenk u.

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
