### PR TITLE
Prefix reject page title with by 'Error:' when validation error occures

### DIFF
--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, 'Reject application' %>
+<% content_for :browser_title, @reject_application.errors.any? ? 'Error: Reject application' : 'Reject application' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
 <%= form_with model: @reject_application,


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The ‘Reject application’ page title is not prefixed by ‘Error:’ when validation errors occur which does not conform with GOV.UK Design System recommendations.

## Changes proposed in this pull request
This PR adds ‘Error:’ prefix to page title when validation errors occur on `provider/applications/:id/reject` page
<!-- If there are UI changes, please include Before and After screenshots. -->

### Before
![image](https://user-images.githubusercontent.com/22743709/71834879-2d3f8d00-30a8-11ea-9676-870ba6dd3fb2.png)

### After
![image](https://user-images.githubusercontent.com/22743709/71834860-1f8a0780-30a8-11ea-9c92-579b0d9e6445.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/RK2v971U/704-dac-page-56-add-error-to-the-page-title-when-rejecting-an-application-without-passing-validation
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
