### PR TITLE
Solve N+1 query on audit page

### DIFF
--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -9,7 +9,7 @@ module SupportInterface
     end
 
     def audits
-      application_form.own_and_associated_audits.order('id desc')
+      application_form.own_and_associated_audits.includes(:user).order('id desc')
     end
 
     attr_reader :application_form


### PR DESCRIPTION
## Context

Visiting the audit history triggers multiple queries for `Candidate`. 

## Changes proposed in this pull request

Before:
<img width="1904" alt="Screenshot 2020-01-07 at 09 55 14" src="https://user-images.githubusercontent.com/233676/71886279-d4b5d180-3133-11ea-884e-54d5d689eb78.png">

After:

<img width="1904" alt="Screenshot 2020-01-07 at 09 54 59" src="https://user-images.githubusercontent.com/233676/71886292-dbdcdf80-3133-11ea-994c-2604fcbf6438.png">

To be honest, I'm not sure why this works, and why Bullet doesn't detect the N+1.

## Guidance to review


## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
