### PR TITLE
SPIKE — DO NOT MERGE. Munge "missing_gcses" into a text field adjacent to "gcse"s

### DIFF
--- a/app/models/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_type_form.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class GcseQualificationTypeForm
     OTHER_UK_QUALIFICATION_TYPE = 'other_uk'.freeze
-    MISSING_QUALIFICATION_TYPE = 'missing'.freeze
 
     include ActiveModel::Model
 

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -45,6 +45,7 @@ module VendorApi
           work_experience: {
             jobs: work_experience_jobs,
             volunteering: work_experience_volunteering,
+            breaks: application_form.work_history_breaks,
           },
           offer: offer,
           rejection: get_rejection,

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -45,7 +45,7 @@ module VendorApi
           work_experience: {
             jobs: work_experience_jobs,
             volunteering: work_experience_volunteering,
-            breaks: application_form.work_history_breaks,
+            work_history_break_explanation: application_form.work_history_breaks,
           },
           offer: offer,
           rejection: get_rejection,

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -138,9 +138,10 @@ module VendorApi
 
     def qualifications
       {
-        gcses: qualifications_of_level('gcse').map { |q| qualification_to_hash(q) },
+        gcses: qualifications_of_level('gcse').reject(&:missing_qualification?).map { |q| qualification_to_hash(q) },
         degrees: qualifications_of_level('degree').map { |q| qualification_to_hash(q) },
         other_qualifications: qualifications_of_level('other').map { |q| qualification_to_hash(q) },
+        missing_gcses_explanation: missing_gcses_explanation(qualifications_of_level('gcse').select(&:missing_qualification?)),
       }
     end
 
@@ -151,6 +152,12 @@ module VendorApi
       application_form.application_qualifications.select do |q|
         q.level == level
       end
+    end
+
+    def missing_gcses_explanation(gcses)
+      gcses
+        .map { |gcse| "#{gcse.subject.capitalize} GCSE or equivalent: #{gcse.missing_explanation}" }
+        .join("\n\n")
     end
 
     def qualification_to_hash(qualification)

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -4,8 +4,12 @@
   [`personal_statement`](/api-docs/reference#applicationattributes-object)
   field to 11624 chars
 - Introduce `work_history_break_explanation` field to
-  [`work_experience`](/api-docs/reference#workexperiences-object).  This
+  [`work_experience`](/api-docs/reference#workexperiences-object). This
   contains the candidate’s explanation for any breaks in work history.
+- Introduce `missing_gcses_explanation` field to
+  [`qualifications`](/api-docs/reference#qualifications-object). This contains
+  the candidate’s explanation for any missing GCSE (or equivalent)
+  qualifications.
 
 ### v1.0 — 18th December 2019
 

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,5 +1,15 @@
+### 7th January 2020
+
+- Correct size of
+  [`personal_statement`](/api-docs/reference#applicationattributes-object)
+  field to 11624 chars
+- Introduce `work_history_break_explanation` field to
+  [`work_experience`](/api-docs/reference#workexperiences-object).  This
+  contains the candidate’s explanation for any breaks in work history.
+
 ### v1.0 — 18th December 2019
 
 Initial release of the API.
 
-For a log of pre-release changes, [see the alpha release notes](/api-docs/alpha-release-notes).
+For a log of pre-release changes, [see the alpha release
+notes](/api-docs/alpha-release-notes).

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -733,6 +733,7 @@ components:
         - gcses
         - degrees
         - other_qualifications
+        - missing_gcses_explanation
       properties:
         gcses:
           type: array
@@ -746,6 +747,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Qualification"
+        missing_gcses_explanation:
+          type: string
+          nullable: true
+          maxLength: 8192 # Up to 800 words
+          description: If the candidate lacks any required GCSEs, this field will contain their free-text explanation of why this is the case.
+          example: 'Maths GCSE or equivalent: I will take Maths GCSE at my local training provider on 18th August 2020'
 
     WorkExperiences:
       type: object

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -753,6 +753,7 @@ components:
       required:
         - jobs
         - volunteering
+        - breaks
       properties:
         jobs:
           type: array
@@ -764,6 +765,12 @@ components:
           description: The candidate’s experience as a volunteer
           items:
             $ref: "#/components/schemas/WorkExperience"
+        breaks:
+          type: string
+          nullable: true
+          description: The candidate’s explanation for any breaks in work history
+          maxLength: 4096 # 400 words
+          example: 'I spent time volunteering overseas...'
 
     WorkExperience:
       type: object

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -377,7 +377,7 @@ components:
           example: "2019-06-13T23:59:59Z"
         personal_statement:
           type: string
-          maxLength: 6144  # 600 words
+          maxLength: 11264  # 1000 words + 100 for our introductory text
           description: The candidate’s personal statement, combined from the "Becoming a Teacher" and "Subject Knowledge" fields in the application form
           example: "Since retiring from the Police Service in 2007..."
         interview_preferences:

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -753,7 +753,7 @@ components:
       required:
         - jobs
         - volunteering
-        - breaks
+        - work_history_break_explanation
       properties:
         jobs:
           type: array
@@ -765,10 +765,10 @@ components:
           description: The candidate’s experience as a volunteer
           items:
             $ref: "#/components/schemas/WorkExperience"
-        breaks:
+        work_history_break_explanation:
           type: string
           nullable: true
-          description: The candidate’s explanation for any breaks in work history
+          description: The candidate’s explanation for any breaks in work history. Will be null if there aren't any breaks in the candidate’s work history. We define a break in work history as more than a month between 2 jobs.
           maxLength: 4096 # 400 words
           example: 'I spent time volunteering overseas...'
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -56,7 +56,7 @@ module CandidateHelper
     candidate_fills_in_a_gcse
 
     click_link 'Science GCSE or equivalent'
-    candidate_fills_in_a_gcse
+    candidate_explains_a_missing_gcse
 
     click_link 'Other relevant academic and non-academic qualifications'
     candidate_fills_in_their_other_qualifications
@@ -261,6 +261,13 @@ module CandidateHelper
     fill_in 'When did you get your qualification?', with: '1990'
     click_button 'Save and continue'
     click_link 'Back to application'
+  end
+
+  def candidate_explains_a_missing_gcse
+    choose('I don’t have this qualification yet')
+    fill_in t('application_form.gcse.missing_explanation.label'), with: 'I will sit the exam at my local college this summer.'
+    click_button 'Save and continue'
+    click_link 'Continue'
   end
 
   def candidate_fills_in_becoming_a_teacher

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -196,6 +196,11 @@ module CandidateHelper
     end
 
     click_button t('application_form.work_history.complete_form_button')
+
+    click_link t('application_form.work_history.break.enter_label')
+    fill_in 'candidate_interface_work_breaks_form[work_history_breaks]', with: 'I was unwell'
+    click_button t('application_form.work_history.break.button')
+
     check t('application_form.work_history.review.completed_checkbox')
     click_button t('application_form.work_history.review.button')
   end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -186,6 +186,7 @@ RSpec.feature 'Vendor receives the application' do
               description: 'I volunteered.',
             },
           ],
+          breaks: 'I was unwell',
         },
       },
     }

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -92,15 +92,6 @@ RSpec.feature 'Vendor receives the application' do
           gcses: [
             {
               qualification_type: 'gcse',
-              subject: 'science',
-              grade: 'B',
-              award_year: '1990',
-              institution_details: nil,
-              awarding_body: nil,
-              equivalency_details: nil,
-            },
-            {
-              qualification_type: 'gcse',
               subject: 'english',
               grade: 'B',
               award_year: '1990',
@@ -140,6 +131,7 @@ RSpec.feature 'Vendor receives the application' do
               equivalency_details: nil,
             },
           ],
+          missing_gcses_explanation: 'Science GCSE or equivalent: I will sit the exam at my local college this summer.',
         },
         references: [
           {

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -186,7 +186,7 @@ RSpec.feature 'Vendor receives the application' do
               description: 'I volunteered.',
             },
           ],
-          breaks: 'I was unwell',
+          work_history_break_explanation: 'I was unwell',
         },
       },
     }


### PR DESCRIPTION
## Context

This information is missing from the API, so we need to add it. However, there's no obvious place to put it.

Existing GCSEs follow the `Qualification` schema, with keys for year, subject, grade, type etc. In the case of a missing GCSE we know only the subject.

Considered implementations:

1. include these GCSEs alongside the others, but nullify all but the `subject` field, and introduce a `missing_explanation` field. (the **nullify** approach)
2. introduce a new data type for a `MissingGCSE` or equivalent and let it appear in the list alongside the other GCSEs (the **mixed list** approach)
3. introduce a new field to the qualifications structure with free text containing the `missing_explanation` for any and all missing GCSEs (the **munge** approach)

Discussed with @stevehook @tijmenb @tvararu.

The **nullify** approach keeps the list consistent, but 
- means consumers have to pick through this data more carefully
- relaxes our OpenAPI spec, which weakens our automated tests
- if a user puts details like qualification level or place of study into the explanation, then this information is in the wrong place

The **mixed list** approach means that we're very explicit about what data we're providing, but consumers still have to pick through this data more carefully

The **munge** approach provides all the information with no guarantees of consistency (it's free text) but isn't easy for machines to read.

On the grounds that machines _probably_ don't need to read this, this PR spikes that approach.

Feedback welcome 🙂 

https://trello.com/c/uzwLb0jR/1436-display-reason-for-missing-gcses-in-provider-ui-and-in-api