### PR TITLE
Update input type for graduation year field

### DIFF
--- a/app/views/candidate_interface/degrees/base/_form.html.erb
+++ b/app/views/candidate_interface/degrees/base/_form.html.erb
@@ -17,6 +17,6 @@
   <% end %>
 <% end %>
 
-<%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label'), size: 'm' }, hint_text: t('application_form.degree.award_year.hint_text'), width: 4 %>
+<%= f.govuk_text_field :award_year, label: { text: t('application_form.degree.award_year.label'), size: 'm' }, type: :number, hint_text: t('application_form.degree.award_year.hint_text'), width: 4 %>
 
 <%= f.govuk_submit t('application_form.degree.base.button') %>


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The `Graduation year` field on `degrees` page has `text` input type, this means that users must manually change the keyboard in order to input numerical data. 

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR updates the input type of `Graduation year` field on `degrees` page to type `number`

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/QKnJCS65/708-dac-page-61-add-typenumber-to-graduation-year-field-in-candidate-degrees-page

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
