### PR TITLE
Add `aria-describedby` for 'Change' links in volunteering

### DIFF
--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -1,6 +1,10 @@
 # TODO: This component is used by CandidateInterface and ProviderInterface, but
 # uses classes from the CandidateInterface namespace directly.
 class VolunteeringReviewComponent < ActionView::Component::Base
+  include AriaDescribedbyHelper
+
+  SECTION = 'volunteering'.freeze
+
   validates :application_form, presence: true
 
   def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
@@ -33,28 +37,34 @@ private
 
   def role_row(volunteering_role)
     {
+      id: generate_id(section: SECTION, entry_id: volunteering_role.id, attribute: 'role'),
       key: t('application_form.volunteering.role.review_label'),
       value: volunteering_role.role,
       action: t('application_form.volunteering.role.change_action'),
       change_path: edit_path(volunteering_role),
+      aria_describedby: aria_describedby(volunteering_role.id),
     }
   end
 
   def organisation_row(volunteering_role)
     {
+      id: generate_id(section: SECTION, entry_id: volunteering_role.id, attribute: 'organisation'),
       key: t('application_form.volunteering.organisation.review_label'),
       value: volunteering_role.organisation,
       action: t('application_form.volunteering.organisation.change_action'),
       change_path: edit_path(volunteering_role),
+      aria_describedby: aria_describedby(volunteering_role.id),
     }
   end
 
   def length_row(volunteering_role)
     {
+      id: generate_id(section: SECTION, entry_id: volunteering_role.id, attribute: 'dates'),
       key: t('application_form.volunteering.review_length.review_label'),
       value: formatted_length(volunteering_role),
       action: t('application_form.volunteering.review_length.change_action'),
       change_path: edit_path(volunteering_role),
+      aria_describedby: aria_describedby(volunteering_role.id),
     }
   end
 
@@ -64,6 +74,7 @@ private
       value: formatted_details(volunteering_role),
       action: t('application_form.volunteering.review_details.change_action'),
       change_path: edit_path(volunteering_role),
+      aria_describedby: aria_describedby(volunteering_role.id),
     }
   end
 
@@ -87,5 +98,13 @@ private
 
   def edit_path(volunteering_role)
     Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role.id)
+  end
+
+  def aria_describedby(volunteering_id)
+    generate_aria_describedby(
+      section: SECTION,
+      entry_id: volunteering_id,
+      attributes: %w[role organisation dates],
+    )
   end
 end

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -1,5 +1,9 @@
 # Used in Candidate and Provider interface
 class WorkHistoryReviewComponent < ActionView::Component::Base
+  include AriaDescribedbyHelper
+
+  SECTION = 'work-history'.freeze
+
   validates :application_form, presence: true
 
   def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
@@ -58,12 +62,12 @@ private
 
   def job_row(work)
     {
-      id: generate_id(work_id: work.id, attribute: 'job'),
+      id: generate_id(section: SECTION, entry_id: work.id, attribute: 'job'),
       key: 'Job',
       value: [work.role, work.organisation],
       action: 'job',
       change_path: candidate_interface_work_history_edit_path(work.id),
-      aria_describedby: generate_aria_describedby(work.id),
+      aria_describedby: aria_describedby(work.id),
     }
   end
 
@@ -73,7 +77,7 @@ private
       value: work.commitment.dasherize.humanize,
       action: 'type',
       change_path: candidate_interface_work_history_edit_path(work.id),
-      aria_describedby: generate_aria_describedby(work.id),
+      aria_describedby: aria_describedby(work.id),
     }
   end
 
@@ -83,18 +87,18 @@ private
       value: work.details,
       action: 'description',
       change_path: candidate_interface_work_history_edit_path(work.id),
-      aria_describedby: generate_aria_describedby(work.id),
+      aria_describedby: aria_describedby(work.id),
     }
   end
 
   def dates_row(work)
     {
-      id: generate_id(work_id: work.id, attribute: 'dates'),
+      id: generate_id(section: SECTION, entry_id: work.id, attribute: 'dates'),
       key: 'Dates',
       value: "#{formatted_start_date(work)} - #{formatted_end_date(work)}",
       action: 'description',
       change_path: candidate_interface_work_history_edit_path(work.id),
-      aria_describedby: generate_aria_describedby(work.id),
+      aria_describedby: aria_describedby(work.id),
     }
   end
 
@@ -108,15 +112,11 @@ private
     work.end_date.to_s(:month_and_year)
   end
 
-  def generate_id(work_id:, attribute:)
-    "work-history-#{work_id}-#{attribute}"
-  end
-
-  def generate_aria_describedby(work_id)
-    [
-      generate_id(work_id: work_id, attribute: 'job'),
-      generate_id(work_id: work_id, attribute: 'dates'),
-    ]
-      .join(' ')
+  def aria_describedby(work_id)
+    generate_aria_describedby(
+      section: SECTION,
+      entry_id: work_id,
+      attributes: %w[job dates],
+    )
   end
 end

--- a/app/helpers/aria_describedby_helper.rb
+++ b/app/helpers/aria_describedby_helper.rb
@@ -1,0 +1,13 @@
+module AriaDescribedbyHelper
+  def generate_id(section:, entry_id:, attribute:)
+    "#{section}-#{entry_id}-#{attribute}"
+  end
+
+  def generate_aria_describedby(section:, entry_id:, attributes:)
+    element_ids = attributes.map do |attribute|
+      generate_id(section: section, entry_id: entry_id, attribute: attribute)
+    end
+
+    element_ids.join(' ')
+  end
+end

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -112,6 +112,39 @@ RSpec.describe VolunteeringReviewComponent do
       )
     end
 
+    it 'renders component with ids for role and dates rows' do
+      result = render_inline(described_class, application_form: application_form)
+
+      volunteering_id = application_form.application_volunteering_experiences.order(created_at: :desc).first.id
+
+      role_row_value = result.css('.govuk-summary-list__value')[0]
+      organisation_row_value = result.css('.govuk-summary-list__value')[1]
+      dates_row_value = result.css('.govuk-summary-list__value')[2]
+
+      expect(role_row_value.attr('id')).to include("volunteering-#{volunteering_id}-role")
+      expect(organisation_row_value.attr('id')).to include("volunteering-#{volunteering_id}-organisation")
+      expect(dates_row_value.attr('id')).to include("volunteering-#{volunteering_id}-dates")
+    end
+
+    it 'renders component with aria-describedby for each attribute row' do
+      result = render_inline(described_class, application_form: application_form)
+
+      volunteering_id = application_form.application_volunteering_experiences.order(created_at: :desc).first.id
+
+      change_links = [
+        result.css('.govuk-summary-list__actions a')[0],
+        result.css('.govuk-summary-list__actions a')[1],
+        result.css('.govuk-summary-list__actions a')[2],
+        result.css('.govuk-summary-list__actions a')[3],
+      ]
+
+      change_links.each do |change_link|
+        expect(change_link.attr('aria-describedby')).to include(
+          "volunteering-#{volunteering_id}-role volunteering-#{volunteering_id}-organisation volunteering-#{volunteering_id}-dates",
+        )
+      end
+    end
+
     context 'when volunteering experiences are not editable' do
       it 'renders component without an edit link' do
         result = render_inline(described_class, application_form: application_form, editable: false)


### PR DESCRIPTION
## Context

In #1032, `aria-describedby` for `Change` links in work history were added to improve the accessibility of them. However, we've got a number of other sections that are yet to be updated.

## Changes proposed in this pull request

This PR adds `aria-describedby` for `Change` links in the `Volunteering with children and young people` section. In order to so a helper `AriaDescribedbyHelper` was added and a refactor was done in `WorkHistoryReviewComponent` to use it. This is so `VolunteeringReviewComponent` can use methods such as `generate_id` and `generate_aria_describedby`.

![image](https://user-images.githubusercontent.com/42817036/71889392-f1ed9e80-3139-11ea-9e29-34c93e98fd40.png)

## Guidance to review

- Review commit by commit
- Is adding a helper and including it the right way to go?
- Next up to fix are the degree and references sections!

**Aside...**

Wanted to have the `entry_id` parameter name to be `id` for the `generate_id` and `generate_aria_describedby` methods but rubocop said no:

```
app/helpers/aria_describedby_helper.rb:2:29: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
  def generate_id(section:, id:, attribute:)

app/helpers/aria_describedby_helper.rb:6:43: C: Naming/MethodParameterName: Method parameter must be at least 3 characters long.
  def generate_aria_describedby(section:, id:, attributes:)
```

**_NANI?!_**

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
