### PR TITLE
Change first cell of the applications table to table header

### DIFF
--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -16,7 +16,7 @@
     <tbody class="govuk-table__body">
       <% @application_choices.each do |application_choice| %>
       <tr class="govuk-table__row">
-        <td class="govuk-table__cell"><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></td>
+        <th class="govuk-table__cell"><%= govuk_link_to application_choice.full_name, provider_interface_application_choice_path(application_choice) %></th>
         <td class="govuk-table__cell"><%= application_choice.course_name_and_code %></td>
         <td class="govuk-table__cell"><%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: application_choice %></td>
         <td class="govuk-table__cell"><%= application_choice.updated_at %></td>


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
On Provider interface the `applications` table has a structure that is challenging to understand when using screen reader. Screen reader users felt that the table content would be easier to understand if row headers were implemented.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR changes the HTML tag on the cells under the `Name` column. 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
The DAC report advises `marking-up the cells under the ‘Name’ column as table row headers`, I used the `<th>` tag to do this, please advise if this is the right solution or any other tag that would fit better in the table hierarchy. 

## Link to Trello card
https://trello.com/c/8XjODzUS/709-dac-page-65-add-row-headers-to-applications-table-in-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
