### PR TITLE
Highlight submitted application count in green

### DIFF
--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -15,6 +15,11 @@
   color: govuk-colour("white");
 }
 
+.app-card--green {
+  background: govuk-colour("green");
+  color: govuk-colour("white");
+}
+
 .app-card__count {
   @include govuk-font($size: 80, $weight: bold);
   display: block;

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -25,7 +25,7 @@
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
-    <div class="app-card">
+    <div class="app-card app-card--green">
       <span class="app-card__count"><%= @statistics[:candidates_with_submitted_forms] %></span>
       <span>submitted</span>
     </div>


### PR DESCRIPTION
## Context

On the stats page the key metric — how many applications are actually submitted — is not picked out and it's hard work for the eye to find it

## Changes proposed in this pull request

Change the colour of the box with that number in

### Before 

<img width="1035" alt="Screenshot 2020-01-07 at 11 21 25" src="https://user-images.githubusercontent.com/642279/71892096-02a11300-3140-11ea-98d0-9054aff7586b.png">

### After

<img width="1015" alt="Screenshot 2020-01-07 at 11 20 44" src="https://user-images.githubusercontent.com/642279/71892105-07fe5d80-3140-11ea-801c-326cad9eeb58.png">

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
