### PR TITLE
Add `aria-describedby` for 'Change' links in degree, other qualifications and referees

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -1,5 +1,9 @@
 module CandidateInterface
   class DegreesReviewComponent < ActionView::Component::Base
+    include AriaDescribedbyHelper
+
+    SECTION = 'degrees'.freeze
+
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
@@ -31,19 +35,23 @@ module CandidateInterface
 
     def qualification_row(degree)
       {
+        id: generate_id(section: SECTION, entry_id: degree.id, attribute: 'qualification'),
         key: t('application_form.degree.qualification.label'),
         value: formatted_qualification(degree),
         action: t('application_form.degree.qualification.change_action'),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
+        aria_describedby: aria_describedby(degree.id),
       }
     end
 
     def award_year_row(degree)
       {
+        id: generate_id(section: SECTION, entry_id: degree.id, attribute: 'year'),
         key: t('application_form.degree.award_year.review_label'),
         value: degree.award_year,
         action: t('application_form.degree.award_year.change_action'),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
+        aria_describedby: aria_describedby(degree.id),
       }
     end
 
@@ -53,6 +61,7 @@ module CandidateInterface
         value: formatted_grade(degree),
         action: t('application_form.degree.grade.change_action'),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
+        aria_describedby: aria_describedby(degree.id),
       }
     end
 
@@ -68,6 +77,14 @@ module CandidateInterface
       else
         t("application_form.degree.grade.#{degree.grade}.label")
       end
+    end
+
+    def aria_describedby(degree_id)
+      generate_aria_describedby(
+        section: SECTION,
+        entry_id: degree_id,
+        attributes: %w[qualification year],
+      )
     end
   end
 end

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -1,5 +1,9 @@
 module CandidateInterface
   class OtherQualificationsReviewComponent < ActionView::Component::Base
+    include AriaDescribedbyHelper
+
+    SECTION = 'other-qualifications'.freeze
+
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, missing_error: false)
@@ -27,28 +31,34 @@ module CandidateInterface
 
     def qualification_row(qualification)
       {
+        id: generate_id(section: SECTION, entry_id: qualification.id, attribute: 'qualification'),
         key: t('application_form.other_qualification.qualification.label'),
         value: qualification.title,
         action: t('application_form.other_qualification.qualification.change_action'),
         change_path: edit_other_qualification_path(qualification),
+        aria_describedby: aria_describedby(qualification.id),
       }
     end
 
     def institution_row(qualification)
       {
+        id: generate_id(section: SECTION, entry_id: qualification.id, attribute: 'institution'),
         key: t('application_form.other_qualification.institution.label'),
         value: qualification.institution_name,
         action: t('application_form.other_qualification.institution.change_action'),
         change_path: edit_other_qualification_path(qualification),
+        aria_describedby: aria_describedby(qualification.id),
       }
     end
 
     def award_year_row(qualification)
       {
+        id: generate_id(section: SECTION, entry_id: qualification.id, attribute: 'year'),
         key: t('application_form.other_qualification.award_year.review_label'),
         value: qualification.award_year,
         action: t('application_form.other_qualification.award_year.change_action'),
         change_path: edit_other_qualification_path(qualification),
+        aria_describedby: aria_describedby(qualification.id),
       }
     end
 
@@ -58,11 +68,20 @@ module CandidateInterface
         value: qualification.grade,
         action: t('application_form.other_qualification.grade.change_action'),
         change_path: edit_other_qualification_path(qualification),
+        aria_describedby: aria_describedby(qualification.id),
       }
     end
 
     def edit_other_qualification_path(qualification)
       Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id)
+    end
+
+    def aria_describedby(qualification_id)
+      generate_aria_describedby(
+        section: SECTION,
+        entry_id: qualification_id,
+        attributes: %w[qualification institution year],
+      )
     end
   end
 end

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -1,5 +1,9 @@
 module CandidateInterface
   class RefereesReviewComponent < ActionView::Component::Base
+    include AriaDescribedbyHelper
+
+    SECTION = 'referees'.freeze
+
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
@@ -33,10 +37,12 @@ module CandidateInterface
 
     def name_row(referee)
       {
+        id: generate_id(section: SECTION, entry_id: referee.id, attribute: 'name'),
         key: 'Name',
         value: referee.name,
         action: 'name',
         change_path: candidate_interface_edit_referee_path(referee.id),
+        aria_describedby: aria_describedby(referee.id),
       }
     end
 
@@ -46,6 +52,7 @@ module CandidateInterface
         value: referee.email_address,
         action: 'email address',
         change_path: candidate_interface_edit_referee_path(referee.id),
+        aria_describedby: aria_describedby(referee.id),
       }
     end
 
@@ -55,7 +62,16 @@ module CandidateInterface
         value: referee.relationship,
         action: 'relationship',
         change_path: candidate_interface_edit_referee_path(referee.id),
+        aria_describedby: aria_describedby(referee.id),
       }
+    end
+
+    def aria_describedby(referee_id)
+      generate_aria_describedby(
+        section: SECTION,
+        entry_id: referee_id,
+        attributes: %w[name],
+      )
     end
   end
 end

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -96,6 +96,34 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
         Rails.application.routes.url_helpers.candidate_interface_confirm_degrees_destroy_path(3),
       )
     end
+
+    it 'renders component with ids for qualification and year rows' do
+      result = render_inline(described_class, application_form: application_form)
+
+      degree_id = application_form.application_qualifications.degrees.order(created_at: :desc).first.id
+
+      qualification_row_value = result.css('.govuk-summary-list__value')[0]
+      year_row_value = result.css('.govuk-summary-list__value')[1]
+
+      expect(qualification_row_value.attr('id')).to include("degrees-#{degree_id}-qualification")
+      expect(year_row_value.attr('id')).to include("degrees-#{degree_id}-year")
+    end
+  end
+
+  it 'renders component with aria-describedby for each attribute row' do
+    result = render_inline(described_class, application_form: application_form)
+
+    degree_id = application_form.application_qualifications.degrees.order(created_at: :desc).first.id
+
+    change_links = [
+      result.css('.govuk-summary-list__actions a')[0],
+      result.css('.govuk-summary-list__actions a')[1],
+      result.css('.govuk-summary-list__actions a')[2],
+    ]
+
+    change_links.each do |change_link|
+      expect(change_link.attr('aria-describedby')).to include("degrees-#{degree_id}-qualification degrees-#{degree_id}-year")
+    end
   end
 
   context 'when degrees are not editable' do

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -62,13 +62,48 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('A-Level Making Cat Sounds')
     end
 
-    it 'renders component along with a delete link for each degree' do
+    it 'renders component along with a delete link for each qualification' do
       result = render_inline(described_class, application_form: application_form)
 
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.other_qualification.delete'))
       expect(result.css('.app-summary-card__actions a')[1].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(2),
       )
+    end
+
+    it 'renders component with ids for qualification, institution and year rows' do
+      result = render_inline(described_class, application_form: application_form)
+
+      qualification_id = application_form.application_qualifications.other.first.id
+
+      qualification_row_value = result.css('.govuk-summary-list__value')[0]
+      institution_row_value = result.css('.govuk-summary-list__value')[1]
+      year_row_value = result.css('.govuk-summary-list__value')[2]
+
+      expect(qualification_row_value.attr('id')).to include("other-qualifications-#{qualification_id}-qualification")
+      expect(institution_row_value.attr('id')).to include("other-qualifications-#{qualification_id}-institution")
+      expect(year_row_value.attr('id')).to include("other-qualifications-#{qualification_id}-year")
+    end
+
+    it 'renders component with aria-describedby for each attribute row' do
+      result = render_inline(described_class, application_form: application_form)
+
+      qualification_id = application_form.application_qualifications.other.first.id
+
+      change_links = [
+        result.css('.govuk-summary-list__actions a')[0],
+        result.css('.govuk-summary-list__actions a')[1],
+        result.css('.govuk-summary-list__actions a')[2],
+        result.css('.govuk-summary-list__actions a')[3],
+      ]
+
+      change_links.each do |change_link|
+        expect(change_link.attr('aria-describedby')).to include(
+          "other-qualifications-#{qualification_id}-qualification "\
+          "other-qualifications-#{qualification_id}-institution "\
+          "other-qualifications-#{qualification_id}-year",
+        )
+      end
     end
   end
 

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -34,6 +34,30 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_referee_path(referee_id),
       )
     end
+
+    it 'renders component with an id for name row' do
+      referee_id = application_form.application_references.first.id
+      result = render_inline(described_class, application_form: application_form)
+
+      name_row_value = result.css('.govuk-summary-list__value')[0]
+
+      expect(name_row_value.attr('id')).to include("referees-#{referee_id}-name")
+    end
+
+    it 'renders component with aria-describedby for each attribute row' do
+      referee_id = application_form.application_references.first.id
+      result = render_inline(described_class, application_form: application_form)
+
+      change_links = [
+        result.css('.govuk-summary-list__actions a')[0],
+        result.css('.govuk-summary-list__actions a')[1],
+        result.css('.govuk-summary-list__actions a')[2],
+      ]
+
+      change_links.each do |change_link|
+        expect(change_link.attr('aria-describedby')).to include("referees-#{referee_id}-name")
+      end
+    end
   end
 
   context 'when referees are not editable' do


### PR DESCRIPTION
## Context

In #1032 and #1039, `aria-describedby` for `Change` links in work history and volunteering were added to improve the accessibility of them. However, we have a number of other sections that have not been updated yet.

## Changes proposed in this pull request

This PR adds `aria-describedby` for `Change` links in:

- degree - combination of the qualification and year awarded row
- other qualifications - combination of the qualification, institution and year awarded row
- referees - just name row

![image](https://user-images.githubusercontent.com/42817036/71893328-3598d600-3143-11ea-90bc-eb612e44a964.png)

![image](https://user-images.githubusercontent.com/42817036/71894663-cf15b700-3146-11ea-8c72-ea0e0b49ff09.png)

![image](https://user-images.githubusercontent.com/42817036/71895249-6fb8a680-3148-11ea-9706-31321e872b28.png)

## Guidance to review

Review commit by commit, each commit is for a section, ~~all of which should be addressed now~~. Other than that, nothing in particular as implementation follows pattern as before.

EDIT: Just realised in the `Review your application`, GCSEs are not unique. Will do another PR for this.

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
