### PR TITLE
Show application support reference on Support Dashboard

### DIFF
--- a/app/components/support_interface/applications_table_component.html.erb
+++ b/app/components/support_interface/applications_table_component.html.erb
@@ -4,6 +4,7 @@
       <th scope="col" class="govuk-table__header">Application</th>
       <th scope="col" class="govuk-table__header">Status</th>
       <th scope="col" class="govuk-table__header">Last updated</th>
+      <th scope="col" class="govuk-table__header">Reference</th>
     </tr>
   </thead>
 
@@ -15,6 +16,7 @@
         </td>
         <td class="govuk-table__cell"><%= t "process_states.#{table_row[:process_state]}.name" %></td>
         <td class="govuk-table__cell"><%= table_row[:updated_at] %></td>
+        <td class="govuk-table__cell"><%= table_row[:support_reference] %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/support_interface/applications_table_component.rb
+++ b/app/components/support_interface/applications_table_component.rb
@@ -15,6 +15,7 @@ module SupportInterface
           application_link: govuk_link_to(email_address, support_interface_application_form_path(application_form)),
           updated_at: application_form.updated_at.to_s(:govuk_date_and_time),
           process_state: ProcessState.new(application_form).state,
+          support_reference: application_form.support_reference,
         }
       end
     end

--- a/spec/system/support_interface/see_applications_spec.rb
+++ b/spec/system/support_interface/see_applications_spec.rb
@@ -7,7 +7,10 @@ RSpec.feature 'See applications' do
     given_i_am_a_support_user
     and_there_are_applications_in_the_system
     and_i_visit_the_support_page
-    then_i_should_see_the_applications
+    then_i_should_see_the_latest_applications
+
+    when_i_follow_the_link_to_applications
+    then_i_should_see_the_application_references
   end
 
   def given_i_am_a_support_user
@@ -24,9 +27,19 @@ RSpec.feature 'See applications' do
     visit support_interface_path
   end
 
-  def then_i_should_see_the_applications
+  def then_i_should_see_the_latest_applications
     expect(page).to have_content @completed_application.candidate.email_address
     expect(page).to have_content @application_with_reference.candidate.email_address
     expect(page).to have_content @unsubmitted_application.candidate.email_address
+  end
+
+  def when_i_follow_the_link_to_applications
+    click_link 'applications list'
+  end
+
+  def then_i_should_see_the_application_references
+    expect(page).to have_content @completed_application.support_reference
+    expect(page).to have_content @application_with_reference.support_reference
+    expect(page).to have_content @unsubmitted_application.support_reference
   end
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Support users need to see the application reference (e.g. FX8568) on the application dashboard so they can easily refer to applications using the unique ID, rather than use names.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds an extra column of `application reference` to `/support/applications` page

### Before
![image](https://trello-attachments.s3.amazonaws.com/5cb88ec4be601441218204a0/5e144edcf0b51758a733d25b/41e12eb37a9a4f3168a3f8efb133593f/Screenshot_2020-01-07_at_10.41.31.png)

### After
![image](https://user-images.githubusercontent.com/22743709/71895759-d8545300-3149-11ea-93ce-dda6a5f486dc.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
The system test can be good guidance, alternatively, visit `/support/applications` to test manually 

## Link to Trello card
https://trello.com/c/ILJArQVI/720-add-user-reference-to-the-support-dashboard
## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
