### PR TITLE
Display the latest application form update on the candidate view

### DIFF
--- a/app/components/support_interface/candidates_table_component.rb
+++ b/app/components/support_interface/candidates_table_component.rb
@@ -12,7 +12,7 @@ module SupportInterface
           candidate_id: candidate.id,
           process_state: ProcessState.new(candidate.last_updated_application).state,
           candidate_link: govuk_link_to(candidate.email_address, support_interface_candidate_path(candidate)),
-          updated_at: candidate.updated_at.to_s(:govuk_date_and_time),
+          updated_at: candidate.last_updated_application&.updated_at&.to_s(:govuk_date_and_time),
         }
       end
     end

--- a/spec/components/support_interface/candidates_table_component_spec.rb
+++ b/spec/components/support_interface/candidates_table_component_spec.rb
@@ -1,17 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::CandidatesTableComponent do
-  let(:candidates) { create_list(:candidate, 3) }
+  let(:today) { Time.zone.local(2020, 1, 7, 12, 0, 0) }
+
+  let(:application_forms) { create_list(:application_form, 3, updated_at: 1.day.ago) }
+  let(:candidates) { application_forms.map(&:candidate) }
+
+  around do |example|
+    Timecop.freeze(today) do
+      example.run
+    end
+  end
 
   subject(:component) { described_class.new(candidates: candidates) }
-
-  def render_result
-    render_inline(described_class, candidates: candidates)
-  end
 
   it 'renders the candidate emails' do
     candidates.collect(&:email_address).each do |email_address|
       expect(render_result.text).to include(email_address)
     end
+  end
+
+  it 'renders the date last updated' do
+    expect(render_result.text).to include(application_forms.first.updated_at.to_s(:govuk_date_and_time))
+  end
+
+  def render_result
+    render_inline(described_class, candidates: candidates)
   end
 end


### PR DESCRIPTION
## Context

In the Support interface the Candidate view displays the last updated time for the `Candidate` object whereas the Application view displays the last updated time for the `ApplicationForm`. 

## Changes proposed in this pull request

Both views should display the last updated time for the `ApplicationForm`.

## Guidance to review

- Does it make sense to show these timestamps?
- Are there any tests missing?

There is still an incongruity with the Provider interface that displays last updates for the `ApplicationChoice`. I'm not attempting to change that here. I had considered adding a `touch` option to the `ApplicationChoice#application_form` association to attempt to keep these in sync however we had this option in the past and removed it.

## Link to Trello card

https://trello.com/c/pItvx0YF/1434-updating-references-doesnt-update-the-application-timestamps-in-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
