### PR TITLE
Fix no method error when signing in a new user in local dev

### DIFF
--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -52,7 +52,7 @@ module SupportInterface
       candidate_application = candidate.application_forms.first
 
       if FeatureFlag.active?('edit_application')
-        if !candidate_application.submitted? || candidate_application.amendable?
+        if candidate_application && (!candidate_application.submitted? || candidate_application.amendable?)
           redirect_to candidate_interface_application_form_path
         else
           redirect_to candidate_interface_application_complete_path


### PR DESCRIPTION
##  Context
The `CandidatesController#impersonate` calls `#submitted?` method on candidate_application, however, a new user does not have an application, which causes `NoMethodError`

![image](https://user-images.githubusercontent.com/22743709/71903512-28d4ac00-315c-11ea-909a-4c07029b7da9.png)

## Changes proposed in this pull request
This PR extends the condition, to check if `candidate_application` exists before checking `#submitted?`
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
<!-- http://trello.com/123-example-card -->

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
