### PR TITLE
Rename Service Performance Dashboard

### DIFF
--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Service performance' %>
+<% content_for :title, 'Service performance dashboard' %>
 
 <div class="app-card app-card--blue govuk-!-margin-bottom-4">
   <span class="app-card__count" id="total-sign-ups"><%= @statistics[:total_non_dfe_sign_ups] %></span>


### PR DESCRIPTION
## Context
Rename Service Performance Dashboard, as suggested by @lauratennant3, a clearer label would be `Service performance dashboard`
## Changes proposed in this pull request
### After 
![image](https://user-images.githubusercontent.com/22743709/71910014-05fcc480-3169-11ea-85ed-fff1a1543926.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->


## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/hOcc5xYi/733-rename-service-performance-to-service-performance-dashboard

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
