### PR TITLE
Render missing GCSE explanation in the Provider UI

### DIFF
--- a/app/components/qualification_row_component.html.erb
+++ b/app/components/qualification_row_component.html.erb
@@ -1,5 +1,9 @@
 <tr class="govuk-table__row">
   <td class="govuk-table__cell"><%= render QualificationTitleComponent, qualification: qualification %></td>
-  <td class="govuk-table__cell"><%= qualification.award_year %></td>
-  <td class="govuk-table__cell"><%= grade %></td>
+  <% if qualification.missing_qualification? %>
+    <td colspan="2" class="govuk-table__cell"><%= qualification.missing_explanation %></td>
+  <% else %>
+    <td class="govuk-table__cell"><%= qualification.award_year %></td>
+    <td class="govuk-table__cell"><%= grade %></td>
+  <% end %>
 </tr>

--- a/app/components/qualification_title_component.html.erb
+++ b/app/components/qualification_title_component.html.erb
@@ -1,1 +1,1 @@
-<%= @qualification.qualification_type %> <%= @qualification.subject %>
+<%= qualification_type %> <%= @qualification.subject %>

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -2,4 +2,12 @@ class QualificationTitleComponent < ActionView::Component::Base
   def initialize(qualification:)
     @qualification = qualification
   end
+
+  def qualification_type
+    if @qualification.level == 'gcse' && @qualification.missing_qualification?
+      'GCSE'
+    else
+      @qualification.qualification_type
+    end
+  end
 end

--- a/spec/components/qualification_row_component_spec.rb
+++ b/spec/components/qualification_row_component_spec.rb
@@ -52,4 +52,21 @@ RSpec.describe QualificationRowComponent do
     expect(result.text).to include('2001')
     expect(result.text).to include('I did my best')
   end
+
+  it 'renders a qualification with a missing_explanation' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :gcse,
+      qualification_type: 'missing',
+      subject: 'Maths',
+      grade: nil,
+      award_year: nil,
+      missing_explanation: 'I am taking the exam this summer',
+    )
+
+    result = render_inline(described_class, qualification: qualification)
+
+    expect(result.text).to include('GCSE Maths')
+    expect(result.text).to include('I am taking the exam this summer')
+  end
 end


### PR DESCRIPTION
## Context

This information is collected from the Candidate but providers can't see it.

## Changes proposed in this pull request

Include the reason following the design in the prototype.

<img width="1043" alt="Screenshot 2020-01-07 at 16 20 32" src="https://user-images.githubusercontent.com/642279/71911437-96d49f80-316b-11ea-9c4a-2f5a6c989914.png">

## Link to Trello card

https://trello.com/c/uzwLb0jR/1436-display-reason-for-missing-gcses-in-provider-ui-and-in-api

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
