### PR TITLE
Simplify signing in as a candidate

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
     def redirect_to_dashboard_if_not_amendable
       if FeatureFlag.active?('edit_application')
-        redirect_to candidate_interface_application_complete_path if current_application.submitted? && current_application.within_amend_period? == false
+        redirect_to candidate_interface_application_complete_path unless current_application.amendable?
       elsif current_application.submitted?
         redirect_to candidate_interface_application_complete_path
       end

--- a/app/controllers/support_interface/candidates_controller.rb
+++ b/app/controllers/support_interface/candidates_controller.rb
@@ -49,17 +49,7 @@ module SupportInterface
 
       flash[:success] = "You are now signed in as candidate #{candidate.email_address}"
 
-      candidate_application = candidate.application_forms.first
-
-      if FeatureFlag.active?('edit_application')
-        if candidate_application && (!candidate_application.submitted? || candidate_application.amendable?)
-          redirect_to candidate_interface_application_form_path
-        else
-          redirect_to candidate_interface_application_complete_path
-        end
-      else
-        redirect_to candidate_interface_application_form_path
-      end
+      redirect_to candidate_interface_application_form_path
     end
 
   private

--- a/spec/system/support_interface/sign_in_as_candidate_spec.rb
+++ b/spec/system/support_interface/sign_in_as_candidate_spec.rb
@@ -3,48 +3,24 @@ require 'rails_helper'
 RSpec.feature 'Sign in as candidate' do
   include DfESignInHelpers
 
-  around do |example|
-    Timecop.freeze(Time.zone.local(2019, 12, 16)) do
-      example.run
-    end
-  end
-
   scenario 'Support user signs in as a candidate' do
     given_i_am_a_support_user
-    and_the_edit_application_feature_flag_is_on
-    and_there_is_an_unsubmitted_application
-    when_i_visit_the_unsubmitted_application_form_page
+    and_there_is_an_application
+    when_i_visit_the_application_form_page
     and_click_the_sign_in_button
     then_i_am_logged_in_as_the_candidate
-    and_i_see_the_your_application_page
-
-    given_there_is_an_amendable_application
-    when_i_visit_the_amendable_application_form_page
-    and_click_the_sign_in_button
-    then_i_am_logged_in_as_the_candidate
-    and_i_see_the_edit_application_page
-
-    given_there_is_an_awaiting_provider_decision_application
-    when_i_visit_the_awaiting_provider_decision_application_form_page
-    and_click_the_sign_in_button
-    then_i_am_logged_in_as_the_candidate
-    and_i_see_the_application_dashboard
   end
 
   def given_i_am_a_support_user
     sign_in_as_support_user
   end
 
-  def and_the_edit_application_feature_flag_is_on
-    FeatureFlag.activate('edit_application')
+  def and_there_is_an_application
+    @application = create(:completed_application_form)
   end
 
-  def and_there_is_an_unsubmitted_application
-    @unsubmitted_application = create(:completed_application_form, submitted_at: nil)
-  end
-
-  def when_i_visit_the_unsubmitted_application_form_page
-    visit support_interface_application_form_path(@unsubmitted_application)
+  def when_i_visit_the_application_form_page
+    visit support_interface_application_form_path(@application)
   end
 
   def and_click_the_sign_in_button
@@ -53,41 +29,5 @@ RSpec.feature 'Sign in as candidate' do
 
   def then_i_am_logged_in_as_the_candidate
     expect(page).to have_content 'You are now signed in as candidate'
-  end
-
-  def and_i_see_the_your_application_page
-    within('.govuk-heading-xl') do
-      expect(page).to have_content t('page_titles.application_form')
-    end
-  end
-
-  def given_there_is_an_amendable_application
-    @amendable_application = create(:completed_application_form, submitted_at: Time.zone.local(2019, 12, 16))
-    create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: @amendable_application)
-  end
-
-  def when_i_visit_the_amendable_application_form_page
-    visit support_interface_application_form_path(@amendable_application)
-  end
-
-  def and_i_see_the_edit_application_page
-    within('.govuk-heading-xl') do
-      expect(page).to have_content t('page_titles.edit_application_form')
-    end
-  end
-
-  def given_there_is_an_awaiting_provider_decision_application
-    @awaiting_provider_decision_application = create(:completed_application_form, submitted_at: Time.zone.local(2019, 12, 2))
-    create(:application_choice, status: :awaiting_provider_decision, edit_by: Time.zone.local(2019, 12, 9), application_form: @awaiting_provider_decision_application)
-  end
-
-  def when_i_visit_the_awaiting_provider_decision_application_form_page
-    visit support_interface_application_form_path(@awaiting_provider_decision_application)
-  end
-
-  def and_i_see_the_application_dashboard
-    within('.govuk-heading-xl') do
-      expect(page).to have_content t('page_titles.application_dashboard')
-    end
   end
 end


### PR DESCRIPTION
## Context

Before christmas it was noted that if you visit a test application that has been progressed (eg an offer is accepted), the application was still editable. This is because the [test application code](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/app/workers/generate_test_applications.rb) cheats and skips over the edit-by date. Therefore, the app thinks that applications that are younger than 5 days are still editable. 

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/962 solved the problem in 2 ways, first fixed the test application script to make sure that we reset the `edit_by` date:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/88bb9aa93f73818fe43ffaf7cba9ccbc3674ff16/app/workers/generate_test_applications.rb#L76

It also added some logic to make sure that we redirect the support user to the correct place when impersonating a candidate (which solved the symptom of the problem, namely that the support user would see the edit screen).

## Changes proposed in this pull request

This removes the code to do the redirect. For new applications, we no longer need it because we have the edit_by reset. For older applications it's no longer needed because the edit_by date has lapsed for them.

## Guidance to review

See if it makes sense.

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
