### PR TITLE
Implement missing GCSEs in API

### DIFF
--- a/app/models/candidate_interface/gcse_qualification_type_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_type_form.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class GcseQualificationTypeForm
     OTHER_UK_QUALIFICATION_TYPE = 'other_uk'.freeze
-    MISSING_QUALIFICATION_TYPE = 'missing'.freeze
 
     include ActiveModel::Model
 

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -138,9 +138,10 @@ module VendorApi
 
     def qualifications
       {
-        gcses: qualifications_of_level('gcse').map { |q| qualification_to_hash(q) },
+        gcses: qualifications_of_level('gcse').reject(&:missing_qualification?).map { |q| qualification_to_hash(q) },
         degrees: qualifications_of_level('degree').map { |q| qualification_to_hash(q) },
         other_qualifications: qualifications_of_level('other').map { |q| qualification_to_hash(q) },
+        missing_gcses_explanation: missing_gcses_explanation(qualifications_of_level('gcse').select(&:missing_qualification?)),
       }
     end
 
@@ -151,6 +152,12 @@ module VendorApi
       application_form.application_qualifications.select do |q|
         q.level == level
       end
+    end
+
+    def missing_gcses_explanation(gcses)
+      gcses
+        .map { |gcse| "#{gcse.subject.capitalize} GCSE or equivalent: #{gcse.missing_explanation}" }
+        .join("\n\n")
     end
 
     def qualification_to_hash(qualification)

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,15 +1,14 @@
+### 14th January 2020
+
+- Introduce `missing_gcses_explanation` field to [`qualifications`](/api-docs/reference#qualifications-object). This contains the candidate’s explanation for any missing GCSE (or equivalent) qualifications.
+
 ### 7th January 2020
 
-- Correct size of
-  [`personal_statement`](/api-docs/reference#applicationattributes-object)
-  field to 11624 chars
-- Introduce `work_history_break_explanation` field to
-  [`work_experience`](/api-docs/reference#workexperiences-object).  This
-  contains the candidate’s explanation for any breaks in work history.
+- Correct size of [`personal_statement`](/api-docs/reference#applicationattributes-object) field to 11624 chars
+- Introduce `work_history_break_explanation` field to [`work_experience`](/api-docs/reference#workexperiences-object). This contains the candidate’s explanation for any breaks in work history.
 
 ### v1.0 — 18th December 2019
 
 Initial release of the API.
 
-For a log of pre-release changes, [see the alpha release
-notes](/api-docs/alpha-release-notes).
+For a log of pre-release changes, [see the alpha release notes](/api-docs/alpha-release-notes).

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -733,6 +733,7 @@ components:
         - gcses
         - degrees
         - other_qualifications
+        - missing_gcses_explanation
       properties:
         gcses:
           type: array
@@ -746,6 +747,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Qualification"
+        missing_gcses_explanation:
+          type: string
+          nullable: true
+          maxLength: 8192 # Up to 800 words
+          description: If the candidate lacks any required GCSEs, this field will contain their free-text explanation of why this is the case.
+          example: 'Maths GCSE or equivalent: I will take Maths GCSE at my local training provider on 18th August 2020'
 
     WorkExperiences:
       type: object

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -56,7 +56,7 @@ module CandidateHelper
     candidate_fills_in_a_gcse
 
     click_link 'Science GCSE or equivalent'
-    candidate_fills_in_a_gcse
+    candidate_explains_a_missing_gcse
 
     click_link 'Other relevant academic and non-academic qualifications'
     candidate_fills_in_their_other_qualifications
@@ -263,6 +263,13 @@ module CandidateHelper
     fill_in 'When did you get your qualification?', with: '1990'
     click_button 'Save and continue'
     click_link 'Back to application'
+  end
+
+  def candidate_explains_a_missing_gcse
+    choose('I don’t have this qualification yet')
+    fill_in t('application_form.gcse.missing_explanation.label'), with: 'I will sit the exam at my local college this summer.'
+    click_button 'Save and continue'
+    click_link 'Continue'
   end
 
   def candidate_fills_in_becoming_a_teacher

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -92,15 +92,6 @@ RSpec.feature 'Vendor receives the application' do
           gcses: [
             {
               qualification_type: 'gcse',
-              subject: 'science',
-              grade: 'B',
-              award_year: '1990',
-              institution_details: nil,
-              awarding_body: nil,
-              equivalency_details: nil,
-            },
-            {
-              qualification_type: 'gcse',
               subject: 'english',
               grade: 'B',
               award_year: '1990',
@@ -140,6 +131,7 @@ RSpec.feature 'Vendor receives the application' do
               equivalency_details: nil,
             },
           ],
+          missing_gcses_explanation: 'Science GCSE or equivalent: I will sit the exam at my local college this summer.',
         },
         references: [
           {


### PR DESCRIPTION
## Context

We collect this information from Candidates but it's not in the API

## Changes proposed in this pull request

Munge any `missing_explanation`s from the GCSEs we collect into a single text field and add it next to the API.

This was considered an acceptable solution following spike #1037.

## Link to Trello card

https://trello.com/c/uzwLb0jR/1436-display-reason-for-missing-gcses-in-provider-ui-and-in-api

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
