### PR TITLE
Allow support users to add/remove provider users to/from organisations

### DIFF
--- a/app/components/support_interface/provider_users_table_component.rb
+++ b/app/components/support_interface/provider_users_table_component.rb
@@ -9,7 +9,7 @@ module SupportInterface
     def table_rows
       provider_users.map do |provider_user|
         {
-          email_address: provider_user.email_address,
+          email_address: govuk_link_to(provider_user.email_address, edit_support_interface_provider_user_path(provider_user)),
           links_to_providers: links_to_providers(provider_user),
           dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
           created_at: provider_user.created_at,

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -22,7 +22,7 @@ module SupportInterface
   private
 
     def provider_user_params
-      params.require(:support_interface_provider_user_form).permit(:email_address, :dfe_sign_in_uid, :provider_ids)
+      params.require(:support_interface_provider_user_form).permit(:email_address, :dfe_sign_in_uid, provider_ids: [])
     end
   end
 end

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -5,11 +5,11 @@ module SupportInterface
     end
 
     def new
-      @form = ProviderUserForm.new(available_providers: Provider.all)
+      @form = ProviderUserForm.new
     end
 
     def create
-      @form = ProviderUserForm.new(provider_user_params.merge(available_providers: Provider.all))
+      @form = ProviderUserForm.new(provider_user_params)
 
       if @form.save
         flash[:success] = 'Provider user created'
@@ -27,7 +27,7 @@ module SupportInterface
     def update
       provider_user = ProviderUser.find(params[:id])
 
-      @form = ProviderUserForm.new(provider_user_params.merge(provider_user: provider_user, available_providers: Provider.all))
+      @form = ProviderUserForm.new(provider_user_params.merge(provider_user: provider_user))
 
       if @form.save
         flash[:success] = 'Provider user updated'

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -27,7 +27,7 @@ module SupportInterface
     def update
       provider_user = ProviderUser.find(params[:id])
 
-      @form = ProviderUserForm.new(provider_user_params.merge(provider_user: provider_user))
+      @form = ProviderUserForm.new(provider_user_params.merge(provider_user: provider_user, available_providers: Provider.all))
 
       if @form.save
         flash[:success] = 'Provider user updated'

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -19,6 +19,24 @@ module SupportInterface
       end
     end
 
+    def edit
+      provider_user = ProviderUser.find(params[:id])
+      @form = ProviderUserForm.from_provider_user(provider_user)
+    end
+
+    def update
+      provider_user = ProviderUser.find(params[:id])
+
+      @form = ProviderUserForm.new(provider_user_params.merge(provider_user: provider_user))
+
+      if @form.save
+        flash[:success] = 'Provider user updated'
+        redirect_to edit_support_interface_provider_user_path(provider_user)
+      else
+        render :edit
+      end
+    end
+
   private
 
     def provider_user_params

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include ActiveModel::Model
     include ActiveModel::Validations
 
-    attr_accessor :email_address, :provider_ids, :available_providers, :provider_user
+    attr_accessor :email_address, :provider_ids, :provider_user
     attr_writer :dfe_sign_in_uid
 
     validates_presence_of :email_address
@@ -23,6 +23,10 @@ module SupportInterface
       )
     end
 
+    def available_providers
+      @available_providers ||= Provider.order(name: :asc)
+    end
+
     def dfe_sign_in_uid
       @dfe_sign_in_uid&.strip == '' ? nil : @dfe_sign_in_uid # allow nil or non-whitespace
     end
@@ -34,7 +38,6 @@ module SupportInterface
     def self.from_provider_user(provider_user)
       new(
         provider_user: provider_user,
-        available_providers: Provider.all,
         email_address: provider_user.email_address,
         provider_ids: provider_user.provider_ids,
         dfe_sign_in_uid: provider_user.dfe_sign_in_uid,

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -8,6 +8,7 @@ module SupportInterface
 
     validates_presence_of :email_address
     validates :provider_ids, presence: true
+    validate :temporarily_one_provider_per_user
     validate :provider_user_uid_unique
 
     def save
@@ -48,6 +49,12 @@ module SupportInterface
           errors.add(:dfe_sign_in_uid, error)
         end
       end
+    end
+
+    def temporarily_one_provider_per_user
+      return unless provider_ids.count(&:present?) > 1
+
+      errors.add(:provider_ids, 'You can only select one provider per user (temporarily)')
     end
   end
 end

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -11,17 +11,33 @@ module SupportInterface
     validate :provider_user_uid_unique
 
     def save
-      @provider_user = ProviderUser.new(
+      return unless valid?
+
+      @provider_user ||= ProviderUser.new
+
+      @provider_user.update!(
         email_address: email_address,
         dfe_sign_in_uid: dfe_sign_in_uid,
         provider_ids: provider_ids,
       )
-
-      valid? && @provider_user.save!
     end
 
     def dfe_sign_in_uid
       @dfe_sign_in_uid&.strip == '' ? nil : @dfe_sign_in_uid # allow nil or non-whitespace
+    end
+
+    def persisted?
+      provider_user && provider_user.persisted?
+    end
+
+    def self.from_provider_user(provider_user)
+      new(
+        provider_user: provider_user,
+        available_providers: Provider.all,
+        email_address: provider_user.email_address,
+        provider_ids: provider_user.provider_ids,
+        dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+      )
     end
 
   private

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -1,0 +1,35 @@
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', support_interface_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= link_to 'Provider users', support_interface_provider_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Add provider user
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: support_interface_provider_user_path(@form.provider_user), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class='govuk-heading-xl'>
+        Edit provider user
+      </h1>
+
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
+      <% blank_uid_notice = 'If you leave this empty, it will be automatically set when this email address signs in for the first time.' %>
+      <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID' }, hint_text: blank_uid_notice %>
+
+      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
+
+      <%= f.govuk_submit 'Update user' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -25,7 +25,7 @@
       <% blank_uid_notice = 'If you leave this empty, it will be automatically set when this email address signs in for the first time.' %>
       <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID' }, hint_text: blank_uid_notice %>
 
-      <%= f.govuk_collection_radio_buttons :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
+      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
 
       <%= f.govuk_submit 'Add provider user' %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -312,7 +312,7 @@ Rails.application.routes.draw do
       get '/' => 'users#index', as: :users
 
       resources :support_users, only: %i[index new create], path: :support
-      resources :provider_users, only: %i[index new create], path: :provider
+      resources :provider_users, only: %i[index new create edit update], path: :provider
     end
 
     get '/sign-in' => 'sessions#new'

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -17,6 +17,10 @@ RSpec.feature 'Managing provider users' do
 
     then_i_should_see_the_list_of_provider_users
     and_i_should_see_the_user_i_created
+
+    when_i_click_on_that_user
+    and_i_add_them_to_another_organisation
+    then_i_see_that_they_have_been_added_to_that_organisation
   end
 
   def given_i_am_a_support_user
@@ -25,6 +29,7 @@ RSpec.feature 'Managing provider users' do
 
   def and_providers_exist
     create(:provider, name: 'Example provider', code: 'ABC')
+    create(:provider, name: 'Another provider', code: 'DEF')
   end
 
   def when_i_visit_the_support_console
@@ -62,5 +67,19 @@ RSpec.feature 'Managing provider users' do
 
   def and_i_should_see_the_user_i_created
     expect(page).to have_content('harrison@example.com')
+  end
+
+  def when_i_click_on_that_user
+    click_link 'harrison@example.com'
+  end
+
+  def and_i_add_them_to_another_organisation
+    check 'Another provider (DEF)'
+    click_button 'Update user'
+  end
+
+  def then_i_see_that_they_have_been_added_to_that_organisation
+    expect(page).to have_checked_field('Example provider (ABC)')
+    expect(page).to have_checked_field('Another provider (DEF)')
   end
 end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -20,6 +20,10 @@ RSpec.feature 'Managing provider users' do
 
     when_i_click_on_that_user
     and_i_add_them_to_another_organisation
+    then_i_see_an_error
+
+    when_i_remove_the_original_organisation
+    and_i_add_them_to_another_organisation
     then_i_see_that_they_have_been_added_to_that_organisation
   end
 
@@ -78,8 +82,16 @@ RSpec.feature 'Managing provider users' do
     click_button 'Update user'
   end
 
+  def then_i_see_an_error
+    expect(page).to have_content 'You can only select one provider per user'
+  end
+
+  def when_i_remove_the_original_organisation
+    uncheck 'Example provider (ABC)'
+  end
+
   def then_i_see_that_they_have_been_added_to_that_organisation
-    expect(page).to have_checked_field('Example provider (ABC)')
+    expect(page).not_to have_checked_field('Example provider (ABC)')
     expect(page).to have_checked_field('Another provider (DEF)')
   end
 end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_providers_exist
-    create(:provider, name: 'Example provider')
+    create(:provider, name: 'Example provider', code: 'ABC')
   end
 
   def when_i_visit_the_support_console
@@ -45,7 +45,7 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_i_select_a_provider
-    choose 'Example provider'
+    check 'Example provider (ABC)'
   end
 
   def and_i_click_the_add_user_link


### PR DESCRIPTION
## Context

This adds functionality to allow support users to edit provider users, and add/remove any organisations they have access to.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Updated create page with checkboxes:

![image](https://user-images.githubusercontent.com/233676/71970949-84a54080-3201-11ea-84af-9a2077677f06.png)

New edit page:

![image](https://user-images.githubusercontent.com/233676/71970986-97b81080-3201-11ea-8d26-4adc4db7dd12.png)


## Guidance to review

Try it out!

## Link to Trello card

https://trello.com/c/o1e8dgLA/1443-allow-support-users-to-add-remove-provider-users-to-from-organisations

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
