### PR TITLE
Refactor forms with `#build_from_application` and `id` as a parameter

### DIFF
--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -19,7 +19,8 @@ module CandidateInterface
     end
 
     def edit
-      @degree = DegreeForm.build_from_application(current_application, current_degree_id)
+      current_qualification = current_application.application_qualifications.degrees.find(current_degree_id)
+      @degree = DegreeForm.build_from_qualification(current_qualification)
     end
 
     def update

--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -1,7 +1,8 @@
 module CandidateInterface
   class Degrees::DestroyController < CandidateInterfaceController
     def confirm_destroy
-      @degree = DegreeForm.build_from_application(current_application, current_degree_id)
+      current_qualification = current_application.application_qualifications.degrees.find(current_degree_id)
+      @degree = DegreeForm.build_from_qualification(current_qualification)
     end
 
     def destroy

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -27,7 +27,8 @@ module CandidateInterface
     end
 
     def edit
-      @qualification = OtherQualificationForm.build_from_application(current_application, current_other_qualification_id)
+      current_qualification = current_application.application_qualifications.other.find(current_other_qualification_id)
+      @qualification = OtherQualificationForm.build_from_qualification(current_qualification)
     end
 
     def update

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -3,10 +3,8 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_not_amendable
 
     def confirm_destroy
-      @qualification = OtherQualificationForm.build_from_application(
-        current_application,
-        current_other_qualification_id,
-      )
+      current_qualification = current_application.application_qualifications.other.find(current_other_qualification_id)
+      @qualification = OtherQualificationForm.build_from_qualification(current_qualification)
     end
 
     def destroy

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -17,7 +17,8 @@ module CandidateInterface
     end
 
     def edit
-      @volunteering_role = VolunteeringRoleForm.build_from_application(current_application, current_volunteering_role_id)
+      current_experience = current_application.application_volunteering_experiences.find(current_volunteering_role_id)
+      @volunteering_role = VolunteeringRoleForm.build_from_experience(current_experience)
     end
 
     def update

--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -3,7 +3,8 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_not_amendable
 
     def confirm_destroy
-      @volunteering_role = VolunteeringRoleForm.build_from_application(current_application, current_volunteering_role_id)
+      current_experience = current_application.application_volunteering_experiences.find(current_volunteering_role_id)
+      @volunteering_role = VolunteeringRoleForm.build_from_experience(current_experience)
     end
 
     def destroy

--- a/app/models/candidate_interface/degree_form.rb
+++ b/app/models/candidate_interface/degree_form.rb
@@ -25,10 +25,8 @@ module CandidateInterface
         end
       end
 
-      def build_from_application(application_form, degree_id)
-        degree = application_form.application_qualifications.find(degree_id)
-
-        new_degree_form(degree)
+      def build_from_qualification(qualification)
+        new_degree_form(qualification)
       end
 
     private

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -19,9 +19,7 @@ module CandidateInterface
         end
       end
 
-      def build_from_application(application_form, qualification_id)
-        qualification = application_form.application_qualifications.find(qualification_id)
-
+      def build_from_qualification(qualification)
         new_other_qualification_form(qualification)
       end
 

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -28,10 +28,8 @@ module CandidateInterface
         end
       end
 
-      def build_from_application(application_form, volunteering_role_id)
-        volunteering_role = application_form.application_volunteering_experiences.find(volunteering_role_id)
-
-        new_volunteering_role_form(volunteering_role)
+      def build_from_experience(experience)
+        new_volunteering_role_form(experience)
       end
 
     private

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -1,39 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::DegreesReviewComponent do
-  let(:application_form) do
-    create(:application_form) do |form|
-      form.application_qualifications.create(
-        id: 1,
-        level: 'degree',
-        qualification_type: 'BA',
-        subject: 'Woof',
-        institution_name: 'University of Doge',
-        grade: 'upper_second',
-        predicted_grade: false,
-        award_year: '2008',
-      )
-      form.application_qualifications.create(
-        id: 2,
-        level: 'degree',
-        qualification_type: 'BA',
-        subject: 'Meow',
-        institution_name: 'University of Cate',
-        grade: 'First',
-        predicted_grade: true,
-        award_year: '2010',
-      )
-      form.application_qualifications.create(
-        id: 3,
-        level: 'degree',
-        qualification_type: 'BA',
-        subject: 'Hoot',
-        institution_name: 'University of Owl',
-        grade: 'Distinction',
-        predicted_grade: false,
-        award_year: '2010',
-      )
-    end
+  let(:application_form) { create(:application_form) }
+  let!(:degree1) do
+    application_form.application_qualifications.create(
+      level: 'degree',
+      qualification_type: 'BA',
+      subject: 'Woof',
+      institution_name: 'University of Doge',
+      grade: 'upper_second',
+      predicted_grade: false,
+      award_year: '2008',
+    )
+  end
+  let(:degree2) do
+    {
+      level: 'degree',
+      qualification_type: 'BA',
+      subject: 'Meow',
+      institution_name: 'University of Cate',
+      grade: 'First',
+      predicted_grade: true,
+      award_year: '2010',
+    }
   end
 
   context 'when degrees are editable' do
@@ -43,8 +32,8 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('BA Woof')
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.qualification.label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('BA Woof<br>University of Doge')
-      expect(result.css('.govuk-summary-list__actions a')[3].attr('href')).to include(
-        Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(2),
+      expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree1),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.degree.qualification.change_action')}")
     end
@@ -68,6 +57,8 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
 
     it 'renders component with correct values for a predicted grade' do
+      application_form.application_qualifications.create(degree2)
+
       result = render_inline(described_class, application_form: application_form)
 
       expect(result.css('.app-summary-card__title').text).to include('BA Meow')
@@ -75,6 +66,16 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
 
     it 'renders component with correct values for an other grade' do
+      application_form.application_qualifications.create(
+        level: 'degree',
+        qualification_type: 'BA',
+        subject: 'Hoot',
+        institution_name: 'University of Owl',
+        grade: 'Distinction',
+        predicted_grade: false,
+        award_year: '2010',
+      )
+
       result = render_inline(described_class, application_form: application_form)
 
       expect(result.css('.app-summary-card__title').text).to include('BA Hoot')
@@ -82,6 +83,8 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
 
     it 'renders component with correct values for multiple degrees' do
+      application_form.application_qualifications.create(degree2)
+
       result = render_inline(described_class, application_form: application_form)
 
       expect(result.css('.app-summary-card__title').text).to include('BA Woof')
@@ -93,7 +96,7 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
 
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.degree.delete'))
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
-        Rails.application.routes.url_helpers.candidate_interface_confirm_degrees_destroy_path(3),
+        Rails.application.routes.url_helpers.candidate_interface_confirm_degrees_destroy_path(degree1),
       )
     end
   end

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -1,25 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
-  let(:application_form) do
-    create(:application_form) do |form|
-      form.application_qualifications.create(
-        id: 1,
-        level: 'other',
-        qualification_type: 'A-Level',
-        subject: 'Making Doggo Sounds',
-        institution_name: 'Doggo Sounds College',
-        grade: 'A',
-        predicted_grade: false,
-        award_year: '2012',
-      )
-      form.application_qualifications.create(
-        id: 2,
-        level: 'other',
-        qualification_type: 'A-Level',
-        subject: 'Making Cat Sounds',
-      )
-    end
+  let(:application_form) { create(:application_form) }
+  let!(:qualification1) do
+    application_form.application_qualifications.create(
+      level: 'other',
+      qualification_type: 'A-Level',
+      subject: 'Making Doggo Sounds',
+      institution_name: 'Doggo Sounds College',
+      grade: 'A',
+      predicted_grade: false,
+      award_year: '2012',
+    )
+  end
+  let!(:qualification2) do
+    application_form.application_qualifications.create(
+      level: 'other',
+      qualification_type: 'A-Level',
+      subject: 'Making Cat Sounds',
+    )
   end
 
   context 'when other qualifications are editable' do
@@ -32,7 +31,7 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include('A-Level Making Doggo Sounds')
       expect(result.css('.govuk-summary-list__value').to_html).to include('Doggo Sounds College')
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(1),
+        Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification1),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.institution.change_action')}")
     end
@@ -62,12 +61,15 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('A-Level Making Cat Sounds')
     end
 
-    it 'renders component along with a delete link for each degree' do
+    it 'renders component along with a delete link for each qualification' do
       result = render_inline(described_class, application_form: application_form)
 
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.other_qualification.delete'))
+      expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
+        Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(qualification1),
+      )
       expect(result.css('.app-summary-card__actions a')[1].attr('href')).to include(
-        Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(2),
+        Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(qualification2),
       )
     end
   end

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -24,27 +24,16 @@ RSpec.describe VolunteeringReviewComponent do
   end
 
   context 'when they have experience in volunteering' do
-    let(:application_form) do
-      create(:application_form) do |form|
-        form.application_volunteering_experiences.create(
-          id: 1,
-          role: 'School Experience Intern',
-          organisation: Faker::Educator.secondary_school,
-          details: Faker::Lorem.paragraph_by_chars(number: 300),
-          working_with_children: false,
-          start_date: Time.zone.local(2018, 5, 1),
-          end_date: Time.zone.local(2019, 5, 1),
-        )
-        form.application_volunteering_experiences.create(
-          id: 2,
-          role: 'School Experience Intern',
-          organisation: 'A Noice School',
-          details: 'I interned.',
-          working_with_children: true,
-          start_date: Time.zone.local(2019, 8, 1),
-          end_date: nil,
-        )
-      end
+    let(:application_form) { create(:application_form) }
+    let!(:volunteering_role) do
+      application_form.application_volunteering_experiences.create(
+        role: 'School Experience Intern',
+        organisation: 'A Noice School',
+        details: 'I interned.',
+        working_with_children: true,
+        start_date: Time.zone.local(2019, 8, 1),
+        end_date: nil,
+      )
     end
 
     it 'renders component with the role in the summary card title' do
@@ -65,7 +54,7 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.role.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('School Experience Intern')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.role.change_action')}")
     end
@@ -76,7 +65,7 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.organisation.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('A Noice School')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.organisation.change_action')}")
     end
@@ -87,7 +76,7 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_length.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('August 2019 - Present')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.review_length.change_action')}")
     end
@@ -98,7 +87,7 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_details.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('<p>I interned.</p>')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(2),
+        Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.review_details.change_action')}")
     end
@@ -108,7 +97,7 @@ RSpec.describe VolunteeringReviewComponent do
 
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.volunteering.delete'))
       expect(result.css('.app-summary-card__actions a').attr('href').value).to include(
-        Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_volunteering_role_path(2),
+        Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role),
       )
     end
 

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -14,19 +14,16 @@ RSpec.describe WorkHistoryReviewComponent do
   context 'when there is not a break in the work history' do
     let(:application_form) do
       create(:application_form) do |form|
-        data[:id] = 1
         data[:organisation] = 'Vararu School'
         data[:start_date] = Time.zone.local(2019, 1, 1)
         data[:end_date] = Time.zone.local(2019, 6, 1)
         form.application_work_experiences.create(data)
 
-        data[:id] = 2
         data[:organisation] = 'Theo School'
         data[:start_date] = Time.zone.local(2019, 6, 1)
         data[:end_date] = Time.zone.local(2019, 8, 1)
         form.application_work_experiences.create(data)
 
-        data[:id] = 3
         data[:organisation] = 'Vararu School'
         data[:start_date] = Time.zone.local(2019, 8, 1)
         data[:end_date] = Time.zone.local(2019, 10, 1)
@@ -102,7 +99,6 @@ RSpec.describe WorkHistoryReviewComponent do
     let(:application_form) do
       Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
         create(:application_form) do |form|
-          data[:id] = 1
           data[:start_date] = Time.zone.local(2019, 8, 1)
           data[:end_date] = Time.zone.local(2019, 9, 1)
           form.application_work_experiences.create(data)

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
           created_at: DateTime.new(2019, 1, 1, 1, 9, 0, 0),
         )
         form.application_qualifications.create(
-          id: 1,
           level: 'other',
           qualification_type: 'BTEC',
           subject: 'Being a Superhero',
@@ -107,23 +106,20 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     end
   end
 
-  describe '.build_from_application' do
-    it 'returns a new OtherQualificationForm object using the id' do
-      application_form = create(:application_form) do |form|
-        form.application_qualifications.create(
-          id: 1,
-          level: 'other',
-          qualification_type: 'BTEC',
-          subject: 'Being a Sidekick',
-          institution_name: 'School of Sidekicks',
-          grade: 'Merit',
-          predicted_grade: false,
-          award_year: '2010',
-        )
-        form.application_qualifications.create(id: 2, level: 'other')
-      end
+  describe '.build_from_qualification' do
+    it 'returns a new OtherQualificationForm object using an application qualification' do
+      application_qualification = build_stubbed(
+        :application_qualification,
+        level: 'other',
+        qualification_type: 'BTEC',
+        subject: 'Being a Sidekick',
+        institution_name: 'School of Sidekicks',
+        grade: 'Merit',
+        predicted_grade: false,
+        award_year: '2010',
+      )
 
-      qualification = CandidateInterface::OtherQualificationForm.build_from_application(application_form, 1)
+      qualification = CandidateInterface::OtherQualificationForm.build_from_qualification(application_qualification)
 
       expect(qualification).to have_attributes(qualification_type: 'BTEC', subject: 'Being a Sidekick')
     end
@@ -161,29 +157,29 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
     end
 
     it 'updates the provided ApplicationForm if valid' do
+      application_form = create(:application_form)
+
+      existing_qualification = application_form.application_qualifications.create(
+        level: 'other',
+        qualification_type: 'BTEC',
+        subject: 'Being a Everyday Hero',
+        institution_name: 'School of Hoomans',
+        grade: 'Pass',
+        predicted_grade: false,
+        award_year: '2011',
+      )
+
       form_data = {
-        id: 1,
+        id: existing_qualification.id,
         qualification_type: 'BTEC',
         subject: 'Being a Everyday Hero',
         institution_name: 'School of Humans',
         grade: 'Distinction',
         award_year: '2011',
       }
-      qualification = CandidateInterface::OtherQualificationForm.new(form_data)
-      application_form = create(:application_form) do |form|
-        form.application_qualifications.create(
-          id: 1,
-          level: 'other',
-          qualification_type: 'BTEC',
-          subject: 'Being a Everyday Hero',
-          institution_name: 'School of Hoomans',
-          grade: 'Pass',
-          predicted_grade: false,
-          award_year: '2011',
-        )
-      end
+      qualification_form = CandidateInterface::OtherQualificationForm.new(form_data)
 
-      expect(qualification.update(application_form)).to eq(true)
+      expect(qualification_form.update(application_form)).to eq(true)
       expect(application_form.application_qualifications.other.first)
         .to have_attributes(form_data)
     end

--- a/spec/models/candidate_interface/volunteering_role_form_spec.rb
+++ b/spec/models/candidate_interface/volunteering_role_form_spec.rb
@@ -28,9 +28,8 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
   describe '.build_all_from_application' do
     it 'creates an array of objects based on the provided ApplicationForm' do
       application_form = create(:application_form) do |form|
-        form.application_volunteering_experiences.create(id: 1, attributes: data)
+        form.application_volunteering_experiences.create(attributes: data)
         form.application_volunteering_experiences.create(
-          id: 2,
           role: 'School Experience Intern',
           organisation: 'A Noice School',
           details: 'I interned.',
@@ -45,7 +44,6 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
       expect(volunteering_roles).to match_array([
         have_attributes(form_data),
         have_attributes(
-          id: 2,
           role: 'School Experience Intern',
           organisation: 'A Noice School',
           details: 'I interned.',
@@ -59,15 +57,13 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
     end
   end
 
-  describe '.build_from_application' do
-    it 'returns a new VolunteeringRoleForm object using the id' do
-      application_form = create(:application_form) do |form|
-        form.application_volunteering_experiences.create(id: 1, attributes: data)
-      end
+  describe '.build_from_experience' do
+    it 'returns a new VolunteeringRoleForm object using an application experience' do
+      application_experience = build_stubbed(:application_volunteering_experience, attributes: data)
 
-      volunteering_roles = CandidateInterface::VolunteeringRoleForm.build_from_application(application_form, 1)
+      volunteering_role = CandidateInterface::VolunteeringRoleForm.build_from_experience(application_experience)
 
-      expect(volunteering_roles).to have_attributes(form_data)
+      expect(volunteering_role).to have_attributes(form_data)
     end
   end
 
@@ -97,12 +93,11 @@ RSpec.describe CandidateInterface::VolunteeringRoleForm, type: :model do
   end
 
   describe '#update' do
-    let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(id: 1) }
-    let(:application_form) do
-      create(:application_form) do |form|
-        form.application_volunteering_experiences.create(id: 1, attributes: data)
-      end
+    let(:application_form) { create(:application_form) }
+    let(:existing_volunteering) do
+      application_form.application_volunteering_experiences.create(attributes: data)
     end
+    let(:volunteering_role) { CandidateInterface::VolunteeringRoleForm.new(id: existing_volunteering.id) }
 
     it 'returns false if not valid' do
       expect(volunteering_role.update(ApplicationForm.new)).to eq(false)


### PR DESCRIPTION
## Context

Master failed (https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=37643&view=logs&j=32f3c9c7-a610-55d2-616a-efba1ecc24a2&t=85c1dfa3-8bc2-5353-acab-1c1a0e7b38db) because of:

```
  1) CandidateInterface::OtherQualificationForm.build_all_from_application orders other qualifications by created at
     Failure/Error:
       form.application_qualifications.create(
         id: 1,
         level: 'other',
         qualification_type: 'BTEC',
         subject: 'Being a Superhero',
         institution_name: 'School of Heroes',
         grade: 'Distinction',
         predicted_grade: false,
         award_year: '2012',
         created_at: DateTime.new(2019, 1, 1, 21, 0, 0),

     ActiveRecord::RecordNotUnique:
       PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "application_qualifications_pkey"
       DETAIL:  Key (id)=(1) already exists.
```

This is a flaky test and related to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/869. Turns out that the `OtherQualificationForm` doesn't need to take in an `id` and can instead take in an `application_qualification` object so that finding it can be handled by the controller. This means that tests aren't needed for asserting `id`s and that these form objects are consistent with other ones like work history and GCSEs.

There are a few other form objects that take in an `application_form` and some form of `id` so this PR refactors those as well.

## Changes proposed in this pull request

This PR refactors:

- `OtherQualificationForm#build_from_application` to be `#build_from_qualification`
- `DegreeForm#build_from_application` to be `#build_from_qualification`
- `VolunteeringRoleForm#build_from_application` to be `#build_from_experience`

## Guidance to review

- Review commit by commit
- Does this make sense?
- Have any other forms been missed?

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
