### PR TITLE
Update 'Change' links in work history for more context

### DIFF
--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -1,4 +1,4 @@
-<% @application_form.application_work_experiences.each do |work| %>
+<% @application_form.application_work_experiences.order(:start_date).each do |work| %>
   <%= render(SummaryCardComponent, rows: work_experience_rows(work), editable: @editable) do %>
     <%= render(SummaryCardHeaderComponent, title: work.role, heading_level: @heading_level, check_icon: work.working_with_children) do %>
       <% if @editable %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -59,7 +59,7 @@ private
     {
       key: 'Job',
       value: [work.role, work.organisation],
-      action: 'job',
+      action: generate_change_action(work: work, attribute: 'job title'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -68,7 +68,7 @@ private
     {
       key: 'Type',
       value: work.commitment.dasherize.humanize,
-      action: 'type',
+      action: generate_change_action(work: work, attribute: 'type'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -77,7 +77,7 @@ private
     {
       key: 'Description',
       value: work.details,
-      action: 'description',
+      action: generate_change_action(work: work, attribute: 'description'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -86,7 +86,7 @@ private
     {
       key: 'Dates',
       value: "#{formatted_start_date(work)} - #{formatted_end_date(work)}",
-      action: 'description',
+      action: generate_change_action(work: work, attribute: 'dates'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -99,5 +99,18 @@ private
     return 'Present' if work.end_date.nil?
 
     work.end_date.to_s(:month_and_year)
+  end
+
+  def generate_change_action(work:, attribute:)
+    if any_jobs_with_same_role_and_organisation?(work)
+      "#{attribute} for #{work.role}, #{work.organisation}, #{formatted_start_date(work)} to #{formatted_end_date(work)}"
+    else
+      "#{attribute} for #{work.role}, #{work.organisation}"
+    end
+  end
+
+  def any_jobs_with_same_role_and_organisation?(work)
+    jobs = @application_form.application_work_experiences.where(role: work.role, organisation: work.organisation)
+    jobs.many?
   end
 end


### PR DESCRIPTION
## Context

We've been wanting to solve an accessibility issue that was reported in our external audit about `Change` links in sections that have multiple entries not having enough context when using the links list functionality of a screen reader. For example in the work history review page, when using the links list it would list multiple `Change job`, `Change type` links if a candidate has entered multiple jobs. This makes it difficult to know the purpose of the link when navigating out of context. 

We believed that adding `aria-describedby` would solve this issue (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1032) but it turns out this isn't the case so we reverted it in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1053. To our knowledge, the only way to allow for more context for a link in the links list is by changing the content of the link.

## Changes proposed in this pull request

This PR updates the `Change` links in work history to have more detailed visually hidden text by adding in the job title and name of employer. Also, if a candidate has more than one entries for the same role and employer, then the dates are added.

![image](https://user-images.githubusercontent.com/42817036/71975434-d8b52280-320b-11ea-86f8-ceaed3f4e0ff.png)

![image](https://user-images.githubusercontent.com/42817036/71975451-e2d72100-320b-11ea-9d33-179e5a1e075c.png)

![image](https://user-images.githubusercontent.com/42817036/71975490-fbdfd200-320b-11ea-826b-ba44075186ed.png)

## Guidance to review

- I wasn't able to take a screenshot of the links list so try it out locally
- Is there a nice Ruby or Rails way to work out uniqueness based on attributes? Ended up with `any_jobs_with_same_role_and_organisation?(work)`
- Had to add ordering when displaying the jobs on the review to prevent flakey tests. Does that make sense?

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
