### PR TITLE
Allow providers to generate their own API tokens

### DIFF
--- a/app/controllers/provider_interface/api_tokens_controller.rb
+++ b/app/controllers/provider_interface/api_tokens_controller.rb
@@ -1,0 +1,12 @@
+module ProviderInterface
+  class ApiTokensController < ProviderInterfaceController
+    def index
+      @api_tokens = VendorApiToken.where(provider: current_provider_user.providers)
+    end
+
+    def create
+      provider = current_provider_user.providers.find(params[:vendor_api_token][:provider_id])
+      @unhashed_token = VendorApiToken.create_with_random_token!(provider: provider)
+    end
+  end
+end

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -39,9 +39,11 @@ class NavigationItems
       end
     end
 
-    def for_provider_interface(current_provider_user, dfe_sign_in_user)
+    def for_provider_interface(current_provider_user, dfe_sign_in_user, current_controller)
       if current_provider_user
         [
+          NavigationItem.new('Applications', provider_interface_applications_path, is_active(current_controller, %w[application_choices decision])),
+          NavigationItem.new('API tokens', provider_interface_api_tokens_path, is_active(current_controller, %w[api_tokens])),
           NavigationItem.new(current_provider_user.email_address, nil, false),
           NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
         ]

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -66,7 +66,7 @@
                  classes: "app-header--#{HostingEnvironment.environment_name}",
                  service_name: service_name,
                  service_url: service_link,
-                 navigation_items: NavigationItems.for_provider_interface(current_provider_user, dfe_sign_in_user)) %>
+                 navigation_items: NavigationItems.for_provider_interface(current_provider_user, dfe_sign_in_user, controller)) %>
     <% when 'api_docs' %>
       <%= render(HeaderComponent,
                  classes: "app-header--#{HostingEnvironment.environment_name}",

--- a/app/views/provider_interface/api_tokens/create.html.erb
+++ b/app/views/provider_interface/api_tokens/create.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, 'API token created' %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_api_tokens_path) %>
+
+<div class="govuk-warning-text">
+  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+  <strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    You can only view this token once, copy it now.
+  </strong>
+</div>
+
+<div class="govuk-panel govuk-panel--confirmation">
+  <h1 class="govuk-panel__title">
+    New API token generated
+  </h1>
+  <div class="govuk-panel__body">
+    Your token is<br> <code><%= @unhashed_token %></code>
+  </div>
+</div>

--- a/app/views/provider_interface/api_tokens/index.html.erb
+++ b/app/views/provider_interface/api_tokens/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, 'API tokens' %>
+
+<h1 class="govuk-heading-xl">API tokens</h1>
+
+<p class="govuk-body">
+  API tokens can be used by Student Record Systems and other software to integrate
+  with this service. For more information <%= govuk_link_to 'refer to our API documentation', api_docs_home_path %>.
+</p>
+
+<h2 class="govuk-heading-m">Generate a new token</h2>
+
+<%= form_with model: VendorApiToken.new, url: provider_interface_api_tokens_path do |f| %>
+  <%= f.govuk_collection_select :provider_id, current_provider_user.providers, :id, :name, label: { text: 'Provider' } %>
+  <%= f.govuk_submit 'Create new token' %>
+<% end %>
+
+<h2 class="govuk-heading-m">Existing tokens</h2>
+
+<% if @api_tokens.empty? %>
+  <p class="govuk-body">
+    You haven't generated any tokens.
+  </p>
+<% else %>
+  <table class='govuk-table'>
+    <thead class='govuk-table__head'>
+      <tr class='govuk-table__row'>
+        <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>ID</th>
+        <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Provider</th>
+        <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Created at</th>
+      </tr>
+    </thead>
+
+    <tbody class='govuk-table__body'>
+      <% @api_tokens.each do |token| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'>#<%= token.id %></td>
+        <td class='govuk-table__cell'><%= token.provider.name %></td>
+        <td class='govuk-table__cell'><%= token.created_at.to_s(:long) %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,8 @@ Rails.application.routes.draw do
     post '/applications/:application_choice_id/offer/confirm' => 'decisions#confirm_offer', as: :application_choice_confirm_offer
     post '/applications/:application_choice_id/offer' => 'decisions#create_offer', as: :application_choice_create_offer
 
+    get '/api-tokens' => 'api_tokens#index', as: :api_tokens
+    post '/api-tokens' => 'api_tokens#create'
 
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'

--- a/spec/system/provider_interface/manage_provider_api_tokens_spec.rb
+++ b/spec/system/provider_interface/manage_provider_api_tokens_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.feature 'Manage API tokens' do
+  include DfESignInHelpers
+
+  scenario 'Provider user creates a token' do
+    given_i_am_signed_in
+    when_i_visit_the_tokens_page
+    and_i_click_on_create_a_token
+    then_i_should_see_a_new_token
+    and_i_am_able_to_connect_to_the_api_using_the_token
+    and_the_token_is_visible_on_the_tokens_page
+  end
+
+  def given_i_am_signed_in
+    provider_user = provider_user_exists_in_apply_database
+    create(:provider, name: 'Super Provider', code: 'ABC', provider_users: [provider_user])
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def when_i_visit_the_tokens_page
+    visit provider_interface_api_tokens_path
+  end
+
+  def and_i_click_on_create_a_token
+    select 'Super Provider'
+    click_on 'Create new token'
+  end
+
+  def then_i_should_see_a_new_token
+    expect(page).to have_content 'Your token is'
+  end
+
+  def and_i_am_able_to_connect_to_the_api_using_the_token
+    api_token = page.find('code').text
+    page.driver.header 'Authorization', "Bearer #{api_token}"
+
+    visit '/api/v1/ping'
+
+    expect(page).to have_content('pong')
+  end
+
+  def and_the_token_is_visible_on_the_tokens_page
+    page.driver.browser.authorize('test', 'test')
+    visit provider_interface_api_tokens_path
+
+    within '.govuk-table' do
+      expect(page).to have_content 'Super Provider'
+    end
+  end
+end


### PR DESCRIPTION
## Context

Allow provider to user to create their own API tokens. This will make more of the service self-serve.

<!-- Why are you making this change? What might surprise someone about it? -->
## Changes proposed in this pull request

To do:

- [ ] Design for index page
- [ ] Design for creation page
- [ ] Update after https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1059 is merged
- [ ] Update API docs to link to this



<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Just look at the code, not the design & copy.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/jsBILlcB/1453-mint-api-keys-in-provider-ui-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
