### PR TITLE
Swallow ConcurrentMigrationErrors on container start

### DIFF
--- a/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
@@ -1,0 +1,14 @@
+# rubocop:disable Lint/SuppressedException
+namespace :db do
+  namespace :migrate do
+    desc 'Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors'
+    task ignore_concurrent_migration_exceptions: :environment do
+      begin
+        Rake::Task['db:migrate'].invoke
+      rescue ActiveRecord::ConcurrentMigrationError
+        # Do nothing
+      end
+    end
+  end
+end
+# rubocop:enable Lint/SuppressedException


### PR DESCRIPTION
## Context

When we deploy, we sometimes see `ConcurrentMigrationErrors` in Sentry (https://sentry.io/organizations/dfe-bat/issues/1346140727/?project=1765973&query=is%3Aunresolved).

## Changes proposed in this pull request

Swallow these exceptions.

Further reading: https://nebulab.it/blog/the-strange-case-of-activerecord-concurrentmigrationerror/

## Guidance to review

Is this foolish & reckless?

## Link to Trello card

https://trello.com/c/YIL1e10L/1421-fix-occasional-concurrentmigrationerrors-upon-deployment

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
