### PR TITLE
Use reference_form flag to sent chaser email with reference form link

### DIFF
--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -1,11 +1,11 @@
 class RefereeMailer < ApplicationMailer
-  def reference_request_email(application_form, reference, unhashed_token)
+  def reference_request_email(application_form, reference)
     @application_form = application_form
     @reference = reference
     @candidate_name = application_form.full_name
 
     if FeatureFlag.active?('reference_form')
-      @reference_link = referee_interface_reference_feedback_url(token: unhashed_token)
+      @reference_link = referee_interface_reference_feedback_url(token: reference.update_token!)
       @decline_reference_link = 'link_to_decline_the_reference' #TODO: implement the flow for Referee decline to give references
       template_name = :reference_request_email
     else

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -23,7 +23,12 @@ class RefereeMailer < ApplicationMailer
     @application_form = application_form
     @reference = reference
     @candidate_name = application_form.full_name
-    @google_form_url = google_form_url_for(@candidate_name, @reference)
+
+    @reference_link = if FeatureFlag.active?('reference_form')
+                        referee_interface_reference_feedback_url(token: reference.update_token!)
+                      else
+                        google_form_url_for(@candidate_name, @reference)
+                      end
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -22,9 +22,7 @@ private
 
   def send_reference_request_email_to_referees(application_form)
     application_form.application_references.includes(:application_form).each do |reference|
-      unhashed_token = reference.update_token!
-
-      RefereeMailer.reference_request_email(application_form, reference, unhashed_token).deliver_later
+      RefereeMailer.reference_request_email(application_form, reference).deliver_later
     end
   end
 

--- a/app/views/referee_mailer/reference_request_chaser_email.text.erb
+++ b/app/views/referee_mailer/reference_request_chaser_email.text.erb
@@ -10,7 +10,7 @@ We haven’t had your reference for <%= @candidate_name %>. They put us in touch
 
 Please use the link below to give a complete reference within 5 working days.
 
-<%= @google_form_url %>
+<%= @reference_link %>
 
 If you won’t give <%= @candidate_name %> a reference, please let us know as soon as possible by emailing: [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -22,40 +22,57 @@ RSpec.describe RefereeMailer, type: :mailer do
     end
     let(:reference) { application_form.application_references.first }
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
-    let(:mail) { mailer.reference_request_email(application_form, reference, 'reference-token') }
+    let(:mail) { mailer.reference_request_email(application_form, reference) }
 
-    before { mail.deliver_now }
+    describe 'with reference_form feature flag on' do
+      before do
+        FeatureFlag.activate('reference_form')
+        mail.deliver_now
+      end
 
-    it 'sends an email with the correct subject' do
-      expect(mail.subject).to include(t('reference_request.subject.initial', candidate_name: candidate_name))
+      it 'sends an email with a link to the reference form' do
+        body = mail.body.encoded
+        expect(body).to include(referee_interface_reference_feedback_url(token: ''))
+      end
     end
 
-    it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include("Give a reference for #{candidate_name}")
-    end
+    describe 'with reference_form feature flag off' do
+      before do
+        FeatureFlag.deactivate('reference_form')
+        mail.deliver_now
+      end
 
-    it 'sends an email with the correct courses listed' do
-      expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
-      expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
-      expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
-    end
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('reference_request.subject.initial', candidate_name: candidate_name))
+      end
 
-    it 'sends an email with a link to a prefilled Google form' do
-      body = mail.body.encoded
-      expect(body).to include(t('reference_request.google_form_url'))
-      expect(body).to include("=#{reference.id}")
-      expect(body).to include("=#{CGI.escape(reference.email_address)}")
-    end
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include("Give a reference for #{candidate_name}")
+      end
 
-    it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
-      expect(mail.body.encoded).to include('Harry%20O%27Potter')
-    end
+      it 'sends an email with the correct courses listed' do
+        expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
+        expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
+        expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
+      end
 
-    context 'an email containing a +' do
-      let(:reference) { build(:reference, email_address: 'email+email@email.com') }
+      it 'sends an email with a link to a prefilled Google form' do
+        body = mail.body.encoded
+        expect(body).to include(t('reference_request.google_form_url'))
+        expect(body).to include("=#{reference.id}")
+        expect(body).to include("=#{CGI.escape(reference.email_address)}")
+      end
 
-      it 'does not strip the plus from the email address' do
-        expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
+      it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
+        expect(mail.body.encoded).to include('Harry%20O%27Potter')
+      end
+
+      context 'an email containing a +' do
+        let(:reference) { build(:reference, email_address: 'email+email@email.com') }
+
+        it 'does not strip the plus from the email address' do
+          expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
+        end
       end
     end
   end

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
+# rubocop:disable RSpec/NestedGroups
 RSpec.describe RefereeMailer, type: :mailer do
   subject(:mailer) { described_class }
 
@@ -98,39 +99,56 @@ RSpec.describe RefereeMailer, type: :mailer do
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
     let(:mail) { mailer.reference_request_chaser_email(application_form, reference) }
 
-    before { mail.deliver_now }
+    describe 'with reference_form feature flag on' do
+      before do
+        FeatureFlag.activate('reference_form')
+        mail.deliver_now
+      end
 
-    it 'sends an email with the correct subject' do
-      expect(mail.subject).to include(t('reference_request.subject.chaser', candidate_name: candidate_name))
+      it 'sends an email with a link to the reference form' do
+        body = mail.body.encoded
+        expect(body).to include(referee_interface_reference_feedback_url(token: ''))
+      end
     end
 
-    it 'sends an email with the correct heading' do
-      expect(mail.body.encoded).to include("Give a reference for #{candidate_name}")
-    end
+    describe 'with reference_form feature flag off' do
+      before do
+        FeatureFlag.deactivate('reference_form')
+        mail.deliver_now
+      end
 
-    it 'sends an email with the correct courses listed' do
-      expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
-      expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
-      expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
-    end
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('reference_request.subject.chaser', candidate_name: candidate_name))
+      end
 
-    it 'sends an email with a link to a prefilled Google form' do
-      body = mail.body.encoded
-      expect(body).to include(t('reference_request.google_form_url'))
-      expect(body).to include("=#{reference.id}")
-      expect(body).to include("=#{CGI.escape(reference.email_address)}")
-    end
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include("Give a reference for #{candidate_name}")
+      end
 
-    it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
-      expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
-      expect(mail.body.encoded).to include("=#{reference.name.gsub(' ', '%20')}")
-    end
+      it 'sends an email with the correct courses listed' do
+        expect(mail.body.encoded).to include("#{first_application_choice.provider.name} - #{first_application_choice.course.name}")
+        expect(mail.body.encoded).to include("#{second_application_choice.provider.name} - #{second_application_choice.course.name}")
+        expect(mail.body.encoded).to include("#{third_application_choice.provider.name} - #{third_application_choice.course.name}")
+      end
 
-    context 'an email containing a +' do
-      let(:reference) { build(:reference, email_address: 'email+email@email.com') }
+      it 'sends an email with a link to a prefilled Google form' do
+        body = mail.body.encoded
+        expect(body).to include(t('reference_request.google_form_url'))
+        expect(body).to include("=#{reference.id}")
+        expect(body).to include("=#{CGI.escape(reference.email_address)}")
+      end
 
-      it 'does not strip the plus from the email address' do
-        expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
+      it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
+        expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
+        expect(mail.body.encoded).to include("=#{reference.name.gsub(' ', '%20')}")
+      end
+
+      context 'an email containing a +' do
+        let(:reference) { build(:reference, email_address: 'email+email@email.com') }
+
+        it 'does not strip the plus from the email address' do
+          expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
+        end
       end
     end
   end
@@ -191,3 +209,4 @@ RSpec.describe RefereeMailer, type: :mailer do
     end
   end
 end
+# rubocop:enable RSpec/NestedGroups


### PR DESCRIPTION
## Context

We currently still send them a link to the Google form.

## Changes proposed in this pull request

Also calculate referee token inside `reference_request_email` which fixes the preview emails, and add some test coverage.

## Guidance to review

First commit is just refactoring for `reference_request_email`.

Ignore whitespace changes.

## Link to Trello card

https://trello.com/c/WSSNWFwl/736-change-google-form-url-in-referee-chaser-email

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)