### PR TITLE
Update 'Change' links in referees for more context

### DIFF
--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -35,7 +35,7 @@ module CandidateInterface
       {
         key: 'Name',
         value: referee.name,
-        action: 'name',
+        action: "name for #{referee.name}",
         change_path: candidate_interface_edit_referee_path(referee.id),
       }
     end
@@ -44,7 +44,7 @@ module CandidateInterface
       {
         key: 'Email address',
         value: referee.email_address,
-        action: 'email address',
+        action: "email address for #{referee.name}",
         change_path: candidate_interface_edit_referee_path(referee.id),
       }
     end
@@ -53,7 +53,7 @@ module CandidateInterface
       {
         key: 'Relationship',
         value: referee.relationship,
-        action: 'relationship',
+        action: "relationship for #{referee.name}",
         change_path: candidate_interface_edit_referee_path(referee.id),
       }
     end

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -34,6 +34,19 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_referee_path(referee_id),
       )
     end
+
+    it 'renders correct text for "Change" links in each attribute row' do
+      first_referee = application_form.application_references.first
+      result = render_inline(described_class, application_form: application_form)
+
+      change_name = result.css('.govuk-summary-list__actions')[0].text.strip
+      change_email = result.css('.govuk-summary-list__actions')[1].text.strip
+      change_relationship = result.css('.govuk-summary-list__actions')[2].text.strip
+
+      expect(change_name).to eq("Change name for #{first_referee.name}")
+      expect(change_email).to eq("Change email address for #{first_referee.name}")
+      expect(change_relationship).to eq("Change relationship for #{first_referee.name}")
+    end
   end
 
   context 'when referees are not editable' do


### PR DESCRIPTION
## Context

We need to make `Change` links in the referees section more accessible. See https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1056 for more context.

## Changes proposed in this pull request

This PR updates the `Change` links in referees to more detailed visually hidden text by adding in the name of the referee.

![image](https://user-images.githubusercontent.com/42817036/72001608-b5a36680-323d-11ea-991b-fc39a5e9093c.png)

![image](https://user-images.githubusercontent.com/42817036/72001646-c81da000-323d-11ea-9b9b-272df5ab479c.png)


## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
