### PR TITLE
Support reference improvements

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -18,6 +18,10 @@ class ApplicationForm < ApplicationRecord
     apply_2: 'apply_2',
   }
 
+  before_create -> {
+    self.support_reference ||= GenerateSupportRef.call
+  }
+
   after_save -> {
     application_choices.update_all(updated_at: Time.zone.now)
   }

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -8,8 +8,7 @@ class SubmitApplication
 
   def call
     ActiveRecord::Base.transaction do
-      application_form.update!(support_reference: GenerateSupportRef.call,
-                               submitted_at: Time.zone.now)
+      application_form.update!(submitted_at: Time.zone.now)
       submit_application
     end
 

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -21,7 +21,7 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <%= render '/candidate_interface/shared/need_help' %>
+    <%= render partial: '/candidate_interface/shared/need_help', locals: { support_reference: @application_form.support_reference } %>
 
     <aside class="app-related" role="complementary">
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Updating your contact details</h2>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -124,6 +124,6 @@
   </div>
 
   <div class="govuk-grid-column-one-third">
-    <%= render '/candidate_interface/shared/need_help' %>
+    <%= render partial: '/candidate_interface/shared/need_help', locals: { support_reference: @application_form.support_reference } %>
   </div>
 </div>

--- a/app/views/candidate_interface/shared/_need_help.html.erb
+++ b/app/views/candidate_interface/shared/_need_help.html.erb
@@ -1,7 +1,7 @@
 <aside class="app-related" role="complementary">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="help-title">Need help?</h2>
   <ul class="govuk-list govuk-!-font-size-16">
-    <li>Email: <%= bat_contact_mail_to %></li>
+    <li>Email: <%= bat_contact_mail_to(html_options: { subject: "Query about application #{support_reference}" }) %></li>
     <li>Monday to Friday (except public holidays)</li>
     <li>We aim to respond within 5 working days, or one working day for more urgent&nbsp;queries</li>
   </ul>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,7 +19,6 @@ FactoryBot.define do
       uk_residency_status { 'I have the right to study and/or work in the UK' }
       disclose_disability { %w[true false].sample }
       disability_disclosure { Faker::Lorem.paragraph_by_chars(number: 300) }
-      support_reference { GenerateSupportRef.call }
       submitted_at { Faker::Time.backward(days: 7, period: :day) }
       phone_number { Faker::PhoneNumber.cell_phone }
       address_line1 { Faker::Address.street_address }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationForm do
+  it 'sets a support reference upon creation' do
+    application_form = create :application_form
+    expect(application_form.support_reference).to be_present
+  end
+
   describe 'auditing', with_audited: true do
     it 'records an audit entry when creating a new ApplicationForm' do
       application_form = create :application_form

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe SubmitApplication do
       SubmitApplication.new(application_form).call
       expect(application_form.application_choices[0]).to be_awaiting_references
       expect(application_form.application_choices[1]).to be_awaiting_references
-      expect(application_form.support_reference).not_to be_empty
     end
 
     it 'sets application_form.submitted_at' do


### PR DESCRIPTION
## Context

If support email links include the support reference number, then the candidate has to provide less information for the support agent to identify and help them quickly.

## Changes proposed in this pull request

- generate the application form support reference earlier in the lifecycle (i.e. upon form creation)
- seed the support email subject with the support reference number

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
