### PR TITLE
Update 'Change' links in volunteering for more context

### DIFF
--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -35,7 +35,7 @@ private
     {
       key: t('application_form.volunteering.role.review_label'),
       value: volunteering_role.role,
-      action: t('application_form.volunteering.role.change_action'),
+      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.role.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -44,7 +44,7 @@ private
     {
       key: t('application_form.volunteering.organisation.review_label'),
       value: volunteering_role.organisation,
-      action: t('application_form.volunteering.organisation.change_action'),
+      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.organisation.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -53,7 +53,7 @@ private
     {
       key: t('application_form.volunteering.review_length.review_label'),
       value: formatted_length(volunteering_role),
-      action: t('application_form.volunteering.review_length.change_action'),
+      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_length.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -62,7 +62,7 @@ private
     {
       key: t('application_form.volunteering.review_details.review_label'),
       value: formatted_details(volunteering_role),
-      action: t('application_form.volunteering.review_details.change_action'),
+      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_details.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -87,5 +87,22 @@ private
 
   def edit_path(volunteering_role)
     Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role.id)
+  end
+
+  def generate_change_action(volunteering_role:, attribute:)
+    if any_roles_with_same_role_and_organisation?(volunteering_role)
+      "#{attribute} for #{volunteering_role.role}, #{volunteering_role.organisation}"\
+        ", #{formatted_start_date(volunteering_role)} to #{formatted_end_date(volunteering_role)}"
+    else
+      "#{attribute} for #{volunteering_role.role}, #{volunteering_role.organisation}"
+    end
+  end
+
+  def any_roles_with_same_role_and_organisation?(volunteering_role)
+    roles = @application_form.application_volunteering_experiences.where(
+      role: volunteering_role.role,
+      organisation: volunteering_role.organisation,
+    )
+    roles.many?
   end
 end

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -56,7 +56,9 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.role.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.volunteering.role.change_action')} for School Experience Intern, A Noice School",
+      )
     end
 
     it 'renders component with correct values for organisation' do
@@ -67,7 +69,9 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.organisation.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.volunteering.organisation.change_action')} for School Experience Intern, A Noice School",
+      )
     end
 
     it 'renders component with correct values for length' do
@@ -78,7 +82,9 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.review_length.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.volunteering.review_length.change_action')} for School Experience Intern, A Noice School",
+      )
     end
 
     it 'renders component with correct values for details of experience' do
@@ -89,7 +95,9 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.volunteering.review_details.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.volunteering.review_details.change_action')} for School Experience Intern, A Noice School",
+      )
     end
 
     it 'renders component along with a delete link for each role' do
@@ -98,6 +106,41 @@ RSpec.describe VolunteeringReviewComponent do
       expect(result.css('.app-summary-card__actions').text).to include(t('application_form.volunteering.delete'))
       expect(result.css('.app-summary-card__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role),
+      )
+    end
+
+    it 'appends dates to "Change" links if same role at same organisation' do
+      application_form.application_volunteering_experiences.create(
+        role: 'School Experience Intern',
+        organisation: 'Gyorfi School',
+        details: 'I interned.',
+        working_with_children: true,
+        start_date: Time.zone.local(2019, 1, 1),
+        end_date: Time.zone.local(2019, 6, 1),
+      )
+      application_form.application_volunteering_experiences.create(
+        role: 'School Experience Intern',
+        organisation: 'Gyorfi School',
+        details: 'I interned again.',
+        working_with_children: true,
+        start_date: Time.zone.local(2019, 6, 1),
+        end_date: Time.zone.local(2019, 8, 1),
+      )
+
+      result = render_inline(described_class, application_form: application_form)
+
+      change_role_for_unique = result.css('.govuk-summary-list__actions')[8].text.strip
+      change_role_for_same1 = result.css('.govuk-summary-list__actions')[4].text.strip
+      change_role_for_same2 = result.css('.govuk-summary-list__actions')[0].text.strip
+
+      expect(change_role_for_unique).to eq(
+        'Change role for School Experience Intern, A Noice School',
+      )
+      expect(change_role_for_same1).to eq(
+        'Change role for School Experience Intern, Gyorfi School, January 2019 to June 2019',
+      )
+      expect(change_role_for_same2).to eq(
+        'Change role for School Experience Intern, Gyorfi School, June 2019 to August 2019',
       )
     end
 


### PR DESCRIPTION
## Context

We need to make `Change` links in the volunteering section more accessible. See #1056 for more context.

## Changes proposed in this pull request

This PR updates the `Change` links in volunteering to have more detailed visually hidden text by adding in the role and organisation. Also, if a candidate has more than one entry for the same role and organisation, then the dates are added.

## Guidance to review

Nothing in particular, follows https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1056, although wouldn't be surprised if some refactoring can be done.

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
