### PR TITLE
Update 'Change' links in degrees for more context

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -33,7 +33,7 @@ module CandidateInterface
       {
         key: t('application_form.degree.qualification.label'),
         value: formatted_qualification(degree),
-        action: t('application_form.degree.qualification.change_action'),
+        action: generate_change_action(degree: degree, attribute: t('application_form.degree.qualification.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
       }
     end
@@ -42,7 +42,7 @@ module CandidateInterface
       {
         key: t('application_form.degree.award_year.review_label'),
         value: degree.award_year,
-        action: t('application_form.degree.award_year.change_action'),
+        action: generate_change_action(degree: degree, attribute: t('application_form.degree.award_year.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
       }
     end
@@ -51,7 +51,7 @@ module CandidateInterface
       {
         key: t('application_form.degree.grade.review_label'),
         value: formatted_grade(degree),
-        action: t('application_form.degree.grade.change_action'),
+        action: generate_change_action(degree: degree, attribute: t('application_form.degree.grade.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
       }
     end
@@ -68,6 +68,10 @@ module CandidateInterface
       else
         t("application_form.degree.grade.#{degree.grade}.label")
       end
+    end
+
+    def generate_change_action(degree:, attribute:)
+      "#{attribute} for #{degree.qualification_type}, #{degree.subject}, #{degree.institution_name}, #{degree.award_year}"
     end
   end
 end

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -35,7 +35,9 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree1),
       )
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.degree.qualification.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.degree.qualification.change_action')} for BA, Woof, University of Doge, 2008",
+      )
     end
 
     it 'renders component with correct values for an award year' do
@@ -44,7 +46,9 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('BA Woof')
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.award_year.review_label'))
       expect(result.css('.govuk-summary-list__value').text).to include('2008')
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.degree.award_year.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.degree.award_year.change_action')} for BA, Woof, University of Doge, 2008",
+      )
     end
 
     it 'renders component with correct values for a known degree grade' do
@@ -53,7 +57,9 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('BA Woof')
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.degree.grade.review_label'))
       expect(result.css('.govuk-summary-list__value').text).to include(t('application_form.degree.grade.upper_second.label'))
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.degree.grade.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.degree.grade.change_action')} for BA, Woof, University of Doge, 2008",
+      )
     end
 
     it 'renders component with correct values for a predicted grade' do


### PR DESCRIPTION
## Context

We need to make `Change` links in the degrees section more accessible. See #1056 for more context.

## Changes proposed in this pull request

This PR updates the `Change` links in degrees to have more detailed visually hidden text by adding in the qualification type, subject, institution name and award year.

![image](https://user-images.githubusercontent.com/42817036/72056103-e1692f80-32c3-11ea-9513-c0cd83b7bdd0.png)

![image](https://user-images.githubusercontent.com/42817036/72056136-ee861e80-32c3-11ea-8b27-fa2ca6049d6d.png)

## Guidance to review

Is adding qualification type, subject, institution name and award year possibly more context than needed? 

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
