### PR TITLE
Update 'Change' links in GCSEs for more context

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -28,7 +28,7 @@ module CandidateInterface
       {
         key: t('application_form.degree.qualification.label'),
         value: gcse_qualification_types[application_qualification.qualification_type.to_sym],
-        action: 'qualification',
+        action: "qualification for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: candidate_interface_gcse_details_edit_type_path(subject: subject),
       }
     end
@@ -37,7 +37,7 @@ module CandidateInterface
       {
         key: 'Year awarded',
         value: application_qualification.award_year || t('gcse_summary.not_specified'),
-        action: 'year awarded',
+        action: "year awarded for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
       }
     end
@@ -46,7 +46,7 @@ module CandidateInterface
       {
         key: 'Grade',
         value: application_qualification.grade ? application_qualification.grade.upcase : t('gcse_summary.not_specified'),
-        action: 'grade',
+        action: "grade for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: candidate_interface_gcse_details_edit_details_path(subject: subject),
       }
     end


### PR DESCRIPTION
## Context

We need to make `Change` links more accessible when reviewing GCSEs, particularly on the `Review your application` page. See #1056 for more context.

## Changes proposed in this pull request

This PR updates the `Change` links in GCSEs to have more detailed visually hidden text by adding in the qualification type and subject.

![image](https://user-images.githubusercontent.com/42817036/72057619-93a1f680-32c6-11ea-934b-1bddb4c7afaf.png)

![image](https://user-images.githubusercontent.com/42817036/72057642-9b619b00-32c6-11ea-965d-cae24d71e4d0.png)

## Guidance to review

A test wasn't added as it's not a complex change and there isn't a spec file for `GcseQualificationReviewComponent` so it didn't feel necessary to add one just for this. Does that seems reasonable?

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
