### PR TITLE
Update 'Change' links in other qualifications for more context

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.qualification.label'),
         value: qualification.title,
-        action: t('application_form.other_qualification.qualification.change_action'),
+        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.qualification.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
@@ -38,7 +38,7 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.institution.label'),
         value: qualification.institution_name,
-        action: t('application_form.other_qualification.institution.change_action'),
+        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.institution.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
@@ -47,7 +47,7 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.award_year.review_label'),
         value: qualification.award_year,
-        action: t('application_form.other_qualification.award_year.change_action'),
+        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.award_year.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
@@ -56,13 +56,18 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.grade.label'),
         value: qualification.grade,
-        action: t('application_form.other_qualification.grade.change_action'),
+        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.grade.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
 
     def edit_other_qualification_path(qualification)
       Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id)
+    end
+
+    def generate_change_action(qualification:, attribute:)
+      "#{attribute} for #{qualification.qualification_type}, #{qualification.subject}, "\
+        "#{qualification.institution_name}, #{qualification.award_year}"
     end
   end
 end

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -33,7 +33,12 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification1),
       )
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.institution.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.other_qualification.qualification.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+      )
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.other_qualification.institution.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+      )
     end
 
     it 'renders component with correct values for an award year' do
@@ -42,7 +47,9 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.award_year.review_label'))
       expect(result.css('.govuk-summary-list__value').text).to include('2012')
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.award_year.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.other_qualification.award_year.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+      )
     end
 
     it 'renders component with correct values for a grade' do
@@ -51,7 +58,9 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       expect(result.css('.app-summary-card__title').text).to include('A-Level Making Doggo Sounds')
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.other_qualification.grade.label'))
       expect(result.css('.govuk-summary-list__value').text).to include('A')
-      expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.other_qualification.grade.change_action')}")
+      expect(result.css('.govuk-summary-list__actions').text).to include(
+        "Change #{t('application_form.other_qualification.grade.change_action')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+      )
     end
 
     it 'renders component with correct values for multiple qualifications' do


### PR DESCRIPTION
## Context

We need to make `Change` links in the other qualifications section more accessible. See #1056 for more context.

## Changes proposed in this pull request

This PR updates the `Change` links in other qualifications to have more detailed visually hidden text by adding in the qualification type, subject, institution name and award year.

![image](https://user-images.githubusercontent.com/42817036/72059523-18424400-32ca-11ea-96bc-ea8e32c9bc39.png)

## Guidance to review

Nothing in particular, follows https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1065.

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
