### PR TITLE
Add a styleguide for acceptance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ for doing so](#deploy-env-setup).
   * [Pipeline Variables](#documentation-pipeline-vars)
   * [Database Restore](#documentation-db-restore)
   * [Connecting to live databases](#documentation-db-connect)
+  * [Testing](#testing)
 
 ## <a name="dependencies"></a>Dependencies
 
@@ -327,3 +328,7 @@ Email alerting is not configured for the `/check` domains using this approach, i
 ### <a name="documentation-db-connect"></a>Connecting to live databases
 
 👉 [See instructions for connection to production database](/docs/connecting-to-databases.md)
+
+### <a name="testing"></a>Testing
+
+👉 [See testing styleguide](/docs/testing-styleguide.md)

--- a/docs/testing-styleguide.md
+++ b/docs/testing-styleguide.md
@@ -1,0 +1,90 @@
+# Testing styleguide
+
+We use ["Futurelearn style" acceptance tests](https://about.futurelearn.com/blog/how-we-write-readable-feature-tests-with-rspec).
+
+## Rules
+
+1. Use a single scenario per file. This prevents the files from becoming too large. Separate logical blocks of steps with newlines.
+2. Use instance variable to carry state between steps. Don't use `let` or `before` blocks.
+3. Define all steps in the file. If you want to share code between scenarios, call helpers that are defined in a module from the step.
+4. The steps should be written in English. Don't use parameters to call the step methods.  
+
+## Examples
+
+A good test looks like this:
+
+```rb
+# do_a_thing_feature_spec.rb
+RSpec.feature 'Do a thing feature' do
+  include TestHelpers
+
+  scenario 'User does a thing' do
+    given_i_am_signed_in
+    when_i_press_a_button
+    then_something_should_happen
+  end
+
+  def given_i_am_signed_in
+    @user = create(:user)
+    sign_in(@user)
+  end
+
+  def when_i_press_a_button
+    click_button 'Do the thing'
+  end
+
+  def then_something_should_happen
+    expect(@user).to have(done_something)
+  end
+end
+
+# helpers.rb
+module TestHelpers
+  def sign_in(user)
+    # do the thing
+  end
+end
+```
+
+A less good test looks like this:
+
+```rb
+# do_a_thing_feature_spec.rb
+RSpec.feature 'Do a thing feature' do
+  include TestHelpers
+
+  let(:user) { create(:user) } # Bad: a `let` block adds noise to the file and adds indirection
+
+  # Bad: a `before` block adds noise to the file and can make it unclear why something is set up
+  before do
+    sign_in_user(user)
+  end
+
+  scenario 'User does a thing' do
+    when_i_press_a_button('Do the thing') # Bad: a parameterised method makes the step harder to read
+    then_something_should_happen # Bad: hidden in a module
+  end
+
+  # Bad: multiple scenarios clutter the file and slow down the test suite
+  scenario 'User does a different thing' do
+    when_i_press_a_button('Do the thing') # Bad: a parameterised method makes the step harder to read
+    then_something_else_should_happen # Bad: hidden in a module
+  end
+
+  # Bad: a parameterised method
+  def when_i_press_a_button(text)
+    click_button(text)
+  end
+
+  def then_something_else_should_happen
+    expect(@user).to have(done_something_else)
+  end
+end
+
+# helpers.rb
+module TestHelpers
+  def then_something_should_happen
+    expect(@user).to have(done_something)
+  end
+end
+```


### PR DESCRIPTION
## Context

We have a lot of acceptance tests now, but they're sometimes inconsistent. For example, we have a number of files that contain multiple scenarios ([documented in the tech debt column](https://trello.com/c/13Hf4Ix9/343-multiple-scenarios-in-acceptance-tests-high-urgency)). 

## Changes proposed in this pull request

This adds styleguide with 4 rules and a few examples:

[👉 rendered version](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/testing-styleguide/docs/testing-styleguide.md)

## Guidance to review

Read the rules and see if you agree, understand why they're there, and if they make sense. 

## Link to Trello card

https://trello.com/c/13Hf4Ix9/343-multiple-scenarios-in-acceptance-tests-high-urgency

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
