### PR TITLE
Update misc non-descriptive links

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.html.erb
+++ b/app/components/candidate_interface/degrees_review_component.html.erb
@@ -4,8 +4,7 @@
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_degrees_destroy_path(degree.id), class: 'govuk-link' do %>
-            <%= t('application_form.degree.delete') %>
-            <span class="govuk-visually-hidden"> <%= degree.subject %></span>
+            <%= t('application_form.degree.delete') %><span class="govuk-visually-hidden"><%= generate_action(degree: degree) %></span>
           <% end %>
         </div>
       <% end %>

--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -33,7 +33,7 @@ module CandidateInterface
       {
         key: t('application_form.degree.qualification.label'),
         value: formatted_qualification(degree),
-        action: generate_change_action(degree: degree, attribute: t('application_form.degree.qualification.change_action')),
+        action: generate_action(degree: degree, attribute: t('application_form.degree.qualification.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
       }
     end
@@ -42,7 +42,7 @@ module CandidateInterface
       {
         key: t('application_form.degree.award_year.review_label'),
         value: degree.award_year,
-        action: generate_change_action(degree: degree, attribute: t('application_form.degree.award_year.change_action')),
+        action: generate_action(degree: degree, attribute: t('application_form.degree.award_year.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
       }
     end
@@ -51,7 +51,7 @@ module CandidateInterface
       {
         key: t('application_form.degree.grade.review_label'),
         value: formatted_grade(degree),
-        action: generate_change_action(degree: degree, attribute: t('application_form.degree.grade.change_action')),
+        action: generate_action(degree: degree, attribute: t('application_form.degree.grade.change_action')),
         change_path: Rails.application.routes.url_helpers.candidate_interface_degrees_edit_path(degree.id),
       }
     end
@@ -70,8 +70,8 @@ module CandidateInterface
       end
     end
 
-    def generate_change_action(degree:, attribute:)
-      "#{attribute} for #{degree.qualification_type}, #{degree.subject}, #{degree.institution_name}, #{degree.award_year}"
+    def generate_action(degree:, attribute: '')
+      "#{attribute.presence} for #{degree.qualification_type}, #{degree.subject}, #{degree.institution_name}, #{degree.award_year}"
     end
   end
 end

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -55,6 +55,7 @@ module CandidateInterface
       {
         key: 'How I expect to gain this qualification',
         value: application_qualification.missing_explanation.presence || t('gcse_summary.not_specified'),
+        action: 'how do you expect to gain this qualification',
         change_path: candidate_interface_gcse_details_edit_type_path(subject: subject),
       }
     end

--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -4,8 +4,7 @@
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_other_qualification_path(qualification.id), class: 'govuk-link' do %>
-            <%= t('application_form.other_qualification.delete') %>
-            <span class="govuk-visually-hidden"> <%= qualification.subject %></span>
+            <%= t('application_form.other_qualification.delete') %><span class="govuk-visually-hidden"><%= generate_action(qualification: qualification) %></span>
           <% end %>
         </div>
       <% end %>

--- a/app/components/candidate_interface/other_qualifications_review_component.rb
+++ b/app/components/candidate_interface/other_qualifications_review_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.qualification.label'),
         value: qualification.title,
-        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.qualification.change_action')),
+        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.qualification.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
@@ -38,7 +38,7 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.institution.label'),
         value: qualification.institution_name,
-        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.institution.change_action')),
+        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.institution.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
@@ -47,7 +47,7 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.award_year.review_label'),
         value: qualification.award_year,
-        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.award_year.change_action')),
+        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.award_year.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
@@ -56,7 +56,7 @@ module CandidateInterface
       {
         key: t('application_form.other_qualification.grade.label'),
         value: qualification.grade,
-        action: generate_change_action(qualification: qualification, attribute: t('application_form.other_qualification.grade.change_action')),
+        action: generate_action(qualification: qualification, attribute: t('application_form.other_qualification.grade.change_action')),
         change_path: edit_other_qualification_path(qualification),
       }
     end
@@ -65,8 +65,8 @@ module CandidateInterface
       Rails.application.routes.url_helpers.candidate_interface_edit_other_qualification_path(qualification.id)
     end
 
-    def generate_change_action(qualification:, attribute:)
-      "#{attribute} for #{qualification.qualification_type}, #{qualification.subject}, "\
+    def generate_action(qualification:, attribute: '')
+      "#{attribute.presence} for #{qualification.qualification_type}, #{qualification.subject}, "\
         "#{qualification.institution_name}, #{qualification.award_year}"
     end
   end

--- a/app/components/volunteering_review_component.html.erb
+++ b/app/components/volunteering_review_component.html.erb
@@ -4,8 +4,7 @@
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role.id), class: 'govuk-link' do %>
-            <%= t('application_form.volunteering.delete') %>
-            <span class="govuk-visually-hidden"> <%= volunteering_role.role %></span>
+            <%= t('application_form.volunteering.delete') %><span class="govuk-visually-hidden"><%= generate_action(volunteering_role: volunteering_role) %></span>
           <% end %>
         </div>
       <% end %>

--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -35,7 +35,7 @@ private
     {
       key: t('application_form.volunteering.role.review_label'),
       value: volunteering_role.role,
-      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.role.change_action')),
+      action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.role.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -44,7 +44,7 @@ private
     {
       key: t('application_form.volunteering.organisation.review_label'),
       value: volunteering_role.organisation,
-      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.organisation.change_action')),
+      action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.organisation.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -53,7 +53,7 @@ private
     {
       key: t('application_form.volunteering.review_length.review_label'),
       value: formatted_length(volunteering_role),
-      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_length.change_action')),
+      action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_length.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -62,7 +62,7 @@ private
     {
       key: t('application_form.volunteering.review_details.review_label'),
       value: formatted_details(volunteering_role),
-      action: generate_change_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_details.change_action')),
+      action: generate_action(volunteering_role: volunteering_role, attribute: t('application_form.volunteering.review_details.change_action')),
       change_path: edit_path(volunteering_role),
     }
   end
@@ -89,12 +89,12 @@ private
     Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role.id)
   end
 
-  def generate_change_action(volunteering_role:, attribute:)
+  def generate_action(volunteering_role:, attribute: '')
     if any_roles_with_same_role_and_organisation?(volunteering_role)
-      "#{attribute} for #{volunteering_role.role}, #{volunteering_role.organisation}"\
+      "#{attribute.presence} for #{volunteering_role.role}, #{volunteering_role.organisation}"\
         ", #{formatted_start_date(volunteering_role)} to #{formatted_end_date(volunteering_role)}"
     else
-      "#{attribute} for #{volunteering_role.role}, #{volunteering_role.organisation}"
+      "#{attribute.presence} for #{volunteering_role.role}, #{volunteering_role.organisation}"
     end
   end
 

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -4,8 +4,7 @@
       <% if @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_work_history_destroy_path(work.id), class: 'govuk-link' do %>
-            <%= t('application_form.work_history.delete_entry') %>
-            <span class="govuk-visually-hidden"> <%= work.role %></span>
+            <%= t('application_form.work_history.delete_entry') %><span class="govuk-visually-hidden"><%= generate_action(work: work) %></span>
           <% end %>
         </div>
       <% end %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -24,7 +24,7 @@ class WorkHistoryReviewComponent < ActionView::Component::Base
       {
         key: 'Explanation of why you’ve been out of the workplace',
         value: @application_form.work_history_explanation,
-        action: 'explanation',
+        action: 'explanation of why you’ve been out of the workplace',
         change_path: candidate_interface_work_history_explanation_path,
       },
     ]

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -59,7 +59,7 @@ private
     {
       key: 'Job',
       value: [work.role, work.organisation],
-      action: generate_change_action(work: work, attribute: 'job title'),
+      action: generate_action(work: work, attribute: 'job title'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -68,7 +68,7 @@ private
     {
       key: 'Type',
       value: work.commitment.dasherize.humanize,
-      action: generate_change_action(work: work, attribute: 'type'),
+      action: generate_action(work: work, attribute: 'type'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -77,7 +77,7 @@ private
     {
       key: 'Description',
       value: work.details,
-      action: generate_change_action(work: work, attribute: 'description'),
+      action: generate_action(work: work, attribute: 'description'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -86,7 +86,7 @@ private
     {
       key: 'Dates',
       value: "#{formatted_start_date(work)} - #{formatted_end_date(work)}",
-      action: generate_change_action(work: work, attribute: 'dates'),
+      action: generate_action(work: work, attribute: 'dates'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
   end
@@ -101,11 +101,11 @@ private
     work.end_date.to_s(:month_and_year)
   end
 
-  def generate_change_action(work:, attribute:)
+  def generate_action(work:, attribute: '')
     if any_jobs_with_same_role_and_organisation?(work)
-      "#{attribute} for #{work.role}, #{work.organisation}, #{formatted_start_date(work)} to #{formatted_end_date(work)}"
+      "#{attribute.presence} for #{work.role}, #{work.organisation}, #{formatted_start_date(work)} to #{formatted_end_date(work)}"
     else
-      "#{attribute} for #{work.role}, #{work.organisation}"
+      "#{attribute.presence} for #{work.role}, #{work.organisation}"
     end
   end
 

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -100,7 +100,9 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     it 'renders component along with a delete link for each degree' do
       result = render_inline(described_class, application_form: application_form)
 
-      expect(result.css('.app-summary-card__actions').text).to include(t('application_form.degree.delete'))
+      expect(result.css('.app-summary-card__actions').text.strip).to include(
+        "#{t('application_form.degree.delete')} for BA, Woof, University of Doge, 2008",
+      )
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_confirm_degrees_destroy_path(degree1),
       )

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -73,7 +73,9 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
     it 'renders component along with a delete link for each qualification' do
       result = render_inline(described_class, application_form: application_form)
 
-      expect(result.css('.app-summary-card__actions').text).to include(t('application_form.other_qualification.delete'))
+      expect(result.css('.app-summary-card__actions').text.strip).to include(
+        "#{t('application_form.other_qualification.delete')} for A-Level, Making Doggo Sounds, Doggo Sounds College, 2012",
+      )
       expect(result.css('.app-summary-card__actions a')[0].attr('href')).to include(
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_other_qualification_path(qualification1),
       )

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -103,7 +103,9 @@ RSpec.describe VolunteeringReviewComponent do
     it 'renders component along with a delete link for each role' do
       result = render_inline(described_class, application_form: application_form)
 
-      expect(result.css('.app-summary-card__actions').text).to include(t('application_form.volunteering.delete'))
+      expect(result.css('.app-summary-card__actions').text.strip).to include(
+        "#{t('application_form.volunteering.delete')} for School Experience Intern, A Noice School",
+      )
       expect(result.css('.app-summary-card__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_confirm_destroy_volunteering_role_path(volunteering_role),
       )

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe WorkHistoryReviewComponent do
         expect(result.css('.govuk-summary-list__actions a')[0].attr('href')).to include(
           Rails.application.routes.url_helpers.candidate_interface_work_history_explanation_path,
         )
-        expect(result.css('.govuk-summary-list__actions').text).to include('Change explanation')
+        expect(result.css('.govuk-summary-list__actions').text).to include('Change explanation of why you’ve been out of the workplace')
       end
     end
 


### PR DESCRIPTION
## Context

We've been update `Change` links to be more accessible. See #1056 for more context. Whilst doing so, it was noticed that some `Delete` links aren't very descriptive.

## Changes proposed in this pull request

This PR updates some astray `Change` links and `Delete` links that need more context so that their purpose is clearer when using the links list feature of a screen reader.

## Guidance to review

Review commit by commit. Try out the links list feature on the `Review your application` page. Any missing?

## Link to Trello card

https://trello.com/c/XsqlA0hu/698-dac-page-33-add-hidden-content-to-change-links-on-work-history-review-and-other-pages

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
