### PR TITLE
Referee can refuse to give feedback to the candidate.

### DIFF
--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -5,8 +5,9 @@ class RefereeMailer < ApplicationMailer
     @candidate_name = application_form.full_name
 
     if FeatureFlag.active?('reference_form')
-      @reference_link = referee_interface_reference_feedback_url(token: reference.update_token!)
-      @decline_reference_link = 'link_to_decline_the_reference' #TODO: implement the flow for Referee decline to give references
+      unhashed_token = reference.update_token!
+      @reference_link = referee_interface_reference_feedback_url(token: unhashed_token)
+      @refuse_to_give_feedback_link = referee_interface_refuse_feedback_url(token: unhashed_token)
       template_name = :reference_request_email
     else
       @reference_link = google_form_url_for(@candidate_name, @reference)
@@ -24,8 +25,9 @@ class RefereeMailer < ApplicationMailer
     @reference = reference
     @candidate_name = application_form.full_name
 
+    @token = reference.update_token!
     @reference_link = if FeatureFlag.active?('reference_form')
-                        referee_interface_reference_feedback_url(token: reference.update_token!)
+                        referee_interface_reference_feedback_url(token: @token)
                       else
                         google_form_url_for(@candidate_name, @reference)
                       end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -21,6 +21,7 @@ class ApplicationReference < ApplicationRecord
     not_requested_yet: 'not_requested_yet',
     feedback_requested: 'feedback_requested',
     feedback_provided: 'feedback_provided',
+    feedback_refused: 'feedback_refused',
   }
 
   def ordinal

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, "Give a teacher training reference for #{@application.full_name}" %>
+
+<%= form_with model: @reference, url: referee_interface_refuse_feedback_path(token: @token_param), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Refuse to give a reference for <%= @application.full_name %></h1>
+
+      <p class="govuk-body"><%= @application.full_name %> applied to the following courses:</p>
+
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <% @application.application_choices.each do |application_choice| %>
+          <li><%= application_choice.course.name %> - <%= application_choice.site.name %></li>
+        <% end %>
+      </ul>
+
+      <p class="govuk-body">
+        Are you sure you want to refuse to give <%= @application.full_name %> a reference?
+      </p>
+
+      <%= f.govuk_radio_button :refuse_to_give_feedback, 'yes', label: { text: 'I don\'t want to give a reference' } %>
+      <%= f.govuk_radio_button :refuse_to_give_feedback, 'no', label: { text: 'I\'d like to provide a reference' } %>
+
+      <%= f.govuk_submit 'Submit' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/referee_mailer/reference_request_chaser_email.text.erb
+++ b/app/views/referee_mailer/reference_request_chaser_email.text.erb
@@ -12,7 +12,17 @@ Please use the link below to give a complete reference within 5 working days.
 
 <%= @reference_link %>
 
+<% if FeatureFlag.active?('reference_form') %>
+
+If you won’t give <%= @reference.name %> a reference, please let us know by clicking the link below.
+
+<%= referee_interface_refuse_feedback_url(token: @token) %>
+
+<% else %>
+
 If you won’t give <%= @candidate_name %> a reference, please let us know as soon as possible by emailing: [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+
+<% end %>
 
 # Your data
 

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -2,14 +2,15 @@ Dear <%= @reference.name %>,
 
 <%= @candidate_name %> put us in touch with you to get a reference for their teacher training application.
 
-Please use the link below to give a reference as soon as possible
+Please use the link below to give a reference as soon as possible.
 
 <%= @reference_link %>
 
-If you won’t give [Jane Doe] a reference, please let us know by clicking the link below:
+If you won’t give <%= @reference.name %> a reference, please let us know by clicking the link below.
 
-<% #TODO: add the link to decline the request of reference %>
+<%= @refuse_to_give_feedback_link %>
 
 Your data
 
-We’ll only use your data to process the candidate’s application, unless you agree to be contacted by us about your experience of giving a reference. We’ll ask about this before you submit any information.
+We’ll only use your data to process the candidate’s application, unless you agree to be contacted about your experience of giving a reference.
+We’ll ask about this before you submit any information.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,9 @@ Rails.application.routes.draw do
     patch '/confirmation' => 'reference#submit_feedback', as: :submit_feedback
 
     patch '/confirm-consent' => 'reference#confirm_consent', as: :confirm_consent
+
+    get '/refuse-feedback' => 'reference#refuse_feedback', as: :refuse_feedback
+    patch '/refuse-feedback' => 'reference#confirm_feedback_refusal'
   end
 
   namespace :vendor_api, path: 'api/v1' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -244,6 +244,6 @@ FactoryBot.define do
 
   factory :provider_user do
     dfe_sign_in_uid { SecureRandom.uuid }
-    email_address { "#{Faker::Name.first_name}@example.com" }
+    email_address { "#{Faker::Name.first_name}-#{SecureRandom.hex}@example.com" }
   end
 end

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -142,14 +142,6 @@ RSpec.describe RefereeMailer, type: :mailer do
         expect(mail.body.encoded).to include("=#{ERB::Util.url_encode(candidate_name)}")
         expect(mail.body.encoded).to include("=#{ERB::Util.url_encode(reference.name)}")
       end
-
-      context 'an email containing a +' do
-        let(:reference) { build(:reference, email_address: 'email+email@email.com') }
-
-        it 'does not strip the plus from the email address' do
-          expect(mail.body.encoded).to include("=#{CGI.escape('email+email@email.com')}")
-        end
-      end
     end
   end
 

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.feature 'Refusing to give a reference', sidekiq: true do
+  include CandidateHelper
+
+  scenario 'Referee refuses to give a reference' do
+    FeatureFlag.activate('training_with_a_disability')
+    FeatureFlag.activate('reference_form')
+
+    given_a_candidate_completed_an_application
+    when_the_candidate_submits_the_application
+    then_i_receive_an_email_with_a_reference_request
+
+    when_i_click_the_refuse_reference_link_in_the_email
+    and_i_say_that_i_do_actually_want_to_give_a_reference
+    then_i_see_the_reference_comment_page
+
+    when_i_click_the_refuse_reference_link_in_the_email
+    and_i_confirm_that_i_wont_give_a_reference
+    when_i_choose_to_be_contactable
+    then_i_see_the_thank_you_page
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+  end
+
+  def then_i_receive_an_email_with_a_reference_request
+    open_email('terri@example.com')
+  end
+
+  def when_i_click_the_refuse_reference_link_in_the_email
+    current_email.click_link(refuse_feedback_url)
+  end
+
+  def and_i_say_that_i_do_actually_want_to_give_a_reference
+    choose 'I\'d like to provide a reference'
+    click_button 'Submit'
+  end
+
+  def then_i_see_the_reference_comment_page
+    expect(page).to have_content("Give a teacher training reference for #{@application.full_name}")
+  end
+
+  def and_i_confirm_that_i_wont_give_a_reference
+    choose 'I don\'t want to give a reference'
+    click_button 'Submit'
+  end
+
+  def when_i_choose_to_be_contactable
+    choose t('contact_form.consent_to_be_contacted')
+    click_button t('contact_form.confirm')
+  end
+
+  def then_i_see_the_thank_you_page
+    expect(page).to have_content('Thank you')
+    expect(page).to have_content('Our user research team will contact you shortly')
+  end
+
+private
+
+  def refuse_feedback_url
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\/refuse-feedback\?token=[\w-]{20})/)
+    matches.captures.first unless matches.nil?
+  end
+end


### PR DESCRIPTION
## Context

This PR allows the referee to refuse to give feedback to the candidate.

## Changes proposed in this pull request

- A new action `refuse_to_give_feedback` in `ReferenceController`
- Update the email with the link to refuse  to give feedback

## Guidance to review
start from `referee_can_submit_a_reference_for_candidate_spec.rb`

## Link to Trello card

https://trello.com/c/3kuEKaQH/666-update-email-content-for-referee-request