### PR TITLE
Add new providers

### DIFF
--- a/config/providers_to_sync.yml
+++ b/config/providers_to_sync.yml
@@ -12,6 +12,18 @@ development: &default
     - D87  # Durham SCITT
     - N83  # North West Shares SCITT
     - 1OT  # The Academy at Shotton Hall
+    - N83  # North West Shares SCITT
+    - 2B2  # Yorkshire and Humber Teacher Training
+    - 255  # Northern Lights SCITT
+    - 2ET  # Prince Henry's High School & South Worcestershire SCITT
+    - T25  # Essex and Thames Primary SCITT
+    - 1OS  # Essex School Direct
+    - S17  # SCITTELS
+    - C76  # Colchester Teacher Training Consortium
+    - M82  # Mid Essex Initial Teacher Training
+    - 2B5  # Hillingdon SCITT
+    - 2GU  # Claydon High School
+    - 1ZN  # Thorpe St Andrew School
 
 production:
   <<: *default


### PR DESCRIPTION
## Context

We want to on-board some new SCITTs.

## Changes proposed in this pull request

This PR adds the following providers:

- North West Shares SCITT
- Yorkshire and Humber Teacher Training
- Northern Lights SCITT
- Prince Henry's High School & South Worcestershire SCITT
- Essex and Thames Primary SCITT
- Essex School Direct
- SCITTELS
- Colchester Teacher Training Consortium
- Mid Essex Initial Teacher Training
- Hillingdon SCITT
- Claydon High School
- Thorpe St Andrew School

## Guidance to review

Please sanity check that I've added all the correct providers.

## Link to Trello card

https://trello.com/c/tr4LEFcK/728-on-board-further-scitts-by-thursday

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
