### PR TITLE
Set missing application forms support references

### DIFF
--- a/db/migrate/20200110071407_set_missing_support_references_on_application_forms.rb
+++ b/db/migrate/20200110071407_set_missing_support_references_on_application_forms.rb
@@ -1,0 +1,11 @@
+class SetMissingSupportReferencesOnApplicationForms < ActiveRecord::Migration[6.0]
+  def up
+    ApplicationForm.where(support_reference: nil).each do |form|
+      form.update(support_reference: GenerateSupportRef.call)
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_08_131221) do
+ActiveRecord::Schema.define(version: 2020_01_10_071407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## Context

PR #1062 moved setting support references from application form submission to form creation. However that change didn't backfill the reference for forms that already exist.

## Changes proposed in this pull request

Backfill missing support references in a migration.

## Guidance to review

This is a data migration - is there a better way of doing it?

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
