### PR TITLE
Support: remove authentication from the service performance page

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -1,5 +1,7 @@
 module SupportInterface
   class PerformanceController < SupportInterfaceController
+    skip_before_action :authenticate_support_user!, only: :index
+
     def index
       @statistics = PerformanceStatistics.new
     end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -1,21 +1,14 @@
 require 'rails_helper'
 
 RSpec.feature 'Service performance' do
-  include DfESignInHelpers
-
   scenario 'View service statistics' do
-    given_i_am_a_support_user
-    and_there_are_candidates_in_the_system
+    given_there_are_candidates_in_the_system
 
     when_i_visit_the_service_performance_page
     then_i_should_see_the_total_count_of_candidates
   end
 
-  def given_i_am_a_support_user
-    sign_in_as_support_user
-  end
-
-  def and_there_are_candidates_in_the_system
+  def given_there_are_candidates_in_the_system
     create_list(:candidate, 2)
   end
 


### PR DESCRIPTION
## Context

To access the service performance dashboard, you need a Support account. However that information isn't particularly sensitive and doesn't need to be gated.

## Changes proposed in this pull request

Remove authentication from just that page. This allows the performance stats to be displayed on Big Visible Displays.

## Guidance to review

Before:

![image](https://user-images.githubusercontent.com/23801/72153168-084b6280-33a5-11ea-8f6b-0217bd86f01f.png)

After:

![image](https://user-images.githubusercontent.com/23801/72152708-b0f8c280-33a3-11ea-83e9-1750014b7cbc.png)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
