### PR TITLE
Create a new form object for providing references

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -10,10 +10,7 @@ module RefereeInterface
     def feedback
       if reference.feedback_requested?
         @application = reference.application_form
-
-        @reference_form = ReceiveReference.new(application_form: @application,
-                                               referee_email: reference.email_address,
-                                               feedback: '')
+        @reference_form = ReferenceFeedbackForm.new(reference: reference)
       else
         render :finish
       end
@@ -22,9 +19,10 @@ module RefereeInterface
     def submit_feedback
       @application = reference.application_form
 
-      @reference_form = ReceiveReference.new(application_form: @application,
-                           referee_email: reference.email_address,
-                           feedback: params[:receive_reference][:feedback])
+      @reference_form = ReferenceFeedbackForm.new(
+        reference: reference,
+        feedback: params[:referee_interface_reference_feedback_form][:feedback],
+      )
 
       if @reference_form.save
         redirect_to referee_interface_confirmation_path(token: @token_param)

--- a/app/models/referee_interface/reference_feedback_form.rb
+++ b/app/models/referee_interface/reference_feedback_form.rb
@@ -1,0 +1,31 @@
+module RefereeInterface
+  class ReferenceFeedbackForm
+    include ActiveModel::Validations
+
+    attr_reader :reference, :feedback
+    validates :feedback, presence: true, word_count: { maximum: 300 }
+
+    def initialize(reference:, feedback: nil)
+      @reference = reference
+      @feedback = feedback
+    end
+
+    def save
+      return unless valid?
+
+      ActiveRecord::Base.transaction do
+        reference.update!(feedback: feedback, feedback_status: 'feedback_provided')
+
+        # If all of the references have been provided we need to change the
+        # state of the application choices
+        if reference.application_form.application_references_complete?
+          reference.application_form.application_choices.includes(:course_option).find_each do |application_choice|
+            ApplicationStateChange.new(application_choice).references_complete!
+          end
+        end
+      end
+
+      true
+    end
+  end
+end

--- a/spec/models/referee_interface/reference_feedback_form_spec.rb
+++ b/spec/models/referee_interface/reference_feedback_form_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::ReferenceFeedbackForm do
+  describe '#save' do
+    it 'progresses the application choices to the "application complete" status once all references have been received' do
+      application_form = FactoryBot.create(:completed_application_form, references_count: 0)
+      application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
+      unsubmitted_reference = build(:reference, :unsubmitted)
+      application_form.application_references << unsubmitted_reference
+      application_form.application_references << build(:reference, :complete)
+
+      action = described_class.new(
+        reference: unsubmitted_reference,
+        feedback: 'A reference',
+      )
+
+      action.save
+
+      expect(application_form.reload).to be_application_references_complete
+      expect(application_form.application_choices).to all(be_application_complete)
+    end
+
+    it 'does not progress the application choices to the "application complete" status without minimum number of references' do
+      application_form = FactoryBot.create(:completed_application_form, references_count: 0)
+      application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
+      unsubmitted_reference = build(:reference, :unsubmitted)
+      application_form.application_references << unsubmitted_reference
+
+      action = described_class.new(
+        reference: unsubmitted_reference,
+        feedback: 'A reference',
+      )
+
+      action.save
+
+      expect(application_form).not_to be_application_references_complete
+      expect(application_form.application_choices).to all(be_awaiting_references)
+    end
+  end
+end


### PR DESCRIPTION
##  Context

Currently we’re re-using the [ReceiveReference class](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/app/services/receive_reference.rb) in the referee interface. This class works in a special way because it was written for the reference CSV importer.

## Changes proposed in this pull request

This replaces it with a purpose built form object, which takes a reference. This save a bunch of complexity, and allows us to delete the ReceiveReference code once the new feature is live (https://trello.com/c/ycutK8Mx).

## Guidance to review

Is the functionality the same?

## Link to Trello card

https://trello.com/c/Xz4AoCxQ/665-reference-and-referee-stories-capture-all

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
