### PR TITLE
Make sure the feedback status PR deploys cleanly

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -31,7 +31,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def application_references_complete?
-    application_references.feedback_provided.count == MINIMUM_COMPLETE_REFERENCES
+    application_references.completed.count == MINIMUM_COMPLETE_REFERENCES
   end
 
   def awaiting_provider_decisions?

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -14,6 +14,7 @@ class ApplicationReference < ApplicationRecord
 
   audited associated_with: :application_form
 
+  # TODO: remove once `feedback_status` is deployed on all environments
   scope :completed, -> { where('feedback IS NOT NULL') }
 
   enum feedback_status: {


### PR DESCRIPTION
## Context

The `application_references_complete?` method is called from a background worker, which means that once we deploy https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1077 we’re likely to see errors like https://sentry.io/organizations/dfe-bat/issues/1431420955. 

## Changes proposed in this pull request

By temporarily reverted to the old, equally valid code we ensure that we won’t be seeing errors after deploying on production.

## Guidance to review

Read the code.

## Link to Trello card

https://trello.com/c/Xz4AoCxQ/665-reference-and-referee-stories-capture-all

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
