### PR TITLE
Clean up nil study_mode course_options

### DIFF
--- a/app/workers/clean_up_course_options_with_no_study_mode.rb
+++ b/app/workers/clean_up_course_options_with_no_study_mode.rb
@@ -1,0 +1,23 @@
+class CleanUpCourseOptionsWithNoStudyMode
+  include Sidekiq::Worker
+
+  def perform
+    CourseOption.where('study_mode = \'0\'').each do |nil_co|
+      if nil_co.application_choices.any?
+        equivalent_course_option = CourseOption.where(
+          course: nil_co.course,
+          site: nil_co.site,
+          study_mode: :full_time,
+        ).first
+        if equivalent_course_option
+          nil_co.application_choices.each do |application_choice|
+            application_choice.update!(course_option_id: equivalent_course_option.id)
+          end
+          nil_co.destroy!
+        end
+      else
+        nil_co.destroy!
+      end
+    end
+  end
+end

--- a/app/workers/clean_up_course_options_with_no_study_mode.rb
+++ b/app/workers/clean_up_course_options_with_no_study_mode.rb
@@ -2,22 +2,28 @@ class CleanUpCourseOptionsWithNoStudyMode
   include Sidekiq::Worker
 
   def perform
-    CourseOption.where('study_mode = \'0\'').each do |nil_co|
-      if nil_co.application_choices.any?
-        equivalent_course_option = CourseOption.where(
-          course: nil_co.course,
-          site: nil_co.site,
-          study_mode: :full_time,
-        ).first
-        if equivalent_course_option
-          nil_co.application_choices.each do |application_choice|
-            application_choice.update!(course_option_id: equivalent_course_option.id)
-          end
-          nil_co.destroy!
+    CourseOption.where('study_mode IN (\'0\',\'1\')').find_each do |nil_co|
+      intended_study_mode = case nil_co.study_mode_before_type_cast
+                            when '0'; :full_time
+                            when '1'; :part_time
+                            end
+      equivalent_course_option = find_equivalent_course_option nil_co, intended_study_mode
+      if equivalent_course_option
+        nil_co.application_choices.each do |application_choice|
+          application_choice.update!(course_option_id: equivalent_course_option.id)
         end
-      else
         nil_co.destroy!
+      else
+        nil_co.update!(study_mode: intended_study_mode)
       end
     end
+  end
+
+  def find_equivalent_course_option(nil_co, intended_study_mode)
+    CourseOption.where(
+      course: nil_co.course,
+      site: nil_co.site,
+      study_mode: intended_study_mode,
+    ).first
   end
 end


### PR DESCRIPTION
## Context

During the database migration converting `study_mode` from `int` to `string` (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/883/files), `CourseOption` records were not converted to 'full_time', instead their value `0` was converted to `'0'`, which the rails model cannot map to the enum values and interprets as `nil`. The `SyncFromFind` tasks then ignore these records when reconciling courses and updating course options, creating records which appear as duplicate sites during the application process.

## Changes proposed in this pull request

Add a temporary `CleanUpCourseOptionsWithNoStudyMode` worker we can either run from `rails c` or schedule through clockwork.

## Guidance to review

Does the code in the worker make sense?

## Link to Trello card

[1471 - Fix duplicated data from syncing courses and study_mode change](https://trello.com/c/SBaXvzJj)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
