### PR TITLE
Content change to first sentence on work history page

### DIFF
--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -1,6 +1,5 @@
 <p class="govuk-body">
-  Please include all your paid work in school (for example as a teaching
-  assistant) in this section.
+  Please include all your paid work in this section.
 </p>
 
 <p class="govuk-body">


### PR DESCRIPTION
Amended the first sentence to make it clearer that we're asking about all paid work experience, not just paid work in a school setting.

## Context

The first sentence said 'Please include all your paid work in school (for example as a teaching assistant) in this section.' This makes it look like we only want to know about paid experience in schools, rather than all paid experience. 

## Changes proposed in this pull request

Changed to: 'Please include all your paid work in this section.' 

## Guidance to review

Does this make it clearer that we're asking about ALL paid work, not just in a school?

## Link to Trello card

https://trello.com/c/Sg1IugEZ/746-work-experience-question-could-be-confusing-and-prevent-people-filling-in-experience-which-wasnt-in-a-school

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
