### PR TITLE
Add new referee request email to CandidateMailer

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -50,4 +50,13 @@ class CandidateMailer < ApplicationMailer
               template_path: 'survey_emails',
               template_name: 'chaser')
   end
+
+  def new_referee_request(application_form, reference)
+    @candidate_name = application_form.first_name
+    @referee_name = reference.name
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: application_form.candidate.email_address,
+              subject: t('new_referee_request.not_responded.subject', referee_name: @referee_name))
+  end
 end

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @candidate_name %>,
+
+# Give details of a new referee
+
+<%= t('new_referee_request.not_responded.explanation', referee_name: @referee_name) %>.
+
+Reply to this email with the name and email address of a new referee, and tell us how you know them.
+
+We can’t send your application to your teacher training providers without 2 complete references.

--- a/config/locales/new_referee_request.yml
+++ b/config/locales/new_referee_request.yml
@@ -1,0 +1,5 @@
+en:
+  new_referee_request:
+    not_responded:
+      subject: "Give details of a new referee: %{referee_name} hasn't responded"
+      explanation: We haven’t had a reference from %{referee_name}.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -84,4 +84,33 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
     end
   end
+
+  describe 'Send request for new referee email' do
+    let(:reference) { build_stubbed(:reference, name: 'Scott Knowles') }
+    let(:application_form) do
+      build_stubbed(
+        :application_form,
+        first_name: 'Tyrell',
+        last_name: 'Wellick',
+        application_references: [reference],
+      )
+    end
+    let(:mail) { mailer.new_referee_request(application_form, reference) }
+
+    before { mail.deliver_later }
+
+    context 'when referee has not responded' do
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'))
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include('Dear Tyrell')
+      end
+
+      it 'sends an email saying referee has not responded' do
+        expect(mail.body.encoded).to include(t('new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

We want to be able to send an email requesting a new referee when a candidate's referee hasn't responded.

## Changes proposed in this pull request

This PR adds the email to the `CandidateMailer`.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/fDuObKQB/719-send-all-standard-not-zendesk-emails-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
