### PR TITLE
Fix some flakey tests causing CI build failures

### DIFF
--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -139,8 +139,8 @@ RSpec.describe RefereeMailer, type: :mailer do
       end
 
       it 'encodes spaces as %20 rather than + in the Google form parameters for correct prefilling' do
-        expect(mail.body.encoded).to include("=#{candidate_name.gsub(' ', '%20')}")
-        expect(mail.body.encoded).to include("=#{reference.name.gsub(' ', '%20')}")
+        expect(mail.body.encoded).to include("=#{ERB::Util.url_encode(candidate_name)}")
+        expect(mail.body.encoded).to include("=#{ERB::Util.url_encode(reference.name)}")
       end
 
       context 'an email containing a +' do

--- a/spec/services/get_pending_data_sharing_agreements_for_provider_user_spec.rb
+++ b/spec/services/get_pending_data_sharing_agreements_for_provider_user_spec.rb
@@ -34,8 +34,7 @@ RSpec.describe GetPendingDataSharingAgreementsForProviderUser do
     it 'returns provider agreements for all associated providers if no agreements exist' do
       pending_agreements = GetPendingDataSharingAgreementsForProviderUser.call provider_user: provider_user
       expect(pending_agreements.count).to eq(2)
-      expect(pending_agreements.first.provider.id).to eq(provider1.id)
-      expect(pending_agreements.second.provider.id).to eq(provider2.id)
+      expect([pending_agreements.first.provider.id, pending_agreements.second.provider.id]).to match_array([provider1.id, provider2.id])
     end
 
     it 'returns provider agreements only for providers that need one' do


### PR DESCRIPTION
## Context

This PR attempts to fix a couple of intermittent test failures that I hit last Friday.

## Changes proposed in this pull request

- Change expectation in `spec/mailers/referee_mailer_spec.rb` about names in URL params to use `ERB::Util.url_encode` rather than just `gsub`ing spaces.
- Change expectation in `spec/services/get_pending_data_sharing_agreements_for_provider_user_spec.rb` to compare an array rather than assume they are defined in the 'right' order.

## Guidance to review

- any gotchas with the changes I made?

## Link to Trello card

https://trello.com/c/g1F1twsW/1477-some-flakey-tests-causing-ci-build-failures

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
