### PR TITLE
Add Colchester Teacher Training to providers to sync

### DIFF
--- a/config/providers_to_sync.yml
+++ b/config/providers_to_sync.yml
@@ -20,6 +20,7 @@ development: &default
     - 1OS  # Essex School Direct
     - S17  # SCITTELS
     - C76  # Colchester Teacher Training Consortium
+    - CDB  # Colchester Teacher Training
     - M82  # Mid Essex Initial Teacher Training
     - 2B5  # Hillingdon SCITT
     - 2GU  # Claydon High School


### PR DESCRIPTION
## Context

In #1071, we added in `C76` for Colchester but this is the code for the accredited body which doesn't have any courses. `2DB` is the code for the actual provider. We need to update this.

## Changes proposed in this pull request

This PR simply adds `2DB` to the `providers_to_sync.yml`.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/tr4LEFcK/728-on-board-further-scitts-by-thursday

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
