### PR TITLE
Add page for choosing which email to send for a reference on Support

### DIFF
--- a/app/components/reference_with_feedback_component.html.erb
+++ b/app/components/reference_with_feedback_component.html.erb
@@ -3,8 +3,14 @@
     <% if @show_send_email %>
       <%= render(SummaryCardHeaderComponent, title: @title) do %>
           <div class='app-summary-card__actions'>
-            <%= link_to support_interface_send_reference_email_path(@reference), class: 'govuk-link' do %>
-              <%= 'Send email' %><span class="govuk-visually-hidden"> for <%= @reference.name %></span>
+            <% if FeatureFlag.active?('send_reference_email_via_support') %>
+              <%= link_to support_interface_send_reference_email_path(@reference), class: 'govuk-link' do %>
+                Send email<span class="govuk-visually-hidden"> for <%= @reference.name %></span>
+              <% end %>
+            <% else %>
+              <%= link_to support_interface_chase_reference_path(@reference), class: 'govuk-link' do %>
+                Chase referee<span class="govuk-visually-hidden">, <%= @reference.name %></span>
+              <% end %>
             <% end %>
           </div>
       <% end %>

--- a/app/components/reference_with_feedback_component.html.erb
+++ b/app/components/reference_with_feedback_component.html.erb
@@ -1,10 +1,10 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent, rows: rows do %>
-    <% if @show_chase_reference %>
+    <% if @show_send_email %>
       <%= render(SummaryCardHeaderComponent, title: @title) do %>
           <div class='app-summary-card__actions'>
-            <%= link_to support_interface_chase_reference_path(@reference), class: 'govuk-link' do %>
-              <%= t('application_form.referees.chase') %>
+            <%= link_to support_interface_send_reference_email_path(@reference), class: 'govuk-link' do %>
+              <%= 'Send email' %><span class="govuk-visually-hidden"> for <%= @reference.name %></span>
             <% end %>
           </div>
       <% end %>

--- a/app/components/reference_with_feedback_component.rb
+++ b/app/components/reference_with_feedback_component.rb
@@ -8,10 +8,10 @@ class ReferenceWithFeedbackComponent < ActionView::Component::Base
            :feedback_status,
            to: :reference
 
-  def initialize(reference:, title: '', show_chase_reference: false)
+  def initialize(reference:, title: '', show_send_email: false)
     @reference = reference
     @title = title
-    @show_chase_reference = show_chase_reference
+    @show_send_email = show_send_email
   end
 
   def rows
@@ -63,5 +63,5 @@ private
     end
   end
 
-  attr_reader :reference, :title, :show_chase_reference
+  attr_reader :reference, :title, :show_send_email
 end

--- a/app/controllers/support_interface/send_reference_email_controller.rb
+++ b/app/controllers/support_interface/send_reference_email_controller.rb
@@ -1,0 +1,29 @@
+module SupportInterface
+  class SendReferenceEmailController < SupportInterfaceController
+    before_action :set_reference
+
+    def new
+      @send_reference_email = SupportInterface::SendReferenceEmailForm.new
+    end
+
+    def create
+      @send_reference_email = SupportInterface::SendReferenceEmailForm.new(send_reference_email_params)
+
+      if @send_reference_email.valid?
+        redirect_to support_interface_chase_reference_path(@reference)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def set_reference
+      @reference = ApplicationReference.find(params[:reference_id])
+    end
+
+    def send_reference_email_params
+      params.fetch(:support_interface_send_reference_email_form, {}).permit(:choice)
+    end
+  end
+end

--- a/app/models/support_interface/send_reference_email_form.rb
+++ b/app/models/support_interface/send_reference_email_form.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class SendReferenceEmailForm
+    include ActiveModel::Model
+
+    attr_accessor :choice
+
+    validates :choice, presence: true
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -7,6 +7,7 @@ class FeatureFlag
     training_with_a_disability
     edit_application
     reference_form
+    send_reference_email_via_support
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -54,7 +54,7 @@
   <h2 class="govuk-heading-l govuk-!-margin-top-8">References</h2>
 
   <% @application_form.application_references.each_with_index do |reference, i| %>
-    <%= render ReferenceWithFeedbackComponent, reference: reference, title: "#{(i + 1).ordinalize} reference", show_chase_reference: true %>
+    <%= render ReferenceWithFeedbackComponent, reference: reference, title: "#{(i + 1).ordinalize} reference", show_send_email: true %>
   <% end %>
 <% end %>
 

--- a/app/views/support_interface/chase_reference/show.html.erb
+++ b/app/views/support_interface/chase_reference/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, t('application_form.referees.confirm_chase') %>
-<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@application_form), 'Back to application') %>
+<% content_for :before_content, govuk_back_link_to(support_interface_send_reference_email_path(@reference), 'Back to send email') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/support_interface/send_reference_email/new.html.erb
+++ b/app/views/support_interface/send_reference_email/new.html.erb
@@ -1,0 +1,20 @@
+<% content_for :browser_title, title_with_error_prefix('Send email', @send_reference_email.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@reference.application_form), 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @send_reference_email, url: support_interface_send_reference_email_path(@reference), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        Send email
+      </h1>
+
+      <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: 'Select the action you want to take on the reference' } do %>
+        <%= f.govuk_radio_button :choice, :chase, label: { text: t('application_form.referees.chase') } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -304,7 +304,7 @@ en:
         - (should never appear)
         - First referee
         - Second referee
-      chase: Chase referee
+      chase: Chase both referee and candidate for the reference
       confirm_chase: Are you sure you want to send emails to chase the referee?
       chase_button: Yes - send the email
       chase_success: Email sent to candidate and referee
@@ -528,6 +528,10 @@ en:
           attributes:
             comment:
               blank: Enter a comment
+        support_interface/send_reference_email_form:
+          attributes:
+            choice:
+              blank: Select the action you want to take on the reference
         receive_reference:
           attributes:
             feedback:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -284,6 +284,9 @@ Rails.application.routes.draw do
     get '/applications/:application_form_id/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
     post '/applications/:application_form_id/comments' => 'application_forms/comments#create', as: :application_form_comments
 
+    get '/send-email/:reference_id' => 'send_reference_email#new', as: :send_reference_email
+    post '/send-email/:reference_id' => 'send_reference_email#create'
+
     get '/candidates' => 'candidates#index'
     get '/candidates/:candidate_id' => 'candidates#show', as: :candidate
     post '/candidates/:candidate_id/hide' => 'candidates#hide_in_reporting', as: :hide_candidate

--- a/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
+++ b/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
@@ -11,7 +11,9 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
     when_i_click_on_the_application_awaiting_references
     then_i_should_be_on_the_view_application_page
 
-    when_i_click_on_chase_reference
+    when_i_click_on_send_email
+    and_i_choose_chase_reference_emails
+    and_i_click_on_continue
     then_i_see_a_confirmation_page
 
     when_i_click_to_confirm_sending_the_chase_email
@@ -29,6 +31,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
 
   def and_there_is_an_application_awaiting_references
     @application_awaiting_references = create(:completed_application_form)
+    @referee = @application_awaiting_references.application_references.first
   end
 
   def and_i_visit_the_support_page
@@ -43,8 +46,16 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
     expect(page).to have_content @application_awaiting_references.candidate.email_address
   end
 
-  def when_i_click_on_chase_reference
-    first(:link, t('application_form.referees.chase')).click
+  def when_i_click_on_send_email
+    click_link "Send email for #{@referee.name}"
+  end
+
+  def and_i_choose_chase_reference_emails
+    choose t('application_form.referees.chase')
+  end
+
+  def and_i_click_on_continue
+    click_on 'Continue'
   end
 
   def then_i_see_a_confirmation_page
@@ -57,7 +68,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
 
   def then_i_see_the_referee_email_is_successfully_sent
     candidate_name = "#{@application_awaiting_references.first_name} #{@application_awaiting_references.last_name}"
-    open_email(@application_awaiting_references.application_references.first.email_address)
+    open_email(@referee.email_address)
 
     expect(current_email.subject).to have_content(t('reference_request.subject.chaser', candidate_name: candidate_name))
   end
@@ -65,7 +76,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
   def and_i_see_the_candidate_email_is_successfully_sent
     open_email(@application_awaiting_references.candidate.email_address)
 
-    expect(current_email.subject).to have_content(t('candidate_reference.subject.chaser', referee_name: @application_awaiting_references.application_references.first.name))
+    expect(current_email.subject).to have_content(t('candidate_reference.subject.chaser', referee_name: @referee.name))
   end
 
   def and_i_am_sent_back_to_the_application_form_with_a_flash
@@ -77,7 +88,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
   end
 
   def then_i_see_a_comment_stating_chase_emails_have_been_sent
-    referee_email = @application_awaiting_references.application_references.first.email_address
+    referee_email = @referee.email_address
     candidate_email = @application_awaiting_references.candidate.email_address
 
     within('tbody tr:eq(1)') do

--- a/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
+++ b/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
     given_i_am_a_support_user
     and_there_is_an_application_awaiting_references
     and_i_visit_the_support_page
+    and_send_reference_email_feature_flag_is_on
 
     when_i_click_on_the_application_awaiting_references
     then_i_should_be_on_the_view_application_page
@@ -36,6 +37,10 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
 
   def and_i_visit_the_support_page
     visit support_interface_path
+  end
+
+  def and_send_reference_email_feature_flag_is_on
+    FeatureFlag.activate('send_reference_email_via_support')
   end
 
   def when_i_click_on_the_application_awaiting_references


### PR DESCRIPTION
## Context

Currently, we can send a chase email to a reference and a candidate from Support but we're going to  need to send more emails to a reference such as requesting a new referee when one hasn't responded.

## Changes proposed in this pull request (Updated: 14:18)

This PR changes the flow a bit for sending a chase email by changing the `Chase referee` link to `Send email` and then adding a page for choosing which email to send between the confirmation page. The additional page is to allow for other emails to be sent from here.

Added in a `send_reference_email_via_support` feature flag so this flow is only shown when it is activated.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/42817036/72257432-8f961180-3603-11ea-94ad-8007f480d819.png)

### After

![image](https://user-images.githubusercontent.com/42817036/72257446-99b81000-3603-11ea-90ab-eb9b8706bc4b.png)

![image](https://user-images.githubusercontent.com/42817036/72257476-b18f9400-3603-11ea-8615-7c8710d52929.png)

![image](https://user-images.githubusercontent.com/42817036/72257509-bf451980-3603-11ea-957d-1bab7ab565d6.png)

## Guidance to review

Nothing in particular. The content likely needs a change but we can iterate on this.

## Link to Trello card

https://trello.com/c/fDuObKQB/719-send-all-standard-not-zendesk-emails-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
