### PR TITLE
Fix edit applications to not redirect loop unsubmitted applications

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -10,11 +10,7 @@ module CandidateInterface
   private
 
     def redirect_to_dashboard_if_not_amendable
-      if FeatureFlag.active?('edit_application')
-        redirect_to candidate_interface_application_complete_path unless current_application.amendable?
-      elsif current_application.submitted?
-        redirect_to candidate_interface_application_complete_path
-      end
+      redirect_to candidate_interface_application_complete_path if current_application.submitted? && !current_application.amendable?
     end
 
     def redirect_to_application_form_unless_submitted

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -12,8 +12,11 @@ RSpec.feature 'A candidate edits their application' do
   scenario 'candidate selects to edit their application', sidekiq: true do
     given_the_edit_application_feature_flag_is_on
     and_i_am_signed_in_as_a_candidate
-    and_i_have_a_completed_application
 
+    when_i_visit_the_application_dashboard
+    then_i_should_see_my_unsubmitted_application
+
+    given_i_have_a_completed_application
     when_i_visit_the_application_dashboard
     and_i_click_the_edit_link
     then_i_see_a_button_to_edit_my_application
@@ -44,13 +47,18 @@ RSpec.feature 'A candidate edits their application' do
     create_and_sign_in_candidate
   end
 
-  def and_i_have_a_completed_application
+  def given_i_have_a_completed_application
+    current_candidate.current_application.destroy! # Destroy the unsubmitted one that was created earlier for simplicity.
     @form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
     create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: @form)
   end
 
   def when_i_visit_the_application_dashboard
     visit candidate_interface_application_complete_path
+  end
+
+  def then_i_should_see_my_unsubmitted_application
+    expect(page).to have_content(t('page_titles.application_form'))
   end
 
   def and_i_click_the_edit_link


### PR DESCRIPTION
## Context

Turning on the edit applications feature flag breaks unsubmitted applications.

## Changes proposed in this pull request

Add a test and fix the underlying issue.

Solving the bug involved just adding `&& current_application.submitted?` to the if clause, but then I realised both the `if` and `else` branches checked for `current_application.submitted?`. So I realised I could refactor to this.

## Guidance to review

Makes sense?

## Link to Trello card

https://trello.com/c/KZvEIjBk/742-candidate-with-unsubmitted-application-cant-sign-in-when-edit-application-feature-flag-is-turned-on

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)