### PR TITLE
Skip eligibility page in some acceptance tests

### DIFF
--- a/spec/system/candidate_interface/candidate_account_multiple_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_multiple_sign_in_spec.rb
@@ -48,14 +48,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def when_i_visit_the_signup_page
-    visit '/'
-
-    click_on t('application_form.begin_button')
-
-    find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
-    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
-
-    click_on 'Continue'
+    visit candidate_interface_sign_up_path
   end
 
   def and_i_accept_the_ts_and_cs

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -59,14 +59,7 @@ RSpec.feature 'Candidate account' do
   end
 
   def when_i_visit_the_signup_page
-    visit '/'
-
-    click_on t('application_form.begin_button')
-
-    find('#candidate-interface-eligibility-form-eligible-citizen-yes-field').click
-    find('#candidate-interface-eligibility-form-eligible-qualifications-yes-field').click
-
-    click_on 'Continue'
+    visit candidate_interface_sign_up_path
   end
 
   def then_i_should_see_validation_errors_for_the_terms_and_conditions


### PR DESCRIPTION
This will speed up the tests and make them more resilient.