### PR TITLE
Fix incorrect updated_at timestamp for application forms

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -1,7 +1,7 @@
 class ApplicationChoice < ApplicationRecord
   before_create :set_initial_status
 
-  belongs_to :application_form
+  belongs_to :application_form, touch: true
   belongs_to :course_option
   belongs_to :offered_course_option, class_name: 'CourseOption', optional: true
   has_one :course, through: :course_option

--- a/app/models/application_qualification.rb
+++ b/app/models/application_qualification.rb
@@ -1,5 +1,5 @@
 class ApplicationQualification < ApplicationRecord
-  belongs_to :application_form
+  belongs_to :application_form, touch: true
 
   scope :degrees, -> { where level: 'degree' }
   scope :gcses, -> { where level: 'gcse' }

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -10,7 +10,7 @@ class ApplicationReference < ApplicationRecord
   validates :relationship, presence: true, word_count: { maximum: 50 }
   validates_presence_of :application_form_id
 
-  belongs_to :application_form
+  belongs_to :application_form, touch: true
 
   audited associated_with: :application_form
 

--- a/app/models/application_volunteering_experience.rb
+++ b/app/models/application_volunteering_experience.rb
@@ -1,5 +1,5 @@
 class ApplicationVolunteeringExperience < ApplicationExperience
-  belongs_to :application_form
+  belongs_to :application_form, touch: true
 
   audited associated_with: :application_form
 end

--- a/app/models/application_work_experience.rb
+++ b/app/models/application_work_experience.rb
@@ -1,5 +1,5 @@
 class ApplicationWorkExperience < ApplicationExperience
-  belongs_to :application_form
+  belongs_to :application_form, touch: true
 
   validates :commitment, presence: true
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -21,24 +21,6 @@ RSpec.describe ApplicationForm do
     end
   end
 
-  describe '#update' do
-    it 'updates the application_choices updated_at as well' do
-      original_time = Time.zone.now - 1.day
-      application_form = create(:application_form)
-      application_choices = create_list(
-        :application_choice,
-        2,
-        application_form: application_form,
-        updated_at: original_time,
-      )
-
-      application_form.update!(first_name: 'Something else')
-      application_choices.each(&:reload)
-
-      expect(application_choices.map(&:updated_at)).not_to include(original_time)
-    end
-  end
-
   describe '#science_gcse_needed?' do
     before { FeatureFlag.activate('conditional_science_gcse') }
 

--- a/spec/models/last_updated_at_spec.rb
+++ b/spec/models/last_updated_at_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe '#update' do
+  it 'updates the application_choices when the form is updated' do
+    original_time = Time.zone.now - 1.day
+    application_form = create(:application_form)
+    application_choices = create_list(
+      :application_choice,
+      2,
+      application_form: application_form,
+      updated_at: original_time,
+    )
+
+    application_form.update!(first_name: 'Something else')
+    application_choices.each(&:reload)
+
+    expect(application_choices.map(&:updated_at)).not_to include(original_time)
+  end
+
+  %w[application_choice reference application_volunteering_experience application_work_experience application_qualification].each do |form_attribute|
+    it "updates the form when a #{form_attribute} is added" do
+      original_time = Time.zone.now - 1.day
+      application_form = create(:application_form, updated_at: original_time)
+
+      create(form_attribute, application_form: application_form)
+
+      expect(application_form.updated_at).not_to eql(original_time)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We currently don't updated the application form's `updated_at` when adding/updating/removing associated models like choices, work experience, references, etc.

Is causes:

- the filtering in support & provider UI to be semi-broken
- the "haven’t started" stat on performance dashboard to be wrong
- the "Last updated" time on the candidate dashboard to be semi-broken
 
## Changes proposed in this pull request

Use `touch: true` to update to form whenever an associated model changes.

## Guidance to review


## Link to Trello card

https://trello.com/c/FceP2pDP/1497-fix-incorrect-updatedat-timestamp-for-application-forms

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
