### PR TITLE
Render strings without underscores for Reference feedback status

### DIFF
--- a/app/components/reference_with_feedback_component.rb
+++ b/app/components/reference_with_feedback_component.rb
@@ -29,7 +29,9 @@ private
   def status_row
     {
       key: 'Feedback status',
-      value: render(TagComponent, text: feedback_status, type: 'blue'),
+      value: render(TagComponent,
+                    text: ApplicationReference.human_attribute_name("feedback_status.#{feedback_status}"),
+                    type: 'blue'),
     }
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -155,6 +155,11 @@ en:
             relationship:
               blank: Tell us about the referee’s relationship to you and how long they’ve known you
               too_many_words: Relationship to referee must be %{count} words or fewer
+            feedback_status:
+              not_requested_yet: Not requested yet
+              feedback_requested: Feedback requested
+              feedback_provided: Feedback provided
+              feedback_refused: Feedback refused
         support_user:
           attributes:
             email_address:


### PR DESCRIPTION
### Before

<img width="1017" alt="Screenshot 2020-01-14 at 11 22 28" src="https://user-images.githubusercontent.com/642279/72340462-2b855300-36c0-11ea-9ae1-3ebae4a5c4f6.png">

### After

<img width="993" alt="Screenshot 2020-01-14 at 11 22 00" src="https://user-images.githubusercontent.com/642279/72340482-3344f780-36c0-11ea-9533-0c3833388b38.png">

