### PR TITLE
Redesign the reference refusal page

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -44,13 +44,8 @@ module RefereeInterface
     end
 
     def confirm_feedback_refusal
-      case params.dig(:application_reference, :refuse_to_give_feedback)
-      when 'yes'
-        reference.update!(feedback_status: 'feedback_refused')
-        redirect_to referee_interface_confirmation_path(token: @token_param)
-      when 'no'
-        redirect_to referee_interface_reference_feedback_path(token: params[:token])
-      end
+      reference.update!(feedback_status: 'feedback_refused')
+      redirect_to referee_interface_confirmation_path(token: @token_param)
     end
 
   private

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -1,27 +1,15 @@
 <% content_for :title, "Give a teacher training reference for #{@application.full_name}" %>
 
-<%= form_with model: @reference, url: referee_interface_refuse_feedback_path(token: @token_param), method: :patch do |f| %>
-  <%= f.govuk_error_summary %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">Refuse to give a reference for <%= @application.full_name %></h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Are you sure you won't give <%= @application.full_name %> a reference?</h1>
 
-      <p class="govuk-body"><%= @application.full_name %> applied to the following courses:</p>
+    <%= form_with model: @reference, url: referee_interface_refuse_feedback_path(token: @token_param), method: :patch do |f| %>
+      <%= f.govuk_submit 'Yes - I\'m sure' %>
+    <% end %>
 
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-        <% @application.application_choices.each do |application_choice| %>
-          <li><%= application_choice.course.name %> - <%= application_choice.site.name %></li>
-        <% end %>
-      </ul>
-
-      <p class="govuk-body">
-        Are you sure you want to refuse to give <%= @application.full_name %> a reference?
-      </p>
-
-      <%= f.govuk_radio_button :refuse_to_give_feedback, 'yes', label: { text: 'I don\'t want to give a reference' } %>
-      <%= f.govuk_radio_button :refuse_to_give_feedback, 'no', label: { text: 'I\'d like to provide a reference' } %>
-
-      <%= f.govuk_submit 'Submit' %>
-    </div>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Cancel', referee_interface_reference_feedback_path(token: @token_param) %>
+    </p>
   </div>
-<% end %>
+</div>

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -38,8 +38,7 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
   end
 
   def and_i_say_that_i_do_actually_want_to_give_a_reference
-    choose 'I\'d like to provide a reference'
-    click_button 'Submit'
+    click_link 'Cancel'
   end
 
   def then_i_see_the_reference_comment_page
@@ -47,8 +46,7 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
   end
 
   def and_i_confirm_that_i_wont_give_a_reference
-    choose 'I don\'t want to give a reference'
-    click_button 'Submit'
+    click_button 'Yes - I\'m sure'
   end
 
   def when_i_choose_to_be_contactable


### PR DESCRIPTION
## Context

This is a design iteration proposed in https://ukgovernmentdfe.slack.com/archives/CN9Q1VB2M/p1578917265006400.

## Changes proposed in this pull request

Before:

![image](https://user-images.githubusercontent.com/233676/72341751-f29aad80-36c2-11ea-9c8e-73b8c9b7be87.png)

After:

![image](https://user-images.githubusercontent.com/233676/72341732-e57dbe80-36c2-11ea-8b4f-2c20db8277af.png)

## Guidance to review


## Link to Trello card

https://trello.com/c/3kuEKaQH/666-the-referee-does-not-provide-a-reference-to-the-candidate

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
