### PR TITLE
Add ability to send request for new referee email via Support

### DIFF
--- a/app/controllers/support_interface/new_referee_request_controller.rb
+++ b/app/controllers/support_interface/new_referee_request_controller.rb
@@ -1,0 +1,27 @@
+module SupportInterface
+  class NewRefereeRequestController < SupportInterfaceController
+    before_action :set_reference
+
+    def show; end
+
+    def deliver
+      application_form = @reference.application_form
+      CandidateMailer.new_referee_request(application_form, @reference).deliver
+
+      candidate_email = application_form.candidate.email_address
+      audit_comment = t('new_referee_request.not_responded.audit_comment', candidate_email: candidate_email)
+      application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
+      application_comment.save(application_form)
+
+      flash[:success] = t('new_referee_request.not_responded.success')
+
+      redirect_to support_interface_application_form_path(application_form)
+    end
+
+  private
+
+    def set_reference
+      @reference = ApplicationReference.find(params[:reference_id])
+    end
+  end
+end

--- a/app/controllers/support_interface/send_reference_email_controller.rb
+++ b/app/controllers/support_interface/send_reference_email_controller.rb
@@ -10,7 +10,11 @@ module SupportInterface
       @send_reference_email = SupportInterface::SendReferenceEmailForm.new(send_reference_email_params)
 
       if @send_reference_email.valid?
-        redirect_to support_interface_chase_reference_path(@reference)
+        if @send_reference_email.chase?
+          redirect_to support_interface_chase_reference_path(@reference)
+        else
+          redirect_to support_interface_new_referee_request_path(@reference)
+        end
       else
         render :new
       end
@@ -23,7 +27,9 @@ module SupportInterface
     end
 
     def send_reference_email_params
-      params.fetch(:support_interface_send_reference_email_form, {}).permit(:choice)
+      params.fetch(:support_interface_send_reference_email_form, {}).permit(
+        :choice, :new_referee_email
+      )
     end
   end
 end

--- a/app/models/support_interface/send_reference_email_form.rb
+++ b/app/models/support_interface/send_reference_email_form.rb
@@ -2,8 +2,17 @@ module SupportInterface
   class SendReferenceEmailForm
     include ActiveModel::Model
 
-    attr_accessor :choice
+    attr_accessor :choice, :new_referee_email
 
     validates :choice, presence: true
+    validates :new_referee_email, presence: true, if: :new_referee_email?
+
+    def chase?
+      choice == 'chase'
+    end
+
+    def new_referee_email?
+      choice == 'new_referee'
+    end
   end
 end

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -2,7 +2,7 @@ Dear <%= @candidate_name %>,
 
 # Give details of a new referee
 
-<%= t('new_referee_request.not_responded.explanation', referee_name: @referee_name) %>.
+<%= t('new_referee_request.not_responded.explanation', referee_name: @referee_name) %>
 
 Reply to this email with the name and email address of a new referee, and tell us how you know them.
 

--- a/app/views/support_interface/new_referee_request/show.html.erb
+++ b/app/views/support_interface/new_referee_request/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, t('new_referee_request.not_responded.confirm', candidate_name: @reference.application_form.full_name) %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@reference.application_form), 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_form, url: support_interface_new_referee_request_path(@reference), method: :post do |f| %>
+      <%= f.submit t('new_referee_request.not_responded.confirm_button'), class: 'govuk-button', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', support_interface_application_form_path(@reference.application_form) %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/send_reference_email/new.html.erb
+++ b/app/views/support_interface/send_reference_email/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :browser_title, title_with_error_prefix('Send email', @send_reference_email.errors.any?) %>
+<% content_for :browser_title, title_with_error_prefix('Take action on this reference', @send_reference_email.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@reference.application_form), 'Back to application') %>
 
 <div class="govuk-grid-row">
@@ -6,12 +6,15 @@
     <%= form_with model: @send_reference_email, url: support_interface_send_reference_email_path(@reference), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        Send email
-      </h1>
-
-      <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: 'Select the action you want to take on the reference' } do %>
-        <%= f.govuk_radio_button :choice, :chase, label: { text: t('application_form.referees.chase') } %>
+      <%= f.govuk_radio_buttons_fieldset :choice, legend: { text: 'Take action on this reference', size: 'xl' } do %>
+        <div class="govuk-!-margin-top-6">
+          <%= f.govuk_radio_button :choice, :chase, label: { text: t('application_form.referees.chase') }, link_errors: true %>
+          <%= f.govuk_radio_button :choice, :new_referee, label: { text: t('new_referee_request.option') } do %>
+            <%= f.govuk_radio_buttons_fieldset :new_referee_email, legend: { text: 'Choose an email to send' } do %>
+              <%= f.govuk_radio_button :new_referee_email, :not_responded, label: { text: t('new_referee_request.not_responded.option') }, link_errors: true %>
+            <% end %>
+          <% end %>
+        </div>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -304,7 +304,7 @@ en:
         - (should never appear)
         - First referee
         - Second referee
-      chase: Chase both referee and candidate for the reference
+      chase: Chase this referee and notify the candidate
       confirm_chase: Are you sure you want to send emails to chase the referee?
       chase_button: Yes - send the email
       chase_success: Email sent to candidate and referee

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -531,7 +531,9 @@ en:
         support_interface/send_reference_email_form:
           attributes:
             choice:
-              blank: Select the action you want to take on the reference
+              blank: Choose the action you want to take on the reference
+            new_referee_email:
+              blank: Choose an email to send
         receive_reference:
           attributes:
             feedback:

--- a/config/locales/new_referee_request.yml
+++ b/config/locales/new_referee_request.yml
@@ -1,5 +1,11 @@
 en:
   new_referee_request:
+    option: Ask the candidate to supply an alternative referee
     not_responded:
       subject: "Give details of a new referee: %{referee_name} hasn't responded"
       explanation: We haven’t had a reference from %{referee_name}.
+      option: Explain the referee has not responded
+      confirm: Are you sure you want to send a request for a new referee email to %{candidate_name}?
+      confirm_button: Yes - send the email
+      success: New referee request sent to candidate
+      audit_comment: New referee request email has been sent to candidate (%{candidate_email}).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,6 +287,9 @@ Rails.application.routes.draw do
     get '/send-email/:reference_id' => 'send_reference_email#new', as: :send_reference_email
     post '/send-email/:reference_id' => 'send_reference_email#create'
 
+    get '/send-new-referee-request-email/:reference_id' => 'new_referee_request#show', as: :new_referee_request
+    post '/send-new-referee-request-email/:reference_id' => 'new_referee_request#deliver'
+
     get '/candidates' => 'candidates#index'
     get '/candidates/:candidate_id' => 'candidates#show', as: :candidate
     post '/candidates/:candidate_id/hide' => 'candidates#hide_in_reporting', as: :hide_candidate

--- a/spec/models/support_interface/send_reference_email_form_spec.rb
+++ b/spec/models/support_interface/send_reference_email_form_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SendReferenceEmailForm, type: :model, with_audited: true do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:choice) }
+
+    it 'validates new referee email if chosen to new referee' do
+      send_reference_email =  SupportInterface::SendReferenceEmailForm.new(choice: 'new_referee')
+      error_message = t('activemodel.errors.models.support_interface/send_reference_email_form.attributes.new_referee_email.blank')
+
+      send_reference_email.validate
+
+      expect(send_reference_email.errors.full_messages_for(:new_referee_email)).to eq(
+        ["New referee email #{error_message}"],
+      )
+    end
+  end
+end

--- a/spec/system/support_interface/send_new_referee_request_email_spec.rb
+++ b/spec/system/support_interface/send_new_referee_request_email_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.feature 'Send new referee request to candidate', with_audited: true do
+  include DfESignInHelpers
+
+  scenario 'Support agent sends a new referee request email to a candidate' do
+    given_i_am_a_support_user
+    and_there_is_an_application
+    and_send_reference_email_feature_flag_is_on
+    and_i_am_on_the_application_support_page
+
+    when_i_click_on_send_email
+    and_i_choose_provide_alternative_referee
+    and_i_choose_referee_has_not_responded
+    and_i_click_on_continue
+    then_i_see_a_confirmation_page
+
+    when_i_click_to_confirm_sending_the_new_referee_request_email
+    then_i_see_the_candidate_email_is_successfully_sent
+    and_i_am_sent_back_to_the_application_form_with_a_flash
+
+    when_i_click_on_the_history_for_the_application
+    then_i_see_a_comment_stating_new_referee_request_email_has_been_sent
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application
+    @application = create(:completed_application_form)
+    @candidate_email = @application.candidate.email_address
+    @referee = @application.application_references.first
+  end
+
+  def and_send_reference_email_feature_flag_is_on
+    FeatureFlag.activate('send_reference_email_via_support')
+  end
+
+  def and_i_am_on_the_application_support_page
+    visit support_interface_application_form_path(@application)
+  end
+
+  def when_i_click_on_send_email
+    click_link "Send email for #{@referee.name}"
+  end
+
+  def and_i_choose_provide_alternative_referee
+    choose t('new_referee_request.option')
+  end
+
+  def and_i_choose_referee_has_not_responded
+    choose t('new_referee_request.not_responded.option')
+  end
+
+  def and_i_click_on_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_a_confirmation_page
+    candidate_name = "#{@application.first_name} #{@application.last_name}"
+    expect(page).to have_content(t('new_referee_request.not_responded.confirm', candidate_name: candidate_name))
+  end
+
+  def when_i_click_to_confirm_sending_the_new_referee_request_email
+    click_on t('new_referee_request.not_responded.confirm_button')
+  end
+
+  def then_i_see_the_candidate_email_is_successfully_sent
+    open_email(@candidate_email)
+
+    expect(current_email.subject).to have_content(t('new_referee_request.not_responded.subject', referee_name: @referee.name))
+  end
+
+  def and_i_am_sent_back_to_the_application_form_with_a_flash
+    expect(page).to have_content @candidate_email
+    expect(page).to have_content(t('new_referee_request.not_responded.success'))
+  end
+
+  def when_i_click_on_the_history_for_the_application
+    click_link 'History'
+  end
+
+  def then_i_see_a_comment_stating_new_referee_request_email_has_been_sent
+    within('tbody tr:eq(1)') do
+      expect(page).to have_content 'Comment on Application Form'
+      expect(page).to have_content t('new_referee_request.not_responded.audit_comment', candidate_email: @candidate_email)
+    end
+  end
+end


### PR DESCRIPTION
## Context

We want to be able to send a request for a new referee to a candidate when their referee hasn't responded. In #1088, the email to the `CandidateMailer` was added.

## Changes proposed in this pull request

This PR adds the ability to send this email and does some content tweaks received from Laura and Adam.

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/42817036/72341423-20cbbd80-36c2-11ea-8612-9921f4e76e67.png)

#### After

![image](https://user-images.githubusercontent.com/42817036/72341773-0514e700-36c3-11ea-89b7-8c4e00bff933.png)

![image](https://user-images.githubusercontent.com/42817036/72341790-1100a900-36c3-11ea-8e67-e719990ba9a2.png)

![image](https://user-images.githubusercontent.com/42817036/72341867-44433800-36c3-11ea-85a9-936075db2e09.png)

![image](https://user-images.githubusercontent.com/42817036/72341885-51f8bd80-36c3-11ea-858c-7e3b35f6b698.png)

## Guidance to review

- To test locally, don't forget to turn on the `send_reference_email_via_support` feature flag to make your life a bit easier
- Not really sure about the naming of things, don't know why though...

## Link to Trello card

https://trello.com/c/fDuObKQB/719-send-all-standard-not-zendesk-emails-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
