### PR TITLE
Remove old feature flags

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -7,11 +7,7 @@ module CandidateInterface
     before_action :check_that_candidate_has_an_offer, only: %i[offer respond_to_offer]
 
     def offer
-      if FeatureFlag.active?('accept_and_decline_via_ui')
-        @respond_to_offer = CandidateInterface::RespondToOfferForm.new
-      else
-        render :offer_via_support
-      end
+      @respond_to_offer = CandidateInterface::RespondToOfferForm.new
     end
 
     def respond_to_offer

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -43,8 +43,6 @@ module CandidateInterface
     def withdraw; end
 
     def confirm_withdraw
-      raise unless FeatureFlag.active?('candidate_withdrawals')
-
       withdrawal = WithdrawApplication.new(application_choice: @application_choice)
       withdrawal.save!
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -93,7 +93,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def science_gcse_needed?
-    application_choices.any? do |application_choice|
+    application_choices.includes(%i[course_option course]).any? do |application_choice|
       application_choice.course_option.course.primary_course?
     end
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -93,8 +93,6 @@ class ApplicationForm < ApplicationRecord
   end
 
   def science_gcse_needed?
-    return true unless FeatureFlag.active?('conditional_science_gcse')
-
     application_choices.any? do |application_choice|
       application_choice.course_option.course.primary_course?
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,7 +1,6 @@
 class FeatureFlag
   FEATURES = %w[
     pilot_open
-    accept_and_decline_via_ui
     conditional_science_gcse
     candidate_withdrawals
     training_with_a_disability

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,7 +1,6 @@
 class FeatureFlag
   FEATURES = %w[
     pilot_open
-    conditional_science_gcse
     candidate_withdrawals
     training_with_a_disability
     edit_application

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,7 +1,6 @@
 class FeatureFlag
   FEATURES = %w[
     pilot_open
-    candidate_withdrawals
     training_with_a_disability
     edit_application
     reference_form

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -9,11 +9,6 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">Confirm you would like to withdraw your application to study:</p>
     <p class="govuk-body"><strong><%= @application_choice.course.name_and_code %> at <%= @application_choice.provider.name %></strong></p>
-    <% if FeatureFlag.active?('candidate_withdrawals') %>
-      <%= button_to 'Withdraw my application', candidate_interface_withdraw_path, class: 'govuk-button govuk-button--warning' %>
-    <% else %>
-      <p class="govuk-body">by emailing us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
-      <p class="govuk-body">We’ll contact your training provider and send you an email confirming that your application has been withdrawn.</p>
-    <% end %>
+    <%= button_to 'Withdraw my application', candidate_interface_withdraw_path, class: 'govuk-button govuk-button--warning' %>
   </div>
 </div>

--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -40,11 +40,7 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 
 You can withdraw your application to your <%= 'course'.pluralize(@application_form.application_choices.count) %> at any point, even after you’ve accepted an offer.
 
-<% if FeatureFlag.active?('candidate_withdrawals') %>
-  [Sign in to your account](<%= candidate_interface_sign_in_url %>) and click ‘withdraw’ next to the <%= 'course'.pluralize(@application_form.application_choices.count) %> you want to withdraw and we’ll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
-<% else %>
-  Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) if you want to withdraw and we’ll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
-<% end %>
+[Sign in to your account](<%= candidate_interface_sign_in_url %>) and click ‘withdraw’ next to the <%= 'course'.pluralize(@application_form.application_choices.count) %> you want to withdraw and we’ll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
 
 # References
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe ApplicationForm do
   end
 
   describe '#science_gcse_needed?' do
-    before { FeatureFlag.activate('conditional_science_gcse') }
-
     context 'when a candidate has no course choices' do
       it 'returns false' do
         application_form = build_stubbed(:application_form)

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and accepts' do
-    given_the_accept_and_decline_feature_is_on
-
     given_i_am_signed_in
     and_i_have_2_offers_on_my_choices
     and_1_withdrawn_choice
@@ -29,10 +27,6 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
 
     when_i_visit_the_decline_page_of_the_accepted_offer
     then_i_see_the_page_not_found
-  end
-
-  def given_the_accept_and_decline_feature_is_on
-    FeatureFlag.activate('accept_and_decline_via_ui')
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_declines_offer_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Candidate declines an offer', sidekiq: true do
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and declines' do
-    given_the_accept_and_decline_feature_is_on
-
     given_i_am_signed_in
     and_i_have_an_offer
 
@@ -17,10 +15,6 @@ RSpec.feature 'Candidate declines an offer', sidekiq: true do
 
     then_a_slack_notification_is_sent
     and_i_see_that_i_declined_the_offer
-  end
-
-  def given_the_accept_and_decline_feature_is_on
-    FeatureFlag.activate('accept_and_decline_via_ui')
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
     and_the_training_with_a_disability_feature_flag_is_on
 
     when_i_visit_the_review_application_page
-    then_i_should_be_able_to_click_through_and_complete_each_section
+    then_i_should_be_able_to_click_through_and_complete_each_section_but_science_gcse
 
     when_i_confirm_my_application
     then_i_should_see_an_error_that_i_have_not_completed_everything
@@ -27,8 +27,8 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
     click_link 'Check your answers before submitting'
   end
 
-  def then_i_should_be_able_to_click_through_and_complete_each_section
-    CandidateHelper::APPLICATION_FORM_SECTIONS.each do |section|
+  def then_i_should_be_able_to_click_through_and_complete_each_section_but_science_gcse
+    (CandidateHelper::APPLICATION_FORM_SECTIONS - [:science_gcse]).each do |section|
       expect(page).to have_selector "[aria-describedby='missing-#{section}']"
       within "#missing-#{section}-error" do
         expect(page).to have_link('Complete section')

--- a/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
@@ -6,13 +6,6 @@ RSpec.feature 'Candidate viewing Science GCSE' do
   scenario 'Candidate views a Science GCSE only when a primary course is chosen' do
     given_i_am_signed_in
     when_i_visit_the_site
-    then_i_see_science_gcse
-
-    when_i_click_on_check_your_answers
-    then_i_see_science_gcse_is_missing_below_the_section
-
-    given_conditional_science_gcse_feature_flag_is_on
-    when_i_visit_the_site
     then_i_dont_see_science_gcse
 
     when_i_click_on_check_your_answers
@@ -53,10 +46,6 @@ RSpec.feature 'Candidate viewing Science GCSE' do
     within('#missing-science_gcse-error') do
       expect(page).to have_content(t('review_application.science_gcse.incomplete'))
     end
-  end
-
-  def given_conditional_science_gcse_feature_flag_is_on
-    FeatureFlag.activate('conditional_science_gcse')
   end
 
   def then_i_dont_see_science_gcse

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -3,14 +3,6 @@ require 'rails_helper'
 RSpec.feature 'A candidate withdraws her application' do
   include CandidateHelper
 
-  before do
-    # It would be pleasanter to use "around" here and explicitly unset the
-    # flag, but RSpec appears to run all "before" blocks after any "around"
-    # blocks, so the "before" which flushes Redis will always wipe the feature
-    # flag unless we use "before" here
-    FeatureFlag.activate('candidate_withdrawals')
-  end
-
   scenario 'successful withdrawal', sidekiq: true do
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_application_choice_awaiting_provider_decision


### PR DESCRIPTION
## Context
This PR removes the following feature flags:

- accept_and_decline_via_ui
- conditional_science_gcse
- candidate_withdrawals

## Link to Trello card

https://trello.com/c/RZrMrHAA/734-remove-old-feature-flags
