### PR TITLE
Allow support users to add provider users to multiple orgs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ coverage/*
 
 # Byebug history files
 .byebug_history
+.erblint*

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,14 +1,14 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     def index
-      application_choices = GetApplicationChoicesForProviders.call(providers: current_provider_user.provider)
+      application_choices = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
         .order(updated_at: :desc)
 
       @application_choices = application_choices
     end
 
     def show
-      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.provider)
+      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
         .find(params[:application_choice_id])
     end
   end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,14 +1,14 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     def index
-      application_choices = GetApplicationChoicesForProvider.call(provider: current_provider_user.provider)
+      application_choices = GetApplicationChoicesForProviders.call(providers: current_provider_user.provider)
         .order(updated_at: :desc)
 
       @application_choices = application_choices
     end
 
     def show
-      @application_choice = GetApplicationChoicesForProvider.call(provider: current_provider_user.provider)
+      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.provider)
         .find(params[:application_choice_id])
     end
   end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -83,7 +83,7 @@ module ProviderInterface
   private
 
     def set_application_choice
-      @application_choice = GetApplicationChoicesForProvider.call(provider: current_provider_user.provider)
+      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.provider)
         .find(params[:application_choice_id])
     end
 

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -83,7 +83,7 @@ module ProviderInterface
   private
 
     def set_application_choice
-      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.provider)
+      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
         .find(params[:application_choice_id])
     end
 

--- a/app/controllers/vendor_api/applications_controller.rb
+++ b/app/controllers/vendor_api/applications_controller.rb
@@ -9,7 +9,7 @@ module VendorApi
     end
 
     def show
-      application_choice = GetApplicationChoicesForProvider.call(provider: current_provider)
+      application_choice = GetApplicationChoicesForProviders.call(providers: current_provider)
         .find(params[:application_id])
 
       render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
@@ -18,7 +18,7 @@ module VendorApi
   private
 
     def get_application_choices_for_provider_since(since:)
-      GetApplicationChoicesForProvider.call(provider: current_provider)
+      GetApplicationChoicesForProviders.call(providers: current_provider)
         .where('application_choices.updated_at > ?', since)
     end
 

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -48,7 +48,7 @@ module VendorApi
   private
 
     def application_choice
-      @application_choice ||= GetApplicationChoicesForProvider.call(provider: current_provider)
+      @application_choice ||= GetApplicationChoicesForProviders.call(providers: current_provider)
         .find(params[:application_id])
     end
 

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -3,10 +3,6 @@ class ProviderUser < ActiveRecord::Base
 
   validates :dfe_sign_in_uid, presence: true, uniqueness: true, allow_nil: true
 
-  def provider
-    providers.first
-  end
-
   def self.load_from_session(session)
     dfe_sign_in_user = DfESignInUser.load_from_session(session)
     return unless dfe_sign_in_user

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -8,7 +8,6 @@ module SupportInterface
 
     validates_presence_of :email_address
     validates :provider_ids, presence: true
-    validate :temporarily_one_provider_per_user
     validate :provider_user_uid_unique
 
     def save
@@ -52,12 +51,6 @@ module SupportInterface
           errors.add(:dfe_sign_in_uid, error)
         end
       end
-    end
-
-    def temporarily_one_provider_per_user
-      return unless provider_ids.count(&:present?) > 1
-
-      errors.add(:provider_ids, 'You can only select one provider per user (temporarily)')
     end
   end
 end

--- a/app/services/get_application_choices_for_providers.rb
+++ b/app/services/get_application_choices_for_providers.rb
@@ -1,6 +1,8 @@
-class GetApplicationChoicesForProvider
-  def self.call(provider:)
-    raise MissingProvider if provider.blank?
+class GetApplicationChoicesForProviders
+  def self.call(providers:)
+    providers = Array.wrap(providers).select(&:present?)
+
+    raise MissingProvider if providers.none?
 
     includes = [
       :course,
@@ -14,9 +16,9 @@ class GetApplicationChoicesForProvider
     ]
 
     ApplicationChoice.includes(*includes)
-      .where('courses.provider_id' => provider)
+      .where('courses.provider_id' => providers)
       .or(ApplicationChoice.includes(*includes)
-        .where('courses.accrediting_provider_id' => provider))
+        .where('courses.accrediting_provider_id' => providers))
       .where('status IN (?)', ApplicationStateChange.states_visible_to_provider)
   end
 end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -17,7 +17,12 @@
       <% @application_choices.each do |application_choice| %>
       <tr class="govuk-table__row">
         <th class="govuk-table__cell"><%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %></th>
-        <td class="govuk-table__cell"><%= application_choice.course.name_and_code %></td>
+        <td class="govuk-table__cell">
+          <% if current_provider_user.providers.size > 1 %>
+              <%= application_choice.provider.name %> -
+          <% end %>
+
+          <%= application_choice.course.name_and_code %></td>
         <td class="govuk-table__cell"><%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: application_choice %></td>
         <td class="govuk-table__cell"><%= application_choice.updated_at.to_s(:govuk_date_and_time) %></td>
       </tr>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">Application for <%= @application_choice.course.name_and_code %></span>
+  <span class="govuk-caption-xl">Application for <%= @application_choice.provider.name_and_code %> - <%= @application_choice.course.name_and_code %></span>
   <%= @application_choice.application_form.full_name %>
 </h1>
 
@@ -27,6 +27,16 @@
     <%= render ProviderInterface::StatusBoxComponent, application_choice: @application_choice %>
   </div>
 </div>
+
+<h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Course</h2>
+
+<%= render SummaryListComponent, rows: [
+  { key: 'Provider', value: @application_choice.provider.name_and_code },
+  { key: 'Course', value: @application_choice.course.name_and_code },
+  { key: 'Cycle', value: @application_choice.course.recruitment_cycle_year },
+  { key: 'Preferred location', value: @application_choice.site.name_and_code },
+  { key: 'Study mode', value: @application_choice.course_option.study_mode.humanize },
+] %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
 

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -17,7 +17,7 @@
     { key: 'Full name', value: @application_choice.application_form.full_name },
     { key: 'Course', value: @application_choice.course.name_and_code },
     { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-    { key: 'Preferred location', value: @application_choice.course.course_options.first.site.name },
+    { key: 'Preferred location', value: @application_choice.site.name },
   ] %>
 
   <div class="govuk-grid-row">

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -17,7 +17,7 @@
     { key: 'Full name', value: @application_choice.application_form.full_name },
     { key: 'Course', value: @application_choice.course.name_and_code },
     { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-    { key: 'Preferred location', value: @application_choice.course.course_options.first.site.name },
+    { key: 'Preferred location', value: @application_choice.site.name },
   ] %>
 
   <div class="govuk-grid-row">

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
         create(:application_choice, status: 'awaiting_provider_decision', application_form: create(:completed_application_form))
       end
 
-      let(:given_relation) { GetApplicationChoicesForProvider.call(provider: application_choice.provider) }
+      let(:given_relation) { GetApplicationChoicesForProviders.call(providers: application_choice.provider) }
       let!(:presenter) { VendorApi::SingleApplicationPresenter.new(given_relation.first) }
 
       it 'does not trigger any additional queries' do

--- a/spec/services/get_application_choices_for_providers_spec.rb
+++ b/spec/services/get_application_choices_for_providers_spec.rb
@@ -19,12 +19,9 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'awaiting_provider_decision',
     )
 
-    alternate_provider = create(:provider, code: 'DIFFERENT')
-
-    create_list(
+    create(
       :application_choice,
-      4,
-      course_option: course_option_for_provider(provider: alternate_provider),
+      course_option: course_option_for_provider(provider: create(:provider, code: 'DIFFERENT')),
       status: 'awaiting_provider_decision',
     )
 
@@ -48,12 +45,9 @@ RSpec.describe GetApplicationChoicesForProviders do
       status: 'awaiting_provider_decision',
     )
 
-    alternate_provider = create(:provider, code: 'DIFFERENT')
-
-    create_list(
+    create(
       :application_choice,
-      1,
-      course_option: course_option_for_provider(provider: alternate_provider),
+      course_option: course_option_for_provider(provider: create(:provider, code: 'DIFFERENT')),
       status: 'awaiting_provider_decision',
     )
 

--- a/spec/services/get_application_choices_for_providers_spec.rb
+++ b/spec/services/get_application_choices_for_providers_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe GetApplicationChoicesForProvider do
+RSpec.describe GetApplicationChoicesForProviders do
   include CourseOptionHelpers
 
   it 'raises an exception when the provider is nil' do
     expect {
-      GetApplicationChoicesForProvider.call(provider: nil)
+      GetApplicationChoicesForProviders.call(providers: nil)
     }.to raise_error(MissingProvider)
   end
 
@@ -28,7 +28,7 @@ RSpec.describe GetApplicationChoicesForProvider do
       status: 'awaiting_provider_decision',
     )
 
-    returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
+    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
     expect(returned_applications.size).to be(2)
   end
 
@@ -56,7 +56,7 @@ RSpec.describe GetApplicationChoicesForProvider do
       status: 'awaiting_references',
     )
 
-    returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
+    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
     expect(returned_applications.size).to be(3)
   end
 
@@ -98,7 +98,7 @@ RSpec.describe GetApplicationChoicesForProvider do
       application_form: create(:application_form, first_name: 'Alex'),
     )
 
-    returned_applications = GetApplicationChoicesForProvider.call(provider: current_provider)
+    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
     returned_application_names = returned_applications.map { |a| a.application_form.first_name }
 
     expect(returned_application_names).to include('Aaron', 'Jim', 'Harry')

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -20,10 +20,6 @@ RSpec.feature 'Managing provider users' do
 
     when_i_click_on_that_user
     and_i_add_them_to_another_organisation
-    then_i_see_an_error
-
-    when_i_remove_the_original_organisation
-    and_i_add_them_to_another_organisation
     then_i_see_that_they_have_been_added_to_that_organisation
   end
 
@@ -82,16 +78,8 @@ RSpec.feature 'Managing provider users' do
     click_button 'Update user'
   end
 
-  def then_i_see_an_error
-    expect(page).to have_content 'You can only select one provider per user'
-  end
-
-  def when_i_remove_the_original_organisation
-    uncheck 'Example provider (ABC)'
-  end
-
   def then_i_see_that_they_have_been_added_to_that_organisation
-    expect(page).not_to have_checked_field('Example provider (ABC)')
+    expect(page).to have_checked_field('Example provider (ABC)')
     expect(page).to have_checked_field('Another provider (DEF)')
   end
 end


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1052 we added the ability to add provider users to multiple orgs, but we had to disable it temporarily until we had design.

## Changes proposed in this pull request

First, provider users can be added to multiple orgs now.

Provider users can then see all of their orgs' applications:

![image](https://user-images.githubusercontent.com/233676/72345777-6097a280-36cc-11ea-9418-367ccb238e37.png)

When viewing the application, there's a new block with previously missing info, including the provider:

![image](https://user-images.githubusercontent.com/233676/72345815-7c02ad80-36cc-11ea-8fc8-ccdb84bb4863.png)
  
## Guidance to review

See if it make sense.

## Link to Trello card

https://trello.com/c/o1e8dgLA/1443-allow-support-users-to-add-remove-provider-users-to-from-organisations

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
