### PR TITLE
Refactor `CandidateMailer#new_referee_request` to handle other two emails

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -51,12 +51,13 @@ class CandidateMailer < ApplicationMailer
               template_name: 'chaser')
   end
 
-  def new_referee_request(application_form, reference)
+  def new_referee_request(application_form, reference, reason: :not_responded)
     @candidate_name = application_form.first_name
-    @referee_name = reference.name
+    @referee = reference
+    @reason = reason
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: application_form.candidate.email_address,
-              subject: t('new_referee_request.not_responded.subject', referee_name: @referee_name))
+              subject: t("new_referee_request.#{@reason}.subject", referee_name: @referee.name))
   end
 end

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -2,8 +2,6 @@ Dear <%= @candidate_name %>,
 
 # Give details of a new referee
 
-<%= t('new_referee_request.not_responded.explanation', referee_name: @referee_name) %>
-
-Reply to this email with the name and email address of a new referee, and tell us how you know them.
+<%= t("new_referee_request.#{@reason}.explanation", referee_name: @referee.name, referee_email: @referee.email_address) %>
 
 We can’t send your application to your teacher training providers without 2 complete references.

--- a/config/locales/new_referee_request.yml
+++ b/config/locales/new_referee_request.yml
@@ -2,10 +2,29 @@ en:
   new_referee_request:
     option: Ask the candidate to supply an alternative referee
     not_responded:
-      subject: "Give details of a new referee: %{referee_name} hasn't responded"
-      explanation: We haven’t had a reference from %{referee_name}.
+      subject: "Give details of a new referee: %{referee_name} hasn’t responded"
+      explanation: |-
+        We haven’t had a reference from %{referee_name}.
+
+        Reply to this email with the name and email address of a new referee, and tell us how you know them.
       option: Explain the referee has not responded
       confirm: Are you sure you want to send a request for a new referee email to %{candidate_name}?
       confirm_button: Yes - send the email
       success: New referee request sent to candidate
       audit_comment: New referee request email has been sent to candidate (%{candidate_email}).
+    refused:
+      subject: "%{referee_name} won’t give a reference"
+      explanation: |-
+        %{referee_name} said they won’t give a reference.
+
+        Reply to this email with the name and email address of a new referee, and tell us how you know them.
+    email_bounced:
+      subject: "Our email didn’t reach %{referee_name}"
+      explanation: |-
+        Our email requesting a reference didn’t reach %{referee_name}.
+
+        We emailed the referee using this address: %{referee_email}
+
+        Please can you check you gave the right email address for %{referee_name}.
+
+        Alternatively, reply to this email with the name and email address of a new referee, and tell us how you know them.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -95,11 +95,12 @@ RSpec.describe CandidateMailer, type: :mailer do
         application_references: [reference],
       )
     end
-    let(:mail) { mailer.new_referee_request(application_form, reference) }
-
-    before { mail.deliver_later }
 
     context 'when referee has not responded' do
+      let(:mail) { mailer.new_referee_request(application_form, reference) }
+
+      before { mail.deliver_later }
+
       it 'sends an email with the correct subject' do
         expect(mail.subject).to include(t('new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'))
       end
@@ -109,7 +110,49 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
 
       it 'sends an email saying referee has not responded' do
-        expect(mail.body.encoded).to include(t('new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles'))
+        explanation = mail.body.encoded.gsub("\r", '')
+
+        expect(explanation).to include(t('new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles'))
+      end
+    end
+
+    context 'when referee has refused' do
+      let(:mail) { mailer.new_referee_request(application_form, reference, reason: :refused) }
+
+      before { mail.deliver_later }
+
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('new_referee_request.refused.subject', referee_name: 'Scott Knowles'))
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include('Dear Tyrell')
+      end
+
+      it 'sends an email saying referee has refused' do
+        explanation = mail.body.encoded.gsub("\r", '')
+
+        expect(explanation).to include(t('new_referee_request.refused.explanation', referee_name: 'Scott Knowles'))
+      end
+    end
+
+    context 'when email address of referee has bounced' do
+      let(:mail) { mailer.new_referee_request(application_form, reference, reason: :email_bounced) }
+
+      before { mail.deliver_later }
+
+      it 'sends an email with the correct subject' do
+        expect(mail.subject).to include(t('new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'))
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(mail.body.encoded).to include('Dear Tyrell')
+      end
+
+      it 'sends an email saying referee email bounced' do
+        explanation = mail.body.encoded.gsub("\r", '')
+
+        expect(explanation).to include(t('new_referee_request.email_bounced.explanation', referee_name: 'Scott Knowles', referee_email: reference.email_address))
       end
     end
   end


### PR DESCRIPTION
## Context

See https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1088, https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1092 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1103.

We want to add in two more new referee request emails: one when they've refused and one when a referee's email has bounced.

## Changes proposed in this pull request

This PR refactors `CandidateMailer#new_referee_request` to handle the two other emails.

## Guidance to review

😕Worried about the readability of this and wondering if it's better to have this 3 separate methods and not worry about the duplication of content? If so, method name suggestions please!

## Link to Trello card

https://trello.com/c/fDuObKQB/719-send-all-standard-not-zendesk-emails-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
