### PR TITLE
Don't retry syncing from find as much

### DIFF
--- a/app/workers/sync_from_find.rb
+++ b/app/workers/sync_from_find.rb
@@ -1,5 +1,6 @@
 class SyncFromFind
   include Sidekiq::Worker
+  sidekiq_options retry: 3
 
   def perform
     Rails.configuration.providers_to_sync[:codes].each do |code|


### PR DESCRIPTION
This limits the number of retries of the sync from find process to 3, which means that it’ll retry for something like a few minutes (Sidekiq’s retry mechanism is partly random -
https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry). This is okay since we reschedule this job every 15 minutes anyway.

Not having this limit will mean that jobs will keep piling up if Find ever goes down (not that it ever would, like yesterday).