### PR TITLE
Add ability to send new referee request due to email bounce via Support

### DIFF
--- a/app/controllers/support_interface/new_referee_request_controller.rb
+++ b/app/controllers/support_interface/new_referee_request_controller.rb
@@ -1,19 +1,19 @@
 module SupportInterface
   class NewRefereeRequestController < SupportInterfaceController
-    before_action :set_reference
+    before_action :set_reference, :set_reason
 
     def show; end
 
     def deliver
       application_form = @reference.application_form
-      CandidateMailer.new_referee_request(application_form, @reference).deliver
+      CandidateMailer.new_referee_request(application_form, @reference, reason: @reason).deliver
 
       candidate_email = application_form.candidate.email_address
-      audit_comment = t('new_referee_request.not_responded.audit_comment', candidate_email: candidate_email)
+      audit_comment = t("new_referee_request.#{@reason}.audit_comment", candidate_email: candidate_email)
       application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
       application_comment.save(application_form)
 
-      flash[:success] = t('new_referee_request.not_responded.success')
+      flash[:success] = t('new_referee_request.success')
 
       redirect_to support_interface_application_form_path(application_form)
     end
@@ -22,6 +22,10 @@ module SupportInterface
 
     def set_reference
       @reference = ApplicationReference.find(params[:reference_id])
+    end
+
+    def set_reason
+      @reason = params[:reason].underscore
     end
   end
 end

--- a/app/controllers/support_interface/send_reference_email_controller.rb
+++ b/app/controllers/support_interface/send_reference_email_controller.rb
@@ -13,7 +13,9 @@ module SupportInterface
         if @send_reference_email.chase?
           redirect_to support_interface_chase_reference_path(@reference)
         else
-          redirect_to support_interface_new_referee_request_path(@reference)
+          reason = @send_reference_email.new_referee_email.dasherize
+
+          redirect_to support_interface_new_referee_request_path(@reference, reason)
         end
       else
         render :new

--- a/app/views/support_interface/new_referee_request/show.html.erb
+++ b/app/views/support_interface/new_referee_request/show.html.erb
@@ -1,10 +1,14 @@
-<% content_for :title, t('new_referee_request.not_responded.confirm', candidate_name: @reference.application_form.full_name) %>
+<% content_for :title, t('new_referee_request.confirm', candidate_name: @reference.application_form.full_name) %>
 <% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@reference.application_form), 'Back to application') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @application_form, url: support_interface_new_referee_request_path(@reference), method: :post do |f| %>
-      <%= f.submit t('new_referee_request.not_responded.confirm_button'), class: 'govuk-button', data: { module: 'govuk-button' } %>
+      <p class="govuk-body">
+        <%= t("new_referee_request.#{@reason}.confirm_text", referee_name: @reference.name) %>
+      </p>
+
+      <%= f.submit t('new_referee_request.confirm_button'), class: 'govuk-button', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
         <%= govuk_link_to 'Cancel', support_interface_application_form_path(@reference.application_form) %>

--- a/app/views/support_interface/send_reference_email/new.html.erb
+++ b/app/views/support_interface/send_reference_email/new.html.erb
@@ -12,6 +12,7 @@
           <%= f.govuk_radio_button :choice, :new_referee, label: { text: t('new_referee_request.option') } do %>
             <%= f.govuk_radio_buttons_fieldset :new_referee_email, legend: { text: 'Choose an email to send' } do %>
               <%= f.govuk_radio_button :new_referee_email, :not_responded, label: { text: t('new_referee_request.not_responded.option') }, link_errors: true %>
+              <%= f.govuk_radio_button :new_referee_email, :email_bounced, label: { text: t('new_referee_request.email_bounced.option') }, link_errors: true %>
             <% end %>
           <% end %>
         </div>

--- a/config/locales/new_referee_request.yml
+++ b/config/locales/new_referee_request.yml
@@ -1,6 +1,9 @@
 en:
   new_referee_request:
     option: Ask the candidate to supply an alternative referee
+    confirm: Are you sure you want to send a request for a new referee email to %{candidate_name}?
+    confirm_button: Yes - send the email
+    success: New referee request sent to candidate
     not_responded:
       subject: "Give details of a new referee: %{referee_name} hasn’t responded"
       explanation: |-
@@ -8,10 +11,8 @@ en:
 
         Reply to this email with the name and email address of a new referee, and tell us how you know them.
       option: Explain the referee has not responded
-      confirm: Are you sure you want to send a request for a new referee email to %{candidate_name}?
-      confirm_button: Yes - send the email
-      success: New referee request sent to candidate
-      audit_comment: New referee request email has been sent to candidate (%{candidate_email}).
+      audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining non-response.
+      confirm_text: We will send an email to explain that their referee (%{referee_name}) has not responded.
     refused:
       subject: "%{referee_name} won’t give a reference"
       explanation: |-
@@ -28,3 +29,6 @@ en:
         Please can you check you gave the right email address for %{referee_name}.
 
         Alternatively, reply to this email with the name and email address of a new referee, and tell us how you know them.
+      option: Explain the referee’s email has bounced
+      audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining email bounce.
+      confirm_text: We will send an email to explain that their referee's email (%{referee_name}) has bounced.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,8 +293,8 @@ Rails.application.routes.draw do
     get '/send-email/:reference_id' => 'send_reference_email#new', as: :send_reference_email
     post '/send-email/:reference_id' => 'send_reference_email#create'
 
-    get '/send-new-referee-request-email/:reference_id' => 'new_referee_request#show', as: :new_referee_request
-    post '/send-new-referee-request-email/:reference_id' => 'new_referee_request#deliver'
+    get '/send-new-referee-request-email/:reference_id/:reason' => 'new_referee_request#show', as: :new_referee_request
+    post '/send-new-referee-request-email/:reference_id/:reason' => 'new_referee_request#deliver'
 
     get '/candidates' => 'candidates#index'
     get '/candidates/:candidate_id' => 'candidates#show', as: :candidate


### PR DESCRIPTION
## Context

We want to be able to send a new referee request email explaining that a referee's email has bounced via Support.

## Changes proposed in this pull request

This PR adds the ability to send the new referee request email due to email bounce by refactoring how we send the non-response email (see https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1103).

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/72359656-93e72b00-36e6-11ea-9579-a924b28ff269.png)

![image](https://user-images.githubusercontent.com/42817036/72359687-a3667400-36e6-11ea-9328-d2d9b56ad530.png)

![image](https://user-images.githubusercontent.com/42817036/72359753-bed17f00-36e6-11ea-986d-62a55b019b80.png)

![image](https://user-images.githubusercontent.com/42817036/72359781-cabd4100-36e6-11ea-8000-a49b6deb78d2.png)

## Guidance to review

As this change uses the same controller and views, an additional line of content has been added e.g. `We will send an email to explain that their referee (Csaba Gyorfi) has not responded.` to the confirmation page so that the Support user can check they've selected the right reason. This hasn't be checked with a content designer but plan to get this and the last email (referee has refused to give a reference) in and then get feedback from Laura. Going with "make it work, then make it right" and "ask for forgiveness, not permission". 😬

## Link to Trello card

https://trello.com/c/fDuObKQB/719-send-all-standard-not-zendesk-emails-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
