### PR TITLE
FOR USER RESEARCH ONLY - Training with a disability

### DIFF
--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -37,7 +37,7 @@ module CandidateInterface
 
     def disability_disclosure_row
       {
-        key: t('application_form.training_with_a_disability.disability_disclosure.label'),
+        key: t('application_form.training_with_a_disability.disability_disclosure.review_label'),
         value: @training_with_a_disability_form.disability_disclosure,
         action: t('application_form.training_with_a_disability.disability_disclosure.change_action'),
         change_path: Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path,

--- a/app/frontend/styles/_related.scss
+++ b/app/frontend/styles/_related.scss
@@ -6,3 +6,17 @@
 .app-related + .app-related {
   border-top-color: transparent;
 }
+
+.app-related__body {
+  @include govuk-font(16);
+}
+
+.app-related__list {
+  @extend %govuk-list;
+}
+
+.app-related__list-item {
+  @include govuk-font(16);
+  font-weight: bold;
+  margin-top: govuk-spacing(3);
+}

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -15,7 +15,7 @@
 <%= render(CandidateInterface::ContactDetailsReviewComponent, application_form: application_form, editable: editable, missing_error: missing_error) %>
 
 <% if FeatureFlag.active?('training_with_a_disability') %>
-  <h3 class="govuk-heading-m">Training with a disability</h3>
+  <h3 class="govuk-heading-m">Get extra assistance to become a teacher</h3>
 
   <%= render(CandidateInterface::TrainingWithADisabilityReviewComponent, application_form: @application_form, editable: editable, missing_error: missing_error) %>
 <% end %>

--- a/app/views/candidate_interface/application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/application_form/submit_show.html.erb
@@ -34,12 +34,6 @@
       </div>
 
       <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
-        <p class="govuk-body">
-          Examples of further information include any disability, health or
-          other personal or professional issue you feel is relevant to your
-          application.
-        </p>
-
         <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_area :further_information_details, label: { text: t('application_form.further_information.further_information_details.label') }, max_words: 300 %>
         <% end %>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -8,16 +8,12 @@
 
       <h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>
 
-      <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>any disability, health or personal issue you feel is relevant</li>
-        <li>special arrangements or assistance you may need</li>
-        <li>dates you are unavailable for interview</li>
-      </ul>
+      <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person.</p>
+      <p class="govuk-body">Give details of any arrangements you might need. Providers can’t always accomodate your preferences.</p>
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label') }, rows: 8, max_words: 200 %>
+          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label'), size: 's' }, hint_text: 'Give a reason if you can', rows: 8, max_words: 200 %>
         <% end %>
 
         <%= f.govuk_radio_button :any_preferences, 'no', label: { text: 'No' } %>

--- a/app/views/candidate_interface/shared/_training_outside_england.html.erb
+++ b/app/views/candidate_interface/shared/_training_outside_england.html.erb
@@ -1,0 +1,8 @@
+<aside class="app-related" role="complementary">
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="training-outside-england-title">Teacher training outside England</h2>
+  <ul class="govuk-list govuk-!-font-size-16">
+    <li><%= govuk_link_to('Teacher training in Wales', 'https://www.discoverteaching.wales/routes-into-teaching/', target: :_blank) %></li>
+    <li><%= govuk_link_to('Teacher training in Scotland', 'https://teachinscotland.scot/', target: :_blank) %></li>
+    <li><%= govuk_link_to('Teacher training in Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland', target: :_blank) %></li>
+  </ul>
+</aside>

--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -1,37 +1,40 @@
 <% content_for :title, t('page_titles.application') %>
 
+<h1 class="govuk-heading-xl">
+  <%= service_name %>
+</h1>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= service_name %>
-    </h1>
-    <p class="govuk-body-l">
-      <%= service_name %> is a new GOV.UK service being trialled with a small number of training providers in England.
-    </p>
-    <div class="govuk-inset-text">
-      Learn more about teacher training in <%= govuk_link_to('Wales', 'https://www.discoverteaching.wales/routes-into-teaching/', target: :_blank) %>, <%= govuk_link_to('Scotland', 'https://teachinscotland.scot/', target: :_blank) %> and <%= govuk_link_to('Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland', target: :_blank) %>
-    </div>
+    <p class="govuk-body-l"><%= service_name %> is a new GOV.UK service being trialled with a small number of training providers in England.</p>
+    <p class="govuk-body">You can <%= govuk_link_to('preview training providers and courses currently available', candidate_interface_providers_path) %> on this service.</p>
+    <p class="govuk-body">For all other courses in England, <%= govuk_link_to('you will need to apply through UCAS Teacher Training', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do', target: :_blank) %>.
 
-    <h2 class="govuk-heading-m">What you’ll need</h2>
-    <p class="govuk-body">
-      To be eligible for teacher training, you need these qualifications (or their non-UK equivalents):
-    </p>
+    <h2 class="govuk-heading-m govuk-!-font-size-27">What you’ll need</h2>
+    <p class="govuk-body">To be eligible for teacher training, you need these qualifications (or their non-UK equivalents):</p>
     <ul class="govuk-list govuk-list--bullet">
       <li>a degree</li>
       <li>grade 4 (C) or above in English and maths GCSEs</li>
       <li>grade 4 (C) or above in GCSE science if you want to teach primary</li>
     </ul>
-    <p class="govuk-body">
-      Before you start a teacher training course, your training provider will usually send you a health questionnaire to complete. This confirms you have the fitness and physical capacity to start training.
-    </p>
-    <h2 class="govuk-heading-m">If you have a disability</h2>
-      <p class="govuk-body">It is against the law for training providers to discriminate against teacher training candidates with disabilities or special educational needs. <%= govuk_link_to 'Learn more about training to teach if you have a disability', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>.</p>
+    <p class="govuk-body">Before you start a teacher training course you’ll also need to:
+    <ul class="govuk-list govuk-list--bullet">
+      <li>confirm you have the health and physical capacity to start training</li>
+      <li>undergo a <%= govuk_link_to('criminal record check', 'https://www.gov.uk/dbs-check-applicant-criminal-record', target: :_blank) %></li>
+    </ul>
 
-    <h2 class="govuk-heading-m">If you do not have a degree</h2>
-    <p class="govuk-body">
-      You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status.
-      <%= govuk_link_to('Learn more about eligibility for teacher training', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
-    </p>
+    <h3 class="govuk-heading-s">If you have a criminal record</h3>
+    <p class="govuk-body"><%= govuk_link_to('Not all convictions prevent you teaching', 'https://www.gov.uk/exoffenders-and-employment', target: :_blank) %>. If you have chosen a training provider, you can ask about their policy on criminal convictions.</p>
+
+    <h3 class="govuk-heading-s">If you have a disability</h3>
+    <p class="govuk-body">It’s unlawful to discriminate against you, and you don’t have to disclose a disability. <%= govuk_link_to 'Learn more about training to teach if you have a disability', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>.</p>
+
+    <h3 class="govuk-heading-s">If you do not have a degree</h3>
+    <p class="govuk-body">You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status. <%= govuk_link_to('Learn more about eligibility for teacher training', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
+
+    <h3 class="govuk-heading-s">You can only apply for 3 courses and accept one offer</h3>
+    <p class="govuk-body"><%= govuk_link_to('Learn more about the application process', 'https://getintoteaching.education.gov.uk/the-way-you-apply-for-teacher-training-is-changing', target: :_blank) %>.</p>
+
     <%= link_to candidate_interface_eligibility_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
@@ -39,5 +42,8 @@
       </svg>
     <% end %>
     <p class="govuk-body">If you have teacher training applications in progress, please <%= govuk_link_to 'sign in', candidate_interface_sign_in_path %></p>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render partial: '/candidate_interface/shared/training_outside_england' %>
   </div>
 </div>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -13,13 +13,17 @@
           </h1>
         </legend>
 
-        <p class="govuk-body">It’s a personal choice if you want to inform your training provider of your disability.</p>
-        <p class="govuk-body">The advantage of disclosure is that it enables support and reasonable adjustments to be put in place. In addition, specialist equipment, extra funding and support, can help you achieve your ambition of becoming a teacher.</p>
-        <p class="govuk-body"><%= govuk_link_to 'The Equality Act 2010', 'https://www.gov.uk/guidance/equality-act-2010-guidance' %> and Special Educational Needs and Disability Act 2001, require teacher training providers to ensure they are not discriminating against applicants with disabilities or special educational needs (SEN).</p>
+        <p class="govuk-body">Training providers might be able to support you to attend the interview or do the training. For example, you might benefit from support if you’re disabled, have a health condition or educational needs.</p>
+        <p class="govuk-body">We recommend contacting your training provider before applying to discuss the support they can give you. Examples of support could be:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>organising assistive equipment, such as a hearing loop or an adapted keyboard</li>
+          <li>making sure classrooms are wheelchair accessible</li>
+          <li>providing additional support, such as a mentor or classroom assistance</li>
+        </ul>
 
         <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { size: 'm', text: t('application_form.training_with_a_disability.disclose_disability.label') } do %>
           <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') } do %>
-            <%= f.govuk_text_area :disability_disclosure, rows: 24, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label') }, max_words: 400 %>
+            <%= f.govuk_text_area :disability_disclosure, rows: 8, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label'), size: 's' }, hint_text: t('application_form.training_with_a_disability.disability_disclosure.hint'), max_words: 400 %>
           <% end %>
 
           <%= f.govuk_radio_button :disclose_disability, 'no', label: { text: t('application_form.training_with_a_disability.disclose_disability.no') } %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -231,14 +231,16 @@ en:
     training_with_a_disability:
       complete_form_button: Continue
       disclose_disability:
-        change_action: whether you want to disclose a disability
-        label: Do you want to disclose a disability?
-        'yes': "Yes"
+        label: Do you want to ask for help to become a teacher?
+        'yes': "Yes, I want to share information about myself so my provider can take steps to support me"
         'no': "No"
+        change_action: whether you want to ask for help
         not_specified: Not entered
       disability_disclosure:
-        label: Tell us about your disability
-        change_action: what you want to tell us about your disability
+        label: Give any relevant information
+        review_label: Relevant information
+        hint: You can also use this space to make a note of any discussions you’ve already had with your provider about getting support.
+        change_action: what information you want to give
       review:
         button: Continue
     volunteering:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,7 +59,7 @@ en:
     becoming_a_teacher: Why do you want to be a teacher?
     subject_knowledge: What do you know about the subject you want to teach?
     interview_preferences: Interview preferences
-    training_with_a_disability: Training with a disability
+    training_with_a_disability: Get extra assistance to become a teacher
     volunteering:
       short: Volunteering with children and young people
       long: "Children and young people: volunteering and experience in school"

--- a/spec/components/candidate_interface/training_with_a_disability_review_component_spec.rb
+++ b/spec/components/candidate_interface/training_with_a_disability_review_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityReviewComponent do
     it 'renders component with correct values for an disability_disclosure' do
       result = render_inline(described_class, application_form: application_form)
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.label'))
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('I have difficulty climbing stairs')
       expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disability_disclosure.change_action')}")


### PR DESCRIPTION
## Context

We want to test the new wording and guidance around training with a disability using the robust and fully accessibility tested production build. We also want to remove the current overlap in guidance for the interview preferences question, and the final catch-all question.

## Changes proposed in this pull request

### Start page

Has revised guidance (includes content from version of this page we intend to use when we remove the link to terms of use from the ‘create account’ page).
 
![start-page](https://user-images.githubusercontent.com/813383/72360019-428b6b80-36e7-11ea-8122-07d838861e42.png)

### Application index

New title for ‘training with a disability’ section.

<img width="670" alt="application-links" src="https://user-images.githubusercontent.com/813383/72360174-7c5c7200-36e7-11ea-8c13-ab1c41b45521.png">

### Get extra assistance to become a teacher

Updated content and guidance.

![get-extra-assistance](https://user-images.githubusercontent.com/813383/72360034-461ef280-36e7-11ea-881a-8f97723344fe.png)

### Get extra assistance to become a teacher - review

Updated labels.

![get-extra-assistance-review](https://user-images.githubusercontent.com/813383/72360037-47e8b600-36e7-11ea-8b51-07e266b933a5.png)

### Interview preferences

Updated content and guidance, removing all references to special arrangements, disability and adaptions.

![interview-preferences](https://user-images.githubusercontent.com/813383/72360048-4cad6a00-36e7-11ea-99fa-5680206e6067.png)

### Submit page

Remove content that gives an example of additional information as being that about a disability or health concern.

![submit](https://user-images.githubusercontent.com/813383/72360053-4e772d80-36e7-11ea-8089-f2bd4c4b62bd.png)

## Link to Trello card

https://trello.com/c/D29yT0k1