### PR TITLE
Add ability to send new referee request due to refusal via Support

### DIFF
--- a/app/views/support_interface/send_reference_email/new.html.erb
+++ b/app/views/support_interface/send_reference_email/new.html.erb
@@ -13,6 +13,7 @@
             <%= f.govuk_radio_buttons_fieldset :new_referee_email, legend: { text: 'Choose an email to send' } do %>
               <%= f.govuk_radio_button :new_referee_email, :not_responded, label: { text: t('new_referee_request.not_responded.option') }, link_errors: true %>
               <%= f.govuk_radio_button :new_referee_email, :email_bounced, label: { text: t('new_referee_request.email_bounced.option') }, link_errors: true %>
+              <%= f.govuk_radio_button :new_referee_email, :refused, label: { text: t('new_referee_request.refused.option') }, link_errors: true %>
             <% end %>
           <% end %>
         </div>

--- a/config/locales/new_referee_request.yml
+++ b/config/locales/new_referee_request.yml
@@ -19,6 +19,9 @@ en:
         %{referee_name} said they won’t give a reference.
 
         Reply to this email with the name and email address of a new referee, and tell us how you know them.
+      option: Explain the referee has declined to give a reference
+      audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining refusal to provide a reference.
+      confirm_text: We will send an email to explain that their referee (%{referee_name}) has refused to provide a reference.
     email_bounced:
       subject: "Our email didn’t reach %{referee_name}"
       explanation: |-

--- a/spec/system/support_interface/send_new_referee_request_email_spec.rb
+++ b/spec/system/support_interface/send_new_referee_request_email_spec.rb
@@ -35,6 +35,20 @@ RSpec.feature 'Send new referee request to candidate', with_audited: true do
 
     when_i_click_on_the_history_for_the_application
     then_i_see_a_comment_stating_email_address_bounced_email_has_been_sent
+
+    when_i_am_on_the_application_support_page
+    and_i_click_on_send_email
+    and_i_choose_provide_alternative_referee
+    and_i_choose_referees_email_has_refused
+    and_i_click_on_continue
+    then_i_see_a_confirmation_page_for_refused_email
+
+    when_i_click_to_confirm_sending_the_new_referee_request_email
+    then_i_see_the_candidate_email_is_successfully_sent_for_refused_email
+    and_i_am_sent_back_to_the_application_form_with_a_flash
+
+    when_i_click_on_the_history_for_the_application
+    then_i_see_a_comment_stating_refused_email_has_been_sent
   end
 
   def given_i_am_a_support_user
@@ -130,6 +144,28 @@ RSpec.feature 'Send new referee request to candidate', with_audited: true do
     within('tbody tr:eq(1)') do
       expect(page).to have_content 'Comment on Application Form'
       expect(page).to have_content t('new_referee_request.email_bounced.audit_comment', candidate_email: @candidate_email)
+    end
+  end
+
+  def and_i_choose_referees_email_has_refused
+    choose t('new_referee_request.refused.option')
+  end
+
+  def then_i_see_a_confirmation_page_for_refused_email
+    expect(page).to have_content(t('new_referee_request.confirm', candidate_name: @candidate_name))
+    expect(page).to have_content(t('new_referee_request.refused.confirm_text', referee_name: @referee.name))
+  end
+
+  def then_i_see_the_candidate_email_is_successfully_sent_for_refused_email
+    open_email(@candidate_email)
+
+    expect(current_email.subject).to have_content(t('new_referee_request.refused.subject', referee_name: @referee.name))
+  end
+
+  def then_i_see_a_comment_stating_refused_email_has_been_sent
+    within('tbody tr:eq(1)') do
+      expect(page).to have_content 'Comment on Application Form'
+      expect(page).to have_content t('new_referee_request.refused.audit_comment', candidate_email: @candidate_email)
     end
   end
 end


### PR DESCRIPTION
## Context

We want to be able to send an email via Support to a candidate to request for a new referee if one of theirs has refused to give a reference. This is the last email needed to be added.

## Changes proposed in this pull request

This PR adds the ability to send the email via Support.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/72364091-d2341880-36ed-11ea-8cc3-e311c4541c04.png)

![image](https://user-images.githubusercontent.com/42817036/72364118-dc561700-36ed-11ea-87b9-26c04607b568.png)

![image](https://user-images.githubusercontent.com/42817036/72364140-e4ae5200-36ed-11ea-987a-50676b28c926.png)

![image](https://user-images.githubusercontent.com/42817036/72364173-f7288b80-36ed-11ea-820e-74dc838910a3.png)

## Guidance to review

Twas super easy to do due to #1110.

## Link to Trello card

https://trello.com/c/fDuObKQB/719-send-all-standard-not-zendesk-emails-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
