### PR TITLE
Add uppercasing when entering and saving postcode

### DIFF
--- a/app/frontend/styles/_postcode.scss
+++ b/app/frontend/styles/_postcode.scss
@@ -1,0 +1,3 @@
+.govuk-input[autocomplete="postal-code"] {
+  text-transform: uppercase;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -23,6 +23,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "_task-list";
 @import "_contents-list";
 @import "_definition-list";
+@import "_postcode";
 
 // Support
 @import "_card";

--- a/app/models/candidate_interface/contact_details_form.rb
+++ b/app/models/candidate_interface/contact_details_form.rb
@@ -39,7 +39,7 @@ module CandidateInterface
         address_line2: address_line2,
         address_line3: address_line3,
         address_line4: address_line4,
-        postcode: postcode,
+        postcode: postcode.upcase,
         country: 'UK',
       )
     end

--- a/spec/models/candidate_interface/contact_details_form_spec.rb
+++ b/spec/models/candidate_interface/contact_details_form_spec.rb
@@ -48,10 +48,12 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         address_line2: Faker::Address.street_address,
         address_line3: Faker::Address.city,
         address_line4: Faker::Address.country,
-        postcode: Faker::Address.postcode,
+        postcode: 'bn1 1aa',
       }
       application_form = build(:application_form)
       contact_details = CandidateInterface::ContactDetailsForm.new(form_data)
+
+      form_data[:postcode] = 'BN1 1AA'
 
       expect(contact_details.save_address(application_form)).to eq(true)
       expect(application_form).to have_attributes(form_data)


### PR DESCRIPTION
## Context

Postcodes should be uppercased.

## Changes proposed in this pull request

This PR adds uppercasing when a candidates enters their postcode to make it easier for text entry on mobile and when we save it.

## Guidance to review

Not sure how I targeted the postcode text field using CSS is okay?

## Link to Trello card

https://trello.com/c/003s4hNf/775-uppercase-postcodes-on-save

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
