### PR TITLE
Fix  unformatted GCSE or equivalent qualification titles

### DIFF
--- a/app/components/qualification_title_component.html.erb
+++ b/app/components/qualification_title_component.html.erb
@@ -1,1 +1,1 @@
-<%= qualification_type %> <%= @qualification.subject %>
+<%= qualification_type %> <%= @qualification.subject&.titleize %>

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -6,9 +6,10 @@ class QualificationTitleComponent < ActionView::Component::Base
   def qualification_type
     if @qualification.level == 'gcse' && @qualification.missing_qualification?
       I18n.t('application_form.gcse.qualification_types_abbreviated.gcse')
+      ApplicationQualification.human_attribute_name('qualification_type.gcse')
     elsif @qualification.level == 'gcse'
-      I18n.t(
-        "application_form.gcse.qualification_types_abbreviated.#{@qualification.qualification_type}",
+      ApplicationQualification.human_attribute_name(
+        "qualification_type.#{@qualification.qualification_type}",
         default: @qualification.qualification_type,
       )
     else

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -5,7 +5,12 @@ class QualificationTitleComponent < ActionView::Component::Base
 
   def qualification_type
     if @qualification.level == 'gcse' && @qualification.missing_qualification?
-      'GCSE'
+      I18n.t('application_form.gcse.qualification_types.gcse')
+    elsif @qualification.level == 'gcse'
+      I18n.t(
+        "application_form.gcse.qualification_types.#{@qualification.qualification_type}",
+        default: @qualification.qualification_type,
+      )
     else
       @qualification.qualification_type
     end

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -5,10 +5,10 @@ class QualificationTitleComponent < ActionView::Component::Base
 
   def qualification_type
     if @qualification.level == 'gcse' && @qualification.missing_qualification?
-      I18n.t('application_form.gcse.qualification_types.gcse')
+      I18n.t('application_form.gcse.qualification_types_abbreviated.gcse')
     elsif @qualification.level == 'gcse'
       I18n.t(
-        "application_form.gcse.qualification_types.#{@qualification.qualification_type}",
+        "application_form.gcse.qualification_types_abbreviated.#{@qualification.qualification_type}",
         default: @qualification.qualification_type,
       )
     else

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -170,6 +170,12 @@ en:
         scottish_national_5: Scottish National 5
         other_uk: Other UK qualification
         missing: I don’t have this qualification yet
+      qualification_types_abbreviated:
+        gcse: GCSE
+        gce_o_level: GCE O Level
+        scottish_national_5: Scottish National 5
+        other_uk: Other UK
+        missing: I don’t have this qualification yet
       other_uk:
         label: Enter type of qualification
       missing_explanation:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -170,12 +170,6 @@ en:
         scottish_national_5: Scottish National 5
         other_uk: Other UK qualification
         missing: I don’t have this qualification yet
-      qualification_types_abbreviated:
-        gcse: GCSE
-        gce_o_level: GCE O Level
-        scottish_national_5: Scottish National 5
-        other_uk: Other UK
-        missing: I don’t have this qualification yet
       other_uk:
         label: Enter type of qualification
       missing_explanation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,13 @@ en:
             rejection_reason:
               blank: Enter feedback for the candidate
   activerecord:
+    attributes:
+      application_qualification/qualification_type:
+        gcse: GCSE
+        gce_o_level: GCE O Level
+        scottish_national_5: Scottish National 5
+        other_uk: Other UK
+        missing: I don’t have this qualification yet
     errors:
       models:
         candidate:

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe QualificationTitleComponent do
+  it 'renders the correct title for a degree' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :degree,
+      qualification_type: 'BSc',
+      subject: 'Psychology',
+    )
+
+    result = render_inline(described_class, qualification: qualification)
+
+    expect(result.text).to include('BSc Psychology')
+  end
+
+  it 'renders the correct title for a GCSE' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :gcse,
+      qualification_type: 'gcse',
+      subject: 'english',
+    )
+
+    result = render_inline(described_class, qualification: qualification)
+
+    expect(result.text).to include('GCSE English')
+  end
+
+  it 'renders the correct title for an other_uk GCSE equivalent' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :gcse,
+      qualification_type: 'other_uk',
+      subject: 'maths',
+    )
+
+    result = render_inline(described_class, qualification: qualification)
+
+    expect(result.text).to include('Other UK Maths')
+  end
+end

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class, qualification: qualification)
 
-    expect(result.text).to include('Other UK Maths')
+    expect(result.text).to include('Other UK qualification Maths')
   end
 end

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class, qualification: qualification)
 
-    expect(result.text).to include('Other UK qualification Maths')
+    expect(result.text).to include('Other UK Maths')
   end
 end


### PR DESCRIPTION
## Context

In the support and provider interfaces the table of qualifications displays unformatted qualification types, e.g. _gcse maths_ rather than _GCSE Maths_.

## Changes proposed in this pull request

- Use existing mappings of qualification types to localisable strings.
- Title case the subject.
- Add some specs for the `QualificationTitleComponent`.

![image](https://user-images.githubusercontent.com/450843/72433485-4a074f00-3791-11ea-8a85-bf7ddf4a9592.png)


## Guidance to review

- Nothing particular. However there are a few more edge cases that I've stumbled on and added to the original card, see link below. I think it's still worth the changes here now and dealing with other issues in further PRs if needed.

## Link to Trello card

https://trello.com/c/miNcm05m/1500-gcse-or-equivalent-fields-are-unformatted-in-provider-and-support-interface

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
