### PR TITLE
Add migration to upcase all existing postcodes

### DIFF
--- a/db/migrate/20200115124513_upcase_postcodes_on_application_forms.rb
+++ b/db/migrate/20200115124513_upcase_postcodes_on_application_forms.rb
@@ -1,0 +1,14 @@
+class UpcasePostcodesOnApplicationForms < ActiveRecord::Migration[6.0]
+  def up
+    execute <<-SQL
+      UPDATE
+        application_forms
+      SET
+        postcode = UPPER(postcode)
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_13_140303) do
+ActiveRecord::Schema.define(version: 2020_01_15_124513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## Context

In #1116, we added in uppercasing when entering and saving postcodes. But as we've only just added in uppercasing when saving, there exists postcodes that aren't uppercase.

## Changes proposed in this pull request

This PR adds a migration to upcase all existing postcodes.

## Guidance to review

Not sure if this is the way to go and if the code is right, help pliz!

## Link to Trello card

https://trello.com/c/003s4hNf/775-uppercase-postcodes-on-save

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
