### PR TITLE
Support console shows when a referee declined to provide a reference

### DIFF
--- a/app/components/reference_with_feedback_component.rb
+++ b/app/components/reference_with_feedback_component.rb
@@ -6,6 +6,7 @@ class ReferenceWithFeedbackComponent < ActionView::Component::Base
            :email_address,
            :relationship,
            :feedback_status,
+           :consent_to_be_contacted,
            to: :reference
 
   def initialize(reference:, title: '', show_send_email: false)
@@ -20,6 +21,7 @@ class ReferenceWithFeedbackComponent < ActionView::Component::Base
       name_row,
       email_address_row,
       relationship_row,
+      consent_row,
       feedback_row,
     ].compact
   end
@@ -62,6 +64,23 @@ private
         key: 'Reference',
         value: feedback,
       }
+    end
+  end
+
+  def consent_row
+    if feedback
+      {
+        key: 'Given consent for research?',
+        value: consent_to_be_contacted_present
+      }
+    end
+  end
+
+  def consent_to_be_contacted_present
+    if consent_to_be_contacted.nil? 
+      ' - ' 
+    else
+      consent_to_be_contacted == true ? 'Yes' : 'No'
     end
   end
 

--- a/app/components/reference_with_feedback_component.rb
+++ b/app/components/reference_with_feedback_component.rb
@@ -30,10 +30,10 @@ private
 
   def status_row
     {
-      key: 'Feedback status',
+      key: 'Reference status',
       value: render(TagComponent,
-                    text: ApplicationReference.human_attribute_name("feedback_status.#{feedback_status}"),
-                    type: 'blue'),
+                    text: t("reference_status.#{feedback_status}"),
+                    type: feedback_tag_color(feedback_status)),
     }
   end
 
@@ -71,17 +71,19 @@ private
     if feedback
       {
         key: 'Given consent for research?',
-        value: consent_to_be_contacted_present
+        value: consent_to_be_contacted_present,
       }
     end
   end
 
   def consent_to_be_contacted_present
-    if consent_to_be_contacted.nil? 
-      ' - ' 
-    else
-      consent_to_be_contacted == true ? 'Yes' : 'No'
-    end
+    return ' - ' if consent_to_be_contacted.nil?
+
+    consent_to_be_contacted == true ? 'Yes' : 'No'
+  end
+
+  def feedback_tag_color(feedback_status)
+    feedback_status == 'feedback_refused' ? 'red' : 'blue'
   end
 
   attr_reader :reference, :title, :show_send_email

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -45,6 +45,9 @@ module RefereeInterface
 
     def confirm_feedback_refusal
       reference.update!(feedback_status: 'feedback_refused')
+
+      send_slack_notification
+
       redirect_to referee_interface_confirmation_path(token: @token_param)
     end
 
@@ -77,6 +80,13 @@ module RefereeInterface
 
     def render_404
       render 'errors/not_found', status: :not_found
+    end
+
+    def send_slack_notification
+      message = ":sadparrot: A referee declined to give feedback for #{reference.application_form.first_name}'s application"
+      url = helpers.support_interface_application_form_url(reference.application_form)
+
+      SlackNotificationWorker.perform_async(message, url)
     end
   end
 end

--- a/config/locales/reference.yml
+++ b/config/locales/reference.yml
@@ -1,0 +1,6 @@
+en:
+  reference_status:
+    not_requested_yet: 'Not requested yet'
+    feedback_requested: 'Requested'
+    feedback_provided: 'Feedback provided'
+    feedback_refused: 'Declined'

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -16,6 +16,8 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
 
     when_i_click_the_refuse_reference_link_in_the_email
     and_i_confirm_that_i_wont_give_a_reference
+    and_a_slack_notification_is_sent
+
     when_i_choose_to_be_contactable
     then_i_see_the_thank_you_page
   end
@@ -42,6 +44,10 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
 
   def then_i_see_the_reference_comment_page
     expect(page).to have_content("Give a teacher training reference for #{@application.full_name}")
+  end
+
+  def and_a_slack_notification_is_sent
+    expect_slack_message_with_text ":sadparrot: A referee declined to give feedback for #{@application.first_name}'s application"
   end
 
   def and_i_confirm_that_i_wont_give_a_reference

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -21,7 +21,8 @@ RSpec.feature 'See an application' do
 
     when_i_return_to_the_support_page
     and_i_click_on_an_application_with_a_reference
-    then_i_should_see_that_reference
+    then_i_should_see_the_reference_from_first_referee
+    and_i_should_not_see_reference_from_second_referee
   end
 
   def given_i_am_a_support_user
@@ -35,6 +36,8 @@ RSpec.feature 'See an application' do
   end
 
   def and_an_application_has_received_a_reference
+    @application_with_reference.application_references.first.update(consent_to_be_contacted: true)
+
     action = ReceiveReference.new(
       application_form: @application_with_reference,
       referee_email: @application_with_reference.reload.application_references.first.email_address,
@@ -103,7 +106,18 @@ RSpec.feature 'See an application' do
     click_on @application_with_reference.candidate.email_address
   end
 
-  def then_i_should_see_that_reference
-    expect(page).to have_content('This is my feedback')
+  def then_i_should_see_the_reference_from_first_referee
+    within page.all('[data-qa="reference"]').to_a.first do
+      expect(page).to have_content('This is my feedback')
+      expect(page).to have_content('Given consent for research?')
+      expect(page).to have_content('Yes')
+    end
+  end
+
+  def and_i_should_not_see_reference_from_second_referee
+    within page.all('[data-qa="reference"]').to_a.second do
+      expect(page).not_to have_content('This is my feedback')
+      expect(page).not_to have_content('Given consent for research?')
+    end
   end
 end


### PR DESCRIPTION
## Context

We want to display on the support console when a referee declined to provide a reference to a candidate and/or has declined to be contacted for research activities. 

## Changes proposed in this pull request

This PR updates:
 
- A support user is able to see when a referee has declined to provide a reference; this should be a separate row called "Given consent for research?"
- "Feedback status" row should be renamed to "Reference status"
- "Feedback requested" badge content should just be "Requested"
- "Feedback declined" badge content should just be "Declined" and red
- A **Slack message** is posted on the channel "twd_apply_support" when a referee declines to give feedback, for example, "X declined to give feedback for Y's application :sadparrot:"

### After
![image](https://user-images.githubusercontent.com/22743709/72449567-ce1cff00-37b0-11ea-8809-90c5b03ab7bb.png)

![image](https://user-images.githubusercontent.com/22743709/72449600-dbd28480-37b0-11ea-8797-a1c2348db3f3.png)


## Link to Trello card
https://trello.com/c/5dYeBzfT/674-support-console-show-when-a-referee-declined-to-provide-a-reference-or-to-be-contacted-for-user-research-purposes-%F0%9F%8F%88