### PR TITLE
Remove DfE Signin UID from provider user forms

### DIFF
--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -40,7 +40,7 @@ module SupportInterface
   private
 
     def provider_user_params
-      params.require(:support_interface_provider_user_form).permit(:email_address, :dfe_sign_in_uid, provider_ids: [])
+      params.require(:support_interface_provider_user_form).permit(:email_address, provider_ids: [])
     end
   end
 end

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -4,11 +4,9 @@ module SupportInterface
     include ActiveModel::Validations
 
     attr_accessor :email_address, :provider_ids, :provider_user
-    attr_writer :dfe_sign_in_uid
 
     validates_presence_of :email_address
     validates :provider_ids, presence: true
-    validate :provider_user_uid_unique
 
     def save
       return unless valid?
@@ -17,17 +15,12 @@ module SupportInterface
 
       @provider_user.update!(
         email_address: email_address,
-        dfe_sign_in_uid: dfe_sign_in_uid,
         provider_ids: provider_ids,
       )
     end
 
     def available_providers
       @available_providers ||= Provider.order(name: :asc)
-    end
-
-    def dfe_sign_in_uid
-      @dfe_sign_in_uid&.strip == '' ? nil : @dfe_sign_in_uid # allow nil or non-whitespace
     end
 
     def persisted?
@@ -39,18 +32,7 @@ module SupportInterface
         provider_user: provider_user,
         email_address: provider_user.email_address,
         provider_ids: provider_user.provider_ids,
-        dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
       )
-    end
-
-  private
-
-    def provider_user_uid_unique
-      if @provider_user && @provider_user.invalid?
-        @provider_user.errors[:dfe_sign_in_uid].each do |error|
-          errors.add(:dfe_sign_in_uid, error)
-        end
-      end
     end
   end
 end

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -24,8 +24,6 @@
       </h1>
 
       <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
-      <% blank_uid_notice = 'If you leave this empty, it will be automatically set when this email address signs in for the first time.' %>
-      <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID' }, hint_text: blank_uid_notice %>
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
 

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -22,8 +22,6 @@
       <h1 class='govuk-heading-xl'>Add provider user</h1>
 
       <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
-      <% blank_uid_notice = 'If you leave this empty, it will be automatically set when this email address signs in for the first time.' %>
-      <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID' }, hint_text: blank_uid_notice %>
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
 

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -46,7 +46,6 @@ RSpec.feature 'Managing provider users' do
 
   def and_i_enter_the_users_email_and_dsi_uid
     fill_in 'support_interface_provider_user_form[email_address]', with: 'harrison@example.com'
-    fill_in 'support_interface_provider_user_form[dfe_sign_in_uid]', with: '12345-ABCDE'
   end
 
   def and_i_select_a_provider


### PR DESCRIPTION
## Context

We don't this UID when creating the user because it’s automatically
filled in. Removing it is clearer.

## Changes proposed in this pull request

Removes the input from the forms.

## Guidance to review



## Link to Trello card

https://trello.com/c/vpb7WNtE/1514-remove-uid-field-from-the-provider-form

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
