### PR TITLE
 Show an error message if a support user already exists

### DIFF
--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,7 +1,7 @@
 class ProviderUser < ActiveRecord::Base
   has_and_belongs_to_many :providers
 
-  validates :dfe_sign_in_uid, presence: true, uniqueness: true, allow_nil: true
+  validates :dfe_sign_in_uid, uniqueness: true, allow_nil: true
 
   before_save :downcase_email_address
 

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
     attr_accessor :provider_ids, :provider_user
     attr_reader :email_address
 
-    validates_presence_of :email_address
+    validates :email_address, presence: true
     validates :provider_ids, presence: true
     validate :email_is_unique
 

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -3,7 +3,8 @@ module SupportInterface
     include ActiveModel::Model
     include ActiveModel::Validations
 
-    attr_accessor :email_address, :provider_ids, :provider_user
+    attr_accessor :provider_ids, :provider_user
+    attr_reader :email_address
 
     validates_presence_of :email_address
     validates :provider_ids, presence: true
@@ -18,6 +19,10 @@ module SupportInterface
         email_address: email_address,
         provider_ids: provider_ids,
       )
+    end
+
+    def email_address=(raw_email_address)
+      @email_address = raw_email_address.downcase
     end
 
     def available_providers

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -7,6 +7,7 @@ module SupportInterface
 
     validates_presence_of :email_address
     validates :provider_ids, presence: true
+    validate :email_is_unique
 
     def save
       return unless valid?
@@ -33,6 +34,16 @@ module SupportInterface
         email_address: provider_user.email_address,
         provider_ids: provider_user.provider_ids,
       )
+    end
+
+  private
+
+    def email_is_unique
+      return if persisted? && provider_user.email_address == email_address
+
+      return unless ProviderUser.exists?(email_address: email_address)
+
+      errors.add(:email_address, 'This email address is already in use')
     end
   end
 end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -11,7 +11,11 @@ RSpec.feature 'Managing provider users' do
     and_i_click_the_users_link
     and_i_click_the_manange_provider_users_link
     and_i_click_the_add_user_link
-    and_i_enter_the_users_email_and_dsi_uid
+    and_i_enter_an_existing_email
+    and_i_click_add_user
+    then_i_see_an_error
+
+    and_i_enter_the_users_email
     and_i_select_a_provider
     and_i_click_add_user
 
@@ -44,16 +48,25 @@ RSpec.feature 'Managing provider users' do
     click_link 'Provider users'
   end
 
-  def and_i_enter_the_users_email_and_dsi_uid
-    fill_in 'support_interface_provider_user_form[email_address]', with: 'harrison@example.com'
-  end
-
   def and_i_select_a_provider
     check 'Example provider (ABC)'
   end
 
   def and_i_click_the_add_user_link
     click_link 'Add provider user'
+  end
+
+  def and_i_enter_an_existing_email
+    create(:provider_user, email_address: 'existing@example.org')
+    fill_in 'support_interface_provider_user_form[email_address]', with: 'existing@example.org'
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content 'This email address is already in use'
+  end
+
+  def and_i_enter_the_users_email
+    fill_in 'support_interface_provider_user_form[email_address]', with: 'harrison@example.com'
   end
 
   def and_i_click_add_user

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Managing provider users' do
 
   def and_i_enter_an_existing_email
     create(:provider_user, email_address: 'existing@example.org')
-    fill_in 'support_interface_provider_user_form[email_address]', with: 'existing@example.org'
+    fill_in 'support_interface_provider_user_form[email_address]', with: 'Existing@example.org'
   end
 
   def then_i_see_an_error


### PR DESCRIPTION
##  Context

Currently, when you enter a duplicate email address in the provider user form on support we raise a 500 error.

## Changes proposed in this pull request

This changes it to a proper validation error.

## Guidance to review



## Link to Trello card

https://trello.com/c/4dsmwvAW/1519-show-a-sensible-error-if-a-user-tries-to-add-the-same-provider-email-twice

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
