### PR TITLE
Automatically notify candidates that one of their referees has declined to give a reference

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -48,6 +48,8 @@ module RefereeInterface
 
       send_slack_notification
 
+      SendNewRefereeRequestEmail.call(application_form: @reference.application_form, reference: @reference, reason: :refused)
+
       redirect_to referee_interface_confirmation_path(token: @token_param)
     end
 

--- a/app/controllers/support_interface/new_referee_request_controller.rb
+++ b/app/controllers/support_interface/new_referee_request_controller.rb
@@ -6,12 +6,8 @@ module SupportInterface
 
     def deliver
       application_form = @reference.application_form
-      CandidateMailer.new_referee_request(application_form, @reference, reason: @reason).deliver
 
-      candidate_email = application_form.candidate.email_address
-      audit_comment = t("new_referee_request.#{@reason}.audit_comment", candidate_email: candidate_email)
-      application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
-      application_comment.save(application_form)
+      SendNewRefereeRequestEmail.call(application_form: application_form, reference: @reference, reason: @reason)
 
       flash[:success] = t('new_referee_request.success')
 

--- a/app/services/send_new_referee_request_email.rb
+++ b/app/services/send_new_referee_request_email.rb
@@ -1,0 +1,10 @@
+class SendNewRefereeRequestEmail
+  def self.call(application_form:, reference:, reason: :not_responded)
+    CandidateMailer.new_referee_request(application_form, reference, reason: reason).deliver
+
+    candidate_email = application_form.candidate.email_address
+    audit_comment = I18n.t("new_referee_request.#{reason}.audit_comment", candidate_email: candidate_email)
+    application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
+    application_comment.save(application_form)
+  end
+end

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -17,6 +17,7 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
     when_i_click_the_refuse_reference_link_in_the_email
     and_i_confirm_that_i_wont_give_a_reference
     and_a_slack_notification_is_sent
+    then_an_email_is_sent_to_the_candidate
 
     when_i_choose_to_be_contactable
     then_i_see_the_thank_you_page
@@ -52,6 +53,12 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
 
   def and_i_confirm_that_i_wont_give_a_reference
     click_button 'Yes - I\'m sure'
+  end
+
+  def then_an_email_is_sent_to_the_candidate
+    open_email(@application.candidate.email_address)
+
+    expect(current_email.subject).to have_content(t('new_referee_request.refused.subject', referee_name: 'Terri Tudor'))
   end
 
   def when_i_choose_to_be_contactable


### PR DESCRIPTION
## Context

We want to automatically send an email to a candidate notifying them that one of their referees has refused to provide a reference.

## Changes proposed in this pull request

This PR adds a new service `SendNewRefereeRequestEmail` which sends the new referee request email and adds an audit comment.

## Guidance to review

- Adding an audit comment wasn't part of the card but I think it makes sense?
- Wondering if we should feature flag this?

## Link to Trello card

https://trello.com/c/NEIqpnk2/760-automatically-notify-candidates-that-one-of-their-referees-has-declined-to-give-a-reference

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
