### PR TITLE
Surface accreditation relationships on the individual provider page in support

### DIFF
--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -1,0 +1,36 @@
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header'>Course</th>
+      <th scope='col' class='govuk-table__header'>Level</th>
+      <th scope='col' class='govuk-table__header'>Recruitment Cycle</th>
+      <th scope='col' class='govuk-table__header'>Apply from Find</th>
+      <th scope='col' class='govuk-table__header'>Page on Find</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% course_rows.each do |course| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'><%= course[:name_and_code] %></td>
+        <td class='govuk-table__cell'><%= course[:level] %></td>
+        <td class='govuk-table__cell'><%= course[:recruitment_cycle_year] %></td>
+        <td class='govuk-table__cell'>
+          <% if course[:apply_from_find_link] %>
+            <%= course[:apply_from_find_link] %>
+          <% else %>
+            <em>N/A - hidden in Find</em>
+          <% end %>
+        </td>
+        <td class='govuk-table__cell'>
+          <% if course[:link_to_find_course_page] %>
+            <%= course[:link_to_find_course_page] %>
+          <% else %>
+            <em>N/A - hidden in Find</em>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+

--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -2,6 +2,9 @@
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>
       <th scope='col' class='govuk-table__header'>Course</th>
+      <% if providers_vary? %>
+        <th scope='col' class='govuk-table__header'>Provider</th>
+      <% end %>
       <th scope='col' class='govuk-table__header'>Level</th>
       <th scope='col' class='govuk-table__header'>Recruitment Cycle</th>
       <th scope='col' class='govuk-table__header'>Apply from Find</th>
@@ -12,7 +15,10 @@
   <tbody class='govuk-table__body'>
     <% course_rows.each do |course| %>
       <tr class='govuk-table__row'>
-        <td class='govuk-table__cell'><%= course[:name_and_code] %></td>
+        <td class='govuk-table__cell'><%= course[:course_link] %></td>
+        <% if providers_vary? %>
+          <td class='govuk-table__cell'><%= course[:provider_link] %></td>
+        <% end %>
         <td class='govuk-table__cell'><%= course[:level] %></td>
         <td class='govuk-table__cell'><%= course[:recruitment_cycle_year] %></td>
         <td class='govuk-table__cell'>

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -1,0 +1,39 @@
+module SupportInterface
+  class ProviderCoursesTableComponent < ActionView::Component::Base
+    include ViewHelper
+
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def course_rows
+      provider.courses.order(:name).map do |course|
+        {
+          name_and_code: govuk_link_to(course.name_and_code, support_interface_course_path(course)),
+          level: course.level,
+          recruitment_cycle_year: course.recruitment_cycle_year,
+          apply_from_find_link: link_to_apply_from_find_page(course),
+          link_to_find_course_page: link_to_find_course_page(course),
+        }
+      end
+    end
+
+  private
+
+    attr_reader :provider
+
+    def link_to_apply_from_find_page(course)
+      if course.exposed_in_find? && course.open_on_apply?
+        govuk_link_to 'Apply from Find (DfE & UCAS)', candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code)
+      elsif course.exposed_in_find?
+        govuk_link_to 'Apply from Find (UCAS only)', candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code)
+      end
+    end
+
+    def link_to_find_course_page(course)
+      if course.exposed_in_find?
+        govuk_link_to 'Find course page', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}"
+      end
+    end
+  end
+end

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -2,14 +2,16 @@ module SupportInterface
   class ProviderCoursesTableComponent < ActionView::Component::Base
     include ViewHelper
 
-    def initialize(provider:)
+    def initialize(provider:, courses:)
       @provider = provider
+      @courses = courses
     end
 
     def course_rows
-      provider.courses.order(:name).map do |course|
+      courses.order(:name).map do |course|
         {
-          name_and_code: govuk_link_to(course.name_and_code, support_interface_course_path(course)),
+          course_link: govuk_link_to(course.name_and_code, support_interface_course_path(course)),
+          provider_link: govuk_link_to(course.provider.name_and_code, support_interface_provider_path(course.provider)),
           level: course.level,
           recruitment_cycle_year: course.recruitment_cycle_year,
           apply_from_find_link: link_to_apply_from_find_page(course),
@@ -18,9 +20,13 @@ module SupportInterface
       end
     end
 
+    def providers_vary?
+      @providers_vary ||= courses.any? { |c| c.provider != provider }
+    end
+
   private
 
-    attr_reader :provider
+    attr_reader :provider, :courses
 
     def link_to_apply_from_find_page(course)
       if course.exposed_in_find? && course.open_on_apply?

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -12,7 +12,7 @@ module SupportInterface
         {
           course_link: govuk_link_to(course.name_and_code, support_interface_course_path(course)),
           provider_link: govuk_link_to(course.provider.name_and_code, support_interface_provider_path(course.provider)),
-          level: course.level,
+          level: course.level.titleize,
           recruitment_cycle_year: course.recruitment_cycle_year,
           apply_from_find_link: link_to_apply_from_find_page(course),
           link_to_find_course_page: link_to_find_course_page(course),

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -10,4 +10,8 @@ class Provider < ApplicationRecord
   def name_and_code
     "#{name} (#{code})"
   end
+
+  def accredited_courses
+    Course.where(accrediting_provider: self)
+  end
 end

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -32,43 +32,7 @@
   <% end %>
 <% end %>
 
-<table class='govuk-table'>
-  <thead class='govuk-table__head'>
-    <tr class='govuk-table__row'>
-      <th scope='col' class='govuk-table__header'>Course</th>
-      <th scope='col' class='govuk-table__header'>Level</th>
-      <th scope='col' class='govuk-table__header'>Recruitment Cycle</th>
-      <th scope='col' class='govuk-table__header'>Apply from Find</th>
-      <th scope='col' class='govuk-table__header'>Page on Find</th>
-    </tr>
-  </thead>
-
-  <tbody class='govuk-table__body'>
-    <% @provider.courses.order(:name).each do |course| %>
-      <tr class='govuk-table__row'>
-        <td class='govuk-table__cell'><%= govuk_link_to course.name_and_code, support_interface_course_path(course) %></td>
-        <td class='govuk-table__cell'><%= course.level %></td>
-        <td class='govuk-table__cell'><%= course.recruitment_cycle_year %></td>
-        <td class='govuk-table__cell'>
-          <% if course.exposed_in_find? && course.open_on_apply? %>
-            <%= govuk_link_to 'Apply from Find (DfE & UCAS)', candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code) %>
-          <% elsif course.exposed_in_find? %>
-            <%= govuk_link_to 'Apply from Find (UCAS only)', candidate_interface_apply_from_find_path(providerCode: course.provider.code, courseCode: course.code) %>
-          <% else %>
-            <em>N/A - hidden in Find</em>
-          <% end %>
-        </td>
-        <td class='govuk-table__cell'>
-          <% if course.exposed_in_find? %>
-            <%= govuk_link_to 'Find course page', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %>
-          <% else %>
-            <em>N/A - hidden in Find</em>
-          <% end %>
-        </td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider) %>
 
 <h2 class='govuk-heading-l'>Sites (<%= @provider.sites.size %>)</h2>
 

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -1,7 +1,5 @@
 <% content_for :title, @provider.name_and_code %>
 
-<h2 class='govuk-heading-l'><%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.applyable.size %> on DfE Apply)</h2>
-
 <%= render(SupportInterface::ProviderSyncCoursesToggleComponent, provider: @provider) %>
 
 <% if @provider.courses.any? %>
@@ -32,7 +30,13 @@
   <% end %>
 <% end %>
 
-<%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider) %>
+<h2 class='govuk-heading-m'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.applyable.size %> on DfE Apply)</h2>
+<%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider, courses: @provider.courses) %>
+
+<% if @provider.accredited_courses.any? %>
+  <h2 class='govuk-heading-m'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.applyable.size %> on DfE Apply)</h2>
+  <%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider, courses: @provider.accredited_courses) %>
+<% end %>
 
 <h2 class='govuk-heading-l'>Sites (<%= @provider.sites.size %>)</h2>
 

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       course_option = create(:course_option, course: course)
       provider = course_option.course.provider
 
-      render_result = render_inline(SupportInterface::ProviderCoursesTableComponent, provider: provider)
+      render_result = render_inline(SupportInterface::ProviderCoursesTableComponent, provider: provider, courses: provider.courses)
 
       # Make a mapping colname -> colvalue
       fields = render_result.css('th').map(&:text).zip(
@@ -26,6 +26,21 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       expect(fields['Recruitment Cycle']).to eq('2020')
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
+    end
+
+    it 'may include courses the provider accredits' do
+      provider = create(:provider)
+      other_course_provider = create(:provider, name: 'Other provider')
+
+      create(:course_option, course: create(:course,
+                                            provider: other_course_provider,
+                                            accrediting_provider: provider,
+                                            name: 'Accredited course'))
+
+      render_result = render_inline(SupportInterface::ProviderCoursesTableComponent, provider: provider, courses: provider.accredited_courses)
+
+      expect(render_result.text).to include('Accredited course')
+      expect(render_result.text).to include('Other provider')
     end
   end
 end

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       ).to_h
 
       expect(fields['Course']).to eq('My course (ABC)')
-      expect(fields['Level']).to eq('secondary')
+      expect(fields['Level']).to eq('Secondary')
       expect(fields['Recruitment Cycle']).to eq('2020')
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ProviderCoursesTableComponent do
+  describe 'course data' do
+    it 'renders the correct data for a course' do
+      course = create(:course,
+                      name: 'My course',
+                      code: 'ABC',
+                      level: 'secondary',
+                      recruitment_cycle_year: 2020,
+                      exposed_in_find: true,
+                      open_on_apply: true)
+
+      course_option = create(:course_option, course: course)
+      provider = course_option.course.provider
+
+      render_result = render_inline(SupportInterface::ProviderCoursesTableComponent, provider: provider)
+
+      # Make a mapping colname -> colvalue
+      fields = render_result.css('th').map(&:text).zip(
+        render_result.css('td').map(&:text),
+      ).to_h
+
+      expect(fields['Course']).to eq('My course (ABC)')
+      expect(fields['Level']).to eq('secondary')
+      expect(fields['Recruitment Cycle']).to eq('2020')
+      expect(fields['Apply from Find']).to match(/DfE & UCAS/)
+      expect(fields['Page on Find']).to match(/Find course page/)
+    end
+  end
+end


### PR DESCRIPTION
## Context

If a provider accredits courses, they aren't visible via the Support UI.

## Changes proposed in this pull request

If the provider has any accredited courses, add a table underneath the main courses table. Label the tables. Tone down the headings a bit now that there are more of them. Get all this done using a `Component` as there's now a bit of logic.

Empty states aren't dealt with but we'll fix them shortly.

### Before

<img width="1036" alt="Screenshot 2020-01-16 at 09 59 24" src="https://user-images.githubusercontent.com/642279/72518103-80ee6b00-384c-11ea-90e1-2d67d56ed1b7.png">

### After

<img width="1015" alt="Screenshot 2020-01-16 at 09 59 07" src="https://user-images.githubusercontent.com/642279/72518150-91064a80-384c-11ea-8a35-c1c03a087195.png">

## Link to Trello card

https://trello.com/c/OUDbdRen/1468-surface-accreditation-relationships-on-the-individual-provider-page-in-support

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
