### PR TITLE
Refactor: Tidy up Clockwork cleanup in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -101,6 +101,8 @@ RSpec.configure do |config|
 
   config.before { Redis.new.flushdb }
 
+  config.after { Clockwork::Test.clear! }
+
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -6,8 +6,6 @@ require './app/workers/send_applications_to_provider_worker'
 require './app/workers/decline_offers_by_default_worker'
 
 RSpec.describe Clockwork do
-  after { Clockwork::Test.clear! }
-
   around do |example|
     Sidekiq::Testing.inline! do
       timecop_safe_mode = Timecop.safe_mode?

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'See provider course syncing' do
   include DfESignInHelpers
   include FindAPIHelper
 
-  after { Clockwork::Test.clear! }
-
   scenario 'User switches sync courses on Provider' do
     given_i_am_a_support_user
     and_a_provider_exists


### PR DESCRIPTION
## Context

This PR is inspired by this comment on a now merged commit - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/439b5f69e16e01794195ca605b28f348488db568#commitcomment-36806075

Tidies up specs and avoids me forgetting to do this in future.

## Changes proposed in this pull request

- Move `Clockwork::Test.clear!` to `spec_helper.rb`

## Guidance to review

Is it tidier?
I timed a full test run before and after and it doesn't seem to make any difference.

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
