### PR TITLE
Make the performance statistics categories exclusive

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -17,7 +17,7 @@ class PerformanceStatistics
   SELECT
       COUNT(*) AS total_non_dfe_sign_ups,
       SUM(CASE WHEN candidate_forms = 0 THEN 1 ELSE 0 END) AS candidates_signed_up_but_not_signed_in,
-      SUM(CASE WHEN candidate_forms > 0 AND candidate_started_form_count = 0 THEN 1 ELSE 0 END) AS candidates_signed_in_but_not_entered_data,
+      SUM(CASE WHEN candidate_forms > 0 AND candidate_started_form_count = 0 AND candidate_submitted_form_count = 0 THEN 1 ELSE 0 END) AS candidates_signed_in_but_not_entered_data,
       SUM(CASE WHEN candidate_started_form_count > 0 AND candidate_submitted_form_count = 0 THEN 1 ELSE 0 END) AS candidates_with_unsubmitted_forms,
       SUM(CASE WHEN candidate_submitted_form_count > 0 THEN 1 ELSE 0 END) AS candidates_with_submitted_forms
   FROM

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -24,4 +24,15 @@ RSpec.describe PerformanceStatistics, type: :model do
     expect(stats[:candidates_with_unsubmitted_forms]).to eq(3)
     expect(stats[:candidates_with_submitted_forms]).to eq(4)
   end
+
+  it 'avoids double counting generated test data' do
+    form = create(:completed_application_form)
+    form.update_column(:updated_at, form.created_at) # this form is both unchanged but also submitted
+
+    stats = PerformanceStatistics.new
+
+    expect(stats[:total_non_dfe_sign_ups]).to eq(1)
+    expect(stats[:candidates_with_submitted_forms]).to eq(1)
+    expect(stats[:candidates_signed_in_but_not_entered_data]).to eq(0)
+  end
 end


### PR DESCRIPTION
## Context

A pathological case (where an application form has been submitted but where the update timestamp matches the creation timestamp) is being double-counted by the stats. This can occur if the application has been generated through the test data generation mechanism.

## Changes proposed in this pull request

Update the SQL query in the performance stats model.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
