### PR TITLE
Use MoJ Design System for sub navigation

### DIFF
--- a/app/components/sub_navigation_component.html.erb
+++ b/app/components/sub_navigation_component.html.erb
@@ -1,0 +1,13 @@
+<nav class="moj-sub-navigation" aria-label="Sub navigation">
+  <ul class="moj-sub-navigation__list">
+    <% items.each do |item| %>
+      <li class="moj-sub-navigation__item">
+        <% if item[:current] %>
+          <%= link_to item.fetch(:name), item.fetch(:url), class: 'moj-sub-navigation__link', 'aria-current': 'page' %>
+        <% else %>
+          <%= link_to item.fetch(:name), item.fetch(:url), class: 'moj-sub-navigation__link' %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/components/sub_navigation_component.rb
+++ b/app/components/sub_navigation_component.rb
@@ -1,0 +1,7 @@
+class SubNavigationComponent < ActionView::Component::Base
+  attr_reader :items
+
+  def initialize(items:)
+    @items = items
+  end
+end

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -10,6 +10,7 @@ $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
+@import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
 @import "_autocomplete";
 @import "_banner";
 @import "_cookie-banner";

--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -13,6 +13,11 @@
       </li>
     </ol>
   </div>
+
+  <%= render SubNavigationComponent, items: [
+    { name: 'Support users', url: support_interface_support_users_path },
+    { name: 'Provider users', url: support_interface_provider_users_path, current: true },
+  ] %>
 <% end %>
 
 <%= render(SupportInterface::ProviderUsersTableComponent, provider_users: @provider_users) %>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -13,6 +13,11 @@
       </li>
     </ol>
   </div>
+
+  <%= render SubNavigationComponent, items: [
+    { name: 'Support users', url: support_interface_support_users_path, current: true },
+    { name: 'Provider users', url: support_interface_provider_users_path },
+  ] %>
 <% end %>
 
 <table class='govuk-table'>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/webpacker": "^4.2.2",
+    "@ministryofjustice/frontend": "0.0.17-alpha",
     "accessible-autocomplete": "^2.0.1",
     "govuk-frontend": "^3.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -692,6 +692,13 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@ministryofjustice/frontend@0.0.17-alpha":
+  version "0.0.17-alpha"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-0.0.17-alpha.tgz#a5e2e2d2dce58102e9245153bd6d4992e7977c5b"
+  integrity sha512-UOwqFA24kd8xJY6XrWxaQxM2xzr8BHdwb5L82xPk3rG7hgEnWRppk7vt9eszqSt3Hwdfj63pD8aaMTMsi89P4Q==
+  dependencies:
+    moment "^2.22.2"
+
 "@rails/webpacker@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-4.2.2.tgz#b9dd3235fdf4d0badbda8e33f6ebee742a9f3abb"
@@ -4324,6 +4331,11 @@ mixin-deep@^1.2.0:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+moment@^2.22.2:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
I was looking at using [MoJ’s Sub navigation component](https://moj-design-system.herokuapp.com/components/sub-navigation) and wanted to copy-paste it.

But what if we just added MoJ’s Design System and used it directly?

We’ll have direct access to some pretty cool new components, like pagination, search, multi-select, and timeline.

https://moj-design-system.herokuapp.com/components

Of course it feels a bit odd for DfE to use a Design System specifically for MoJ - but the longer I think about it, the more it makes sense. Let’s break down these silos and re-use the good stuff
that we’ve built in government!

![](https://www.pardot.com/content/uploads/2015/03/shutterstock_125338115.jpg)

I used the sub nav component to test if it works:

![image](https://user-images.githubusercontent.com/233676/72525321-c5cdce00-385b-11ea-8b85-7afd396f11dc.png)

Thoughts - @adamsilver @fofr @paulrobertlloyd @duncanjbrown @tvararu? 

