### PR TITLE
Automate DfE Sign-In invitation as part of creating a provider user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,5 @@ DFE_SIGN_IN_SECRET=
 DFE_SIGN_IN_ISSUER=https://signin-test-oidc-as.azurewebsites.net
 BYPASS_DFE_SIGN_IN=true
 GOVUK_NOTIFY_CALLBACK_API_KEY=
+DSI_API_URL=https://test-api.signin.education.gov.uk
+DSI_API_SECRET=xxxxxxxxxxxx-xxxxx-xxxxxxxx-xxxxxxxx

--- a/.env.test
+++ b/.env.test
@@ -5,3 +5,5 @@ SUPPORT_PASSWORD=test
 HOSTING_ENVIRONMENT_NAME=test
 STATE_CHANGE_SLACK_URL=https://example.com/slack-webhook
 GOVUK_NOTIFY_CALLBACK_API_KEY=test
+DSI_API_URL=https://test-api.signin.education.gov.uk
+DSI_API_SECRET=some-secret

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'clockwork'
 # For outgoing http requests
 gem 'http'
 
+# For DSI api integration
+gem 'jwt'
+
 gem 'openapi3_parser', '0.8.0'
 gem 'rouge'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -536,6 +536,7 @@ DEPENDENCIES
   http
   json-schema
   json_api_client
+  jwt
   launchy
   listen (>= 3.0.5, < 3.3)
   lograge

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -10,8 +10,9 @@ module SupportInterface
 
     def create
       @form = ProviderUserForm.new(provider_user_params)
+      service = InviteProviderUser.new(provider_user_form: @form)
 
-      if @form.save
+      if service.call
         flash[:success] = 'Provider user created'
         redirect_to support_interface_provider_users_path
       else
@@ -40,7 +41,7 @@ module SupportInterface
   private
 
     def provider_user_params
-      params.require(:support_interface_provider_user_form).permit(:email_address, provider_ids: [])
+      params.require(:support_interface_provider_user_form).permit(:email_address, :first_name, :last_name, provider_ids: [])
     end
   end
 end

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -10,15 +10,19 @@ module SupportInterface
     validates :provider_ids, presence: true
     validate :email_is_unique
 
-    def save
+    def build
       return unless valid?
 
       @provider_user ||= ProviderUser.new
+      @provider_user.first_name = first_name
+      @provider_user.last_name = last_name
+      @provider_user.email_address = email_address
+      @provider_user.provider_ids = provider_ids
+      @provider_user if @provider_user.valid?
+    end
 
-      @provider_user.update!(
-        email_address: email_address,
-        provider_ids: provider_ids,
-      )
+    def save
+      @provider_user.save! if build
     end
 
     def email_address=(raw_email_address)
@@ -30,12 +34,14 @@ module SupportInterface
     end
 
     def persisted?
-      provider_user && provider_user.persisted?
+      @provider_user && @provider_user.persisted?
     end
 
     def self.from_provider_user(provider_user)
       new(
         provider_user: provider_user,
+        first_name: provider_user.first_name,
+        last_name: provider_user.last_name,
         email_address: provider_user.email_address,
         provider_ids: provider_user.provider_ids,
       )

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -3,7 +3,7 @@ module SupportInterface
     include ActiveModel::Model
     include ActiveModel::Validations
 
-    attr_accessor :provider_ids, :provider_user
+    attr_accessor :first_name, :last_name, :provider_ids, :provider_user
     attr_reader :email_address
 
     validates :email_address, presence: true

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,6 +5,7 @@ class FeatureFlag
     edit_application
     send_reference_email_via_support
     confirm_course_choice_from_find
+    send_dfe_sign_in_invitations
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -1,0 +1,61 @@
+require 'jwt'
+
+class InviteProviderUser
+  def initialize(provider_user_form:)
+    @provider_user_form = provider_user_form
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      if @provider_user_form.save
+        invite_user_to_dfe_sign_in
+
+        # TODO: send welcome/invitation email
+        true
+      end
+    end
+  rescue DfeSignInApiError => e
+    e.errors.each { |error| @provider_user_form.errors.add(:base, error) }
+    false
+  end
+
+  def dfe_invite_url
+    baseurl = ENV.fetch('DSI_API_URL')
+    if baseurl.present?
+      "#{baseurl}/services/apply/invitations"
+    end
+  end
+
+  def invite_user_to_dfe_sign_in
+    return unless FeatureFlag.active?('send_dfe_sign_in_invitations')
+
+    jwt_payload = { iss: 'apply', aud: 'signin.education.gov.uk' }
+    token = JWT.encode jwt_payload, ENV['DSI_API_SECRET'], 'HS256'
+    auth_string = "Bearer #{token}"
+
+    request_params = {
+      sourceId: @provider_user_form.provider_user.id,
+      given_name: @provider_user_form.first_name,
+      family_name: @provider_user_form.last_name,
+      email: @provider_user_form.email_address,
+      userRedirect: Rails.application.routes.url_helpers.provider_interface_url,
+    }
+
+    response = HTTP.auth(auth_string).post dfe_invite_url, json: request_params
+    raise DfeSignInApiError.new(response) unless response.status.success?
+  end
+end
+
+class DfeSignInApiError < StandardError
+  attr_reader :response
+
+  def initialize(response = nil)
+    @response = response
+    msg = response ? response.status.to_s : 'No response'
+    super(msg)
+  end
+
+  def errors
+    JSON.parse(response.body)['errors'] rescue []
+  end
+end

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -24,6 +24,8 @@
       </h1>
 
       <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
+      <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
 

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -22,6 +22,8 @@
       <h1 class='govuk-heading-xl'>Add provider user</h1>
 
       <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
+      <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
 

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -56,7 +56,8 @@ parameters:
     "Service Offering": "Become a Teacher"
   }'
   govukNotifyCallbackAPIKey:
-
+  dsiApiUrl:
+  dsiApiSecret:
 
 jobs:
   - deployment: deploy_${{parameters.resourceEnvironmentName}}
@@ -140,6 +141,8 @@ jobs:
                 -dfeSignInIssuer "${{parameters.dfeSignInIssuer}}"
                 -customAvailabilityMonitors "${{parameters.customAvailabilityMonitors}}"
                 -alertRecipientEmails "${{parameters.alertRecipientEmails}}"
+                -dsiApiUrl "${{parameters.dsiApiUrl}}"
+                -dsiApiSecret "${{parameters.dsiApiSecret}}"
                 -govukNotifyCallbackAPIKey "${{parameters.govukNotifyCallbackAPIKey}}"'
               deploymentOutputs: DeploymentOutput
 

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -91,8 +91,8 @@ stages:
       customAvailabilityMonitors: '$(customAvailabilityMonitors)'
       alertRecipientEmails: '$(alertRecipientEmails)'
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
-
-
+      dsiApiUrl: '$(dsiApiUrl)'
+      dsiApiSecret: '$(dsiApiSecret)'
 
 - stage: deploy_sandbox
   displayName: 'Deploy - Sandbox'
@@ -142,6 +142,8 @@ stages:
       customAvailabilityMonitors: '$(customAvailabilityMonitors)'
       alertRecipientEmails: '$(alertRecipientEmails)'
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
+      dsiApiUrl: '$(dsiApiUrl)'
+      dsiApiSecret: '$(dsiApiSecret)'
 
 
 - stage: deploy_production
@@ -196,3 +198,6 @@ stages:
       customAvailabilityMonitors: '$(customAvailabilityMonitors)'
       alertRecipientEmails: '$(alertRecipientEmails)'
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
+      dsiApiUrl: '$(dsiApiUrl)'
+      dsiApiSecret: '$(dsiApiSecret)'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -194,6 +194,8 @@ stages:
       customAvailabilityMonitors: '$(customAvailabilityMonitors)'
       alertRecipientEmails: '$(alertRecipientEmails)'
       govukNotifyCallbackAPIKey: $(govukNotifyCallbackAPIKey)
+      dsiApiUrl: '$(dsiApiUrl)'
+      dsiApiSecret: '$(dsiApiSecret)'
 
 
 - stage: deploy_devops
@@ -243,3 +245,6 @@ stages:
       customAvailabilityMonitors: '$(customAvailabilityMonitors)'
       alertRecipientEmails: '$(alertRecipientEmails)'
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
+      dsiApiUrl: '$(dsiApiUrl)'
+      dsiApiSecret: '$(dsiApiSecret)'
+

--- a/azure/template.json
+++ b/azure/template.json
@@ -323,6 +323,18 @@
                 "description": "The URL of the DfE Sign-in OIDC interface (differs for test, pre-prod and prod)"
             }
         },
+        "dsiApiUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "The DfE Sign-in API baseurl for this environment"
+            }
+        },
+        "dsiApiSecret": {
+            "type": "string",
+            "metadata": {
+                "description": "The DfE Sign-in API_SECRET for authenticating API requests"
+            }
+        },
         "stateChangeSlackUrl": {
             "type": "string",
             "metadata": {
@@ -676,6 +688,14 @@
                             {
                                 "name": "DFE_SIGN_IN_ISSUER",
                                 "value": "[parameters('dfeSignInIssuer')]"
+                            },
+                            {
+                                "name": "DSI_API_URL",
+                                "value": "[parameters('dsiApiUrl')]"
+                            },
+                            {
+                                "name": "DSI_API_SECRET",
+                                "value": "[parameters('dsiApiSecret')]"
                             },
                             {
                                 "name": "REDIS_URL",

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -23,3 +23,5 @@ services:
       - LOGSTASH_PORT
       - LOGSTASH_SSL
       - STATE_CHANGE_SLACK_URL
+      - DSI_API_URL
+      - DSI_API_SECRET

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe InviteProviderUser do
   include DsiAPIHelper
 
   let(:provider) { create(:provider) }
-  let(:new_provider_user_form) {
+  let(:new_provider_user_from_form) {
     SupportInterface::ProviderUserForm.new(
       email_address: 'test+invite_provider_user@example.com',
       first_name: 'Firstname',
       last_name: 'Lastname',
       provider_ids: [provider.id],
-    )
+    ).build
   }
 
   describe '#initialize' do
-    it 'requires a provider_user_form:' do
+    it 'requires a provider_user:' do
       expect { InviteProviderUser.new }.to raise_error(ArgumentError)
-      expect { InviteProviderUser.new(provider_user_form: SupportInterface::ProviderUserForm.new) }.not_to raise_error
+      expect { InviteProviderUser.new(provider_user: ProviderUser.new) }.not_to raise_error
     end
   end
 
   context 'with feature flag on' do
-    describe '#call if API response is successful' do
+    describe '#save_and_invite! if API response is successful' do
       before do
         FeatureFlag.activate('send_dfe_sign_in_invitations')
         set_dsi_api_response(success: true)
-        InviteProviderUser.new(provider_user_form: new_provider_user_form).call
+        InviteProviderUser.new(provider_user: new_provider_user_from_form).save_and_invite!
       end
 
       it 'a provider user is created' do
@@ -33,18 +33,18 @@ RSpec.describe InviteProviderUser do
       end
     end
 
-    describe '#call if API response is not successful' do
+    describe '#save_and_invite! if API response is not successful' do
       before do
         FeatureFlag.activate('send_dfe_sign_in_invitations')
         set_dsi_api_response(success: false)
-        InviteProviderUser.new(provider_user_form: new_provider_user_form).call
       end
 
-      it 'adds ProviderUserForm errors based on the API response' do
-        expect(new_provider_user_form.errors).not_to be_empty
+      it 'raises DfeSignInApiError with errors from the API' do
+        expect { InviteProviderUser.new(provider_user: new_provider_user_from_form).save_and_invite! }.to raise_error(DfeSignInApiError)
       end
 
       it 'rolls back provider user creation' do
+        InviteProviderUser.new(provider_user: new_provider_user_from_form).save_and_invite! rescue nil
         expect(ProviderUser.find_by_email_address('test+invite_provider_user@example.com')).to be_nil
       end
     end
@@ -57,14 +57,14 @@ RSpec.describe InviteProviderUser do
       FeatureFlag.deactivate('send_dfe_sign_in_invitations')
       allow(HTTP).to receive(:auth).and_return http_spy
 
-      InviteProviderUser.new(provider_user_form: new_provider_user_form).call
+      InviteProviderUser.new(provider_user: new_provider_user_from_form).save_and_invite!
     end
 
-    it '#call no DfE Sign-In invitations are triggered' do
+    it '#save_and_invite! no DfE Sign-In invitations are triggered' do
       expect(http_spy).not_to have_received(:post)
     end
 
-    it '#call a provider user is created' do
+    it '#save_and_invite! a provider user is created' do
       expect(ProviderUser.find_by_email_address('test+invite_provider_user@example.com')).not_to be_nil
     end
   end

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -1,0 +1,71 @@
+require 'rails_helper'
+
+RSpec.describe InviteProviderUser do
+  include DsiAPIHelper
+
+  let(:provider) { create(:provider) }
+  let(:new_provider_user_form) {
+    SupportInterface::ProviderUserForm.new(
+      email_address: 'test+invite_provider_user@example.com',
+      first_name: 'Firstname',
+      last_name: 'Lastname',
+      provider_ids: [provider.id],
+    )
+  }
+
+  describe '#initialize' do
+    it 'requires a provider_user_form:' do
+      expect { InviteProviderUser.new }.to raise_error(ArgumentError)
+      expect { InviteProviderUser.new(provider_user_form: SupportInterface::ProviderUserForm.new) }.not_to raise_error
+    end
+  end
+
+  context 'with feature flag on' do
+    describe '#call if API response is successful' do
+      before do
+        FeatureFlag.activate('send_dfe_sign_in_invitations')
+        set_dsi_api_response(success: true)
+        InviteProviderUser.new(provider_user_form: new_provider_user_form).call
+      end
+
+      it 'a provider user is created' do
+        expect(ProviderUser.find_by_email_address('test+invite_provider_user@example.com')).not_to be_nil
+      end
+    end
+
+    describe '#call if API response is not successful' do
+      before do
+        FeatureFlag.activate('send_dfe_sign_in_invitations')
+        set_dsi_api_response(success: false)
+        InviteProviderUser.new(provider_user_form: new_provider_user_form).call
+      end
+
+      it 'adds ProviderUserForm errors based on the API response' do
+        expect(new_provider_user_form.errors).not_to be_empty
+      end
+
+      it 'rolls back provider user creation' do
+        expect(ProviderUser.find_by_email_address('test+invite_provider_user@example.com')).to be_nil
+      end
+    end
+  end
+
+  context 'with feature flag off' do
+    let(:http_spy) { class_spy('HTTP') }
+
+    before do
+      FeatureFlag.deactivate('send_dfe_sign_in_invitations')
+      allow(HTTP).to receive(:auth).and_return http_spy
+
+      InviteProviderUser.new(provider_user_form: new_provider_user_form).call
+    end
+
+    it '#call no DfE Sign-In invitations are triggered' do
+      expect(http_spy).not_to have_received(:post)
+    end
+
+    it '#call a provider user is created' do
+      expect(ProviderUser.find_by_email_address('test+invite_provider_user@example.com')).not_to be_nil
+    end
+  end
+end

--- a/spec/support/test_helpers/dsi_api_helper.rb
+++ b/spec/support/test_helpers/dsi_api_helper.rb
@@ -1,0 +1,13 @@
+module DsiAPIHelper
+  def set_dsi_api_response(success:)
+    if success
+      stub_request(:post, "#{ENV.fetch('DSI_API_URL')}/services/apply/invitations").to_return(status: 202)
+    else
+      stub_request(:post, "#{ENV.fetch('DSI_API_URL')}/services/apply/invitations").to_return(
+        status: 400,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: { errors: ['Missing given_name', 'Missing family_name'] }.to_json,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

Inviting a provider user is a very manual process which doesn't scale. We would like to automate as many steps of this process as possible, and we are starting with invitations to the DfE Sign-In platform.

DfE Sign-In provides an API. This API requires `sourceId`, as well as `given_name` and `family_name`, alongside `email` (see https://github.com/DFE-Digital/login.dfe.public-api#invite-user). Currently, we do not ask for any names when creating provider users within the Support console. This may have to change because names are required by:

- DfE Sign-In invitations
- our own email templates 

Planning to add a database migration for storing names against `provider_users` as a separate PR.

## Changes proposed in this pull request

This PR introduces an `InviteProviderUser` service, which handles saving the form and also inviting users to DfE Sign-In via their API. In the future, it will also send welcome emails etc. Operations are wrapped in a transaction because that's a good thing (tm), but also because the DSI API requires `sourceId`, which is our unique identifier for the user (i.e. their AR id). So the code creates a `ProviderUser`, which is rolled back if the DSI invitation fails.

Two new environment variables are added, `DSI_API_URL` and `DSI_API_SECRET`.
![image](https://user-images.githubusercontent.com/107591/72529333-ff570700-3864-11ea-94f6-7c2a6bec797e.png)

## Guidance to review

The form for creating new provider users within the support console now contains first and last name fields. These are now stored against the provider user. Editing an existing provider user is exactly the same as before, with added name-related text fields. The update action is restricted to updating names, as `uid` is set automatically the first time a user logs in, and `email` will soon be updated automatically every time a user sign in.

Slack me if you're reviewing this for the appropriate `DSI_API_URL` and `DSI_API_SECRET` values for your local environment.

You'll also need to switch on the relevant feature flag on the environment you are testing (via the support interface):
![image](https://user-images.githubusercontent.com/107591/72629277-e6735200-3947-11ea-9e6c-dafb2679c524.png)

Invite a provider user and complete the sign-up flow. You'll be redirected back to the provider interface of the environment you are testing.

It is not possible to avoid the additional click on the green sign in button when a user is redirected back to the app (once completing DSI sign-up), because triggering the sign-in flow requires a `POST`.

## Link to Trello card

[When a user is added, call the Signin API to invite the user](https://trello.com/c/H9oC6kxo)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
