### PR TITLE
Small typographical fixes

### DIFF
--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -24,7 +24,7 @@
     <p class="govuk-body">If your training provider decides to offer you an interview, they will get in touch directly via email to organise a date and give you all the information you need.</p>
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
-    <p class="govuk-body">You have 5 working days to make changes to a submitted application. We won't send your application to your training provider(s) until the 5 working days are up.</p>
+    <p class="govuk-body">You have 5 working days to make changes to a submitted application. We won’t send your application to your training provider(s) until the 5 working days are up.</p>
     <p class="govuk-body">To edit your application, return to your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -14,7 +14,7 @@
       <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, hint_text: t('authentication.sign_up.email_address.hint_label'), type: :email, width: 'two-thirds', autocomplete: 'email' %>
 
       <h2 class="govuk-heading-m">You won’t need a password to use this service</h2>
-      <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we'll send you a link so you can return to your application.</p>
+      <p class="govuk-body">Instead, you’ll sign in using your email address. Each time you sign in, we’ll send you a link so you can return to your application.</p>
 
       <h2 class="govuk-heading-m">How we look after your data</h2>
       <p class="govuk-body">Your data will be looked after by the Department for Education and the training providers you apply to.</p>

--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -288,7 +288,7 @@
           <p>
             Within DfE, access to data will be restricted to teams that need it for processing applications, building a better teacher training application and getting insight to inform government policy.
             DfE uses some third-party data processors, including Google Analytics, G Suite, Zendesk and Microsoft Azure.
-            Providers must follow guidance from the Information Commissioner's Office on appointing and using appropriate data processors.
+            Providers must follow guidance from the Information Commissioner’s Office on appointing and using appropriate data processors.
             It is the provider’s responsibility to ensure that data subjects know who processes data on their behalf and under what legal authority.
             By signing this agreement, the provider confirms that:
           </p>

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Are you sure you won't give <%= @application.full_name %> a reference?</h1>
+    <h1 class="govuk-heading-xl">Are you sure you won’t give <%= @application.full_name %> a reference?</h1>
 
     <%= form_with model: @reference, url: referee_interface_refuse_feedback_path(token: @token_param), method: :patch do |f| %>
       <%= f.govuk_submit 'Yes - I\'m sure' %>


### PR DESCRIPTION
A couple of places in the interfaces where we probably should be using [smart quotes](https://smartquotesforsmartpeople.com/).