### PR TITLE
Send welcome email to provider user when they are added

### DIFF
--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -1,0 +1,7 @@
+class ProviderMailerPreview < ActionMailer::Preview
+  def account_created_email
+    provider_user = FactoryBot.build :provider_user
+
+    ProviderMailer.account_created(provider_user)
+  end
+end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -4,8 +4,8 @@ class ProviderMailer < ApplicationMailer
 
     view_mail(
       GENERIC_NOTIFY_TEMPLATE,
-      to: provider_user.email_address,
-      subject: t('provider_account_created.email.subject')
+      to: @provider_user.email_address,
+      subject: t('provider_account_created.email.subject'),
     )
   end
 end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -1,0 +1,11 @@
+class ProviderMailer < ApplicationMailer
+  def account_created(provider_user)
+    @provider_user = provider_user
+
+    view_mail(
+      GENERIC_NOTIFY_TEMPLATE,
+      to: provider_user.email_address,
+      subject: t('provider_account_created.email.subject')
+    )
+  end
+end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -21,6 +21,10 @@ class ProviderUser < ActiveRecord::Base
     end
   end
 
+  def full_name
+    "#{first_name} #{last_name}"
+  end
+
 private
 
   def downcase_email_address

--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -24,9 +24,9 @@ class InviteProviderUser
     end
   end
 
-  def invite_user_to_dfe_sign_in
-    return unless FeatureFlag.active?('send_dfe_sign_in_invitations')
+private
 
+  def invite_user_to_dfe_sign_in
     jwt_payload = { iss: 'apply', aud: 'signin.education.gov.uk' }
     token = JWT.encode jwt_payload, ENV['DSI_API_SECRET'], DSI_JWT_HMAC
     auth_string = "Bearer #{token}"
@@ -42,12 +42,8 @@ class InviteProviderUser
     raise DfeSignInApiError.new(response) unless response.status.success?
   end
 
-private
-
   def send_welcome_email
-    return unless FeatureFlag.active?('send_dfe_sign_in_invitations')
-
-    ProviderMailer.account_created(@provider_user).deliver
+    ProviderMailer.account_created(@provider_user).deliver_later
   end
 end
 

--- a/app/views/provider_mailer/account_created.text.erb
+++ b/app/views/provider_mailer/account_created.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @provider_user_name %>,
+Dear <%= @provider_user.full_name %>,
 
 You've created an account with DfE Sign-in.
 

--- a/app/views/provider_mailer/account_created.text.erb
+++ b/app/views/provider_mailer/account_created.text.erb
@@ -1,13 +1,15 @@
-Dear <%= @provider_user.full_name %>,
+Dear <%= @provider_user.full_name %>
 
-You've created an account with DfE Sign-in.
+Welcome to Manage teacher training applications.
 
-<b>Sign in to Manage teacher training applications.</b>
+You will need to use DfE Sign-in to access your applications.
 
-You can now sign in to the service to start managing applications:
+# Already activated your DfE Sign-in account?
 
-[<%= provider_interface_url %>](<%= provider_interface_url %>)
+Visit [Manage teacher training applications](<%= provider_interface_url %>) to sign in.
 
-You'll need your DfE Sign-in account details to log in each time.
+# Don’t have a DfE Sign-in account?
 
-If you have any questions you can contact us at becomingateacher@digital.education.gov.uk
+Please check your inbox for an email from us inviting you to create a DfE Sign-in account.
+
+You can contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to request a new email, or for help and support. 

--- a/app/views/provider_mailer/account_created.text.erb
+++ b/app/views/provider_mailer/account_created.text.erb
@@ -6,7 +6,7 @@ You've created an account with DfE Sign-in.
 
 You can now sign in to the service to start managing applications:
 
-[<%= provider_interface_applications_url %>](<%= provider_interface_applications_url %>)
+[<%= provider_interface_url %>](<%= provider_interface_url %>)
 
 You'll need your DfE Sign-in account details to log in each time.
 

--- a/app/views/provider_mailer/account_created.text.erb
+++ b/app/views/provider_mailer/account_created.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @provider_user_name %>,
+
+You've created an account with DfE Sign-in.
+
+<b>Sign in to Manage teacher training applications.</b>
+
+You can now sign in to the service to start managing applications:
+
+[<%= provider_interface_applications_url %>](<%= provider_interface_applications_url %>)
+
+You'll need your DfE Sign-in account details to log in each time.
+
+If you have any questions you can contact us at becomingateacher@digital.education.gov.uk

--- a/config/locales/provider_account_created.yml
+++ b/config/locales/provider_account_created.yml
@@ -1,0 +1,4 @@
+en:
+  provider_account_created:
+    email:
+      subject: Sign in to Manage teacher training applications.

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -245,5 +245,7 @@ FactoryBot.define do
   factory :provider_user do
     dfe_sign_in_uid { SecureRandom.uuid }
     email_address { "#{Faker::Name.first_name.downcase}-#{SecureRandom.hex}@example.com" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
   end
 end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
 
     it 'addresses the provider by name' do
-      expect(@mail.body.encoded).to include("Dear #{@provider_user.first_name} #{@provider_user.last_name}")
+      expect(@mail.body.encoded).to include("Dear #{@provider_user.full_name}")
     end
 
     it 'includes a link to the provider home page' do

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe ProviderMailer, type: :mailer do
   subject(:mailer) { described_class }
 
   describe 'Send account created email' do
-    let(:mail) { mailer.account_created(build_stubbed(:provider_user)) }
-
-    before { mail.deliver_later }
+    before do
+      @provider_user = build_stubbed(:provider_user)
+      @mail = mailer.account_created(@provider_user)
+    end
 
     it 'sends an email with the correct subject' do
-      expect(mail.subject).to include(t('provider_account_created.email.subject'))
+      expect(@mail.subject).to include(t('provider_account_created.email.subject'))
     end
 
     it 'addresses the provider by name' do
-      pending 'we don\'t yet store the names - only email addresses but this is being added because it\'s needed for DSI registration'
-      expect(mail.body.encoded).to include('Dear Bob')
+      expect(@mail.body.encoded).to include("Dear #{@provider_user.first_name} #{@provider_user.last_name}")
     end
 
     it 'includes a link to the provider home page' do
-      expect(mail.body.encoded).to include(provider_interface_applications_url)
+      expect(@mail.body.encoded).to include(provider_interface_applications_url)
     end
   end
 end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe ProviderMailer, type: :mailer do
+  subject(:mailer) { described_class }
+
+  describe 'Send account created email' do
+    let(:mail) { mailer.account_created(build_stubbed(:provider_user)) }
+
+    before { mail.deliver_later }
+
+    it 'sends an email with the correct subject' do
+      expect(mail.subject).to include(t('provider_account_created.email.subject'))
+    end
+
+    it 'addresses the provider by name' do
+      pending 'we don\'t yet store the names - only email addresses but this is being added because it\'s needed for DSI registration'
+      expect(mail.body.encoded).to include('Dear Bob')
+    end
+
+    it 'includes a link to the provider home page' do
+      expect(mail.body.encoded).to include(provider_interface_applications_url)
+    end
+  end
+end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
 
     it 'includes a link to the provider home page' do
-      expect(@mail.body.encoded).to include(provider_interface_applications_url)
+      expect(@mail.body.encoded).to include(provider_interface_url)
     end
   end
 end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -29,4 +29,11 @@ RSpec.describe ProviderUser, type: :model do
       expect(provider_user.reload.dfe_sign_in_uid).to eq 'ABC123'
     end
   end
+
+  describe '#full_name' do
+    it 'concatenates the first and last names of the user' do
+      provider_user = build :provider_user
+      expect(provider_user.full_name).to eq "#{provider_user.first_name} #{provider_user.last_name}"
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,4 +70,6 @@ RSpec.configure do |config|
   config.include ActionView::Component::TestHelpers
 
   config.before { Faker::UniqueGenerator.clear }
+
+  config.before { ActionMailer::Base.deliveries.clear }
 end

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -33,10 +33,7 @@ RSpec.describe InviteProviderUser do
       end
 
       it 'queues an email' do
-        message_delivery = instance_double(ActionMailer::MessageDelivery, deliver_later: nil)
-        allow(ProviderMailer).to receive(:account_created).and_return(message_delivery)
-        InviteProviderUser.new(provider_user: new_provider_user_from_form).save_and_invite! rescue nil
-        expect(ProviderMailer).to have_received(:account_created)
+        expect(ProviderMailer.deliveries.count).to be 1
       end
     end
 
@@ -56,10 +53,7 @@ RSpec.describe InviteProviderUser do
       end
 
       it 'does not queue an email' do
-        message_delivery = instance_double(ActionMailer::MessageDelivery)
-        allow(ProviderMailer).to receive(:account_created).and_return(message_delivery)
-        InviteProviderUser.new(provider_user: new_provider_user_from_form).save_and_invite! rescue nil
-        expect(ProviderMailer).not_to have_received(:account_created)
+        expect(ProviderMailer.deliveries.count).to be 0
       end
     end
   end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 RSpec.feature 'Managing provider users' do
   include DfESignInHelpers
+  include DsiAPIHelper
 
   scenario 'creating a new provider user' do
-    given_i_am_a_support_user
+    given_the_send_dfe_sign_in_invitations_feature_flag_is_on
+    and_dfe_signin_is_configured
+    and_i_am_a_support_user
     and_providers_exist
 
     when_i_visit_the_support_console
@@ -21,13 +24,22 @@ RSpec.feature 'Managing provider users' do
 
     then_i_should_see_the_list_of_provider_users
     and_i_should_see_the_user_i_created
+    and_the_user_should_be_sent_a_welcome_email
 
     when_i_click_on_that_user
     and_i_add_them_to_another_organisation
     then_i_see_that_they_have_been_added_to_that_organisation
   end
 
-  def given_i_am_a_support_user
+  def given_the_send_dfe_sign_in_invitations_feature_flag_is_on
+    FeatureFlag.activate('send_dfe_sign_in_invitations')
+  end
+
+  def and_dfe_signin_is_configured
+    set_dsi_api_response(success: true)
+  end
+
+  def and_i_am_a_support_user
     sign_in_as_support_user
   end
 
@@ -79,6 +91,11 @@ RSpec.feature 'Managing provider users' do
 
   def and_i_should_see_the_user_i_created
     expect(page).to have_content('harrison@example.com')
+  end
+
+  def and_the_user_should_be_sent_a_welcome_email
+    open_email('harrison@example.com')
+    expect(current_email.subject).to have_content t('provider_account_created.email.subject')
   end
 
   def when_i_click_on_that_user


### PR DESCRIPTION
## Context

To streamline the onboarding process a DSI account can be created when provider users are added via the support interface. We also need to send out a welcome email with a link to the provider interface.

## Changes proposed in this pull request

- add a new mailer for providers with a method to send the 'account created' email.
- queue a job from the `InviteProviderUser` service to send the email after the new DSI account has been requested
- for convenience a `ProviderUser#full_name` method has been added

## Guidance to review

- does it make sense to queue the mailer from the service?
- have I tested the changes to the service and the mailer itself adequately?
- do we ever have to worry about `ProviderUser#first_name` or `last_name` being nil? (the database column is nullable but they are required fields at signup time I think).

## Link to Trello card

https://trello.com/c/cYX0hWq8/1515-automatically-send-an-email-to-the-provider-user-when-theyre-added

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
