### PR TITLE
Add notify reference to #reference_request_email

### DIFF
--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -8,6 +8,7 @@ class RefereeMailer < ApplicationMailer
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,
               subject: t('reference_request.subject.initial', candidate_name: @candidate_name),
+              reference: "#{Rails.env}-reference_request-#{reference.id}",
               template_name: :reference_request_email)
   end
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe RefereeMailer, type: :mailer do
       body = mail.body.encoded
       expect(body).to include(referee_interface_reference_feedback_url(token: ''))
     end
+
+    it 'sends a request with a notify reference' do
+      mail.deliver_now
+      expect(mail[:reference].value).to eq("#{Rails.env}-reference_request-#{reference.id}")
+    end
   end
 
   describe 'Send chasing reference email' do


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
This is the first slice of monitoring bounced back emails. We want to be able to keep track on emails that bounce back, so that we can tell candidates if they provided an incorrect reference email.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds a `notify reference` to the `reference_request_email` so that we can identify which email bounced back.  The notify reference is generated from `environment name`-`email_type`-`reference_id`

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/FuEKJx9W/772-bounced-email-monitoring

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
