### PR TITLE
Remove whitespace dividing Data sharing agreement title

### DIFF
--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= t("page_titles.#{page_name}") %></h1>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-3"><%= t("page_titles.#{page_name}") %></h1>
 
     <div class="app-styled-content">
 


### PR DESCRIPTION
This looked a bit odd, and as it's the first thing providers see when they first sign in, it shouldn't.

### Before

<img width="768" alt="Screenshot 2020-01-16 at 15 10 26" src="https://user-images.githubusercontent.com/642279/72537081-611e6d80-3873-11ea-86a5-1e743219599d.png">


### After

<img width="1052" alt="Screenshot 2020-01-16 at 15 15 33" src="https://user-images.githubusercontent.com/642279/72537089-6380c780-3873-11ea-8b42-f8dba9a120b9.png">

(with help from @adamsilver)