### PR TITLE
Disable pentest environment in release pipeline

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -141,54 +141,6 @@ stages:
       alertRecipientEmails: '$(alertRecipientEmails)'
 
 
-  #- stage: deploy_pentest
-  #displayName: 'Deploy - Pentest'
-  #dependsOn: publish_arm_template
-  #condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_pentest, true))
-  #variables:
-  #- group: APPLY - ENV - Pentest
-  #jobs:
-  #- template: azure-pipelines-deploy-template.yml
-  #  parameters:
-  #    debug: $(debug)
-  #    subscriptionPrefix: 's106'
-  #    subscriptionName: 'Apply (106) - Test'
-  #    environment: 'pentest'
-  #    resourceEnvironmentName: 't03'
-  #    serviceName: 'apply'
-  #    containerImageReference: '$(imageName):$(build.buildNumber)'
-  #    keyVaultName: 's106t01-shared-kv-01'
-  #    keyVaultResourceGroup: 's106t01-shared-rg'
-  #    databaseName: 'apply'
-  #    databaseUsername: 'applyadm512'
-  #    databasePassword: '$(databasePassword)'
-  #    databaseStorageAutoGrow: 'disabled'
-  #    databaseBackupRetentionDays: 7
-  #    dockerhubUsername: '$(dockerHubUsername)'
-  #    railsSecretKeyBase: '$(railsSecretKeyBase)'
-  #    railsEnv: 'production'
-  #    basicAuthEnabled: '$(basicAuthEnabled)'
-  #    basicAuthUsername: '$(basicAuthUsername)'
-  #    basicAuthPassword: '$(basicAuthPassword)'
-  #    supportUsername: '$(supportUsername)'
-  #    supportPassword: '$(supportPassword)'
-  #    authorisedHosts: '$(authorisedHosts)'
-  #    sentryDSN: '$(sentryDSN)'
-  #    logstashEnable: '$(logstashEnable)'
-  #    logstashRemote: '$(logstashRemote)'
-  #    logstashHost: '$(logstashHost)'
-  #    logstashPort: '$(logstashPort)'
-  #    logstashSsl: '$(logstashSsl)'
-  #    govukNotifyAPIKey: '$(govukNotifyAPIKey)'
-  #    findBaseUrl: '$(findBaseUrl)'
-  #    dfeSignInClientId: '$(dfeSignInClientId)'
-  #    dfeSignInSecret: '$(dfeSignInSecret)'
-  #    dfeSignInIssuer: '$(dfeSignInIssuer)'
-  #    stateChangeSlackUrl: '$(stateChangeSlackUrl)'
-  #    customAvailabilityMonitors: '$(customAvailabilityMonitors)'
-  #    alertRecipientEmails: '$(alertRecipientEmails)'
-
-
 - stage: deploy_production
   displayName: 'Deploy - Production'
   dependsOn: publish_arm_template

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -141,52 +141,52 @@ stages:
       alertRecipientEmails: '$(alertRecipientEmails)'
 
 
-- stage: deploy_pentest
-  displayName: 'Deploy - Pentest'
-  dependsOn: publish_arm_template
-  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_pentest, true))
-  variables:
-  - group: APPLY - ENV - Pentest
-  jobs:
-  - template: azure-pipelines-deploy-template.yml
-    parameters:
-      debug: $(debug)
-      subscriptionPrefix: 's106'
-      subscriptionName: 'Apply (106) - Test'
-      environment: 'pentest'
-      resourceEnvironmentName: 't03'
-      serviceName: 'apply'
-      containerImageReference: '$(imageName):$(build.buildNumber)'
-      keyVaultName: 's106t01-shared-kv-01'
-      keyVaultResourceGroup: 's106t01-shared-rg'
-      databaseName: 'apply'
-      databaseUsername: 'applyadm512'
-      databasePassword: '$(databasePassword)'
-      databaseStorageAutoGrow: 'disabled'
-      databaseBackupRetentionDays: 7
-      dockerhubUsername: '$(dockerHubUsername)'
-      railsSecretKeyBase: '$(railsSecretKeyBase)'
-      railsEnv: 'production'
-      basicAuthEnabled: '$(basicAuthEnabled)'
-      basicAuthUsername: '$(basicAuthUsername)'
-      basicAuthPassword: '$(basicAuthPassword)'
-      supportUsername: '$(supportUsername)'
-      supportPassword: '$(supportPassword)'
-      authorisedHosts: '$(authorisedHosts)'
-      sentryDSN: '$(sentryDSN)'
-      logstashEnable: '$(logstashEnable)'
-      logstashRemote: '$(logstashRemote)'
-      logstashHost: '$(logstashHost)'
-      logstashPort: '$(logstashPort)'
-      logstashSsl: '$(logstashSsl)'
-      govukNotifyAPIKey: '$(govukNotifyAPIKey)'
-      findBaseUrl: '$(findBaseUrl)'
-      dfeSignInClientId: '$(dfeSignInClientId)'
-      dfeSignInSecret: '$(dfeSignInSecret)'
-      dfeSignInIssuer: '$(dfeSignInIssuer)'
-      stateChangeSlackUrl: '$(stateChangeSlackUrl)'
-      customAvailabilityMonitors: '$(customAvailabilityMonitors)'
-      alertRecipientEmails: '$(alertRecipientEmails)'
+  #- stage: deploy_pentest
+  #displayName: 'Deploy - Pentest'
+  #dependsOn: publish_arm_template
+  #condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_pentest, true))
+  #variables:
+  #- group: APPLY - ENV - Pentest
+  #jobs:
+  #- template: azure-pipelines-deploy-template.yml
+  #  parameters:
+  #    debug: $(debug)
+  #    subscriptionPrefix: 's106'
+  #    subscriptionName: 'Apply (106) - Test'
+  #    environment: 'pentest'
+  #    resourceEnvironmentName: 't03'
+  #    serviceName: 'apply'
+  #    containerImageReference: '$(imageName):$(build.buildNumber)'
+  #    keyVaultName: 's106t01-shared-kv-01'
+  #    keyVaultResourceGroup: 's106t01-shared-rg'
+  #    databaseName: 'apply'
+  #    databaseUsername: 'applyadm512'
+  #    databasePassword: '$(databasePassword)'
+  #    databaseStorageAutoGrow: 'disabled'
+  #    databaseBackupRetentionDays: 7
+  #    dockerhubUsername: '$(dockerHubUsername)'
+  #    railsSecretKeyBase: '$(railsSecretKeyBase)'
+  #    railsEnv: 'production'
+  #    basicAuthEnabled: '$(basicAuthEnabled)'
+  #    basicAuthUsername: '$(basicAuthUsername)'
+  #    basicAuthPassword: '$(basicAuthPassword)'
+  #    supportUsername: '$(supportUsername)'
+  #    supportPassword: '$(supportPassword)'
+  #    authorisedHosts: '$(authorisedHosts)'
+  #    sentryDSN: '$(sentryDSN)'
+  #    logstashEnable: '$(logstashEnable)'
+  #    logstashRemote: '$(logstashRemote)'
+  #    logstashHost: '$(logstashHost)'
+  #    logstashPort: '$(logstashPort)'
+  #    logstashSsl: '$(logstashSsl)'
+  #    govukNotifyAPIKey: '$(govukNotifyAPIKey)'
+  #    findBaseUrl: '$(findBaseUrl)'
+  #    dfeSignInClientId: '$(dfeSignInClientId)'
+  #    dfeSignInSecret: '$(dfeSignInSecret)'
+  #    dfeSignInIssuer: '$(dfeSignInIssuer)'
+  #    stateChangeSlackUrl: '$(stateChangeSlackUrl)'
+  #    customAvailabilityMonitors: '$(customAvailabilityMonitors)'
+  #    alertRecipientEmails: '$(alertRecipientEmails)'
 
 
 - stage: deploy_production


### PR DESCRIPTION
## Context

The pentest was completed in December and we no longer require the s106t03 which will be deleted to remove charges for unnecessary hosted infrastructure.

## Changes proposed in this pull request

Commented out the block of code specific to the pentest environment so that it cannot be recreated again mistakenly.

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/nUx2GIQU/1520-devops-remove-pentest-environment

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
