### PR TITLE
Providers can change offers to rejections

### DIFF
--- a/app/components/provider_interface/change_decision_component.html.erb
+++ b/app/components/provider_interface/change_decision_component.html.erb
@@ -1,0 +1,19 @@
+<%= form_with url: provider_interface_application_choice_confirm_change_decision_path, method: :post do |f| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <p class="govuk-body">
+        <%= choice.current_state %>
+      </p>
+
+      <%= f.govuk_collection_radio_buttons :desired_change, choice.change_options, :value, :label, :description %>
+
+      <%= f.govuk_submit 'Continue' %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(application_choice), class: 'govuk-link--no-visited-state' %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/components/provider_interface/change_decision_component.rb
+++ b/app/components/provider_interface/change_decision_component.rb
@@ -1,0 +1,26 @@
+module ProviderInterface
+  class ChangeDecisionComponent < ActionView::Component::Base
+    include ViewHelper
+
+    ChangeOption = Struct.new(:value, :label, :description)
+    Choice = Struct.new(:current_state, :change_options)
+
+    attr_reader :application_choice
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def choice
+      case application_choice.status
+      when 'offer'
+        Choice.new(
+          'You have made this candidate an offer, but they have not accepted it yet.',
+          [ChangeOption.new(:reject, 'Change offer to rejection', 'Use this to rescind the offer, for example when a course is oversubscribed')],
+        )
+      else
+        raise RuntimeError.new("Tried to render a ChangeDecisionComponent for an ApplicationChoice in the #{application_choice.status} state")
+      end
+    end
+  end
+end

--- a/app/components/provider_interface/change_decision_component.rb
+++ b/app/components/provider_interface/change_decision_component.rb
@@ -15,8 +15,8 @@ module ProviderInterface
       case application_choice.status
       when 'offer'
         Choice.new(
-          'You have made this candidate an offer, but they have not accepted it yet.',
-          [ChangeOption.new(:reject, 'Change offer to rejection', 'Use this to rescind the offer, for example when a course is oversubscribed')],
+          'This candidate has not accepted your offer yet. Would you like to withdraw your offer and reject this application?',
+          [ChangeOption.new(:reject, 'Reject this application', 'The candidate will be notified')],
         )
       else
         raise RuntimeError.new("Tried to render a ChangeDecisionComponent for an ApplicationChoice in the #{application_choice.status} state")

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -42,7 +42,7 @@
     </div>
   <% elsif application_choice.offer? && FeatureFlag.active?('providers_can_change_offers') %>
     <div class="govuk-!-margin-top-6">
-      <%= govuk_button_link_to 'Edit your decision', provider_interface_application_choice_change_decision_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
+      <%= govuk_button_link_to 'Edit response', provider_interface_application_choice_change_decision_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
     </div>
   <% end %>
 </div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -3,35 +3,35 @@
   <%= render ProviderInterface::ApplicationStatusTagComponent, application_choice: application_choice %>
 
   <dl class="app-definition-list govuk-!-margin-top-4">
-    <dt>Application submitted</dt>
+    <dt>Application submitted:</dt>
     <dd><%= submitted_at %></dd>
 
     <% if application_choice.awaiting_provider_decision? %>
-      <dt>Respond to the applicant by</dt>
+      <dt>Respond to the applicant by:</dt>
       <dd><%= respond_by %></dd>
     <% elsif application_choice.withdrawn? %>
       <dt>Application withdrawn</dt>
       <dd><%= withdrawn_at %></dd>
     <% elsif application_choice.offer? %>
-      <dt>Needs to respond by</dt>
+      <dt>Candidate must respond by:</dt>
       <dd><%= candidate_respond_by %></dd>
     <% elsif application_choice.rejected? %>
-      <dt>Rejected at</dt>
+      <dt>Rejected on:</dt>
       <dd><%= rejected_at %></dd>
     <% elsif application_choice.recruited? %>
-      <dt>Recruited at</dt>
+      <dt>Recruited on:</dt>
       <dd><%= recruited_at %></dd>
     <% elsif application_choice.declined? %>
-      <dt>Declined at</dt>
+      <dt>Declined on:</dt>
       <dd><%= declined_at %></dd>
     <% elsif application_choice.pending_conditions? %>
-      <dt>Accepted at</dt>
+      <dt>Accepted on:</dt>
       <dd><%= accepted_at %></dd>
     <% elsif application_choice.conditions_not_met? %>
       <dt>Conditions not met</dt>
       <dd><%= conditions_not_met_at %></dd>
     <% elsif application_choice.enrolled? %>
-      <dt>Enrolled at</dt>
+      <dt>Enrolled on:</dt>
       <dd><%= enrolled_at %></dd>
     <% end %>
   </dl>
@@ -42,7 +42,7 @@
     </div>
   <% elsif application_choice.offer? && FeatureFlag.active?('providers_can_change_offers') %>
     <div class="govuk-!-margin-top-6">
-      <%= govuk_button_link_to 'Change decision', provider_interface_application_choice_change_decision_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
+      <%= govuk_button_link_to 'Edit your decision', provider_interface_application_choice_change_decision_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
     </div>
   <% end %>
 </div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -40,5 +40,9 @@
     <div class="govuk-!-margin-top-6">
       <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
     </div>
+  <% elsif application_choice.offer? && FeatureFlag.active?('providers_can_change_offers') %>
+    <div class="govuk-!-margin-top-6">
+      <%= govuk_button_link_to 'Change decision', provider_interface_application_choice_change_decision_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
+    </div>
   <% end %>
 </div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -7,7 +7,7 @@
     <dd><%= submitted_at %></dd>
 
     <% if application_choice.awaiting_provider_decision? %>
-      <dt>Respond to the applicant by:</dt>
+      <dt>Respond to the candidate by:</dt>
       <dd><%= respond_by %></dd>
     <% elsif application_choice.withdrawn? %>
       <dt>Application withdrawn</dt>

--- a/app/controllers/provider_interface/change_decision_controller.rb
+++ b/app/controllers/provider_interface/change_decision_controller.rb
@@ -1,0 +1,17 @@
+module ProviderInterface
+  class ChangeDecisionController < ProviderInterfaceController
+    def new
+      @application_choice = ApplicationChoice.find(params[:application_choice_id])
+    end
+
+    def dispatch_decision
+      case params[:desired_change]
+      when 'reject'
+        redirect_to controller: :decisions, action: :new_reject
+      else
+        @application_choice = ApplicationChoice.find(params[:application_choice_id])
+        render :new
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -44,7 +44,7 @@ module ProviderInterface
       )
 
       if @application_offer.save
-        flash[:success] = 'Application status changed to ‘Offer Made’'
+        flash[:success] = 'Application status changed to ‘Offer made’'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,
         )

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,7 @@
 class FeatureFlag
   FEATURES = %w[
     pilot_open
+    providers_can_change_offers
     training_with_a_disability
     edit_application
     send_reference_email_via_support

--- a/app/views/provider_interface/change_decision/new.html.erb
+++ b/app/views/provider_interface/change_decision/new.html.erb
@@ -1,11 +1,11 @@
-<% content_for :browser_title, 'Edit your decision' %>
+<% content_for :browser_title, 'Edit your response' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
     <%= @application_choice.application_form.full_name %>’s application for  <%= @application_choice.course.name_and_code %>
   </span>
-  Edit your decision
+  Edit your response
 </h1>
 
 <%= render(ProviderInterface::ChangeDecisionComponent, application_choice: @application_choice) %>

--- a/app/views/provider_interface/change_decision/new.html.erb
+++ b/app/views/provider_interface/change_decision/new.html.erb
@@ -1,11 +1,11 @@
-<% content_for :browser_title, 'Change decision' %>
+<% content_for :browser_title, 'Edit your decision' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">
     <%= @application_choice.application_form.full_name %>’s application for  <%= @application_choice.course.name_and_code %>
   </span>
-  Change decision
+  Edit your decision
 </h1>
 
 <%= render(ProviderInterface::ChangeDecisionComponent, application_choice: @application_choice) %>

--- a/app/views/provider_interface/change_decision/new.html.erb
+++ b/app/views/provider_interface/change_decision/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :browser_title, 'Change decision' %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice)) %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">
+    <%= @application_choice.application_form.full_name %>’s application for  <%= @application_choice.course.name_and_code %>
+  </span>
+  Change decision
+</h1>
+
+<%= render(ProviderInterface::ChangeDecisionComponent, application_choice: @application_choice) %>

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -25,7 +25,7 @@
       <div class="govuk-form-group">
         <%= f.govuk_text_area :rejection_reason,
                               label: { text: 'Tell the candidate why their application was rejected', size: 'm' },
-                              hint_text: 'We’ll forward your feedback to the candidate',
+                              hint_text: 'We’ll forward them your feedback',
                               rows: 5 %>
       </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,8 @@ Rails.application.routes.draw do
     post '/applications/:application_choice_id/respond' => 'decisions#submit_response', as: :application_choice_submit_response
     get '/applications/:application_choice_id/offer' => 'decisions#new_offer', as: :application_choice_new_offer
     get '/applications/:application_choice_id/reject' => 'decisions#new_reject', as: :application_choice_new_reject
+    get '/applications/:application_choice_id/change-decision' => 'change_decision#new', as: :application_choice_change_decision
+    post '/applications/:application_choice_id/change-decision' => 'change_decision#dispatch_decision', as: :application_choice_confirm_change_decision
     post '/applications/:application_choice_id/reject/confirm' => 'decisions#confirm_reject', as: :application_choice_confirm_reject
     post '/applications/:application_choice_id/reject' => 'decisions#create_reject', as: :application_choice_create_reject
     post '/applications/:application_choice_id/offer/confirm' => 'decisions#confirm_offer', as: :application_choice_confirm_offer

--- a/spec/components/provider_interface/status_box_component_spec.rb
+++ b/spec/components/provider_interface/status_box_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ProviderInterface::StatusBoxComponent do
 
     result = render_inline(described_class, application_choice: application_choice)
 
-    expect(result.text).to include('Needs to respond by')
+    expect(result.text).to include('Candidate must respond by:')
   end
 
   it 'outputs a date for applications in the rejected state' do
@@ -30,7 +30,7 @@ RSpec.describe ProviderInterface::StatusBoxComponent do
 
     result = render_inline(described_class, application_choice: application_choice)
 
-    expect(result.text).to include('Rejected at')
+    expect(result.text).to include('Rejected on')
   end
 
   it 'outputs a date for applications in the pending_conditions (offer accepted) state' do

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'A provider changes their offer' do
   end
 
   def and_i_click_change_offer
-    click_link 'Edit your decision'
+    click_link 'Edit your response'
   end
 
   def and_i_choose_to_reject_the_offer

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'A provider changes their offer' do
   end
 
   def and_i_click_change_offer
-    click_link 'Change decision'
+    click_link 'Edit your decision'
   end
 
   def and_i_choose_to_reject_the_offer

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.feature 'A provider changes their offer' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'from offered to rejected' do
+    given_the_providers_can_change_offers_feature_flag_is_on
+    and_i_am_logged_in_as_a_provider
+    and_i_have_made_an_offer_to_a_candidate
+
+    when_i_visit_their_application
+    and_i_click_change_offer
+    and_i_choose_to_reject_the_offer
+    and_i_complete_the_rejection_flow
+
+    then_i_should_see_the_application_again
+    and_i_should_see_the_application_status_has_changed
+  end
+
+  def given_the_providers_can_change_offers_feature_flag_is_on
+    FeatureFlag.activate('providers_can_change_offers')
+  end
+
+  def and_i_am_logged_in_as_a_provider
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def and_i_have_made_an_offer_to_a_candidate
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    @application_choice = create(:application_choice, :with_offer,
+                                 course_option: course_option,
+                                 application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
+  end
+
+  def when_i_visit_their_application
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_click_change_offer
+    click_link 'Change decision'
+  end
+
+  def and_i_choose_to_reject_the_offer
+    choose 'Change offer to rejection'
+    click_button 'Continue'
+  end
+
+  def and_i_complete_the_rejection_flow
+    fill_in 'Tell the candidate why their application was rejected', with: 'The course is full now'
+    click_button 'Continue'
+    click_button 'Confirm rejection'
+  end
+
+  def then_i_should_see_the_application_again
+    expect(page).to have_current_path(
+      provider_interface_application_choice_path(
+        @application_choice.id,
+      )
+    )
+  end
+
+  def and_i_should_see_the_application_status_has_changed
+    expect(page).to have_content('Rejected')
+  end
+end

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -99,6 +99,6 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_can_see_the_application_has_an_offer_made
-    expect(page).to have_content 'Application status changed to ‘Offer Made’'
+    expect(page).to have_content 'Application status changed to ‘Offer made’'
   end
 end


### PR DESCRIPTION
## Draft for now

Needs a look from designers. There’s an argument that the radio buttons are unnecessary and these alternatives could be links instead

## Context

Providers need to be able to reject applications that already have offers.

## Changes proposed in this pull request

Create a new `ChangeDecision` controller in the Provider Interface. Its job is to present users with a set of radio buttons and redirect them to the right place once they pick one.

<img width="1052" alt="Screenshot 2020-01-16 at 17 27 40" src="https://user-images.githubusercontent.com/642279/72547915-861bdc00-3885-11ea-8c66-ba339b24520c.png">

<img width="1077" alt="Screenshot 2020-01-16 at 17 12 02" src="https://user-images.githubusercontent.com/642279/72547893-77cdc000-3885-11ea-8041-fdb969c35578.png">

The copy is mine 😬 

## Link to Trello card

https://trello.com/c/KLy8enLu/1482-ui-reject-offered-applications

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
