### PR TITLE
Skip the 'waiting to be sent' state in sandbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,4 @@ BYPASS_DFE_SIGN_IN=true
 GOVUK_NOTIFY_CALLBACK_API_KEY=
 DSI_API_URL=https://test-api.signin.education.gov.uk
 DSI_API_SECRET=xxxxxxxxxxxx-xxxxx-xxxxxxxx-xxxxxxxx
+SANDBOX=false

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -53,4 +53,8 @@ module HostingEnvironment
   def self.production?
     environment_name == 'production'
   end
+
+  def self.sandbox?
+    ENV.fetch('SANDBOX') { 'false' } == 'true'
+  end
 end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -55,6 +55,6 @@ module HostingEnvironment
   end
 
   def self.sandbox?
-    ENV.fetch('SANDBOX') { 'false' } == 'true'
+    ENV.fetch('SANDBOX', 'false') == 'true'
   end
 end

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -26,7 +26,7 @@ class ReceiveReference
 
       if @application_form.application_references_complete?
         @application_form.application_choices.includes(:course_option).each do |application_choice|
-          ApplicationStateChange.new(application_choice).references_complete!
+          complete_references(application_choice)
         end
       end
     end
@@ -44,6 +44,13 @@ private
   def referee_must_exist_on_application_form
     if @application_form.application_references.where(email_address: @referee_email).empty?
       errors.add(:referee_email, 'does not match any of the provided referees')
+    end
+  end
+
+  def complete_references(application_choice)
+    ApplicationStateChange.new(application_choice).references_complete!
+    if application_choice.edit_by <= Time.zone.now
+      SendApplicationToProvider.new(application_choice: application_choice).call
     end
   end
 end

--- a/app/services/sandbox_time_limit_calculator.rb
+++ b/app/services/sandbox_time_limit_calculator.rb
@@ -1,0 +1,7 @@
+class SandboxTimeLimitCalculator
+  def initialize(*); end
+
+  def call
+    [0, Time.zone.now]
+  end
+end

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -17,13 +17,13 @@ class SendApplicationToProvider
 private
 
   def set_reject_by_default
-    days = TimeLimitCalculator.new(
+    days, time = TimeLimitCalculator.new(
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     ).call
 
     application_choice.reject_by_default_days = days
-    application_choice.reject_by_default_at = days.business_days.from_now.end_of_day
+    application_choice.reject_by_default_at = time
     application_choice.save!
   end
 end

--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -12,15 +12,13 @@ class SetDeclineByDefault
       application_choices.maximum(:withdrawn_at),
     ].compact.max
 
-    dbd_days = TimeLimitCalculator.new(
+    dbd_days, dbd_time = TimeLimitCalculator.new(
       rule: :decline_by_default,
       effective_date: most_recent_decision_date,
     ).call
 
-    dbd_date = dbd_days.business_days.after(most_recent_decision_date).end_of_day
-
     application_choices.where(status: 'offer').update_all(
-      decline_by_default_at: dbd_date,
+      decline_by_default_at: dbd_time,
       decline_by_default_days: dbd_days,
     )
   end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -34,6 +34,16 @@ private
 
       application_choice.edit_by = edit_by_days.business_days.after(application_form.submitted_at).end_of_day
       ApplicationStateChange.new(application_choice).submit!
+
+      send_to_provider_immediately if sandbox?
     end
+  end
+
+  def sandbox?
+    ENV['SANDBOX'] == 'true'
+  end
+
+  def send_to_provider_immediately
+    # TODO:
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -34,12 +34,12 @@ private
   def submit_application_choice(application_choice)
     return send_to_provider_immediately(application_choice) if sandbox?
 
-    edit_by_days = TimeLimitCalculator.new(
+    edit_by = TimeLimitCalculator.new(
       rule: :edit_by,
       effective_date: application_form.submitted_at,
-    ).call
+    ).call.second
 
-    application_choice.edit_by = edit_by_days.business_days.after(application_form.submitted_at).end_of_day
+    application_choice.edit_by = edit_by
     ApplicationStateChange.new(application_choice).submit!
   end
 

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -32,17 +32,13 @@ private
   end
 
   def submit_application_choice(application_choice)
-    edit_by = time_limit_calculator.call.second
-    application_choice.edit_by = edit_by
+    _edit_by_days, edit_by_time = time_limit_calculator.call
+    application_choice.edit_by = edit_by_time
     ApplicationStateChange.new(application_choice).submit!
   end
 
-  def sandbox?
-    ENV.fetch('SANDBOX') { 'false' } == 'true'
-  end
-
   def time_limit_calculator
-    klass = sandbox? ? SandboxTimeLimitCalculator : TimeLimitCalculator
+    klass = HostingEnvironment.sandbox? ? SandboxTimeLimitCalculator : TimeLimitCalculator
     klass.new(
       rule: :edit_by,
       effective_date: application_form.submitted_at,

--- a/app/services/time_limit_calculator.rb
+++ b/app/services/time_limit_calculator.rb
@@ -7,6 +7,19 @@ class TimeLimitCalculator
   end
 
   def call
+    days = calculate_days
+    [days, calculate_time(days)]
+  end
+
+private
+
+  def calculate_time(days)
+    return nil unless days
+
+    days.business_days.after(effective_date).end_of_day
+  end
+
+  def calculate_days
     to_and_from_time_limits.each do |time_limit|
       return time_limit.limit if effective_date <= time_limit.to_date && effective_date >= time_limit.from_date
     end
@@ -18,8 +31,6 @@ class TimeLimitCalculator
     end
     default_time_limit&.limit
   end
-
-private
 
   def time_limits_for_rule
     @time_limits_for_rule ||= TimeLimitConfig.limits_for(rule)

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -51,6 +51,7 @@ parameters:
   stateChangeSlackUrl:
   customAvailabilityMonitors: []
   alertRecipientEmails: []
+  sandbox:
   commonResourceTags: '{
     "Parent Business Service": "Teacher Services",
     "Service Offering": "Become a Teacher"
@@ -143,7 +144,8 @@ jobs:
                 -alertRecipientEmails "${{parameters.alertRecipientEmails}}"
                 -dsiApiUrl "${{parameters.dsiApiUrl}}"
                 -dsiApiSecret "${{parameters.dsiApiSecret}}"
-                -govukNotifyCallbackAPIKey "${{parameters.govukNotifyCallbackAPIKey}}"'
+                -govukNotifyCallbackAPIKey "${{parameters.govukNotifyCallbackAPIKey}}"
+                -sandbox "${{parameters.sandbox}}"'
               deploymentOutputs: DeploymentOutput
 
           - task: AzurePowerShell@3

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -93,6 +93,7 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      sandbox: '$(sandbox)'
 
 - stage: deploy_sandbox
   displayName: 'Deploy - Sandbox'
@@ -144,6 +145,7 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      sandbox: '$(sandbox)'
 
 
 - stage: deploy_production
@@ -200,4 +202,4 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
-
+      sandbox: '$(sandbox)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ stages:
         AUTHORISED_HOSTS: $(authorisedHosts)
         FIND_BASE_URL: $(findBaseUrl)
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+        SANDBOX: $(sandbox)
 
     - script: make ci.lint-ruby
       displayName: 'Rubocop'
@@ -60,6 +61,7 @@ stages:
         AUTHORISED_HOSTS: $(authorisedHosts)
         FIND_BASE_URL: $(findBaseUrl)
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+        SANDBOX: $(sandbox)
 
     - script: make ci.lint-erb
       displayName: 'ERB lint'
@@ -71,6 +73,7 @@ stages:
         AUTHORISED_HOSTS: $(authorisedHosts)
         FIND_BASE_URL: $(findBaseUrl)
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+        SANDBOX: $(sandbox)
 
     - script: |
         make ci.cucumber
@@ -91,6 +94,7 @@ stages:
         AUTHORISED_HOSTS: $(authorisedHosts)
         FIND_BASE_URL: $(findBaseUrl)
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+        SANDBOX: $(sandbox)
 
     - script: |
         make ci.test
@@ -111,6 +115,7 @@ stages:
         AUTHORISED_HOSTS: $(authorisedHosts)
         FIND_BASE_URL: $(findBaseUrl)
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+        SANDBOX: $(sandbox)
 
     - task: Docker@1
       displayName: Tag image with current build number $(Build.BuildNumber)
@@ -196,6 +201,7 @@ stages:
       govukNotifyCallbackAPIKey: $(govukNotifyCallbackAPIKey)
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
+      sandbox: '$(sandbox)'
 
 
 - stage: deploy_devops
@@ -247,4 +253,4 @@ stages:
       govukNotifyCallbackAPIKey: '$(govukNotifyCallbackAPIKey)'
       dsiApiUrl: '$(dsiApiUrl)'
       dsiApiSecret: '$(dsiApiSecret)'
-
+      sandbox: '$(sandbox)'

--- a/azure/template.json
+++ b/azure/template.json
@@ -360,6 +360,12 @@
           "metadata": {
               "description": "GOV.UK Notify service callback API key."
           }
+        },
+        "sandbox": {
+            "type": "string",
+            "metadata": {
+                "description": "Set this to 'true' to switch on Sandox-specific business logic"
+            }
         }
     },
     "variables": {
@@ -702,10 +708,14 @@
                                 "secureValue": "[concat('rediss://:', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')), '2018-03-01').primaryKey, '@', parameters('redisCacheName'), '.redis.cache.windows.net:6380')]"
                             },
                             {
-                              "name": "GOVUK_NOTIFY_CALLBACK_API_KEY",
-                              "secureValue": "[parameters('govukNotifyCallbackAPIKey')]"
+                                "name": "GOVUK_NOTIFY_CALLBACK_API_KEY",
+                                "secureValue": "[parameters('govukNotifyCallbackAPIKey')]"
+                            },
+                            {
+                                "name": "SANDBOX",
+                                "value": "[parameters('sandbox')]"
                             }
-			]
+                        ]
                     }
                 }
             },
@@ -713,7 +723,7 @@
                 "app-service-plan",
                 "app-service-certificate",
                 "redis-cache",
-		"postgresql-database"
+                "postgresql-database"
             ]
         },
         {

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -25,3 +25,4 @@ services:
       - STATE_CHANGE_SLACK_URL
       - DSI_API_URL
       - DSI_API_SECRET
+      - SANDBOX

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -22,12 +22,13 @@ RSpec.describe SendApplicationToProvider do
   end
 
   it 'sets the `reject_by_default_at` date and `reject_by_default_days`' do
-    time_limit_calculator = instance_double(TimeLimitCalculator, call: 20)
+    reject_by_default_at = 20.business_days.from_now.end_of_day
+    time_limit_calculator = instance_double(TimeLimitCalculator, call: [20, reject_by_default_at])
     allow(TimeLimitCalculator).to receive(:new).and_return(time_limit_calculator)
 
     SendApplicationToProvider.new(application_choice: application_choice).call
 
-    expect(application_choice.reload.reject_by_default_at.round).to eq 20.business_days.from_now.end_of_day.round
+    expect(application_choice.reload.reject_by_default_at.round).to eq reject_by_default_at.round
     expect(application_choice.reject_by_default_days).to eq 20
   end
 

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe SetDeclineByDefault do
   describe '#call' do
     let(:application_form) { create(:completed_application_form, application_choices_count: 3) }
     let(:choices) { application_form.application_choices }
-    let(:time_limit_calculator) { instance_double('TimeLimitCalculator', call: 10) }
     let(:now) { Time.zone.local(2019, 11, 26, 12, 0, 0) }
+    let(:time_limit_calculator) { instance_double('TimeLimitCalculator', call: [10, 9.business_days.after(now).end_of_day]) }
     let(:call_service) { SetDeclineByDefault.new(application_form: application_form).call }
 
     before { allow(TimeLimitCalculator).to receive(:new).and_return(time_limit_calculator) }

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SubmitApplication do
         end
       end
 
-      it 'sets the edit_by timestamp to now and pushes the status on to `awaiting_provider_decision`' do
+      it 'sets the edit_by timestamp to now' do
         application_form = create_application_form
         now = Time.zone.local(2019, 11, 11, 15, 0, 0)
         Timecop.freeze(now) do

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -2,20 +2,22 @@ require 'rails_helper'
 
 RSpec.describe SubmitApplication do
   describe 'Submit an application' do
-    let(:application_form) { create(:application_form) }
-
-    before do
+    def create_application_form
+      application_form ||= create(:application_form)
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
+      application_form
     end
 
     it 'updates the application to Submitted' do
+      application_form = create_application_form
       SubmitApplication.new(application_form).call
       expect(application_form.application_choices[0]).to be_awaiting_references
       expect(application_form.application_choices[1]).to be_awaiting_references
     end
 
     it 'sets application_form.submitted_at' do
+      application_form = create_application_form
       Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
         expected_edit_by = Time.zone.local(2019, 11, 18).end_of_day # business days
         SubmitApplication.new(application_form).call
@@ -27,6 +29,7 @@ RSpec.describe SubmitApplication do
     end
 
     it 'sends Slack notifications' do
+      application_form = create_application_form
       allow(SlackNotificationWorker).to receive(:perform_async)
       SubmitApplication.new(application_form).call
       expect(SlackNotificationWorker).to have_received(:perform_async).once # per application_form, not application_choices
@@ -40,6 +43,7 @@ RSpec.describe SubmitApplication do
       end
 
       it 'sets the edit_by timestamp to now and pushes the status on to `awaiting_provider_decision`' do
+        application_form = create_application_form
         now = Time.zone.local(2019, 11, 11, 15, 0, 0)
         Timecop.freeze(now) do
           SubmitApplication.new(application_form).call

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SubmitApplication do
   describe 'Submit an application' do
     def create_application_form
-      application_form ||= create(:application_form)
+      application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
       application_form

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SubmitApplication do
         end
       end
 
-      it 'sets the edit_by timestamp to now' do
+      it 'sets the edit_by timestamp to now and pushes the status on to `awaiting_provider_decision`' do
         now = Time.zone.local(2019, 11, 11, 15, 0, 0)
         Timecop.freeze(now) do
           SubmitApplication.new(application_form).call

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq 20
+    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day]
   end
 
   it 'returns value for rule with `from_date` when effective date matches rule' do
@@ -31,7 +31,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq 10
+    expect(calculator.call).to eq [10, Time.zone.local(2019, 6, 17).end_of_day]
   end
 
   it 'returns value for default rule rather than one with `from_date` when effective date does not match rule' do
@@ -45,7 +45,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq 20
+    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day]
   end
 
   it 'returns value for rule with `to_date` and `from_date` when effective date matches rule' do
@@ -60,7 +60,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq 5
+    expect(calculator.call).to eq [5, Time.zone.local(2019, 6, 10).end_of_day]
   end
 
   it 'returns nil when there is no rule for the given effective date' do
@@ -69,6 +69,6 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: 20.days.ago,
     )
-    expect(calculator.call).to eq nil
+    expect(calculator.call).to eq [nil, nil]
   end
 end


### PR DESCRIPTION
## Context

When testing the application workflow in a Sandbox environment it's not practical for providers to wait for 5 business days before seeing a complete referenced application. So we need to skip the wait period.

## Changes proposed in this pull request

- Assume that in the Sandbox there will be an environment variable called `SANDBOX` set to `true`. Add it to the Azure config files as per instructions.
- Adjust the `SubmitApplication` service to set the `edit_by` date to now so that the normal delay is skipped.
- Adjust the `ReceiveReference` service so that it immediately calls the `SendApplicationToProvider` service iff the references are complete and the `edit_by` time has elapsed so that providers don't have to wait for scheduled jobs to run.
- Encapsulate the business days/end of day calculation in TimeLimitCalculator to reduce and make it easier to customise the absolute time limit (not just a number of working days).

Note that this change will be more useful when we implement a mechanism for automatic reference completion in the Sandbox.

## Guidance to review

- Are the tests adequate?
- Does it make sense to trigger `SendApplicationToProvider` from `ReceiveReference`?
- Is all the Azure config right (Just followed the instructions, I don't understand it!)

## Link to Trello card

https://trello.com/c/2rnwDpEo/1529-in-the-sandbox-skip-the-waiting-to-be-sent-state

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
