### PR TITLE
Retain course selection from find

### DIFF
--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -29,7 +29,13 @@ module CandidateInterface
   private
 
     def candidate_sign_up_form_params
-      params.require(:candidate_interface_sign_up_form).permit(:email_address, :accept_ts_and_cs)
+      params.require(:candidate_interface_sign_up_form).permit(:email_address, :accept_ts_and_cs).merge(course_id: course_id)
+    end
+
+    def course_id
+      @provider = Provider.find_by(code: params[:providerCode])
+      @course = @provider.courses.find_by(code: params[:courseCode]) if @provider.present?
+      @course.id if @course.present?
     end
   end
 end

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
       if !@eligibility_form.valid?
         render :eligibility
       elsif @eligibility_form.eligible_to_use_dfe_apply?
-        redirect_to candidate_interface_sign_up_path
+        redirect_to candidate_interface_sign_up_path(providerCode: params[:providerCode], courseCode: params[:courseCode])
       else
         redirect_to candidate_interface_not_eligible_path
       end

--- a/app/models/candidate_interface/sign_up_form.rb
+++ b/app/models/candidate_interface/sign_up_form.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class SignUpForm
     include ActiveModel::Model
-    attr_accessor :email_address, :accept_ts_and_cs, :candidate
+    attr_accessor :email_address, :accept_ts_and_cs, :candidate, :course_from_find_id
 
     validates :email_address, :accept_ts_and_cs, presence: true
     validates :email_address, length: { maximum: 100 }
@@ -12,6 +12,7 @@ module CandidateInterface
       @email_address = params[:email_address]
       @accept_ts_and_cs = params[:accept_ts_and_cs]
       @candidate = Candidate.for_email @email_address
+      @course_from_find_id = params[:course_from_find_id]
     end
 
     def existing_candidate?
@@ -21,6 +22,7 @@ module CandidateInterface
     def save
       return false if existing_candidate? || !valid?
 
+      candidate.course_from_find_id = course_from_find_id
       candidate.save
     end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,6 +4,7 @@ class FeatureFlag
     training_with_a_disability
     edit_application
     send_reference_email_via_support
+    confirm_course_choice_from_find
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -37,7 +37,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= govuk_button_link_to t('apply_from_find.apply_button'), candidate_interface_eligibility_path, class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-3' %>
+      <%= govuk_button_link_to t('apply_from_find.apply_button'), candidate_interface_eligibility_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-3' %>
     </p>
 
     <p class="govuk-body">or</p>

--- a/app/views/candidate_interface/sign_up/new.html.erb
+++ b/app/views/candidate_interface/sign_up/new.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= form_with model: @sign_up_form, url: candidate_interface_sign_up_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
+    <%= form_with model: @sign_up_form, url: candidate_interface_sign_up_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), builder: GOVUKDesignSystemFormBuilder::FormBuilder, html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @eligibility_form, url: candidate_interface_eligibility_path, method: :post do |f| %>
+    <%= form_with model: @eligibility_form, url: candidate_interface_eligibility_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">

--- a/db/migrate/20200120120940_add_course_from_find_id_to_candidate_model.rb
+++ b/db/migrate/20200120120940_add_course_from_find_id_to_candidate_model.rb
@@ -1,0 +1,9 @@
+class AddCourseFromFindIdToCandidateModel < ActiveRecord::Migration[6.0]
+  def up
+    add_column :candidates, :course_from_find_id, :integer, default: nil
+  end
+
+  def down
+    remove_column :candidates, :course_from_find_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_20_095434) do
+ActiveRecord::Schema.define(version: 2020_01_20_120940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -148,6 +148,7 @@ ActiveRecord::Schema.define(version: 2020_01_20_095434) do
     t.string "magic_link_token"
     t.datetime "magic_link_token_sent_at"
     t.boolean "hide_in_reporting", default: false, null: false
+    t.bigint "course_from_find_id"
     t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
     t.index ["magic_link_token"], name: "index_candidates_on_magic_link_token", unique: true
   end

--- a/spec/models/candidate_interface/sign_up_form_spec.rb
+++ b/spec/models/candidate_interface/sign_up_form_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
   let(:existing_candidate) { create(:candidate) }
   let(:existing_email) { existing_candidate.email_address }
 
-  def new_form(email:, accept_ts_and_cs:)
-    described_class.new(email_address: email, accept_ts_and_cs: accept_ts_and_cs)
+  def new_form(email:, accept_ts_and_cs:, course_from_find_id: nil)
+    described_class.new(email_address: email, accept_ts_and_cs: accept_ts_and_cs, course_from_find_id: course_from_find_id)
   end
 
   describe '#save' do
@@ -42,6 +42,12 @@ RSpec.describe CandidateInterface::SignUpForm, type: :model do
       form = new_form(email: existing_email.upcase, accept_ts_and_cs: true)
       expect(form.existing_candidate?).to eq(true)
       expect(form.save).to eq(false)
+    end
+
+    it 'returns true if course_from_find_id if a value is given for course_from_find_id' do
+      form = new_form(email: new_email, accept_ts_and_cs: true, course_from_find_id: 12)
+      expect(form.save).to eq(true)
+      expect(form.course_from_find_id).to eq(12)
     end
   end
 

--- a/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
     when_i_arrive_from_find_with_invalid_course_parameters
     then_i_should_see_an_error_page
 
-    given_confirm_course_choice_from_find_is_activated
-
     when_i_arrive_from_find_to_a_course_that_is_ucas_only
     then_i_should_see_the_landing_page
     and_i_should_see_the_provider_and_course_codes
@@ -22,12 +20,6 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
     then_i_should_be_able_to_apply_through_apply
-
-    when_i_arrive_from_find_to_a_course_that_is_open_on_apply
-    and_i_click_apply_on_apply
-    then_the_url_should_contain_the_course_code_and_provider_code_param
-    and_i_fill_in_the_eligiblity_form_with_yes
-    then_the_url_should_contain_the_course_code_and_provider_code_param
 
     when_i_visit_the_available_courses_page
     then_i_should_see_the_available_providers_and_courses
@@ -43,10 +35,6 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def given_confirm_course_choice_from_find_is_activated
-    FeatureFlag.activate('confirm_course_choice_from_find')
   end
 
   def when_i_arrive_from_find_with_invalid_course_parameters
@@ -69,8 +57,8 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def when_i_arrive_from_find_to_a_course_that_is_open_on_apply
-    @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
-    visit candidate_interface_apply_from_find_path providerCode: @course.provider.code, courseCode: @course.code
+    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
+    visit candidate_interface_apply_from_find_path providerCode: course.provider.code, courseCode: course.code
   end
 
   def then_i_should_see_the_landing_page
@@ -102,26 +90,5 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   def then_i_should_see_the_available_providers_and_courses
     expect(page).to have_content 'Biology'
     expect(page).to have_content 'Potions'
-  end
-
-  def and_i_click_apply_on_apply
-    click_on t('apply_from_find.apply_button')
-  end
-
-  def then_the_url_should_contain_the_course_code_and_provider_code_param
-    expect(page.current_url).to have_content "providerCode=#{@course.provider.code}"
-    expect(page.current_url).to have_content "courseCode=#{@course.code}"
-  end
-
-  def and_i_fill_in_the_eligiblity_form_with_yes
-    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
-      choose 'Yes'
-    end
-
-    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
-      choose 'Yes'
-    end
-
-    click_on 'Continue'
   end
 end

--- a/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
     when_i_arrive_from_find_with_invalid_course_parameters
     then_i_should_see_an_error_page
 
+    given_confirm_course_choice_from_find_is_activated
+
     when_i_arrive_from_find_to_a_course_that_is_ucas_only
     then_i_should_see_the_landing_page
     and_i_should_see_the_provider_and_course_codes
@@ -20,6 +22,12 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
     then_i_should_be_able_to_apply_through_apply
+
+    when_i_arrive_from_find_to_a_course_that_is_open_on_apply
+    and_i_click_apply_on_apply
+    then_the_url_should_contain_the_course_code_and_provider_code_param
+    and_i_fill_in_the_eligiblity_form_with_yes
+    then_the_url_should_contain_the_course_code_and_provider_code_param
 
     when_i_visit_the_available_courses_page
     then_i_should_see_the_available_providers_and_courses
@@ -35,6 +43,10 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def given_confirm_course_choice_from_find_is_activated
+    FeatureFlag.activate('confirm_course_choice_from_find')
   end
 
   def when_i_arrive_from_find_with_invalid_course_parameters
@@ -57,8 +69,8 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def when_i_arrive_from_find_to_a_course_that_is_open_on_apply
-    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
-    visit candidate_interface_apply_from_find_path providerCode: course.provider.code, courseCode: course.code
+    @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
+    visit candidate_interface_apply_from_find_path providerCode: @course.provider.code, courseCode: @course.code
   end
 
   def then_i_should_see_the_landing_page
@@ -90,5 +102,26 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   def then_i_should_see_the_available_providers_and_courses
     expect(page).to have_content 'Biology'
     expect(page).to have_content 'Potions'
+  end
+
+  def and_i_click_apply_on_apply
+    click_on t('apply_from_find.apply_button')
+  end
+
+  def then_the_url_should_contain_the_course_code_and_provider_code_param
+    expect(page.current_url).to have_content "providerCode=#{@course.provider.code}"
+    expect(page.current_url).to have_content "courseCode=#{@course.code}"
+  end
+
+  def and_i_fill_in_the_eligiblity_form_with_yes
+    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
+      choose 'Yes'
+    end
+
+    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
+      choose 'Yes'
+    end
+
+    click_on 'Continue'
   end
 end

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'A new candidate arriving from Find with a course and provider code' do
+  include FindAPIHelper
+
+  scenario 'retaining their course selection through the sign up process' do
+    given_confirm_course_choice_from_find_is_activated
+
+    when_i_arrive_from_find_to_a_course_that_is_open_on_apply
+    and_i_click_apply_on_apply
+    then_the_url_should_contain_the_course_code_and_provider_code_param
+    and_i_fill_in_the_eligiblity_form_with_yes
+    then_the_url_should_contain_the_course_code_and_provider_code_param
+  end
+
+  def given_confirm_course_choice_from_find_is_activated
+    FeatureFlag.activate('confirm_course_choice_from_find')
+  end
+
+  def when_i_arrive_from_find_to_a_course_that_is_open_on_apply
+    @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
+    visit candidate_interface_apply_from_find_path providerCode: @course.provider.code, courseCode: @course.code
+  end
+
+  def and_i_click_apply_on_apply
+    click_on t('apply_from_find.apply_button')
+  end
+
+  def then_the_url_should_contain_the_course_code_and_provider_code_param
+    expect(page.current_url).to have_content "providerCode=#{@course.provider.code}"
+    expect(page.current_url).to have_content "courseCode=#{@course.code}"
+  end
+
+  def and_i_fill_in_the_eligiblity_form_with_yes
+    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
+      choose 'Yes'
+    end
+
+    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
+      choose 'Yes'
+    end
+
+    click_on 'Continue'
+  end
+end


### PR DESCRIPTION
## Context

A new users course selection from find is currently not being retained through the sign-up process for a non-signed in user.

This PR contains the initial stages required to implement this feature.
 
## Changes proposed in this pull request

- Pass courseCode and providerCode params through the apply, eligibility and sign-up pages/controllers
- Migration to add a column to the Candidate model for storing the selected course id
- Logic to save this id if is a new candidate

**Out of Scope(to be added in follow up PRs)** 

- Users who selected a course with one site will be redirected to the course choices page with their selected course
- Users who selected a course with multiple sites will be redirected to the site selection page for the relevant course
- Users who have already signed up to apply

## Guidance to review

You could test this by running the app locally and signing up with a course form an opted in provider e.g. '1N1' '238T'

Any feedback would be appreciated.

## Link to Trello card

https://trello.com/c/EQQoWqun/632-you-selected-a-course-page-a-candidate-can-confirm-their-course-choice-if-they-have-come-from-find

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
