### PR TITLE
Merge provider_interface and provider_interface_sign_in paths

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -50,7 +50,7 @@ module ProviderInterface
       end
 
       session['post_dfe_sign_in_path'] = request.path
-      redirect_to provider_interface_sign_in_path
+      redirect_to provider_interface_path
     end
 
     def add_identity_to_log

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -3,7 +3,9 @@ module ProviderInterface
     skip_before_action :authenticate_provider_user!
     skip_before_action :check_data_sharing_agreements
 
-    def new; end
+    def new
+      redirect_to provider_interface_applications_path if current_provider_user
+    end
 
     def destroy
       DfESignInUser.end_session!(session)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,8 +252,6 @@ Rails.application.routes.draw do
   end
 
   namespace :provider_interface, path: '/provider' do
-    get '/' => redirect('/provider/applications')
-
     get '/accessibility', to: 'content#accessibility'
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/cookies', to: 'content#cookies_provider', as: :cookies
@@ -274,7 +272,7 @@ Rails.application.routes.draw do
     post '/applications/:application_choice_id/offer/confirm' => 'decisions#confirm_offer', as: :application_choice_confirm_offer
     post '/applications/:application_choice_id/offer' => 'decisions#create_offer', as: :application_choice_create_offer
 
-    get '/sign-in' => 'sessions#new'
+    get '/' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
   end
 

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'See applications' do
     and_another_organisation_has_applications
 
     when_i_have_been_assigned_to_my_training_provider
-    and_i_visit_the_provider_page
+    and_i_visit_a_provider_page
 
     then_i_should_see_no_applications
   end
@@ -19,12 +19,12 @@ RSpec.feature 'See applications' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_applications
 
-    when_i_visit_the_provider_page
+    when_i_visit_a_provider_page
     then_i_should_see_the_account_creation_in_progress_page
     and_i_should_see_a_sign_out_link
 
     when_my_apply_account_has_been_created
-    and_i_visit_the_provider_page
+    and_i_visit_a_provider_page
     then_i_should_see_the_applications_from_my_organisation
 
     when_i_click_on_an_application
@@ -70,11 +70,11 @@ RSpec.feature 'See applications' do
     @other_provider_choice = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
   end
 
-  def and_i_visit_the_provider_page
-    visit provider_interface_path
+  def and_i_visit_a_provider_page
+    visit provider_interface_applications_path
   end
 
-  alias :when_i_visit_the_provider_page :and_i_visit_the_provider_page
+  alias :when_i_visit_a_provider_page :and_i_visit_a_provider_page
 
   def then_i_should_see_the_applications_from_my_organisation
     expect(page).to have_content @my_provider_choice1.application_form.first_name


### PR DESCRIPTION
## Context

There is a plan for a public page explaining the provider interface/console, with a sign-up/sign-in/'get access' links/buttons. The ideal path for this page is at `/provider`.

## Changes proposed in this pull request

Merge the sign-in path with root interface path. If a user is authenticated, they are redirected to `/provider/applications`. All other pages redirect to `/provider` if the user has no session.

## Guidance to review

The sign-in route has disappeared, people log in from `/provider`. The rest of the application remains exactly the same.

## Link to Trello card

[Modify DfE sign-in flow to support 'about' content when user is not signed in](https://trello.com/c/KfUknW84)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
