### PR TITLE
Fix broken links in environment variables docs

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -18,28 +18,28 @@ If an environment variable is required for use in the local development environm
 
 `VARIABLE_NAME=Value`
 
-The [.env.example](./.env.example) file contains the essential environment variables that must exist for local development builds to succeed.
+The [.env.example](../.env.example) file contains the essential environment variables that must exist for local development builds to succeed.
 
 ## Docker Compose
 
 For docker compose to make the necessary environment variables available in the container at run time they must be declared in the relevant docker-compose.yaml file, of which there are three.
 
-* [docker-compose.yml](./docker-compose.yml) - Variables that are required for local dev and the docker image build phase in azure only should be defined the *environment* section in this file. This will in general only be for the database.
-* [docker-compose.override.yml](./docker-compose.override.yml) - This file is used exclusively for local development. No further changes are required here.
-* [docker-compose.azure.yml](./docker-compose.azure.yml) - This file is exclusively used in the Azure devops pipeline. Any environment variables required in the Azure build/deployment need to be declared in the *environment* section of this file. **You should only declare the environment variable here, not its value.** The only exception to this is where we need to map variables due to the use of protected variable names, e.g. Rails SECRET_KEY_BASE.
+* [docker-compose.yml](../docker-compose.yml) - Variables that are required for local dev and the docker image build phase in azure only should be defined the *environment* section in this file. This will in general only be for the database.
+* [docker-compose.override.yml](../docker-compose.override.yml) - This file is used exclusively for local development. No further changes are required here.
+* [docker-compose.azure.yml](../docker-compose.azure.yml) - This file is exclusively used in the Azure devops pipeline. Any environment variables required in the Azure build/deployment need to be declared in the *environment* section of this file. **You should only declare the environment variable here, not its value.** The only exception to this is where we need to map variables due to the use of protected variable names, e.g. Rails SECRET_KEY_BASE.
 
 ## Azure Hosting (DevOps pipeline)
 
 These steps describe the process for making environment variables available to the the Azure DevOps pipeline.
 
 1. Declare the desired variable in the appropriate "variable group" in the Library section of the Azure DevOps site (https://dfe-ssp.visualstudio.com/Become-A-Teacher/_library?itemType=VariableGroups). All variable groups related to apply are suffixed as such and there is a variable group per deployment environment.
-1. In the [azure-pipelines.yml](./azure-pipelines.yml) and [azure-pipelines-release.yml](./azure-pipelines-release.yml) file there are several changes to be made:
-   1. (Applies to [azure-pipelines.yml](./azure-pipelines.yml) only) For each "make" command script step, add your environment variable to the *env* section in the format `ENV_VAR_NAME: $(varName)` where **ENV_VAR_NAME** is the environment variable name as it should appear in the docker container and **varName** is the name of the variable defined in the Azure DevOps variable group.
+1. In the [azure-pipelines.yml](../azure-pipelines.yml) and [azure-pipelines-release.yml](../azure-pipelines-release.yml) file there are several changes to be made:
+   1. (Applies to [azure-pipelines.yml](../azure-pipelines.yml) only) For each "make" command script step, add your environment variable to the *env* section in the format `ENV_VAR_NAME: $(varName)` where **ENV_VAR_NAME** is the environment variable name as it should appear in the docker container and **varName** is the name of the variable defined in the Azure DevOps variable group.
    1. For each 'deployment stage' you must add your variable to the template *parameters* section in the format `varName: '$(varName)'`.
-1. In the [azure-pipelines-deploy-template.yaml](./azure-pipelines-deploy-template.yml) file you need to make the following additions:
+1. In the [azure-pipelines-deploy-template.yaml](../azure-pipelines-deploy-template.yml) file you need to make the following additions:
    1. Add your variable to the *parameters* section at the start of the file using the name of the variable as it appears in the variable group.
    1. In the Azure Resource Group deployment task *overrideParameters* section add your variable in the format `-varName: "${{parameters.varName}}"`
-1. In the [azure/template.json](./azure/template.json) file you need to make the following additions:
+1. In the [azure/template.json](../azure/template.json) file you need to make the following additions:
    1. Duplicate this block of code for your new variable in the *parameters* section at the start of the file.
       ```
       "varName": {


### PR DESCRIPTION
## Context

When adding an environment variable recently, it was noticed a few broken links were found in the documentation for adding an environment variable.

## Changes proposed in this pull request

Fixaroo the broken links in `docs/environment-variables.md`