### PR TITLE
Add Climate Control to bounced email specs

### DIFF
--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -29,9 +29,12 @@ RSpec.describe RefereeMailer, type: :mailer do
       expect(body).to include(referee_interface_reference_feedback_url(token: ''))
     end
 
-    it 'sends a request with a notify reference' do
-      mail.deliver_now
-      expect(mail[:reference].value).to eq("test-reference_request-#{reference.id}")
+    it 'sends a request with a Notify reference' do
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'example_env' do
+        mail.deliver_now
+      end
+
+      expect(mail[:reference].value).to eq("example_env-reference_request-#{reference.id}")
     end
   end
 

--- a/spec/services/process_notify_callback_spec.rb
+++ b/spec/services/process_notify_callback_spec.rb
@@ -15,13 +15,19 @@ RSpec.shared_examples "a callback that doesn't change the feedback status of a r
 end
 
 RSpec.describe ProcessNotifyCallback do
+  around do |example|
+    ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'example_env' do
+      example.run
+    end
+  end
+
   let(:reference) do
     application_form = create(:application_form)
     create(:reference, feedback_status: 'feedback_requested', application_form: application_form)
   end
 
   context 'when expected Notify reference is provided' do
-    let(:notify_reference) { "test-reference_request-#{reference.id}" }
+    let(:notify_reference) { "example_env-reference_request-#{reference.id}" }
 
     context 'with permanent-failure status' do
       let(:status) { 'permanent-failure' }
@@ -66,7 +72,7 @@ RSpec.describe ProcessNotifyCallback do
 
     context 'with email type not reference request' do
       let(:email_type) { 'survey_email' }
-      let(:notify_reference) { "test-#{email_type}-#{reference.id}" }
+      let(:notify_reference) { "example_env-#{email_type}-#{reference.id}" }
 
       it_behaves_like "a callback that doesn't change the feedback status of a reference"
     end


### PR DESCRIPTION
## Context

Specs added in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1135 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1150 related to bounced emails passed build but when running tests using Rake, they failed. This was because we assumed that the environment tests would run in would be `test`. However, when doing `bundle exec rake` tests are run in `development`, this seems to be a wider thing so this is sort of a work around but also just better practice.

## Changes proposed in this pull request

This PR adds `ClimateControl` to set the environment variable `HOSTING_ENVIRONMENT_NAME` in the `referee_mailer_spec.rb` and `process_notify_callback_spec.rb`.

## Guidance to review

Does this make sense?

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
