### PR TITLE
Fix skip the 'waiting to be sent' state in sandbox 

### DIFF
--- a/app/models/referee_interface/reference_feedback_form.rb
+++ b/app/models/referee_interface/reference_feedback_form.rb
@@ -13,12 +13,10 @@ module RefereeInterface
     def save
       return unless valid?
 
-      ActiveRecord::Base.transaction do
-        ReceiveReference.new(
-          reference: reference,
-          feedback: feedback,
-        ).save
-      end
+      ReceiveReference.new(
+        reference: reference,
+        feedback: feedback,
+      ).save
     end
   end
 end

--- a/app/models/referee_interface/reference_feedback_form.rb
+++ b/app/models/referee_interface/reference_feedback_form.rb
@@ -15,8 +15,7 @@ module RefereeInterface
 
       ActiveRecord::Base.transaction do
         ReceiveReference.new(
-          application_form: reference.application_form,
-          referee_email: reference.email_address,
+          reference: reference,
           feedback: feedback,
         ).save
       end

--- a/app/models/referee_interface/reference_feedback_form.rb
+++ b/app/models/referee_interface/reference_feedback_form.rb
@@ -14,18 +14,12 @@ module RefereeInterface
       return unless valid?
 
       ActiveRecord::Base.transaction do
-        reference.update!(feedback: feedback, feedback_status: 'feedback_provided')
-
-        # If all of the references have been provided we need to change the
-        # state of the application choices
-        if reference.application_form.application_references_complete?
-          reference.application_form.application_choices.includes(:course_option).find_each do |application_choice|
-            ApplicationStateChange.new(application_choice).references_complete!
-          end
-        end
+        ReceiveReference.new(
+          application_form: reference.application_form,
+          referee_email: reference.email_address,
+          feedback: feedback,
+        ).save
       end
-
-      true
     end
   end
 end

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -7,6 +7,8 @@ class SendApplicationToProvider
   end
 
   def call
+    return false unless application_choice.application_complete?
+
     ActiveRecord::Base.transaction do
       set_reject_by_default
       ApplicationStateChange.new(application_choice).send_to_provider!

--- a/spec/models/referee_interface/reference_feedback_form_spec.rb
+++ b/spec/models/referee_interface/reference_feedback_form_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe RefereeInterface::ReferenceFeedbackForm do
   describe '#save' do
     it 'invokes the ReceiveReference class if input is valid' do
-
       application_form = FactoryBot.create(:completed_application_form, references_count: 0)
       application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
       unsubmitted_reference = build(:reference, :unsubmitted)
@@ -29,6 +28,7 @@ RSpec.describe RefereeInterface::ReferenceFeedbackForm do
         reference: unsubmitted_reference,
         feedback: '',
       ).save
+
       expect(ReceiveReference).not_to have_received(:new)
     end
   end

--- a/spec/models/referee_interface/reference_feedback_form_spec.rb
+++ b/spec/models/referee_interface/reference_feedback_form_spec.rb
@@ -2,57 +2,34 @@ require 'rails_helper'
 
 RSpec.describe RefereeInterface::ReferenceFeedbackForm do
   describe '#save' do
-    it 'progresses the application choices to the "application complete" status once all references have been received' do
+    it 'invokes the ReceiveReference class if input is valid' do
+
       application_form = FactoryBot.create(:completed_application_form, references_count: 0)
       application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
       unsubmitted_reference = build(:reference, :unsubmitted)
       application_form.application_references << unsubmitted_reference
-      application_form.application_references << build(:reference, :complete)
+      allow(ReceiveReference).to receive(:new).and_return(instance_double(ReceiveReference, save: true))
 
-      action = described_class.new(
+      described_class.new(
         reference: unsubmitted_reference,
         feedback: 'A reference',
-      )
+      ).save
 
-      action.save
-
-      expect(application_form.reload).to be_application_references_complete
-      expect(application_form.application_choices).to all(be_application_complete)
+      expect(ReceiveReference).to have_received(:new)
     end
 
-    it 'does not progress the application choices to the "application complete" status without minimum number of references' do
+    it 'does not invoke the ReceiveReference class if input is invalid' do
       application_form = FactoryBot.create(:completed_application_form, references_count: 0)
       application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
       unsubmitted_reference = build(:reference, :unsubmitted)
       application_form.application_references << unsubmitted_reference
+      allow(ReceiveReference).to receive(:new).and_return(instance_double(ReceiveReference, save: true))
 
-      action = described_class.new(
+      described_class.new(
         reference: unsubmitted_reference,
-        feedback: 'A reference',
-      )
-
-      action.save
-
-      expect(application_form).not_to be_application_references_complete
-      expect(application_form.application_choices).to all(be_awaiting_references)
-    end
-
-    it 'progresses the application choices to the "awaiting_provider_decision" status once all references have been received if edit_by expired' do
-      application_form = FactoryBot.create(:completed_application_form, references_count: 0)
-      application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.ago) }
-      unsubmitted_reference = build(:reference, :unsubmitted)
-      application_form.application_references << unsubmitted_reference
-      application_form.application_references << build(:reference, :complete)
-
-      action = described_class.new(
-        reference: unsubmitted_reference,
-        feedback: 'A reference',
-      )
-
-      action.save
-
-      expect(application_form.reload).to be_application_references_complete
-      expect(application_form.application_choices).to all(be_awaiting_provider_decision)
+        feedback: '',
+      ).save
+      expect(ReceiveReference).not_to have_received(:new)
     end
   end
 end

--- a/spec/models/referee_interface/reference_feedback_form_spec.rb
+++ b/spec/models/referee_interface/reference_feedback_form_spec.rb
@@ -36,5 +36,23 @@ RSpec.describe RefereeInterface::ReferenceFeedbackForm do
       expect(application_form).not_to be_application_references_complete
       expect(application_form.application_choices).to all(be_awaiting_references)
     end
+
+    it 'progresses the application choices to the "awaiting_provider_decision" status once all references have been received if edit_by expired' do
+      application_form = FactoryBot.create(:completed_application_form, references_count: 0)
+      application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.ago) }
+      unsubmitted_reference = build(:reference, :unsubmitted)
+      application_form.application_references << unsubmitted_reference
+      application_form.application_references << build(:reference, :complete)
+
+      action = described_class.new(
+        reference: unsubmitted_reference,
+        feedback: 'A reference',
+      )
+
+      action.save
+
+      expect(application_form.reload).to be_application_references_complete
+      expect(application_form.application_choices).to all(be_awaiting_provider_decision)
+    end
   end
 end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SubmitApplication do
-  describe 'Submit an application' do
+  describe 'Submit an application', sandbox: false do
     def create_application_form
       application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: 'unsubmitted')
@@ -35,13 +35,7 @@ RSpec.describe SubmitApplication do
       expect(SlackNotificationWorker).to have_received(:perform_async).once # per application_form, not application_choices
     end
 
-    context 'when running in a provider sandbox' do
-      around do |example|
-        ClimateControl.modify(SANDBOX: 'true') do
-          example.run
-        end
-      end
-
+    context 'when running in a provider sandbox', sandbox: true do
       it 'sets the edit_by timestamp to now' do
         application_form = create_application_form
         now = Time.zone.local(2019, 11, 11, 15, 0, 0)

--- a/spec/support/sandbox.rb
+++ b/spec/support/sandbox.rb
@@ -1,0 +1,13 @@
+RSpec.configure do |config|
+  config.around sandbox: true do |example|
+    ClimateControl.modify(SANDBOX: 'true') do
+      example.run
+    end
+  end
+
+  config.around sandbox: false do |example|
+    ClimateControl.modify(SANDBOX: 'false') do
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
## Context

The business logic that was originally in the `ReceiveReference` service class moved to `RefereeInterface::ReferenceFeedbackForm`. While this was happening https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1140/files modified `ReceiveReference` with some extra logic needed to support Sandbox. This logic needs to be moved to `RefereeInterface::ReferenceFeedbackForm`.

We also need to remove the `ReceiveReference` class but this will be covered in a separate PR.

## Changes proposed in this pull request

- Add logic to `RefereeInterface::ReferenceFeedbackForm` to move straight to `awaiting_provider_decision` when all references are complete and `edit_by` is in the past (the edit by time limit has expired).

## Guidance to review

- Is the one new test adequate?
- Are we mixing too many concerns into the form object here?

Note that https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1140 already ensures that `edit_by` is set to the current time when operating in the Sandbox.

## Link to Trello card

Original card was:

https://trello.com/c/2rnwDpEo/1529-in-the-sandbox-skip-the-waiting-to-be-sent-state

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
