### PR TITLE
Refactor test application generation

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,0 +1,99 @@
+module TestApplications
+  def self.create_an_application(application_index)
+    first_name = Faker::Name.unique.first_name
+    last_name = Faker::Name.unique.last_name
+    candidate = FactoryBot.create(
+      :candidate,
+      email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
+    )
+
+    Audited.audit_class.as_user(candidate) do
+      application_form = FactoryBot.create(
+        :completed_application_form,
+        application_choices_count: 0,
+        submitted_at: nil,
+        candidate: candidate,
+        first_name: first_name,
+        last_name: last_name,
+      )
+
+      [1, 2, 3].sample.times do
+        FactoryBot.create(
+          :application_choice,
+          status: 'unsubmitted',
+          course_option: CourseOption.all.sample,
+          application_form: application_form,
+          personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
+        )
+      end
+
+      return if application_index == 1
+
+      # The application is submitted by the candidate
+      SubmitApplication.new(application_form).call
+
+      return if application_index == 2
+
+      # References come in
+      application_form.application_references.each do |reference|
+        ReceiveReference.new(
+          application_form: application_form,
+          referee_email: reference.email_address,
+          feedback: 'You are awesome',
+        ).save
+      end
+
+      return if application_index == 3
+
+      application_form.reload
+
+      application_form.application_choices.each do |application_choice|
+        # This is only supposed to happen after 7 days, but SendApplicationToProvider
+        # doesn't check the `edit_by` date of the ApplicationChoice
+        SendApplicationToProvider.new(application_choice: application_choice).call
+
+        # This is so the application is no longer amendable
+        application_choice.update(edit_by: Time.zone.now)
+      end
+
+      return if application_index == 4
+
+      main_application_choice = application_form.application_choices[0]
+
+      # First one gets an offer
+      MakeAnOffer.new(application_choice: main_application_choice, offer_conditions: ['Complete DBS']).save
+
+      return if application_index == 5
+
+      if (second = application_form.application_choices[1])
+        RejectApplication.new(application_choice: second, rejection_reason: 'Some').save
+      end
+
+      return if application_index == 6
+
+      if (third = application_form.application_choices[2])
+        RejectApplication.new(application_choice: third, rejection_reason: 'Some').save
+      end
+
+      if application_index == 7
+        DeclineOffer.new(application_choice: main_application_choice).save!
+        return
+      end
+
+      AcceptOffer.new(application_choice: main_application_choice).save!
+
+      return if application_index == 9
+
+      ConfirmOfferConditions.new(application_choice: main_application_choice).save
+
+      if application_index == 10
+        ConfirmEnrolment.new(application_choice: main_application_choice).save
+        return
+      end
+
+      if application_index == 11
+        WithdrawApplication.new(application_choice: main_application_choice).save!
+      end
+    end
+  end
+end

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -6,7 +6,7 @@ class GenerateTestApplications
 
     without_slack_message_sending do
       (1..11).each do |i|
-        create_an_application(i)
+        TestApplications.create_an_application(i)
       end
     end
   end
@@ -17,103 +17,5 @@ private
     RequestStore.store[:disable_slack_messages] = true
     yield
     RequestStore.store[:disable_slack_messages] = false
-  end
-
-  def create_an_application(application_index)
-    first_name = Faker::Name.unique.first_name
-    last_name = Faker::Name.unique.last_name
-    candidate = FactoryBot.create(
-      :candidate,
-      email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
-    )
-
-    Audited.audit_class.as_user(candidate) do
-      application_form = FactoryBot.create(
-        :completed_application_form,
-        application_choices_count: 0,
-        submitted_at: nil,
-        candidate: candidate,
-        first_name: first_name,
-        last_name: last_name,
-      )
-
-      [1, 2, 3].sample.times do
-        FactoryBot.create(
-          :application_choice,
-          status: 'unsubmitted',
-          course_option: CourseOption.all.sample,
-          application_form: application_form,
-          personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
-        )
-      end
-
-      return if application_index == 1
-
-      # The application is submitted by the candidate
-      SubmitApplication.new(application_form).call
-
-      return if application_index == 2
-
-      # References come in
-      application_form.application_references.each do |reference|
-        ReceiveReference.new(
-          application_form: application_form,
-          referee_email: reference.email_address,
-          feedback: 'You are awesome',
-        ).save
-      end
-
-      return if application_index == 3
-
-      application_form.reload
-
-      application_form.application_choices.each do |application_choice|
-        # This is only supposed to happen after 7 days, but SendApplicationToProvider
-        # doesn't check the `edit_by` date of the ApplicationChoice
-        SendApplicationToProvider.new(application_choice: application_choice).call
-
-        # This is so the application is no longer amendable
-        application_choice.update(edit_by: Time.zone.now)
-      end
-
-      return if application_index == 4
-
-      main_application_choice = application_form.application_choices[0]
-
-      # First one gets an offer
-      MakeAnOffer.new(application_choice: main_application_choice, offer_conditions: ['Complete DBS']).save
-
-      return if application_index == 5
-
-      if (second = application_form.application_choices[1])
-        RejectApplication.new(application_choice: second, rejection_reason: 'Some').save
-      end
-
-      return if application_index == 6
-
-      if (third = application_form.application_choices[2])
-        RejectApplication.new(application_choice: third, rejection_reason: 'Some').save
-      end
-
-      if application_index == 7
-        DeclineOffer.new(application_choice: main_application_choice).save!
-        return
-      end
-
-      AcceptOffer.new(application_choice: main_application_choice).save!
-
-      return if application_index == 9
-
-      ConfirmOfferConditions.new(application_choice: main_application_choice).save
-
-      if application_index == 10
-        ConfirmEnrolment.new(application_choice: main_application_choice).save
-        return
-      end
-
-      if application_index == 11
-        WithdrawApplication.new(application_choice: main_application_choice).save!
-      end
-    end
   end
 end

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -5,9 +5,18 @@ class GenerateTestApplications
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
     without_slack_message_sending do
-      (1..11).each do |i|
-        TestApplications.create_an_application(i)
-      end
+      TestApplications.create_application [:unsubmitted]
+      TestApplications.create_application [:awaiting_references]
+      TestApplications.create_application [:application_complete]
+      TestApplications.create_application [:awaiting_provider_decision]
+      TestApplications.create_application %i[offer offer]
+      TestApplications.create_application %i[offer rejected]
+      TestApplications.create_application %i[rejected rejected]
+      TestApplications.create_application [:declined]
+      TestApplications.create_application [:accepted]
+      TestApplications.create_application [:recruited]
+      TestApplications.create_application [:enrolled]
+      TestApplications.create_application [:withdrawn]
     end
   end
 

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe GenerateTestApplications do
 
   it 'generates 11 test candidates with applications in various states' do
     GenerateTestApplications.new.perform
-    expect(Candidate.count).to be 11
+
+    expect(Candidate.count).to be 12
     expect(ApplicationChoice.pluck(:status)).to include(
       'awaiting_provider_decision',
       'awaiting_references',

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe GenerateTestApplications do
+  before do
+    create(:course_option)
+  end
+
+  it 'generates 11 test candidates with applications in various states' do
+    GenerateTestApplications.new.perform
+    expect(Candidate.count).to be 11
+    expect(ApplicationChoice.pluck(:status)).to include(
+      'awaiting_provider_decision',
+      'awaiting_references',
+      'offer',
+      'rejected',
+      'declined',
+      'withdrawn',
+      'recruited',
+      'enrolled',
+    )
+  end
+end


### PR DESCRIPTION
## Context

In preparation for improving test data generation via the API, make the `GenerateTestApplications` service a bit more user friendly

## Changes proposed in this pull request

- Pull the code that makes test applications out of the Sidekiq worker
- Give it a more declarative interface, eg `TestApplications.create_application [:awaiting_provider_decision, :offer, :rejected]`
- Declare what we want in the Sidekiq worker instead of looping n times

## Link to Trello card

Part of https://trello.com/c/VLw7X81Z/1526-improvements-to-the-generatetestdata-api-feature-for-tribal

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
