### PR TITLE
Add content to provider and support sign in pages

### DIFF
--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -1,1 +1,19 @@
-<%= render(DfESignInButtonComponent, bypass: DfESignIn.bypass?) %>
+<% content_for :title, t('page_titles.sign_in') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.sign_in') %>
+    </h1>
+
+    <p class="govuk-body-l">You must sign in to your account to manage teacher training applications.</p>
+
+    <%= render(DfESignInButtonComponent, bypass: DfESignIn.bypass?) %>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Ask for an account</h2>
+    <p class="govuk-body">Don’t have an account? You can get one by emailing <%= bat_contact_mail_to %>. Please include the full names and email addresses of anyone who needs access.</p>
+  </div>
+</div>

--- a/app/views/support_interface/sessions/new.html.erb
+++ b/app/views/support_interface/sessions/new.html.erb
@@ -1,1 +1,8 @@
-<%= render(DfESignInButtonComponent, bypass: DfESignIn.bypass?) %>
+<% content_for :title, t('page_titles.sign_in') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body-l">You must sign in to use the support console.</p>
+    <%= render(DfESignInButtonComponent, bypass: DfESignIn.bypass?) %>
+  </div>
+</div>


### PR DESCRIPTION
## Context

Adds content to provider sign in page to make it more user-friendly, and provide a contact address if you require access. We’ll link to this sign in page from the new provider marketing page, when it’s ready.

Updated the support sign in page too, to match.

## Changes proposed in this pull request

![sign-in-provider](https://user-images.githubusercontent.com/813383/72813391-2180c880-3c5b-11ea-9a66-3260e3ced5ae.png)

![sign-in-support](https://user-images.githubusercontent.com/813383/72813392-22195f00-3c5b-11ea-9f19-4199a5f3f143.png)
