### PR TITLE
Update content when referee refuses to give a reference

### DIFF
--- a/app/views/referee_interface/reference/confirmation.html.erb
+++ b/app/views/referee_interface/reference/confirmation.html.erb
@@ -1,19 +1,27 @@
-<% content_for :title, t('page_titles.give_a_reference.confirmation') %>
-<div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
-  <h1 class="govuk-panel__title">
-    Your reference for <%= @reference.application_form.full_name %> has been&nbsp;submitted
-  </h1>
-</div>
+<% if @reference.feedback_refused? %>
+  <% content_for :title, t('page_titles.give_a_reference.finish') %>
+  <h1 class="govuk-heading-xl">Thank you</h1>
 
-<%= form_with model: @reference, url: referee_interface_confirm_consent_path(token: @token_param), method: :patch do |f| %>
-  <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, legend: { size: 'm', text: 'Can we contact you for research purposes?' } do %>
-    <p class="govuk-body">
-      You can opt in to being contacted by the Department for Education for research purposes.
-    </p>
-    <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('contact_form.consent_to_be_contacted') } %>
-    <%= f.govuk_radio_button :consent_to_be_contacted, false, label: { text: t('contact_form.not_consent_to_be_contacted') } %>
+  <p class="govuk-body">We'll ask the candidate to suggest another referee.</p>
+
+  <p class="govuk-body">If you have any questions about the Apply for teacher training service, please contact <%= bat_contact_mail_to %>.</p>
+<% else %>
+  <% content_for :title, t('page_titles.give_a_reference.confirmation') %>
+  <div class="govuk-panel govuk-panel--confirmation govuk-!-margin-bottom-8">
+    <h1 class="govuk-panel__title">
+      Your reference for <%= @reference.application_form.full_name %> has been&nbsp;submitted
+    </h1>
+  </div>
+
+  <%= form_with model: @reference, url: referee_interface_confirm_consent_path(token: @token_param), method: :patch do |f| %>
+    <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, legend: { size: 'm', text: 'Can we contact you for research purposes?' } do %>
+      <p class="govuk-body">
+        You can opt in to being contacted by the Department for Education for research purposes.
+      </p>
+      <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('contact_form.consent_to_be_contacted') } %>
+      <%= f.govuk_radio_button :consent_to_be_contacted, false, label: { text: t('contact_form.not_consent_to_be_contacted') } %>
+    <% end %>
+
+    <%= f.govuk_submit t('contact_form.confirm') %>
   <% end %>
-
-  <%= f.govuk_submit t('contact_form.confirm') %>
-
 <% end %>

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -18,9 +18,7 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
     and_i_confirm_that_i_wont_give_a_reference
     and_a_slack_notification_is_sent
     then_an_email_is_sent_to_the_candidate
-
-    when_i_choose_to_be_contactable
-    then_i_see_the_thank_you_page
+    and_i_should_see_the_thank_you_page
   end
 
   def given_a_candidate_completed_an_application
@@ -61,14 +59,8 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
     expect(current_email.subject).to have_content(t('new_referee_request.refused.subject', referee_name: 'Terri Tudor'))
   end
 
-  def when_i_choose_to_be_contactable
-    choose t('contact_form.consent_to_be_contacted')
-    click_button t('contact_form.confirm')
-  end
-
-  def then_i_see_the_thank_you_page
+  def and_i_should_see_the_thank_you_page
     expect(page).to have_content('Thank you')
-    expect(page).to have_content('Our user research team will contact you shortly')
   end
 
 private


### PR DESCRIPTION
## Context

Currently we thank users for submitting a reference even if they refuse. This is confusing.

## Changes proposed in this pull request

Check the `@reference` in the view and display conditional content.

## Guidance to review

Should we hoist the `@reference.feedback_status == 'feedback_refused'` logic into a `#method?` on the model?

Review without whitespace.

## Before

<img width="1029" alt="Screenshot 2020-01-21 at 15 28 03" src="https://user-images.githubusercontent.com/1650875/72818012-a7544200-3c62-11ea-8e99-5fa324c85fe2.png">

## After

<img width="1019" alt="Screenshot 2020-01-21 at 15 27 27" src="https://user-images.githubusercontent.com/1650875/72818009-a6231500-3c62-11ea-8add-1f554078a553.png">

## Link to Trello card

https://trello.com/c/e2WQISLg/790-update-content-when-user-declines-to-give-a-reference

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)