### PR TITLE
Log emails to log/mail.log in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,8 +33,16 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
-    api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
+    api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY'),
   }
+  config.action_mailer.logger = Logger.new('log/mail.log', formatter: proc { |_, _, _, msg|
+    if(msg =~ /quoted-printable/)
+      message = Mail::Message.new(msg)
+      "\nTo: #{message.to}\n\n#{message.decoded}\n\n"
+    else
+      "\n#{msg}"
+    end
+  })
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 


### PR DESCRIPTION
Getting links to references is painful in development. Log all outgoing
mail to log/mail.log, properly decoded.

example log entry:

```
Delivered mail 5e2715ea58e52_269a3fdfa256c07c328aa@maple.local.mail (237.1ms)
To: ["eeaada628f@example.com"]

Dear Malka Lehner,

Gregg Crona put us in touch with you to get a reference for their teacher training application.

Please use the link below to give a reference as soon as possible.

http://localhost:3000/reference?token=MakRK-jWkBtzy-mziqFb

If you won’t give Malka Lehner a reference, please let us know by clicking the link below.

http://localhost:3000/reference/refuse-feedback?token=MakRK-jWkBtzy-mziqFb

Your data

We’ll only use your data to process the candidate’s application, unless you agree to be contacted about your experience of giving a reference.
We’ll ask about this before you submit any information.

```