### PR TITLE
Only show providers/courses that Apply offers

### DIFF
--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -20,7 +20,7 @@ module CandidateInterface
 
     def providers
       @courses_by_provider = Course
-        .visible_to_candidates
+        .open_on_apply
         .includes(:provider)
         .group_by { |c| c.provider.name }
         .sort_by { |provider_name, _| provider_name }

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -63,7 +63,7 @@ module CandidateInterface
 
       if !@pick_course.valid?
         render :options_for_course
-      elsif !@pick_course.applyable?
+      elsif !@pick_course.open_on_apply?
         redirect_to candidate_interface_course_choices_on_ucas_path
       elsif @pick_course.single_site?
         course_id = Course.find_by(code: course_code)

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -6,13 +6,13 @@ module CandidateInterface
     validates :code, presence: true
     validate :user_cant_apply_to_same_course_twice
 
-    def applyable?
+    def open_on_apply?
       course.open_on_apply?
     end
 
     def available_courses
       @available_courses ||= begin
-        provider.courses.visible_to_candidates.order(:name)
+        provider.courses.exposed_in_find.order(:name)
       end
     end
 

--- a/app/models/candidate_interface/pick_provider_form.rb
+++ b/app/models/candidate_interface/pick_provider_form.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
     def available_providers
       @available_providers ||= begin
-        Course.includes(:provider).visible_to_candidates.map(&:provider).uniq.sort_by(&:name)
+        Course.includes(:provider).exposed_in_find.map(&:provider).uniq.sort_by(&:name)
       end
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,8 +7,8 @@ class Course < ApplicationRecord
   validates :level, presence: true
   validates :code, uniqueness: { scope: :provider_id }
 
-  scope :visible_to_candidates, -> { where(exposed_in_find: true) }
-  scope :applyable, -> { visible_to_candidates.where(open_on_apply: true) }
+  scope :open_on_apply, -> { where(open_on_apply: true) }
+  scope :exposed_in_find, -> { where(exposed_in_find: true) }
 
   CODE_LENGTH = 4
 

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -25,7 +25,7 @@
         </td>
         <td class='govuk-table__cell'>
           <% if provider.sync_courses? %>
-            <%= pluralize provider.courses.size, 'course' %> (<%= provider.courses.applyable.size %> on DfE Apply)
+            <%= pluralize provider.courses.size, 'course' %> (<%= provider.courses.open_on_apply.size %> on DfE Apply)
           <% else %>
             Not synced from Find
           <% end %>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -30,11 +30,11 @@
   <% end %>
 <% end %>
 
-<h2 class='govuk-heading-m'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.applyable.size %> on DfE Apply)</h2>
+<h2 class='govuk-heading-m'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.open_on_apply.size %> on DfE Apply)</h2>
 <%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider, courses: @provider.courses) %>
 
 <% if @provider.accredited_courses.any? %>
-  <h2 class='govuk-heading-m'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.applyable.size %> on DfE Apply)</h2>
+  <h2 class='govuk-heading-m'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
   <%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider, courses: @provider.accredited_courses) %>
 <% end %>
 

--- a/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/candidate_apply_from_find_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def then_i_should_see_the_available_providers_and_courses
-    expect(page).to have_content 'Biology'
+    expect(page).not_to have_content 'Biology'
     expect(page).to have_content 'Potions'
   end
 end


### PR DESCRIPTION
## Context

The courses page currently shows all courses that are in our system, and aren’t hidden in find (drafts).

## Changes proposed in this pull request

We should be showing the courses that candidates can apply to on Apply instead.

Renamed the scopes together with @tvararu to avoid future confusion.

## Guidance to review

Do the scope names make sense?

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
