### PR TITLE
Update content of initial survey email to candidate and add mailer preview for it

### DIFF
--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -19,4 +19,11 @@ class CandidateMailerPreview < ActionMailer::Preview
       ),
     )
   end
+
+  def survey_email
+    application_form = FactoryBot.build(:application_form, first_name: 'Gemma', last_name: 'Say')
+    FactoryBot.build(:reference, application_form: application_form)
+
+    CandidateMailer.survey_email(application_form)
+  end
 end

--- a/app/views/survey_emails/initial.text.erb
+++ b/app/views/survey_emails/initial.text.erb
@@ -2,17 +2,9 @@ Dear <%= @name %>,
 
 <%= @thank_you_message %>
 
-As you’re one of the first users of our new service, we’d love to hear about your experience. We’re paying £100 to those willing to take part.
-
-This research will be in two stages:
-
-1) You fill in a short survey (most people complete it in under 5 minutes).
-
-2) Once you’ve completed the survey, we’ll follow up with a phone call to talk about your responses.
+As you’re one of the first users of our new service, we’d love to hear about your experience through a short survey (most people complete it in under 5 minutes).
 
 To take part, go to <%= t('survey_emails.survey_link') %>
-
-Once you’re finished, we’ll contact you to confirm payment.
 
 If you have any questions about our service or our research, please get in touch by emailing [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
 

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -1,7 +1,7 @@
 en:
   survey_emails:
     subject:
-      initial: Get £100 for helping us improve our service
+      initial: We’d love to hear from you about your teacher training application
       chaser: We’d love to hear from you about your teacher training application
     survey_link: https://forms.gle/QQqurrCs9YSpTfbc8
     thank_you:


### PR DESCRIPTION
## Context

We are no longer providing an incentive for participating in research so the content of the survey email needs to change.

## Changes proposed in this pull request

This PR updates the content of the initial survey email to candidates by updating `CandidateMailer#survey_email` and adds a mailer preview for it.

![image](https://user-images.githubusercontent.com/42817036/72886461-c229c380-3d01-11ea-9b03-b0a8b8aa7ca2.png)

## Guidance to review

Is the content the same as specified on the Trello card?

## Link to Trello card

https://trello.com/c/hs3Puash/797-change-text-on-survey-email-to-candidate
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
