### PR TITLE
Add page to explain testing in the Sandbox

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,0 +1,5 @@
+class ContentController < ApplicationController
+  layout 'application'
+
+  def sandbox; end
+end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -24,13 +24,15 @@ module HostingEnvironment
   end
 
   def self.phase_banner_text
+    if sandbox?
+      return 'This is a <a href="/">test version of Apply</a> for providers and software vendors'.html_safe
+    end
+
     case environment_name
     when 'production'
       'This is a new service - <a href="mailto:becomingateacher@digital.education.gov.uk?subject=Apply+feedback" class="govuk-link">give feedback or report a problem</a>'.html_safe
     when 'qa'
       'This is the QA version of the Apply service'
-    when 'sandbox'
-      'This is a demo environment for software vendors who integrate with our API'
     when 'staging'
       'This is a internal environment used by DfE to test deploys'
     when 'development'

--- a/app/views/api_docs/pages/home.md
+++ b/app/views/api_docs/pages/home.md
@@ -53,6 +53,10 @@ Information about deprecations (for instance attributes/endpoints that will be m
 
 We will update our [release notes](/api-docs/release-notes) with all breaking and non-breaking changes.
 
+## Testing
+
+To get familiar with our system and perform testing, you can use [our sandbox environment](https://sandbox.apply-for-teacher-training.education.gov.uk).
+
 ## Application Lifecycle
 
 The following diagram gives an overview of the states in the application lifecycle:

--- a/app/views/content/sandbox.html.erb
+++ b/app/views/content/sandbox.html.erb
@@ -1,0 +1,89 @@
+<%= content_for :title, t('page_titles.sandbox') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('page_titles.sandbox') %></h1>
+
+    <p class='govuk-body'>
+      The Apply sandbox is a test environment which allows you to experience the service as a software vendor, training provider and candidate.
+    </p>
+
+    <h2 class='govuk-heading-m'>You can:</h2>
+
+    <ul class='govuk-list govuk-list--bullet'>
+      <li>sign in as a candidate and submit an application</li>
+      <li>sign in as a training provider and process an application</li>
+      <li>test Apply's <%= link_to 'API integrations', 'https://www.apply-for-teacher-training.education.gov.uk/api-docs' %></li>
+    </ul>
+
+    <p class='govuk-body'>Throughout, you’ll be able to give us feedback so we can improve the service.</p>
+
+    <h2 class='govuk-heading-l'>Get started as a candidate</h2>
+
+    <p class='govuk-body'>You'll be asked to enter your email address to open a candidate account in the Apply sandbox.</p>
+
+    <p class='govuk-body'>Please do not use anybody else’s address, as the system will generate real emails as part of the test.</p>
+
+    <p class='govuk-body'>Any other data you enter should be anonymised or invented.</p>
+
+    <h4 class='govuk-heading-s'>A note on references</h4>
+
+    <p class='govuk-body'>In the live service, an application is only sent to a provider when 2 references have been supplied.</p>
+
+    <p class='govuk-body'>In the Apply sandbox, to avoid testers having to request real references, we've enabled dummy referee email addresses:</p>
+
+    <ul class='govuk-list govuk-list--bullet'>
+      <li>refbot1@example.com</li>
+      <li>refbot2@example.com</li>
+    </ul>
+
+    <p class='govuk-body'>In sandbox, enter these email addresses to generate 2 references for your test application.</p>
+
+    <h4 class='govuk-heading-s'>A note on editing after submission</h4>
+
+    <p class='govuk-body'>In the live service, applications are sent to the provider 5 working days after submission. This gives candidates a window to edit their application.</p>
+
+    <p class='govuk-body'>In the Apply sandbox, applications are sent immediately, if the references are complete.</p>
+
+    <a href="/candidate" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
+      Continue as a candidate
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    </a>
+
+    <h2 class='govuk-heading-l'>Get started as a training provider</h2>
+
+    <p class='govuk-body'>To test the service as a training provider, you'll need to open a Department for Education (DfE) Sign-In account.</p>
+
+    <p class='govuk-body'>Email <%= bat_contact_mail_to %> to request access.</p>
+
+    <h4 class='govuk-heading-s'>Test as a candidate</h4>
+
+    <p class='govuk-body'>From the provider interface in the sandbox, you'll be able to sign in as a specific candidate. This is useful if you have generated test applications via the API.</p>
+
+    <a href="/provider" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
+      Continue as a training provider
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    </a>
+
+    <h2 class='govuk-heading-l'>Get started with the API</h2>
+
+    <p class='govuk-body'>Our API allows you to integrate your software with our service.</p>
+
+    <p class='govuk-body'>In the sandbox, you'll be able to test your integration. You'll also be able to generate dummy applications to process as a training provider.</p>
+
+    <a href="https://www.apply-for-teacher-training.education.gov.uk/api-docs" class="govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-8 govuk-button--start">
+      Review our API documentation
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    </a>
+
+    <h2 class='govuk-heading-l'>Help and support</h2>
+
+    <p class='govuk-body'>Email us at <%= bat_contact_mail_to %> for support using Apply sandbox or any other aspect of the Apply for teacher training service.
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
     submitted_application: Your submitted application
     sign_up: Create an account
     sign_in: Sign in
+    sandbox: Use our sandbox to test Apply for teacher training for yourself
     check_your_email: Check your email
     not_found: Page not found
     internal_server_error: Sorry, there is a problem with the service

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,11 @@ Rails.application.routes.draw do
     get '/candidate/sign-out', to: 'devise/sessions#destroy', as: :candidate_interface_sign_out
   end
 
-  root to: redirect('/candidate')
+  if HostingEnvironment.sandbox?
+    root to: 'content#sandbox'
+  else
+    root to: redirect('/candidate')
+  end
 
   namespace :candidate_interface, path: '/candidate' do
     get '/' => 'start_page#show', as: :start


### PR DESCRIPTION
## Context

This adds a page that explains what the sandbox does.

## Changes proposed in this pull request

Add a new page. It is *only* available on the sandbox, and appears on the sandbox homepage.

You can look at it on Heroku (I've set Heroku to be `SANDBOX=true`):

https://apply-for-te-1549-docum-zwmix9.herokuapp.com/

![image](https://user-images.githubusercontent.com/233676/73376709-c92e7400-42b5-11ea-815e-42d702fd1fbb.png)

## Guidance to review

Is it true? Does it make sense?

## Link to Trello card

https://trello.com/c/8ywUv2yc/1549-document-what-the-sandbox-does

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
