### PR TITLE
Refactor the ReceiveReference class

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -34,8 +34,7 @@ module TestApplications
 
       application_form.application_references.each do |reference|
         ReceiveReference.new(
-          application_form: application_form,
-          referee_email: reference.email_address,
+          reference: reference,
           feedback: 'You are awesome',
         ).save
       end

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -2,27 +2,15 @@ class ReceiveReference
   attr_reader :referee_email
   attr_reader :feedback
 
-  include ActiveModel::Validations
-
-  validates_presence_of :referee_email, :feedback
-  validates :feedback, word_count: { maximum: 300 }
-
-  validate :referee_must_exist_on_application_form
-
-  def initialize(application_form:, referee_email:, feedback:)
-    @application_form = application_form
-    @referee_email = referee_email
+  def initialize(reference:, feedback:)
+    @reference = reference
+    @application_form = reference.application_form
     @feedback = feedback
   end
 
   def save
-    return false unless valid?
-
     ActiveRecord::Base.transaction do
-      @application_form
-        .application_references
-        .find { |reference| reference.email_address == @referee_email }
-        .update!(feedback: @feedback, feedback_status: 'feedback_provided')
+      @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
 
       if @application_form.application_references_complete?
         @application_form.application_choices.includes(:course_option).each do |application_choice|
@@ -40,12 +28,6 @@ class ReceiveReference
   end
 
 private
-
-  def referee_must_exist_on_application_form
-    if @application_form.application_references.where(email_address: @referee_email).empty?
-      errors.add(:referee_email, 'does not match any of the provided referees')
-    end
-  end
 
   def complete_references(application_choice)
     ApplicationStateChange.new(application_choice).references_complete!

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -65,9 +65,10 @@ When(/^the (\w+) takes action "([\w\s]+)"$/) do |_actor, action|
 end
 
 When('{string} provides a reference') do |referee_email|
+  reference = @application_choice.application_form.application_references.find_by!(email_address: referee_email)
+
   action = ReceiveReference.new(
-    application_form: @application_choice.application_form.reload,
-    referee_email: referee_email,
+    reference: reference,
     feedback: Faker::Lorem.sentence(word_count: 20),
   )
   expect(action.save).to be true

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -5,105 +5,47 @@ RSpec.describe ReceiveReference do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
     application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
-    application_form.application_references << build(:reference, :unsubmitted, email_address: 'xy@z.com')
+    reference = build(:reference, :unsubmitted, email_address: 'xy@z.com')
+    application_form.application_references << reference
 
-    action = ReceiveReference.new(
-      application_form: application_form,
-      referee_email: 'xy@z.com',
+    ReceiveReference.new(
+      reference: reference,
       feedback: 'A reference',
-    )
+    ).save
 
-    expect(action).to be_valid
-    expect(action.save).to be true
-
-    expect(application_form.application_references.find_by!(email_address: 'xy@z.com').feedback).to eq('A reference')
-    expect(application_form.application_references.find_by!(email_address: 'ab@c.com').feedback).to be_nil
+    expect(reference.feedback).to eq('A reference')
+    expect(application_form).not_to be_application_references_complete
+    expect(application_form.application_choices).to all(be_awaiting_references)
   end
 
   it 'progresses the application choices to the "application complete" status once all references have been received' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
-    application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    reference = build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.application_references << reference
     application_form.application_references << build(:reference, :complete)
 
-    action = ReceiveReference.new(
-      application_form: application_form,
-      referee_email: 'ab@c.com',
+    ReceiveReference.new(
+      reference: reference,
       feedback: 'A reference',
-    )
-    action.save
+    ).save
 
     expect(application_form.reload).to be_application_references_complete
     expect(application_form.application_choices).to all(be_application_complete)
   end
 
-  it 'does not progress the application choices to the "application complete" status without minimum number of references' do
-    application_form = FactoryBot.create(:completed_application_form, references_count: 0)
-    application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
-    application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
-
-    action = ReceiveReference.new(
-      application_form: application_form,
-      referee_email: 'ab@c.com',
-      feedback: 'A reference',
-    )
-    action.save
-
-    expect(application_form).not_to be_application_references_complete
-    expect(application_form.application_choices).to all(be_awaiting_references)
-  end
-
   it 'progresses the application choices to the "awaiting_provider_decision" status once all references have been received if edit_by has elapsed' do
     application_form = FactoryBot.create(:completed_application_form, references_count: 0)
     application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.ago) }
-    application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    reference = build(:reference, :unsubmitted, email_address: 'ab@c.com')
+    application_form.application_references << reference
     application_form.application_references << build(:reference, :complete)
 
-    action = ReceiveReference.new(
-      application_form: application_form,
-      referee_email: 'ab@c.com',
+    ReceiveReference.new(
+      reference: reference,
       feedback: 'A reference',
-    )
-    action.save
+    ).save
 
-    expect(application_form.reload).to be_application_references_complete
-    expect(application_form.application_choices).to all(be_awaiting_provider_decision)
-  end
-
-  describe 'validation' do
-    it 'validates the presence of referee email and feedback' do
-      action = ReceiveReference.new(
-        application_form: build_stubbed(:application_form),
-        referee_email: nil,
-        feedback: '',
-      )
-
-      expect(action).not_to be_valid
-
-      expect(action.errors[:feedback]).to eq(['Enter your reference'])
-      expect(action.errors[:referee_email]).not_to be_empty
-    end
-
-    it 'validates the feedback is max 300 words' do
-      action = ReceiveReference.new(
-        application_form: build_stubbed(:application_form),
-        referee_email: nil,
-        feedback: Faker::Lorem.sentence(word_count: 301),
-        )
-
-      expect(action).not_to be_valid
-
-      expect(action.errors[:feedback]).to eq(['Your reference must be 300 words or fewer'])
-    end
-
-    it 'validates that the referee email matches the references on the application form' do
-      action = ReceiveReference.new(
-        application_form: build_stubbed(:application_form),
-        referee_email: 'madeupemail@example.com',
-        feedback: 'A reference',
-      )
-
-      expect(action).not_to be_valid
-    end
+    expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
   end
 end

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -39,8 +39,7 @@ RSpec.feature 'See an application' do
     @application_with_reference.application_references.first.update(consent_to_be_contacted: true)
 
     action = ReceiveReference.new(
-      application_form: @application_with_reference,
-      referee_email: @application_with_reference.reload.application_references.first.email_address,
+      reference: @application_with_reference.reload.application_references.first,
       feedback: 'This is my feedback',
     )
     action.save

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -24,13 +24,15 @@ RSpec.feature 'Vendor receives the application' do
   end
 
   def and_references_have_been_received
-    ReceiveReference.new(application_form: @application,
-                         referee_email: @application.application_references.first.email_address,
-                         feedback: 'My ideal person').save
+    ReceiveReference.new(
+      reference: @application.application_references.first,
+      feedback: 'My ideal person',
+    ).save
 
-    ReceiveReference.new(application_form: @application,
-                         referee_email: @application.application_references.last.email_address,
-                         feedback: 'Lovable').save
+    ReceiveReference.new(
+      reference: @application.application_references.last,
+      feedback: 'Lovable',
+    ).save
   end
 
   def and_the_edit_by_date_has_passed


### PR DESCRIPTION
## Context

We originally intended to deprecate this class, but it turns out it’s still useful to extract logic from ReferenceFeedbackForm into a different class. https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1159 will change the form to use ReceiveReference instead of duplicating the logic.

## Changes proposed in this pull request

Refactor the class to remove validation (that's done by the form) and to use an ApplicationReference object directly, instead of relying on an email lookup (which is a holdover from when we imported references using a CSV).

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/2rnwDpEo/1529-in-the-sandbox-skip-the-waiting-to-be-sent-state

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
