### PR TITLE
Refactor NotifyController and ProcessNotifyCallback

### DIFF
--- a/app/controllers/notify_controller.rb
+++ b/app/controllers/notify_controller.rb
@@ -8,7 +8,9 @@ class NotifyController < ApplicationController
   def callback
     return render_unauthorized unless authorized?
 
-    response = ProcessNotifyCallback.call(notify_reference: params.fetch(:reference), status: params.fetch(:status))
+    process_notify_callback = ProcessNotifyCallback.new(notify_reference: params.fetch(:reference), status: params.fetch(:status))
+
+    response = process_notify_callback.call
 
     if response == :not_found
       render_not_found

--- a/app/controllers/notify_controller.rb
+++ b/app/controllers/notify_controller.rb
@@ -10,9 +10,9 @@ class NotifyController < ApplicationController
 
     process_notify_callback = ProcessNotifyCallback.new(notify_reference: params.fetch(:reference), status: params.fetch(:status))
 
-    response = process_notify_callback.call
+    process_notify_callback.call
 
-    if response == :not_found
+    if process_notify_callback.not_found?
       render_not_found
     else
       render json: nil, status: :ok

--- a/app/services/process_notify_callback.rb
+++ b/app/services/process_notify_callback.rb
@@ -2,7 +2,7 @@ class ProcessNotifyCallback
   def initialize(notify_reference:, status:)
     @environment, @email_type, @reference_id = notify_reference.split('-')
     @status = status
-    @process_status = :not_updated
+    @not_found = false
   end
 
   def call
@@ -19,22 +19,12 @@ class ProcessNotifyCallback
         reason: :email_bounced,
       )
     end
-
-    @process_status = :updated
   rescue ActiveRecord::RecordNotFound
-    @process_status = :not_found
+    @not_found = true
   end
 
   def not_found?
-    @process_status == :not_found
-  end
-
-  def updated?
-    @process_status == :updated
-  end
-
-  def not_updated?
-    @process_status == :not_updated
+    @not_found
   end
 
 private

--- a/app/services/process_notify_callback.rb
+++ b/app/services/process_notify_callback.rb
@@ -1,40 +1,40 @@
 class ProcessNotifyCallback
-  class << self
-    def call(notify_reference:, status:)
-      @environment, @email_type, reference_id = notify_reference.split('-')
-      @status = status
+  def initialize(notify_reference:, status:)
+    @environment, @email_type, @reference_id = notify_reference.split('-')
+    @status = status
+  end
 
-      return :not_updated unless same_environment? && reference_request_email? && permanent_failure_status?
+  def call
+    return :not_updated unless same_environment? && reference_request_email? && permanent_failure_status?
 
-      ActiveRecord::Base.transaction do
-        reference = ApplicationReference.find(reference_id)
+    ActiveRecord::Base.transaction do
+      reference = ApplicationReference.find(@reference_id)
 
-        reference.update!(feedback_status: 'email_bounced')
+      reference.update!(feedback_status: 'email_bounced')
 
-        SendNewRefereeRequestEmail.call(
-          application_form: reference.application_form,
-          reference: reference,
-          reason: :email_bounced,
-        )
-      end
-
-      :updated
-    rescue ActiveRecord::RecordNotFound
-      :not_found
+      SendNewRefereeRequestEmail.call(
+        application_form: reference.application_form,
+        reference: reference,
+        reason: :email_bounced,
+      )
     end
 
-  private
+    :updated
+  rescue ActiveRecord::RecordNotFound
+    :not_found
+  end
 
-    def same_environment?
-      @environment == HostingEnvironment.environment_name
-    end
+private
 
-    def reference_request_email?
-      @email_type == 'reference_request'
-    end
+  def same_environment?
+    @environment == HostingEnvironment.environment_name
+  end
 
-    def permanent_failure_status?
-      @status == 'permanent-failure'
-    end
+  def reference_request_email?
+    @email_type == 'reference_request'
+  end
+
+  def permanent_failure_status?
+    @status == 'permanent-failure'
   end
 end

--- a/spec/requests/post_notify_callback_spec.rb
+++ b/spec/requests/post_notify_callback_spec.rb
@@ -54,9 +54,9 @@ RSpec.describe 'Notify Callback - POST /notify/callback', type: :request do
   end
 
   it 'returns not found if Notify reference includes unknown reference id' do
-    allow(ProcessNotifyCallback).to receive(:call)
-      .with(notify_reference: "test-reference_request-#{reference.id}", status: 'permanent-failure')
-      .and_return(:not_found)
+    process_notify_callback = instance_double('ProcessNotifyCallback')
+    allow(ProcessNotifyCallback).to receive(:new).and_return(process_notify_callback)
+    allow(process_notify_callback).to receive(:call).and_return(:not_found)
 
     request_body = {
       reference: "test-reference_request-#{reference.id}",

--- a/spec/requests/post_notify_callback_spec.rb
+++ b/spec/requests/post_notify_callback_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe 'Notify Callback - POST /notify/callback', type: :request do
   it 'returns not found if Notify reference includes unknown reference id' do
     process_notify_callback = instance_double('ProcessNotifyCallback')
     allow(ProcessNotifyCallback).to receive(:new).and_return(process_notify_callback)
-    allow(process_notify_callback).to receive(:call).and_return(:not_found)
+    allow(process_notify_callback).to receive(:call)
+    allow(process_notify_callback).to receive(:not_found?).and_return(true)
 
     request_body = {
       reference: "test-reference_request-#{reference.id}",

--- a/spec/services/process_notify_callback_spec.rb
+++ b/spec/services/process_notify_callback_spec.rb
@@ -2,13 +2,17 @@ require 'rails_helper'
 
 RSpec.shared_examples "a callback that doesn't change the feedback status of a reference" do
   it 'returns not updated' do
-    process_notify_callback = ProcessNotifyCallback.call(notify_reference: notify_reference, status: status)
+    process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
-    expect(process_notify_callback).to eq(:not_updated)
+    response = process_notify_callback.call
+
+    expect(response).to eq(:not_updated)
   end
 
   it 'does not update the feedback status of the reference' do
-    ProcessNotifyCallback.call(notify_reference: notify_reference, status: status)
+    process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+
+    process_notify_callback.call
 
     expect(reference.reload.feedback_status).to eq('feedback_requested')
   end
@@ -33,13 +37,17 @@ RSpec.describe ProcessNotifyCallback do
       let(:status) { 'permanent-failure' }
 
       it 'returns updated' do
-        process_notify_callback = ProcessNotifyCallback.call(notify_reference: notify_reference, status: status)
+        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
-        expect(process_notify_callback).to eq(:updated)
+        response = process_notify_callback.call
+
+        expect(response).to eq(:updated)
       end
 
       it 'updates the feedback status of the reference to email bounced' do
-        ProcessNotifyCallback.call(notify_reference: notify_reference, status: status)
+        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+
+        process_notify_callback.call
 
         expect(reference.reload.feedback_status).to eq('email_bounced')
       end
@@ -47,9 +55,11 @@ RSpec.describe ProcessNotifyCallback do
       it 'returns not found if reference cannot be found' do
         allow(ApplicationReference).to receive(:find).with(reference.id.to_s).and_raise(ActiveRecord::RecordNotFound)
 
-        process_notify_callback = ProcessNotifyCallback.call(notify_reference: notify_reference, status: status)
+        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
-        expect(process_notify_callback).to eq(:not_found)
+        response = process_notify_callback.call
+
+        expect(response).to eq(:not_found)
       end
     end
 

--- a/spec/services/process_notify_callback_spec.rb
+++ b/spec/services/process_notify_callback_spec.rb
@@ -1,14 +1,6 @@
 require 'rails_helper'
 
 RSpec.shared_examples "a callback that doesn't change the feedback status of a reference" do
-  it 'sets process status to not updated' do
-    process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
-
-    process_notify_callback.call
-
-    expect(process_notify_callback).to be_not_updated
-  end
-
   it 'does not update the feedback status of the reference' do
     process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
@@ -36,14 +28,6 @@ RSpec.describe ProcessNotifyCallback do
     context 'with permanent-failure status' do
       let(:status) { 'permanent-failure' }
 
-      it 'sets process status to updated' do
-        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
-
-        process_notify_callback.call
-
-        expect(process_notify_callback).to be_updated
-      end
-
       it 'updates the feedback status of the reference to email bounced' do
         process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
@@ -52,7 +36,7 @@ RSpec.describe ProcessNotifyCallback do
         expect(reference.reload.feedback_status).to eq('email_bounced')
       end
 
-      it 'sets process status to not found if reference cannot be found' do
+      it 'sets not found to true if reference cannot be found' do
         allow(ApplicationReference).to receive(:find).with(reference.id.to_s).and_raise(ActiveRecord::RecordNotFound)
 
         process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)

--- a/spec/services/process_notify_callback_spec.rb
+++ b/spec/services/process_notify_callback_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 RSpec.shared_examples "a callback that doesn't change the feedback status of a reference" do
-  it 'returns not updated' do
+  it 'sets process status to not updated' do
     process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
-    response = process_notify_callback.call
+    process_notify_callback.call
 
-    expect(response).to eq(:not_updated)
+    expect(process_notify_callback).to be_not_updated
   end
 
   it 'does not update the feedback status of the reference' do
@@ -36,12 +36,12 @@ RSpec.describe ProcessNotifyCallback do
     context 'with permanent-failure status' do
       let(:status) { 'permanent-failure' }
 
-      it 'returns updated' do
+      it 'sets process status to updated' do
         process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
-        response = process_notify_callback.call
+        process_notify_callback.call
 
-        expect(response).to eq(:updated)
+        expect(process_notify_callback).to be_updated
       end
 
       it 'updates the feedback status of the reference to email bounced' do
@@ -52,14 +52,14 @@ RSpec.describe ProcessNotifyCallback do
         expect(reference.reload.feedback_status).to eq('email_bounced')
       end
 
-      it 'returns not found if reference cannot be found' do
+      it 'sets process status to not found if reference cannot be found' do
         allow(ApplicationReference).to receive(:find).with(reference.id.to_s).and_raise(ActiveRecord::RecordNotFound)
 
         process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
 
-        response = process_notify_callback.call
+        process_notify_callback.call
 
-        expect(response).to eq(:not_found)
+        expect(process_notify_callback).to be_not_found
       end
     end
 


### PR DESCRIPTION
## Context

Addressing feedback from @tijmenb in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1150 which was made after it was merged.

## Changes proposed in this pull request

This PR refactors `NotifyController` and `ProcessNotifyCallback`, see commits.

## Guidance to review

Is this better than before? Particularly unsure about https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/09c46a9c75d1e2c24dd58b1847e31d6e705ed786 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/5a97188d93a5b892cbeae3df9ee15291966900e6, whether the refactoring of `ProcessNotifyCallback.call` to an instance method has been done correctly.

A new namespace for callbacks will be added in another PR.

## Link to Trello card

https://trello.com/c/eRWPVFng/783-bounced-email-candidate-strategic

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
