### PR TITLE
Improve test speed by creating fewer dependent records

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -12,6 +12,10 @@ module TestApplications
       application_form = FactoryBot.create(
         :completed_application_form,
         application_choices_count: 0,
+        work_experiences_count: 1,
+        volunteering_experiences_count: 1,
+        references_count: 2,
+        with_gces: true,
         submitted_at: nil,
         candidate: candidate,
         first_name: first_name,

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -14,7 +14,6 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_under_consideration(
       FactoryBot.build(
         :completed_application_form,
-        :without_application_choices,
         application_choices: [application_choice],
       ),
     )

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -62,10 +62,9 @@
 
 <%= render PersonalStatementComponent, application_form: @application_choice.application_form %>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-8" id="first-reference">First reference</h2>
-
-<%= render ReferenceWithFeedbackComponent, reference: @application_choice.application_form.application_references.first %>
-
-<h2 class="govuk-heading-l govuk-!-margin-top-8" id="second-reference">Second reference</h2>
-
-<%= render ReferenceWithFeedbackComponent, reference: @application_choice.application_form.application_references.second %>
+<% if @application_choice.application_form.application_references.any? %>
+  <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8"><%= "#{(i + 1).ordinalize} reference" %></h2>
+    <%= render ReferenceWithFeedbackComponent, reference: reference %>
+  <% end %>
+<% end %>

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -83,8 +83,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
 
     it 'renders when all offers have been withdrawn' do
-      application_form = create(:completed_application_form, :without_application_choices)
-
+      application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: :withdrawn)
 
       render_result = render_inline(described_class, application_form: application_form)
@@ -93,8 +92,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
 
     it 'renders when one offer has been withdrawn and one offered' do
-      application_form = create(:completed_application_form, :without_application_choices)
-
+      application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: :withdrawn)
       create(:application_choice, application_form: application_form, status: :offer, decline_by_default_at: 1.day.from_now)
 
@@ -104,8 +102,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
     end
 
     it 'renders when the only offer has been rejected' do
-      application_form = create(:completed_application_form, :without_application_choices)
-
+      application_form = create(:application_form)
       create(:application_choice, application_form: application_form, status: :rejected)
 
       render_result = render_inline(described_class, application_form: application_form)

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
   end
 
   context 'when referees are editable' do
-    let(:application_form) { create(:completed_application_form, references_count: 2) }
+    let(:application_form) { create(:completed_application_form, references_count: 2, with_gces: true) }
 
     it "renders component with correct values for a referee's name" do
       first_referee = application_form.application_references.first
@@ -50,7 +50,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
   end
 
   context 'when referees are not editable' do
-    let(:application_form) { create(:completed_application_form, references_count: 1) }
+    let(:application_form) { create(:completed_application_form, references_count: 1, with_gces: true) }
 
     it 'renders component without an edit link' do
       result = render_inline(described_class, application_form: application_form, editable: false)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -145,22 +145,16 @@ FactoryBot.define do
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     name { Faker::Educator.university }
 
-    transient do
-      provider_agreements_count { 1 }
-    end
-
-    trait :without_agreements do
-      provider_agreements_count { 0 }
-    end
-
-    after(:build) do |provider, evaluator|
-      create_list(:provider_agreement, evaluator.provider_agreements_count, provider: provider)
+    trait :with_signed_agreement do
+      after(:build) do |provider|
+        create(:provider_agreement, provider: provider)
+      end
     end
   end
 
   factory :provider_agreement do
     provider_user
-    association :provider, factory: %i[provider without_agreements]
+    provider
 
     agreement_type { :data_sharing_agreement }
     accept_agreement { true }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -55,6 +55,7 @@ FactoryBot.define do
         end
       end
 
+      # Use this trait if you want to create your own application choices
       trait :without_application_choices do
         application_choices_count { 0 }
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -228,11 +228,6 @@ FactoryBot.define do
     end
   end
 
-  factory :sign_up_form do
-    email_address { "#{SecureRandom.hex(5)}@example.com" }
-    accept_ts_and_cs { true }
-  end
-
   factory :support_user do
     dfe_sign_in_uid { SecureRandom.uuid }
     email_address { "#{Faker::Name.first_name.downcase}@example.com" }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -126,9 +126,7 @@ FactoryBot.define do
 
   factory :course_option do
     course
-    site do
-      association(:site, provider: course.provider)
-    end
+    site { association(:site, provider: course.provider) }
 
     vacancy_status { 'B' }
   end
@@ -161,8 +159,9 @@ FactoryBot.define do
   end
 
   factory :provider_agreement do
-    association :provider, factory: %i[provider without_agreements]
     provider_user
+    association :provider, factory: %i[provider without_agreements]
+
     agreement_type { :data_sharing_agreement }
     accept_agreement { true }
 
@@ -174,6 +173,7 @@ FactoryBot.define do
   factory :application_choice do
     application_form
     course_option
+
     status { ApplicationStateChange.valid_states.sample }
     personal_statement { 'hello' }
 
@@ -206,14 +206,16 @@ FactoryBot.define do
   end
 
   factory :vendor_api_user do
-    association :vendor_api_token
+    vendor_api_token
+
     full_name { 'Bob' }
     email_address { 'bob@example.com' }
     vendor_user_id { '123' }
   end
 
   factory :vendor_api_token do
-    association :provider
+    provider
+
     hashed_token { '1234567890' }
   end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe 'Send reference chaser email' do
-    let(:application_form) { create(:completed_application_form) }
+    let(:application_form) { create(:completed_application_form, references_count: 1, with_gces: true) }
     let(:reference) { application_form.application_references.first }
     let(:mail) { mailer.reference_chaser_email(application_form, reference) }
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe RefereeMailer, type: :mailer do
         :completed_application_form,
         first_name: 'Harry',
         last_name: "O'Potter",
+        references_count: 1,
+        with_gces: true,
         application_choices_count: 0,
         application_choices: [
           first_application_choice,
@@ -45,9 +47,11 @@ RSpec.describe RefereeMailer, type: :mailer do
     let(:application_form) do
       create(
         :completed_application_form,
+        with_gces: true,
         first_name: 'Harry',
         last_name: 'Potter',
         application_choices_count: 0,
+        references_count: 1,
         application_choices: [
           first_application_choice,
           second_application_choice,

--- a/spec/models/application_dates_spec.rb
+++ b/spec/models/application_dates_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationDates, type: :model do
   let(:submitted_at) { Time.zone.local(2019, 5, 1, 12, 0, 0).end_of_day }
 
   let(:application_form) do
-    create(:completed_application_form, :without_application_choices, submitted_at: submitted_at)
+    create(:application_form, submitted_at: submitted_at)
   end
 
   let!(:application_choice) do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApplicationForm do
     end
 
     it 'can view audit records for ApplicationForm and its associated ApplicationChoices' do
-      application_form = create :completed_application_form
+      application_form = create(:completed_application_form, application_choices_count: 1)
 
       expect {
         application_form.application_choices.first.update!(personal_statement: 'hello again')

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ApplicationReference, type: :model do
   # be 1, so that we can still use that to describe 'First referee' etc in the
   # interface
   describe 'after deleting a reference' do
-    let!(:application_form) { create(:completed_application_form, references_count: 2) }
+    let!(:application_form) { create(:completed_application_form, references_count: 2, with_gces: true) }
 
     describe 'the ordinal of the remaining references' do
       let(:ordinals) { application_form.application_references.map(&:ordinal) }

--- a/spec/models/provider_agreement_spec.rb
+++ b/spec/models/provider_agreement_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProviderAgreement, type: :model do
 
   describe 'provider/provider_user association' do
     it 'is validated in the model' do
-      provider = create(:provider, :without_agreements)
+      provider = create(:provider)
       provider_user = create(:provider_user)
       agreement = ProviderAgreement.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
       expect(agreement).not_to be_valid
@@ -21,7 +21,7 @@ RSpec.describe ProviderAgreement, type: :model do
 
   describe ':accepted_at' do
     it 'is set automatically on :create' do
-      provider = create(:provider, :without_agreements)
+      provider = create(:provider)
       provider_user = create(:provider_user)
       provider.provider_users << provider_user
       agreement = ProviderAgreement.create(agreement_type: :data_sharing_agreement, provider: provider, provider_user: provider_user, accept_agreement: true)
@@ -41,7 +41,7 @@ RSpec.describe ProviderAgreement, type: :model do
   describe '#for_provider' do
     it 'returns agreements scoped to a provider' do
       data_sharing_agreement = create(:provider_agreement, agreement_type: :data_sharing_agreement)
-      other_provider = create(:provider, :without_agreements, code: 'ZZZ', name: 'Other')
+      other_provider = create(:provider, code: 'ZZZ', name: 'Other')
       create(:provider_agreement, provider: other_provider)
       expect(ProviderAgreement.count).to eq(2)
       expect(ProviderAgreement.for_provider(data_sharing_agreement.provider).count).to eq(1)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
 
   describe '#application_choices_added?' do
     it 'returns true if application choices are added' do
-      application_form = FactoryBot.build(:completed_application_form)
+      application_form = FactoryBot.build(:completed_application_form, application_choices_count: 1)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_application_choices_added

--- a/spec/services/get_application_forms_ready_to_send_to_providers_spec.rb
+++ b/spec/services/get_application_forms_ready_to_send_to_providers_spec.rb
@@ -1,13 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe GetApplicationFormsReadyToSendToProviders do
-  subject(:returned_application_forms) do
-    GetApplicationFormsReadyToSendToProviders.call
-  end
+  subject(:returned_application_forms) { GetApplicationFormsReadyToSendToProviders.call }
 
-  let(:application_form) do
-    create(:completed_application_form, :without_application_choices)
-  end
+  let(:application_form) { create(:application_form) }
 
   context 'when the edit_by dates have passed and the application_choices are application_complete' do
     before do

--- a/spec/services/get_pending_data_sharing_agreements_for_provider_user_spec.rb
+++ b/spec/services/get_pending_data_sharing_agreements_for_provider_user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GetPendingDataSharingAgreementsForProviderUser do
   describe 'one user, one provider' do
-    let(:provider) { create(:provider, :without_agreements, code: 'ABC', name: 'Example provider') }
+    let(:provider) { create(:provider, code: 'ABC', name: 'Example provider') }
     let(:provider_user) { create(:provider_user) }
 
     before { provider.provider_users << provider_user }
@@ -22,8 +22,8 @@ RSpec.describe GetPendingDataSharingAgreementsForProviderUser do
   end
 
   describe 'one user, many providers' do
-    let(:provider1) { create(:provider, :without_agreements, code: 'ABC', name: 'Example provider 1') }
-    let(:provider2) { create(:provider, :without_agreements, code: 'CBA', name: 'Example provider 2') }
+    let(:provider1) { create(:provider, code: 'ABC', name: 'Example provider 1') }
+    let(:provider2) { create(:provider, code: 'CBA', name: 'Example provider 2') }
     let(:provider_user) { create(:provider_user) }
 
     before do

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -6,7 +6,7 @@ module CourseOptionHelpers
   end
 
   def course_option_for_provider_code(provider_code:)
-    provider = create(:provider, code: provider_code)
+    provider = create(:provider, :with_signed_agreement, code: provider_code)
     course = create(:course, provider: provider)
     site = create(:site, provider: provider)
     create(:course_option, course: course, site: site)

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature 'A candidate edits their application' do
 
   def given_i_have_a_completed_application
     current_candidate.current_application.destroy! # Destroy the unsubmitted one that was created earlier for simplicity.
-    @form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
+    @form = create(:completed_application_form, :with_completed_references, references_count: 2, with_gces: true, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
     create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: @form)
   end
 

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'A candidate edits their course choice after submission' do
   end
 
   def and_i_have_a_completed_application
-    form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
+    form = create(:completed_application_form, :with_completed_references, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
     @application_choice = create(:application_choice, status: :awaiting_references, edit_by: Time.zone.local(2019, 12, 20), application_form: form)
   end
 

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'A candidate withdraws her application' do
   end
 
   def and_i_have_an_application_choice_awaiting_provider_decision
-    form = create(:completed_application_form, :with_completed_references, :without_application_choices, candidate: current_candidate)
+    form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
     @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: form)
   end
 

--- a/spec/system/provider_interface/first_login_spec.rb
+++ b/spec/system/provider_interface/first_login_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature 'See applications' do
   include DfESignInHelpers
 
   let(:pre_approved_provider_user) do
-    provider = create(:provider, code: 'ABC')
+    provider = create(:provider, :with_signed_agreement, code: 'ABC')
     create(:provider_user, providers: [provider], dfe_sign_in_uid: nil)
   end
 

--- a/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
+++ b/spec/system/provider_interface/see_applications_for_accrediting_provider_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'See applications for accrediting provider' do
   end
 
   def and_my_organisation_has_accredited_courses_with_applications
-    current_provider = create(:provider, code: 'ABC')
+    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
     other_provider = create(:provider, code: 'ANOTHER_ORG')
     course_option = course_option_for_provider(provider: current_provider)
     accredited_course_option_where_current_provider_is_accrediting = course_option_for_accrediting_provider(provider: other_provider, accrediting_provider: current_provider)

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -33,11 +33,11 @@ RSpec.feature 'See applications' do
 
   def when_my_apply_account_has_been_created
     provider_user = provider_user_exists_in_apply_database
-    create(:provider, code: 'ABC', provider_users: [provider_user])
+    create(:provider, :with_signed_agreement, code: 'ABC', provider_users: [provider_user])
   end
 
   def and_my_training_provider_exists
-    create(:provider, code: 'ABC')
+    create(:provider, :with_signed_agreement, code: 'ABC')
   end
 
   def given_i_am_a_provider_user_authenticated_with_dfe_sign_in

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -30,9 +30,9 @@ RSpec.feature 'See an application' do
   end
 
   def and_there_are_applications_in_the_system
-    @completed_application = create(:completed_application_form)
+    @completed_application = create(:completed_application_form, references_count: 2, with_gces: true)
     @unsubmitted_application = create(:application_form)
-    @application_with_reference = create(:completed_application_form)
+    @application_with_reference = create(:completed_application_form, references_count: 2, with_gces: true)
   end
 
   def and_an_application_has_received_a_reference

--- a/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
+++ b/spec/system/support_interface/send_chase_email_to_referee_and_candidate_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Send chase email to referee and candidate', with_audited: true do
   end
 
   def and_there_is_an_application_awaiting_references
-    @application_awaiting_references = create(:completed_application_form)
+    @application_awaiting_references = create(:completed_application_form, references_count: 1, with_gces: true)
     @referee = @application_awaiting_references.application_references.first
   end
 

--- a/spec/system/support_interface/send_new_referee_request_email_spec.rb
+++ b/spec/system/support_interface/send_new_referee_request_email_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Send new referee request to candidate', with_audited: true do
   end
 
   def and_there_is_an_application
-    @application = create(:completed_application_form)
+    @application = create(:completed_application_form, references_count: 1, with_gces: true)
     @candidate_name = "#{@application.first_name} #{@application.last_name}"
     @candidate_email = @application.candidate.email_address
     @referee = @application.application_references.first


### PR DESCRIPTION
## Context

We use factories extensively in our tests. Some factories are very expensive to create. For example, running `create(:completed_application_form)` creates what is commonly referred to as "way too many" records:

```rb
[2] pry(main)> FactoryBot.create(:completed_application_form)
   (0.1ms)  BEGIN
  Candidate Exists? (1.6ms)  SELECT 1 AS one FROM "candidates" WHERE LOWER("candidates"."email_address") = LOWER($1) LIMIT $2  [["email_address", "c6e71853cc@example.com"], ["LIMIT", 1]]
  Candidate Create (0.4ms)  INSERT INTO "candidates" ("email_address", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"  [["email_address", "c6e71853cc@example.com"], ["created_at", "2020-01-22 14:44:22.025655"], ["updated_at", "2020-01-22 14:44:22.025655"]]
   (0.4ms)  COMMIT
Creating scope :other. Overwriting existing method ApplicationQualification.other.
An enum element in ApplicationReference uses the prefix 'not_'. This will cause a conflict with auto generated negative scopes.
   (0.2ms)  BEGIN
  ApplicationForm Create (3.3ms)  INSERT INTO "application_forms" ("candidate_id", "first_name", "last_name", "created_at", "updated_at", "first_nationality", "english_main_language", "english_language_details", "other_language_details", "date_of_birth", "further_information", "phone_number", "address_line1", "address_line2", "address_line3", "address_line4", "country", "postcode", "submitted_at", "support_reference", "disability_disclosure", "uk_residency_status", "work_history_completed", "work_history_explanation", "degrees_completed", "becoming_a_teacher", "subject_knowledge", "interview_preferences", "other_qualifications_completed", "disclose_disability", "work_history_breaks", "course_choices_completed", "volunteering_completed") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33) RETURNING "id"  [["candidate_id", 12], ["first_name", "Ernest"], ["last_name", "Maggio"], ["created_at", "2020-01-22 14:44:22.701957"], ["updated_at", "2020-01-22 14:44:22.701957"], ["first_nationality", "Namibian"], ["english_main_language", true], ["english_language_details", "Quod maiores sed. Qui eum ut. Quasi ex repellat. Occaecati nihil blanditiis. Deleniti neque impedit. Error assumenda velit. Necessitatibus laboriosam officiis. Incidunt quis eveniet. Labore cumque id."], ["other_language_details", "Sint quas accusantium. Neque est omnis. Molestiae in sed. Dolore ea iste. Omnis qui harum. Modi sequi repudiandae. Et corporis iusto. Et tenetur et. Cumque vel enim. Quia sunt corporis. Harum laborum."], ["date_of_birth", "1985-02-08"], ["further_information", "Voluptatum cupiditate ea. Qui qui odio. Vel quis animi. Est sit ab. Rem accusamus officia. Soluta quasi saepe. Non eos tempora. Est fugiat sed. Quo architecto eveniet. Aliquid rem ut. Omnis quia repellat. Qui magni nihil. Aliquam possimus blanditiis. Et distinctio atque. Odio optio accusamus. Rerum."], ["phone_number", "07416 976705"], ["address_line1", "62516 Mraz Oval"], ["address_line2", "South Drew"], ["address_line3", "Hertfordshire"], ["address_line4", ""], ["country", "GB"], ["postcode", "WH6V 6AH"], ["submitted_at", "2020-01-17 09:11:44"], ["support_reference", "AJ9545"], ["disability_disclosure", "Consequuntur libero aut. Rem pariatur et. Laboriosam voluptate quo. Corporis dolorem laboriosam. Libero id repellendus. Nesciunt nulla harum. Veritatis architecto blanditiis. Voluptatem ex aliquid. Qui fuga molestiae. Consequatur illo esse. Repellat qui autem. Fugiat enim nisi. Eos necessitatibus i."], ["uk_residency_status", "I have the right to study and/or work in the UK"], ["work_history_completed", true], ["work_history_explanation", "Excepturi adipisci fugiat. Blanditiis temporibus enim. Qui ducimus facilis. Natus fuga et. Maxime repudiandae accusamus. Culpa soluta ut. Adipisci debitis nobis. Atque dicta qui. Voluptates sint consequuntur. Delectus et placeat. Omnis laudantium eos. Ex illo quaerat. Architecto hic sed. Dolorem exercitationem laudantium. Quasi omnis et. Laborum cum provident. Nam in qui. Tempora alias vel. Et rerum ad. Dolor dolor vero. Ut necessitatibus et. Cupiditate illo consequatur. Voluptatibus sed alias. Dolores quo id. Consequuntur id est. Exercitationem accusamus tempore. Repellat eos excepturi. Et u."], ["degrees_completed", true], ["becoming_a_teacher", "Voluptatem dolorem delectus. Aut molestias omnis. Eos eum ipsa. Fugit iusto sed. Unde culpa molestiae. Itaque quo aut. Et ratione voluptas. Exercitationem ut vel. Deleniti incidunt rerum. Ut autem aut. Sequi architecto delectus. Possimus consequatur aut. Qui enim accusamus. Totam aut dolorem. Voluptates voluptas amet. Veritatis assumenda quasi. Voluptatem voluptatem assumenda. Est sunt temporibus. Ab aut dicta. Est enim debitis. Tenetur adipisci dolor. Natus error iusto. Sed ea voluptatibus. Ma."], ["subject_knowledge", "Consequatur blanditiis sunt. Deserunt earum quia. Eligendi ea rerum. Totam voluptatibus sit. Commodi natus amet. Ullam et enim. Voluptatibus et sed. Eum accusamus aut. Nobis dolorem id. Et nam ducimus. Inventore veniam consequuntur. In sequi asperiores. Officiis eum architecto. Veritatis sunt archi."], ["interview_preferences", "Inventore id at. Autem et quidem. Sapiente impedit ut. Dicta odit dolorem. Ut perferendis expedita.."], ["other_qualifications_completed", true], ["disclose_disability", false], ["work_history_breaks", "Eos nam in. Adipisci aspernatur perspiciatis. Deserunt amet vitae. Doloremque harum quam. Quaerat enim corrupti. Eligendi minima doloribus. Dolor expedita autem. Et unde consequatur. Vel omnis aut. Magnam et dolor. Molestiae odio tenetur. Exercitationem soluta est. Natus officia et. Magnam porro laudantium. Delectus ea est. Ipsum mollitia incidunt. Quia qui hic. Et ut ea. Consequatur aperiam offi."], ["course_choices_completed", true], ["volunteering_completed", true]]
   (1.7ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 12], ["auditable_type", "ApplicationForm"]]
  Audited::Audit Create (0.8ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["auditable_id", 12], ["auditable_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"candidate_id\":12,\"first_name\":\"Ernest\",\"last_name\":\"Maggio\",\"first_nationality\":\"Namibian\",\"second_nationality\":null,\"english_main_language\":true,\"english_language_details\":\"Quod maiores sed. Qui eum ut. Quasi ex repellat. Occaecati nihil blanditiis. Deleniti neque impedit. Error assumenda velit. Necessitatibus laboriosam officiis. Incidunt quis eveniet. Labore cumque id.\",\"other_language_details\":\"Sint quas accusantium. Neque est omnis. Molestiae in sed. Dolore ea iste. Omnis qui harum. Modi sequi repudiandae. Et corporis iusto. Et tenetur et. Cumque vel enim. Quia sunt corporis. Harum laborum.\",\"date_of_birth\":\"1985-02-08\",\"further_information\":\"Voluptatum cupiditate ea. Qui qui odio. Vel quis animi. Est sit ab. Rem accusamus officia. Soluta quasi saepe. Non eos tempora. Est fugiat sed. Quo architecto eveniet. Aliquid rem ut. Omnis quia repellat. Qui magni nihil. Aliquam possimus blanditiis. Et distinctio atque. Odio optio accusamus. Rerum.\",\"phone_number\":\"07416 976705\",\"address_line1\":\"62516 Mraz Oval\",\"address_line2\":\"South Drew\",\"address_line3\":\"Hertfordshire\",\"address_line4\":\"\",\"country\":\"GB\",\"postcode\":\"WH6V 6AH\",\"submitted_at\":\"2020-01-17T09:11:44.000+00:00\",\"support_reference\":\"AJ9545\",\"disability_disclosure\":\"Consequuntur libero aut. Rem pariatur et. Laboriosam voluptate quo. Corporis dolorem laboriosam. Libero id repellendus. Nesciunt nulla harum. Veritatis architecto blanditiis. Voluptatem ex aliquid. Qui fuga molestiae. Consequatur illo esse. Repellat qui autem. Fugiat enim nisi. Eos necessitatibus i.\",\"uk_residency_status\":\"I have the right to study and/or work in the UK\",\"work_history_completed\":true,\"work_history_explanation\":\"Excepturi adipisci fugiat. Blanditiis temporibus enim. Qui ducimus facilis. Natus fuga et. Maxime repudiandae accusamus. Culpa soluta ut. Adipisci debitis nobis. Atque dicta qui. Voluptates sint consequuntur. Delectus et placeat. Omnis laudantium eos. Ex illo quaerat. Architecto hic sed. Dolorem exercitationem laudantium. Quasi omnis et. Laborum cum provident. Nam in qui. Tempora alias vel. Et rerum ad. Dolor dolor vero. Ut necessitatibus et. Cupiditate illo consequatur. Voluptatibus sed alias. Dolores quo id. Consequuntur id est. Exercitationem accusamus tempore. Repellat eos excepturi. Et u.\",\"degrees_completed\":true,\"becoming_a_teacher\":\"Voluptatem dolorem delectus. Aut molestias omnis. Eos eum ipsa. Fugit iusto sed. Unde culpa molestiae. Itaque quo aut. Et ratione voluptas. Exercitationem ut vel. Deleniti incidunt rerum. Ut autem aut. Sequi architecto delectus. Possimus consequatur aut. Qui enim accusamus. Totam aut dolorem. Voluptates voluptas amet. Veritatis assumenda quasi. Voluptatem voluptatem assumenda. Est sunt temporibus. Ab aut dicta. Est enim debitis. Tenetur adipisci dolor. Natus error iusto. Sed ea voluptatibus. Ma.\",\"subject_knowledge\":\"Consequatur blanditiis sunt. Deserunt earum quia. Eligendi ea rerum. Totam voluptatibus sit. Commodi natus amet. Ullam et enim. Voluptatibus et sed. Eum accusamus aut. Nobis dolorem id. Et nam ducimus. Inventore veniam consequuntur. In sequi asperiores. Officiis eum architecto. Veritatis sunt archi.\",\"interview_preferences\":\"Inventore id at. Autem et quidem. Sapiente impedit ut. Dicta odit dolorem. Ut perferendis expedita..\",\"other_qualifications_completed\":true,\"disclose_disability\":false,\"work_history_breaks\":\"Eos nam in. Adipisci aspernatur perspiciatis. Deserunt amet vitae. Doloremque harum quam. Quaerat enim corrupti. Eligendi minima doloribus. Dolor expedita autem. Et unde consequatur. Vel omnis aut. Magnam et dolor. Molestiae odio tenetur. Exercitationem soluta est. Natus officia et. Magnam porro laudantium. Delectus ea est. Ipsum mollitia incidunt. Quia qui hic. Et ut ea. Consequatur aperiam offi.\",\"course_choices_completed\":true,\"volunteering_completed\":true,\"volunteering_experience\":null,\"phase\":\"apply_1\"}"], ["version", 1], ["request_uuid", "eaf51f13-042a-414a-86a1-4d8769d22b13"], ["created_at", "2020-01-22 14:44:22.725569"]]
  ApplicationChoice Update All (0.6ms)  UPDATE "application_choices" SET "updated_at" = $1 WHERE "application_choices"."application_form_id" = $2  [["updated_at", "2020-01-22 14:44:22.739111"], ["application_form_id", 12]]
  ApplicationQualification Create (0.9ms)  INSERT INTO "application_qualifications" ("application_form_id", "level", "qualification_type", "subject", "grade", "predicted_grade", "award_year", "institution_name", "institution_country", "awarding_body", "equivalency_details", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING "id"  [["application_form_id", 12], ["level", "gcse"], ["qualification_type", "GCSE"], ["subject", "maths"], ["grade", "A"], ["predicted_grade", false], ["award_year", "1969"], ["institution_name", "Marblewald University"], ["institution_country", "GB"], ["awarding_body", "Brookville Technical College"], ["equivalency_details", "Adipisci neque necessitatibus. Consequatur aut et. Qui hic magnam. Quo corporis culpa. Soluta aperiam et. Eos nulla eos. Excepturi harum asperiores. Dicta doloremque debitis. Voluptatem nesciunt prov."], ["created_at", "2020-01-22 14:44:22.743472"], ["updated_at", "2020-01-22 14:44:22.743472"]]
   (0.3ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 34], ["auditable_type", "ApplicationQualification"]]
  Audited::Audit Create (0.3ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 34], ["auditable_type", "ApplicationQualification"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"application_form_id\":12,\"level\":\"gcse\",\"qualification_type\":\"GCSE\",\"subject\":\"maths\",\"grade\":\"A\",\"predicted_grade\":false,\"award_year\":\"1969\",\"institution_name\":\"Marblewald University\",\"institution_country\":\"GB\",\"awarding_body\":\"Brookville Technical College\",\"equivalency_details\":\"Adipisci neque necessitatibus. Consequatur aut et. Qui hic magnam. Quo corporis culpa. Soluta aperiam et. Eos nulla eos. Excepturi harum asperiores. Dicta doloremque debitis. Voluptatem nesciunt prov.\",\"other_uk_qualification_type\":null,\"missing_explanation\":null}"], ["version", 1], ["request_uuid", "9aba77cf-ceed-4b55-8579-58bde699cb7a"], ["created_at", "2020-01-22 14:44:22.747194"]]
  ApplicationForm Update (0.5ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.745296"], ["id", 12]]
   (0.5ms)  COMMIT
   (0.1ms)  BEGIN
  ApplicationQualification Create (0.3ms)  INSERT INTO "application_qualifications" ("application_form_id", "level", "qualification_type", "subject", "grade", "predicted_grade", "award_year", "institution_name", "institution_country", "awarding_body", "equivalency_details", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING "id"  [["application_form_id", 12], ["level", "gcse"], ["qualification_type", "GCSE"], ["subject", "english"], ["grade", "first"], ["predicted_grade", false], ["award_year", "1998"], ["institution_name", "Bluemeadow TAFE"], ["institution_country", "GB"], ["awarding_body", "Clearcourt Technical College"], ["equivalency_details", "Sunt vero blanditiis. Esse quidem vel. Quia praesentium deleniti. Eveniet iure dolores. Enim suscipit velit. Voluptate quia sint. Fugiat quasi quis. Eum sunt praesentium. Alias numquam odio. Eos dign."], ["created_at", "2020-01-22 14:44:22.753500"], ["updated_at", "2020-01-22 14:44:22.753500"]]
   (0.4ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 35], ["auditable_type", "ApplicationQualification"]]
  Audited::Audit Create (0.2ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 35], ["auditable_type", "ApplicationQualification"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"application_form_id\":12,\"level\":\"gcse\",\"qualification_type\":\"GCSE\",\"subject\":\"english\",\"grade\":\"first\",\"predicted_grade\":false,\"award_year\":\"1998\",\"institution_name\":\"Bluemeadow TAFE\",\"institution_country\":\"GB\",\"awarding_body\":\"Clearcourt Technical College\",\"equivalency_details\":\"Sunt vero blanditiis. Esse quidem vel. Quia praesentium deleniti. Eveniet iure dolores. Enim suscipit velit. Voluptate quia sint. Fugiat quasi quis. Eum sunt praesentium. Alias numquam odio. Eos dign.\",\"other_uk_qualification_type\":null,\"missing_explanation\":null}"], ["version", 1], ["request_uuid", "04bdfbb4-9989-42ee-a0ae-6588f824f889"], ["created_at", "2020-01-22 14:44:22.755573"]]
  ApplicationForm Update (0.2ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.754652"], ["id", 12]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  ApplicationQualification Create (0.3ms)  INSERT INTO "application_qualifications" ("application_form_id", "level", "qualification_type", "subject", "grade", "predicted_grade", "award_year", "institution_name", "institution_country", "awarding_body", "equivalency_details", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING "id"  [["application_form_id", 12], ["level", "gcse"], ["qualification_type", "GCSE"], ["subject", "science"], ["grade", "B"], ["predicted_grade", true], ["award_year", "1963"], ["institution_name", "Vertapple University"], ["institution_country", "GB"], ["awarding_body", "Mallowpond Technical College"], ["equivalency_details", "Sed quia voluptatem. Reiciendis ea ut. A voluptatem quia. Voluptatem voluptas ea. Nihil soluta saepe. Rerum et cupiditate. Sed aut aliquam. Corporis iusto minus. Suscipit sed nesciunt. Ut voluptatem ."], ["created_at", "2020-01-22 14:44:22.761012"], ["updated_at", "2020-01-22 14:44:22.761012"]]
   (0.2ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 36], ["auditable_type", "ApplicationQualification"]]
  Audited::Audit Create (0.2ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 36], ["auditable_type", "ApplicationQualification"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"application_form_id\":12,\"level\":\"gcse\",\"qualification_type\":\"GCSE\",\"subject\":\"science\",\"grade\":\"B\",\"predicted_grade\":true,\"award_year\":\"1963\",\"institution_name\":\"Vertapple University\",\"institution_country\":\"GB\",\"awarding_body\":\"Mallowpond Technical College\",\"equivalency_details\":\"Sed quia voluptatem. Reiciendis ea ut. A voluptatem quia. Voluptatem voluptas ea. Nihil soluta saepe. Rerum et cupiditate. Sed aut aliquam. Corporis iusto minus. Suscipit sed nesciunt. Ut voluptatem .\",\"other_uk_qualification_type\":null,\"missing_explanation\":null}"], ["version", 1], ["request_uuid", "7e84e3bb-ff75-414c-95af-ffd46608dd63"], ["created_at", "2020-01-22 14:44:22.763088"]]
  ApplicationForm Update (0.4ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.762228"], ["id", 12]]
   (0.3ms)  COMMIT
  Provider Load (1.0ms)  SELECT "providers".* FROM "providers" WHERE "providers"."code" = $1 LIMIT $2  [["code", "XE7"], ["LIMIT", 1]]
   (0.1ms)  BEGIN
  Provider Create (0.4ms)  INSERT INTO "providers" ("code", "created_at", "updated_at") VALUES ($1, $2, $3) RETURNING "id"  [["code", "XE7"], ["created_at", "2020-01-22 14:44:22.815180"], ["updated_at", "2020-01-22 14:44:22.815180"]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  ProviderUser Exists? (0.9ms)  SELECT 1 AS one FROM "provider_users" WHERE "provider_users"."dfe_sign_in_uid" = $1 LIMIT $2  [["dfe_sign_in_uid", "c1f633b5-7e38-4948-8fdc-7acf262bba8e"], ["LIMIT", 1]]
  ProviderUser Create (0.3ms)  INSERT INTO "provider_users" ("email_address", "dfe_sign_in_uid", "created_at", "updated_at") VALUES ($1, $2, $3, $4) RETURNING "id"  [["email_address", "taneka-a8d05fd5efbf099a574a4f88b764979d@example.com"], ["dfe_sign_in_uid", "c1f633b5-7e38-4948-8fdc-7acf262bba8e"], ["created_at", "2020-01-22 14:44:22.835879"], ["updated_at", "2020-01-22 14:44:22.835879"]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  Provider::HABTM_ProviderUsers Create (0.5ms)  INSERT INTO "provider_users_providers" ("provider_id", "provider_user_id") VALUES ($1, $2)  [["provider_id", 1934], ["provider_user_id", 2]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
   (0.4ms)  SELECT "provider_users"."id" FROM "provider_users" INNER JOIN "provider_users_providers" ON "provider_users"."id" = "provider_users_providers"."provider_user_id" WHERE "provider_users_providers"."provider_id" = $1  [["provider_id", 1934]]
  ProviderAgreement Create (0.8ms)  INSERT INTO "provider_agreements" ("provider_id", "provider_user_id", "agreement_type", "accepted_at", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"  [["provider_id", 1934], ["provider_user_id", 2], ["agreement_type", "data_sharing_agreement"], ["accepted_at", "2020-01-22 14:44:22.852886"], ["created_at", "2020-01-22 14:44:22.852827"], ["updated_at", "2020-01-22 14:44:22.852827"]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  Provider Update (0.3ms)  UPDATE "providers" SET "name" = $1, "updated_at" = $2 WHERE "providers"."id" = $3  [["name", "Bluemeadow University"], ["updated_at", "2020-01-22 14:44:22.854736"], ["id", 1934]]
   (0.2ms)  COMMIT
   (0.1ms)  BEGIN
  Course Exists? (0.8ms)  SELECT 1 AS one FROM "courses" WHERE "courses"."code" = $1 AND "courses"."provider_id" = $2 LIMIT $3  [["code", "GSOU"], ["provider_id", 1934], ["LIMIT", 1]]
  Course Create (0.5ms)  INSERT INTO "courses" ("provider_id", "name", "code", "created_at", "updated_at", "level", "recruitment_cycle_year") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["provider_id", 1934], ["name", "Applied Science (Psychology)"], ["code", "GSOU"], ["created_at", "2020-01-22 14:44:22.858561"], ["updated_at", "2020-01-22 14:44:22.858561"], ["level", "Primary"], ["recruitment_cycle_year", 2020]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  Site Create (1.2ms)  INSERT INTO "sites" ("code", "name", "provider_id", "created_at", "updated_at", "address_line1", "address_line2", "address_line3", "address_line4", "postcode") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING "id"  [["code", "V"], ["name", "Falconholt High School"], ["provider_id", 1934], ["created_at", "2020-01-22 14:44:22.872020"], ["updated_at", "2020-01-22 14:44:22.872020"], ["address_line1", "207 Carter Harbors"], ["address_line2", "West Lindsayberg"], ["address_line3", "Oxfordshire"], ["address_line4", ""], ["postcode", "ZF3R 4JA"]]
   (0.4ms)  COMMIT
   (0.1ms)  BEGIN
  CourseOption Create (0.9ms)  INSERT INTO "course_options" ("site_id", "course_id", "vacancy_status", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5) RETURNING "id"  [["site_id", 97], ["course_id", 428], ["vacancy_status", "B"], ["created_at", "2020-01-22 14:44:22.875582"], ["updated_at", "2020-01-22 14:44:22.875582"]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  ApplicationChoice Create (0.6ms)  INSERT INTO "application_choices" ("application_form_id", "personal_statement", "created_at", "updated_at", "status", "course_option_id", "edit_by") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "id"  [["application_form_id", 12], ["personal_statement", "hello"], ["created_at", "2020-01-22 14:44:22.878331"], ["updated_at", "2020-01-22 14:44:22.878331"], ["status", "awaiting_references"], ["course_option_id", 961], ["edit_by", "2020-01-24 09:11:44"]]
   (0.2ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 24], ["auditable_type", "ApplicationChoice"]]
  Audited::Audit Create (0.4ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 24], ["auditable_type", "ApplicationChoice"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"application_form_id\":12,\"personal_statement\":\"hello\",\"status\":\"awaiting_references\",\"offer\":null,\"rejection_reason\":null,\"course_option_id\":961,\"edit_by\":\"2020-01-24T09:11:44.000+00:00\",\"reject_by_default_at\":null,\"rejected_by_default\":false,\"reject_by_default_days\":null,\"decline_by_default_at\":null,\"decline_by_default_days\":null,\"offered_at\":null,\"rejected_at\":null,\"withdrawn_at\":null,\"declined_at\":null,\"declined_by_default\":false,\"offered_course_option_id\":null,\"accepted_at\":null,\"recruited_at\":null,\"conditions_not_met_at\":null,\"enrolled_at\":null}"], ["version", 1], ["request_uuid", "65081996-3d73-4a6c-8f79-0044f4ae168d"], ["created_at", "2020-01-22 14:44:22.881533"]]
  ApplicationForm Update (0.3ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.879865"], ["id", 12]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  ApplicationWorkExperience Create (0.6ms)  INSERT INTO "application_experiences" ("application_form_id", "type", "role", "organisation", "details", "working_with_children", "start_date", "commitment", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING "id"  [["application_form_id", 12], ["type", "ApplicationWorkExperience"], ["role", "Teaching Assistant"], ["organisation", "Mallowpond High School"], ["details", "Ut et ipsum. Et similique distinctio. Error quae et. Impedit consequatur assumenda. Illum exercitationem alias. Qui aperiam tempore. Dolorem commodi qui. Sequi vel autem. Dolorum odit nobis. Sint omnis inventore. Est eum totam. Et enim esse. Placeat et qui. Vero ut ipsum. Dolores laborum ab. Et qui."], ["working_with_children", true], ["start_date", "2010-12-29 00:00:00"], ["commitment", "Full-time"], ["created_at", "2020-01-22 14:44:22.906685"], ["updated_at", "2020-01-22 14:44:22.906685"]]
   (0.3ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 23], ["auditable_type", "ApplicationExperience"]]
  Audited::Audit Create (0.2ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 23], ["auditable_type", "ApplicationExperience"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"application_form_id\":12,\"role\":\"Teaching Assistant\",\"organisation\":\"Mallowpond High School\",\"details\":\"Ut et ipsum. Et similique distinctio. Error quae et. Impedit consequatur assumenda. Illum exercitationem alias. Qui aperiam tempore. Dolorem commodi qui. Sequi vel autem. Dolorum odit nobis. Sint omnis inventore. Est eum totam. Et enim esse. Placeat et qui. Vero ut ipsum. Dolores laborum ab. Et qui.\",\"working_with_children\":true,\"start_date\":\"2010-12-29T00:00:00.000+00:00\",\"end_date\":null,\"commitment\":\"Full-time\"}"], ["version", 1], ["request_uuid", "a2abc336-ce52-4e3d-a92e-0d887e97db95"], ["created_at", "2020-01-22 14:44:22.910131"]]
  ApplicationForm Update (0.2ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.908376"], ["id", 12]]
   (0.3ms)  COMMIT
   (0.2ms)  BEGIN
  ApplicationVolunteeringExperience Create (0.3ms)  INSERT INTO "application_experiences" ("application_form_id", "type", "role", "organisation", "details", "working_with_children", "start_date", "end_date", "commitment", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING "id"  [["application_form_id", 12], ["type", "ApplicationVolunteeringExperience"], ["role", "Teaching Assistant"], ["organisation", "Clearcourt Secondary College"], ["details", "A aut est. Earum repellendus qui. Non officiis ipsam. Sit sit perspiciatis. Hic dolorem aut. Ipsa consectetur voluptas. Ut quaerat ut. Adipisci impedit est. Dicta facere et. Et labore consequatur. Iste earum ut. Quia perspiciatis sapiente. Qui eum fugit. Nihil neque dolores. Labore fugiat quaerat. ."], ["working_with_children", false], ["start_date", "2005-03-16 00:00:00"], ["end_date", "2019-06-17 23:00:00"], ["commitment", "part_time"], ["created_at", "2020-01-22 14:44:22.925548"], ["updated_at", "2020-01-22 14:44:22.925548"]]
   (0.1ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 24], ["auditable_type", "ApplicationExperience"]]
  Audited::Audit Create (0.2ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 24], ["auditable_type", "ApplicationExperience"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"application_form_id\":12,\"role\":\"Teaching Assistant\",\"organisation\":\"Clearcourt Secondary College\",\"details\":\"A aut est. Earum repellendus qui. Non officiis ipsam. Sit sit perspiciatis. Hic dolorem aut. Ipsa consectetur voluptas. Ut quaerat ut. Adipisci impedit est. Dicta facere et. Et labore consequatur. Iste earum ut. Quia perspiciatis sapiente. Qui eum fugit. Nihil neque dolores. Labore fugiat quaerat. .\",\"working_with_children\":false,\"start_date\":\"2005-03-16T00:00:00.000+00:00\",\"end_date\":\"2019-06-18T00:00:00.000+01:00\",\"commitment\":\"part_time\"}"], ["version", 1], ["request_uuid", "c80ce830-0390-41c0-94ed-4898a02605e7"], ["created_at", "2020-01-22 14:44:22.928546"]]
  ApplicationForm Update (0.2ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.927005"], ["id", 12]]
   (0.2ms)  COMMIT
   (0.2ms)  BEGIN
  ApplicationReference Exists? (0.7ms)  SELECT 1 AS one FROM "references" WHERE LOWER("references"."email_address") = LOWER($1) AND "references"."application_form_id" = $2 LIMIT $3  [["email_address", "104aa3be59@example.com"], ["application_form_id", 12], ["LIMIT", 1]]
  ApplicationReference Create (0.5ms)  INSERT INTO "references" ("email_address", "application_form_id", "created_at", "updated_at", "name", "relationship") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"  [["email_address", "104aa3be59@example.com"], ["application_form_id", 12], ["created_at", "2020-01-22 14:44:22.964785"], ["updated_at", "2020-01-22 14:44:22.964785"], ["name", "Troy Lynch"], ["relationship", "Corporis ea possimus. Similique non fugiat. Blanditiis tenetur expedita."]]
   (0.1ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 23], ["auditable_type", "ApplicationReference"]]
  Audited::Audit Create (0.2ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 23], ["auditable_type", "ApplicationReference"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"email_address\":\"104aa3be59@example.com\",\"feedback\":null,\"application_form_id\":12,\"name\":\"Troy Lynch\",\"relationship\":\"Corporis ea possimus. Similique non fugiat. Blanditiis tenetur expedita.\",\"hashed_sign_in_token\":null,\"consent_to_be_contacted\":null,\"feedback_status\":\"not_requested_yet\"}"], ["version", 1], ["request_uuid", "1198338a-539f-4374-8f04-7a6b750e7be9"], ["created_at", "2020-01-22 14:44:22.967692"]]
  ApplicationForm Update (0.2ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.965987"], ["id", 12]]
   (0.3ms)  COMMIT
   (0.1ms)  BEGIN
  ApplicationReference Exists? (0.2ms)  SELECT 1 AS one FROM "references" WHERE LOWER("references"."email_address") = LOWER($1) AND "references"."application_form_id" = $2 LIMIT $3  [["email_address", "e85d3650d8@example.com"], ["application_form_id", 12], ["LIMIT", 1]]
  ApplicationReference Create (0.3ms)  INSERT INTO "references" ("email_address", "application_form_id", "created_at", "updated_at", "name", "relationship") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"  [["email_address", "e85d3650d8@example.com"], ["application_form_id", 12], ["created_at", "2020-01-22 14:44:22.972384"], ["updated_at", "2020-01-22 14:44:22.972384"], ["name", "Laurette Murazik"], ["relationship", "Ut cupiditate quam. Ea iste et. Illo est nulla."]]
   (0.1ms)  SELECT MAX("audits"."version") FROM "audits" WHERE "audits"."auditable_id" = $1 AND "audits"."auditable_type" = $2  [["auditable_id", 24], ["auditable_type", "ApplicationReference"]]
  Audited::Audit Create (0.3ms)  INSERT INTO "audits" ("auditable_id", "auditable_type", "associated_id", "associated_type", "action", "audited_changes", "version", "request_uuid", "created_at") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING "id"  [["auditable_id", 24], ["auditable_type", "ApplicationReference"], ["associated_id", 12], ["associated_type", "ApplicationForm"], ["action", "create"], ["audited_changes", "{\"email_address\":\"e85d3650d8@example.com\",\"feedback\":null,\"application_form_id\":12,\"name\":\"Laurette Murazik\",\"relationship\":\"Ut cupiditate quam. Ea iste et. Illo est nulla.\",\"hashed_sign_in_token\":null,\"consent_to_be_contacted\":null,\"feedback_status\":\"not_requested_yet\"}"], ["version", 1], ["request_uuid", "1d6c95a0-49c8-445c-aaa5-f5786a4bfd52"], ["created_at", "2020-01-22 14:44:22.974015"]]
  ApplicationForm Update (0.2ms)  UPDATE "application_forms" SET "updated_at" = $1 WHERE "application_forms"."id" = $2  [["updated_at", "2020-01-22 14:44:22.973170"], ["id", 12]]
   (0.3ms)  COMMIT
  ApplicationReference Load (0.3ms)  SELECT "references".* FROM "references" WHERE "references"."application_form_id" = $1 ORDER BY id ASC  [["application_form_id", 12]]
   (0.1ms)  BEGIN
  ApplicationChoice Update All (0.2ms)  UPDATE "application_choices" SET "updated_at" = $1 WHERE "application_choices"."application_form_id" = $2  [["updated_at", "2020-01-22 14:44:22.977870"], ["application_form_id", 12]]
   (0.2ms)  COMMIT
```

## Changes proposed in this pull request

See individual commits for details, but the general approach is to limit the number of indirectly created records for all factory calls.

Before: Finished in 2 minutes 8.6 seconds (files took 6.7 seconds to load)

After: Finished in 2 minutes 30.7 seconds (files took 6.22 seconds to load)

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/OEjmIn3C/327-the-tests-are-becoming-slow-high

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
