### PR TITLE
Tidy up how we search for completed references

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -31,7 +31,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def application_references_complete?
-    application_references.completed.count == MINIMUM_COMPLETE_REFERENCES
+    application_references.feedback_provided.count == MINIMUM_COMPLETE_REFERENCES
   end
 
   def awaiting_provider_decisions?

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -14,9 +14,6 @@ class ApplicationReference < ApplicationRecord
 
   audited associated_with: :application_form
 
-  # TODO: remove once `feedback_status` is deployed on all environments
-  scope :completed, -> { where('feedback IS NOT NULL') }
-
   enum feedback_status: {
     not_requested_yet: 'not_requested_yet',
     feedback_requested: 'feedback_requested',


### PR DESCRIPTION
## Context

The `completed` scope was a holdover from the time we didn’t have a `feedback_status`.

## Changes proposed in this pull request

 This commit makes sure we use the feedback_status through the automatically generated scope.

## Guidance to review

Nothing.

## Link to Trello card

This makes sure that https://trello.com/c/jdqG5Lif/798-bug-maybe-references-are-sent-to-provider-if-last-referee-declines really isn't a thing.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
