### PR TITLE
Update NotifyController to check for nil parameters

### DIFF
--- a/app/controllers/notify_controller.rb
+++ b/app/controllers/notify_controller.rb
@@ -7,6 +7,8 @@ class NotifyController < ApplicationController
 
   def callback
     return render_unauthorized unless authorized?
+    return render_unprocessable_entity if params.fetch(:status).nil?
+    return render json: nil, status: :ok if params.fetch(:reference).nil?
 
     process_notify_callback = ProcessNotifyCallback.new(notify_reference: params.fetch(:reference), status: params.fetch(:status))
 
@@ -33,10 +35,10 @@ private
     )
   end
 
-  def render_unprocessable_entity(e)
+  def render_unprocessable_entity
     render_error(
       name: 'UnprocessableEntity',
-      message: e.message,
+      message: "A 'reference' or 'status' key was not included or empty in the request body",
       status: :unprocessable_entity,
     )
   end

--- a/spec/requests/post_notify_callback_spec.rb
+++ b/spec/requests/post_notify_callback_spec.rb
@@ -53,6 +53,28 @@ RSpec.describe 'Notify Callback - POST /notify/callback', type: :request do
     expect(response).to have_http_status(:unprocessable_entity)
   end
 
+  it 'returns success if Notify reference is nil' do
+    request_body = {
+      reference: nil,
+      status: 'permanent-failure',
+    }.to_json
+
+    post '/notify/callback', headers: headers, params: request_body
+
+    expect(response).to have_http_status(:success)
+  end
+
+  it 'returns unprocessable entity if Notify status is nil' do
+    request_body = {
+      reference: "test-reference_request-#{reference.id}",
+      status: nil,
+    }.to_json
+
+    post '/notify/callback', headers: headers, params: request_body
+
+    expect(response).to have_http_status(:unprocessable_entity)
+  end
+
   it 'returns not found if Notify reference includes unknown reference id' do
     process_notify_callback = instance_double('ProcessNotifyCallback')
     allow(ProcessNotifyCallback).to receive(:new).and_return(process_notify_callback)


### PR DESCRIPTION
## Context

We refactored `NotifyController` to use `params.fetch` in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1174/commits/2619a69f1d83015e52b26159fe9e8a13ad002952. However, we've just learnt that if there isn't a Notify reference provided when we send an email using the service, Notify calls back to us with a `nil` reference instead of not having the key at all which is what we tested for.

See Sentry error - https://sentry.io/organizations/dfe-bat/issues/1463891477/?project=1765973.

## Changes proposed in this pull request (Updated: 22 Jan, 17:01)

This PR updates the `NotifyController` to check for nil parameters.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/FuEKJx9W/772-bounced-email-monitoring

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
