### PR TITLE
Test applications no longer have multiple identical course choices

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,11 +1,23 @@
 module TestApplications
-  def self.create_application(states)
+  def self.create_application(states:)
     first_name = Faker::Name.unique.first_name
     last_name = Faker::Name.unique.last_name
     candidate = FactoryBot.create(
       :candidate,
       email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
     )
+
+    courses_to_apply_to = Course.joins(:course_options)
+      .where(open_on_apply: true)
+      .order('RANDOM()')
+      .limit(states.count)
+
+    # it does not make sense to apply to the same course multiple times
+    # in the course of the same application, and it’s forbidden in the UI.
+    # Throw an exception if we try to do that here.
+    if courses_to_apply_to.count < states.count
+      raise "Not enough distinct courses to generate a #{states.count}-course application"
+    end
 
     #rubocop:disable Metrics/BlockLength
     Audited.audit_class.as_user(candidate) do
@@ -18,14 +30,15 @@ module TestApplications
         last_name: last_name,
       )
 
-      application_choices = FactoryBot.create_list(
-        :application_choice,
-        states.count,
-        status: 'unsubmitted',
-        course_option: CourseOption.all.sample,
-        application_form: application_form,
-        personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
-      )
+      application_choices = courses_to_apply_to.map do |course|
+        FactoryBot.create(
+          :application_choice,
+          status: 'unsubmitted',
+          course_option: course.course_options.first,
+          application_form: application_form,
+          personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
+        )
+      end
 
       return if states.include? :unsubmitted
 

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -5,18 +5,18 @@ class GenerateTestApplications
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
     without_slack_message_sending do
-      TestApplications.create_application [:unsubmitted]
-      TestApplications.create_application [:awaiting_references]
-      TestApplications.create_application [:application_complete]
-      TestApplications.create_application [:awaiting_provider_decision]
-      TestApplications.create_application %i[offer offer]
-      TestApplications.create_application %i[offer rejected]
-      TestApplications.create_application %i[rejected rejected]
-      TestApplications.create_application [:declined]
-      TestApplications.create_application [:accepted]
-      TestApplications.create_application [:recruited]
-      TestApplications.create_application [:enrolled]
-      TestApplications.create_application [:withdrawn]
+      TestApplications.create_application states: [:unsubmitted]
+      TestApplications.create_application states: [:awaiting_references]
+      TestApplications.create_application states: [:application_complete]
+      TestApplications.create_application states: [:awaiting_provider_decision]
+      TestApplications.create_application states: %i[offer offer]
+      TestApplications.create_application states: %i[offer rejected]
+      TestApplications.create_application states: %i[rejected rejected]
+      TestApplications.create_application states: [:declined]
+      TestApplications.create_application states: [:accepted]
+      TestApplications.create_application states: [:recruited]
+      TestApplications.create_application states: [:enrolled]
+      TestApplications.create_application states: [:withdrawn]
     end
   end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe TestApplications do
+  it 'generates an application with choices in the given states' do
+    create(:course_option, course: create(:course, open_on_apply: true))
+    create(:course_option, course: create(:course, open_on_apply: true))
+
+    choices = TestApplications.create_application(states: %i[offer rejected])
+
+    expect(choices.count).to eq(2)
+  end
+
+  it 'throws an exception if there aren’t enough courses to apply to' do
+    expect {
+      TestApplications.create_application(states: %i[offer])
+    }.to raise_error(/Not enough distinct courses/)
+  end
+end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -2,10 +2,11 @@ require 'rails_helper'
 
 RSpec.describe GenerateTestApplications do
   before do
-    create(:course_option)
+    create(:course_option, course: create(:course, open_on_apply: true))
+    create(:course_option, course: create(:course, open_on_apply: true))
   end
 
-  it 'generates 11 test candidates with applications in various states' do
+  it 'generates 12 test candidates with applications in various states' do
     GenerateTestApplications.new.perform
 
     expect(Candidate.count).to be 12


### PR DESCRIPTION
A defect was introduced in #1160 when we turned a loop that called `CourseOption.all.sample` into a call to `FactoryBot.create_list`. This resulted in all test applications having ApplicationChoices associated with the same CourseOption.

Also, instead of sampling a random CourseOption when we create the application — which may result in the candidate applying to the same course at two different sites, not permitted via the UI — ensure we pick distinct courses. If there aren't enough distinct courses, throw an exception.

<img width="993" alt="Screenshot 2020-01-22 at 17 16 39" src="https://user-images.githubusercontent.com/642279/72917145-32087000-3d3b-11ea-83fa-d6348402ffbf.png">


## Guidance to review

Try running `rake setup_local_dev_data`

## Link to Trello card

Towards https://trello.com/c/VLw7X81Z/1526-improvements-to-the-generatetestdata-api-feature-for-tribal

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
