### PR TITLE
Show the 'decline by default date' in support

### DIFF
--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -43,6 +43,7 @@
       { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent, application_choice: application_choice) },
     ] %>
     <% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at %>
+    <% rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at %>
 
     <%= render SummaryCardComponent, rows: rows  do %>
       <%= render SummaryCardHeaderComponent, title: application_choice.course.name_and_code %>


### PR DESCRIPTION
## Context

It's useful for support agents to see when application choices will be declined by default.

## Changes proposed in this pull request

Add the DBD date when available to the component.

![image](https://user-images.githubusercontent.com/23801/72922631-47829780-3d45-11ea-876e-9b07eeca93de.png)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
