### PR TITLE
Add missing mailer previews

### DIFF
--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -19,10 +19,37 @@ class CandidateMailerPreview < ActionMailer::Preview
     )
   end
 
-  def survey_email
-    application_form = FactoryBot.build(:application_form, first_name: 'Gemma', last_name: 'Say')
-    FactoryBot.build(:reference, application_form: application_form)
+  def reference_chaser_email
+    CandidateMailer.reference_chaser_email(application_form, reference)
+  end
 
+  def survey_email
     CandidateMailer.survey_email(application_form)
+  end
+
+  def survey_chaser_email
+    CandidateMailer.survey_chaser_email(application_form)
+  end
+
+  def new_referee_request_with_not_responded
+    CandidateMailer.new_referee_request(application_form, reference, reason: :not_responded)
+  end
+
+  def new_referee_request_with_refused
+    CandidateMailer.new_referee_request(application_form, reference, reason: :refused)
+  end
+
+  def new_referee_request_with_email_bounced
+    CandidateMailer.new_referee_request(application_form, reference, reason: :email_bounced)
+  end
+
+private
+
+  def application_form
+    FactoryBot.build_stubbed(:application_form, first_name: 'Gemma')
+  end
+
+  def reference
+    FactoryBot.build_stubbed(:reference, application_form: application_form)
   end
 end

--- a/app/mailers/previews/referee_mailer_preview.rb
+++ b/app/mailers/previews/referee_mailer_preview.rb
@@ -1,15 +1,29 @@
 class RefereeMailerPreview < ActionMailer::Preview
   def reference_request_email
-    application_form = FactoryBot.build(:completed_application_form)
-    reference = application_form.application_references.reload.first
+    application_form = FactoryBot.create(:application_form)
+    reference = FactoryBot.create(:reference, application_form: application_form)
 
     RefereeMailer.reference_request_email(application_form, reference)
   end
 
   def reference_request_chaser_email
-    application_form = FactoryBot.build(:completed_application_form)
-    reference = application_form.application_references.reload.first
+    application_form = FactoryBot.create(:application_form)
+    reference = FactoryBot.create(:reference, application_form: application_form)
 
     RefereeMailer.reference_request_chaser_email(application_form, reference)
+  end
+
+  def survey_email
+    application_form = FactoryBot.build_stubbed(:application_form, first_name: 'Rachael')
+    reference = FactoryBot.build_stubbed(:reference, application_form: application_form)
+
+    RefereeMailer.survey_email(application_form, reference)
+  end
+
+  def survey_chaser_email
+    application_form = FactoryBot.build_stubbed(:application_form, first_name: 'Rachael')
+    reference = FactoryBot.build_stubbed(:reference, application_form: application_form)
+
+    RefereeMailer.survey_chaser_email(reference)
   end
 end


### PR DESCRIPTION
## Context

I didn't know that mailer previews were a thing until recently.

They are super useful.

## Changes proposed in this pull request

This PR adds mailer previews for a number of missing emails in `CandidateMailer` and `RefereeMailer`.

## Guidance to review

Nothing in particular.

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
