### PR TITLE
Add ability to see if candidate sign up email bounced in Support

### DIFF
--- a/app/components/support_interface/candidates_table_component.rb
+++ b/app/components/support_interface/candidates_table_component.rb
@@ -10,7 +10,7 @@ module SupportInterface
       candidates.map do |candidate|
         {
           candidate_id: candidate.id,
-          process_state: ProcessState.new(candidate.last_updated_application).state,
+          process_state: process_state(candidate),
           candidate_link: govuk_link_to(candidate.email_address, support_interface_candidate_path(candidate)),
           updated_at: candidate.last_updated_application&.updated_at&.to_s(:govuk_date_and_time),
         }
@@ -20,5 +20,11 @@ module SupportInterface
   private
 
     attr_reader :candidates
+
+    def process_state(candidate)
+      return :sign_up_email_bounced if candidate.sign_up_email_bounced
+
+      ProcessState.new(candidate.last_updated_application).state
+    end
   end
 end

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -4,7 +4,8 @@ class AuthenticationMailer < ApplicationMailer
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: candidate.email_address,
-              subject: t('authentication.sign_up.email.subject'))
+              subject: t('authentication.sign_up.email.subject'),
+              reference: "#{HostingEnvironment.environment_name}-sign_up_email-#{candidate.id}")
   end
 
   def sign_in_email(candidate:, token:)

--- a/app/services/process_notify_callback.rb
+++ b/app/services/process_notify_callback.rb
@@ -1,23 +1,33 @@
 class ProcessNotifyCallback
+  EXPECTED_EMAIL_TYPES = %w[reference_request sign_up_email].freeze
+
   def initialize(notify_reference:, status:)
-    @environment, @email_type, @reference_id = notify_reference.split('-')
+    @environment, @email_type, @id = notify_reference.split('-')
     @status = status
     @not_found = false
   end
 
   def call
-    return unless same_environment? && reference_request_email? && permanent_failure_status?
+    return unless same_environment? && expected_email_type? && permanent_failure_status?
 
-    ActiveRecord::Base.transaction do
-      reference = ApplicationReference.find(@reference_id)
+    if reference_request_email?
+      ActiveRecord::Base.transaction do
+        reference = ApplicationReference.find(@id)
 
-      reference.update!(feedback_status: 'email_bounced')
+        reference.update!(feedback_status: 'email_bounced')
 
-      SendNewRefereeRequestEmail.call(
-        application_form: reference.application_form,
-        reference: reference,
-        reason: :email_bounced,
-      )
+        SendNewRefereeRequestEmail.call(
+          application_form: reference.application_form,
+          reference: reference,
+          reason: :email_bounced,
+        )
+      end
+    end
+
+    if sign_up_email?
+      candidate = Candidate.find(@id)
+
+      candidate.update!(sign_up_email_bounced: true, hide_in_reporting: true)
     end
   rescue ActiveRecord::RecordNotFound
     @not_found = true
@@ -33,8 +43,16 @@ private
     @environment == HostingEnvironment.environment_name
   end
 
+  def expected_email_type?
+    EXPECTED_EMAIL_TYPES.include?(@email_type)
+  end
+
   def reference_request_email?
     @email_type == 'reference_request'
+  end
+
+  def sign_up_email?
+    @email_type == 'sign_up_email'
   end
 
   def permanent_failure_status?

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -1,5 +1,8 @@
 en:
   process_states:
+    sign_up_email_bounced:
+      name: Sign up email bounced
+      description: Candidate was sent a sign up email but it bounced
     never_signed_in:
       name: Never signed in
       description: Candidate has signed up but never signed into the service

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :candidate do
     email_address { "#{SecureRandom.hex(5)}@example.com" }
+    sign_up_email_bounced { false }
   end
 
   factory :application_form do

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe AuthenticationMailer, type: :mailer do
     it 'sends an email with a magic link' do
       expect(mail.body.encoded).to include("http://localhost:3000/candidate/authenticate?token=#{token}")
     end
+
+    it 'sends a request with a Notify reference' do
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'example_env' do
+        mail.deliver_now
+      end
+
+      expect(mail[:reference].value).to eq("example_env-sign_up_email-#{candidate.id}")
+    end
   end
 
   describe 'the candidate receives the sign in email containing the magic link' do

--- a/spec/services/process_notify_callback_spec.rb
+++ b/spec/services/process_notify_callback_spec.rb
@@ -21,8 +21,9 @@ RSpec.describe ProcessNotifyCallback do
     application_form = create(:application_form)
     create(:reference, feedback_status: 'feedback_requested', application_form: application_form)
   end
+  let(:candidate) { create(:candidate, sign_up_email_bounced: false, hide_in_reporting: false) }
 
-  context 'when expected Notify reference is provided' do
+  context 'when expected Notify reference is provided with reference request' do
     let(:notify_reference) { "example_env-reference_request-#{reference.id}" }
 
     context 'with permanent-failure status' do
@@ -54,6 +55,40 @@ RSpec.describe ProcessNotifyCallback do
     end
   end
 
+  context 'when expected Notify reference is provided with sign up email' do
+    let(:notify_reference) { "example_env-sign_up_email-#{candidate.id}" }
+
+    context 'with permanent-failure status' do
+      let(:status) { 'permanent-failure' }
+
+      it 'updates sign up email bounced to true for candidate' do
+        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+
+        process_notify_callback.call
+
+        expect(candidate.reload.sign_up_email_bounced).to eq(true)
+      end
+
+      it 'updates hide in reporting to true for candidate' do
+        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+
+        process_notify_callback.call
+
+        expect(candidate.reload.hide_in_reporting).to eq(true)
+      end
+
+      it 'sets not found to true if candidate cannot be found' do
+        allow(Candidate).to receive(:find).with(candidate.id.to_s).and_raise(ActiveRecord::RecordNotFound)
+
+        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+
+        process_notify_callback.call
+
+        expect(process_notify_callback).to be_not_found
+      end
+    end
+  end
+
   context 'when unexpected Notify reference is provided' do
     let(:status) { 'permanent-failure' }
 
@@ -64,11 +99,21 @@ RSpec.describe ProcessNotifyCallback do
       it_behaves_like "a callback that doesn't change the feedback status of a reference"
     end
 
-    context 'with email type not reference request' do
-      let(:email_type) { 'survey_email' }
+    context 'with email type not reference request or sign up email bounced' do
+      let(:email_type) { 'example_email' }
       let(:notify_reference) { "example_env-#{email_type}-#{reference.id}" }
 
       it_behaves_like "a callback that doesn't change the feedback status of a reference"
+
+      it 'does not update sign up email bounced and hide in reporting to true for candidate' do
+        notify_reference = "example_env-#{email_type}-#{candidate.id}"
+        process_notify_callback = ProcessNotifyCallback.new(notify_reference: notify_reference, status: status)
+
+        process_notify_callback.call
+
+        expect(candidate.reload.sign_up_email_bounced).to eq(false)
+        expect(candidate.reload.hide_in_reporting).to eq(false)
+      end
     end
   end
 end

--- a/spec/system/support_interface/see_candidates_spec.rb
+++ b/spec/system/support_interface/see_candidates_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'See candidates' do
   end
 
   def and_there_are_candidates_in_the_system
+    @candidate_with_sign_up_email_bounced = create(:candidate, sign_up_email_bounced: true)
     @candidate_who_has_signed_up_but_not_signed_in = create(:candidate)
     @candidate_with_a_submitted_application = create(:application_form).candidate
   end
@@ -31,6 +32,10 @@ RSpec.feature 'See candidates' do
   end
 
   def then_i_should_see_the_candidates
+    within("[data-qa='candidate-#{@candidate_with_sign_up_email_bounced.id}']") do
+      expect(page).to have_content @candidate_with_sign_up_email_bounced.email_address
+      expect(page).to have_content('Sign up email bounced')
+    end
     within("[data-qa='candidate-#{@candidate_who_has_signed_up_but_not_signed_in.id}']") do
       expect(page).to have_content @candidate_who_has_signed_up_but_not_signed_in.email_address
       expect(page).to have_content('Never signed in')


### PR DESCRIPTION
## Context

We want to be able to see in Support if a candidate tried to sign up but the email bounced.

## Changes proposed in this pull request

This PR adds the ability to see if candidate sign up email bounced in Support by:

- adding a Notify reference when we send a candidate a sign up email
- adding checking in `ProcessNotifyCallback` to see if an email with `sign_up_email` in the Notify reference and `permanent-failure` status, then updating `sign_up_email_bounced` and `hide_in_reporting` attributes of the candidate to `true`.
- displaying `Sign up email bounced` on the candidates page in Support

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/72981766-7c3e2f80-3dd5-11ea-89dd-55b1e1f4d1f5.png)

## Guidance to review

- ~~Making a draft as want to test using Heroku preview app~~
- Review commit by commit

## Link to Trello card

https://trello.com/c/eRWPVFng/783-bounced-email-candidate-strategic

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
