### PR TITLE
Restore pipeline test result publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-RESULTS_PATH = "/results"
+RESULTS_PATH=/results
 
 define copy_test_results
-	#Obtains the results folder from within the stopped container and copies it to the local file system on the agent.
-	container_id=$$(docker ps -a --no-trunc | grep apply-for-postgraduate-teacher-training | cut -d ' ' -f1); \
-        docker cp $$container_id:$(RESULTS_PATH)/ .
+	## Obtains the results folder from within the stopped container and copies it to the local file system on the agent.
+	container_id=$$(docker ps -a --no-trunc | grep apply-for-postgraduate-teacher-training | head -1 | cut -d ' ' -f1); \
+	docker cp $$container_id:$(RESULTS_PATH)/ .
 endef
 
 .PHONY: help
@@ -42,7 +42,7 @@ ci.lint-erb: ## Run the ERB linter
 
 .PHONY: ci.cucumber
 ci.cucumber: ## Run the Cucumber specs
-	docker-compose run web /bin/sh -c 'mkdir $(RESULTS_PATH) && \
+	-docker-compose run web /bin/sh -c 'mkdir $(RESULTS_PATH) && \
 		bundle exec cucumber --format junit --out $(RESULTS_PATH)'
 	$(call copy_test_results)
 	docker-compose rm -f -v web
@@ -52,6 +52,6 @@ ci.test: ## Run the tests with results formatted for CI
 	docker-compose run web /bin/sh -c 'mkdir $(RESULTS_PATH) && \
 		apk add nodejs yarn && \
 		bundle exec rails assets:precompile && \
-		bundle exec --verbose rspec'
+		bundle exec --verbose rspec --failure-exit-code 0 --format RspecJunitFormatter --out $(RESULTS_PATH)/rspec-results.xml'
 	$(call copy_test_results)
 	docker-compose rm -f -v web

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,7 @@ stages:
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
 
     - script: make ci.lint-ruby
+      name: ci_lint_ruby
       displayName: 'Rubocop'
       env:
         dockerHubUsername: $(dockerHubUsername)
@@ -62,7 +63,9 @@ stages:
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
 
     - script: make ci.lint-erb
+      name: ci_lint_erb
       displayName: 'ERB lint'
+      condition: succeededOrFailed()
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -77,12 +80,52 @@ stages:
         test_result=$?
         if [ "$test_result" == "0" ]
         then
-          true;
+          if [ $(find results/ -type f -name TEST*.xml | wc -l) -gt 0 ]
+          then
+            errors=0
+            warnings=0
+
+            for line in $(grep "^<testsuite " results/TEST*.xml)
+            do
+              if [[ $line == failure* ]]
+              then
+                test_failures=$(echo $line | cut -d '"' -f2)
+                errors=$((errors+test_failures))
+              fi
+              if [[ $line == error* ]]
+              then
+                test_errors=$(echo $line | cut -d '"' -f2)
+                errors=$((errors+test_errors))
+              fi
+              if [[ $line == skipped* ]]
+              then
+                test_skipped=$(echo $line | cut -d '"' -f2)
+                warnings=$((warning+test_skipped))
+              fi
+            done
+
+            if [ $errors -gt 0 ]
+            then
+              echo "##vso[task.logissue type=error]One or more cucumber tests failed."
+              exit 1
+            fi
+            if [ $warnings -gt 0 ]
+            then
+              echo "##vso[task.logissue type=warning]One or more cucumber tests were skipped."
+            fi
+
+          else
+            echo "##vso[task.logissue type=error]Cucumber test result files not found."
+            exit 1
+          fi
+          exit 0
         else
-          echo "ERROR: Cucumber spec tests failed."
-          false
+          echo "##vso[task.logissue type=error]Cucumber test task exited abnormally."
+          exit 1
         fi
+      name: ci_cucumber
       displayName: 'Cucumber specs'
+      condition: succeededOrFailed()
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -97,12 +140,30 @@ stages:
         test_result=$?
         if [ "$test_result" == "0" ]
         then
-          true;
+          if [ -f results/rspec-results.xml ]
+          then
+            if [ $(grep "^<testsuite name=\"rspec\"" results/rspec-results.xml | cut -d' ' -f5 | cut -d'"' -f2) -gt 0 ]
+            then
+              echo "##vso[task.logissue type=error]One or more rspec tests failed"
+              exit 1
+            fi
+            if [ $(grep "^<testsuite name=\"rspec\"" results/rspec-results.xml | cut -d' ' -f4 | cut -d'"' -f2) -gt 0 ]
+            then
+              echo "##vso[task.logissue type=warning]One or more rspec tests were skipped"
+              exit 1
+            fi
+          else
+            echo "##vso[task.logissue type=error]rspec-results file not found."
+            exit 1
+          fi
+          exit 0
         else
-          echo "ci.test failed"
-          false
+          echo "##vso[task.logissue type=error]Rspec test task exited abnormally."
+          exit 1
         fi
+      name: ci_test
       displayName: 'Execute tests'
+      condition: succeededOrFailed()
       env:
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
@@ -144,6 +205,13 @@ stages:
       inputs:
         path: '$(System.DefaultWorkingDirectory)/azure/'
         artifactName: 'arm_template'
+
+    - task: PublishTestResults@2
+      displayName: 'Publish Test Results'
+      condition: succeededOrFailed()
+      inputs:
+        testRunner: JUnit
+        testResultsFiles: 'results/*.xml'
 
 
 - stage: deploy_qa


### PR DESCRIPTION
## Context

Publishing of the test results in the Azure DevOps pipeline was removed some months ago because when the tests failed no meaningful information about what had failed could be determined from teh DevOps GUI.
This change rectified that by restoring the test publishing task into the pipeline and better handling of results publishing when any of the rspec or cucumber tests fail such that the details of the failed test can be viewed from the "Test" tab in the pipeline run results page.

## Changes proposed in this pull request

- Restore pipeline results publishing task
- Amend the tests in the Makefile such that they handle a test case failure more gracefully. Previously an test failure would cause an immediate abort in the DevOps task and consequently no results could then be displayed in the pipeline Test tab. This behaviour has been changed so that all tests run and results can be displayed.
- The pipeline is now configured to run all test steps irrespective of whether earlier tests failed. Onwards tasks will only run if ALL tests tasks succeed.

## Guidance to review

Examples of the different failure scenario can be viewed in the DevOps GUI at the following link where you can see the resultant test tabs highlighting the test failures.
https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary&repositoryFilter=37&branchFilter=6110

## Link to Trello card

https://trello.com/c/msL7IJDT/1264-fix-rspec-test-reporting-in-azure-pipelines

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
