### PR TITLE
Update email and personal details of provider and support users when they log in

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class ProviderInterfaceController < ActionController::Base
     include LogQueryParams
+
     before_action :authenticate_provider_user!
     around_action :set_audit_username
     before_action :add_identity_to_log

--- a/app/lib/dsi_profile.rb
+++ b/app/lib/dsi_profile.rb
@@ -1,0 +1,11 @@
+class DsiProfile
+  def self.update_profile_from_dfe_sign_in(dfe_user:, local_user:)
+    fields_to_update = {}
+    if local_user.dfe_sign_in_uid && dfe_user.email_address.present?
+      fields_to_update[:email_address] = dfe_user.email_address
+    end
+    fields_to_update[:first_name] = dfe_user.first_name if dfe_user.first_name.present?
+    fields_to_update[:last_name] = dfe_user.last_name if dfe_user.last_name.present?
+    local_user.update(fields_to_update) if fields_to_update.present?
+  end
+end

--- a/app/models/dfe_sign_in_user.rb
+++ b/app/models/dfe_sign_in_user.rb
@@ -1,15 +1,20 @@
 class DfESignInUser
   attr_reader :email_address, :dfe_sign_in_uid
+  attr_accessor :first_name, :last_name
 
-  def initialize(email_address:, dfe_sign_in_uid:)
+  def initialize(email_address:, dfe_sign_in_uid:, first_name:, last_name:)
     @email_address = email_address&.downcase
     @dfe_sign_in_uid = dfe_sign_in_uid
+    @first_name = first_name
+    @last_name = last_name
   end
 
   def self.begin_session!(session, omniauth_payload)
     session['dfe_sign_in_user'] = {
       'email_address' => omniauth_payload['info']['email'],
       'dfe_sign_in_uid' => omniauth_payload['uid'],
+      'first_name' => omniauth_payload['info']['first_name'],
+      'last_name' => omniauth_payload['info']['last_name'],
       'last_active_at' => Time.zone.now,
     }
     if (associated_user = SupportUser.load_from_session(session) || ProviderUser.load_from_session(session))
@@ -32,6 +37,8 @@ class DfESignInUser
     new(
       email_address: dfe_sign_in_session['email_address'],
       dfe_sign_in_uid: dfe_sign_in_session['dfe_sign_in_uid'],
+      first_name: dfe_sign_in_session['first_name'],
+      last_name: dfe_sign_in_session['last_name'],
     )
   end
 

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -9,7 +9,7 @@ options = {
   name: :dfe,
   discovery: true,
   response_type: :code,
-  scope: %i[email],
+  scope: %i[email profile],
   path_prefix: '/auth',
   callback_path: '/auth/dfe/callback',
   client_options: {
@@ -25,7 +25,7 @@ options = {
 if DfESignIn.bypass?
   Rails.application.config.middleware.use OmniAuth::Builder do
     provider :developer,
-             fields: %i[uid email],
+             fields: %i[uid email first_name last_name],
              uid_field: :uid
   end
 else

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -234,10 +234,14 @@ FactoryBot.define do
   factory :support_user do
     dfe_sign_in_uid { SecureRandom.uuid }
     email_address { "#{Faker::Name.first_name.downcase}@example.com" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
   end
 
   factory :provider_user do
     dfe_sign_in_uid { SecureRandom.uuid }
     email_address { "#{Faker::Name.first_name.downcase}-#{SecureRandom.hex}@example.com" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
   end
 end

--- a/spec/lib/dsi_profile_spec.rb
+++ b/spec/lib/dsi_profile_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe DsiProfile do
+  describe '#update_profile_from_dfe_sign_in' do
+    let(:provider_user) { create(:provider_user) }
+    let(:support_user) { create(:provider_user) }
+    let(:dfe_user) {
+      DfESignInUser.new(
+        email_address: 'new+email@example.com',
+        dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+        first_name: provider_user.first_name,
+        last_name: provider_user.last_name,
+      )
+    }
+
+    context 'local_user\'s email_address' do
+      it 'is updated if uid is previously known' do
+        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        expect(provider_user.email_address).to eq('new+email@example.com')
+      end
+
+      it 'is not updated if uid is not yet established' do
+        provider_user.update(dfe_sign_in_uid: nil)
+        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        expect(provider_user.email_address).to eq(provider_user.email_address)
+      end
+
+      it 'is not updated if no email is provided' do
+        dfe_user_no_email = DfESignInUser.new(
+          email_address: '',
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: nil,
+          last_name: nil,
+        )
+        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user_no_email, local_user: provider_user
+        expect(provider_user.email_address).to eq(provider_user.email_address)
+      end
+    end
+
+    context 'local_user\'s profile fields' do
+      it 'updates first_name if supplied' do
+        dfe_user.first_name = 'New name'
+        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        expect(provider_user.first_name).to eq('New name')
+        dfe_user.first_name = ' '
+        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        expect(provider_user.first_name).to eq('New name')
+      end
+
+      it 'updates last_name if supplied' do
+        dfe_user.last_name = 'New name'
+        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        expect(provider_user.last_name).to eq('New name')
+        dfe_user.last_name = ' '
+        DsiProfile.update_profile_from_dfe_sign_in dfe_user: dfe_user, local_user: provider_user
+        expect(provider_user.last_name).to eq('New name')
+      end
+    end
+  end
+end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe ProviderUser, type: :model do
       dsi_user = DfESignInUser.new(
         email_address: provider_user.email_address,
         dfe_sign_in_uid: 'ABC123',
+        first_name: nil,
+        last_name: nil,
       )
       ProviderUser.onboard!(dsi_user)
       expect(provider_user.reload.dfe_sign_in_uid).to eq 'ABC123'
@@ -24,6 +26,8 @@ RSpec.describe ProviderUser, type: :model do
       dsi_user = DfESignInUser.new(
         email_address: 'BoB@example.com',
         dfe_sign_in_uid: 'ABC123',
+        first_name: nil,
+        last_name: nil,
       )
       ProviderUser.onboard!(dsi_user)
       expect(provider_user.reload.dfe_sign_in_uid).to eq 'ABC123'

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -1,7 +1,12 @@
 module DfESignInHelpers
-  def user_exists_in_dfe_sign_in(email_address: 'email@provider.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  def user_exists_in_dfe_sign_in(email_address: 'email@provider.ac.uk', dfe_sign_in_uid: 'DFE_SIGN_IN_UID', first_name: nil, last_name: nil)
     OmniAuth.config.mock_auth[:dfe] = OmniAuth::AuthHash.new(
-      fake_dfe_sign_in_auth_hash(email_address: email_address, dfe_sign_in_uid: dfe_sign_in_uid),
+      fake_dfe_sign_in_auth_hash(
+        email_address: email_address,
+        dfe_sign_in_uid: dfe_sign_in_uid,
+        first_name: first_name,
+        last_name: last_name,
+      ),
     )
   end
 
@@ -27,7 +32,7 @@ module DfESignInHelpers
     create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
   end
 
-  def fake_dfe_sign_in_auth_hash(email_address:, dfe_sign_in_uid:)
+  def fake_dfe_sign_in_auth_hash(email_address:, dfe_sign_in_uid:, first_name:, last_name:)
     {
       'provider' => 'dfe',
       'uid' => dfe_sign_in_uid,
@@ -35,8 +40,8 @@ module DfESignInHelpers
         'name' => 'Firstname Lastname',
         'email' => email_address,
         'nickname' => nil,
-        'first_name' => 'Firstname',
-        'last_name' => 'Lastname',
+        'first_name' => first_name,
+        'last_name' => last_name,
         'gender' => nil,
         'image' => nil,
         'phone' => nil,

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'A provider authenticates via DfE Sign-in' do
   include DfESignInHelpers
 
-  let(:provider_user) { create(:provider_user, email_address: 'provider@example.com', dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+  let(:provider_user) { create(:provider_user, email_address: 'provider@example.com', dfe_sign_in_uid: 'DFE_SIGN_IN_UID', first_name: 'Michael') }
 
   scenario 'signing in successfully' do
     given_i_am_registered_as_a_provider_user
@@ -14,6 +14,7 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
 
     then_i_should_see_my_email_address
     and_the_timestamp_of_this_sign_in_is_recorded
+    and_my_profile_details_are_refreshed
 
     when_i_signed_in_more_than_2_hours_ago
     then_i_should_see_the_login_page_again
@@ -24,7 +25,11 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
   end
 
   def and_i_have_a_dfe_sign_in_account
-    provider_exists_in_dfe_sign_in(email_address: 'provider@example.com', dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    provider_exists_in_dfe_sign_in(
+      email_address: 'provider@example.com',
+      dfe_sign_in_uid: 'DFE_SIGN_IN_UID',
+      first_name: 'Mike',
+    )
   end
 
   def when_i_visit_the_provider_interface_sign_in_path
@@ -59,5 +64,9 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
 
   def and_the_timestamp_of_this_sign_in_is_recorded
     expect(provider_user.reload.last_signed_in_at).not_to be_nil
+  end
+
+  def and_my_profile_details_are_refreshed
+    expect(provider_user.reload.first_name).to eq('Mike')
   end
 end

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
   include DfESignInHelpers
 
   scenario 'signing in successfully' do
-    given_i_have_a_dfe_sign_in_account
+    given_i_have_a_dfe_sign_in_account_and_support_authorisation
 
     when_i_visit_the_support_interface
     then_i_should_be_redirected_to_login_page
@@ -14,13 +14,15 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
     then_i_should_be_redirected_to_the_support_home_page
     and_i_should_see_my_email_address
+    and_my_profile_details_are_refreshed
 
     when_i_click_sign_out
     then_i_should_see_the_login_page_again
   end
 
-  def given_i_have_a_dfe_sign_in_account
-    support_user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
+  def given_i_have_a_dfe_sign_in_account_and_support_authorisation
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc', first_name: 'John')
+    user_is_a_support_user(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
   end
 
   def when_i_visit_the_support_interface
@@ -47,6 +49,11 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
   def and_i_should_see_my_email_address
     expect(page).to have_content('user@apply-support.com')
+  end
+
+  def and_my_profile_details_are_refreshed
+    support_user = SupportUser.find_by_email_address 'user@apply-support.com'
+    expect(support_user.first_name).to eq('John')
   end
 
   def when_i_click_sign_out


### PR DESCRIPTION
### Context

Provider and support users in our database now have name fields in the database that should be updated every time they log in to Apply. This will make DfE Sign-In the primary source of truth for these fields, namely `email_address`, `first_name` and `last_name`. With the exception of the first time they log in (when we match on email address rather than uid, because that's not known in advance), the rest of the time we match on `uid`, making these updates safe.

### Changes proposed in this pull request

Add `profile` to the omniauth scope (config/initializers/omniauth.rb), so that the payload we receive in the authentication callback contains `first_name` and `last_name` information (otherwise, the fields are there but the values are `nil`). 

Add `first_name` and `last_name` fields to the development omniauth bypass, so that developers can easily test/develop with arbitrary DfE Sign-In profiles.

Add `first_name` and `last_name` attributes to DfESignInUser and populate these from the session object, so that this information is available for both provider and support users.

Trigger a new method `#update_profile_from_dfe_sign_in` within `DfESignInController#callback`, to update user details in our database at the time of sign in.

The update logic is common to both types of user,  and the method is defined in a separate class (`DsiProfile`).

The update profile logic is:

- update `first_name` and `last_name` if the values provided from DfE Sign-In are not blank
- update `email_address` if we have a `dfe_sign_in_uid` for the user
- do not update `email_address` if we don't

The conditional for `email_address` is necessary because when provider users are first invited, we don't have their uid yet and the first time they log in we match on email address. Matching on uid takes precedence, so after their first log in it is safe to update their email address, if they have changed it on DfE Sign-In. It is, however, possible, they have changed the email address to another that already exists in our database, which will fail validation and throw an error on login.

For this reason, we allow the update to fail without disrupting sign in. Should there be a Slack or equivalent notification?

### Guidance to review

See `spec/lib/sync_with_dsi_profile_spec.rb` for the update logic.

You can also test updates in development mode, by creating provider or support users in the support console, then logging in as those users while providing different names or email addresses. User details are updated on signing in.

![image](https://user-images.githubusercontent.com/107591/73007918-52046600-3e05-11ea-893a-60e8a5b495f8.png)

### Link to Trello card

[1543 - Update email_address and name fields for provider users every time they log in](https://trello.com/c/8lQvOrem)

### Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)