### PR TITLE
Add auditing to provider and support users

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -4,7 +4,8 @@ class Provider < ApplicationRecord
   has_many :course_options, through: :courses
   has_many :application_choices, through: :course_options
 
-  has_and_belongs_to_many :provider_users
+  has_many :provider_users_providers, dependent: :destroy
+  has_many :provider_users, through: :provider_users_providers
   has_many :provider_agreements
 
   def name_and_code

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -5,6 +5,8 @@ class ProviderUser < ActiveRecord::Base
 
   before_save :downcase_email_address
 
+  audited except: [:last_signed_in_at]
+
   def self.load_from_session(session)
     dfe_sign_in_user = DfESignInUser.load_from_session(session)
     return unless dfe_sign_in_user

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -7,6 +7,7 @@ class ProviderUser < ActiveRecord::Base
   before_save :downcase_email_address
 
   audited except: [:last_signed_in_at]
+  has_associated_audits
 
   def self.load_from_session(session)
     dfe_sign_in_user = DfESignInUser.load_from_session(session)

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,5 +1,6 @@
 class ProviderUser < ActiveRecord::Base
-  has_and_belongs_to_many :providers
+  has_many :provider_users_providers, dependent: :destroy
+  has_many :providers, through: :provider_users_providers
 
   validates :dfe_sign_in_uid, uniqueness: true, allow_nil: true
 

--- a/app/models/provider_users_provider.rb
+++ b/app/models/provider_users_provider.rb
@@ -1,0 +1,4 @@
+class ProviderUsersProvider < ActiveRecord::Base
+  belongs_to :provider_user
+  belongs_to :provider
+end

--- a/app/models/provider_users_provider.rb
+++ b/app/models/provider_users_provider.rb
@@ -1,4 +1,6 @@
 class ProviderUsersProvider < ActiveRecord::Base
   belongs_to :provider_user
   belongs_to :provider
+
+  audited associated_with: :provider_user
 end

--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -4,6 +4,8 @@ class SupportUser < ActiveRecord::Base
 
   before_save :downcase_email_address
 
+  audited except: [:last_signed_in_at]
+
   def self.load_from_session(session)
     dfe_sign_in_user = DfESignInUser.load_from_session(session)
     return unless dfe_sign_in_user

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -40,4 +40,13 @@ RSpec.describe ProviderUser, type: :model do
       expect(provider_user.full_name).to eq "#{provider_user.first_name} #{provider_user.last_name}"
     end
   end
+
+  describe 'auditing', with_audited: true do
+    it 'records an audit entry when creating and updating a new ProviderUser' do
+      provider_user = create :provider_user, first_name: 'Bob'
+      expect(provider_user.audits.count).to eq 1
+      provider_user.update(first_name: 'Alice')
+      expect(provider_user.audits.count).to eq 2
+    end
+  end
 end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -48,5 +48,14 @@ RSpec.describe ProviderUser, type: :model do
       provider_user.update(first_name: 'Alice')
       expect(provider_user.audits.count).to eq 2
     end
+
+    it 'records an audit entry when creating adding an existing ProviderUser to a Provider' do
+      provider_user = create :provider_user, first_name: 'Bob'
+      provider = create :provider
+      expect(provider_user.audits.count).to eq 1
+      provider_user.providers << provider
+      expect(provider_user.associated_audits.count).to eq 1
+      expect(provider_user.associated_audits.first.audited_changes['provider_id']).to eq provider.id
+    end
   end
 end

--- a/spec/models/support_user_spec.rb
+++ b/spec/models/support_user_spec.rb
@@ -7,4 +7,13 @@ RSpec.describe SupportUser, type: :model do
       expect(support_user.reload.email_address).to eq 'bob.roberts@example.com'
     end
   end
+
+  describe 'auditing', with_audited: true do
+    it 'records an audit entry when creating and updating a new SupportUser' do
+      support_user = create :support_user, first_name: 'Bob'
+      expect(support_user.audits.count).to eq 1
+      support_user.update(first_name: 'Alice')
+      expect(support_user.audits.count).to eq 2
+    end
+  end
 end


### PR DESCRIPTION
DO NOT MERGE UNTIL https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1194 is DEPLOYED

## Context

Support and provider users can be created and/or updated by many different people. We want to retain a history of who did what when. e.g. who added Bob as a support user and when did they do it?

## Changes proposed in this pull request

- Add auditing to the `ProviderUser` and `SupportUser` models via the `audited` gem.

## Guidance to review

- I'm deliberately skipping `last_signed_in_at` column otherwise you'll see an entry every time the user logs in - this is up for debate if you think it might be useful?
- This PR doesn't include a UI to view the audit trail for users. We expect this to be included in the support interface in future. Any thoughts on what this should look like?

## Link to Trello card

https://trello.com/c/KsueSMF8/1521-add-auditing-to-provider-and-support-users

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
