### PR TITLE
Add section to document states & transitions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,6 +104,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gem-
 
+      - name: 'Install Graphviz'
+        run: |
+          sudo apt-get -yqq install graphviz
+
       - uses: actions/setup-node@v1
         with:
           node-version: '10.x'

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -98,6 +98,7 @@ Rails/OutputSafety:
     - 'app/helpers/content_helper.rb'
     - 'app/helpers/markdown_helper.rb'
     - 'app/helpers/view_helper.rb'
+    - 'app/lib/state_diagram.rb'
 
 # Offense count: 2
 # Configuration parameters: Include.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ruby:2.6.5-alpine AS common-build-env
 
 ARG APP_HOME=/app
 ARG BUILD_PACKAGES="build-base"
-ARG DEV_PACKAGES="postgresql-dev git nodejs yarn"
+ARG DEV_PACKAGES="postgresql-dev git nodejs yarn graphviz"
 ARG RUBY_PACKAGES="tzdata"
 ARG bundleWithout=""
 
@@ -74,7 +74,7 @@ RUN rm -rf tmp/cache app/assets lib/assets vendor/assets node_modules
 FROM ruby:2.6.5-alpine AS prod-build
 ARG bundleWithout=""
 ARG APP_HOME=/app
-ARG PACKAGES="tzdata postgresql-client"
+ARG PACKAGES="tzdata postgresql-client graphviz"
 
 ENV RAILS_ENV=production
 ENV BUNDLE_WITHOUT=${bundleWithout}

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'jwt'
 
 gem 'openapi3_parser', '0.8.0'
 gem 'rouge'
+gem 'ruby-graphviz'
 
 group :development do
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -563,6 +563,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop-govuk
+  ruby-graphviz
   selenium-webdriver
   sentry-raven
   shoulda-matchers (~> 4.2)

--- a/app.json
+++ b/app.json
@@ -29,6 +29,9 @@
       "url": "heroku/ruby"
     },
     {
+      "url": "https://github.com/weibeld/heroku-buildpack-graphviz"
+    },
+    {
       "url": "heroku-community/cli"
     }
   ]

--- a/app/components/support_interface/application_status_tag_component.html.erb
+++ b/app/components/support_interface/application_status_tag_component.html.erb
@@ -1,1 +1,3 @@
-<%= render TagComponent, text: text, type: type %>
+<%= link_to support_interface_process_path + '#' + status do %>
+  <%= render TagComponent, text: text, type: type %>
+<% end %>

--- a/app/components/support_interface/application_status_tag_component.rb
+++ b/app/components/support_interface/application_status_tag_component.rb
@@ -9,7 +9,7 @@ module SupportInterface
     end
 
     def text
-      I18n.t!("support_application_states.#{status}")
+      I18n.t!("application_states.#{status}.name")
     end
 
     def type

--- a/app/components/support_interface/state_event_explanation_component.html.erb
+++ b/app/components/support_interface/state_event_explanation_component.html.erb
@@ -1,0 +1,21 @@
+<li>
+  <p class='govuk-body'>
+    <strong><%= StateDiagram.event_name(from_state, event) %></strong> (by <%= by %>). <%= description %>
+
+    This will transition the application to the <%= govuk_link_to "#{I18n.t("application_states.#{transitions_to}.name")} state", "##{transitions_to}" %>.
+  </p>
+
+  <p class='govuk-body'>
+    <% if emails_sent_from_event.any? %>
+      Emails sent:
+
+      <ul class='govuk-list govuk-list--bullet'>
+      <% emails_sent_from_event.each do |email| %>
+        <li><%= govuk_link_to email.gsub('-', ' '), "/rails/mailers/" + email.gsub('-', '/') %></li>
+      <% end %>
+      </ul>
+    <% else %>
+      No emails are sent with this transition.
+    <% end %>
+  </p>
+</li>

--- a/app/components/support_interface/state_event_explanation_component.rb
+++ b/app/components/support_interface/state_event_explanation_component.rb
@@ -1,0 +1,32 @@
+module SupportInterface
+  class StateEventExplanationComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :from_state, :event
+
+    def initialize(from_state:, event:)
+      @from_state = from_state
+      @event = event
+    end
+
+    def emails_sent_from_event
+      if I18n.exists?("events.#{from_state}-#{event.name}.emails")
+        I18n.t!("events.#{from_state}-#{event.name}.emails")
+      else
+        []
+      end
+    end
+
+    def transitions_to
+      event.transitions_to.to_s
+    end
+
+    def by
+      I18n.t!("events.#{from_state}-#{event}.by")
+    end
+
+    def description
+      I18n.t!("events.#{from_state}-#{event.name}.description")
+    end
+  end
+end

--- a/app/components/support_interface/state_explanation_component.html.erb
+++ b/app/components/support_interface/state_explanation_component.html.erb
@@ -11,7 +11,7 @@
     </div>
 
     <% if state.events.any? %>
-      <h4 class='govuk-heading-m'>Actions</h4>
+      <h3 class='govuk-heading-m'>Actions</h3>
 
       <ul class="govuk-list">
       <% state.events.each do |_, events| %>

--- a/app/components/support_interface/state_explanation_component.html.erb
+++ b/app/components/support_interface/state_explanation_component.html.erb
@@ -1,0 +1,31 @@
+<h2 class='govuk-heading-l' id='<%= state_name %>'><%= t("application_states.#{state_name}.name") %></h2>
+
+<p class='govuk-body-l'>
+  There <%= link_to pluralize(ApplicationChoice.where(status: state_name).count, 'application'), support_interface_applications_path %> currently in this state
+</p>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-body">
+      <%= t "application_states.#{state_name}.description" %>
+    </div>
+
+    <% if state.events.any? %>
+      <h4 class='govuk-heading-m'>Actions</h4>
+
+      <ul class="govuk-list">
+      <% state.events.each do |_, events| %>
+        <%= render SupportInterface::StateEventExplanationComponent, from_state: state_name, event: events.first %>
+      <% end %>
+      </ul>
+    <% else %>
+      <div class="govuk-body">
+        This state doesn't have any more actions.
+      </div>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <%= StateDiagram.svg(state_name) %>
+  </div>
+</div>

--- a/app/components/support_interface/state_explanation_component.rb
+++ b/app/components/support_interface/state_explanation_component.rb
@@ -1,0 +1,15 @@
+module SupportInterface
+  class StateExplanationComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :state
+
+    def initialize(state:)
+      @state = state
+    end
+
+    def state_name
+      state.name.to_s
+    end
+  end
+end

--- a/app/controllers/support_interface/docs_controller.rb
+++ b/app/controllers/support_interface/docs_controller.rb
@@ -1,0 +1,5 @@
+module SupportInterface
+  class DocsController < SupportInterfaceController
+    def index; end
+  end
+end

--- a/app/lib/state_diagram.rb
+++ b/app/lib/state_diagram.rb
@@ -1,0 +1,71 @@
+class StateDiagram
+  def self.svg(only_from_state = nil)
+    graph = GraphViz.new('G', rankdir: 'TB', ratio: 'fill')
+
+    states_to_show = []
+
+    ApplicationStateChange.workflow_spec.states.each do |_, state|
+      next if only_from_state && state.name != only_from_state.to_sym
+
+      state.events.flat.each do |event|
+        states_to_show << state.name
+        states_to_show << event.transitions_to
+
+        graph.add_edges(
+          state.name.to_s,
+          event.transitions_to.to_s,
+          label: event_name(state.name, event),
+          fontname: 'Arial',
+          color: '#0b0c0c',
+          fontcolor: '#0b0c0c',
+          fontsize: 12,
+          tooltip: I18n.t!("events.#{state}-#{event}.description"),
+        )
+      end
+    end
+
+    states_to_show.flatten!
+    states_to_show.uniq!
+
+    ApplicationStateChange.workflow_spec.states.each do |state_name, state|
+      if only_from_state
+        next unless only_from_state.to_sym == state.name || state.name.to_sym.in?(states_to_show)
+      end
+
+      graph.add_nodes(
+        state_name.to_s,
+        label: I18n.t!("application_states.#{state_name}.name"),
+        width: '0.5',
+        height: '0.5',
+        shape: 'rect',
+        style: 'filled',
+        color: '#1d70b8',
+        fontcolor: '#ffffff',
+        fontname: 'Arial',
+        fontsize: 15,
+        margin: 0.2,
+        tooltip: I18n.t!("application_states.#{state_name}.description"),
+        URL: "/support/process##{state_name}",
+      )
+    end
+
+    if graph.node_count > 3 && only_from_state
+      graph[:rankdir] = 'LR'
+    end
+
+    graph.output(svg: String).force_encoding('UTF-8').html_safe
+  end
+
+  def self.event_name(state, event)
+    by = I18n.t!("events.#{state}-#{event}.by")
+
+    emoji = {
+      'candidate' => '👩‍🎓',
+      'referee' => '👩‍🏫',
+      'provider' => '🏫',
+      'system' => '🤖',
+    }.fetch(by)
+
+    emoji + ' ' + I18n.t!("events.#{state}-#{event}.name")
+  end
+end

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -1,8 +1,13 @@
-<% if Rails.application.config.action_mailer.show_previews %>
-  <h2 class="govuk-heading-m">Development</h2>
-  <ul class="govuk-footer__inline-list">
-    <li class="govuk-footer__inline-list-item">
-      <%= govuk_link_to 'Mail previews', '/rails/mailers' %>
-    </li>
-  </ul>
-<% end %>
+<h2 class="govuk-heading-m">Product development</h2>
+
+<ul class="govuk-footer__inline-list">
+  <li class="govuk-footer__inline-list-item">
+    <%= govuk_link_to 'Process documentation', support_interface_process_path %>
+  </li>
+
+  <% if Rails.application.config.action_mailer.show_previews %>
+  <li class="govuk-footer__inline-list-item">
+    <%= govuk_link_to 'Mail previews', '/rails/mailers' %>
+  </li>
+  <% end %>
+</ul>

--- a/app/views/support_interface/docs/index.html.erb
+++ b/app/views/support_interface/docs/index.html.erb
@@ -1,0 +1,25 @@
+<%= content_for :title, 'Apply process' %>
+
+<p class="govuk-body">
+  This page documents the states and transitions that make up the Apply service.
+</p>
+
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      View full diagram
+    </span>
+  </summary>
+  <div class="govuk-details__text">
+    <%= StateDiagram.svg %>
+  </div>
+</details>
+
+<style>
+  svg { max-width: 100%; }
+</style>
+
+<% ApplicationStateChange.workflow_spec.states.each do |_, state| %>
+  <%= render SupportInterface::StateExplanationComponent, state: state %>
+  <hr class='govuk-section-break govuk-section-break--xl govuk-section-break--visible'>
+<% end %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -62,16 +62,191 @@ en:
     unsubmitted: Not submitted yet
     withdrawn: Candidate withdrawn
     conditions_not_met: Conditions not met
-  support_application_states:
-    application_complete: Waiting to be sent
-    awaiting_provider_decision: Awaiting decision
-    awaiting_references: Awaiting references
-    declined: Candidate declined
-    enrolled: Candidate enrolled
-    offer: Offer made
-    pending_conditions: Pending conditions
-    recruited: Candidate recruited
-    rejected: Provider rejected
-    unsubmitted: Not submitted yet
-    withdrawn: Candidate withdrawn
-    conditions_not_met: Conditions not met
+
+  application_states:
+    unsubmitted:
+      name: Not submitted yet
+      description: |
+        When a candidate has filled in their email address, they’ve started an
+        application. Until they submit their application to a provider, it is
+        in the unsubmitted state. The providers don’t see the application at this stage.
+
+    awaiting_references:
+      name: Awaiting references
+      description: |
+        Applicants submit their application choices with list of referees. Until 2 references have been received the application remains at the Awaiting References state.
+        The providers don’t see the application at this stage.
+
+    application_complete:
+      name: Waiting to be sent
+      description: |
+        After the references have come back and have been added to the application.
+        The providers don’t see the application at this stage in order to give
+        candidates a fixed period of 5 days to modify their application. They can't
+        modify the references.
+
+    awaiting_provider_decision:
+      name: Awaiting provider decision
+      description: |
+        The providers only see the application after the references have come back
+        and have been added to the application and 5 days have elapsed for
+        the candidate to review and modify the application.
+
+        When both of these prerequisites are met the application moves to the
+        Awaiting provider decision state.
+
+    offer:
+      name: Offer made
+      description: |
+        A provider makes an offer to the candidate. The candidate then has to accept
+        or reject the offer, which sets the application status to 'Pending
+        conditions'.
+
+        We assume that all offers have some conditions, even if there
+        are no academic conditions.
+
+    recruited:
+      name: Recruited
+      description: |
+        If the candidate has met all conditions of their offer, the provider marks
+        their application as 'recruited'.
+
+    enrolled:
+      name: Candidate enrolled
+      description: |
+        Once a candidate has completed the enrolment process, the provider confirms
+        their enrolment onto the training programme. Since this status would be used
+        to claim bursaries/grants from DfE, the provider may delay enrolling the trainee
+        until a few weeks after the start of the training, since trainees can still
+        not show up on the first day or drop out within the first couple of weeks.
+        This reduces the risk that DfE over-pays that provider for training they didn’t
+        deliver and having to reconcile later on.
+
+    pending_conditions:
+      name: Pending conditions
+      description: Provider is waiting for the candidate to prove that they’ve met the conditions.
+
+    rejected:
+      name: Rejected
+      description: |
+        Provider has rejected the candidate’s application.
+
+    withdrawn:
+      name: Withdrawn
+      description: |
+        If a candidate withdraws an application in progress it moves to the Withdrawn (end) state.
+
+    conditions_not_met:
+      name: Conditions not met
+      description: The candidate did not meet the conditions set out in the offer.
+
+    declined:
+      name: Offer declined
+      description: The candidate has declined the offer.
+
+  events:
+    unsubmitted-submit:
+      name: Candidate submits
+      by: candidate
+      description: The candidate can submit the form once all required fields are completed.
+      emails:
+        - candidate_mailer-submit_application_email
+        - referee_mailer-reference_request_email
+
+    awaiting_references-references_complete:
+      name: References are completed
+      by: referee
+      description: Occurs when 2 referees have provided feedback about the candidate.
+
+    application_complete-send_to_provider:
+      name: Send to provider
+      by: system
+      description: 5 days after submission the application is sent to providers. This is to give candidates the opportunity to edit their application.
+      emails:
+        - candidate_mailer-application_under_consideration
+
+    application_complete-withdraw:
+      name: Withdraw
+      by: candidate
+      description: Candidates can withdraw at any time.
+
+    awaiting_provider_decision-make_offer:
+      name: Provider makes offer
+      by: provider
+      description: |
+        Providers can make offers to candidates. Making an offer guarantees the candidate a place on the course that they applied to. Offers include conditions, that the candidate must meet in order to gain their place on a course.
+
+        All offers must include the following non-academic conditions:
+        - Candidates must pass a DBS & childen’s barred list check
+        - Candidates must pass a fitness to work health check
+
+    awaiting_provider_decision-reject:
+      name: Provider rejects
+      by: provider
+      description: The provider rejects the candidate.
+
+    awaiting_provider_decision-withdraw:
+      name: Withdraw
+      by: candidate
+      description: |
+        A candidate makes a withdrawal decision to inform a provider that they no longer want their application to be considered. A candidate can withdraw an application at any time.
+
+    awaiting_provider_decision-reject_by_default:
+      name: Reject by default
+      by: system
+      description: |
+        An application is rejected by default (RBD) if a provider doesn’t make an offer within 40 working days after they have received an application.
+    offer-make_offer:
+      name: Amend offer conditions
+      by: provider
+      description: Providers can amend the offer conditions as long as its not been accepted or declined by the user.
+
+    offer-decline_by_default:
+      name: Decline by default
+      by: system
+      description: Candidate has to respond within 5 days, otherwise the system will decline the offer.
+
+    offer-reject:
+      name: Provider rescinds offer
+      by: provider
+      description: As long as the candidate hasn’t accepted the offer, the provider can reject the application.
+
+    offer-accept:
+      name: Candidate accepts
+      by: candidate
+      description: The candidate can accept the offer. All other application choices will be withdrawn.
+
+    offer-decline:
+      name: Candidate declines
+      by: candidate
+      description: The candidate can decline the offer from the provider.
+
+    pending_conditions-confirm_conditions_met:
+      name: Confirm conditions are met
+      by: provider
+      description: The provider confirms that the candidate has met the conditions set out in the offer.
+
+    pending_conditions-conditions_not_met:
+      name: Mark conditions as not met
+      by: provider
+      description: The provider says the candidate hasn’t met the conditions set out in the offer.
+
+    pending_conditions-withdraw:
+      name: Withdraw
+      by: candidate
+      description: Candidates can withdraw at any time.
+
+    recruited-confirm_enrolment:
+      name: Confirm enrolment
+      by: provider
+      description: (TBD)
+
+    recruited-withdraw:
+      name: Withdraw
+      by: candidate
+      description: Candidates can withdraw at any time.
+
+    rejected-make_offer:
+      name: Make offer
+      by: provider
+      description: (TBD)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,6 +288,9 @@ Rails.application.routes.draw do
   namespace :support_interface, path: '/support' do
     get '/' => redirect('/support/candidates')
 
+    get '/process', to: 'docs#index', as: :process
+    get '/process/diagram', to: 'docs#state_diagram', as: :process_diagram
+
     get '/applications' => 'application_forms#index'
     get '/applications/:application_form_id' => 'application_forms#show', as: :application_form
     get '/applications/:application_form_id/audit' => 'application_forms#audit', as: :application_form_audit

--- a/features/successful_application_statuses.feature
+++ b/features/successful_application_statuses.feature
@@ -1,60 +1,6 @@
 @candidate @provider
 Feature: successful application statuses
 
-  Unsubmitted
-  ========================================
-  When a candidate has filled in their email address, they've started an application. Until they submit their application to a provider, it is in the unsubmitted state.
-
-  Awaiting references
-  ===================
-  Applicants submit their application choices with list of referees. Until 2 references have been received the application remains at the Awaiting References state.
-  The providers don't see the application at this stage.
-
-  Application complete
-  ====================
-  After the references have come back and have been added to the application
-  the application moves to the Application Complete state.  The providers don't
-  see the application at this stage in order to give candidates a fixed period
-  of time to modify their application.
-
-  Awaiting provider feedback
-  ==========================
-  The providers only see the application after the references have come back
-  and have been added to the application and a period of time has elapsed for
-  the candidate to review and modify the application.  When both of these
-  prerequisites are met the application moves to the Awaiting Provider Feedback
-  state.
-
-  Offers & meeting conditions
-  =======================================
-  A provider makes an offer to the candidate. The candidate then has to accept
-  or reject the offer, which sets the application status to 'Pending
-  conditions'.  We assume that all offers have some conditions, even if there
-  are no academic conditions.
-
-  Recruited
-  =========
-  If the candidate has met all conditions of their offer, the provider marks
-  their application as 'recruited'.
-
-  Enrolment
-  =========
-  Once a candidate has completed the enrolment process, the provider confirms
-  their enrolment onto the training programme. Since this status would be used
-  to claim bursaries/grants from DfE, the provider may delay enrolling the trainee
-  until a few weeks after the start of the training, since trainees can still
-  not show up on the first day or drop out within the first couple of weeks.
-  This reduces the risk that DfE over-pays that provider for training they didn't
-  deliver and having to reconcile or claw back that money later on.
-
-  Rejected
-  ========
-  If a candidate turns down an offer it moves to the Rejected (end) state.
-
-  Withdrawn
-  =========
-  If a candidate withdraws an application in progress it moves to the Withdrawn (end) state.
-
   Scenario Outline: A successful application changes status depending on candidate, referee and provider actions.
     Given an application choice has "<original status>" status
     When the <actor> takes action "<action>"

--- a/spec/services/application_state_change_spec.rb
+++ b/spec/services/application_state_change_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ApplicationStateChange do
   describe '.valid_states' do
     it 'has human readable translations' do
       expect(ApplicationStateChange.valid_states)
-        .to match_array(I18n.t('support_application_states').keys)
+        .to match_array(I18n.t('application_states').keys)
 
       expect(ApplicationStateChange.valid_states)
         .to match_array(I18n.t('candidate_application_states').keys)

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'Docs' do
+  include DfESignInHelpers
+
+  scenario 'Support user visits process documentation' do
+    given_i_am_a_support_user
+    when_i_visit_the_process_documentation
+    then_i_see_the_documentation
+    and_it_contains_documentation_for_all_emails
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def when_i_visit_the_process_documentation
+    visit support_interface_process_path
+  end
+
+  def then_i_see_the_documentation
+    expect(page).to have_content 'Process'
+  end
+
+  def and_it_contains_documentation_for_all_emails
+    emails_outside_of_states = %w[
+      candidate_mailer-new_referee_request
+      candidate_mailer-survey_chaser_email
+      candidate_mailer-survey_email
+      referee_mailer-survey_chaser_email
+      referee_mailer-survey_email
+      candidate_mailer-reference_chaser_email
+      referee_mailer-reference_request_chaser_email
+    ]
+
+    # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"
+    emails_sent = [CandidateMailer, RefereeMailer].flat_map { |k| k.public_instance_methods(false).map { |m| "#{k.name.underscore}-#{m}" } }
+
+    emails_documented = I18n.t('events').flat_map { |_name, attrs| attrs[:emails] }.compact + emails_outside_of_states
+
+    expect(emails_documented).to match_array(emails_sent)
+  end
+end


### PR DESCRIPTION
## Context

We discovered this week that we weren't sending emails to candidates that had received an offer (because we didn't implement it).

The idea of this page is to add living documentation to the app that product managers, designers and business analysts can easily see how the service works (how we progress applications through the system) and when we send email notifications.

Needs https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1189 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1192 to be merged first.

## Changes proposed in this pull request

This creates a new page that documents states & transitions:

![image](https://user-images.githubusercontent.com/233676/73174499-d30e7680-40ff-11ea-8067-6fcf0528a169.png)

## Guidance to review

Best reviewed in the review app.

https://apply-for-te-document-s-8rcfpo.herokuapp.com/support/process

- Do the new state names make sense?
- Do the state/event explanations make sense?
- Does does make the process more understandable?

## Link to Trello card

https://trello.com/c/geyePkVs

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
