### PR TITLE
Show Rails email previews on QA and Heroku

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -50,6 +50,10 @@ module HostingEnvironment
     environment_name == 'review'
   end
 
+  def self.qa?
+    environment_name == 'qa'
+  end
+
   def self.production?
     environment_name == 'production'
   end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -7,6 +7,8 @@
           <%= render 'layouts/footer_meta_candidate' %>
         <% when 'provider_interface' %>
           <%= render 'layouts/footer_meta_provider' %>
+        <% when 'support_interface' %>
+          <%= render 'layouts/footer_meta_support' %>
         <% end %>
       </div>
       <div class="govuk-footer__meta-item">

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -1,0 +1,8 @@
+<% if Rails.application.config.action_mailer.show_previews %>
+  <h2 class="govuk-heading-m">Development</h2>
+  <ul class="govuk-footer__inline-list">
+    <li class="govuk-footer__inline-list-item">
+      <%= govuk_link_to 'Mail previews', '/rails/mailers' %>
+    </li>
+  </ul>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ require "action_view/component"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+require "./app/lib/hosting_environment"
+
 module ApplyForPostgraduateTeacherTraining
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -32,6 +34,7 @@ module ApplyForPostgraduateTeacherTraining
     config.exceptions_app = self.routes
 
     config.action_mailer.preview_path = "#{Rails.root}/app/mailers/previews"
+    config.action_mailer.show_previews = Rails.env.development? || HostingEnvironment.qa? || HostingEnvironment.review?
 
     config.time_zone = 'London'
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,7 +2,6 @@
 require_relative 'application'
 
 # Avoid constant autoloading in initializers deprecation warnings
-require './app/lib/hosting_environment'
 require './app/lib/logstash_logging'
 require './app/warden/magic_link_strategy'
 


### PR DESCRIPTION
## Context

Currently we only show the Rails email previews in development. Now that we’re going to send a lot more emails, it will be useful to be able to product review the emails in QA and Heroku.

## Changes proposed in this pull request

This enables the mail previews and adds a link in the footer.

## Guidance to review

Check if it works on Heroku.

## Link to Trello card

https://trello.com/c/geyePkVs

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
