### PR TITLE
Add providerCode & courseCode params flow for existing users

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -36,6 +36,9 @@ module CandidateInterface
           redirect_to candidate_interface_course_choices_site_path(course.provider.code, course.code)
         elsif service.candidate_does_not_have_a_course_from_find_id?
           redirect_to candidate_interface_application_form_path
+        elsif service.candidate_already_has_3_courses?
+          flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
         end
       else
         redirect_to action: :new

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -14,6 +14,8 @@ module CandidateInterface
       if @sign_up_form.existing_candidate?
         MagicLinkSignIn.call(candidate: @sign_up_form.candidate)
         add_identity_to_log @sign_up_form.candidate.id
+        candidate = Candidate.find(@sign_up_form.candidate.id)
+        candidate.update!(course_from_find_id: @sign_up_form.course_from_find_id)
         redirect_to candidate_interface_check_email_sign_up_path
       elsif @sign_up_form.save
         MagicLinkSignUp.call(candidate: @sign_up_form.candidate)

--- a/app/services/candidate_interface/existing_candidate_authentication.rb
+++ b/app/services/candidate_interface/existing_candidate_authentication.rb
@@ -4,13 +4,17 @@ module CandidateInterface
 
     def initialize(candidate:)
       @candidate = candidate
+      @candidate_already_has_3_courses = false
       @candidate_has_new_course_added = false
       @candidate_should_choose_site = false
       @candidate_does_not_have_a_course_from_find_id = false
     end
 
     def execute
-      if has_course_from_find? && course_has_one_site?
+      if candidate_already_has_3_courses
+        set_course_from_find_id_to_nil
+        @candidate_already_has_3_courses = true
+      elsif has_course_from_find? && course_has_one_site?
         add_application_choice
         set_course_from_find_id_to_nil
         @candidate_has_new_course_added = true
@@ -20,6 +24,10 @@ module CandidateInterface
       else
         @candidate_does_not_have_a_course_from_find_id = true
       end
+    end
+
+    def candidate_already_has_3_courses?
+      @candidate_already_has_3_courses
     end
 
     def candidate_has_new_course_added?
@@ -52,6 +60,10 @@ module CandidateInterface
 
     def course_has_one_site?
       CourseOption.where(course_id: @candidate.course_from_find_id).one?
+    end
+
+    def candidate_already_has_3_courses
+      @candidate.current_application.application_choices.count >= 3
     end
   end
 end

--- a/spec/services/candidate_interface/existing_candidate_authentication_spec.rb
+++ b/spec/services/candidate_interface/existing_candidate_authentication_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
 
   describe '#execute' do
     context 'when the candidate already has 3 application choices' do
-      it 'sets the candidates course_from_find_id to nil and sets candidate_already_has_3_courses too true' do
+      it 'sets the candidates course_from_find_id to nil and sets candidate_already_has_3_courses to true' do
         new_course = create(:course)
         candidate = create(:candidate, course_from_find_id: new_course.id)
         create(:completed_application_form, candidate: candidate, application_choices_count: 3)
@@ -13,10 +13,10 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service).to be_candidate_already_has_3_courses
-        expect(service).not_to be_candidate_has_new_course_added
-        expect(service).not_to be_candidate_should_choose_site
-        expect(service).not_to be_candidate_does_not_have_a_course_from_find_id
+        expect(service.candidate_already_has_3_courses?).to be_truthy
+        expect(service.candidate_has_new_course_added?).to be_falsey
+        expect(service.candidate_should_choose_site?).to be_falsey
+        expect(service.candidate_does_not_have_a_course_from_find_id?).to be_falsey
         expect(candidate.course_from_find_id).to eq(nil)
       end
     end
@@ -31,10 +31,10 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service).to be_candidate_has_new_course_added
-        expect(service).not_to be_candidate_should_choose_site
-        expect(service).not_to be_candidate_does_not_have_a_course_from_find_id
-        expect(service).not_to be_candidate_already_has_3_courses
+        expect(service.candidate_has_new_course_added?).to be_truthy
+        expect(service.candidate_should_choose_site?).to be_falsey
+        expect(service.candidate_does_not_have_a_course_from_find_id?).to be_falsey
+        expect(service.candidate_already_has_3_courses?).to be_falsey
         expect(candidate.course_from_find_id).to eq(nil)
         expect(candidate.current_application.application_choices.first.course_option_id).to eq(course_options_id)
       end
@@ -49,10 +49,10 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service).to be_candidate_should_choose_site
-        expect(service).not_to be_candidate_has_new_course_added
-        expect(service).not_to be_candidate_does_not_have_a_course_from_find_id
-        expect(service).not_to be_candidate_already_has_3_courses
+        expect(service.candidate_should_choose_site?).to be_truthy
+        expect(service.candidate_has_new_course_added?).to be_falsey
+        expect(service.candidate_does_not_have_a_course_from_find_id?).to be_falsey
+        expect(service.candidate_already_has_3_courses?).to be_falsey
         expect(candidate.course_from_find_id).to eq(nil)
         expect(candidate.current_application.application_choices).not_to be_present
       end
@@ -66,10 +66,10 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service).to be_candidate_does_not_have_a_course_from_find_id
-        expect(service).not_to be_candidate_has_new_course_added
-        expect(service).not_to be_candidate_should_choose_site
-        expect(service).not_to be_candidate_already_has_3_courses
+        expect(service.candidate_does_not_have_a_course_from_find_id?).to be_truthy
+        expect(service.candidate_has_new_course_added?).to be_falsey
+        expect(service.candidate_should_choose_site?).to be_falsey
+        expect(service.candidate_already_has_3_courses?).to be_falsey
       end
     end
   end

--- a/spec/services/candidate_interface/existing_candidate_authentication_spec.rb
+++ b/spec/services/candidate_interface/existing_candidate_authentication_spec.rb
@@ -4,8 +4,25 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
   include CourseOptionHelpers
 
   describe '#execute' do
+    context 'when the candidate already has 3 application choices' do
+      it 'sets the candidates course_from_find_id to nil and sets candidate_already_has_3_courses too true' do
+        new_course = create(:course)
+        candidate = create(:candidate, course_from_find_id: new_course.id)
+        create(:completed_application_form, candidate: candidate, application_choices_count: 3)
+
+        service = described_class.new(candidate: candidate)
+        service.execute
+
+        expect(service).to be_candidate_already_has_3_courses
+        expect(service).not_to be_candidate_has_new_course_added
+        expect(service).not_to be_candidate_should_choose_site
+        expect(service).not_to be_candidate_does_not_have_a_course_from_find_id
+        expect(candidate.course_from_find_id).to eq(nil)
+      end
+    end
+
     context 'when the candidate has a course_from_find_id and the course has one site' do
-      it 'adds a the course, resets the course_from_find_in to nil and returns sets candidate_has_new_course_added to true' do
+      it 'adds a the course, resets the course_from_find_in to nil and sets candidate_has_new_course_added to true' do
         provider = create(:provider)
         course_option_for_provider(provider: provider)
         candidate = create(:candidate, course_from_find_id: provider.courses.first.id)
@@ -17,12 +34,13 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         expect(service).to be_candidate_has_new_course_added
         expect(service).not_to be_candidate_should_choose_site
         expect(service).not_to be_candidate_does_not_have_a_course_from_find_id
+        expect(service).not_to be_candidate_already_has_3_courses
         expect(candidate.course_from_find_id).to eq(nil)
         expect(candidate.current_application.application_choices.first.course_option_id).to eq(course_options_id)
       end
     end
 
-    context 'when the candidate has a course_from_find_id  and the course has multiple sites' do
+    context 'when the candidate has a course_from_find_id and the course has multiple sites' do
       it 'sets the course_from_find_id to nil and sets candidate_should_choose_site to true' do
         course = create(:course)
         create_two_course_options_for_course(course: course)
@@ -34,6 +52,7 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         expect(service).to be_candidate_should_choose_site
         expect(service).not_to be_candidate_has_new_course_added
         expect(service).not_to be_candidate_does_not_have_a_course_from_find_id
+        expect(service).not_to be_candidate_already_has_3_courses
         expect(candidate.course_from_find_id).to eq(nil)
         expect(candidate.current_application.application_choices).not_to be_present
       end
@@ -50,6 +69,7 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         expect(service).to be_candidate_does_not_have_a_course_from_find_id
         expect(service).not_to be_candidate_has_new_course_added
         expect(service).not_to be_candidate_should_choose_site
+        expect(service).not_to be_candidate_already_has_3_courses
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.describe 'An existing candidate arriving from Find with a course and provider code' do
+  include CourseOptionHelpers
+  scenario 'retaining their course selection through the sign up process' do
+    given_the_pilot_is_open
+    and_confirm_course_choice_from_find_is_activated
+    and_i_an_existing_candidate_on_apply
+    and_i_have_less_than_3_application_options
+    and_the_course_i_selected_only_has_one_site
+
+    when_i_arrive_at_the_sign_up_page_with_course_params_with_one_site
+    and_i_submit_my_email_address
+    and_click_on_the_magic_link
+    then_i_should_see_the_courses_review_page
+    and_i_should_see_the_course_name_and_code
+    and_i_should_see_the_site
+    and_my_find_from_id_course_should_be_set_to_nil
+
+    given_the_course_i_selected_has_multiple_sites
+    and_i_an_existing_candidate_on_apply
+    and_i_have_less_than_3_application_options
+
+    when_i_arrive_at_the_sign_up_page_with_course_params_with_multiple_sites
+    and_i_submit_my_email_address
+    and_click_on_the_magic_link
+    then_i_should_see_the_course_choices_site_page
+    and_i_see_the_form_to_pick_a_location
+    and_my_find_from_id_course_should_be_set_to_nil
+
+    and_the_course_i_selected_only_has_one_site
+    and_i_an_existing_candidate_on_apply
+    and_i_have_3_application_options
+
+    when_i_arrive_at_the_sign_up_page_with_course_params_with_multiple_sites
+    and_i_submit_my_email_address
+    and_click_on_the_magic_link
+    then_i_should_see_the_courses_review_page
+    and_my_find_from_id_course_should_be_set_to_nil
+    and_i_should_be_informed_i_already_have_3_courses
+  end
+
+  def and_confirm_course_choice_from_find_is_activated
+    FeatureFlag.activate('confirm_course_choice_from_find')
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_course_i_selected_only_has_one_site
+    @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
+    @site = create(:site, provider: @course.provider)
+    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+  end
+
+  def and_i_an_existing_candidate_on_apply
+    @email = "#{SecureRandom.hex}@example.com"
+    @candidate = create(:candidate, email_address: @email)
+  end
+
+  def and_i_have_less_than_3_application_options
+    application_choice_for_candidate(candidate: @candidate, application_choice_count: 2)
+  end
+
+  def and_i_have_3_application_options
+    application_choice_for_candidate(candidate: @candidate, application_choice_count: 3)
+  end
+
+  def when_i_arrive_at_the_sign_up_page_with_course_params_with_one_site
+    visit candidate_interface_sign_up_path providerCode: @course.provider.code, courseCode: @course.code
+  end
+
+  def when_i_arrive_at_the_sign_up_page_with_course_params_with_multiple_sites
+    visit candidate_interface_sign_up_path providerCode: @course_with_multiple_sites.provider.code, courseCode: @course_with_multiple_sites.code
+  end
+
+  def and_i_submit_my_email_address
+    perform_enqueued_jobs do
+      fill_in t('authentication.sign_up.email_address.label'), with: @email
+      check t('authentication.sign_up.accept_terms_checkbox')
+      click_on t('authentication.sign_up.button_continue')
+    end
+  end
+
+  def and_click_on_the_magic_link
+    open_email(@email)
+    current_email.find_css('a').first.click
+  end
+
+  def then_i_should_see_the_courses_review_page
+    expect(page).to have_current_path(candidate_interface_course_choices_review_path)
+  end
+
+  def and_i_should_see_the_course_name_and_code
+    expect(page).to have_content "#{@course.name} (#{@course.code})"
+  end
+
+  def and_i_should_see_the_site
+    expect(page).to have_content @site.name
+    expect(page).to have_content @site.address_line1
+    expect(page).to have_content @site.address_line2
+    expect(page).to have_content @site.address_line3
+    expect(page).to have_content @site.address_line4
+    expect(page).to have_content @site.postcode
+  end
+
+  def and_i_see_the_form_to_pick_a_location
+    expect(page).to have_content @site1.name
+    expect(page).to have_content @site1.address_line1
+    expect(page).to have_content @site1.address_line2
+    expect(page).to have_content @site1.address_line3
+    expect(page).to have_content @site1.address_line4
+    expect(page).to have_content @site1.postcode
+    expect(page).to have_content @site2.name
+    expect(page).to have_content @site2.address_line1
+    expect(page).to have_content @site2.address_line2
+    expect(page).to have_content @site2.address_line3
+    expect(page).to have_content @site2.address_line4
+    expect(page).to have_content @site2.postcode
+  end
+
+  def and_my_find_from_id_course_should_be_set_to_nil
+    candidate = Candidate.find_by!(email_address: @email)
+    expect(candidate.course_from_find_id).to eq(nil)
+  end
+
+  def given_the_course_i_selected_has_multiple_sites
+    @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
+    @site1 = create(:site, provider: @course_with_multiple_sites.provider)
+    @site2 = create(:site, provider: @course_with_multiple_sites.provider)
+    create(:course_option, site: @site1, course: @course_with_multiple_sites, vacancy_status: 'B')
+    create(:course_option, site: @site2, course: @course_with_multiple_sites, vacancy_status: 'B')
+  end
+
+  def then_i_should_see_the_course_choices_site_page
+    expect(page).to have_current_path(candidate_interface_course_choices_site_path(@course_with_multiple_sites.provider.code, @course_with_multiple_sites.code))
+  end
+
+  def then_i_should_see_the_candidate_interface_application_form
+    expect(page).to have_current_path(candidate_interface_application_form_path)
+  end
+
+  def and_i_should_be_informed_i_already_have_3_courses
+    expect(page).to have_content "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course_with_multiple_sites.name_and_code}"
+  end
+
+private
+
+  def application_choice_for_candidate(candidate:, application_choice_count:)
+    provider = create(:provider)
+    application_form = create(:application_form, candidate: candidate)
+    application_choice_count.times { course_option_for_provider(provider: provider) }
+    provider.courses.each do |course|
+      create(:application_choice, application_form: application_form, course_option_id: course.course_options.first.id)
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   scenario 'retaining their course selection through the sign up process' do
     given_the_pilot_is_open
     and_confirm_course_choice_from_find_is_activated
-    and_i_an_existing_candidate_on_apply
+    and_i_am_an_existing_candidate_on_apply
     and_i_have_less_than_3_application_options
     and_the_course_i_selected_only_has_one_site
 
@@ -15,10 +15,10 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     then_i_should_see_the_courses_review_page
     and_i_should_see_the_course_name_and_code
     and_i_should_see_the_site
-    and_my_find_from_id_course_should_be_set_to_nil
+    and_my_course_from_find_id_should_be_set_to_nil
 
     given_the_course_i_selected_has_multiple_sites
-    and_i_an_existing_candidate_on_apply
+    and_i_am_an_existing_candidate_on_apply
     and_i_have_less_than_3_application_options
 
     when_i_arrive_at_the_sign_up_page_with_course_params_with_multiple_sites
@@ -26,17 +26,17 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_click_on_the_magic_link
     then_i_should_see_the_course_choices_site_page
     and_i_see_the_form_to_pick_a_location
-    and_my_find_from_id_course_should_be_set_to_nil
+    and_my_course_from_find_id_should_be_set_to_nil
 
     and_the_course_i_selected_only_has_one_site
-    and_i_an_existing_candidate_on_apply
+    and_i_am_an_existing_candidate_on_apply
     and_i_have_3_application_options
 
     when_i_arrive_at_the_sign_up_page_with_course_params_with_multiple_sites
     and_i_submit_my_email_address
     and_click_on_the_magic_link
     then_i_should_see_the_courses_review_page
-    and_my_find_from_id_course_should_be_set_to_nil
+    and_my_course_from_find_id_should_be_set_to_nil
     and_i_should_be_informed_i_already_have_3_courses
   end
 
@@ -54,7 +54,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     create(:course_option, site: @site, course: @course, vacancy_status: 'B')
   end
 
-  def and_i_an_existing_candidate_on_apply
+  def and_i_am_an_existing_candidate_on_apply
     @email = "#{SecureRandom.hex}@example.com"
     @candidate = create(:candidate, email_address: @email)
   end
@@ -120,7 +120,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     expect(page).to have_content @site2.postcode
   end
 
-  def and_my_find_from_id_course_should_be_set_to_nil
+  def and_my_course_from_find_id_should_be_set_to_nil
     candidate = Candidate.find_by!(email_address: @email)
     expect(candidate.course_from_find_id).to eq(nil)
   end

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
     then_i_should_see_the_courses_review_page
     and_i_should_see_the_course_name_and_code
     and_i_should_see_the_site
-    and_my_find_from_id_course_should_be_set_to_nil
+    and_my_course_from_find_id_should_be_set_to_nil
 
     given_the_course_i_selected_has_multiple_sites
 
@@ -26,7 +26,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
     and_click_on_the_magic_link
     then_i_should_see_the_course_choices_site_page
     and_i_see_the_form_to_pick_a_location
-    and_my_find_from_id_course_should_be_set_to_nil
+    and_my_course_from_find_id_should_be_set_to_nil
   end
 
   def and_confirm_course_choice_from_find_is_activated
@@ -124,7 +124,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
     expect(page).to have_content @site2.postcode
   end
 
-  def and_my_find_from_id_course_should_be_set_to_nil
+  def and_my_course_from_find_id_should_be_set_to_nil
     candidate = Candidate.find_by!(email_address: @email)
     expect(candidate.course_from_find_id).to eq(nil)
   end


### PR DESCRIPTION
## Context

This PR builds on the work done in #1165 

It implements the flow for existing candidates who arrive from find with course params in the query string.

The logic for the expected is behaviour is similar to that of a new Candidate. 

## Changes proposed in this pull request
The desired behaviour is

If they have less than 3 course options && course_from_find_id is present on a candidate && and the course has one site

  - It should add an ApplicationChoice with the relevant CourseOption. 
  - Set the candidates course_from_find_id to nil
  - Redirect to the candidate_interface_course_choices_review_path 

elsif they have less than 3 course option && course_from_find_id is present on a candidate && the course has multiple sites
  - It should redirect the site selection page for their selected course
  - set the candidates course_from_find_id to nil

elsif they already have 3 course choices
    - Redirect to the candidate_interface_course_choices_review_path 
    - Present a flash message telling them they can't have more than 3 course options


![image](https://user-images.githubusercontent.com/42515961/73071209-2f785880-3eaa-11ea-9e46-a5b95329f709.png)

## Guidance to review
- Navigate the login flow with a course with one site (/candidate/apply?providerCode=C58&courseCode=3D2X)

- Navigate the login flow with a course with multiple sites (/candidate/apply?providerCode=2LR&courseCode=3255)

- Add any 3 courses while logged in. Logout, then follow the flow for any other course in the Apply database.

## Link to Trello card

https://trello.com/c/EQQoWqun/632-you-selected-a-course-page-a-candidate-can-confirm-their-course-choice-if-they-have-come-from-find

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
