### PR TITLE
Display reason for rejection in support

### DIFF
--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -42,6 +42,7 @@
       { key: 'Location', value: application_choice.site.name_and_code },
       { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent, application_choice: application_choice) },
     ] %>
+    <% rows << { key: 'Reason for rejection', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>
     <% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at %>
     <% rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at %>
 


### PR DESCRIPTION
## Context

It's useful for us to see this information.

## Changes proposed in this pull request

Add the row.

## Guidance to review

Should I add a test for this?

## After

<img width="1030" alt="Screenshot 2020-01-27 at 11 58 25" src="https://user-images.githubusercontent.com/1650875/73173189-adcc3900-40fc-11ea-9fb8-33f80bb36021.png">

## Link to Trello card

https://trello.com/c/Us84ozho/826-display-reasons-for-rejection-in-support-ui

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)