### PR TITLE
Display reason for rejection in candidate interface

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -18,6 +18,7 @@ module CandidateInterface
         location_row(course_choice),
       ].tap do |r|
         r << status_row(course_choice) if @show_status
+        r << rejection_reason_row(course_choice) if course_choice.rejection_reason.present?
       end
     end
 
@@ -73,6 +74,13 @@ module CandidateInterface
       {
         key: 'Status',
         value: render(TagComponent, text: t("candidate_application_states.#{course_choice.status}"), type: type),
+      }
+    end
+
+    def rejection_reason_row(course_choice)
+      {
+        key: 'Reason for rejection',
+        value: course_choice.rejection_reason,
       }
     end
   end

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -62,6 +62,25 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
     end
   end
 
+  context 'when a course choice is rejected' do
+    it 'renders component with the status as rejected and displays the reason' do
+      application_form = create(:application_form)
+      create(
+        :application_choice,
+        application_form: application_form,
+        status: 'rejected',
+        rejection_reason: 'Course full',
+      )
+
+      result = render_inline(described_class, application_form: application_form, editable: false, show_status: true)
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Rejected')
+      expect(result.css('.govuk-summary-list__key').text).to include('Reason for rejection')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Course full')
+    end
+  end
+
   context 'when a course choice is application complete' do
     it 'renders component with the status as submitted when application is complete' do
       application_form = create_application_form_with_course_choices(statuses: %w[application_complete])


### PR DESCRIPTION
## Context

Candidates should be able to see this.

See https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1198.

## Changes proposed in this pull request

Adds the row, updates the unit tests.

## Guidance to review

<img width="687" alt="Screenshot 2020-01-27 at 12 29 12" src="https://user-images.githubusercontent.com/1650875/73175411-03efab00-4102-11ea-8518-10ec8e1ed248.png">

## Link to Trello card

https://trello.com/c/dhJ9gGiA/497-display-reasons-for-rejection-to-candidates-in-service

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)