### PR TITLE
Set feedback_status synchronously when sending reference requests

### DIFF
--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -3,7 +3,7 @@ class RefereeMailer < ApplicationMailer
     @application_form = application_form
     @reference = reference
     @candidate_name = application_form.full_name
-    @unhashed_token = reference.update_token!
+    @unhashed_token = reference.refresh_feedback_token!
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,
@@ -16,8 +16,7 @@ class RefereeMailer < ApplicationMailer
     @application_form = application_form
     @reference = reference
     @candidate_name = application_form.full_name
-
-    @token = reference.update_token!
+    @token = reference.refresh_feedback_token!
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: reference.email_address,

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -34,9 +34,9 @@ class ApplicationReference < ApplicationRecord
     errors.add(:email_address, :own) if email_address == candidate_email_address
   end
 
-  def update_token!
+  def refresh_feedback_token!
     unhashed_token, hashed_token = Devise.token_generator.generate(ApplicationReference, :hashed_sign_in_token)
-    update!(hashed_sign_in_token: hashed_token, feedback_status: 'feedback_requested')
+    update!(hashed_sign_in_token: hashed_token)
     unhashed_token
   end
 

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -25,6 +25,8 @@ private
   def send_reference_request_email_to_referees(application_form)
     application_form.application_references.includes(:application_form).each do |reference|
       RefereeMailer.reference_request_email(application_form, reference).deliver_later
+
+      reference.update!(feedback_status: 'feedback_requested')
     end
   end
 


### PR DESCRIPTION
When this value is set asynchronously, it's possible for the sidekiq job to complete after the reference has been returned — not a problem IRL, but it is in sandbox, where references can be instacompleted, or in GenerateTestApplications.

Rename ApplicationReference#update_token! to refresh_feedback_token!, which is more explicit, and stop it updating the feedback status as a side effect.

Callers (ie services) are now responsible for synchronously setting the feedback_status of references, but as services are responsible for managing all our status transitions this feels like the right place to keep this responsibility.

## Link to Trello card

Cropped up during https://trello.com/c/VLw7X81Z/1526-improvements-to-the-generatetestdata-api-feature-for-tribal

Bug appeared as https://sentry.io/organizations/dfe-bat/issues/1466968936/?referrer=slack