### PR TITLE
Remove rubocop  RSpec/PredicateMatcher

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,8 +70,7 @@ RSpec/InstanceVariable:
   Enabled: false
 
 RSpec/PredicateMatcher:
-  Exclude:
-    - 'spec/support_specs/clockwork_spec.rb'
+  Enabled: false
 
 RSpec/DescribeClass:
   Enabled: false


### PR DESCRIPTION
## Context

This cop needs to be taken off the beat  🙅‍♂ 👮 👮‍♀ 🙅‍♂ 

![image](https://user-images.githubusercontent.com/42515961/73188873-699c6100-411b-11ea-943e-a87543d20824.png)



## Changes proposed in this pull request

- Begin our ruthless culling of annoying Rubocop cops

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
