### PR TITLE
Add `id` attribute to qualifications and work experience in API

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -163,6 +163,7 @@ module VendorApi
 
     def qualification_to_hash(qualification)
       {
+        id: qualification.id,
         qualification_type: qualification.qualification_type,
         subject: qualification.subject,
         grade: "#{qualification.grade}#{' (Predicted)' if qualification.predicted_grade}",

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -111,6 +111,7 @@ module VendorApi
 
     def experience_to_hash(experience)
       {
+        id: experience.id,
         start_date: experience.start_date.to_date,
         end_date: experience.end_date&.to_date,
         role: experience.role,

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,10 @@
+### 28th January 2020
+
+New attributes:
+
+- `WorkExperience` now has a unique `id` attribute of type integer.
+- `Qualification` now has a unique `id` attribute of type integer.
+
 ### 14th January 2020
 
 - Introduce `missing_gcses_explanation` field to [`qualifications`](/api-docs/reference#qualifications-object). This contains the candidate’s explanation for any missing GCSE (or equivalent) qualifications.

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -783,6 +783,7 @@ components:
       type: object
       additionalProperties: false
       required:
+        - id
         - organisation_name
         - start_date
         - end_date
@@ -791,6 +792,10 @@ components:
         - working_with_children
         - commitment
       properties:
+        id:
+          type: integer
+          description: The work experience ID in the Apply system
+          example: 12345
         organisation_name:
           type: string
           description: The organisation worked for

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -622,6 +622,7 @@ components:
       type: object
       additionalProperties: false
       required:
+        - id
         - qualification_type
         - subject
         - grade
@@ -630,6 +631,10 @@ components:
         - equivalency_details
         - awarding_body
       properties:
+        id:
+          type: integer
+          description: The qualification ID in the Apply system
+          example: 123
         qualification_type:
           type: string
           maxLength: 255

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -93,6 +93,7 @@ RSpec.feature 'Vendor receives the application' do
         qualifications: {
           gcses: [
             {
+              id: @application.english_gcse.id,
               qualification_type: 'gcse',
               subject: 'english',
               grade: 'B',
@@ -102,6 +103,7 @@ RSpec.feature 'Vendor receives the application' do
               equivalency_details: nil,
             },
             {
+              id: @application.maths_gcse.id,
               qualification_type: 'gcse',
               subject: 'maths',
               grade: 'B',
@@ -113,6 +115,7 @@ RSpec.feature 'Vendor receives the application' do
             ],
          degrees: [
            {
+              id: @application.qualification_in_subject(:degree, 'Doge').id,
               qualification_type: 'BA',
               subject: 'Doge',
               grade: 'first',
@@ -124,6 +127,7 @@ RSpec.feature 'Vendor receives the application' do
           ],
          other_qualifications: [
            {
+              id: @application.qualification_in_subject(:other, 'Believing in the Heart of the Cards').id,
               qualification_type: 'A-Level',
               subject: 'Believing in the Heart of the Cards',
               grade: 'A',

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -160,6 +160,7 @@ RSpec.feature 'Vendor receives the application' do
         work_experience: {
           jobs: [
             {
+              id: @application.application_work_experiences.first.id,
               start_date: '2014-05-01',
               end_date: '2019-01-01',
               role: 'Teacher',
@@ -171,6 +172,7 @@ RSpec.feature 'Vendor receives the application' do
           ],
           volunteering: [
             {
+              id: @application.application_volunteering_experiences.first.id,
               start_date: '2018-05-01',
               end_date: '2019-01-01',
               role: 'Classroom Volunteer',


### PR DESCRIPTION
## Context

Tribal need this to make sure they don't ingest the same thing twice in the event that a candidate edits an entry beyond recognition

## Changes proposed in this pull request

- Updated `config/vendor-api-v1.yml`.
- Added `id` fields to the `SingleApplicationPresenter` class which serialises applications.
- Updated release notes .
- Updated existing specs.

## Guidance to review

- Is it OK to use the raw primary `id` value?
- Anything missing? I think I've updated the necessary bits - schema, release notes and implementation etc.
- Are the release notes correct? I picked tomorrow as the release date (maybe optimistic).

## Link to Trello card

https://trello.com/c/Cx0MEShz/1528-add-id-to-qualifications-and-work-experience

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
