### PR TITLE
Bugfix: use the candidate's name in reference request

### DIFF
--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -6,7 +6,7 @@ Please use the link below to give a reference as soon as possible.
 
 <%= referee_interface_reference_feedback_url(token: @unhashed_token) %>
 
-If you won’t give <%= @reference.name %> a reference, please let us know by clicking the link below.
+If you won’t give <%= @candidate_name %> a reference, please let us know by clicking the link below.
 
 <%= referee_interface_refuse_feedback_url(token: @unhashed_token) %>
 


### PR DESCRIPTION
## Context

The reference request use the referee's name instead of the candidate's name in one place.

## Changes proposed in this pull request

Use the right name

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
