### PR TITLE
Migration to add last_signed_in_at to candidate

### DIFF
--- a/db/migrate/20200127171445_add_last_signed_in_at_to_candidate.rb
+++ b/db/migrate/20200127171445_add_last_signed_in_at_to_candidate.rb
@@ -1,0 +1,5 @@
+class AddLastSignedInAtToCandidate < ActiveRecord::Migration[6.0]
+  def change
+    add_column :candidates, :last_signed_in_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_24_114452) do
+ActiveRecord::Schema.define(version: 2020_01_27_171445) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -150,6 +150,7 @@ ActiveRecord::Schema.define(version: 2020_01_24_114452) do
     t.boolean "hide_in_reporting", default: false, null: false
     t.bigint "course_from_find_id"
     t.boolean "sign_up_email_bounced", default: false, null: false
+    t.datetime "last_signed_in_at"
     t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
     t.index ["magic_link_token"], name: "index_candidates_on_magic_link_token", unique: true
   end


### PR DESCRIPTION
## Context

There has been discussion about the implementation of flash messages which inform users of their account being created. After some discussion, it was noted that adding a last signed in the column in the candidate would allow more robust data collection.

This PR adds a last_changed_at to a candidate

## Guidance to review

You could run the migration locally and check the candidate has a last signed in at which is set to nil by default.

## Link to Trello card

https://trello.com/c/c7y4d7cu/819-show-flash-message-when-user-first-signs-up
## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
