### PR TITLE
Withdraw from choices awaiting decision when a candidate accepts an offer

### DIFF
--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -11,6 +11,10 @@ class AcceptOffer
       other_application_choices_with_offers.each do |other_application_choice|
         DeclineOffer.new(application_choice: other_application_choice).save!
       end
+
+      application_choices_awaiting_provider_decision.each do |application_choices|
+        WithdrawApplication.new(application_choice: application_choices).save!
+      end
     end
 
     StateChangeNotifier.call(:offer_accepted, application_choice: @application_choice)
@@ -24,5 +28,12 @@ private
       .application_choices
       .offer
       .where.not(id: @application_choice.id)
+  end
+
+  def application_choices_awaiting_provider_decision
+    @application_choice
+      .application_form
+      .application_choices
+      .awaiting_provider_decision
   end
 end

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
   scenario 'Candidate views an offer and accepts' do
     given_i_am_signed_in
     and_i_have_2_offers_on_my_choices
-    and_1_withdrawn_choice
+    and_1_choice_that_is_awaiting_provider_decision
 
     when_i_visit_the_application_dashboard
     and_i_click_on_view_and_respond_to_offer_link
@@ -18,6 +18,7 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
     then_a_slack_notification_is_sent
     and_i_see_that_i_accepted_the_offer
     and_i_see_that_i_declined_the_other_offer
+    and_i_see_that_i_withdrawn_from_the_third_choice
 
     when_i_visit_the_offer_page_of_the_declined_offer
     then_i_see_the_page_not_found
@@ -55,10 +56,10 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
     )
   end
 
-  def and_1_withdrawn_choice
-    create(
+  def and_1_choice_that_is_awaiting_provider_decision
+    @third_application_choice = create(
       :application_choice,
-      status: 'withdrawn',
+      status: 'awaiting_provider_decision',
       application_form: @application_form,
     )
   end
@@ -101,6 +102,12 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
   def and_i_see_that_i_declined_the_other_offer
     within ".qa-application-choice-#{@other_application_choice.id}" do
       expect(page).to have_content 'Declined'
+    end
+  end
+
+  def and_i_see_that_i_withdrawn_from_the_third_choice
+    within ".qa-application-choice-#{@third_application_choice.id}" do
+      expect(page).to have_content 'Withdrawn'
     end
   end
 


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
When a candidate accepts an offer, if they have applied to other courses, they should automatically withdraw from courses that are awaiting a decision.

Other offers are already declined by default as a result of https://trello.com/c/M9zmZH7I/368-candidates-can-decline-an-offer

## Changes proposed in this pull request
This PR updates the `Accept Offer` service to automatically withdraw applications that are awaiting provider decision when a candidate accepts an offer

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Get a cup of 🍵and have a look at the system spec

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/wJsNq8xX/831-withdraw-from-choices-awaiting-decision-when-a-user-accepts-an-offer

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
