### PR TITLE
Migration to add sign in count to user

### DIFF
--- a/db/migrate/20200128110357_add_sign_in_count_to_candidate.rb
+++ b/db/migrate/20200128110357_add_sign_in_count_to_candidate.rb
@@ -1,0 +1,5 @@
+class AddSignInCountToCandidate < ActiveRecord::Migration[6.0]
+  def change
+    add_column :candidates, :sign_in_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_27_171445) do
+ActiveRecord::Schema.define(version: 2020_01_28_110357) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -151,6 +151,7 @@ ActiveRecord::Schema.define(version: 2020_01_27_171445) do
     t.bigint "course_from_find_id"
     t.boolean "sign_up_email_bounced", default: false, null: false
     t.datetime "last_signed_in_at"
+    t.integer "sign_in_count", default: 0, null: false
     t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
     t.index ["magic_link_token"], name: "index_candidates_on_magic_link_token", unique: true
   end


### PR DESCRIPTION
## Context

As we're adding in the trackable from Devise, sign in count seems like an easy free win in terms of data collection

## Changes proposed in this pull request

Add a sign_in_count column to the candidate table.

## Guidance to review

Run the migration. Is there a new attribute on candidate?

## Link to Trello card

https://trello.com/c/c7y4d7cu/819-show-flash-message-when-user-first-signs-up
## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
