### PR TITLE
Add the environment to Slack test messages

### DIFF
--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -19,10 +19,12 @@ private
   end
 
   def post_to_slack(text)
+    slack_message = HostingEnvironment.production? ? text : "[#{HostingEnvironment.environment_name.upcase}] #{text}"
+
     payload = {
       username: 'ApplyBot',
       icon_emoji: ':parrot:',
-      text: text,
+      text: slack_message,
       mrkdwn: true,
     }
     response = HTTP.post @webhook_url, body: payload.to_json

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SlackNotificationWorker do
         end
         expect(HTTP).to have_received(:post).with \
           'https://example.com/webhook',
-          body: '{"username":"ApplyBot","icon_emoji":":parrot:","text":"\u003chttps://example.com/support|example text\u003e","mrkdwn":true}'
+          body: '{"username":"ApplyBot","icon_emoji":":parrot:","text":"[TEST] \u003chttps://example.com/support|example text\u003e","mrkdwn":true}'
       end
     end
   end


### PR DESCRIPTION
## Context

Having the environment in the message makes it easier to see from which environment the Slack are coming from on `#twd_apply_test`.

## Changes proposed in this pull request

See code.

## Guidance to review

N/A

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
