### PR TITLE
Add environment name to emails, except in production

### DIFF
--- a/config/initializers/mail_interceptors.rb
+++ b/config/initializers/mail_interceptors.rb
@@ -1,5 +1,8 @@
 require 'test_email_interceptor'
+require 'environment_flag_interceptor'
 
 if Rails.env.production?
   ActionMailer::Base.register_interceptor(TestEmailInterceptor)
 end
+
+ActionMailer::Base.register_interceptor(EnvironmentFlagInterceptor)

--- a/lib/environment_flag_interceptor.rb
+++ b/lib/environment_flag_interceptor.rb
@@ -1,0 +1,7 @@
+class EnvironmentFlagInterceptor
+  def self.delivering_email(message)
+    unless HostingEnvironment.production?
+      message.subject = "[#{HostingEnvironment.environment_name.upcase}] #{message.subject}"
+    end
+  end
+end

--- a/spec/lib/environment_flag_interceptor_spec.rb
+++ b/spec/lib/environment_flag_interceptor_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe EnvironmentFlagInterceptor do
+  it 'adds the environment to the email' do
+    message = Mail::Message.new(subject: 'Hi hello')
+
+    ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'example_env' do
+      described_class.delivering_email(message)
+    end
+
+    expect(message.subject).to eql '[EXAMPLE_ENV] Hi hello'
+  end
+
+  it 'does not add the environment to production emails' do
+    message = Mail::Message.new(subject: 'Hi hello')
+
+    ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'production' do
+      described_class.delivering_email(message)
+    end
+
+    expect(message.subject).to eql 'Hi hello'
+  end
+end

--- a/spec/requests/integrations/post_notify_callback_spec.rb
+++ b/spec/requests/integrations/post_notify_callback_spec.rb
@@ -124,6 +124,6 @@ RSpec.describe 'Notify Callback - POST /integrations/notify/callback', type: :re
     candidate_email = application_form.candidate.email_address
     open_email(candidate_email)
 
-    expect(current_email.subject).to eq(t('new_referee_request.email_bounced.subject', referee_name: reference.name))
+    expect(current_email.subject).to end_with(t('new_referee_request.email_bounced.subject', referee_name: reference.name))
   end
 end

--- a/spec/system/candidate_interface/application_choices_are_delivered_to_providers_spec.rb
+++ b/spec/system/candidate_interface/application_choices_are_delivered_to_providers_spec.rb
@@ -20,6 +20,6 @@ RSpec.feature 'Candidate application choices are delivered to providers' do
   def then_i_should_receive_an_email_saying_my_application_is_under_consideration
     open_email(@application_choice.application_form.candidate.email_address)
 
-    expect(current_email.subject).to eq(t('application_under_consideration.email.subject'))
+    expect(current_email.subject).to end_with(t('application_under_consideration.email.subject'))
   end
 end


### PR DESCRIPTION
## Context

It's useful to see where emails come from in the subject line.

## Changes proposed in this pull request

Add a new interceptor that tags the subject with a prefix.

## Guidance to review

Read the code.

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
