### PR TITLE
Do not open courses not visible in Find when opening all courses for a provider

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -15,7 +15,7 @@ module SupportInterface
     end
 
     def open_all_courses
-      update_provider('Successfully updated all courses') { |provider| provider.courses.update_all(open_on_apply: true) }
+      update_provider('Successfully updated all courses') { |provider| OpenProviderCourses.new(provider: provider).call }
     end
 
     def enable_course_syncing

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -7,7 +7,7 @@ class Course < ApplicationRecord
   validates :level, presence: true
   validates :code, uniqueness: { scope: :provider_id }
 
-  scope :open_on_apply, -> { where(open_on_apply: true) }
+  scope :open_on_apply, -> { exposed_in_find.where(open_on_apply: true) }
   scope :exposed_in_find, -> { where(exposed_in_find: true) }
 
   CODE_LENGTH = 4

--- a/app/services/open_provider_courses.rb
+++ b/app/services/open_provider_courses.rb
@@ -1,0 +1,9 @@
+class OpenProviderCourses
+  def initialize(provider:)
+    @provider = provider
+  end
+
+  def call
+    @provider.courses.exposed_in_find.update_all(open_on_apply: true)
+  end
+end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -6,7 +6,9 @@ task setup_local_dev_data: :environment do
   end
 
   puts 'Making all the courses open on Apply...'
-  Course.update_all(open_on_apply: true)
+  Provider.all.each do |provider|
+    OpenProviderCourses.new(provider: provider).call
+  end
 
   FeatureFlag.activate('pilot_open')
 

--- a/spec/services/open_provider_courses_spec.rb
+++ b/spec/services/open_provider_courses_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe OpenProviderCourses do
+  it 'opens all courses shown on Find for a given provider' do
+    provider = create(:provider)
+    create_list(:course, 2, exposed_in_find: true, provider: provider)
+
+    expect { OpenProviderCourses.new(provider: provider).call }
+      .to(change { Course.open_on_apply.count }.from(0).to(2))
+  end
+
+  it 'does not open courses that are not exposed in Find' do
+    provider = create(:provider)
+    create(:course, exposed_in_find: false, provider: provider)
+
+    expect { OpenProviderCourses.new(provider: provider).call }
+      .not_to(change { Course.open_on_apply.count })
+  end
+end


### PR DESCRIPTION
## Context

Courses `open_on_apply` should be a subset of courses `exposed_in_find`, at least when we first mark them open. (It’s possible for them to be hidden in Find on a subsequent sync).

Some courses not `exposed_in_find` have eg zero course options and are therefore impossible to apply to anyway. We should not mark these courses `open_on_apply`.

## Changes proposed in this pull request

Only mark courses as open on apply if they're also exposed in Find.

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
