### PR TITLE
Add application form reporting to the service performance page

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -23,8 +23,59 @@ class PerformanceStatistics
   FROM
       raw_data".freeze
 
+  APPLICATION_FORM_STATUS_COUNTS_QUERY = "
+  WITH raw_data AS (
+      SELECT
+          f.id,
+          COUNT(f.id) FILTER (WHERE f.id IS NOT NULL) application_forms,
+          COUNT(ch.id) FILTER (WHERE f.id IS NOT NULL) application_choices,
+          CASE
+            WHEN ARRAY_AGG(DISTINCT ch.status) = '{NULL}' THEN ARRAY['0', 'unsubmitted']
+            WHEN ARRAY_AGG(DISTINCT ch.status) = '{unsubmitted}' THEN ARRAY['0', 'unsubmitted']
+            WHEN 'awaiting_references' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['1', 'awaiting_references']
+            WHEN 'application_complete' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['2', 'waiting_to_be_sent']
+            WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['3', 'awaiting_provider_decisions']
+            WHEN 'offer' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['5', 'awaiting_candidate_response']
+            WHEN 'enrolled' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['8', 'enrolled']
+            WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'recruited']
+            WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['6', 'pending_conditions']
+            WHEN ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_AGG(DISTINCT ch.status), 'withdrawn'), 'rejected'), 'declined'), 'conditions_not_met') = '{}' THEN ARRAY['4', 'ended_without_success']
+            ELSE ARRAY['9', 'unknown_state']
+          END status
+      FROM
+          candidates c
+      LEFT JOIN
+          application_forms f ON f.candidate_id = c.id
+      LEFT JOIN
+          application_choices ch ON ch.application_form_id = f.id
+      WHERE
+          NOT c.hide_in_reporting
+      GROUP BY
+          f.id
+  )
+  SELECT
+      raw_data.status[2],
+      COUNT(*)
+  FROM
+      raw_data
+  GROUP BY
+      raw_data.status
+  ORDER BY
+      raw_data.status[1]".freeze
+
   def [](key)
     candidate_counts[key.to_s]
+  end
+
+  def application_form_status_counts
+    @application_form_status_counts ||= ActiveRecord::Base
+      .connection
+      .execute(APPLICATION_FORM_STATUS_COUNTS_QUERY)
+      .to_a
+  end
+
+  def application_form_counts_total
+    application_form_status_counts.sum { |row| row['count'].to_i }
   end
 
 private

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -15,7 +15,7 @@ class PerformanceStatistics
           c.id
   )
   SELECT
-      COUNT(*) AS total_non_dfe_sign_ups,
+      COUNT(*) AS total_candidate_count,
       SUM(CASE WHEN candidate_forms = 0 THEN 1 ELSE 0 END) AS candidates_signed_up_but_not_signed_in,
       SUM(CASE WHEN candidate_forms > 0 AND candidate_started_form_count = 0 AND candidate_submitted_form_count = 0 THEN 1 ELSE 0 END) AS candidates_signed_in_but_not_entered_data,
       SUM(CASE WHEN candidate_started_form_count > 0 AND candidate_submitted_form_count = 0 THEN 1 ELSE 0 END) AS candidates_with_unsubmitted_forms,

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -1,5 +1,5 @@
 class PerformanceStatistics
-  QUERY = "
+  CANDIDATE_COUNTS_QUERY = "
   WITH raw_data AS (
       SELECT
           COUNT(c.id) FILTER (WHERE f.id IS NOT NULL) candidate_forms,
@@ -24,12 +24,12 @@ class PerformanceStatistics
       raw_data".freeze
 
   def [](key)
-    results[key.to_s]
+    candidate_counts[key.to_s]
   end
 
 private
 
-  def results
-    @results ||= ActiveRecord::Base.connection.execute(QUERY)[0]
+  def candidate_counts
+    @candidate_counts ||= ActiveRecord::Base.connection.execute(CANDIDATE_COUNTS_QUERY)[0]
   end
 end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,8 +1,10 @@
 <% content_for :title, 'Service performance dashboard' %>
 
+<h2 class="govuk-heading-m govuk-!-font-size-27">Candidates</h2>
+
 <div class="app-card app-card--blue govuk-!-margin-bottom-4">
   <span class="app-card__count" id="total-sign-ups"><%= @statistics[:total_candidate_count] %></span>
-  <span>sign ups (excluding DfE users)</span>
+  <span>sign ups (excluding test users)</span>
 </div>
 
 <div class="govuk-grid-row">

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, 'Service performance dashboard' %>
 
 <div class="app-card app-card--blue govuk-!-margin-bottom-4">
-  <span class="app-card__count" id="total-sign-ups"><%= @statistics[:total_non_dfe_sign_ups] %></span>
+  <span class="app-card__count" id="total-sign-ups"><%= @statistics[:total_candidate_count] %></span>
   <span>sign ups (excluding DfE users)</span>
 </div>
 

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -33,3 +33,34 @@
     </div>
   </div>
 </div>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Application forms</h2>
+
+<div class="app-card app-card--blue govuk-!-margin-bottom-4">
+  <span class="app-card__count" id="total-application-forms"><%= @statistics.application_form_counts_total %></span>
+  <span>application forms (excluding test users)</span>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <table class="govuk-table">
+      <caption class="govuk-table__caption">Application form breakdown</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header">Status</th>
+          <th scope="col" class="govuk-table__header govuk-table__header--numeric">Count</th>
+          <th scope="col" class="govuk-table__header">Description</th>
+        </tr>
+      </thead>
+
+      <tbody class="govuk-table__body">
+        <% @statistics.application_form_status_counts.each do |row| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
+            <td class="govuk-table__cell govuk-table__cell--numeric"><%= row['count'] %></td>
+            <td class="govuk-table__cell"><%= t("candidate_flow_application_states.#{row['status']}.description") %></td>
+          </tr>
+        <% end %>
+    </table>
+  </div>
+</div>

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -1,16 +1,114 @@
 require 'rails_helper'
 
 RSpec.describe PerformanceStatistics, type: :model do
+  describe '#application_form_status_counts' do
+    it 'counts unsubmitted applications' do
+      application_choice = create(:application_choice, status: 'unsubmitted')
+
+      expect(ProcessState.new(application_choice.application_form).state).to be :unsubmitted
+
+      expect(count_for_process_state(:unsubmitted)).to be(1)
+    end
+
+    it 'counts awaiting references applications' do
+      application_choice = create(:application_choice, status: 'awaiting_references')
+
+      expect(ProcessState.new(application_choice.application_form).state).to be :awaiting_references
+
+      expect(count_for_process_state(:awaiting_references)).to be(1)
+    end
+
+    it 'counts applications that are waiting to be sent to the provider' do
+      application_choice = create(:application_choice, status: 'application_complete')
+
+      expect(ProcessState.new(application_choice.application_form).state).to be :waiting_to_be_sent
+
+      expect(count_for_process_state(:waiting_to_be_sent)).to be(1)
+    end
+
+    it 'counts applications awaiting a provider decision' do
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision')
+      create(:application_choice, application_form: application_choice.application_form, status: 'offer')
+
+      expect(ProcessState.new(application_choice.application_form).state).to be :awaiting_provider_decisions
+
+      expect(count_for_process_state(:awaiting_provider_decisions)).to be(1)
+    end
+
+    it 'counts applications with offers' do
+      form = create(:application_form)
+      create_list(:application_choice, 2, application_form: form, status: 'offer')
+
+      expect(ProcessState.new(form).state).to be :awaiting_candidate_response
+
+      expect(count_for_process_state(:awaiting_candidate_response)).to be(1)
+    end
+
+    it 'counts enrolled applications' do
+      application_choice = create(:application_choice, status: 'enrolled')
+
+      expect(ProcessState.new(application_choice.application_form).state).to be :enrolled
+
+      expect(count_for_process_state(:enrolled)).to be(1)
+    end
+
+    it 'counts recruited applications' do
+      application_choice = create(:application_choice, status: 'recruited')
+
+      expect(ProcessState.new(application_choice.application_form).state).to be :recruited
+
+      expect(count_for_process_state(:recruited)).to be(1)
+    end
+
+    it 'counts applications pending conditions' do
+      application_choice = create(:application_choice, status: 'pending_conditions')
+
+      expect(ProcessState.new(application_choice.application_form).state).to be :pending_conditions
+
+      expect(count_for_process_state(:pending_conditions)).to be(1)
+    end
+
+    it 'counts unsubmitted applications without choices' do
+      form = create(:application_form)
+
+      expect(ProcessState.new(form).state).to be :unsubmitted
+
+      expect(count_for_process_state(:unsubmitted)).to be(1)
+    end
+
+    it 'counts applications that ended without success' do
+      withdrawn_form, rejected_form, declined_form, conditions_not_met_form = create_list(:application_form, 4)
+      create_list(:application_choice, 2, application_form: withdrawn_form, status: 'withdrawn')
+      create_list(:application_choice, 2, application_form: rejected_form, status: 'rejected')
+      create_list(:application_choice, 2, application_form: declined_form, status: 'declined')
+      create_list(:application_choice, 2, application_form: conditions_not_met_form, status: 'conditions_not_met')
+
+      expect(ProcessState.new(withdrawn_form).state).to be :ended_without_success
+      expect(ProcessState.new(rejected_form).state).to be :ended_without_success
+      expect(ProcessState.new(declined_form).state).to be :ended_without_success
+      expect(ProcessState.new(conditions_not_met_form).state).to be :ended_without_success
+
+      expect(count_for_process_state(:ended_without_success)).to be(4)
+    end
+  end
+
+  def count_for_process_state(process_state)
+    PerformanceStatistics.new.application_form_status_counts.find { |x| x['status'] == process_state.to_s }['count']
+  end
+
   it 'excludes candidates marked as hidden from reporting' do
-    create(:candidate, hide_in_reporting: true)
-    create(:candidate, hide_in_reporting: false)
+    hidden_candidate = create(:candidate, hide_in_reporting: true)
+    visible_candidate = create(:candidate, hide_in_reporting: false)
+    create(:application_form, candidate: hidden_candidate)
+    create(:application_form, candidate: visible_candidate)
 
     stats = PerformanceStatistics.new
 
     expect(stats[:total_candidate_count]).to eq(1)
+    expect(stats.application_form_counts_total).to eq(1)
   end
 
-  it 'includes only those users in each category' do
+  it 'breaks down candidates with unsubmitted forms into stages' do
     create(:candidate)
     create_list(:application_form, 2)
     create_list(:application_form, 3, updated_at: 3.minutes.from_now) # changed forms

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PerformanceStatistics, type: :model do
 
     stats = PerformanceStatistics.new
 
-    expect(stats[:total_non_dfe_sign_ups]).to eq(1)
+    expect(stats[:total_candidate_count]).to eq(1)
   end
 
   it 'includes only those users in each category' do
@@ -18,7 +18,7 @@ RSpec.describe PerformanceStatistics, type: :model do
 
     stats = PerformanceStatistics.new
 
-    expect(stats[:total_non_dfe_sign_ups]).to eq(10)
+    expect(stats[:total_candidate_count]).to eq(10)
     expect(stats[:candidates_signed_up_but_not_signed_in]).to eq(1)
     expect(stats[:candidates_signed_in_but_not_entered_data]).to eq(2)
     expect(stats[:candidates_with_unsubmitted_forms]).to eq(3)
@@ -31,7 +31,7 @@ RSpec.describe PerformanceStatistics, type: :model do
 
     stats = PerformanceStatistics.new
 
-    expect(stats[:total_non_dfe_sign_ups]).to eq(1)
+    expect(stats[:total_candidate_count]).to eq(1)
     expect(stats[:candidates_with_submitted_forms]).to eq(1)
     expect(stats[:candidates_signed_in_but_not_entered_data]).to eq(0)
   end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -2,14 +2,15 @@ require 'rails_helper'
 
 RSpec.feature 'Service performance' do
   scenario 'View service statistics' do
-    given_there_are_candidates_in_the_system
+    given_there_are_candidates_and_application_forms_in_the_system
 
     when_i_visit_the_service_performance_page
     then_i_should_see_the_total_count_of_candidates
+    and_i_should_see_the_total_count_of_application_forms
   end
 
-  def given_there_are_candidates_in_the_system
-    create_list(:candidate, 2)
+  def given_there_are_candidates_and_application_forms_in_the_system
+    create_list(:application_form, 3)
   end
 
   def when_i_visit_the_service_performance_page
@@ -18,7 +19,13 @@ RSpec.feature 'Service performance' do
 
   def then_i_should_see_the_total_count_of_candidates
     within '#total-sign-ups' do
-      expect(page).to have_content '2'
+      expect(page).to have_content '3'
+    end
+  end
+
+  def and_i_should_see_the_total_count_of_application_forms
+    within '#total-application-forms' do
+      expect(page).to have_content '3'
     end
   end
 end


### PR DESCRIPTION
## Context

Before this change, the service performance reporting only displays candidates, not applications, and doesn't show what happens post-submission.

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/23801/73387431-77dbb000-42c8-11ea-8d21-35317c0064d6.png)

* Clearly separate candidate and application-centric reporting
* Port the [`ProcessState` class](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/app/services/process_state.rb) to SQL so it can be used for calculating aggregate statistics

## Guidance to review

* I need some help with the visual design of the page – clearly there are issues with spacing, and I'm not sure that the table is the most effective way of conveying this information
* How could the application form states unit test be made more performant, while still maintaining coverage? It's very slow at the moment but there are lots of nasty `CASE...WHEN` statements in the SQL query to cover

After this PR, I would be keen to break the application form status table further into weekly cohorts, so that we would be able to see how the application statuses develop over time.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
