### PR TITLE
Add expired link page and automatically send sign in email if encrypted candidate ID

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -12,6 +12,7 @@ class CandidateMailer < ApplicationMailer
 
   def application_under_consideration(application_form)
     @application = OpenStruct.new(
+      candidate: application_form.candidate,
       candidate_name: application_form.first_name,
       choice_count: application_form.application_choices.count,
       rbd_date: application_form.application_choices.first.reject_by_default_at,

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -1,0 +1,18 @@
+<% content_for :title, t('authentication.expired_token.heading') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @candidate, url: candidate_interface_sign_in_path, method: :post do |f| %>
+      <h1 class="govuk-heading-xl">
+        <%= t('authentication.expired_token.heading') %>
+      </h1>
+      <p class="govuk-body">
+        Sign in links only work for one hour, so you need to request a new one. We'll send this by email.
+      </p>
+
+      <%= f.hidden_field :email_address %>
+
+      <%= f.govuk_submit t('authentication.expired_token.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_mailer/application_under_consideration.text.erb
+++ b/app/views/candidate_mailer/application_under_consideration.text.erb
@@ -10,6 +10,6 @@ They’ll be in touch with you sooner if they want to arrange an interview.
 
 You can review your application by signing in to Apply for teacher training:
 
-[<%= candidate_interface_sign_in_url %>](<%= candidate_interface_sign_in_url %>)
+<%= candidate_sign_in_url(@application.candidate) %>
 
 You’ll be able to see the outcome of your application when a decision has been made.

--- a/config/locales/authentication.yml
+++ b/config/locales/authentication.yml
@@ -30,3 +30,6 @@ en:
     sign_in_without_account:
       email:
         subject: Sign up to Apply for teacher training
+    expired_token:
+      heading: The link you clicked has expired
+      button: Email me a new link

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
     get '/sign-in', to: 'sign_in#new', as: :sign_in
     post '/sign-in', to: 'sign_in#create'
     get '/sign-in/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_in
+    get '/sign-in/expired', to: 'sign_in#expired', as: :expired_sign_in
 
     get '/authenticate', to: 'sign_in#authenticate', as: :authenticate
 

--- a/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate clicks on an expired link', sidekiq: true do
+  scenario 'Candidate clicks on a link with an id in an email' do
+    given_the_pilot_is_open
+    and_the_improved_expired_token_flow_feature_flag_is_on
+    and_i_am_a_candidate_with_an_application
+    and_i_received_the_submitted_application_email
+
+    when_i_click_on_the_sign_in_link_with_an_id
+    then_i_am_redirected_to_the_expired_link_page
+
+    when_i_click_the_button_to_send_me_a_sign_in_email
+    then_i_receive_a_sign_in_email
+    and_i_see_the_check_your_email_page
+
+    when_i_visit_the_sign_in_page_with_an_invalid_id_parameter
+    then_i_am_taken_to_the_sign_in_page
+
+    when_i_visit_the_expired_sign_in_page_without_id_parameter
+    then_i_am_taken_to_the_sign_in_page
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_improved_expired_token_flow_feature_flag_is_on
+    FeatureFlag.activate('improved_expired_token_flow')
+  end
+
+  def and_i_am_a_candidate_with_an_application
+    @candidate = create(:candidate)
+    @application_form = create(:application_form, candidate: @candidate)
+  end
+
+  def and_i_received_the_submitted_application_email
+    CandidateMailer.submit_application_email(@application_form).deliver_now
+  end
+
+  def when_i_click_on_the_sign_in_link_with_an_id
+    open_email(@candidate.email_address)
+    current_email.find_css('a').first.click
+  end
+
+  def then_i_am_redirected_to_the_expired_link_page
+    expect(page).to have_content(t('authentication.expired_token.heading'))
+  end
+
+  def when_i_click_the_button_to_send_me_a_sign_in_email
+    click_button t('authentication.expired_token.button')
+  end
+
+  def then_i_receive_a_sign_in_email
+    open_email(@candidate.email_address)
+    expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+  end
+
+  def and_i_see_the_check_your_email_page
+    expect(page).to have_content('Check your email')
+  end
+
+  def when_i_visit_the_sign_in_page_with_an_invalid_id_parameter
+    visit candidate_interface_sign_in_path(u: 'unencrypted_candidate_id')
+  end
+
+  def then_i_am_taken_to_the_sign_in_page
+    expect(page).to have_content(t('page_titles.sign_in'))
+  end
+
+  def when_i_visit_the_expired_sign_in_page_without_id_parameter
+    visit candidate_interface_expired_sign_in_path
+  end
+end


### PR DESCRIPTION
## Context

We want to improve the flow for when a candidate clicks on a link in an email we've sent them.

For example, currently when we send them an email to confirm they've submitted their application, that email contains links to the application dashboard and sign in page. If a candidate is not signed in and they click the link, then they'll have to enter their email address and click the Continue button. To improve this flow, we want to remove the need of a candidate entering their email address and instead automatically send them a sign in email by using the encrypted candidate ID provided as a query parameter.

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1214, the encrypted candidate ID was added to the submitted application email as well as the encryptor.

## Changes proposed in this pull request

This PR:

- adds handling of the encrypted candidate ID and ~~automatically sends~~ ask candidate to click a button to send the sign in email to them if valid `u` parameter provided
- adds a new page to notify them
- updates the application under consideration email to use the `ViewHelper#candidate_sign_in_url` helper

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/73376095-c7b07c00-42b4-11ea-9dd9-87e0766393e7.png)

## Guidance to review

Received new content for the page with the help of Emma HF and Paul H.

## Link to Trello card

https://trello.com/c/ZyModi4f/811-improve-flow-for-expired-tokens-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
