### PR TITLE
Fix broken previews of authentication emails

### DIFF
--- a/app/mailers/previews/authentication_mailer_preview.rb
+++ b/app/mailers/previews/authentication_mailer_preview.rb
@@ -1,9 +1,9 @@
 class AuthenticationMailerPreview < ActionMailer::Preview
   def sign_up_email
-    AuthenticationMailer.sign_up_email(to: "#{SecureRandom.hex}@example.com", token: SecureRandom.hex)
+    AuthenticationMailer.sign_up_email(candidate: FactoryBot.build_stubbed(:candidate), token: SecureRandom.hex)
   end
 
   def sign_in_email
-    AuthenticationMailer.sign_in_email(to: "#{SecureRandom.hex}@example.com", token: SecureRandom.hex)
+    AuthenticationMailer.sign_in_email(candidate: FactoryBot.build_stubbed(:candidate), token: SecureRandom.hex)
   end
 end


### PR DESCRIPTION
## Context

They broke cos they changed.

## Changes proposed in this pull request

Fixaroo the previews for authentication emails.

## Guidance to review

:shipit: 

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
