### PR TITLE
Allow provider users to act as candidates in sandbox environments

### DIFF
--- a/app/controllers/provider_interface/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidates_controller.rb
@@ -4,21 +4,34 @@ module ProviderInterface
 
     def impersonate
       candidate = Candidate.find(params[:candidate_id])
-      # bypass_sign_in will not update the database when signing in
-      # https://stackoverflow.com/questions/50405133/devise-bypass-sign-in-without-active-for-authentication-callback#50409127
-      bypass_sign_in(candidate, scope: :candidate)
 
-      flash[:success] = "You are now signed in as candidate #{candidate.email_address}"
+      if verify_provider_association(candidate: candidate, providers: current_provider_user.providers)
+        bypass_sign_in(candidate, scope: :candidate)
 
-      redirect_to candidate_interface_application_form_path
+        flash[:success] = "You are now signed in as candidate #{candidate.email_address}"
+
+        redirect_to candidate_interface_application_form_path
+      else
+        flash[:warning] = 'This candidate is not associated with your account'
+
+        redirect_to provider_interface_applications_path
+      end
     end
 
   private
 
+    def verify_provider_association(candidate:, providers:)
+      provider_ids_from_candidate = candidate.application_forms. \
+                                              map(&:application_choices).flatten. \
+                                              map(&:provider).map(&:id).uniq
+
+      providers.any? { |provider| provider_ids_from_candidate.include? provider.id }
+    end
+
     def disable_on_production
       return unless HostingEnvironment.production?
 
-      render_404
+      head :not_found
     end
   end
 end

--- a/app/controllers/provider_interface/candidates_controller.rb
+++ b/app/controllers/provider_interface/candidates_controller.rb
@@ -1,0 +1,24 @@
+module ProviderInterface
+  class CandidatesController < ProviderInterfaceController
+    before_action :disable_on_production, only: :impersonate
+
+    def impersonate
+      candidate = Candidate.find(params[:candidate_id])
+      # bypass_sign_in will not update the database when signing in
+      # https://stackoverflow.com/questions/50405133/devise-bypass-sign-in-without-active-for-authentication-callback#50409127
+      bypass_sign_in(candidate, scope: :candidate)
+
+      flash[:success] = "You are now signed in as candidate #{candidate.email_address}"
+
+      redirect_to candidate_interface_application_form_path
+    end
+
+  private
+
+    def disable_on_production
+      return unless HostingEnvironment.production?
+
+      render_404
+    end
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -29,7 +29,7 @@
 </div>
 
 <% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this candidate (sandbox-only)', provider_interface_impersonate_candidate_path(@application_choice.application_form.candidate), class: 'govuk-button' %>
+  <%= button_to 'Sign in as this candidate (Test environments only)', provider_interface_impersonate_candidate_path(@application_choice.application_form.candidate), class: 'govuk-button' %>
 <% end %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Course</h2>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -28,6 +28,10 @@
   </div>
 </div>
 
+<% unless HostingEnvironment.production? %>
+  <%= button_to 'Sign in as this candidate (sandbox-only)', provider_interface_impersonate_candidate_path(@application_choice.application_form.candidate), class: 'govuk-button' %>
+<% end %>
+
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Course</h2>
 
 <%= render SummaryListComponent, rows: [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -274,6 +274,8 @@ Rails.application.routes.draw do
     post '/applications/:application_choice_id/offer/confirm' => 'decisions#confirm_offer', as: :application_choice_confirm_offer
     post '/applications/:application_choice_id/offer' => 'decisions#create_offer', as: :application_choice_create_offer
 
+    post '/candidates/:candidate_id/impersonate' => 'candidates#impersonate', as: :impersonate_candidate
+
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
   end

--- a/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
+++ b/spec/requests/provider_interface/provider_user_impersonates_candidate_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'POST /provider/candidates/:id/impersonate' do
+  include CourseOptionHelpers
+
+  context 'when the user is logged in to Apply' do
+    let(:provider) { create(:provider, :with_signed_agreement) }
+    let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+    let(:course_option) { course_option_for_provider_code(provider_code: provider.code) }
+    let(:application_choice) { create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option) }
+
+    before do
+      allow(DfESignInUser).to receive(:load_from_session)
+        .and_return(
+          DfESignInUser.new(
+            email_address: provider_user.email_address,
+            dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+            first_name: provider_user.first_name,
+            last_name: provider_user.last_name,
+          ),
+      )
+    end
+
+    it 'redirects to Candidate Interface if candidate associated with user\'s providers' do
+      post provider_interface_impersonate_candidate_path(application_choice.application_form.candidate)
+      expect(response).to have_http_status 302
+
+      get candidate_interface_application_form_path
+      expect(response).to have_http_status 200 # a 200 response suggests a candidate session
+    end
+
+    it 'redirects back to Provider Interface if candidate is not associated with user\'s providers' do
+      unrelated_application = create(:application_choice, status: 'awaiting_provider_decision')
+
+      post provider_interface_impersonate_candidate_path(unrelated_application.application_form.candidate)
+      expect(response).to have_http_status 302
+
+      get candidate_interface_application_form_path
+      expect(response).to have_http_status 302 # no candidate session redirects to candidate_interface_path
+    end
+
+    it 'returns 404 on production' do
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+
+      post provider_interface_impersonate_candidate_path(application_choice.application_form.candidate)
+
+      expect(response).to have_http_status 404
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'A Provider can log in as a candidate' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'when viewing an application on non-production environments' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_my_organisation_has_received_an_application
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_that_application_in_the_provider_interface
+    and_i_click_on_the_sign_in_button
+
+    then_i_am_redirected_to_the_candidate_interface
+    and_i_see_a_flash_message
+    and_i_am_logged_in_as_that_candidate
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    @provider = create(:provider, :with_signed_agreement)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  end
+
+  def and_my_organisation_has_received_an_application
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_choice = create(:application_choice, status: 'awaiting_provider_decision', course_option: course_option)
+    @candidate = @application_choice.application_form.candidate
+  end
+
+  def when_i_visit_that_application_in_the_provider_interface
+    visit provider_interface_application_choice_path(@application_choice)
+  end
+
+  def and_i_click_on_the_sign_in_button
+    click_on 'Sign in as this candidate (Test environments only)'
+  end
+
+  def then_i_am_redirected_to_the_candidate_interface
+    expect(page).to have_current_path(candidate_interface_application_form_path)
+  end
+
+  def and_i_see_a_flash_message
+    expect(page).to have_content('You are now signed in as')
+  end
+
+  def and_i_am_logged_in_as_that_candidate
+    expect(page).to have_content(@candidate.email_address)
+  end
+end


### PR DESCRIPTION
### Context

From a vendor:

> It would be really useful to be able to act as a candidate whose data has been generated via /generate_test_data (the alternative is to go through the form multiple times)

It is already possible to masquerade as a candidate, but only via support, and granting all sandbox providers/vendors access to support is not a good idea.

### Changes proposed in this pull request

Allow provider users to masquerade as candidates within sandbox environments.

This is what the support page for the candidate already looks like (note the sign-in button):
![image](https://user-images.githubusercontent.com/107591/73346384-af713a80-427d-11ea-857b-e77edb601cf6.png)

This PR introduces a similar button to the provider interface. As there is no concept of a candidates index within the provider interface, the natural place for such a button is on an application page.

Pending:
- [x] Should masquerading be restricted to candidates who have applied to this particular provider?
- [x] Test coverage

### Guidance to review

Before:
![image](https://user-images.githubusercontent.com/107591/73346289-82bd2300-427d-11ea-8682-ac453d3829a4.png)

After:
![image](https://user-images.githubusercontent.com/107591/73346314-8fda1200-427d-11ea-9e7e-613dfd82f050.png)

Clicking on this button:
![image](https://user-images.githubusercontent.com/107591/73346336-9a94a700-427d-11ea-8628-ad90c3dd8a48.png)

Attempting to impersonate an unrelated candidate:
![image](https://user-images.githubusercontent.com/107591/73368288-a184df00-42a8-11ea-8cd9-18326e35af48.png)

### Link to Trello card

[1527 - How can vendors/providers act as candidates in the Sandbox?](https://trello.com/c/rVEXKbEU)

### Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
