### PR TITLE
Revert reverted encrypted candidate ID PR and update Encryptor

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -61,6 +61,16 @@ module ViewHelper
     dates.edit_by.to_s(:govuk_date).strip
   end
 
+  def candidate_sign_in_url(candidate)
+    encrypted_candidate_id = Encryptor.encrypt(candidate.id)
+
+    if FeatureFlag.active?('improved_expired_token_flow')
+      candidate_interface_sign_in_url(u: encrypted_candidate_id)
+    else
+      candidate_interface_sign_in_url
+    end
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,9 +1,12 @@
 class CandidateMailer < ApplicationMailer
+  helper :view
+
   def submit_application_email(application_form)
     @application_form = application_form
+    @candidate = @application_form.candidate
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: application_form.candidate.email_address,
+              to: @candidate.email_address,
               subject: t('submit_application_success.email.subject'))
   end
 

--- a/app/services/encryptor.rb
+++ b/app/services/encryptor.rb
@@ -1,5 +1,5 @@
 class Encryptor
-  ENCRYPTOR = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..31])
+  ENCRYPTOR = ActiveSupport::MessageEncryptor.new(Rails.application.secret_key_base[0..31])
 
   def self.encrypt(text)
     ENCRYPTOR.encrypt_and_sign(text)

--- a/app/services/encryptor.rb
+++ b/app/services/encryptor.rb
@@ -1,0 +1,11 @@
+class Encryptor
+  ENCRYPTOR = ActiveSupport::MessageEncryptor.new(Rails.application.secrets.secret_key_base[0..31])
+
+  def self.encrypt(text)
+    ENCRYPTOR.encrypt_and_sign(text)
+  end
+
+  def self.decrypt(text)
+    ENCRYPTOR.decrypt_and_verify(text)
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,6 +6,7 @@ class FeatureFlag
     send_reference_email_via_support
     confirm_course_choice_from_find
     send_dfe_sign_in_invitations
+    improved_expired_token_flow
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_mailer/submit_application_email.text.erb
+++ b/app/views/candidate_mailer/submit_application_email.text.erb
@@ -12,14 +12,14 @@ Your application reference is <%= @application_form.support_reference %>.
 
 You can track the progress of your <%= 'application'.pluralize(@application_form.application_choices.count) %> here:
 
-<%= candidate_interface_application_form_url %>
+<%= candidate_sign_in_url(@candidate) %>
 
 # Making changes to your application
 
 <% if FeatureFlag.active?('edit_application') %>
   You have 5 working days to edit your application or change your choice of provider, course or training location.
 
-  To make changes, [sign back in to your account](<%= candidate_interface_sign_in_url %>).
+  To make changes, [sign back in to your account](<%= candidate_sign_in_url(@candidate) %>).
 
   You can sign back in to change your name or contact details at any point up until enrolment.
 
@@ -40,7 +40,7 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 
 You can withdraw your application to your <%= 'course'.pluralize(@application_form.application_choices.count) %> at any point, even after you’ve accepted an offer.
 
-[Sign in to your account](<%= candidate_interface_sign_in_url %>) and click ‘withdraw’ next to the <%= 'course'.pluralize(@application_form.application_choices.count) %> you want to withdraw and we’ll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
+[Sign in to your account](<%= candidate_sign_in_url(@candidate) %>) and click ‘withdraw’ next to the <%= 'course'.pluralize(@application_form.application_choices.count) %> you want to withdraw and we’ll let your training <%= 'provider'.pluralize(@application_form.application_choices.count) %> know.
 
 # References
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -4,9 +4,14 @@ RSpec.describe CandidateMailer, type: :mailer do
   subject(:mailer) { described_class }
 
   describe 'Send submit application email' do
-    let(:mail) { mailer.submit_application_email(build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE')) }
+    let(:candidate) { build_stubbed(:candidate) }
+    let(:application_form) { build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE', candidate: candidate) }
+    let(:mail) { mailer.submit_application_email(application_form) }
 
-    before { mail.deliver_later }
+    before do
+      allow(Encryptor).to receive(:encrypt).with(candidate.id).and_return('example_encrypted_id')
+      mail.deliver_later
+    end
 
     it 'sends an email with the correct subject' do
       expect(mail.subject).to include(t('submit_application_success.email.subject'))
@@ -18,6 +23,23 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     it 'sends an email containing the support reference' do
       expect(mail.body.encoded).to include('SUPPORT-REFERENCE')
+    end
+
+    context 'when the improved_expired_token_flow feature flag is on' do
+      before { FeatureFlag.activate('improved_expired_token_flow') }
+
+      it 'sends an email containing a link to sign in and id' do
+        expect(mail.body.encoded).to include(candidate_interface_sign_in_url(u: 'example_encrypted_id'))
+      end
+    end
+
+    context 'when the improved_expired_token_flow feature flag is off' do
+      before { FeatureFlag.deactivate('improved_expired_token_flow') }
+
+      it 'sends an email containing a link to sign in without id' do
+        expect(mail.body.encoded).to include(candidate_interface_sign_in_url)
+        expect(mail.body.encoded).not_to include(candidate_interface_sign_in_url(u: 'example_encrypted_id'))
+      end
     end
   end
 

--- a/spec/services/encryptor_spec.rb
+++ b/spec/services/encryptor_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Encryptor do
+  it 'returns the original string when decrypting an encrypted string' do
+    encrypted_data = Encryptor.encrypt('example')
+
+    expect(Encryptor.decrypt(encrypted_data)).to eq('example')
+  end
+end


### PR DESCRIPTION
## Context

We reverted https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1214 in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1226, because it was the cause of us not being able to deploy QA. The issue was related to secret key base as we were unable to find a value for it using `Rails.application.secrets.secret_key_base`.

## Changes proposed in this pull request

This PR reverts our revert in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1214 and then updates `Encryptor` to use `Rails.application.secret_key_base` to retrieve the `SECRET_KEY_BASE` environment variable.

## Guidance to review

- Does this make sense?
- Review individual commits

## Link to Trello card

https://trello.com/c/ZyModi4f/811-improve-flow-for-expired-tokens-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
