### PR TITLE
Add Climate Control for Slack worker and Notify request specs

### DIFF
--- a/spec/requests/integrations/post_notify_callback_spec.rb
+++ b/spec/requests/integrations/post_notify_callback_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe 'Notify Callback - POST /integrations/notify/callback', type: :re
     { 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{notify_callback_token}" }
   end
 
+  around do |example|
+    ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'test' do
+      example.run
+    end
+  end
+
   it 'returns success if token matches environment variable' do
     request_body = {
       reference: "test-reference_request-#{reference.id}",

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -9,6 +9,12 @@ RSpec.describe SlackNotificationWorker do
     let(:url) { 'https://example.com/support' }
     let(:output) { capture_logstash_output(rails_config) { invoke_worker } }
 
+    around do |example|
+      ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'TEST' do
+        example.run
+      end
+    end
+
     before { allow(HTTP).to receive(:post) }
 
     def invoke_worker


### PR DESCRIPTION
## Context

Csaba ran `be rake` and tests failed. This has happened before and related to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1155.

See Duncan's explanation (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1155#issuecomment-576628827):

>👍 to clarify a bit: the tests are run in RAILS_ENV=test but dotenv-rails loads the .env.development file when rake first sets up the environment and and then doesn't override it with .env.test when rspec happens within that rake environment. The behaviour we see is that the value of HOSTING_ENVIRONMENT_NAME from .env.development has precedence under be rake but not under plain be rspec.

## Changes proposed in this pull request

Add `ClimateControl` in the failing specs.

## Guidance to review

Run `bundle exec rake` and ensure all tests pass.

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
