### PR TITLE
rake setup_local_dev_data adds a provider-only user

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ sister service `Find`. To populate your local database with course data from
 
 Among other things, this task also creates a support user with DfE Sign-in UID
 `dev-support` that you can use to log into the Support interface in your
-development environment.
+development environment, and a provider user with the UID `dev-provider`.
 
 ### Background processing
 

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -15,11 +15,14 @@ task setup_local_dev_data: :environment do
   puts 'Generating some test applications...'
   GenerateTestApplications.new.perform
 
-  puts 'Creating a provider user with DfE Sign-in UID `dev-support` and email `support@example.com`...'
-  ProviderUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com') do |u|
+  puts 'Creating a provider-only user with DfE Sign-in UID `dev-provider` and email `provider@example.com`...'
+  ProviderUser.find_or_create_by!(dfe_sign_in_uid: 'dev-provider', email_address: 'provider@example.com') do |u|
     u.providers = [ApplicationChoice.first.provider]
   end
 
-  puts 'Creating a support user with DfE Sign-in UID `dev-support` and email `support@example.com`...'
+  puts 'Creating a support & provider user with DfE Sign-in UID `dev-support` and email `support@example.com`...'
+  ProviderUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com') do |u|
+    u.providers = [ApplicationChoice.first.provider]
+  end
   SupportUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com')
 end


### PR DESCRIPTION
## Context

This makes testing provider features locally a bit simpler as we don't have to worry about the extra state of being logged into support too.

## Changes proposed in this pull request

Add a `dev-provider` user in the `setup_local_dev_data` rake task.

## Guidance to review

Run the task, log in using `dev-provider`. You can see /provider but not /support
