### PR TITLE
Make sure we generate test applications for random courses

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -20,9 +20,8 @@ module TestApplications
 
     courses_to_apply_to ||= Course.joins(:course_options)
       .open_on_apply
-      .order('RANDOM()')
 
-    courses_to_apply_to = courses_to_apply_to.take(states.count)
+    courses_to_apply_to = courses_to_apply_to.sample(states.count)
 
     # it does not make sense to apply to the same course multiple times
     # in the course of the same application, and it’s forbidden in the UI.


### PR DESCRIPTION
##  Context

We currently don’t randomise the courses that a test application can be for.

## Changes proposed in this pull request

This fixes that, and removes a now redundant `RANDOM()` call.

## Guidance to review

Trust.

## Link to Trello card

https://trello.com/c/YnZM44Vo

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
