### PR TITLE
Add redirect to send new sign in email page when expired token is used

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -35,7 +35,9 @@ module CandidateInterface
     def authenticate
       candidate = FindCandidateByToken.call(raw_token: params[:token])
 
-      if candidate
+      if candidate.nil?
+        redirect_to action: :new
+      elsif FindCandidateByToken.token_not_expired?(candidate)
         flash[:success] = t('apply_from_find.account_created_message') if candidate.last_signed_in_at.nil?
 
         sign_in(candidate, scope: :candidate)
@@ -57,7 +59,7 @@ module CandidateInterface
           redirect_to candidate_interface_course_choices_review_path
         end
       else
-        redirect_to action: :new
+        redirect_to candidate_interface_expired_sign_in_path(id: candidate.id)
       end
     end
 

--- a/app/services/find_candidate_by_token.rb
+++ b/app/services/find_candidate_by_token.rb
@@ -3,9 +3,8 @@ class FindCandidateByToken
 
   def self.call(raw_token:)
     token = MagicLinkToken.from_raw(raw_token)
-    candidate = Candidate.find_by(magic_link_token: token)
 
-    candidate if self.token_not_expired?(candidate)
+    Candidate.find_by(magic_link_token: token)
   end
 
   def self.token_not_expired?(candidate)

--- a/app/warden/magic_link_strategy.rb
+++ b/app/warden/magic_link_strategy.rb
@@ -6,7 +6,7 @@ class MagicLinkStrategy < Warden::Strategies::Base
   def authenticate!
     candidate = FindCandidateByToken.call(raw_token: params[:token])
 
-    if candidate.present?
+    if FindCandidateByToken.token_not_expired?(candidate)
       success!(candidate)
     else
       fail!


### PR DESCRIPTION
## Context

When a candidate clicks on their most recent sign in email and 1 hour has passed (the maximum token duration), they are taken to the sign in page. This means they have to enter in their email address and then click a button to get a new email. We can save the candidate from having to enter their email address by redirecting them to the recently added new sign in email page (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1222).

## Changes proposed in this pull request

This PR:

- refactors `FindCandidateByToken.call` to always return a candidate. By only returning a candidate if the token was not expired felt like it was lying to me and doing more than it says it is. Also it was necessary to make this work...
- redirects the candidate to the new sign in email page if token is expired

## Guidance to review

- Does the refactor in `FindCandidateByToken` make sense?
- Should this be tested in `spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb` or `spec/system/candidate_interface/candidate_account_spec.rb` or a separate one?

## Link to Trello card

https://trello.com/c/ZyModi4f/811-improve-flow-for-expired-tokens-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
