### PR TITLE
Create referee questionnaire table

### DIFF
--- a/db/migrate/20200130131300_create_referee_questionnaire.rb
+++ b/db/migrate/20200130131300_create_referee_questionnaire.rb
@@ -1,0 +1,15 @@
+class CreateRefereeQuestionnaire < ActiveRecord::Migration[6.0]
+  def change
+    create_table :referee_questionnaires do |t|
+        t.string :experience_rating
+        t.string :experience_text
+        t.string :guidance_rating
+        t.string :guidance_text
+        t.boolean :safe_to_work_with_children
+        t.string :safe_to_work_with_children_text
+        t.boolean :permission_to_contact
+        t.string :permission_to_contact_text
+        t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_164924) do
+ActiveRecord::Schema.define(version: 2020_01_30_131300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -224,6 +224,19 @@ ActiveRecord::Schema.define(version: 2020_01_28_164924) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "sync_courses", default: false, null: false
     t.index ["code"], name: "index_providers_on_code", unique: true
+  end
+
+  create_table "referee_questionnaires", force: :cascade do |t|
+    t.string "experience_rating"
+    t.string "experience_text"
+    t.string "guidance_rating"
+    t.string "guidance_text"
+    t.boolean "safe_to_work_with_children"
+    t.string "safe_to_work_with_children_text"
+    t.boolean "permission_to_contact"
+    t.string "permission_to_contact_text"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "references", force: :cascade do |t|


### PR DESCRIPTION
## Context

Referees will now be asked to fill out a questionnaire after completing a reference for a candidate. This migration adds a referee questionnaire table.

This will belong to an application reference.

## Changes proposed in this pull request

-  Adds a RefereeQuestionnaire table

## Guidance to review

Any thoughts on naming?

## Link to Trello card

https://trello.com/c/BebZdXWo/865-build-referee-questionnaire-into-reference-form-sent-to-referees

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
