### PR TITLE
Surface accrediting providers in support interface

### DIFF
--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -9,8 +9,8 @@
       <th scope='col' class='govuk-table__header'>Recruitment Cycle</th>
       <th scope='col' class='govuk-table__header'>Apply from Find</th>
       <th scope='col' class='govuk-table__header'>Page on Find</th>
-      <% if accrediting_providers_vary? %>
-        <th scope='col' class='govuk-table__header'>Accredited provider</th>
+      <% if accredited_bodies_vary? %>
+        <th scope='col' class='govuk-table__header'>Accredited body</th>
       <% end %>
     </tr>
   </thead>
@@ -38,8 +38,8 @@
             <em>N/A - hidden in Find</em>
           <% end %>
         </td>
-        <% if accrediting_providers_vary? %>
-          <td class='govuk-table__cell'><%= course[:accrediting_provider] %></td>
+        <% if accredited_bodies_vary? %>
+          <td class='govuk-table__cell'><%= course[:accredited_body] %></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -10,7 +10,7 @@
       <th scope='col' class='govuk-table__header'>Apply from Find</th>
       <th scope='col' class='govuk-table__header'>Page on Find</th>
       <% if accrediting_providers_vary? %>
-        <th scope='col' class='govuk-table__header'>Accrediting provider</th>
+        <th scope='col' class='govuk-table__header'>Accredited provider</th>
       <% end %>
     </tr>
   </thead>

--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -9,6 +9,9 @@
       <th scope='col' class='govuk-table__header'>Recruitment Cycle</th>
       <th scope='col' class='govuk-table__header'>Apply from Find</th>
       <th scope='col' class='govuk-table__header'>Page on Find</th>
+      <% if accrediting_providers_vary? %>
+        <th scope='col' class='govuk-table__header'>Accrediting provider</th>
+      <% end %>
     </tr>
   </thead>
 
@@ -35,6 +38,9 @@
             <em>N/A - hidden in Find</em>
           <% end %>
         </td>
+        <% if accrediting_providers_vary? %>
+          <td class='govuk-table__cell'><%= course[:accrediting_provider] %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -11,12 +11,12 @@ module SupportInterface
       courses.order(:name).map do |course|
         {
           course_link: govuk_link_to(course.name_and_code, support_interface_course_path(course)),
-          provider_link: govuk_link_to(course.provider.name_and_code, support_interface_provider_path(course.provider)),
+          provider_link: link_to_provider_page(course.provider),
           level: course.level.titleize,
           recruitment_cycle_year: course.recruitment_cycle_year,
           apply_from_find_link: link_to_apply_from_find_page(course),
           link_to_find_course_page: link_to_find_course_page(course),
-          accrediting_provider: course.accrediting_provider&.name,
+          accrediting_provider: link_to_provider_page(course.accrediting_provider),
         }
       end
     end
@@ -44,6 +44,15 @@ module SupportInterface
     def link_to_find_course_page(course)
       if course.exposed_in_find?
         govuk_link_to 'Find course page', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}"
+      end
+    end
+
+    def link_to_provider_page(provider)
+      if provider
+        govuk_link_to(
+          provider.name_and_code,
+          support_interface_provider_path(provider),
+        )
       end
     end
   end

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -16,7 +16,7 @@ module SupportInterface
           recruitment_cycle_year: course.recruitment_cycle_year,
           apply_from_find_link: link_to_apply_from_find_page(course),
           link_to_find_course_page: link_to_find_course_page(course),
-          accrediting_provider: link_to_provider_page(course.accrediting_provider),
+          accredited_body: link_to_provider_page(course.accrediting_provider),
         }
       end
     end
@@ -25,8 +25,8 @@ module SupportInterface
       @providers_vary ||= courses.any? { |c| c.provider != provider }
     end
 
-    def accrediting_providers_vary?
-      @accrediting_providers_vary ||= courses.any? { |c| c.accrediting_provider && c.accrediting_provider != provider }
+    def accredited_bodies_vary?
+      @accredited_bodies_vary ||= courses.any? { |c| c.accrediting_provider && c.accrediting_provider != provider }
     end
 
   private

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -16,12 +16,17 @@ module SupportInterface
           recruitment_cycle_year: course.recruitment_cycle_year,
           apply_from_find_link: link_to_apply_from_find_page(course),
           link_to_find_course_page: link_to_find_course_page(course),
+          accrediting_provider: course.accrediting_provider&.name,
         }
       end
     end
 
     def providers_vary?
       @providers_vary ||= courses.any? { |c| c.provider != provider }
+    end
+
+    def accrediting_providers_vary?
+      @accrediting_providers_vary ||= courses.any? { |c| c.accrediting_provider && c.accrediting_provider != provider }
     end
 
   private

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -10,6 +10,17 @@
     </dd>
   </div>
 
+  <% if @course.accrediting_provider %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Accrediting provider
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <%= @course.accrediting_provider&.name_and_code %>
+      </dd>
+    </div>
+  <% end %>
+
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">
       Name

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -13,7 +13,7 @@
   <% if @course.accrediting_provider %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        Accredited provider
+        Accredited body
       </dt>
       <dd class="govuk-summary-list__value">
         <%= @course.accrediting_provider&.name_and_code %>

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -13,7 +13,7 @@
   <% if @course.accrediting_provider %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        Accrediting provider
+        Accredited provider
       </dt>
       <dd class="govuk-summary-list__value">
         <%= @course.accrediting_provider&.name_and_code %>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -31,7 +31,7 @@
 <% end %>
 
 <h2 class='govuk-heading-m'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.open_on_apply.size %> on DfE Apply)</h2>
-<%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider, courses: @provider.courses) %>
+<%= render(SupportInterface::ProviderCoursesTableComponent, provider: @provider, courses: @provider.courses.includes(:accrediting_provider)) %>
 
 <% if @provider.accredited_courses.any? %>
   <h2 class='govuk-heading-m'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
     end
 
     it 'may include accrediting providers' do
-      accrediting_provider = create(:provider, name: 'Accrediting University')
+      accrediting_provider = create(:provider, name: 'Accrediting University', code: 'AU1')
       provider = create(:provider)
 
       course = create(
@@ -74,7 +74,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
       expect(fields).to have_key('Accrediting provider')
-      expect(fields['Accrediting provider']).to eq('Accrediting University')
+      expect(fields['Accrediting provider']).to eq('Accrediting University (AU1)')
     end
   end
 end

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       expect(fields['Recruitment Cycle']).to eq('2020')
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
-      expect(fields).not_to have_key('Accredited provider')
+      expect(fields).not_to have_key('Accredited body')
     end
 
     it 'may include courses the provider accredits' do
@@ -73,8 +73,8 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       expect(fields['Recruitment Cycle']).to eq('2020')
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
-      expect(fields).to have_key('Accrediting provider')
-      expect(fields['Accrediting provider']).to eq('Accredited University (AU1)')
+      expect(fields).to have_key('Accredited body')
+      expect(fields['Accredited body']).to eq('Accredited University (AU1)')
     end
   end
 end

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       expect(fields['Recruitment Cycle']).to eq('2020')
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
-      expect(fields).not_to have_key('Accrediting provider')
+      expect(fields).not_to have_key('Accredited provider')
     end
 
     it 'may include courses the provider accredits' do
@@ -45,7 +45,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
     end
 
     it 'may include accrediting providers' do
-      accrediting_provider = create(:provider, name: 'Accrediting University', code: 'AU1')
+      accrediting_provider = create(:provider, name: 'Accredited University', code: 'AU1')
       provider = create(:provider)
 
       course = create(
@@ -74,7 +74,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
       expect(fields).to have_key('Accrediting provider')
-      expect(fields['Accrediting provider']).to eq('Accrediting University (AU1)')
+      expect(fields['Accrediting provider']).to eq('Accredited University (AU1)')
     end
   end
 end

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'See providers' do
   def then_i_see_the_updated_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
     expect(page).to have_content '1 course (1 on DfE Apply)'
-    expect(page).to have_content 'Accredited provider'
+    expect(page).to have_content 'Accredited body'
     expect(page).to have_content 'University of Chester'
   end
 

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'See providers' do
   def then_i_see_the_updated_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
     expect(page).to have_content '1 course (1 on DfE Apply)'
-    expect(page).to have_content 'Accrediting provider'
+    expect(page).to have_content 'Accredited provider'
     expect(page).to have_content 'University of Chester'
   end
 

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -67,11 +67,15 @@ RSpec.feature 'See providers' do
       },
     ])
 
-    @request1 = stub_find_api_provider_200(
+    @request1 = stub_find_api_provider_200_with_accrediting_provider(
       provider_code: 'ABC',
       provider_name: 'Royal Academy of Dance',
       course_code: 'ABC-1',
       site_code: 'X',
+      accrediting_provider_code: 'XYZ',
+      accrediting_provider_name: 'University of Chester',
+      findable: true,
+      study_mode: 'full_time',
     )
 
     @request2 = stub_find_api_provider_200(
@@ -135,6 +139,8 @@ RSpec.feature 'See providers' do
   def then_i_see_the_updated_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
     expect(page).to have_content '1 course (1 on DfE Apply)'
+    expect(page).to have_content 'Accrediting provider'
+    expect(page).to have_content 'University of Chester'
   end
 
   def when_i_click_on_a_different_provider


### PR DESCRIPTION
## Context

Support users need to be able to see the accrediting provider (where applicable) for a given course in the provider (course list) view and course detail views.

Relates to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1126

## Changes proposed in this pull request

- Add a column to the `ProviderCoursesTableComponent` (HTML) table for _Accrediting provider_ for each course iff the table data includes 1 or more accrediting providers. Values are links.
- Add a field to the view that renders the course details page to show the _Accrediting provider_ iff that course has an accrediting provider.



![image](https://user-images.githubusercontent.com/450843/73475442-49250e80-4388-11ea-8bbf-7976c7aac2ee.png)
![image](https://user-images.githubusercontent.com/450843/73475653-ae78ff80-4388-11ea-8381-394d4e4dfda6.png)



## Guidance to review

- Does the UI look OK?
- Is it OK to add the accrediting provider case to the existing system spec? (or is it mixing things up too much?)

## Link to Trello card

https://trello.com/c/OUDbdRen/1468-surface-accreditation-relationships-on-the-individual-provider-page-in-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
