### PR TITLE
Don't include candidates without forms in the process stats

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -43,9 +43,9 @@ class PerformanceStatistics
             ELSE ARRAY['9', 'unknown_state']
           END status
       FROM
-          candidates c
+          application_forms f
       LEFT JOIN
-          application_forms f ON f.candidate_id = c.id
+          candidates c ON f.candidate_id = c.id
       LEFT JOIN
           application_choices ch ON ch.application_form_id = f.id
       WHERE

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -108,6 +108,14 @@ RSpec.describe PerformanceStatistics, type: :model do
     expect(stats.application_form_counts_total).to eq(1)
   end
 
+  it 'excludes candidates without application forms' do
+    create(:candidate)
+
+    stats = PerformanceStatistics.new
+
+    expect(stats.application_form_counts_total).to eq(0)
+  end
+
   it 'breaks down candidates with unsubmitted forms into stages' do
     create(:candidate)
     create_list(:application_form, 2)


### PR DESCRIPTION
## Context

We currently make the initial query for the process state states against the candidates table, but then count the number of distinct states per application form. This means we’re counting the 10 user who don’t have an application form (in practice, this gets condensed to a off-by-one error because all form_ids are nil).

## Changes proposed in this pull request

Fix the bug by basing the initial query on forms.

## Guidance to review

Does the test make sense?

## Link to Trello card

This is a @benilovj special. 

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
