### PR TITLE
Link to Find from the course choice review component

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class CourseChoicesReviewComponent < ActionView::Component::Base
+    include ViewHelper
     validates :application_form, presence: true
 
     def initialize(application_form:, editable: true, heading_level: 2, show_status: false, show_incomplete: false, missing_error: false)
@@ -41,9 +42,11 @@ module CandidateInterface
     attr_reader :application_form
 
     def course_row(course_choice)
+      url = "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course_choice.provider.code}/#{course_choice.course.code}"
+
       {
         key: 'Course',
-        value: "#{course_choice.course.name} (#{course_choice.course.code})",
+        value: govuk_link_to("#{course_choice.course.name} (#{course_choice.course.code})", url, target: '_blank', rel: 'noopener'),
       }
     end
 


### PR DESCRIPTION
## Context

This is useful for candidates to more easily check which course they've chosen.

## Changes proposed in this pull request

Adds a `govuk_link_to` on the course name and code.

## Guidance to review

No tests because this doesn't actually change logic and the test would duplicate the functionality pretty much.

This link is implemented as part of `/components/support_interface/provider_courses_table_component.rb`, but it's only the second time we need it so I didn't think it's time to abstract this as its own helper or component.

<img width="1010" alt="Screenshot 2020-01-30 at 16 20 57" src="https://user-images.githubusercontent.com/1650875/73468960-8506a680-437d-11ea-92f4-b933424239e7.png">


## Link to Trello card

https://trello.com/c/D90B3MuO/855-tactical-fix-add-link-to-find-from-candidate-course-choice

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)