### PR TITLE
Add missing lines to application submitted mail template (provider)

### DIFF
--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -1,10 +1,17 @@
 Dear <%= @application.provider_user_name %>
 
+# Application received
+
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name %> <%= @application.course_code %>. 
 
+# Next steps
+
 Log in to Manage teacher training applications to respond:
+
 <%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
 
 We’ll reject the application on your behalf after 40 working days.   
+
+# Give feedback or report a problem
 
 Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The mail template was missing a few lines in the previous PR https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1230

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
Added the missing lines according to content design:
![image](https://user-images.githubusercontent.com/22743709/73470039-322dee80-437f-11ea-94b0-17e1feecade6.png)

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/09ms2J92/835-email-%F0%9F%93%AC-an-application-has-been-submitted-to-provider

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
