### PR TITLE
Add backfill reminder to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,6 @@
 ## Things to check
 
 - [ ] This code doesn't rely on migrations in the same Pull Request
+- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
 - [ ] API release notes have been updated if necessary
 - [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)


### PR DESCRIPTION
## Context

We had a dev retro and talked about bugs introduced by not remembering to backfill when we changed or added columns.

## Changes proposed in this pull request

Add a checkbox to the PR template

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
