### PR TITLE
Email provider when an application has been rejected by default

### DIFF
--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -1,7 +1,24 @@
 class ProviderMailerPreview < ActionMailer::Preview
   def account_created_email
-    provider_user = FactoryBot.build :provider_user
-
     ProviderMailer.account_created(provider_user)
+  end
+
+  def application_submitted
+    ProviderMailer.application_submitted(provider_user, application_choice)
+  end
+
+  def application_rejected_by_default
+    ProviderMailer.application_rejected_by_default(provider_user, application_choice)
+  end
+
+private
+
+  def application_choice
+    course_option = FactoryBot.create(:course_option, course: FactoryBot.build(:course))
+    FactoryBot.create(:submitted_application_choice, course_option: course_option)
+  end
+
+  def provider_user
+    FactoryBot.build :provider_user
   end
 end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -10,11 +10,17 @@ class ProviderMailer < ApplicationMailer
   end
 
   def application_submitted(provider_user, application_choice)
-    @application = OpenStruct.new(
-      course_name_and_code: application_choice.course.name_and_code,
-      provider_user_name: provider_user.full_name,
-      candidate_name: application_choice.application_form.full_name,
-      application_choice_id: application_choice.id,
+    @application = 
+      Struct.new(
+        :course_name_and_code,
+        :provider_user_name,
+        :candidate_name,
+        :application_choice_id,
+      ).new(
+          application_choice.course.name_and_code,
+          provider_user.full_name,
+          application_choice.application_form.full_name,
+          application_choice.id,
     )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
@@ -23,17 +29,23 @@ class ProviderMailer < ApplicationMailer
   end
 
   def application_rejected_by_default(provider_user, application_choice)
-    @application = OpenStruct.new(
-      candidate_name: application_choice.application_form.full_name,
-      provider_user_name: provider_user.full_name,
-      course_name: application_choice.course.name,
-      course_code: application_choice.course.code,
-      submitted_at: application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
-      application_choice_id: application_choice.id,
+    @application = 
+      Struct.new(
+        :candidate_name,
+        :provider_user_name,
+        :course_name_and_code,
+        :submitted_at,
+        :application_choice_id,
+      ).new(
+          application_choice.application_form.full_name,
+          provider_user.full_name,
+          application_choice.course.name_and_code,
+          application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
+          application_choice.id,
     )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: provider_user.email_address,
-              subject: t('provider_application_rejected_by_default.email.subject', candidate_name: @application.candidate_name))
+              subject: t('provider_application_rejected_by_default.email.subject', course_name_and_code: @application.course_name_and_code))
   end
 end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -21,4 +21,19 @@ class ProviderMailer < ApplicationMailer
               to: provider_user.email_address,
               subject: t('provider_application_submitted.email.subject', course_name_and_code: @application.course_name_and_code))
   end
+
+  def application_rejected_by_default(provider_user, application_choice)
+    @application = OpenStruct.new(
+      candidate_name: application_choice.application_form.full_name,
+      provider_user_name: provider_user.full_name,
+      course_name: application_choice.course.name,
+      course_code: application_choice.course.code,
+      submitted_at: application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
+      application_choice_id: application_choice.id,
+    )
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: provider_user.email_address,
+              subject: t('provider_application_rejected_by_default.email.subject', candidate_name: @application.candidate_name))
+  end
 end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -10,17 +10,17 @@ class ProviderMailer < ApplicationMailer
   end
 
   def application_submitted(provider_user, application_choice)
-    @application = 
+    @application =
       Struct.new(
         :course_name_and_code,
         :provider_user_name,
         :candidate_name,
         :application_choice_id,
       ).new(
-          application_choice.course.name_and_code,
-          provider_user.full_name,
-          application_choice.application_form.full_name,
-          application_choice.id,
+        application_choice.course.name_and_code,
+        provider_user.full_name,
+        application_choice.application_form.full_name,
+        application_choice.id,
     )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
@@ -29,23 +29,23 @@ class ProviderMailer < ApplicationMailer
   end
 
   def application_rejected_by_default(provider_user, application_choice)
-    @application = 
+    @application =
       Struct.new(
         :candidate_name,
         :provider_user_name,
         :course_name_and_code,
         :submitted_at,
-        :application_choice_id,
+        :application_choice,
       ).new(
-          application_choice.application_form.full_name,
-          provider_user.full_name,
-          application_choice.course.name_and_code,
-          application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
-          application_choice.id,
+        application_choice.application_form.full_name,
+        provider_user.full_name,
+        application_choice.course.name_and_code,
+        application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
+        application_choice,
     )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: provider_user.email_address,
-              subject: t('provider_application_rejected_by_default.email.subject', course_name_and_code: @application.course_name_and_code))
+              subject: t('provider_application_rejected_by_default.email.subject', candidate_name: @application.candidate_name))
   end
 end

--- a/app/services/reject_application_by_default.rb
+++ b/app/services/reject_application_by_default.rb
@@ -11,6 +11,8 @@ class RejectApplicationByDefault
       ApplicationStateChange.new(application_choice).reject_by_default!
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
       StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice)
+
+      SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
     end
   end
 end

--- a/app/services/reject_applications_by_default.rb
+++ b/app/services/reject_applications_by_default.rb
@@ -3,6 +3,7 @@ class RejectApplicationsByDefault
   def call
     GetApplicationChoicesReadyToRejectByDefault.call.each do |application_choice|
       RejectApplicationByDefault.new(application_choice: application_choice).call
+      SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
     end
   end
 end

--- a/app/services/reject_applications_by_default.rb
+++ b/app/services/reject_applications_by_default.rb
@@ -3,7 +3,6 @@ class RejectApplicationsByDefault
   def call
     GetApplicationChoicesReadyToRejectByDefault.call.each do |application_choice|
       RejectApplicationByDefault.new(application_choice: application_choice).call
-      SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
     end
   end
 end

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -11,14 +11,11 @@ class SendRejectByDefaultEmailToProvider
     application_choice.provider.provider_users.each do |provider_user|
       ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_now
 
-      course_name = application_choice.course.name
-      course_code = application_choice.course.code
-      audit_comment = I18n.t('provider_application_rejected_by_default.email.audit_comment',
-                             provider_user_email: provider_user.email_address,
-                             course_name: course_name,
-                             course_code: course_code)
-      application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
-      application_comment.save(application_choice.application_form)
+      course_name_and_code = application_choice.course.name_and_code
+      audit_comment =
+        'Rejected by default email have been sent to the provider user' +
+        " #{provider_user.email_address} for application #{course_name_and_code}."
+      application_choice.application_form.update!(audit_comment: audit_comment)
     end
   end
 end

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -1,0 +1,24 @@
+class SendRejectByDefaultEmailToProvider
+  attr_accessor :application_choice
+
+  def initialize(application_choice:)
+    self.application_choice = application_choice
+  end
+
+  def call
+    return false unless application_choice.rejected?
+
+    application_choice.provider.provider_users.each do |provider_user|
+      ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_now
+
+      course_name = application_choice.course.name
+      course_code = application_choice.course.code
+      audit_comment = I18n.t('provider_application_rejected_by_default.email.audit_comment',
+                             provider_user_email: provider_user.email_address,
+                             course_name: course_name,
+                             course_code: course_code)
+      application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
+      application_comment.save(application_choice.application_form)
+    end
+  end
+end

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -1,0 +1,15 @@
+Dear <%= @application.provider_user_name %>
+
+# Application rejected automatically  
+
+<%= @application.candidate_name %> submitted an application for <%= @application.course_name %> <%= @application.course_code %> on <%= @application.submitted_at %>. 
+
+You did not respond within 40 working days so we rejected the application on your behalf. 
+
+You can log in to Manage teacher training applications to check the status of your applications:
+
+<%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -2,13 +2,13 @@ Dear <%= @application.provider_user_name %>
 
 # Application rejected automatically  
 
-<%= @application.candidate_name %> submitted an application for <%= @application.course_name %> <%= @application.course_code %> on <%= @application.submitted_at %>. 
+<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>. 
 
 You did not respond within 40 working days so we rejected the application on your behalf. 
 
 You can log in to Manage teacher training applications to check the status of your applications:
 
-<%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
+<%= provider_interface_application_choice_url(@application.application_choice) %>
 
 # Give feedback or report a problem
 

--- a/config/locales/provider_notifications.yml
+++ b/config/locales/provider_notifications.yml
@@ -4,4 +4,13 @@ en:
       subject: Sign in to Manage teacher training applications.
   provider_application_submitted:
     email:
+<<<<<<< HEAD
       subject: Application received for %{course_name_and_code}
+=======
+      subject: Application received for %{course_name} %{course_code}
+  provider_application_rejected_by_default:
+    email:
+      subject: '%{candidate_name}’s application rejected automatically'
+      audit_comment: "Rejected by default email have been sent to the provider user (%{provider_user_email}) for application (%{course_name}) (%{course_code})."
+
+>>>>>>> Extend provider mailer with rejected by default mail

--- a/config/locales/provider_notifications.yml
+++ b/config/locales/provider_notifications.yml
@@ -4,13 +4,7 @@ en:
       subject: Sign in to Manage teacher training applications.
   provider_application_submitted:
     email:
-<<<<<<< HEAD
       subject: Application received for %{course_name_and_code}
-=======
-      subject: Application received for %{course_name} %{course_code}
   provider_application_rejected_by_default:
     email:
       subject: '%{candidate_name}’s application rejected automatically'
-      audit_comment: "Rejected by default email have been sent to the provider user (%{provider_user_email}) for application (%{course_name}) (%{course_code})."
-
->>>>>>> Extend provider mailer with rejected by default mail

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
 
     it 'includes a link to the application' do
-      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: @application_choice.id))
+      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(@application_choice))
     end
   end
 

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.feature 'An application has been rejected by default' do
+  include CourseOptionHelpers
+
+  scenario 'the provider receives email', with_audited: true do
+    given_i_am_a_provider_user_with_a_provider
+    and_an_application_is_ready_to_reject_by_default
+
+    when_the_application_is_rejected_by_default
+
+    then_i_should_receive_an_email_with_a_link_to_the_application
+    and_an_audit_comment_has_submitted
+  end
+
+  def given_i_am_a_provider_user_with_a_provider
+    @course_option = course_option_for_provider_code(provider_code: 'ABC')
+    @provider_user = Provider.find_by(code: 'ABC').provider_users.first
+  end
+
+  def and_an_application_is_ready_to_reject_by_default
+    @application_choice =
+      create(
+        :application_choice,
+        status: 'awaiting_provider_decision',
+        reject_by_default_at: Time.zone.today,
+        course_option: @course_option,
+        application_form:
+          create(
+            :completed_application_form,
+            submitted_at: Time.zone.today,
+          ),
+      )
+  end
+
+  def when_the_application_is_rejected_by_default
+    RejectApplicationsByDefaultWorker.new.perform
+  end
+
+  def then_i_should_receive_an_email_with_a_link_to_the_application
+    open_email(@provider_user.email_address)
+
+    expect(current_email.subject).to include(t('provider_application_rejected_by_default.email.subject',
+                                               candidate_name: @application_choice.application_form.full_name))
+
+    expect(current_email.body).to include("http://localhost:3000/provider/applications/#{@application_choice.id}")
+  end
+
+  def and_an_audit_comment_has_submitted
+    expected_audit_comment =
+      'Rejected by default email have been sent to the provider user' +
+      " (#{@provider_user.email_address}) for application (#{@application_choice.course.name})" +
+      " (#{@application_choice.course.code})."
+
+    expect(@application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
+  end
+end

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
@@ -49,8 +49,7 @@ RSpec.feature 'An application has been rejected by default' do
   def and_an_audit_comment_has_submitted
     expected_audit_comment =
       'Rejected by default email have been sent to the provider user' +
-      " (#{@provider_user.email_address}) for application (#{@application_choice.course.name})" +
-      " (#{@application_choice.course.code})."
+      " #{@provider_user.email_address} for application #{@application_choice.course.name_and_code}."
 
     expect(@application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Currently, a support user must notify the provider that a candidate's application has been rejected by default when the 40 working day period is up. We want to send an automatic email to provider informing them that the application has been rejected.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds a service to send emails to providers when an application has been rejected by default, also audits these emails so they appear on the application history.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Currently, the only way we keep a record of these emails is by using audit comments, is there anything more to do about this? (I saw some discussions about a table of notifications) Does the audit comment make sense? 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/mDK8SMmL/837-email-%F0%9F%98%9E-an-application-has-been-rejected-by-default-because-you-didnt-respond-within-40-working-days-to-provider

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
