### PR TITLE
Fix course code formatting in provider mail template

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -11,8 +11,7 @@ class ProviderMailer < ApplicationMailer
 
   def application_submitted(provider_user, application_choice)
     @application = OpenStruct.new(
-      course_name: application_choice.course.name,
-      course_code: application_choice.course.code,
+      course_name_and_code: application_choice.course.name_and_code,
       provider_user_name: provider_user.full_name,
       candidate_name: application_choice.application_form.full_name,
       application_choice_id: application_choice.id,
@@ -20,6 +19,6 @@ class ProviderMailer < ApplicationMailer
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: provider_user.email_address,
-              subject: t('provider_application_submitted.email.subject', course_name: @application.course_name, course_code: @application.course_code))
+              subject: t('provider_application_submitted.email.subject', course_name_and_code: @application.course_name_and_code))
   end
 end

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application.provider_user_name %>
 
 # Application received
 
-<%= @application.candidate_name %> submitted an application for <%= @application.course_name %> <%= @application.course_code %>. 
+<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %>. 
 
 # Next steps
 

--- a/config/locales/provider_notifications.yml
+++ b/config/locales/provider_notifications.yml
@@ -4,4 +4,4 @@ en:
       subject: Sign in to Manage teacher training applications.
   provider_application_submitted:
     email:
-      subject: Application received for %{course_name} %{course_code}
+      subject: Application received for %{course_name_and_code}

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -41,9 +41,8 @@ RSpec.describe ProviderMailer, type: :mailer do
     it 'sends an email with the correct subject' do
       expect(@mail.subject).to include(
         t('provider_application_submitted.email.subject',
-          course_name: @application_choice.course.name,
-           course_code: @application_choice.course.code),
-          )
+          course_name_and_code: @application_choice.course.name_and_code),
+      )
     end
 
     it 'addresses the provider user by name' do

--- a/spec/system/provider_interface/provider_receives_email_when_a_new_application_has_been_submitted_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_a_new_application_has_been_submitted_spec.rb
@@ -40,9 +40,7 @@ RSpec.feature 'A new application has been submitted' do
   def then_i_should_receive_an_email_with_a_link_to_the_application
     open_email(@provider_user.email_address)
 
-    expect(current_email.subject).to include(t('provider_application_submitted.email.subject',
-                                               course_name: @application_choice.course.name,
-                                                course_code: @application_choice.course.code))
+    expect(current_email.subject).to include("Application received for #{@application_choice.course.name_and_code}")
 
     expect(current_email.body).to include("http://localhost:3000/provider/applications/#{@application_choice.id}")
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Received review post-merge, about missing bracket around the course code in Provider mailer, application submission email temple and email subject:
`The course code must always be in brackets after the course name, eg:
Mathematics (X100) not Mathematics X100` 
https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1230/files

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds the missing brackets in `application_submitted.text.erb ` and in email subject `provider_notifications.yml`


## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/09ms2J92/835-email-%F0%9F%93%AC-an-application-has-been-submitted-to-provider

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
