### PR TITLE
Add chaser emails table

### DIFF
--- a/db/migrate/20200131130342_create_chasers_sent.rb
+++ b/db/migrate/20200131130342_create_chasers_sent.rb
@@ -1,0 +1,9 @@
+class CreateChasersSent < ActiveRecord::Migration[6.0]
+  def change
+    create_table :chasers_sents do |t|
+      t.string :type
+      t.integer :application_choice_id
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_28_164924) do
+ActiveRecord::Schema.define(version: 2020_01_31_130342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -153,6 +153,13 @@ ActiveRecord::Schema.define(version: 2020_01_28_164924) do
     t.datetime "last_signed_in_at"
     t.index ["email_address"], name: "index_candidates_on_email_address", unique: true
     t.index ["magic_link_token"], name: "index_candidates_on_magic_link_token", unique: true
+  end
+
+  create_table "chasers_sents", force: :cascade do |t|
+    t.string "type"
+    t.integer "application_choice_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "course_options", force: :cascade do |t|


### PR DESCRIPTION
## Context

As discussed yesterday. We need a table for chaser_emails (notifications email on the whiteboard).

## Changes proposed in this pull request

- A migration to add the chaser_emails table

## Guidance to review
 
I think that's all the columns we need.

## Link to Trello card

https://trello.com/c/WFu3BfcB/843-automatically-send-chase-email-to-candidate-and-referee-after-5-days

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
