### PR TITLE
Make sign in link more obvious on start page

### DIFF
--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -32,12 +32,13 @@
       You can teach in further education (age 14 to adult), or study for a degree leading to qualified teacher status.
       <%= govuk_link_to('Learn more about eligibility for teacher training', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
     </p>
-    <%= link_to candidate_interface_eligibility_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-3 govuk-button--start', 'data-module': 'govuk-button' do %>
+    <%= link_to candidate_interface_eligibility_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-4 govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
       </svg>
     <% end %>
-    <p class="govuk-body">If you have teacher training applications in progress, please <%= govuk_link_to 'sign in', candidate_interface_sign_in_path %></p>
+    <p class="govuk-body">or</p>
+    <p class="govuk-body"><%= govuk_link_to 'Sign in to an existing application', candidate_interface_sign_in_path %></p>
   </div>
 </div>

--- a/spec/system/candidate_interface/candidate_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_account_spec.rb
@@ -110,7 +110,7 @@ RSpec.feature 'Candidate account' do
 
   def when_i_click_the_signin_link
     visit '/'
-    click_on 'sign in'
+    click_on 'Sign in to an existing application'
   end
 
   def when_i_signed_in_more_than_a_week_ago

--- a/spec/system/candidate_interface/candidate_signs_in_without_account_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_in_without_account_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Candidate tries to sign in without an account' do
 
   def when_i_go_to_sign_in
     visit '/'
-    click_on 'sign in'
+    click_on 'Sign in to an existing application'
   end
 
   def and_i_submit_my_email_address


### PR DESCRIPTION
Candidates are missing the sign in link.

- Move the link so it's scannable in a downward motion from the button (previous link is at the end of sentence to the right)
- Include the `or` text to encourage onward reading
- Make the link longer to make it stand out without competing with Start now button

## Before
![Screen Shot 2020-01-31 at 16 04 05](https://user-images.githubusercontent.com/319055/73556523-84d2dd80-4447-11ea-9243-5c1faa547ea7.png)

## After
![Screen Shot 2020-01-31 at 16 23 50](https://user-images.githubusercontent.com/319055/73556530-87353780-4447-11ea-8db6-b1b2082f89e9.png)

https://trello.com/c/Ma1IoQjs/841-review-the-journey-for-candidates-signing-back-in