### PR TITLE
Fix bug that causes candidates to apply to a different course

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -66,8 +66,7 @@ module CandidateInterface
       elsif !@pick_course.open_on_apply?
         redirect_to candidate_interface_course_choices_on_ucas_path
       elsif @pick_course.single_site?
-        course_id = Course.find_by(code: course_code)
-        course_option = CourseOption.where(course_id: course_id).first
+        course_option = CourseOption.where(course_id: @pick_course.course.id).first
 
         pick_site_for_course(course_code, course_option.id)
       else

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -21,7 +21,7 @@ module CandidateInterface
     end
 
     def course
-      @course ||= Course.find_by!(code: code)
+      @course ||= provider.courses.find_by!(code: code)
     end
 
   private

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -17,8 +17,11 @@ module CandidateInterface
     end
 
     def single_site?
-      course_id = Course.find_by(code: code)
-      CourseOption.where(course_id: course_id).one?
+      CourseOption.where(course_id: course.id).one?
+    end
+
+    def course
+      @course ||= Course.find_by!(code: code)
     end
 
   private
@@ -33,10 +36,6 @@ module CandidateInterface
       if application_form.application_choices.any? { |application_choice| application_choice.course == course }
         errors[:base] << 'You have already selected this course'
       end
-    end
-
-    def course
-      @course ||= Course.find_by!(code: code)
     end
   end
 end

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -25,7 +25,11 @@ module CandidateInterface
     end
 
     def course
-      @course ||= Course.find_by!(code: course_code)
+      @course ||= provider.courses.find_by!(code: course_code)
+    end
+
+    def provider
+      @provider ||= Provider.find_by!(code: provider_code)
     end
 
     def candidate_can_only_apply_to_3_courses

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -72,6 +72,11 @@ RSpec.feature 'Selecting a course' do
       postcode: 'LS8 5DQ'
     )
     multi_site_course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true, open_on_apply: true)
+
+    # TODO: this is a test to check we don't rely on uniqueness of course codes. Replace by a better unit test.
+    clashing_course = create(:course, name: 'A course with the same code, but a different provider', code: '2XT2', exposed_in_find: true, open_on_apply: true)
+    create(:course_option, course: clashing_course)
+
     create(:course_option, site: first_site, course: multi_site_course, vacancy_status: 'B')
     create(:course_option, site: second_site, course: multi_site_course, vacancy_status: 'B')
 


### PR DESCRIPTION
## Context

Course codes are unique for a provider, but not unique globally. In the candidate interface, there are 2 places where we use the course code as a unique identifier. In cases where a course code is shared between 2 providers, this can cause the system to accidentally choose the wrong course. 

## Changes proposed in this pull request

This fixes the issue by scoping the course finding to the provider.

This is a tactical fix - we should remove any usage of course code and provider code to do lookups. 

## Guidance to review

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
