### PR TITLE
Improve UI for adding/editing provider/support users

### DIFF
--- a/app/frontend/styles/_checkboxes.scss
+++ b/app/frontend/styles/_checkboxes.scss
@@ -1,0 +1,5 @@
+.app-checkboxes-scroll {
+  max-height: 13.5em;
+  overflow-y: scroll;
+  -webkit-overflow-scrolling: touch;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -31,6 +31,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "_count";
 @import "_masthead";
 @import "_product-section";
+@import "_checkboxes";
 
 // Support
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -8,7 +8,7 @@
         <%= link_to 'Provider users', support_interface_provider_users_path, class: 'govuk-breadcrumbs__link' %>
       </li>
       <li class="govuk-breadcrumbs__list-item" aria-current="page">
-        Add provider user
+        Edit provider user
       </li>
     </ol>
   </div>
@@ -23,11 +23,11 @@
         Edit provider user
       </h1>
 
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
       <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
 
-      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
+      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
 
       <%= f.govuk_submit 'Update user' %>
     <% end %>

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -21,11 +21,11 @@
 
       <h1 class='govuk-heading-xl'>Add provider user</h1>
 
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
       <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
 
-      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' } %>
+      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
 
       <%= f.govuk_submit 'Add provider user' %>
     <% end %>

--- a/app/views/support_interface/support_users/new.html.erb
+++ b/app/views/support_interface/support_users/new.html.erb
@@ -21,8 +21,8 @@
 
       <h1 class='govuk-heading-xl'>Add support user</h1>
 
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address' } %>
-      <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID' } %>
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
+      <%= f.govuk_text_field :dfe_sign_in_uid, label: { text: 'DfE Sign-in UID', size: 'm' } %>
 
       <%= f.govuk_submit 'Add support user' %>
     <% end %>


### PR DESCRIPTION
- Bump form builder to be able to set class on checkboxes container
- Create class name to make sure checkboxes area is scrollable
- Make form labels bold/bigger
- Fix copy from add to edit on the edit page

## Context

When adding a user it's really hard to select the provider checkboxes. So I'm making it a scrollable area with a max height so the submit button stays in view.

And while I'm there I'll fix a couple other things:

- incorrect ‘add’ text when on edit page
- bold labels

## Changes proposed in this pull request

![image](https://user-images.githubusercontent.com/37163/73636945-fd5fb700-465e-11ea-9a1a-0cf3fb0ada41.png)

![image](https://user-images.githubusercontent.com/37163/73636997-22542a00-465f-11ea-89ab-c210f0afe5c2.png)

![image](https://user-images.githubusercontent.com/37163/73637032-38fa8100-465f-11ea-8ec6-f9bf359eca64.png)

## Link to Trello card

https://trello.com/c/rhOjOgxB/1594-improve-ui-around-adding-editing-users-in-support-for-apply
