### PR TITLE
Speed up system tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           bin/rails db:setup
-          RAILS_ENV=test rails webpacker:compile
+          RAILS_ENV=test bin/rails webpacker:compile
 
       - name: 'Run tests'
         env:
@@ -145,7 +145,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           bin/rails db:setup
-          RAILS_ENV=test rails webpacker:compile
+          RAILS_ENV=test bin/rails webpacker:compile
 
       - name: 'Run tests'
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           bin/rails db:setup
+          RAILS_ENV=test rails webpacker:compile
 
       - name: 'Run tests'
         env:
@@ -144,6 +145,7 @@ jobs:
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
           bin/rails db:setup
+          RAILS_ENV=test rails webpacker:compile
 
       - name: 'Run tests'
         env:

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -76,10 +76,8 @@ development:
 
 test:
   <<: *default
-  compile: true
-
-  # Compile test packs to a separate directory
-  public_output_path: packs-test
+  compile: false
+  cache_manifest: true
 
 production:
   <<: *default

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -45,8 +45,13 @@ end
 desc 'Run all the linters'
 task linting: %i[rubocop erblint]
 
+desc 'Compile assets for testing'
+task :compile_assets do
+  sh 'RAILS_ENV=test rails webpacker:compile'
+end
+
 desc 'Run all acceptance tests'
 task acceptance_tests: %i[rspec_acceptance_tests cucumber]
 
 desc 'Run all the tests'
-task run_tests: %i[linting spec_without_performance brakeman]
+task run_tests: %i[compile_assets linting spec_without_performance brakeman]

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,7 +30,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-puts "ℹ️ If you change CSS, JS, or Assets - don't forget to run `RAILS_ENV=test rails webpacker:compile` before your test runs"
+puts "ℹ️ If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs"
 
 Timecop.safe_mode = true
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,8 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
+puts "ℹ️ If you change CSS, JS, or Assets - don't forget to run `RAILS_ENV=test rails webpacker:compile` before your test runs"
+
 Timecop.safe_mode = true
 
 Faker::Config.locale = 'en-GB'


### PR DESCRIPTION
## Context

I was investigating the performance of our system tests when I noticed a large number of log lines like this:

```
[Webpacker] Everything's up-to-date. Nothing to do
```

<img width="1484" alt="Screenshot 2020-02-03 at 09 20 52" src="https://user-images.githubusercontent.com/233676/73640630-85958a80-4666-11ea-9aed-3f6e4246329d.png">

I think this is Webpacker trying to compile the assets and then telling us that no CSS/JS changes were detected.

Turns out this system is *super* expensive. Turning the `compile` flag off in test causes a preposterous speedup in the tests:

```
Before: Finished in 2 minutes 36.5 seconds
After: Finished in 57.61 seconds
```

## Changes proposed in this pull request

Because `compile: true` does a compile on each request, we have to make sure that our assets are compiled before running the tests, similarly to how production works. We can do this by sprinkling the compile task in relevant places:

```
RAILS_ENV=test rails webpacker:compile
```

I’ve also added a reminder that shows every test run, so that if you run `bundle exec rspec` you won’t get caught out. I think this is a reasonable trade-off for the speed up that we’re seeing.

Note that there’s something I don’t understand in the compilation - the current compilation saves the result in `public/packs-test`, but running our rake task saves it in `public/packs`. But it still works.

## Guidance to review

Not sure.

## Link to Trello card

https://trello.com/c/OEjmIn3C

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
