### PR TITLE
Remove temporary code needed for safe deploys

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -36,16 +36,7 @@ class ApplicationReference < ApplicationRecord
 
   def refresh_feedback_token!
     unhashed_token, hashed_token = Devise.token_generator.generate(ApplicationReference, :hashed_sign_in_token)
-
-    # TODO: This is an edge case possible when calling code enqueues a mailer
-    # to request feedback without also setting the feedback_status to feedback_requested.
-    # This calling code has been removed but when we deploy this the two
-    # versions will briefly coexist across the app server and the worker
-    if(feedback_status == 'not_requested_yet')
-      update!(hashed_sign_in_token: hashed_token, feedback_status: 'feedback_requested')
-    else
-      update!(hashed_sign_in_token: hashed_token)
-    end
+    update!(hashed_sign_in_token: hashed_token)
     unhashed_token
   end
 

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -96,26 +96,4 @@ RSpec.describe ApplicationReference, type: :model do
       expect(reference.audits.last.user).to eq candidate
     end
   end
-
-  describe '#refresh_feedback_token!' do
-    let(:application_form) { create(:application_form) }
-
-    context 'the feedback_status field is anything but "not_requested_yet"' do
-      it 'does not update the feedback_status field' do
-        reference = create(:reference, application_form: application_form, feedback_status: 'feedback_provided')
-
-        expect { reference.refresh_feedback_token! }
-          .not_to change(reference, :feedback_status)
-      end
-    end
-
-    context 'the feedback_status field is "not_requested_yet"' do
-      it 'initialises the feedback_status field to "feedback_requested"' do
-        reference = create(:reference, application_form: application_form, feedback_status: 'not_requested_yet')
-
-        expect { reference.refresh_feedback_token! }
-          .to change(reference, :feedback_status).to('feedback_requested')
-      end
-    end
-  end
 end


### PR DESCRIPTION
This reverts DFE-Digital/apply-for-postgraduate-teacher-training#1209, we no longer need it now everythign is deployed.