### PR TITLE
Provider can confirm conditions met or not met for accepted offers

### DIFF
--- a/app/components/provider_interface/application_status_tag_component.rb
+++ b/app/components/provider_interface/application_status_tag_component.rb
@@ -25,6 +25,12 @@ module ProviderInterface
         :orange
       when 'enrolled'
         :blue
+      when 'recruited'
+        :green
+      when 'conditions_not_met'
+        :red
+      when 'withdrawn'
+        :orange
       end
     end
 

--- a/app/components/provider_interface/conditions_component.html.erb
+++ b/app/components/provider_interface/conditions_component.html.erb
@@ -1,0 +1,1 @@
+<%= render SummaryListComponent, rows: condition_rows %>

--- a/app/components/provider_interface/conditions_component.rb
+++ b/app/components/provider_interface/conditions_component.rb
@@ -1,0 +1,23 @@
+module ProviderInterface
+  class ConditionsComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :application_choice
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+
+    def conditions
+      @application_choice.offer['conditions']
+    end
+
+    def condition_rows
+      if conditions.empty?
+        [{ value: 'No conditions have been specified' }]
+      else
+        conditions.map { |condition| { value: condition } }
+      end
+    end
+  end
+end

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -40,7 +40,7 @@
     <div class="govuk-!-margin-top-6">
       <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
     </div>
-  <% elsif application_choice.pending_conditions? %>
+  <% elsif application_choice.pending_conditions? && FeatureFlag.active?('confirm_conditions') %>
     <div class="govuk-!-margin-top-6">
       <%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
     </div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -25,7 +25,7 @@
       <dt>Declined on:</dt>
       <dd><%= declined_at %></dd>
     <% elsif application_choice.pending_conditions? %>
-      <dt>Accepted on:</dt>
+      <dt>Offer accepted:</dt>
       <dd><%= accepted_at %></dd>
     <% elsif application_choice.conditions_not_met? %>
       <dt>Conditions not met</dt>
@@ -39,6 +39,10 @@
   <% if application_choice.awaiting_provider_decision? %>
     <div class="govuk-!-margin-top-6">
       <%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
+    </div>
+  <% elsif application_choice.pending_conditions? %>
+    <div class="govuk-!-margin-top-6">
+      <%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
     </div>
   <% end %>
 </div>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -1,9 +1,11 @@
 <dl class="govuk-summary-list">
   <% rows.each do |row| %>
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">
-        <%= row[:key] %>
-      </dt>
+      <% if row[:key] %>
+        <dt class="govuk-summary-list__key">
+          <%= row[:key] %>
+        </dt>
+      <% end %>
       <dd class="govuk-summary-list__value">
         <% if row[:value].is_a?(Array) %>
           <% row[:value].each do |value| %><%= value %><br><% end %>

--- a/app/components/tag_component.html.erb
+++ b/app/components/tag_component.html.erb
@@ -1,3 +1,3 @@
-<strong class="govuk-tag <%= @css_classes %>">
+<strong class="govuk-tag app-tag <%= @css_classes %>">
   <%= @text %>
 </strong>

--- a/app/controllers/provider_interface/conditions_controller.rb
+++ b/app/controllers/provider_interface/conditions_controller.rb
@@ -1,0 +1,42 @@
+module ProviderInterface
+  class ConditionsController < ProviderInterfaceController
+    before_action :set_application_choice
+
+    def edit
+      @conditions_form = ConfirmConditionsForm.new
+    end
+
+    def confirm_update
+      @conditions_form = ConfirmConditionsForm.new(
+        conditions_met: params.dig(:provider_interface_confirm_conditions_form, :conditions_met),
+      )
+
+      render action: :edit unless @conditions_form.valid?
+    end
+
+    def update
+      @conditions_form = ConfirmConditionsForm.new(
+        conditions_met: params.dig(:provider_interface_confirm_conditions_form, :conditions_met),
+      )
+
+      redirect_to action: :edit unless @conditions_form.valid?
+
+      if @conditions_form.conditions_met?
+        ConfirmOfferConditions.new(application_choice: @application_choice).save || raise('ConfirmOfferConditions failure')
+        flash[:success] = 'Conditions successfully marked as met'
+      else
+        ConditionsNotMet.new(application_choice: @application_choice).save || raise('ConditionsNotMet failure')
+        flash[:success] = 'Conditions successfully marked as not met'
+      end
+
+      redirect_to provider_interface_application_choice_path(@application_choice.id)
+    end
+
+  private
+
+    def set_application_choice
+      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
+        .find(params[:application_choice_id])
+    end
+  end
+end

--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -1,3 +1,7 @@
+.app-tag {
+  white-space: nowrap;
+}
+
 .app-tag--red {
   color: govuk-shade(govuk-colour("red"), 20);
   background: govuk-tint(govuk-colour("red"), 80);

--- a/app/models/provider_interface/confirm_conditions_form.rb
+++ b/app/models/provider_interface/confirm_conditions_form.rb
@@ -1,0 +1,12 @@
+module ProviderInterface
+  class ConfirmConditionsForm
+    include ActiveModel::Model
+
+    attr_accessor :conditions_met
+    validates :conditions_met, presence: true
+
+    def conditions_met?
+      conditions_met == 'yes'
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,6 +9,7 @@ class FeatureFlag
     improved_expired_token_flow
     work_breaks
     experimental_api_features
+    confirm_conditions
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/provider_interface/conditions/confirm_update.html.erb
+++ b/app/views/provider_interface/conditions/confirm_update.html.erb
@@ -1,0 +1,41 @@
+<% content_for :browser_title, 'Confirm conditions' %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
+
+<%= form_with model: @conditions_form,
+      url: provider_interface_application_choice_update_conditions_path(@application_choice.id),
+      method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl">
+    <% if @conditions_form.conditions_met? %>
+      Are you sure the candidate met the conditions?
+    <% else %>
+      Are you sure the candidate did not meet the conditions?
+    <% end %>
+  </h1>
+
+  <%= render SummaryListComponent, rows: [
+    { key: 'Candidate name', value: @application_choice.application_form.full_name },
+    { key: 'Course', value: @application_choice.course.name_and_code },
+    { key: 'Preferred location', value: @application_choice.site.name },
+    { key: 'Provider', value: @application_choice.course.provider.name_and_code },
+  ] %>
+
+  <h2 class="govuk-heading-l">
+    Conditions
+  </h2>
+
+  <%= render ProviderInterface::ConditionsComponent, application_choice: @application_choice %>
+
+  <%= f.hidden_field :conditions_met %>
+
+  <% if @conditions_form.conditions_met? %>
+    <%= f.submit 'Yes I’m sure – they met the conditions', class: 'govuk-button', data: { module: 'govuk-button' } %>
+  <% else %>
+    <%= f.submit 'Yes I’m sure – they did not meet the conditions', class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+  <% end %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+  </p>
+<% end %>

--- a/app/views/provider_interface/conditions/edit.html.erb
+++ b/app/views/provider_interface/conditions/edit.html.erb
@@ -1,0 +1,36 @@
+<% content_for :browser_title, 'Confirm conditions' %>
+<% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
+
+<%= form_with model: @conditions_form,
+      url: provider_interface_application_choice_confirm_update_conditions_path(@application_choice.id),
+      method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl">
+    Confirm if the candidate has met all conditions
+  </h1>
+
+  <%= render SummaryListComponent, rows: [
+    { key: 'Candidate name', value: @application_choice.application_form.full_name },
+    { key: 'Course', value: @application_choice.course.name_and_code },
+    { key: 'Preferred location', value: @application_choice.site.name },
+    { key: 'Provider', value: @application_choice.course.provider.name_and_code },
+  ] %>
+
+  <h2 class="govuk-heading-l govuk-!-margin-top-8">
+    Conditions
+  </h2>
+
+  <%= render ProviderInterface::ConditionsComponent, application_choice: @application_choice %>
+
+  <%= f.govuk_radio_buttons_fieldset :conditions_met, legend: { size: 'm', text: 'Has the candidate met all of the conditions?', tag: 'span' } do %>
+    <%= f.govuk_radio_button :conditions_met, 'yes', label: { text: 'Yes, they’ve met all of the conditions' }, link_errors: true %>
+    <%= f.govuk_radio_button :conditions_met, 'no', label: { text: 'No' } %>
+  <% end %>
+
+  <%= f.govuk_submit 'Continue' %>
+
+  <p class="govuk-body">
+    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+  </p>
+<% end %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -60,10 +60,10 @@ en:
     enrolled: Enrolled
     offer: Offered
     pending_conditions: Accepted
-    recruited: Candidate recruited
+    recruited: Conditions met
     rejected: Rejected
     unsubmitted: Not submitted yet
-    withdrawn: Candidate withdrawn
+    withdrawn: Application withdrawn
     conditions_not_met: Conditions not met
 
   application_states:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,6 +129,10 @@ en:
           attributes:
             decision:
               blank: Select if you want to make an offer or reject the application
+        provider_interface/confirm_conditions_form:
+          attributes:
+            conditions_met:
+              blank: Please specify if the candidate has met the conditions of the offer
         reject_application:
           attributes:
             rejection_reason:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -280,6 +280,9 @@ Rails.application.routes.draw do
     post '/applications/:application_choice_id/reject' => 'decisions#create_reject', as: :application_choice_create_reject
     post '/applications/:application_choice_id/offer/confirm' => 'decisions#confirm_offer', as: :application_choice_confirm_offer
     post '/applications/:application_choice_id/offer' => 'decisions#create_offer', as: :application_choice_create_offer
+    get '/applications/:application_choice_id/conditions' => 'conditions#edit', as: :application_choice_edit_conditions
+    patch '/applications/:application_choice_id/conditions/confirm' => 'conditions#confirm_update', as: :application_choice_confirm_update_conditions
+    patch '/applications/:application_choice_id/conditions' => 'conditions#update', as: :application_choice_update_conditions
 
     post '/candidates/:candidate_id/impersonate' => 'candidates#impersonate', as: :impersonate_candidate
 

--- a/spec/components/provider_interface/status_box_component_spec.rb
+++ b/spec/components/provider_interface/status_box_component_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ProviderInterface::StatusBoxComponent do
 
     result = render_inline(described_class, application_choice: application_choice)
 
-    expect(result.text).to include('Accepted on:')
+    expect(result.text).to include('Offer accepted:')
   end
 
   it 'outputs a date for applications in the declined state' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -212,6 +212,12 @@ FactoryBot.define do
       decline_by_default_days { 10 }
       offer { { 'conditions' => ['Be cool'] } }
     end
+
+    trait :with_accepted_offer do
+      with_offer
+      status { 'pending_conditions' }
+      accepted_at { Time.zone.now - 2.days }
+    end
   end
 
   factory :vendor_api_user do

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.feature 'Confirm conditions met' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider user confirms offer conditions have been met by the candidate' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_an_authorised_provider_user
+    and_i_can_access_the_provider_interface
+
+    when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_click_on_confirm_conditions
+    and_select_they_have_met_the_conditions
+    and_confirm_my_selection_in_the_next_page
+
+    then_i_get_feedback_that_my_action_succeeded
+    and_i_am_back_on_the_application_page
+    and_the_candidate_is_recruited
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_an_authorised_provider_user
+    @provider = create(:provider, :with_signed_agreement)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  end
+
+  def and_i_can_access_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_applications_path
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def when_i_navigate_to_an_offer_accepted_by_the_candidate
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'John',
+      last_name: 'Smith',
+    )
+    @application_choice = create(
+      :application_choice,
+      :with_accepted_offer,
+      course_option: course_option,
+      application_form: @application_form,
+    )
+    visit provider_interface_application_choice_path(@application_choice.id)
+  end
+
+  def and_click_on_confirm_conditions
+    click_on 'Confirm conditions'
+  end
+
+  def and_select_they_have_met_the_conditions
+    within_fieldset('Has the candidate met all of the conditions?') do
+      choose 'Yes, they’ve met all of the conditions'
+    end
+
+    click_on 'Continue'
+  end
+
+  def and_confirm_my_selection_in_the_next_page
+    click_on 'Yes I’m sure – they met the conditions'
+  end
+
+  def then_i_get_feedback_that_my_action_succeeded
+    expect(page).to have_content 'Conditions successfully marked as met'
+  end
+
+  def and_i_am_back_on_the_application_page
+    expect(page).to have_current_path provider_interface_application_choice_path(@application_choice.id)
+  end
+
+  def and_the_candidate_is_recruited
+    expect(@application_choice.reload.recruited?).to be_truthy
+    expect(page).to have_content 'Recruited'
+  end
+end

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Confirm conditions met' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
+    and_the_confirm_conditions_feature_flag_is_on
 
     when_i_navigate_to_an_offer_accepted_by_the_candidate
     and_click_on_confirm_conditions
@@ -32,6 +33,10 @@ RSpec.feature 'Confirm conditions met' do
     provider_signs_in_using_dfe_sign_in
     visit provider_interface_applications_path
     expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def and_the_confirm_conditions_feature_flag_is_on
+    FeatureFlag.activate('confirm_conditions')
   end
 
   def when_i_navigate_to_an_offer_accepted_by_the_candidate

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Confirm conditions not met' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_an_authorised_provider_user
     and_i_can_access_the_provider_interface
+    and_the_confirm_conditions_feature_flag_is_on
 
     when_i_navigate_to_an_offer_accepted_by_the_candidate
     and_click_on_confirm_conditions
@@ -32,6 +33,10 @@ RSpec.feature 'Confirm conditions not met' do
     provider_signs_in_using_dfe_sign_in
     visit provider_interface_applications_path
     expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def and_the_confirm_conditions_feature_flag_is_on
+    FeatureFlag.activate('confirm_conditions')
   end
 
   def when_i_navigate_to_an_offer_accepted_by_the_candidate

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.feature 'Confirm conditions not met' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider user confirms offer conditions have not been met by the candidate' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_an_authorised_provider_user
+    and_i_can_access_the_provider_interface
+
+    when_i_navigate_to_an_offer_accepted_by_the_candidate
+    and_click_on_confirm_conditions
+    and_select_they_have_not_met_the_conditions
+    and_confirm_my_selection_in_the_next_page
+
+    then_i_get_feedback_that_my_action_succeeded
+    and_i_am_back_on_the_application_page
+    and_the_application_status_is_conditions_not_met
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_an_authorised_provider_user
+    @provider = create(:provider, :with_signed_agreement)
+    create(:provider_user, providers: [@provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  end
+
+  def and_i_can_access_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+    visit provider_interface_applications_path
+    expect(page).to have_current_path provider_interface_applications_path
+  end
+
+  def when_i_navigate_to_an_offer_accepted_by_the_candidate
+    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @application_form = create(
+      :completed_application_form,
+      first_name: 'John',
+      last_name: 'Smith',
+    )
+    @application_choice = create(
+      :application_choice,
+      :with_accepted_offer,
+      course_option: course_option,
+      application_form: @application_form,
+    )
+    visit provider_interface_application_choice_path(@application_choice.id)
+  end
+
+  def and_click_on_confirm_conditions
+    click_on 'Confirm conditions'
+  end
+
+  def and_select_they_have_not_met_the_conditions
+    within_fieldset('Has the candidate met all of the conditions?') do
+      choose 'No'
+    end
+
+    click_on 'Continue'
+  end
+
+  def and_confirm_my_selection_in_the_next_page
+    click_on 'Yes I’m sure – they did not meet the conditions'
+  end
+
+  def then_i_get_feedback_that_my_action_succeeded
+    expect(page).to have_content 'Conditions successfully marked as not met'
+  end
+
+  def and_i_am_back_on_the_application_page
+    expect(page).to have_current_path provider_interface_application_choice_path(@application_choice.id)
+  end
+
+  def and_the_application_status_is_conditions_not_met
+    expect(@application_choice.reload.conditions_not_met?).to be_truthy
+    expect(page).to have_content 'Conditions not met'
+  end
+end


### PR DESCRIPTION
### Context

We need a UI within the provider console to allow providers to confirm whether the conditions set out as part of an offer have been met or not. This is high priority because we now have a user on our system in the accepted state and the relevant provider can't progress their application.

The scope for this work is limited to confirming all conditions have been met, not individual conditions. This means our system cannot be used for tracking the progress of meeting conditions at this stage. Conditions are either met in their entirety or not at all.

A minimal set of views, including confirmation steps, has been designed for this process. As these provider actions represent a different feedback phase for an application, a new controller and set of views will be added to the system.

### Changes proposed in this pull request

Add new controller (`ConditionsController`) and associated routes to provider interface.

```
get '/applications/:application_choice_id/conditions' => 'conditions#edit', as: :application_choice_edit_conditions

patch '/applications/:application_choice_id/conditions/confirm' => 'conditions#confirm_update', as: :application_choice_confirm_update_conditions

patch '/applications/:application_choice_id/conditions' => 'conditions#update', as: :application_choice_update_conditions
```

In the future, we are planning to allow marking individual conditions as met/not met, this setup will accommodate this.

Add `ConfirmConditionsForm` to handle the presence validation for `:conditions_met`.

### Guidance to review

Run the specs.

To test manually, you'll need applications at the `pending_conditions` state (they show up as 'ACCEPTED' in the provider interface).

#### -- Starting point
![image](https://user-images.githubusercontent.com/107591/73655035-06fc1580-4685-11ea-8691-bfd6fcb00bd7.png)

#### -- Form
![image](https://user-images.githubusercontent.com/107591/73655051-0d8a8d00-4685-11ea-9f87-bac3a3c04dc4.png)

#### -- Confirmation page if conditions met
![image](https://user-images.githubusercontent.com/107591/73655065-13806e00-4685-11ea-9f65-c832fcdc468f.png)

#### -- Confirmation page if conditions not met
![image](https://user-images.githubusercontent.com/107591/73655077-19764f00-4685-11ea-903d-9113287eaf52.png)

#### -- Flash message when conditions met
![image](https://user-images.githubusercontent.com/107591/73655091-1ed39980-4685-11ea-8edc-d435310bf51f.png)

#### -- Flash message when conditions not met
![image](https://user-images.githubusercontent.com/107591/73655104-24c97a80-4685-11ea-9ed2-bcaafd91de94.png)

Note: The border to flash messages is blue instead of green, because that's the current definition of an :info level flash message in the app. Both are considered success cases.

### Link to Trello card

[1579 - Providers can confirm conditions met/not met (applies to all conditions)](https://trello.com/c/GsKZRset)

### Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
