### PR TITLE
Send emails when application is insta-sent to providers

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -63,7 +63,7 @@ module TestApplications
         ReceiveReference.new(
           reference: reference,
           feedback: 'You are awesome',
-        ).save
+        ).save!
       end
       return if states.include? :application_complete
 

--- a/app/models/referee_interface/reference_feedback_form.rb
+++ b/app/models/referee_interface/reference_feedback_form.rb
@@ -16,7 +16,9 @@ module RefereeInterface
       ReceiveReference.new(
         reference: reference,
         feedback: feedback,
-      ).save
+      ).save!
+
+      true
     end
   end
 end

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -22,10 +22,8 @@ private
 
     application_form.application_choices.each do |application_choice|
       ApplicationStateChange.new(application_choice).references_complete!
-
-      if application_choice.edit_by <= Time.zone.now
-        SendApplicationToProvider.new(application_choice: application_choice).call
-      end
     end
+
+    SendApplicationsToProvider.new.call
   end
 end

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -6,18 +6,11 @@ class ReceiveReference
     @feedback = feedback
   end
 
-  def save
+  def save!
     ActiveRecord::Base.transaction do
       @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
       progress_application_if_enough_references_have_been_submitted
     end
-    true
-  rescue Workflow::NoTransitionAllowed
-    errors.add(
-      :base,
-      I18n.t('activerecord.errors.models.application_choice.attributes.status.invalid_transition'),
-    )
-    false
   end
 
 private

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -1,5 +1,6 @@
 class ReceiveReference
   attr_reader :reference, :feedback
+  delegate :application_form, to: :reference
 
   def initialize(reference:, feedback:)
     @reference = reference
@@ -16,14 +17,19 @@ class ReceiveReference
 private
 
   def progress_application_if_enough_references_have_been_submitted
-    application_form = reference.application_form
-
-    return unless application_form.application_references_complete?
+    return unless there_are_now_enough_references_to_progress?
 
     application_form.application_choices.each do |application_choice|
       ApplicationStateChange.new(application_choice).references_complete!
     end
 
     SendApplicationsToProvider.new.call
+  end
+
+  # Only progress the applications if the reference that is being submitted is
+  # the 2nd referee, since there might be more than 2 references per form
+  # in the future.
+  def there_are_now_enough_references_to_progress?
+    application_form.application_references.feedback_provided.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES
   end
 end

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -13,6 +13,7 @@ class SendApplicationToProvider
       set_reject_by_default
       ApplicationStateChange.new(application_choice).send_to_provider!
       StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice)
+      SendNewApplicationEmailToProvider.new(application_choice: application_choice).call
     end
   end
 

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -4,7 +4,6 @@ class SendApplicationsToProvider
     GetApplicationFormsReadyToSendToProviders.call.each do |application_form|
       application_form.application_choices.each do |choice|
         SendApplicationToProvider.new(application_choice: choice).call
-        SendNewApplicationEmailToProvider.new(application_choice: choice).call
       end
 
       CandidateMailer.application_under_consideration(application_form).deliver_now

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -40,7 +40,7 @@ private
     ReceiveReference.new(
       reference: reference,
       feedback: I18n.t('new_referee_request.auto_approve_feedback'),
-    ).save
+    ).save!
   end
 
   def email_address_is_a_bot?(reference)

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -67,11 +67,10 @@ end
 When('{string} provides a reference') do |referee_email|
   reference = @application_choice.application_form.application_references.find_by!(email_address: referee_email)
 
-  action = ReceiveReference.new(
+  ReceiveReference.new(
     reference: reference,
     feedback: Faker::Lorem.sentence(word_count: 20),
-  )
-  expect(action.save!).to be true
+  ).save!
 end
 
 When(/the (date|time) is "(.*)"/) do |_, date_or_time|

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -71,7 +71,7 @@ When('{string} provides a reference') do |referee_email|
     reference: reference,
     feedback: Faker::Lorem.sentence(word_count: 20),
   )
-  expect(action.save).to be true
+  expect(action.save!).to be true
 end
 
 When(/the (date|time) is "(.*)"/) do |_, date_or_time|

--- a/spec/models/referee_interface/reference_feedback_form_spec.rb
+++ b/spec/models/referee_interface/reference_feedback_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe RefereeInterface::ReferenceFeedbackForm do
       application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
       unsubmitted_reference = build(:reference, :unsubmitted)
       application_form.application_references << unsubmitted_reference
-      allow(ReceiveReference).to receive(:new).and_return(instance_double(ReceiveReference, save: true))
+      allow(ReceiveReference).to receive(:new).and_return(instance_double(ReceiveReference, save!: true))
 
       described_class.new(
         reference: unsubmitted_reference,
@@ -22,7 +22,7 @@ RSpec.describe RefereeInterface::ReferenceFeedbackForm do
       application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
       unsubmitted_reference = build(:reference, :unsubmitted)
       application_form.application_references << unsubmitted_reference
-      allow(ReceiveReference).to receive(:new).and_return(instance_double(ReceiveReference, save: true))
+      allow(ReceiveReference).to receive(:new).and_return(instance_double(ReceiveReference, save!: true))
 
       described_class.new(
         reference: unsubmitted_reference,

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -2,11 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ReceiveReference do
   it 'updates the reference on an application form with the provided text' do
-    application_form = FactoryBot.create(:completed_application_form, references_count: 0)
-    application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references') }
-    application_form.application_references << build(:reference, :unsubmitted, email_address: 'ab@c.com')
-    reference = build(:reference, :unsubmitted, email_address: 'xy@z.com')
-    application_form.application_references << reference
+    application_form = create(:completed_application_form)
+    create(:application_choice, application_form: application_form, status: 'awaiting_references')
+    create(:reference, :unsubmitted, application_form: application_form)
+    reference = create(:reference, :unsubmitted, application_form: application_form)
 
     ReceiveReference.new(
       reference: reference,
@@ -19,11 +18,10 @@ RSpec.describe ReceiveReference do
   end
 
   it 'progresses the application choices to the "application complete" status once all references have been received' do
-    application_form = FactoryBot.create(:completed_application_form, references_count: 0)
-    application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.from_now) }
-    reference = build(:reference, :unsubmitted, email_address: 'ab@c.com')
-    application_form.application_references << reference
-    application_form.application_references << build(:reference, :complete)
+    application_form = create(:completed_application_form)
+    create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.from_now)
+    create(:reference, :complete, application_form: application_form)
+    reference = create(:reference, :unsubmitted, application_form: application_form)
 
     ReceiveReference.new(
       reference: reference,
@@ -35,11 +33,10 @@ RSpec.describe ReceiveReference do
   end
 
   it 'progresses the application choices to the "awaiting_provider_decision" status once all references have been received if edit_by has elapsed' do
-    application_form = FactoryBot.create(:completed_application_form, references_count: 0)
-    application_form.application_choices.each { |choice| choice.update(status: 'awaiting_references', edit_by: 1.day.ago) }
-    reference = build(:reference, :unsubmitted, email_address: 'ab@c.com')
-    application_form.application_references << reference
-    application_form.application_references << build(:reference, :complete)
+    application_form = create(:completed_application_form)
+    create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.ago)
+    create(:reference, :complete, application_form: application_form)
+    reference = create(:reference, :unsubmitted, application_form: application_form)
 
     ReceiveReference.new(
       reference: reference,

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ReceiveReference do
     ReceiveReference.new(
       reference: reference,
       feedback: 'A reference',
-    ).save
+    ).save!
 
     expect(reference.feedback).to eq('A reference')
     expect(application_form).not_to be_application_references_complete
@@ -28,7 +28,7 @@ RSpec.describe ReceiveReference do
     ReceiveReference.new(
       reference: reference,
       feedback: 'A reference',
-    ).save
+    ).save!
 
     expect(application_form.reload).to be_application_references_complete
     expect(application_form.application_choices).to all(be_application_complete)
@@ -44,7 +44,7 @@ RSpec.describe ReceiveReference do
     ReceiveReference.new(
       reference: reference,
       feedback: 'A reference',
-    ).save
+    ).save!
 
     expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
   end

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -45,4 +45,23 @@ RSpec.describe ReceiveReference do
 
     expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
   end
+
+  it 'is okay with a 3rd reference being provided' do
+    application_form = create(:completed_application_form)
+    create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.ago)
+    create(:reference, :complete, application_form: application_form)
+    reference = create(:reference, :unsubmitted, application_form: application_form)
+
+    ReceiveReference.new(
+      reference: reference,
+      feedback: 'A reference',
+    ).save!
+
+    another_reference = create(:reference, :unsubmitted, application_form: application_form)
+
+    ReceiveReference.new(
+      reference: another_reference,
+      feedback: 'A 3rd reference',
+    ).save!
+  end
 end

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'See an application' do
       reference: @application_with_reference.reload.application_references.first,
       feedback: 'This is my feedback',
     )
-    action.save
+    action.save!
   end
 
   def and_i_visit_the_support_page

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -27,12 +27,12 @@ RSpec.feature 'Vendor receives the application' do
     ReceiveReference.new(
       reference: @application.application_references.first,
       feedback: 'My ideal person',
-    ).save
+    ).save!
 
     ReceiveReference.new(
       reference: @application.application_references.last,
       feedback: 'Lovable',
-    ).save
+    ).save!
   end
 
   def and_the_edit_by_date_has_passed


### PR DESCRIPTION
## Context

Currently when the 2nd referee provides a reference, AND the candidate submitted more than 5 days ago (so the edit by date has elapsed), we send the application to the provider. We do this by calling `SendApplicationToProvider`, which doesn't send emails to providers and candidates.

## Changes proposed in this pull request

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/53d86dae594f535d94d0fc703926ca94a7f7237a does the important bits. The rest are mostly refactorings to make it easy.

## Guidance to review

Does this make sense?

## Link to Trello card

Related to https://trello.com/c/hzgtm77m

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
