### PR TITLE
Add ID to audit trail entries

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -12,7 +12,7 @@ module SupportInterface
       if audit.comment.present? && audit.audited_changes.empty?
         "Comment on #{audit.auditable_type.titlecase}"
       else
-        "#{audit.action.capitalize} #{audit.auditable_type.titlecase}"
+        "#{audit.action.capitalize} #{audit.auditable_type.titlecase} ##{audit.auditable_id}"
       end
     end
 


### PR DESCRIPTION
##  Context

We currently don’t show the ID of associated records, which makes it hard to see which application choice / work / qualification was created and updated.

## Changes proposed in this pull request

Before:

<img width="1176" alt="Screenshot 2020-02-03 at 13 36 59" src="https://user-images.githubusercontent.com/233676/73657493-4c6f1180-468a-11ea-8aac-f2d5f9e423fa.png">

After:

<img width="1094" alt="Screenshot 2020-02-03 at 13 36 54" src="https://user-images.githubusercontent.com/233676/73657501-5133c580-468a-11ea-8508-85319826f20d.png">

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Ib7aemnJ/877-wrap-up-friday-course-confusion-incident

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
