### PR TITLE
Add print styles

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -16,8 +16,8 @@
     <div class="govuk-header__content">
       <%= link_to service_name, service_url, class: 'govuk-header__link govuk-header__link--service-name' %>
       <% if navigation_items.any? %>
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <ul id="navigation" class="govuk-header__navigation " aria-label="Top Level Navigation">
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-!-print-display-none" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+        <ul id="navigation" class="govuk-header__navigation app-!-print-display-none" aria-label="Top Level Navigation">
           <% navigation_items.each do |nav_item| %>
             <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
               <% if nav_item.href %>

--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -2,4 +2,9 @@
   .app-\!-print-display-none {
     display: none !important;
   }
+
+  // TODO: Remove when breadcrumbs are a component
+  .govuk-breadcrumbs {
+    display: none;
+  }
 }

--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -1,0 +1,5 @@
+@include govuk-media-query($media-type: print) {
+  .app-\!-print-display-none {
+    display: none !important;
+  }
+}

--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -1,34 +1,62 @@
 .app-tag--red {
   color: govuk-shade(govuk-colour("red"), 20);
   background: govuk-tint(govuk-colour("red"), 80);
+
+  @include govuk-media-query($media-type: print) {
+    border: 2px solid govuk-shade(govuk-colour("red"), 20);
+  }
 }
 
 .app-tag--blue {
   color: govuk-shade(govuk-colour("blue"), 30);
   background: govuk-tint(govuk-colour("blue"), 80);
+
+  @include govuk-media-query($media-type: print) {
+    border: 2px solid govuk-shade(govuk-colour("blue"), 30);
+  }
 }
 
 .app-tag--purple {
   color: govuk-shade(govuk-colour("purple"), 20);
   background: govuk-tint(govuk-colour("purple"), 80);
+
+  @include govuk-media-query($media-type: print) {
+    border: 2px solid govuk-shade(govuk-colour("purple"), 20);
+  }
 }
 
 .app-tag--grey {
   color: govuk-shade(govuk-colour("dark-grey"), 30);
   background: govuk-tint(govuk-colour("dark-grey"), 90);
+
+  @include govuk-media-query($media-type: print) {
+    border: 2px solid govuk-shade(govuk-colour("dark-grey"), 30);
+  }
 }
 
 .app-tag--turquoise {
   color: govuk-shade(govuk-colour("turquoise"), 40);
   background: govuk-tint(govuk-colour("turquoise"), 70);
+
+  @include govuk-media-query($media-type: print) {
+    border: 2px solid govuk-shade(govuk-colour("turquoise"), 40);
+  }
 }
 
 .app-tag--green {
   color: govuk-shade(govuk-colour("green"), 20);
   background: govuk-tint(govuk-colour("green"), 80);
+
+  @include govuk-media-query($media-type: print) {
+    border: 2px solid govuk-shade(govuk-colour("green"), 20);
+  }
 }
 
 .app-tag--orange {
   color: govuk-shade(govuk-colour("orange"), 55);
   background: govuk-tint(govuk-colour("orange"), 70);
+
+  @include govuk-media-query($media-type: print) {
+    border: 2px solid govuk-shade(govuk-colour("orange"), 55);
+  }
 }

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -10,7 +10,6 @@ $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
 @import "~govuk-frontend/govuk/all";
-@import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
 @import "_autocomplete";
 @import "_banner";
 @import "_cookie-banner";
@@ -25,6 +24,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "_contents-list";
 @import "_definition-list";
 @import "_postcode";
+@import "_print-helpers";
 
 // Provider
 @import "_button";
@@ -33,6 +33,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "_product-section";
 
 // Support
+@import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";
 @import "_card";
 
 // API docs

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer govuk-footer--app" role="contentinfo">
+<footer class="govuk-footer govuk-footer--app app-!-print-display-none" role="contentinfo">
   <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">

--- a/app/views/layouts/_phase_banner.html.erb
+++ b/app/views/layouts/_phase_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-phase-banner">
+<div class="govuk-phase-banner app-!-print-display-none">
   <p class="govuk-phase-banner__content"><strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--<%= HostingEnvironment.environment_name %>">
     <%= HostingEnvironment.phase %>
   </strong>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -21,7 +21,7 @@
 
     <meta property="og:image" content="<%= asset_pack_path('media/images/govuk-opengraph-image.png') %>">
 
-    <%= stylesheet_pack_tag 'application' %>
+    <%= stylesheet_pack_tag 'application', media: 'all' %>
 
     <% unless Rails.env.development? %>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':


### PR DESCRIPTION
## Context

Pages look broken when printing because we include no styles.

## Changes proposed in this pull request

- Include styles for all media, meaning most of our styles are applied when printing
- Add a helper to hide elements from the print view (eg footer, menus)
- Tweak tags to have a border for when background colours aren't printed

https://trello.com/c/5Drj12u0/1602-no-print-friendly-view-for-applications

## Before
![qa apply-for-teacher-training education gov uk_provider_applications_869 (1)](https://user-images.githubusercontent.com/319055/73670515-45073280-46a1-11ea-9361-31325b5e9eb3.png)

## After
![localhost_3000_provider_applications_57](https://user-images.githubusercontent.com/319055/73670522-48022300-46a1-11ea-9694-19088d936742.png)

