### PR TITLE
Refactor calculating of work gaps and add handling for current job covering following breaks

### DIFF
--- a/app/components/break_in_work_history_component.html.erb
+++ b/app/components/break_in_work_history_component.html.erb
@@ -1,9 +1,7 @@
-<% if break_in_months > 0 %>
-  <section class="app-summary-card govuk-!-margin-bottom-6">
-    <header class="app-summary-card__header">
-      <h3 class="app-summary-card__title">
-        You have a break in your work history (<%= pluralize(break_in_months, 'month')%>)
-      </h3>
-    </header>
-  </section>
-<% end %>
+<section class="app-summary-card govuk-!-margin-bottom-6">
+  <header class="app-summary-card__header">
+    <h3 class="app-summary-card__title">
+      You have a break in your work history (<%= pluralize(break_in_months, 'month') %>)
+    </h3>
+  </header>
+</section>

--- a/app/components/break_in_work_history_component.rb
+++ b/app/components/break_in_work_history_component.rb
@@ -1,13 +1,7 @@
 class BreakInWorkHistoryComponent < ActionView::Component::Base
   attr_reader :break_in_months
 
-  def initialize(work1:, work2:)
-    @break_in_months = if work2 # is not last work entry
-                         GetBreaksInMonths.call(work1.end_date, work2.start_date)
-                       elsif work1.end_date # is not current job
-                         GetBreaksInMonths.call(work1.end_date, nil)
-                       else
-                         0
-                       end
+  def initialize(work_break:)
+    @break_in_months = work_break.break_in_months
   end
 end

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -1,18 +1,20 @@
-<%@application_form.application_work_experiences.order(:start_date).to_a.append(nil).each_cons(2) do |work1, work2| %>
-  <%= render(SummaryCardComponent, rows: work_experience_rows(work1), editable: @editable) do %>
-    <%= render(SummaryCardHeaderComponent, title: work1.role, heading_level: @heading_level, check_icon: work1.working_with_children) do %>
-      <% if @editable %>
-        <div class="app-summary-card__actions">
-          <%= link_to candidate_interface_work_history_destroy_path(work1.id), class: 'govuk-link' do %>
-            <%= t('application_form.work_history.delete_entry') %><span class="govuk-visually-hidden"><%= generate_action(work: work1) %></span>
-          <% end %>
-        </div>
+<% @work_history_with_breaks.each do |history| %>
+  <% if history[:type] == :job %>
+    <%= render(SummaryCardComponent, rows: work_experience_rows(history[:entry]), editable: @editable) do %>
+      <%= render(SummaryCardHeaderComponent, title: history[:entry].role, heading_level: @heading_level, check_icon: history[:entry].working_with_children) do %>
+        <% if @editable %>
+          <div class="app-summary-card__actions">
+            <%= link_to candidate_interface_work_history_destroy_path(history[:entry].id), class: 'govuk-link' do %>
+              <%= t('application_form.work_history.delete_entry') %><span class="govuk-visually-hidden"><%= generate_action(work: history[:entry]) %></span>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
-  <% end %>
-
-  <% if FeatureFlag.active?('work_breaks') %>
-    <%= render(BreakInWorkHistoryComponent, work1: work1, work2: work2) %>
+  <% elsif history[:type] == :break %>
+    <% if FeatureFlag.active?('work_breaks') %>
+      <%= render(BreakInWorkHistoryComponent, work_break: history[:entry]) %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -7,6 +7,7 @@ class WorkHistoryReviewComponent < ActionView::Component::Base
     @heading_level = heading_level
     @show_incomplete = show_incomplete
     @missing_error = missing_error
+    @work_history_with_breaks = GetWorkHistoryWithBreaks.new(@application_form.application_work_experiences).call
   end
 
   def work_experience_rows(work)

--- a/app/services/get_work_history_with_breaks.rb
+++ b/app/services/get_work_history_with_breaks.rb
@@ -1,0 +1,45 @@
+class GetWorkHistoryWithBreaks
+  def initialize(work_history)
+    @work_history = work_history.sort_by(&:start_date).to_a.append(nil)
+    @work_history_with_breaks = []
+    @current_job = nil
+  end
+
+  def call
+    @work_history.each_cons(2) do |first_job, second_job|
+      @current_job = first_job if current_job?(first_job)
+
+      break_in_months = if second_job
+                          GetBreaksInMonths.call(first_job.end_date, second_job.start_date)
+                        else
+                          GetBreaksInMonths.call(first_job.end_date, nil)
+                        end
+
+      @work_history_with_breaks << job_entry(first_job)
+
+      if break?(break_in_months, first_job)
+        @work_history_with_breaks << break_entry(break_in_months)
+      end
+    end
+
+    @work_history_with_breaks
+  end
+
+private
+
+  def current_job?(job)
+    job.end_date.nil?
+  end
+
+  def break?(break_in_months, job)
+    break_in_months.positive? && (@current_job.nil? || @current_job.start_date >= job.start_date)
+  end
+
+  def job_entry(job)
+    { type: :job, entry: job }
+  end
+
+  def break_entry(months)
+    { type: :break, entry: OpenStruct.new(break_in_months: months) }
+  end
+end

--- a/spec/components/break_in_work_history_component_spec.rb
+++ b/spec/components/break_in_work_history_component_spec.rb
@@ -1,38 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe BreakInWorkHistoryComponent do
-  it 'shows the correct break between 2 works' do
-    jan2019 = Time.zone.local(2019, 1, 1)
+  it 'renders the component with the break in months' do
+    work_break = double
+    allow(work_break).to receive(:break_in_months).and_return(3)
 
-    work1 = instance_double(ApplicationWorkExperience, start_date: jan2019, end_date: jan2019 + 2.months)
-    work2 = instance_double(ApplicationWorkExperience, start_date: jan2019 + 6.months, end_date: nil)
+    result = render_inline(BreakInWorkHistoryComponent, work_break: work_break)
 
-    component = BreakInWorkHistoryComponent.new(work1: work1, work2: work2)
-
-    expect(render_inline(component).text).to include('You have a break in your work history (3 months)')
-  end
-
-  context 'when work1 is the last entry' do
-    it 'does not show the break if work1 is the current job)' do
-      jan2019 = Time.zone.local(2019, 1, 1)
-
-      work1 = instance_double(ApplicationWorkExperience, start_date: jan2019, end_date: nil)
-
-      component = BreakInWorkHistoryComponent.new(work1: work1, work2: nil)
-
-      expect(render_inline(component).text).to be_empty
-    end
-
-    it 'show the correct break between the end of the work1 and current time)' do
-      jan2019 = Time.zone.local(2019, 1, 1)
-
-      work1 = instance_double(ApplicationWorkExperience, start_date: jan2019, end_date: jan2019 + 2.months)
-
-      Timecop.freeze(Time.zone.local(2020, 1, 1)) do
-        component = BreakInWorkHistoryComponent.new(work1: work1, work2: nil)
-
-        expect(render_inline(component).text).to include('You have a break in your work history (9 months)')
-      end
-    end
+    expect(result.text).to include('You have a break in your work history (3 months)')
   end
 end

--- a/spec/services/get_work_history_with_breaks_spec.rb
+++ b/spec/services/get_work_history_with_breaks_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.describe GetWorkHistoryWithBreaks do
+  describe '#call' do
+    let(:january2019) { Time.zone.local(2019, 1, 1) }
+    let(:february2019) { Time.zone.local(2019, 2, 1) }
+    let(:march2019) { Time.zone.local(2019, 3, 1) }
+    let(:april2019) { Time.zone.local(2019, 4, 1) }
+    let(:september2019) { Time.zone.local(2019, 9, 1) }
+    let(:october2019) { Time.zone.local(2019, 10, 1) }
+    let(:november2019) { Time.zone.local(2019, 11, 1) }
+    let(:december2019) { Time.zone.local(2019, 12, 1) }
+    let(:january2020) { Time.zone.local(2020, 1, 1) }
+    let(:february2020) { Time.zone.local(2020, 2, 1) }
+    let(:current_date) { february2020 }
+
+    around do |example|
+      Timecop.freeze(current_date) do
+        example.run
+      end
+    end
+
+    context 'when there are no jobs' do
+      it 'returns an empty array' do
+        work_history = []
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks).to eq([])
+      end
+    end
+
+    context 'when there is only one job' do
+      it 'returns an array containing a hash if the job is current role i.e. end date is nil' do
+        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: nil)
+        work_history = [job1]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+      end
+
+      it 'returns an array containing a hash if the job ends at current date' do
+        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: current_date)
+        work_history = [job1]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+      end
+
+      it 'returns an array containing a hash for a job and a break if one month break' do
+        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: december2019)
+        work_history = [job1]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[1][:type]).to eq(:break)
+        expect(work_history_with_breaks[1][:entry].break_in_months).to eq(1)
+      end
+
+      it 'returns an array containing a hash for a job and a break if more than a month break' do
+        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: october2019)
+        work_history = [job1]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[1][:type]).to eq(:break)
+        expect(work_history_with_breaks[1][:entry].break_in_months).to eq(3)
+      end
+    end
+
+    context 'when there are multiple jobs' do
+      it 'returns an array containing hashes for jobs if there are no breaks' do
+        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: october2019)
+        job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: december2019)
+        job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
+        work_history = [job1, job2, job3]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
+        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job3)
+      end
+
+      it 'returns an array containing hashes for jobs and a break if there is a break' do
+        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: october2019)
+        job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: november2019)
+        job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
+        work_history = [job1, job2, job3]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(4)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
+        expect(work_history_with_breaks[2][:type]).to eq(:break)
+        expect(work_history_with_breaks[2][:entry].break_in_months).to eq(1)
+        expect(work_history_with_breaks[3]).to eq(type: :job, entry: job3)
+      end
+
+      it 'returns an array containing hashes for jobs if current job covers breaks between following jobs' do
+        job1 = build_stubbed(:application_work_experience, start_date: march2019, end_date: nil)
+        job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
+        job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
+        work_history = [job1, job2, job3]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
+        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job3)
+      end
+
+      it 'returns an array containing hashes for jobs and a break if current job covers break between job after and present' do
+        job1 = build_stubbed(:application_work_experience, start_date: january2019, end_date: february2019)
+        job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
+        job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
+        work_history = [job1, job2, job3]
+
+        get_work_history_with_breaks = GetWorkHistoryWithBreaks.new(work_history)
+        work_history_with_breaks = get_work_history_with_breaks.call
+
+        expect(work_history_with_breaks.count).to eq(4)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[1][:type]).to eq(:break)
+        expect(work_history_with_breaks[1][:entry].break_in_months).to eq(1)
+        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job2)
+        expect(work_history_with_breaks[3]).to eq(type: :job, entry: job3)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We currently don't handle a scenario where a candidate's current job covers breaks in other jobs.

For example:

- Job 1 => start_date: Jan 2019, end_date: nil
- Job 2 => start_date: Mar 2019, end_date: May 2019
- Job 3 => start_date: Sept 2019, end_date: December 2019

There is a break between Job 2 and Job 3 however, we don't need to show this as Job 1 covers this period.

## Changes proposed in this pull request

This PR refactors how we calculate work breaks in order to cover this scenario and to make it easier to test.

It does so by:

- removing responsibility of `BreakInWorkHistoryComponent` and `WorkHistoryReviewComponent` to calculate work breaks
- redirecting the responsibility to a new service called `GetWorkHistoryWithBreaks` which takes in a work history and returns the work history with breaks via an array of hashes with a `type` and `entry` key

This means the only responsibility of the components is to render.

## Screenshot

![image](https://user-images.githubusercontent.com/42817036/73729179-78db6a00-472c-11ea-9d20-24e347ae44fe.png)

## Guidance to review

Would like feedback on:

- whether there's a simpler way to do this with the current implementation instead of this refactoring
- whether the refactoring makes sense
- whether test coverage is good enough or any edge cases are missing
- whether `GetBreaksInMonths` service should be moved into `GetWorkHistoryWithBreaks`
- whether `GetWorkHistoryWithBreaks` and/or its spec can be further refactored

## Link to Trello card

https://trello.com/c/RgdlCMai/862-multiple-current-work-for-work-experiences

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
