### PR TITLE
Make provider text small and grey

### DIFF
--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -19,7 +19,9 @@
         <th class="govuk-table__cell"><%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %></th>
         <td class="govuk-table__cell">
           <% if current_provider_user.providers.size > 1 %>
-              <%= application_choice.provider.name %> -
+            <span class="govuk-caption-m govuk-!-font-size-16">
+              <%= application_choice.provider.name %>
+            </span>
           <% end %>
 
           <%= application_choice.course.name_and_code %></td>


### PR DESCRIPTION
This is to make it easy to differentiate between the provider and
course details within the same column on the application list view.

## Before

![image](https://user-images.githubusercontent.com/37163/73729087-4d587f80-472c-11ea-901d-5d748bf00edf.png)

## After

![image](https://user-images.githubusercontent.com/37163/73729031-3d40a000-472c-11ea-980d-71e49caebd1c.png)

## Link to Trello card

https://trello.com/c/uCQ0BUqT/1608-application-list-provider-course-hierarchy
