### PR TITLE
Highlight the ‘sign in as a candidate’ sandbox feature

### DIFF
--- a/app/frontend/styles/_status-box.scss
+++ b/app/frontend/styles/_status-box.scss
@@ -2,3 +2,7 @@
   background: govuk-colour("light-grey");
   padding: 20px;
 }
+
+.app-status-box--sandbox {
+  border-left: 5px solid govuk-colour("purple");
+}

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -21,16 +21,26 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render PersonalDetailsComponent, application_form: @application_choice.application_form %>
+
+    <% unless HostingEnvironment.production? %>
+      <div class="app-status-box app-status-box--sandbox">
+        <p class="govuk-body">
+          <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--sandbox">
+            sandbox feature
+          </strong>
+        </p>
+        <p class="govuk-body">
+          See what this application looks like from the candidate side by signing in as <%= @application_choice.application_form.full_name %>:
+        </p>
+        <%= button_to 'Sign in as this candidate', provider_interface_impersonate_candidate_path(@application_choice.application_form.candidate), class: 'govuk-button govuk-!-margin-bottom-0' %>
+      </div>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-third">
     <%= render ProviderInterface::StatusBoxComponent, application_choice: @application_choice %>
   </div>
 </div>
-
-<% unless HostingEnvironment.production? %>
-  <%= button_to 'Sign in as this candidate (Test environments only)', provider_interface_impersonate_candidate_path(@application_choice.application_form.candidate), class: 'govuk-button' %>
-<% end %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Course</h2>
 

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'A Provider can log in as a candidate' do
   end
 
   def and_i_click_on_the_sign_in_button
-    click_on 'Sign in as this candidate (Test environments only)'
+    click_on 'Sign in as this candidate'
   end
 
   def then_i_am_redirected_to_the_candidate_interface


### PR DESCRIPTION
## Context

Indicate that signing in as a candidate is a sandbox feature, and describe the feature's purpose.

It needs to be clear to:
- sandbox users that this is specifically a sandbox feature
- maintainers that this is a feature scoped to the sandbox

https://trello.com/c/b22uQJJk/1605-highlight-sandbox-features-to-sandbox-users

## Changes proposed in this pull request

Use the sandbox colour and tag to denote a sandbox feature.

### Before

![Screen Shot 2020-02-03 at 15 46 06](https://user-images.githubusercontent.com/319055/73748444-645d9880-4751-11ea-8d2a-a0c26209560d.png)

### After

![Screen Shot 2020-02-04 at 13 23 14](https://user-images.githubusercontent.com/319055/73748562-9a028180-4751-11ea-8d01-07d649b9ad00.png)

