### PR TITLE
Hide the impersonation button in the print stylesheet

### DIFF
--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -23,7 +23,7 @@
     <%= render PersonalDetailsComponent, application_form: @application_choice.application_form %>
 
     <% unless HostingEnvironment.production? %>
-      <div class="app-status-box app-status-box--sandbox">
+      <div class="app-status-box app-status-box--sandbox app-!-print-display-none">
         <p class="govuk-body">
           <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--sandbox">
             sandbox feature


### PR DESCRIPTION
Before

<img width="485" alt="Screenshot 2020-02-04 at 14 35 28" src="https://user-images.githubusercontent.com/642279/73754028-9e339c80-475b-11ea-8b18-7b38bcab3a9c.png">

After

<img width="505" alt="Screenshot 2020-02-04 at 14 35 08" src="https://user-images.githubusercontent.com/642279/73754038-a1c72380-475b-11ea-91dd-f63b0106ab5d.png">
