### PR TITLE
Remove spaces from email addresses when adding provider users

### DIFF
--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
     attr_accessor :first_name, :last_name, :provider_ids, :provider_user
     attr_reader :email_address
 
-    validates :email_address, presence: true
+    validates :email_address, presence: true, email: true
     validates :provider_ids, presence: true
     validate :email_is_unique
 
@@ -26,7 +26,7 @@ module SupportInterface
     end
 
     def email_address=(raw_email_address)
-      @email_address = raw_email_address.downcase
+      @email_address = raw_email_address.downcase.strip
     end
 
     def available_providers


### PR DESCRIPTION
## Context

User input can include trailing spaces after email addresses, and the current form doesn't validate email addresses beyond presence. This can lead to invited provider users getting the 'your account is not ready' message.

## Changes proposed in this pull request

Strip whitespace around email addresses, to make support users' lives easier.
Start validating the format of email addresses entered.

## Guidance to review

Read the code changes. Run tests. Try it out.

## Link to Trello card

https://trello.com/c/PMX4B436

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
