### PR TITLE
Add field for capturing working patterns for part time jobs

### DIFF
--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -13,7 +13,7 @@ class WorkHistoryReviewComponent < ActionView::Component::Base
   def work_experience_rows(work)
     [
       job_row(work),
-      type_row(work),
+      working_pattern_row(work),
       description_row(work),
       dates_row(work),
     ]
@@ -65,10 +65,10 @@ private
     }
   end
 
-  def type_row(work)
+  def working_pattern_row(work)
     {
-      key: 'Type',
-      value: work.commitment.dasherize.humanize,
+      key: 'Working pattern',
+      value: working_pattern(work),
       action: generate_action(work: work, attribute: 'type'),
       change_path: candidate_interface_work_history_edit_path(work.id),
     }
@@ -113,5 +113,11 @@ private
   def any_jobs_with_same_role_and_organisation?(work)
     jobs = @application_form.application_work_experiences.where(role: work.role, organisation: work.organisation)
     jobs.many?
+  end
+
+  def working_pattern(work)
+    return work.commitment.dasherize.humanize if work.working_pattern.blank?
+
+    "#{work.commitment.dasherize.humanize}\n #{work.working_pattern}"
   end
 end

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -41,7 +41,7 @@ module CandidateInterface
       params.require(:candidate_interface_work_experience_form)
         .permit(
           :role, :organisation, :details, :working_with_children, :commitment,
-          :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
+          :working_pattern, :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
           :"end_date(3i)", :"end_date(2i)", :"end_date(1i)"
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     include DateValidationHelper
 
     attr_accessor :role, :organisation, :details, :working_with_children,
-                  :commitment,
+                  :commitment, :working_pattern,
                   :start_date_day, :start_date_month, :start_date_year,
                   :end_date_day, :end_date_month, :end_date_year
 
@@ -22,7 +22,7 @@ module CandidateInterface
     validates :role, :organisation,
               length: { maximum: 60 }
 
-    validates :details,
+    validates :details, :working_pattern,
               word_count: { maximum: 150 }
 
     def self.build_from_experience(work_experience)
@@ -38,6 +38,7 @@ module CandidateInterface
         end_date_day: work_experience.end_date&.day || '',
         end_date_month: work_experience.end_date&.month || '',
         end_date_year: work_experience.end_date&.year || '',
+        working_pattern: work_experience.working_pattern,
       )
     end
 
@@ -52,6 +53,7 @@ module CandidateInterface
         working_with_children: ActiveModel::Type::Boolean.new.cast(working_with_children),
         start_date: start_date,
         end_date: end_date,
+        working_pattern: working_pattern,
       )
     end
 
@@ -66,6 +68,7 @@ module CandidateInterface
         working_with_children: ActiveModel::Type::Boolean.new.cast(working_with_children),
         start_date: start_date,
         end_date: end_date,
+        working_pattern: working_pattern,
       )
     end
 

--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -118,8 +118,14 @@ module VendorApi
         organisation_name: experience.organisation,
         working_with_children: experience.working_with_children,
         commitment: experience.commitment,
-        description: experience.details,
+        description: experience_description(experience),
       }
+    end
+
+    def experience_description(experience)
+      return experience.details if experience.working_pattern.blank?
+
+      "Working pattern: #{experience.working_pattern}\n\nDescription: #{experience.details}"
     end
 
     def references

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -13,8 +13,9 @@
 
 <%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: 'Was this job full-time or part-time?', tag: 'span' } do %>
   <%= f.govuk_radio_button :commitment, 'full_time', label: { text: 'Full-time' }, link_errors: true %>
-
-  <%= f.govuk_radio_button :commitment, 'part_time', label: { text: 'Part-time' } %>
+  <%= f.govuk_radio_button :commitment, 'part_time', label: { text: 'Part-time' } do %>
+    <%= f.govuk_text_area :working_pattern, label: { text: 'Give details about your working pattern' }, rows: 3 %>
+  <% end %>
 <% end %>
 
 <div class="app-work-experience__start-date" data-qa="start-date">

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -14,7 +14,7 @@
 <%= f.govuk_radio_buttons_fieldset :commitment, legend: { text: 'Was this job full-time or part-time?', tag: 'span' } do %>
   <%= f.govuk_radio_button :commitment, 'full_time', label: { text: 'Full-time' }, link_errors: true %>
   <%= f.govuk_radio_button :commitment, 'part_time', label: { text: 'Part-time' } do %>
-    <%= f.govuk_text_area :working_pattern, label: { text: 'Give details about your working pattern' }, rows: 3 %>
+    <%= f.govuk_text_area :working_pattern, label: { text: 'Give details about your working pattern', size: 's' }, hint_text: 'For example: ‘20 hours per week’', rows: 3 %>
   <% end %>
 <% end %>
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -482,6 +482,8 @@ en:
             end_date:
               invalid: Enter an end date in the correct format
               in_the_future: Enter an end date that is not in the future
+            working_pattern:
+              too_many_words: Details about your working pattern must be %{count} words or fewer
         candidate_interface/gcse_qualification_details_form:
           attributes:
             grade:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -103,6 +103,7 @@ FactoryBot.define do
     start_date { Faker::Date.between(from: 20.years.ago, to: 5.years.ago) }
     end_date { [Faker::Date.between(from: 4.years.ago, to: Date.today), nil].sample }
     commitment { %w[full_time part_time].sample }
+    working_pattern { Faker::Lorem.paragraph_by_chars(number: 30) }
   end
 
   factory :application_volunteering_experience, parent: :application_experience, class: 'ApplicationVolunteeringExperience'

--- a/spec/models/candidate_interface/work_experience_form_spec.rb
+++ b/spec/models/candidate_interface/work_experience_form_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
       working_with_children: [true, true, true, false].sample,
       start_date: Time.zone.local(2018, 5, 1),
       end_date: Time.zone.local(2019, 5, 1),
+      working_pattern: Faker::Lorem.paragraph_by_chars(number: 20),
     }
   end
 
@@ -24,6 +25,7 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
       start_date_year: data[:start_date].year,
       end_date_month: data[:end_date].month,
       end_date_year: data[:end_date].year,
+      working_pattern: data[:working_pattern],
     }
   end
 
@@ -200,8 +202,10 @@ RSpec.describe CandidateInterface::WorkExperienceForm, type: :model do
       saved_work_experience = work_experience.save(application_form)
 
       work_experience.role = 'Something else'
+      work_experience.working_pattern = 'New working pattern'
       work_experience.update(saved_work_experience)
       expect(saved_work_experience.reload).to have_attributes(role: 'Something else')
+      expect(saved_work_experience.reload).to have_attributes(working_pattern: 'New working pattern')
     end
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -180,7 +180,9 @@ module CandidateHelper
     with_options scope: 'application_form.work_history' do |locale|
       fill_in locale.t('role.label'), with: 'Teacher'
       fill_in locale.t('organisation.label'), with: 'Oakleaf Primary School'
-      choose 'Full-time'
+      choose 'Part-time'
+
+      fill_in 'Give details about your working pattern', with: 'I had a working pattern'
 
       within('[data-qa="start-date"]') do
         fill_in 'Month', with: '5'

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -128,7 +128,9 @@ RSpec.feature 'Entering their work history' do
     fill_in t('role.label', scope: scope), with: 'Chief Terraforming Officer'
     fill_in t('organisation.label', scope: scope), with: 'Weyland-Yutani'
 
-    choose 'Full-time'
+    choose 'Part-time'
+
+    fill_in 'Give details about your working pattern', with: 'I had a working pattern'
 
     within('[data-qa="start-date"]') do
       fill_in 'Month', with: '5'
@@ -149,6 +151,7 @@ RSpec.feature 'Entering their work history' do
 
   def then_i_should_see_my_completed_job
     expect(page).to have_content('Chief Terraforming Officer')
+    expect(page).to have_content('I had a working pattern')
   end
 
   def when_i_click_on_delete_entry

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe 'A Provider viewing an individual application' do
            role: 'Smuggler',
            organisation: 'The Empire',
            details: 'I used to work for The Empire',
+           working_pattern: 'Working pattern at the Empire',
            working_with_children: false)
 
     create(:application_volunteering_experience,
@@ -98,6 +99,7 @@ RSpec.describe 'A Provider viewing an individual application' do
     within '[data-qa="work-history"]' do
       expect(page).to have_content 'Smuggler'
       expect(page).to have_content 'The Empire'
+      expect(page).to have_content 'Working pattern at the Empire'
       expect(page).to have_content 'I used to work for'
       expect(page).not_to have_content 'This role involved working with children'
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -170,8 +170,8 @@ RSpec.feature 'Vendor receives the application' do
               role: 'Teacher',
               organisation_name: 'Oakleaf Primary School',
               working_with_children: false,
-              commitment: 'full_time',
-              description: 'I learned a lot about teaching',
+              commitment: 'part_time',
+              description: "Working pattern: I had a working pattern\n\nDescription: I learned a lot about teaching",
             },
           ],
           volunteering: [


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to add another field to work history because:
- As a provider, I need detail about a candidate’s work history so that I have enough information to make decisions on their application.
- As a candidate, I need to be able to describe my part-time jobs, so that I can show how much work I did.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR updates:
- The `WorkExperienceForm`, `WorkHistory::EditController` and work_history/edit views to capture and display working pattern information when a candidate fills up a part-time work experience record. 
- The `SingleApplicationPresenter` to present this information in `work_experience#description`

### Before
![image](https://user-images.githubusercontent.com/22743709/73767446-5d458300-476f-11ea-8851-edd598ddbd60.png)
![image](https://user-images.githubusercontent.com/22743709/73767459-633b6400-476f-11ea-8738-cef7c47c2c6c.png)


### After
![image](https://user-images.githubusercontent.com/22743709/73767021-c8428a00-476e-11ea-8a64-74f355c5e645.png)
![image](https://user-images.githubusercontent.com/22743709/73827832-2a939d00-47f8-11ea-9132-6b3b59df6a2b.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
As discussed with @duncanjbrown in the current API documentation the `The WorkExperience object` has a `description` field, if we include working pattern information in this field, no further API update needed. Let me know if you disagree.
![image](https://user-images.githubusercontent.com/22743709/73765139-05f1e380-476c-11ea-8804-1f45f778150b.png)


## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/M9ktUBA0/861-add-field-for-capturing-working-patterns-for-part-time-jobs

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
