### PR TITLE
Put expired link flow behind the feature flag

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -61,11 +61,18 @@ module CandidateInterface
           redirect_to candidate_interface_course_choices_review_path
         end
       else
-        redirect_to candidate_interface_expired_sign_in_path(id: candidate.id)
+        # rubocop:disable Style/IfInsideElse
+        if FeatureFlag.active?('improved_expired_token_flow')
+          redirect_to candidate_interface_expired_sign_in_path(id: candidate.id)
+        else
+          redirect_to action: :new
+        end
+        # rubocop:enable Style/IfInsideElse
       end
     end
 
     def expired
+      raise unless FeatureFlag.active?('improved_expired_token_flow')
       return redirect_to candidate_interface_sign_in_path unless params[:id]
 
       @candidate = Candidate.find(params[:id])


### PR DESCRIPTION
## Context

I think the redirect should have been behind a feature flag like the rest of the improved expired tokens stuff. It was added in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1233.

## Changes proposed in this pull request

Check the feature flag before exposing the feature.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
