### PR TITLE
Allow candidates to have more than 2 references

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -29,10 +29,6 @@ class ApplicationForm < ApplicationRecord
     submitted_at.present?
   end
 
-  def application_references_complete?
-    application_references.feedback_provided.count == MINIMUM_COMPLETE_REFERENCES
-  end
-
   def awaiting_provider_decisions?
     application_choices.where(status: :awaiting_provider_decision).any?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -11,7 +11,6 @@ class ApplicationForm < ApplicationRecord
   has_many :application_references, -> { order('id ASC') }
 
   MINIMUM_COMPLETE_REFERENCES = 2
-  validates_length_of :application_references, maximum: MINIMUM_COMPLETE_REFERENCES
 
   enum phase: {
     apply_1: 'apply_1',

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -156,7 +156,7 @@ module CandidateInterface
     end
 
     def all_referees_provided_by_candidate?
-      @application_form.application_references.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+      @application_form.application_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
     end
 
   private

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -27,8 +27,9 @@ private
   end
 
   # Only progress the applications if the reference that is being submitted is
-  # the 2nd referee, since there might be more than 2 references per form
-  # in the future.
+  # the 2nd referee, since there might be more than 2 references per form. We
+  # don't want to send the references to the provider *again* when the 3rd or
+  # 4th reference is submitted.
   def there_are_now_enough_references_to_progress?
     application_form.application_references.feedback_provided.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES
   end

--- a/app/workers/detect_invariants.rb
+++ b/app/workers/detect_invariants.rb
@@ -8,8 +8,12 @@ class DetectInvariants
 
   def detect_application_choices_stuck_in_awaiting_references_state
     # Application choices with completed feedback, but still awaiting references
+    forms_with_completed_references = ApplicationForm.includes(:application_references).select do |form|
+      form.application_references.feedback_provided.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+    end
+
     choices_in_wrong_state = begin
-      ApplicationChoice.where(status: 'awaiting_references', application_form: ApplicationForm.includes(:application_references).select(&:application_references_complete?))
+      ApplicationChoice.where(status: 'awaiting_references', application_form: forms_with_completed_references)
     end
 
     if choices_in_wrong_state.any?

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -245,6 +245,16 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
         expect(presenter.all_referees_provided_by_candidate?).to eq(true)
       end
     end
+
+    context 'when there are 3 referees' do
+      before do
+        create_list(:reference, 3, application_form: application_form)
+      end
+
+      it 'returns true' do
+        expect(presenter.all_referees_provided_by_candidate?).to eq(true)
+      end
+    end
   end
 
   describe '#work_experience_path' do

--- a/spec/services/receive_reference_spec.rb
+++ b/spec/services/receive_reference_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe ReceiveReference do
     ).save!
 
     expect(reference.feedback).to eq('A reference')
-    expect(application_form).not_to be_application_references_complete
     expect(application_form.application_choices).to all(be_awaiting_references)
   end
 
@@ -28,7 +27,6 @@ RSpec.describe ReceiveReference do
       feedback: 'A reference',
     ).save!
 
-    expect(application_form.reload).to be_application_references_complete
     expect(application_form.application_choices).to all(be_application_complete)
   end
 


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1279 we're going to allow more than 2 references. For https://trello.com/c/hzgtm77m we need to manually add a reference. 

We need to update our assumptions in several places.

## Changes proposed in this pull request

Assume more than 2 references can come back.

## Guidance to review

Does this make sense? Are there any other places where we assume that there are only 2 references?

## Link to Trello card

https://trello.com/c/hzgtm77m/863-changes-related-to-application-ct3898

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
