### PR TITLE
Handle missing provider name for email notifications

### DIFF
--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -26,7 +26,7 @@ class ProviderUser < ActiveRecord::Base
   end
 
   def full_name
-    "#{first_name} #{last_name}"
+    "#{first_name} #{last_name}" if first_name.present? && last_name.present?
   end
 
 private

--- a/app/views/provider_mailer/account_created.text.erb
+++ b/app/views/provider_mailer/account_created.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @provider_user.full_name %>
+Dear <%= @provider_user.full_name || 'colleague' %>
 
 Welcome to Manage teacher training applications.
 
@@ -12,4 +12,4 @@ Visit [Manage teacher training applications](<%= provider_interface_url %>) to s
 
 Please check your inbox for an email from us inviting you to create a DfE Sign-in account.
 
-You can contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to request a new email, or for help and support. 
+You can contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to request a new email, or for help and support.

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -1,10 +1,10 @@
-Dear <%= @application.provider_user_name %>
+Dear <%= @application.provider_user_name || 'colleague' %>
 
-# Application rejected automatically  
+# Application rejected automatically
 
-<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>. 
+<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
-You did not respond within 40 working days so we rejected the application on your behalf. 
+You did not respond within 40 working days so we rejected the application on your behalf.
 
 You can log in to Manage teacher training applications to check the status of your applications:
 

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -1,8 +1,8 @@
-Dear <%= @application.provider_user_name %>
+Dear <%= @application.provider_user_name || 'colleague' %>
 
 # Application received
 
-<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %>. 
+<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %>.
 
 # Next steps
 
@@ -10,7 +10,7 @@ Log in to Manage teacher training applications to respond:
 
 <%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
 
-We’ll reject the application on your behalf after 40 working days.   
+We’ll reject the application on your behalf after 40 working days.
 
 # Give feedback or report a problem
 

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe ProviderUser, type: :model do
       provider_user = build :provider_user
       expect(provider_user.full_name).to eq "#{provider_user.first_name} #{provider_user.last_name}"
     end
+
+    it 'is nil if the first and last names are nil' do
+      provider_user = build(:provider_user, first_name: nil, last_name: nil)
+      expect(provider_user.full_name).to be_nil
+    end
   end
 
   describe 'auditing', with_audited: true do


### PR DESCRIPTION
## Context

Provider users can be whitelisted/on-boarded with only an email, without providing a name. The name is then pulled in from DfE Sign-in, the first time that the provider user logs in.

This can mean that providers (who have never once logged in) will be missing their name in notifications that are sent to them:

![image](https://user-images.githubusercontent.com/23801/73839166-3c336f80-480d-11ea-9e16-bf6762b2c007.png)

## Changes proposed in this pull request

Fall back to 'colleague' when the provider's name is unavailable.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
