### PR TITLE
Show refbot1 and refbot2 instructions in a Sandbox-only block

### DIFF
--- a/app/views/candidate_interface/referees/_form.html.erb
+++ b/app/views/candidate_interface/referees/_form.html.erb
@@ -6,6 +6,18 @@
 </ul>
 
 <%= f.govuk_text_field :name, label: { text: t('application_form.referees.name.label'), size: 'm' } %>
+<% if HostingEnvironment.sandbox_mode? %>
+  <div class="app-status-box app-status-box--sandbox govuk-!-margin-bottom-4">
+    <p class="govuk-body">
+      <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag app-environment-tag--sandbox">
+        sandbox feature
+      </strong>
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      Enter <code>refbot1@example.com</code> and <code>refbot2@example.com</code> as your referee email addresses to have the references automatically completed
+    </p>
+  </div>
+<% end %>
 <%= f.govuk_text_field :email_address, type: 'email', label: { text: t('application_form.referees.email_address.label'), size: 'm' }, hint_text: t('application_form.referees.email_address.hint_text') %>
 <%= f.govuk_text_area :relationship, label: { text: t('application_form.referees.relationship.label'), size: 'm' }, hint_text: t('application_form.referees.relationship.hint_text'), max_words: 50 %>
 


### PR DESCRIPTION
## Context

Dan Williams pointed out that during the demo he'd felt he needed to remember the refbot1 and refbot2 email addresses. We should present this information close to where it's needed by users of the sandbox.

## Changes proposed in this pull request

Add another sandbox-only block, this time on the "Details of referee" page

<img width="727" alt="Screenshot 2020-02-05 at 13 58 55" src="https://user-images.githubusercontent.com/642279/73848275-ba007680-481f-11ea-8736-44cb2b7a273c.png">

## Guidance to review

Check the copy. Should the field be inside the box?

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
