### PR TITLE
Add hosting environment to logs

### DIFF
--- a/app/lib/logstash_logging.rb
+++ b/app/lib/logstash_logging.rb
@@ -9,6 +9,7 @@ class LogstashLogging
     LogStashLogger.configure do |logstash_config|
       logstash_config.customize_event do |event|
         event['domain'] = DOMAIN_FOR_LOGS
+        event['hosting_environment'] = HostingEnvironment.environment_name
         event['service'] = SERVICE_TYPE
         params = RequestLocals.fetch(:params) {} # block is required
         if params


### PR DESCRIPTION
This will allow us to search the logs for the hosting env name (production, staging, sandbox) instead of the domain.