### PR TITLE
Email to provider when a decision is needed on an application because it has been submitted for 20 working days

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -69,6 +69,6 @@ class ProviderMailer < ApplicationMailer
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: provider_user.email_address,
-              subject: t('provider_application_waiting_for_decision.email.subject', candidate_name: @application.candidate_name))
+              subject: I18n.t!('provider_application_waiting_for_decision.email.subject', candidate_name: @application.candidate_name))
   end
 end

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -1,4 +1,6 @@
 class ApplicationChoice < ApplicationRecord
+  include Chased
+
   before_create :set_initial_status
 
   belongs_to :application_form, touch: true

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -3,5 +3,6 @@ class ChaserSent < ApplicationRecord
 
   enum chaser_type: {
     reference_request: 'reference_request',
+    provider_decision_request: 'provider_decision_request',
   }
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -11,6 +11,7 @@ class FeatureFlag
     experimental_api_features
     confirm_conditions
     automated_referee_chaser
+    automated_provider_chaser
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/get_application_forms_waiting_for_provider_decision.rb
+++ b/app/services/get_application_forms_waiting_for_provider_decision.rb
@@ -1,0 +1,12 @@
+class GetApplicationFormsWaitingForProviderDecision
+  def self.call
+    ApplicationChoice
+      .where(status: :awaiting_provider_decision)
+      .where('reject_by_default_at < ?', chase_provider_time_limit)
+      .where.not(id: ChaserSent.provider_decision_request.select(:chased_id))
+  end
+
+  def self.chase_provider_time_limit
+    TimeLimitCalculator.new(rule: :chase_provider_by, effective_date: Time.zone.now).call.second
+  end
+end

--- a/app/services/send_chase_email_to_provider.rb
+++ b/app/services/send_chase_email_to_provider.rb
@@ -1,0 +1,17 @@
+class SendChaseEmailToProvider
+  def self.call(application_choice:)
+    application_choice.provider.provider_users.each do |provider_user|
+      ProviderMailer.chase_provider_decision(provider_user, application_choice).deliver
+      audit_chase_email(provider_user, application_choice)
+    end
+    ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)
+  end
+
+  def self.audit_chase_email(provider_user, application_choice)
+    course_name_and_code = application_choice.course.name_and_code
+    audit_comment =
+      "Chase emails have been sent to the provider #{provider_user.email_address} because " +
+      "the application for #{course_name_and_code} is close to its RBD date."
+    application_choice.application_form.update!(audit_comment: audit_comment)
+  end
+end

--- a/app/workers/send_chase_email_to_providers_worker.rb
+++ b/app/workers/send_chase_email_to_providers_worker.rb
@@ -1,0 +1,11 @@
+class SendChaseEmailToProvidersWorker
+  include Sidekiq::Worker
+
+  def perform
+    return unless FeatureFlag.active?('automated_provider_chaser')
+
+    GetApplicationFormsWaitingForProviderDecision.call.each do |application_choice|
+      SendChaseEmailToProvider.call(application_choice: application_choice)
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -13,4 +13,5 @@ class Clock
   every(1.hour, 'RejectApplicationsByDefault', at: '**:10') { RejectApplicationsByDefaultWorker.perform_async }
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'SendChaseEmailToReferees', at: '**:20') { SendChaseEmailToRefereesWorker.perform_async }
+  every(1.hour, 'SendChaseEmailToProviders', at: '**:25') { SendChaseEmailToProvidersWorker.perform_async }
 end

--- a/lib/tasks/backfill_provider_chasers.rake
+++ b/lib/tasks/backfill_provider_chasers.rake
@@ -1,0 +1,5 @@
+desc 'Markes all application choices as chased that had to be chased by the date'
+task backfill_provider_chasers: :environment do
+  application_choices = GetApplicationFormsWaitingForProviderDecision.call
+  application_choices.each { |choice| ChaserSent.create!(chased: choice, chaser_type: :provider_decision_request) }
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -264,4 +264,9 @@ FactoryBot.define do
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
   end
+
+  factory :provider_users_provider do
+    provider
+    provider_user
+  end
 end

--- a/spec/services/get_application_forms_waiting_for_provider_decision_spec.rb
+++ b/spec/services/get_application_forms_waiting_for_provider_decision_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe GetApplicationFormsWaitingForProviderDecision do
+  let(:current_time) { Time.zone.local(2019, 6, 1, 12, 0, 0) }
+
+  around do |example|
+    Timecop.freeze(current_time) do
+      example.run
+    end
+  end
+
+  def create_application(status:, reject_by_default_at:)
+    create(
+      :application_choice,
+      status: status,
+      reject_by_default_at: reject_by_default_at,
+    )
+  end
+
+  it 'returns an application that has not more than 20 working days till RBD date' do
+    application_choice = create_application(
+      status: 'awaiting_provider_decision',
+      reject_by_default_at: 21.business_days.from_now,
+    )
+
+    Timecop.travel(1.business_days.from_now) do
+      expect(described_class.call).to include application_choice
+    end
+  end
+
+  it 'does not return an application that has more than 20 working days till RBD date' do
+    application_choice = create_application(
+      status: 'awaiting_provider_decision',
+      reject_by_default_at: 22.business_days.from_now,
+    )
+    Timecop.travel(1.business_days.from_now) do
+      expect(described_class.call).not_to include application_choice
+    end
+  end
+
+  it 'does not return an application if it has been chased already' do
+    application_choice = create_application(
+      status: 'awaiting_provider_decision',
+      reject_by_default_at: 10.business_days.from_now,
+    )
+
+    ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)
+
+    Timecop.travel(1.business_days.from_now) do
+      expect(described_class.call).not_to include application_choice
+    end
+  end
+end

--- a/spec/services/send_chase_email_to_provider_spec.rb
+++ b/spec/services/send_chase_email_to_provider_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe SendChaseEmailToProvider do
+  describe '#call' do
+    let(:application_choice) do
+      create(:submitted_application_choice,
+             application_form: create(:completed_application_form),
+             status: 'awaiting_provider_decision')
+    end
+    let(:provider_user) { create(:provider_user) }
+    let(:provider_id) { application_choice.provider.id }
+
+    before do
+      create(:provider_users_provider, provider_id: application_choice.provider.id, provider_user_id: provider_user.id)
+      described_class.call(application_choice: application_choice)
+    end
+
+    it 'sends a chaser email to the provider' do
+      expect(application_choice.chasers_sent.provider_decision_request.count).to eq(1)
+    end
+
+    it 'audits the chase emails', with_audited: true do
+      expected_comment =
+        "Chase emails have been sent to the provider #{provider_user.email_address}" +
+        " because the application for #{application_choice.course.name_and_code} is close to its RBD date."
+      expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_is_waiting_for_decision_for_20_days_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_is_waiting_for_decision_for_20_days_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.feature 'An application is waiting for decision for 20 working days' do
+  include CourseOptionHelpers
+  include CandidateHelper
+
+  scenario 'the provider receives a chaser email', sidekiq: true do
+    FeatureFlag.activate('training_with_a_disability')
+    FeatureFlag.activate('automated_provider_chaser')
+
+    given_a_candidate_has_submitted_an_application_form
+    and_an_application_was_sent_to_provider
+    and_i_am_a_provider_user_at_the_course_provider
+
+    when_the_application_is_waiting_for_decision_for_20_working_days
+
+    then_i_should_receive_a_chaser_email_with_a_link_to_the_application
+  end
+
+  def given_a_candidate_has_submitted_an_application_form
+    candidate_completes_application_form
+    candidate_submits_application
+  end
+
+  def and_an_application_was_sent_to_provider
+    @submitted_application_choice = build(:submitted_application_choice)
+    @application.application_choices << @submitted_application_choice
+  end
+
+  def and_i_am_a_provider_user_at_the_course_provider
+    @provider_user = create(:provider_user)
+    provider_id = @submitted_application_choice.provider.id
+    create(:provider_users_provider, provider_id: provider_id, provider_user_id: @provider_user.id)
+  end
+
+  def when_the_application_is_waiting_for_decision_for_20_working_days
+    Timecop.travel(20.business_days.after(Time.zone.now + 5.minutes)) do
+      SendChaseEmailToProvidersWorker.perform_async
+    end
+  end
+
+  def then_i_should_receive_a_chaser_email_with_a_link_to_the_application
+    open_email(@provider_user.email_address)
+
+    expected_subject = I18n.t('provider_application_waiting_for_decision.email.subject', candidate_name: @application.full_name)
+    expect(current_email.subject).to include(expected_subject)
+
+    expect(current_email.body).to include("http://localhost:3000/provider/applications/#{@submitted_application_choice.id}")
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Currently, a support user must notify the provider when they are halfway through their RBD period. We want to send automatic emails to providers warning them of RBD.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds:
- GetApplicationFormsWaitingForProviderDecision service to find application choices that halfway through the RBD period
- SendChaseEmailToProvider service to call the provider mailer and send chaser emails
- SendChaseEmailToProvidersWorker so we can schedule the task

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I would suggest following the commit and the system spec also can be helpful. Before we can merge this PR we need to backfill the chased provider data so we won't double send chasers.

## Link to Trello card
https://trello.com/c/BTWWHYOj/836-email-%EF%B8%8F-a-decision-is-needed-on-an-application-because-it-has-been-submitted-for-20-working-days-to-provider

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
