### PR TITLE
Update provider mailer with decision chaser

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -11,6 +11,9 @@ class TimeLimitConfig
     edit_by: [
       Rule.new(nil, nil, 5),
     ],
+    chase_provider_by: [
+      Rule.new(nil, nil, 20),
+    ],
   }.freeze
 
   def self.limits_for(rule)

--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -11,6 +11,10 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.application_rejected_by_default(provider_user, application_choice)
   end
 
+  def chase_provider_decision_after_twenty_working_days
+    ProviderMailer.chase_provider_decision(provider_user, application_choice)
+  end
+
 private
 
   def application_choice

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -48,4 +48,27 @@ class ProviderMailer < ApplicationMailer
               to: provider_user.email_address,
               subject: t('provider_application_rejected_by_default.email.subject', candidate_name: @application.candidate_name))
   end
+
+  def chase_provider_decision(provider_user, application_choice)
+    @application =
+      Struct.new(
+        :candidate_name,
+        :provider_user_name,
+        :course_name_and_code,
+        :submitted_at,
+        :application_choice,
+        :rbd_date,
+      ).new(
+        application_choice.application_form.full_name,
+        provider_user.full_name,
+        application_choice.course.name_and_code,
+        application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
+        application_choice,
+        application_choice.reject_by_default_at,
+    )
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: provider_user.email_address,
+              subject: t('provider_application_waiting_for_decision.email.subject', candidate_name: @application.candidate_name))
+  end
 end

--- a/app/views/provider_mailer/chase_provider_decision.text.erb
+++ b/app/views/provider_mailer/chase_provider_decision.text.erb
@@ -1,0 +1,15 @@
+Dear <%= @application.provider_user_name || 'colleague' %>
+
+# Only 20 working days left to respond
+
+<%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
+
+Log in to Manage teacher training applications to respond within 20 working days:
+
+<%= provider_interface_application_choice_url(@application.application_choice) %>
+
+If you do not respond to the application by <%= @application.rbd_date.to_s(:govuk_date) %>, we’ll reject it on your behalf.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/app/views/provider_mailer/chase_provider_decision.text.erb
+++ b/app/views/provider_mailer/chase_provider_decision.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @application.provider_user_name || 'colleague' %>
 
-# Only 20 working days left to respond
+# Only <%= TimeLimitConfig.limits_for(:chase_provider_by).first.limit %> working days left to respond
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
-Log in to Manage teacher training applications to respond within 20 working days:
+Log in to Manage teacher training applications to respond within <%= TimeLimitConfig.limits_for(:chase_provider_by).first.limit %> working days:
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
 

--- a/config/locales/provider_notifications.yml
+++ b/config/locales/provider_notifications.yml
@@ -8,3 +8,6 @@ en:
   provider_application_rejected_by_default:
     email:
       subject: '%{candidate_name}’s application rejected automatically'
+  provider_application_waiting_for_decision:
+    email:
+      subject: 'Respond to %{candidate_name}’s application'

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -13,5 +13,9 @@ RSpec.describe TimeLimitConfig do
     it ':edit_by returns a default limit of 5 days' do
       expect(TimeLimitConfig.limits_for(:edit_by).first.limit).to eq(5)
     end
+
+    it ':chase_provider_by returns a default limit of 20 days' do
+      expect(TimeLimitConfig.limits_for(:chase_provider_by).first.limit).to eq(20)
+    end
   end
 end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe ProviderMailer, type: :mailer do
 
   subject(:mailer) { described_class }
 
+  let(:course_option) { course_option_for_provider_code(provider_code: 'ABC') }
+  let(:application_choice) do
+    build_stubbed(:submitted_application_choice,
+                  course_option: course_option,
+                  application_form:
+                    build_stubbed(
+                      :completed_application_form,
+                   ))
+  end
+  let(:provider_user) { application_choice.provider.provider_users.first }
+
   describe 'Send account created email' do
     before do
       @provider_user = build_stubbed(:provider_user)
@@ -26,131 +37,105 @@ RSpec.describe ProviderMailer, type: :mailer do
 
   describe 'Send application submitted email' do
     before do
-      @course_option = course_option_for_provider_code(provider_code: 'ABC')
-      @application_choice = create(:application_choice, status: 'application_complete', edit_by: Time.zone.today,
-        course_option: @course_option,
-        application_form:
-          create(
-            :completed_application_form,
-            submitted_at: Time.zone.today,
-        ))
-      @provider_user = @application_choice.provider.provider_users.first
-      @mail = mailer.application_submitted(@provider_user, @application_choice)
+      @mail = mailer.application_submitted(provider_user, application_choice)
     end
 
     it 'sends an email with the correct subject' do
       expect(@mail.subject).to include(
         t('provider_application_submitted.email.subject',
-          course_name_and_code: @application_choice.course.name_and_code),
+          course_name_and_code: application_choice.course.name_and_code),
       )
     end
 
     it 'addresses the provider user by name' do
-      expect(@mail.body.encoded).to include("Dear #{@provider_user.full_name}")
+      expect(@mail.body.encoded).to include("Dear #{provider_user.full_name}")
     end
 
     it 'includes the candidate name' do
-      expect(@mail.body.encoded).to include("#{@application_choice.application_form.full_name} submitted an application for")
+      expect(@mail.body.encoded).to include("#{application_choice.application_form.full_name} submitted an application for")
     end
 
     it 'includes the course details' do
-      expect(@mail.body.encoded).to include(@application_choice.course.name)
-      expect(@mail.body.encoded).to include(@application_choice.course.code)
+      expect(@mail.body.encoded).to include(application_choice.course.name)
+      expect(@mail.body.encoded).to include(application_choice.course.code)
     end
 
     it 'includes a link to the application' do
-      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(@application_choice))
+      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice))
     end
   end
 
   describe 'Send application rejected by default email' do
     before do
-      @course_option = course_option_for_provider_code(provider_code: 'ABC')
-      @submission_date = Time.zone.today - 40.days
-      @application_choice = create(:application_choice, status: 'rejected',
-        course_option: @course_option,
-        application_form:
-          create(
-            :completed_application_form,
-            submitted_at: @submission_date,
-        ))
-      @provider_user = @application_choice.provider.provider_users.first
-      @mail = mailer.application_rejected_by_default(@provider_user, @application_choice)
+      @mail = mailer.application_rejected_by_default(provider_user, application_choice)
     end
 
     it 'sends an email with the correct subject' do
       expect(@mail.subject).to include(
         t('provider_application_rejected_by_default.email.subject',
-          candidate_name: @application_choice.application_form.full_name),
+          candidate_name: application_choice.application_form.full_name),
         )
     end
 
     it 'addresses the provider user by name' do
-      expect(@mail.body.encoded).to include("Dear #{@provider_user.full_name}")
+      expect(@mail.body.encoded).to include("Dear #{provider_user.full_name}")
     end
 
     it 'includes the candidate name' do
-      expect(@mail.body.encoded).to include("#{@application_choice.application_form.full_name} submitted an application for")
+      expect(@mail.body.encoded).to include("#{application_choice.application_form.full_name} submitted an application for")
     end
 
     it 'includes the course details' do
-      expect(@mail.body.encoded).to include(@application_choice.course.name)
-      expect(@mail.body.encoded).to include(@application_choice.course.code)
+      expect(@mail.body.encoded).to include(application_choice.course.name)
+      expect(@mail.body.encoded).to include(application_choice.course.code)
     end
 
     it 'includes a readable submission date' do
-      expect(@mail.body.encoded).to include("on #{@submission_date.to_s(:govuk_date).strip}")
+      submission_date = application_choice.application_form.submitted_at
+      expect(@mail.body.encoded).to include("on #{submission_date.to_s(:govuk_date).strip}")
     end
 
     it 'includes a link to the application' do
-      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: @application_choice.id))
+      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: application_choice.id))
     end
   end
 
   describe 'Send provider decision chaser email' do
     before do
-      @course_option = course_option_for_provider_code(provider_code: 'ABC')
-      @application_choice = create(:submitted_application_choice,
-                                   course_option: @course_option,
-                                   application_form:
-                                     create(
-                                       :completed_application_form,
-                                    ))
-      @provider_user = @application_choice.provider.provider_users.first
-      @mail = mailer.chase_provider_decision(@provider_user, @application_choice)
+      @mail = mailer.chase_provider_decision(provider_user, application_choice)
     end
 
     it 'sends an email with the correct subject' do
       expect(@mail.subject).to include(
         t('provider_application_waiting_for_decision.email.subject',
-          candidate_name: @application_choice.application_form.full_name),
+          candidate_name: application_choice.application_form.full_name),
         )
     end
 
     it 'addresses the provider user by name' do
-      expect(@mail.body.encoded).to include("Dear #{@provider_user.full_name}")
+      expect(@mail.body.encoded).to include("Dear #{provider_user.full_name}")
     end
 
     it 'includes the candidate name' do
-      expect(@mail.body.encoded).to include("#{@application_choice.application_form.full_name} submitted an application for")
+      expect(@mail.body.encoded).to include("#{application_choice.application_form.full_name} submitted an application for")
     end
 
     it 'includes the course details' do
-      expect(@mail.body.encoded).to include(@application_choice.course.name)
-      expect(@mail.body.encoded).to include(@application_choice.course.code)
+      expect(@mail.body.encoded).to include(application_choice.course.name)
+      expect(@mail.body.encoded).to include(application_choice.course.code)
     end
 
     it 'includes a readable submission date' do
-      submission_date = @application_choice.application_form.submitted_at
+      submission_date = application_choice.application_form.submitted_at
       expect(@mail.body.encoded).to include("on #{submission_date.to_s(:govuk_date).strip}")
     end
 
     it 'includes a link to the application' do
-      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: @application_choice.id))
+      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: application_choice.id))
     end
 
     it 'includes a readable RBD date' do
-      rbd_date = @application_choice.reject_by_default_at
+      rbd_date = application_choice.reject_by_default_at
       expect(@mail.body.encoded).to include("by #{rbd_date.to_s(:govuk_date).strip}")
     end
   end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -120,6 +120,11 @@ RSpec.describe ProviderMailer, type: :mailer do
       expect(@mail.body.encoded).to include("#{application_choice.application_form.full_name} submitted an application for")
     end
 
+    it 'includes the time limit when we start chasing providers' do
+      expected_days_left = "Only #{TimeLimitConfig.limits_for(:chase_provider_by).first.limit} working days left to respond"
+      expect(@mail.body.encoded).to include(expected_days_left)
+    end
+
     it 'includes the course details' do
       expect(@mail.body.encoded).to include(application_choice.course.name)
       expect(@mail.body.encoded).to include(application_choice.course.code)

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -106,4 +106,52 @@ RSpec.describe ProviderMailer, type: :mailer do
       expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: @application_choice.id))
     end
   end
+
+  describe 'Send provider decision chaser email' do
+    before do
+      @course_option = course_option_for_provider_code(provider_code: 'ABC')
+      @application_choice = create(:submitted_application_choice,
+                                   course_option: @course_option,
+                                   application_form:
+                                     create(
+                                       :completed_application_form,
+                                    ))
+      @provider_user = @application_choice.provider.provider_users.first
+      @mail = mailer.chase_provider_decision(@provider_user, @application_choice)
+    end
+
+    it 'sends an email with the correct subject' do
+      expect(@mail.subject).to include(
+        t('provider_application_waiting_for_decision.email.subject',
+          candidate_name: @application_choice.application_form.full_name),
+        )
+    end
+
+    it 'addresses the provider user by name' do
+      expect(@mail.body.encoded).to include("Dear #{@provider_user.full_name}")
+    end
+
+    it 'includes the candidate name' do
+      expect(@mail.body.encoded).to include("#{@application_choice.application_form.full_name} submitted an application for")
+    end
+
+    it 'includes the course details' do
+      expect(@mail.body.encoded).to include(@application_choice.course.name)
+      expect(@mail.body.encoded).to include(@application_choice.course.code)
+    end
+
+    it 'includes a readable submission date' do
+      submission_date = @application_choice.application_form.submitted_at
+      expect(@mail.body.encoded).to include("on #{submission_date.to_s(:govuk_date).strip}")
+    end
+
+    it 'includes a link to the application' do
+      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: @application_choice.id))
+    end
+
+    it 'includes a readable RBD date' do
+      rbd_date = @application_choice.reject_by_default_at
+      expect(@mail.body.encoded).to include("by #{rbd_date.to_s(:govuk_date).strip}")
+    end
+  end
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to send chaser emails to providers when they are halfway through their RBD period.
#### Content design:
![image](https://user-images.githubusercontent.com/22743709/73939097-9ea97000-48e0-11ea-8b5d-de44d2bd8f3d.png)

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR extends the provider mailer with a chaser email
### Email preview
![image](https://user-images.githubusercontent.com/22743709/73939074-92251780-48e0-11ea-9286-4e226e687a52.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/BTWWHYOj/836-email-%EF%B8%8F-a-decision-is-needed-on-an-application-because-it-has-been-submitted-for-20-working-days-to-provider

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
