### PR TITLE
Add feature flag for automated referee chaser

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -10,6 +10,7 @@ class FeatureFlag
     work_breaks
     experimental_api_features
     confirm_conditions
+    automated_referee_chaser
   ].freeze
 
   def self.activate(feature_name)

--- a/app/workers/send_chase_email_to_referees_worker.rb
+++ b/app/workers/send_chase_email_to_referees_worker.rb
@@ -2,6 +2,8 @@ class SendChaseEmailToRefereesWorker
   include Sidekiq::Worker
 
   def perform
+    return unless FeatureFlag.active?('automated_referee_chaser')
+
     GetRefereesToChase.call.each do |reference|
       SendChaseEmailToRefereeAndCandidate.call(application_form: reference.application_form, reference: reference)
     end

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Referee does not respond within 5 days', sidekiq: true do
 
   scenario 'A chase email is sent if a referee does not respond within 5 days' do
     FeatureFlag.activate('training_with_a_disability')
+    FeatureFlag.activate('automated_referee_chaser')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application


### PR DESCRIPTION
##  Context

We need to be careful to not turn on this feature before backfilling the data - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1299.

## Changes proposed in this pull request

This feature flag allows us to do a dry run on production first, to double check that we will be sending out the correct emails.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/WFu3BfcB/843-automatically-send-chase-email-to-candidate-and-referee-after-5-days

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
