### PR TITLE
Put Google Tag Manager behind a feature flag

### DIFF
--- a/app/helpers/content_helper.rb
+++ b/app/helpers/content_helper.rb
@@ -1,6 +1,12 @@
 module ContentHelper
   def render_content_page(page_name)
-    @converted_markdown = Govuk::MarkdownRenderer.render(File.read("app/views/content/#{page_name}.md")).html_safe
+    path_to_source = "app/views/content/#{page_name}.md"
+    markdown_source = if File.exist?("#{path_to_source}.erb")
+                        ERB.new(File.read("#{path_to_source}.erb")).result(binding)
+                      else
+                        File.read(path_to_source)
+                      end
+    @converted_markdown = Govuk::MarkdownRenderer.render(markdown_source).html_safe
     @page_name = page_name
     render 'rendered_markdown_template'
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -11,6 +11,7 @@ class FeatureFlag
     experimental_api_features
     confirm_conditions
     automated_referee_chaser
+    google_tag_manager
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/content/cookies_candidate.md.erb
+++ b/app/views/content/cookies_candidate.md.erb
@@ -10,6 +10,7 @@ Apply for teacher training cookies aren’t used to identify you personally.
 
 ## How we use cookies
 
+<% if FeatureFlag.active?('google_tag_manager') %>
 ### Measuring website usage (Google Analytics)
 
 We use Google Analytics software to collect information about how you use Apply for teacher training. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
@@ -32,6 +33,7 @@ Google Analytics sets the following cookies:
 | \_gat    | Throttle requests	                  | 10 minutes  |
 
 You can opt out of [Google Analytics](https://tools.google.com/dlpage/gaoptout).
+<% end %>
 
 ### Our introductory message
 

--- a/app/views/content/cookies_provider.md.erb
+++ b/app/views/content/cookies_provider.md.erb
@@ -10,6 +10,7 @@ Manage teacher training applications cookies aren’t used to identify you perso
 
 ## How we use cookies
 
+<% if FeatureFlag.active?('google_tag_manager') %>
 ### Measuring website usage (Google Analytics)
 
 We use Google Analytics software to collect information about how you use Manage teacher training applications. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.
@@ -32,6 +33,7 @@ Google Analytics sets the following cookies:
 | \_gat    | Throttle requests	                  | 10 minutes  |
 
 You can opt out of [Google Analytics](https://tools.google.com/dlpage/gaoptout).
+<% end %>
 
 ### Our introductory message
 

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -23,7 +23,7 @@
 
     <%= stylesheet_pack_tag 'application', media: 'all' %>
 
-    <% unless Rails.env.development? %>
+    <% if !Rails.env.development? && FeatureFlag.active?('google_tag_manager') %>
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/spec/system/candidate_interface/candidate_viewing_cookie_policy_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_cookie_policy_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Viewing cookie policy' do
+  scenario 'Candidate views the cookie policy' do
+    given_i_am_on_the_candidate_interface
+    when_i_can_click_on_cookie_policy
+    then_i_can_see_the_cookie_policy
+  end
+
+  def given_i_am_on_the_candidate_interface
+    visit '/'
+  end
+
+  def when_i_can_click_on_cookie_policy
+    within('.govuk-footer') { click_link t('layout.cookie_policy') }
+  end
+
+  def then_i_can_see_the_cookie_policy
+    expect(page).to have_content(t('page_titles.cookies_candidate'))
+  end
+end


### PR DESCRIPTION
## Context

It's useful to be able to disable Google Tag Manager in certain environments.

## Changes proposed in this pull request

- put the Google Tag Manager code behind a feature flag
- add spec coverage for candidates visiting the cookie page
- extend the Markdown rendering mechanism to be able to pre-process the source with ERB first, if `.erb` is in the name
- don't display cookie information about Google Tag Manager if the feature flag is switched off

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
