### PR TITLE
Clarify why we are asking eligibility questions

### DIFF
--- a/app/views/candidate_interface/start_page/eligibility.html.erb
+++ b/app/views/candidate_interface/start_page/eligibility.html.erb
@@ -10,7 +10,11 @@
         <%= t('page_titles.eligibility') %>
       </h1>
 
-      <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK, EU or EEA?', tag: 'span' } do %>
+      <p class="govuk-body">This service is new so it’s not ready for everyone yet. Check if we’re ready for you by answering the questions below.</p>
+
+      <p class="govuk-body govuk-!-margin-bottom-7">If you can’t use our service, you can still apply for teacher training through&nbsp;<%= govuk_link_to 'UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %>.</p>
+
+      <%= f.govuk_radio_buttons_fieldset :eligible_citizen, inline: true, legend: { size: 'm', text: 'Are you a citizen of the UK or the EU?', tag: 'span' } do %>
         <%= f.govuk_radio_button :eligible_citizen, 'yes', label: { text: 'Yes' }, link_errors: true %>
         <%= f.govuk_radio_button :eligible_citizen, 'no', label: { text: 'No' } %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
     edit_application_form: Edit your application
     application_dashboard: Application dashboard
     application_edit: Editing your application
-    eligibility: First, check you can use this service
+    eligibility: Check we’re ready for you to use this service
     error_prefix: 'Error: '
     success_prefix: 'Success: '
     not_eligible_yet: We’re sorry, but we’re not ready for you yet

--- a/spec/system/candidate_interface/candidate_eligibility_spec.rb
+++ b/spec/system/candidate_interface/candidate_eligibility_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Candidate eligibility' do
   end
 
   def and_i_answer_no_to_some_questions
-    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
+    within_fieldset('Are you a citizen of the UK or the EU?') do
       choose 'No'
     end
 
@@ -49,7 +49,7 @@ RSpec.feature 'Candidate eligibility' do
   end
 
   def when_i_answer_yes_to_all_questions
-    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
+    within_fieldset('Are you a citizen of the UK or the EU?') do
       choose 'Yes'
     end
 

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   end
 
   def when_i_fill_in_the_eligiblity_form_with_yes
-    within_fieldset('Are you a citizen of the UK, EU or EEA?') do
+    within_fieldset('Are you a citizen of the UK or the EU?') do
       choose 'Yes'
     end
 


### PR DESCRIPTION
- It's us and not you, research showed us that candidates weren't sure what these questions were about. We set the context if they answered no, but not beforehand
- Remove "EEA" as it was confusing, we temporarily exclude citizens of Lichtenstein, Norway and Iceland from our pilot by doing this

![Screen Shot 2020-02-07 at 10 54 22](https://user-images.githubusercontent.com/319055/74023715-36b66080-4998-11ea-9ee5-442778f276a8.png)

https://trello.com/c/EOZDqPD7/888-making-it-clear-why-were-asking-the-eligibility-questions