### PR TITLE
Clarify reference example

### DIFF
--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -296,7 +296,7 @@ en:
         label: Full name
       relationship:
         label: What is your relationship to this referee and how long have you known them?
-        hint_text: For example, ‘They were the headteacher at my secondary school between 2003 and 2005’
+        hint_text: For example, ‘They were the headteacher at the school where I worked between 2003 and 2005’
       review:
         button: Continue
       sure_delete_entry: Yes I’m sure - delete this referee


### PR DESCRIPTION
Giving the headteacher of where you went to school as a reference wouldn't be appropriate. An old headteacher is not a good reference. A provider suggested it implies that no one from their adult career/studies wants to give a reference.

A headteacher at a place you have volunteered or worked as an adult is a good reference.