### PR TITLE
Drop ChaseProviderDecisionAt From ApplicationChoices table

### DIFF
--- a/db/migrate/20200210102130_drop_chase_provider_decision_at_from_application_choices.rb
+++ b/db/migrate/20200210102130_drop_chase_provider_decision_at_from_application_choices.rb
@@ -1,0 +1,7 @@
+class DropChaseProviderDecisionAtFromApplicationChoices < ActiveRecord::Migration[6.0]
+  def change
+    # rubocop:disable Rails/ReversibleMigration
+    remove_column :application_choices, :chase_provider_decision_at
+    # rubocop:enable Rails/ReversibleMigration
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
As flagged by @tijmenb on https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1298 reverting a migration won't drop the column from the DB. This migration is to drop the redundant column. 

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
Drop ChaseProviderDecisionAt From ApplicationChoices table from DB as we won't need it

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
