### PR TITLE
Add authorisation service to enforce make_offer user/course association

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -19,11 +19,15 @@ module ProviderInterface
     end
 
     def new_offer
-      @application_offer = MakeAnOffer.new(application_choice: @application_choice)
+      @application_offer = MakeAnOffer.new(
+        actor: current_provider_user,
+        application_choice: @application_choice,
+      )
     end
 
     def confirm_offer
       @application_offer = MakeAnOffer.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
         standard_conditions: make_an_offer_params[:standard_conditions],
         further_conditions: make_an_offer_params.permit(
@@ -40,6 +44,7 @@ module ProviderInterface
       offer_conditions_array = JSON.parse(params.dig(:offer_conditions))
 
       @application_offer = MakeAnOffer.new(
+        actor: current_provider_user,
         application_choice: @application_choice,
         offer_conditions: offer_conditions_array,
       )

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -3,7 +3,12 @@ module VendorApi
     before_action :validate_metadata!
 
     def make_offer
+      api_user = VendorApiUser.find_or_initialize_by(
+        vendor_api_token_id: @current_vendor_api_token.id,
+      )
+
       decision = MakeAnOffer.new(
+        actor: api_user,
         application_choice: application_choice,
         offer_conditions: params.dig(:data, :conditions),
         course_data: params.dig(:data, :course),

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -85,26 +85,30 @@ module TestApplications
     return if state == :awaiting_provider_decision
 
     if state == :offer
-      MakeAnOffer.new(application_choice: choice, offer_conditions: ['Complete DBS']).save
+      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
     elsif state == :rejected
       RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
     elsif state == :declined
-      MakeAnOffer.new(application_choice: choice, offer_conditions: ['Complete DBS']).save
+      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       DeclineOffer.new(application_choice: choice).save!
     elsif state == :accepted
-      MakeAnOffer.new(application_choice: choice, offer_conditions: ['Complete DBS']).save
+      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       AcceptOffer.new(application_choice: choice).save!
     elsif state == :recruited
-      MakeAnOffer.new(application_choice: choice, offer_conditions: ['Complete DBS']).save
+      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       AcceptOffer.new(application_choice: choice).save!
       ConfirmOfferConditions.new(application_choice: choice).save
     elsif state == :enrolled
-      MakeAnOffer.new(application_choice: choice, offer_conditions: ['Complete DBS']).save
+      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       AcceptOffer.new(application_choice: choice).save!
       ConfirmOfferConditions.new(application_choice: choice).save
       ConfirmEnrolment.new(application_choice: choice).save
     elsif state == :withdrawn
       WithdrawApplication.new(application_choice: choice).save!
     end
+  end
+
+  def self.actor
+    SupportUser.first_or_initialize
   end
 end

--- a/app/models/vendor_api_user.rb
+++ b/app/models/vendor_api_user.rb
@@ -4,4 +4,8 @@ class VendorApiUser < ApplicationRecord
   validates :email_address, presence: true
   validates :vendor_user_id, presence: true
   validates :full_name, presence: true
+
+  def providers
+    [vendor_api_token.provider]
+  end
 end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -1,6 +1,7 @@
 class MakeAnOffer
   attr_accessor :standard_conditions
   attr_accessor :further_conditions0, :further_conditions1, :further_conditions2, :further_conditions3
+  attr_accessor :auth
 
   include ActiveModel::Validations
 
@@ -12,12 +13,14 @@ class MakeAnOffer
   validate :validate_further_conditions
 
   def initialize(
+    actor:,
     application_choice:,
     offer_conditions: nil,
     standard_conditions: nil,
     further_conditions: {},
     course_data: nil
   )
+    @auth = ProviderAuthorisation.new(actor: actor)
     @application_choice = application_choice
     @offer_conditions = offer_conditions
     @standard_conditions = standard_conditions
@@ -27,6 +30,8 @@ class MakeAnOffer
 
   def save
     return unless valid?
+
+    @auth.assert_can_make_offer! application_choice: application_choice
 
     ApplicationStateChange.new(application_choice).make_offer!
     application_choice.offered_course_option = offered_course_option

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -1,0 +1,17 @@
+class ProviderAuthorisation
+  PERMISSION_METHOD_REGEXP = /^can_(\w+)\?$/.freeze
+
+  def initialize(actor:)
+    @actor = actor
+  end
+
+  def can_make_offer?(application_choice:)
+    @actor.is_a?(SupportUser) || @actor.providers.include?(application_choice.course.provider)
+  end
+
+  def assert_can_make_offer!(application_choice:)
+    raise ProviderAuthorisation::NotAuthorisedError, 'assert_can_make_offer!' if !can_make_offer?(application_choice: application_choice)
+  end
+
+  class NotAuthorisedError < StandardError; end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -233,6 +233,10 @@ FactoryBot.define do
     provider
 
     hashed_token { '1234567890' }
+
+    trait :with_random_token do
+      hashed_token { _unhashed_token, hashed_token = Devise.token_generator.generate(VendorApiToken, :hashed_token); hashed_token }
+    end
   end
 
   factory :reference, class: 'ApplicationReference' do

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe ProviderAuthorisation do
+  include CourseOptionHelpers
+
+  describe 'assert! methods' do
+    it 'raise errors if the corresponding permission methods return false' do
+      auth_context = ProviderAuthorisation.new(actor: nil)
+      allow(auth_context).to receive(:can_make_offer?).and_return(true)
+      expect { auth_context.assert_can_make_offer!(application_choice: nil) }.not_to raise_error
+      allow(auth_context).to receive(:can_make_offer?).and_return(false)
+      expect { auth_context.assert_can_make_offer!(application_choice: nil) }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
+    end
+  end
+
+  describe '#can_make_offer?' do
+    context 'with provider user' do
+      let(:agreement) { create(:provider_agreement) } # easiest way to associate provider and provider_user
+      let(:provider_user) { agreement.provider_user }
+
+      it 'is false if user is not associated with the provider that offers the course' do
+        application_choice = create(:application_choice, :awaiting_provider_decision)
+        auth_context = ProviderAuthorisation.new(actor: provider_user)
+        expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_falsy
+      end
+
+      it 'is true if user is associated with the provider that offers the course' do
+        course_option = course_option_for_provider(provider: agreement.provider)
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
+        auth_context = ProviderAuthorisation.new(actor: provider_user)
+        expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_truthy
+      end
+
+      it 'is true even if user is associated with multiple providers' do
+        new_provider = create(:provider)
+        new_provider.provider_users << provider_user
+        course_option = course_option_for_provider(provider: new_provider)
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
+        auth_context = ProviderAuthorisation.new(actor: provider_user)
+        expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_truthy
+      end
+    end
+
+    context 'with support user' do
+      it 'is true no matter what' do
+        application_choice = create(:application_choice, :awaiting_provider_decision)
+        auth_context = ProviderAuthorisation.new(actor: create(:support_user))
+        expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_truthy
+      end
+    end
+
+    context 'with api key' do
+      it 'is false if api key is not associated with the provider that offers the course' do
+        application_choice = create(:application_choice, :awaiting_provider_decision)
+        auth_context = ProviderAuthorisation.new(actor: create(:vendor_api_user))
+        expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_falsy
+      end
+
+      it 'is true if api key is associated with the provider that offers the course' do
+        vendor_api_user = create(:vendor_api_user)
+        course_option = course_option_for_provider(provider: vendor_api_user.vendor_api_token.provider)
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
+        auth_context = ProviderAuthorisation.new(actor: vendor_api_user)
+        expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_truthy
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

As the service scales and more providers join, we'll be onboarding increasing numbers of provider users. These users will be responsible for managing applications for their associated providers, but we are already researching scenaria which require different levels of access, either on a per user or per provider level.

There is no explicit authorisation framework within the app yet. In most cases, authorisation is either minimal/implicit (checks in controller actions) or missing. For example, provider users can make offers on courses unrelated to any of their providers through the API. Going forward, we'll need a consistent way to express and enforce such rules for the applications workflow.

State transitions within the app are already organised/performed through services. These services currently lack authorisation logic, operating outside any notions of user/actor/client. A weak association of such calls with a user actually already exists, in the form of attribution/auditing, but this is not well suited for authorisation. To identify a good authorisation pattern around services, a number of different options were considered:

- make authorisation part of state transitions within workflow gem (pros: we already handle state transition exceptions / cons: current implementation is intentionally minimal; and how do we pass the user context?)
- pass a user/agent/client context to the service and make it the service's responsibility to check authorisation (pros: easy to follow, works well for both UI and API contexts / cons: adding more responsibility to services)
- pass a user/agent/client context to the service but use meta-programming so that authorisation happens behind the scenes with no changes to service logic (pros: programmers follow existing service guidelines without worrying about authorisation / cons: if we are passing a user context, we might as well be explicit about using it)
- expect controller to authorise actions outside the service and only call services if authorisation steps succeed (pros: no changes, this is the current approach / cons: inconsistent, authorisation logic for same service will be scattered/replicated in multiple controllers)

We have decided to make authorisation the responsibility of the service (second option), but pass a pre-configured authorisation context rather a user, which should work well regardless of the controller context (UI vs API) and provide a consistent authorisation API.

Using an authorisation context rather than a user helps us deal with the fact that api keys are currently not associated with a list of providers but with a single provider, whereas provider users can be associated with multiple providers. Both api keys and provider users are allowed to make offers. The providers association is key for validating this specific use case, i.e. that the calling party has permission to offer a specific course.

### Changes proposed in this pull request

Add `ProviderAuthorisation` service, which is configured with an actor context, representing a provider user, support user or api key. `MakeAnOffer` service requires a new keyword `actor:` and uses a `ProviderAuthorisation` object to determine if this user has permission to offer this application choice.

In the calling code:

```ruby
result = MakeAnOffer.new(actor: current_provider_user, application_choice: a).save
```

Within the service:

```ruby
def initialize(actor: actor, ....)
  @auth = ProviderAuthorisation.new(actor: actor)
  ...
end

def save
  @auth.assert_can_make_offer! application_choice: application_choice
  ...
end
```

The default interface to `ProviderAuthorisation` is expected to raise errors if actions are not allowed, because in most situations the user should only be presented with actions they are allowed to perform in the UI. If a service expects authorisation to fail as part of normal operation, this is a special case and errors can be handled in the service code.

For the very specific case of making offers, `#can_make_offer?` checks the list of providers associated with the user (api tokens are currently only associated with one provider each). Passing a `SupportUser` to the `ProviderAuthorisation` context will skip `providers` checks.

### Guidance to review

Run the specs, read the code. It is hard to make an offer for an unrelated course within the UI. Not so hard through the API.

### Link to Trello card

[1623 - Prevent provider users from making offers on courses none of their associated providers run](https://trello.com/c/aYMUGX4C)