### PR TITLE
Add ability to add another job when there is a break

### DIFF
--- a/app/components/break_in_work_history_component.html.erb
+++ b/app/components/break_in_work_history_component.html.erb
@@ -1,7 +1,10 @@
 <section class="app-summary-card govuk-!-margin-bottom-6">
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
-      You have a break in your work history (<%= pluralize(break_in_months, 'month') %>)
+      You have a break in your work history (<%= pluralize(work_break.length, 'month') %>)
     </h3>
+    <div class="app-summary-card__actions">
+      <%= govuk_link_to t('application_form.work_history.add_another_job'), candidate_interface_work_history_new_path(start_date: work_break.start_date, end_date: work_break.end_date) %>
+    </div>
   </header>
 </section>

--- a/app/components/break_in_work_history_component.rb
+++ b/app/components/break_in_work_history_component.rb
@@ -1,7 +1,9 @@
 class BreakInWorkHistoryComponent < ActionView::Component::Base
-  attr_reader :break_in_months
+  include ViewHelper
+
+  attr_reader :work_break
 
   def initialize(work_break:)
-    @break_in_months = work_break.length
+    @work_break = work_break
   end
 end

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -3,7 +3,19 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_not_amendable
 
     def new
-      @work_experience_form = WorkExperienceForm.new
+      @work_experience_form = if params[:start_date] && params[:end_date]
+                                start_date = params[:start_date].to_date
+                                end_date = params[:end_date].to_date
+
+                                WorkExperienceForm.new(
+                                  start_date_month: start_date.month,
+                                  start_date_year: start_date.year,
+                                  end_date_month: end_date.month,
+                                  end_date_year: end_date.year,
+                                )
+                              else
+                                WorkExperienceForm.new
+                              end
     end
 
     def create

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -5,7 +5,11 @@ class WorkHistoryWithBreaks
     end
 
     def start_date
-      @month_range.first
+      @month_range.first.prev_month
+    end
+
+    def end_date
+      @month_range.last.next_month
     end
 
     def length

--- a/spec/components/break_in_work_history_component_spec.rb
+++ b/spec/components/break_in_work_history_component_spec.rb
@@ -1,12 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe BreakInWorkHistoryComponent do
-  it 'renders the component with the break in months' do
-    work_break = double
-    allow(work_break).to receive(:length).and_return(3)
+  let(:work_break) { double }
 
+  before do
+    allow(work_break).to receive(:length).and_return(3)
+    allow(work_break).to receive(:start_date).and_return(Date.new(2020, 1, 1))
+    allow(work_break).to receive(:end_date).and_return(Date.new(2020, 5, 1))
+  end
+
+  it 'renders the component with the break in months' do
     result = render_inline(BreakInWorkHistoryComponent, work_break: work_break)
 
     expect(result.text).to include('You have a break in your work history (3 months)')
+  end
+
+  it 'renders the component with a link to add another job' do
+    result = render_inline(BreakInWorkHistoryComponent, work_break: work_break)
+
+    expect(result.text).to include('Add another job')
   end
 end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -65,6 +65,8 @@ RSpec.describe WorkHistoryWithBreaks do
         expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
         expect(work_history_with_breaks[1][:type]).to eq(:break_placeholder)
         expect(work_history_with_breaks[1][:entry].length).to eq(1)
+        expect(work_history_with_breaks[1][:entry].start_date).to eq(Date.new(2019, 12, 1))
+        expect(work_history_with_breaks[1][:entry].end_date).to eq(Date.new(2020, 2, 1))
       end
 
       it 'returns an array containing a hash for a job and a break if more than a month break' do

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -36,14 +36,14 @@ RSpec.feature 'Entering their work history' do
     when_i_click_on_add_another_job
     and_i_fill_in_the_job_form_with_another_job_with_a_break # 3/2019 - current
     and_i_do_not_fill_in_end_date
-
     then_i_should_see_my_second_job
-
     and_i_should_see_the_length_of_the_gap_in_months # 1 months
-    and_i_should_not_see_0_months_gap
-
     and_i_should_be_asked_to_explain_the_break_in_my_work_history
 
+    when_i_click_add_another_job_for_my_break
+    then_i_should_see_the_start_and_end_date_filled_in
+
+    given_i_am_on_review_work_history_page
     when_i_click_to_enter_break_explanation
     then_i_see_the_work_history_break_form
 
@@ -171,7 +171,7 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_click_on_add_another_job
-    click_link t('application_form.work_history.add_another_job')
+    all('a', text: 'Add another job')[1].click
   end
 
   def and_i_fill_in_the_job_form
@@ -207,12 +207,23 @@ RSpec.feature 'Entering their work history' do
     expect(page).to have_content('You have a break in your work history (1 month)')
   end
 
-  def and_i_should_not_see_0_months_gap
-    expect(page).not_to have_content('(0 months)')
-  end
-
   def and_i_should_be_asked_to_explain_the_break_in_my_work_history
     expect(page).to have_content(t('application_form.work_history.break.label'))
+  end
+
+  def when_i_click_add_another_job_for_my_break
+    first(:link, t('application_form.work_history.add_another_job')).click
+  end
+
+  def then_i_should_see_the_start_and_end_date_filled_in
+    expect(page).to have_selector("input[value='1']")
+    expect(page).to have_selector("input[value='2019']")
+    expect(page).to have_selector("input[value='3']")
+    expect(page).to have_selector("input[value='2019']")
+  end
+
+  def given_i_am_on_review_work_history_page
+    visit candidate_interface_work_history_show_path
   end
 
   def when_i_click_to_enter_break_explanation


### PR DESCRIPTION
## Context

Currently, we can see when a break has occurred in a candidate's work history - https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1167, https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1295. What's missing now is allowing the candidate to enter a reason and being able to add another job in place of the break.

## Changes proposed in this pull request

This PR adds the `Add another job` link to a break. When a candidate clicks on the link they are taken to the add job with the start and end date filled in already.

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/74145768-88105b00-4bf7-11ea-8aa8-6e646be436fb.png)

![image](https://user-images.githubusercontent.com/42817036/74145793-91012c80-4bf7-11ea-9a7e-642e20268210.png)

## Guidance to review

Is using get params to way to go? Can't think of another way of doing it.

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
