### PR TITLE
Remove GTM code left behind after PR #1304

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -25,10 +25,6 @@
   </head>
 
   <body class="govuk-template__body">
-    <% unless Rails.env.development? %>
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KW7NPTJ"
-    height="0" width="0" style="display:none; visibility:hidden"></iframe></noscript>
-    <% end %>
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>


### PR DESCRIPTION
## Context

PR #1304 didn't quite get rid of all Google Tag Manager code.

## Changes proposed in this pull request

- remove (hopefully) the last bits of GTM

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
