### PR TITLE
Correct reference chasing dates

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -18,13 +18,13 @@ module SupportInterface
     def rows
       [
         status_row,
-        requested_row,
+        date_rows,
         name_row,
         email_address_row,
         relationship_row,
         consent_row,
         feedback_row,
-      ].compact
+      ].flatten.compact
     end
 
   private
@@ -38,11 +38,21 @@ module SupportInterface
       }
     end
 
-    def requested_row
-      {
-        key: 'Requested at',
-        value: reference.requested_at&.to_s(:govuk_date_and_time),
-      }
+    def date_rows
+      [
+        {
+          key: 'Requested on',
+          value: reference.requested_at&.to_s(:govuk_date_and_time),
+        },
+        {
+          key: 'Chase on',
+          value: reference.chase_referee_at&.to_s(:govuk_date_and_time),
+        },
+        {
+          key: 'Replace on',
+          value: reference.replace_referee_at&.to_s(:govuk_date_and_time),
+        },
+      ].select { |row| row[:value] }
     end
 
     def name_row

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -14,6 +14,12 @@ class TimeLimitConfig
     chase_provider_by: [
       Rule.new(nil, nil, 20),
     ],
+    chase_referee_by: [
+      Rule.new(nil, nil, 5),
+    ],
+    replace_referee_by: [
+      Rule.new(nil, nil, 10),
+    ],
   }.freeze
 
   def self.limits_for(rule)

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -46,4 +46,16 @@ class ApplicationReference < ApplicationRecord
     hashed_token = Devise.token_generator.digest(ApplicationReference, :hashed_sign_in_token, unhashed_token)
     find_by(hashed_sign_in_token: hashed_token)
   end
+
+  def chase_referee_at
+    return unless requested_at
+
+    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: requested_at).call.second
+  end
+
+  def replace_referee_at
+    return unless requested_at
+
+    TimeLimitCalculator.new(rule: :replace_referee_by, effective_date: requested_at).call.second
+  end
 end

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -2,7 +2,7 @@ class GetRefereesToChase
   def self.call
     ApplicationReference
       .feedback_requested
-      .where(['requested_at < ?', Time.zone.now - 5.days])
+      .where(['requested_at < ?', 5.business_days.ago])
       .where.not(id: ChaserSent.reference_request.select(:chased_id))
   end
 end

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -2,7 +2,11 @@ class GetRefereesToChase
   def self.call
     ApplicationReference
       .feedback_requested
-      .where(['requested_at < ?', 5.business_days.ago])
+      .where(['requested_at < ?', chase_referee_time_limit])
       .where.not(id: ChaserSent.reference_request.select(:chased_id))
+  end
+
+  def self.chase_referee_time_limit
+    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: Time.zone.now).call[2]
   end
 end

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -2,7 +2,7 @@ class GetRefereesToChase
   def self.call
     ApplicationReference
       .feedback_requested
-      .where(['created_at < ?', Time.zone.now - 5.days])
+      .where(['requested_at < ?', Time.zone.now - 5.days])
       .where.not(id: ChaserSent.reference_request.select(:chased_id))
   end
 end

--- a/app/services/time_limit_calculator.rb
+++ b/app/services/time_limit_calculator.rb
@@ -8,15 +8,21 @@ class TimeLimitCalculator
 
   def call
     days = calculate_days
-    [days, calculate_time(days)]
+    [days, calculate_time_in_future(days), calculate_time_in_past(days)]
   end
 
 private
 
-  def calculate_time(days)
+  def calculate_time_in_future(days)
     return nil unless days
 
     days.business_days.after(effective_date).end_of_day
+  end
+
+  def calculate_time_in_past(days)
+    return nil unless days
+
+    days.business_days.before(effective_date).end_of_day
   end
 
   def calculate_days

--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -1,28 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe GetRefereesToChase do
-  describe '#perform' do
+  describe '.call' do
     it 'returns referees that were sent their reference email more than 5 days ago and have not already been chased' do
-      reference = create(:reference, feedback_status: 'feedback_requested', created_at: 6.days.ago)
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.days.ago)
 
       expect(described_class.call).to include reference
     end
 
     it 'only returns application choices which are awaiting references' do
-      create(:reference, :complete, created_at: 6.days.ago)
+      create(:reference, :complete, requested_at: 6.days.ago)
 
       expect(described_class.call).to be_empty
     end
 
     it 'does not return referees which were sent their reference email less than 5 days ago' do
-      create(:reference, feedback_status: 'feedback_requested', created_at: 4.days.ago)
+      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.days.ago)
 
       expect(described_class.call).to be_empty
     end
 
 
     it 'does not return referess who have already been sent a chase email' do
-      reference = create(:reference, feedback_status: 'feedback_requested', created_at: 6.days.ago)
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.days.ago)
 
       SendChaseEmailToRefereeAndCandidate.call(application_form: reference.application_form, reference: reference)
 

--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -3,26 +3,26 @@ require 'rails_helper'
 RSpec.describe GetRefereesToChase do
   describe '.call' do
     it 'returns referees that were sent their reference email more than 5 days ago and have not already been chased' do
-      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.days.ago)
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.business_days.ago)
 
       expect(described_class.call).to include reference
     end
 
     it 'only returns application choices which are awaiting references' do
-      create(:reference, :complete, requested_at: 6.days.ago)
+      create(:reference, :complete, requested_at: 6.business_days.ago)
 
       expect(described_class.call).to be_empty
     end
 
     it 'does not return referees which were sent their reference email less than 5 days ago' do
-      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.days.ago)
+      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.business_days.ago)
 
       expect(described_class.call).to be_empty
     end
 
 
     it 'does not return referess who have already been sent a chase email' do
-      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.days.ago)
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.business_days.ago)
 
       SendChaseEmailToRefereeAndCandidate.call(application_form: reference.application_form, reference: reference)
 

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day]
+    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day, Time.zone.local(2019, 5, 1).end_of_day]
   end
 
   it 'returns value for rule with `from_date` when effective date matches rule' do
@@ -31,7 +31,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [10, Time.zone.local(2019, 6, 17).end_of_day]
+    expect(calculator.call).to eq [10, Time.zone.local(2019, 6, 17).end_of_day, Time.zone.local(2019, 5, 16).end_of_day]
   end
 
   it 'returns value for default rule rather than one with `from_date` when effective date does not match rule' do
@@ -45,7 +45,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day]
+    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day, Time.zone.local(2019, 5, 1).end_of_day]
   end
 
   it 'returns value for rule with `to_date` and `from_date` when effective date matches rule' do
@@ -60,7 +60,7 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [5, Time.zone.local(2019, 6, 10).end_of_day]
+    expect(calculator.call).to eq [5, Time.zone.local(2019, 6, 10).end_of_day, Time.zone.local(2019, 5, 23).end_of_day]
   end
 
   it 'returns nil when there is no rule for the given effective date' do
@@ -69,6 +69,6 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: 20.days.ago,
     )
-    expect(calculator.call).to eq [nil, nil]
+    expect(calculator.call).to eq [nil, nil, nil]
   end
 end

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Referee does not respond within 5 days', sidekiq: true do
   end
 
   def and_the_referee_does_not_respond_within_5_days
-    Timecop.travel(Time.zone.now + 5.days + 1.second) do
+    Timecop.travel(6.business_days.from_now) do
       SendChaseEmailToRefereesWorker.perform_async
     end
   end


### PR DESCRIPTION
##  Context

We currently look at the `created_at` for references when deciding when to sent a chaser. We should look at the time was sent, otherwise we’re going to shorten the allowed period for referees.

This PR depends on https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1316 having been **deployed**.

## Changes proposed in this pull request

- Use `requested_at`
- Use business days

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/5AQezpqR

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
