### PR TITLE
Make provider email subject more readable

### DIFF
--- a/config/locales/provider_notifications.yml
+++ b/config/locales/provider_notifications.yml
@@ -7,7 +7,7 @@ en:
       subject: Application received for %{course_name_and_code}
   provider_application_rejected_by_default:
     email:
-      subject: '%{candidate_name}’s application rejected automatically'
+      subject: '%{candidate_name}’s application was rejected automatically'
   provider_application_waiting_for_decision:
     email:
       subject: 'Respond to %{candidate_name}’s application'


### PR DESCRIPTION
## Context

"John Smith's application was rejected automatically" reads a bit better than "John Smith's application rejected automatically".

<img width="855" alt="Screenshot 2020-02-10 at 14 23 28" src="https://user-images.githubusercontent.com/642279/74157869-f3b2f200-4c10-11ea-8c60-9882c629683a.png">

## Changes proposed in this pull request

Change the subject line.

