### PR TITLE
Refactor provider select page to have a drop down bar

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -2,10 +2,13 @@ require.context("govuk-frontend/govuk/assets");
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
 import initNationalityAutocomplete from "./nationality-autocomplete";
 import initCoursesAutocomplete from "./courses-autocomplete";
+import initProvidersAutocomplete from "./providers-autocomplete";
+
 
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import "../styles/application.scss";
 govUKFrontendInitAll();
 
 initNationalityAutocomplete();
+initProvidersAutocomplete();
 initCoursesAutocomplete();

--- a/app/frontend/packs/providers-autocomplete.js
+++ b/app/frontend/packs/providers-autocomplete.js
@@ -1,0 +1,27 @@
+import accessibleAutocomplete from "accessible-autocomplete";
+
+const initProvidersAutocomplete = () => {
+  try {
+    [
+      "#candidate-interface-pick-provider-form-code-field",
+      "#candidate-interface-pick-provider-form-code-field-error"
+    ].forEach(id => {
+      const providersSelect = document.querySelector(id);
+
+      if (!providersSelect) return;
+
+      // Replace "Select a provider" with empty string
+      providersSelect.querySelector("[value='']").innerHTML = "";
+
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: providersSelect,
+        showAllValues: true,
+        confirmOnBlur: false
+      });
+    });
+  } catch (err) {
+    console.error("Could not enhance providers select:", err);
+  }
+};
+
+export default initProvidersAutocomplete;

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -33,6 +33,12 @@ module ViewHelper
     ] + courses.map { |course| OpenStruct.new(id: course.code, name: "#{course.name} (#{course.code})") }
   end
 
+  def select_provider_options(providers)
+    [
+      OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_provider_form.attributes.code.blank')),
+    ] + providers.map { |provider| OpenStruct.new(id: provider.code, name: "#{provider.name} (#{provider.code})") }
+  end
+
   def submitted_at_date
     dates = ApplicationDates.new(@application_form)
     dates.submitted_at.to_s(:govuk_date).strip

--- a/app/models/candidate_interface/pick_provider_form.rb
+++ b/app/models/candidate_interface/pick_provider_form.rb
@@ -11,7 +11,7 @@ module CandidateInterface
 
     def available_providers
       @available_providers ||= begin
-        Course.includes(:provider).exposed_in_find.map(&:provider).uniq.sort_by(&:name)
+        Provider.all.order(:name)
       end
     end
   end

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -6,16 +6,12 @@
     <%= form_with model: @pick_provider, url: candidate_interface_course_choices_provider_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :code, legend: { size: 'xl', text: t('page_titles.which_provider') } do %>
-        <div class="govuk-!-margin-top-6">
-          <% @pick_provider.available_providers.each_with_index do |provider, i| %>
-            <%= f.govuk_radio_button :code, provider.code, label: { text: "#{provider.name} (#{provider.code})" }, link_errors: i.zero? %>
+      <%= f.govuk_collection_select :code, select_provider_options(@pick_provider.available_providers), :id, :name, label: { text: t('page_titles.which_provider'), size: 'xl' } do %>
+        <p class="govuk-body">You can
+          <%= link_to candidate_interface_providers_path, class: 'govuk-link' do %>
+            preview a list of training providers and courses
           <% end %>
-
-          <%= f.govuk_radio_divider %>
-
-          <%= f.govuk_radio_button :code, :other, label: { text: 'Another provider' } %>
-        </div>
+        currently available on Apply for teacher training.</p>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/spec/models/candidate_interface/pick_provider_form_spec.rb
+++ b/spec/models/candidate_interface/pick_provider_form_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickProviderForm do
   describe '#available_providers' do
-    it 'returns providers with available courses' do
+    it 'returns all providers' do
       create(:provider, name: 'School without courses')
       create(:course, open_on_apply: false, exposed_in_find: false, provider: create(:provider, name: 'School with disabled courses'))
       create(:course, open_on_apply: true, exposed_in_find: true, provider: create(:provider, name: 'School with courses'))
 
       form = CandidateInterface::PickProviderForm.new({})
 
-      expect(form.available_providers.map(&:name)).to eql(['School with courses'])
+      expect(form.available_providers.map(&:name)).to eql(['School with courses', 'School with disabled courses', 'School without courses'])
     end
   end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -95,7 +95,7 @@ module CandidateHelper
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
 
-    choose 'Gorse SCITT (1N1)'
+    select 'Gorse SCITT (1N1)'
     click_button 'Continue'
 
     select 'Primary (2XT2)'

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -100,7 +100,7 @@ RSpec.feature 'A candidate edits their course choice after submission' do
     click_link 'Continue'
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
-    choose 'Gorse SCITT (1N1)'
+    select 'Gorse SCITT (1N1)'
     click_button 'Continue'
     select 'Primary (2XT2)'
     click_button 'Continue'

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -11,10 +11,6 @@ RSpec.feature 'Selecting a course not on Apply' do
     and_i_click_on_course_choices
     and_i_click_on_add_course
     and_i_choose_that_i_know_where_i_want_to_apply
-    and_i_choose_another_provider
-    then_i_see_that_i_should_apply_on_ucas
-
-    when_i_click_on_back
     and_i_choose_a_provider
     and_i_choose_another_course
     then_i_see_that_i_should_apply_on_ucas
@@ -52,21 +48,12 @@ RSpec.feature 'Selecting a course not on Apply' do
     click_button 'Continue'
   end
 
-  def and_i_choose_another_provider
-    choose 'Another provider'
-    click_button 'Continue'
-  end
-
   def then_i_see_that_i_should_apply_on_ucas
     expect(page).to have_content(t('page_titles.not_eligible_yet'))
   end
 
-  def when_i_click_on_back
-    click_link 'Back'
-  end
-
   def and_i_choose_a_provider
-    choose 'Gorse SCITT (1N1)'
+    select 'Gorse SCITT (1N1)'
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -113,7 +113,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_a_provider
-    choose 'Gorse SCITT (1N1)'
+    select 'Gorse SCITT (1N1)'
     click_button 'Continue'
   end
 
@@ -159,7 +159,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_another_provider
-    choose 'Royal Academy of Dance (R55)'
+    select 'Royal Academy of Dance (R55)'
     click_button 'Continue'
   end
 


### PR DESCRIPTION
## Context

When a user selects wants to select a course they currently have to select a provider from a large list of radio buttons.

## Changes proposed in this pull request

- Refactor this provider list into a drop-down bar

![image](https://user-images.githubusercontent.com/42515961/74158418-f3ffbd00-4c11-11ea-89c2-5628b4c88249.png)

![image](https://user-images.githubusercontent.com/42515961/74158474-0da10480-4c12-11ea-89fb-f8506980a1ef.png)


## Guidance to review

Follow the add a course flow locally. Does it look and behave correctly

## Link to Trello card

https://trello.com/c/Owhx0uVG/889-use-autocomplete-drop-down-to-allow-candidates-to-select-a-provider

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
