### PR TITLE
Added persistence settings for Redis to ARM template.

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -449,9 +449,18 @@
                     },
                     "enableNonSslPort": {
                         "value": true
+                    },
+                    "dataPersistence": {
+                        "value": "aof"
+                    },
+                    "storageConnectionString": {
+                        "value": "[reference('storage-account').outputs.storageConnectionString.value]"
                     }
                 }
-            }
+            },
+            "dependsOn": [
+                "storage-account"
+            ]
         },
         {
             "name": "app-service-plan",


### PR DESCRIPTION
## Context

It was discovered late last week that persistence wasn't actually enabled on our production and staging Redis cache. This feature was enabled manually through the portal at the time the issue was discovered and the purpose of this change is to retrospectively configure the persistence features of Redis through our ARM templates.

## Changes proposed in this pull request

ARM template changes to leverage new features added to the Building Blocks template for Redis:
1. Enable persistence in "AOF" mode
2. Provide connection string to storage account where persistence data will be kept
3. Add dependency on the storage account to the Redis resource.

## Guidance to review

Verify in the Azure portal that persistence is enabled.

## Link to Trello card

https://trello.com/c/MKV4wpy9/1618-bug-persistence-not-enabled-on-production-redis-cache

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
