### PR TITLE
Rename other qualifications section

### DIFF
--- a/app/components/candidate_interface/other_qualifications_review_component.html.erb
+++ b/app/components/candidate_interface/other_qualifications_review_component.html.erb
@@ -13,5 +13,5 @@
 <% end %>
 
 <% if @qualifications.empty? %>
-  <p class="govuk-body">No other qualifications entered.</p>
+  <p class="govuk-body">No academic or other qualifications entered.</p>
 <% end %>

--- a/app/components/qualifications_component.html.erb
+++ b/app/components/qualifications_component.html.erb
@@ -1,3 +1,3 @@
 <%= render QualificationsTableComponent, qualifications: application_form.application_qualifications.degrees, type_label: 'Degree' %>
 <%= render QualificationsTableComponent, qualifications: application_form.application_qualifications.gcses, type_label: 'GCSE or equivalent' %>
-<%= render QualificationsTableComponent, qualifications: application_form.application_qualifications.other, type_label: 'Other qualification' %>
+<%= render QualificationsTableComponent, qualifications: application_form.application_qualifications.other, type_label: 'Academic or other qualification' %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -48,7 +48,7 @@
   <%= render(CandidateInterface::GcseQualificationReviewComponent, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error) %>
 <% end %>
 
-<h3 class="govuk-heading-m">Other relevant qualifications</h3>
+<h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>
 
 <%= render(CandidateInterface::OtherQualificationsReviewComponent, application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error) %>
 

--- a/app/views/candidate_interface/other_qualifications/base/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/_form.html.erb
@@ -1,6 +1,5 @@
 <p class="govuk-body">
-  Enter your qualifications as completely as you can, including all
-  your GCSEs, A levels and vocational, practical and creative qualifications.
+  Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
 </p>
 <p class="govuk-body">
   Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.

--- a/app/views/candidate_interface/other_qualifications/base/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/_form.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">
-  Enter your other qualifications as completely as you can, including all
+  Enter your qualifications as completely as you can, including all
   your GCSEs, A levels and vocational, practical and creative qualifications.
 </p>
 <p class="govuk-body">

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -1,9 +1,13 @@
 <% content_for :title, t('page_titles.other_qualification') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
-<h1 class="govuk-heading-xl">
-  <%= t('page_titles.other_qualification') %>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.other_qualification') %>
+    </h1>
+  </div>
+</div>
 
 <%= render(CandidateInterface::OtherQualificationsReviewComponent, application_form: @application_form) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,9 +53,9 @@ en:
     which_course: Which course are you applying to?
     which_location: Which location are you applying to?
     edit_degree: Edit degree
-    other_qualification: Other relevant academic and non-academic qualifications
-    add_other_qualification: Other relevant qualifications
-    edit_other_qualification: Other relevant qualifications
+    other_qualification: Academic and other relevant qualifications
+    add_other_qualification: Academic and other relevant qualifications
+    edit_other_qualification: Edit qualification
     destroy_other_qualification: Are you sure you want to delete this qualification?
     becoming_a_teacher: Why do you want to be a teacher?
     subject_knowledge: What do you know about the subject you want to teach?

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -58,7 +58,7 @@ module CandidateHelper
     click_link 'Science GCSE or equivalent'
     candidate_explains_a_missing_gcse
 
-    click_link 'Other relevant academic and non-academic qualifications'
+    click_link 'Academic and other relevant qualifications'
     candidate_fills_in_their_other_qualifications
 
     click_link 'Why do you want to be a teacher?'

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -156,7 +156,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_the_section_is_not_completed
-    expect(page).not_to have_css('#other-relevant-academic-and-non-academic-qualifications-badge-id', text: 'Completed')
+    expect(page).not_to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
   end
 
   def then_i_can_check_my_answers
@@ -176,6 +176,6 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#other-relevant-academic-and-non-academic-qualifications-badge-id', text: 'Completed')
+    expect(page).to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
   end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'A Provider viewing an individual application' do
   end
 
   def and_i_should_see_the_candidates_other_qualifications
-    expect(page).to have_selector('[data-qa="qualifications-table-other-qualification"] tbody tr', count: 3)
+    expect(page).to have_selector('[data-qa="qualifications-table-academic-or-other-qualification"] tbody tr', count: 3)
   end
 
   def and_i_should_see_the_candidates_work_history


### PR DESCRIPTION
Indicate that this section is for "academic qualifications and other relevant" rather than "other relevant academic and non-academic".

We hope this will nudge users to put in more of their academic qualifications and aligns better with our existing guidance.

https://trello.com/c/j1otdP43/454-change-content-for-other-relevant-qualifications-tactical