### PR TITLE
Error and catch to stop zero applications creation

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -24,6 +24,8 @@ module VendorApi
       render json: { data: { ids: application_choices.map { |ac| ac.id.to_s } } }
     rescue TestApplications::NotEnoughCoursesError => e
       render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
+    rescue TestApplications::ZeroCoursesPerApplicationError => e
+      render json: { errors: [{ error: 'ParameterInvalid', message: e }] }, status: :unprocessable_entity
     end
 
     def clear!

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,5 +1,6 @@
 module TestApplications
   class NotEnoughCoursesError < RuntimeError; end
+  class ZeroCoursesPerApplicationError < RuntimeError; end
 
   def self.generate_for_provider(provider:, courses_per_application:, count:)
     1.upto(count).flat_map do
@@ -11,6 +12,8 @@ module TestApplications
   end
 
   def self.create_application(states:, courses_to_apply_to: nil)
+    raise ZeroCoursesPerApplicationError.new('You can\'t have zero courses per application') unless states.any?
+
     first_name = Faker::Name.unique.first_name
     last_name = Faker::Name.unique.last_name
     candidate = FactoryBot.create(

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -4,6 +4,10 @@ New attributes:
 
 - `Rejection` now includes offer withdrawal reasons
 
+### 10 February 2020
+
+- Add minimum of 1 to `courses_per_application` field for [`test-data/generate`](/experimental/test-data/generate). Stops test application data being generated that have zero courses per application.
+
 ### 5th February 2020
 
 Field lengths updated:

--- a/config/vendor-api-experimental.yml
+++ b/config/vendor-api-experimental.yml
@@ -29,6 +29,7 @@ paths:
         schema:
           type: integer
           default: 1
+          minimum: 1
           maximum: 3
       responses:
         '201':

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe TestApplications do
     }.to raise_error(/Not enough distinct courses/)
   end
 
+  it 'throws an exception if zero courses are specified per application' do
+    expect {
+      TestApplications.create_application(states: [])
+    }.to raise_error(/You can't have zero courses per application/)
+  end
+
   describe 'supplying our own courses' do
     it 'creates applications only for the supplied courses' do
       course_we_want = create(:course_option, course: create(:course, :open_on_apply)).course

--- a/spec/requests/vendor_api/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_generate_spec.rb
@@ -53,4 +53,12 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request do
 
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
   end
+
+  it 'returns error when you ask for zero courses per application' do
+    create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
+
+    post_api_request '/api/v1/experimental/test-data/generate?count=1&courses_per_application=0'
+
+    expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
+  end
 end


### PR DESCRIPTION
Adds Error and catch to stop generation of test users with zero courses per application.

## Context

You were able to generate courses with zero courses per application - which is not a state that would be consistent with the functioning of the production application. 

## Changes proposed in this pull request

Adds a check to the module `TestApplications.create_applications(states:, courses_to_apply_to: nil)` that raises an error if the `states:` is an empty array `[]` 

Adds new unit and feature tests to ensure correct behaviour.

Updates API related documentation.

## Guidance to review

Make a request to `/experimental/test-data/generate?count=1&courses_per_application=0` and you should receive an error response.

## Link to Trello card

[1627-Investigate how an application on Sandbox was submitted without any course choices](https://trello.com/c/x7395Ph4)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
