### PR TITLE
Add new emails to the state documentation

### DIFF
--- a/app/components/state_explanation_component.html.erb
+++ b/app/components/state_explanation_component.html.erb
@@ -1,12 +1,12 @@
 <h2 class='govuk-heading-l' id='<%= state_name %>'><%= human_state_name %></h2>
 
 <p class="govuk-caption-m">
-  Application status: <%= link_to state_name.inspect, api_docs_reference_path(anchor: 'applicationattributes-object') %>
+  Application status: <%= govuk_link_to state_name.inspect, api_docs_reference_path(anchor: 'applicationattributes-object') %>
 </p>
 
 <% if development_details %>
 <p class='govuk-body-l'>
-  We have <%= link_to pluralize(machine.state_count(state_name), 'application'), support_interface_applications_path %> currently in this state
+  We have <%= govuk_link_to pluralize(machine.state_count(state_name), 'application'), support_interface_applications_path %> currently in this state
 </p>
 <% end %>
 

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -168,6 +168,7 @@ en:
       description: 5 days after submission the application is sent to providers. This is to give candidates the opportunity to edit their application.
       emails:
         - candidate_mailer-application_under_consideration
+        - provider_mailer-application_submitted
 
     application_complete-withdraw:
       name: Withdraw
@@ -200,6 +201,9 @@ en:
       by: system
       description: |
         An application is rejected by default (RBD) if the provider doesn’t make an offer within 40 working days after they have received an application.
+      emails:
+        - provider_mailer-application_rejected_by_default
+
     offer-make_offer:
       name: Provider updates offer
       by: provider

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -29,22 +29,25 @@ RSpec.feature 'Docs' do
 
   def and_it_contains_documentation_for_all_emails
     emails_outside_of_states = %w[
-      candidate_mailer-new_referee_request
-      candidate_mailer-survey_chaser_email
-      candidate_mailer-survey_email
-      referee_mailer-survey_chaser_email
-      referee_mailer-survey_email
-      candidate_mailer-reference_chaser_email
-      referee_mailer-reference_request_chaser_email
-
       authentication_mailer-sign_in_email
       authentication_mailer-sign_in_without_account_email
+      candidate_mailer-new_referee_request
+      candidate_mailer-reference_chaser_email
+      candidate_mailer-survey_chaser_email
+      candidate_mailer-survey_email
+      provider_mailer-account_created
+      provider_mailer-chase_provider_decision
+      referee_mailer-reference_request_chaser_email
+      referee_mailer-survey_chaser_email
+      referee_mailer-survey_email
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"
-    emails_sent = [CandidateMailer, RefereeMailer, AuthenticationMailer].flat_map { |k| k.public_instance_methods(false).map { |m| "#{k.name.underscore}-#{m}" } }
+    emails_sent = [CandidateMailer, ProviderMailer, RefereeMailer, AuthenticationMailer].flat_map { |k| k.public_instance_methods(false).map { |m| "#{k.name.underscore}-#{m}" } }
+    documented_application_choice_emails = I18n.t('events').flat_map { |_name, attrs| attrs[:emails] }.compact
+    documented_application_form_emails = I18n.t('candidate_flow_events').flat_map { |_name, attrs| attrs[:emails] }.compact
 
-    emails_documented = I18n.t('events').flat_map { |_name, attrs| attrs[:emails] }.compact + I18n.t('candidate_flow_events').flat_map { |_name, attrs| attrs[:emails] }.compact + emails_outside_of_states
+    emails_documented = documented_application_choice_emails + documented_application_form_emails + emails_outside_of_states
 
     expect(emails_documented).to match_array(emails_sent)
   end


### PR DESCRIPTION
## Context

This adds the 2 new emails to the documentation - https://qa.apply-for-teacher-training.education.gov.uk/support/provider-flow.

## Changes proposed in this pull request

Refactors the docs spec a bit too to make it easier (?) to parse.

## Guidance to review

<img width="1246" alt="Screenshot 2020-02-10 at 17 34 19" src="https://user-images.githubusercontent.com/233676/74174321-a132ff00-4c2b-11ea-994a-dd23ae2c90e8.png">

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
