### PR TITLE
Remove hard-coded RBD date from email

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -16,11 +16,13 @@ class ProviderMailer < ApplicationMailer
         :provider_user_name,
         :candidate_name,
         :application_choice_id,
+        :rbd_days,
       ).new(
         application_choice.course.name_and_code,
         provider_user.full_name,
         application_choice.application_form.full_name,
         application_choice.id,
+        application_choice.reject_by_default_days,
     )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -10,7 +10,7 @@ Log in to Manage teacher training applications to respond:
 
 <%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
 
-We’ll reject the application on your behalf after 40 working days.
+We’ll reject the application on your behalf after <%= @application.rbd_days %> working days.
 
 # Give feedback or report a problem
 

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ProviderMailer, type: :mailer do
   let(:application_choice) do
     build_stubbed(:submitted_application_choice,
                   course_option: course_option,
+                  reject_by_default_days: 123,
                   application_form:
                     build_stubbed(
                       :completed_application_form,
@@ -58,6 +59,10 @@ RSpec.describe ProviderMailer, type: :mailer do
     it 'includes the course details' do
       expect(@mail.body.encoded).to include(application_choice.course.name)
       expect(@mail.body.encoded).to include(application_choice.course.code)
+    end
+
+    it 'includes the reject by default days' do
+      expect(@mail.body.encoded).to include('after 123 working days')
     end
 
     it 'includes a link to the application' do


### PR DESCRIPTION
## Context

We shouldn't be sprinkling the codebase with hardcoded business logic constants, because those will be very hard to unpick/change later on and will introduce all sorts of subtle bugs.

## Changes proposed in this pull request

When emailing the provider, use the 'reject by default' date that is already on the application.

## Guidance to review

This is the way the candidate notification already works:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/master/app/mailers/candidate_mailer.rb#L19

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
