### PR TITLE
Revert "Wrap referee mailer previews in transactions"

### DIFF
--- a/app/mailers/previews/referee_mailer_preview.rb
+++ b/app/mailers/previews/referee_mailer_preview.rb
@@ -1,20 +1,16 @@
 class RefereeMailerPreview < ActionMailer::Preview
   def reference_request_email
-    preview_with_rollback do
-      application_form = FactoryBot.create(:application_form, first_name: 'Jane', last_name: 'Smith')
-      reference = FactoryBot.create(:reference, application_form: application_form)
+    application_form = FactoryBot.create(:application_form, first_name: 'Jane', last_name: 'Smith')
+    reference = FactoryBot.create(:reference, application_form: application_form)
 
-      RefereeMailer.reference_request_email(application_form, reference)
-    end
+    RefereeMailer.reference_request_email(application_form, reference)
   end
 
   def reference_request_chaser_email
-    preview_with_rollback do
-      application_form = FactoryBot.create(:application_form, first_name: 'Jane', last_name: 'Smith')
-      reference = FactoryBot.create(:reference, application_form: application_form)
+    application_form = FactoryBot.create(:application_form, first_name: 'Jane', last_name: 'Smith')
+    reference = FactoryBot.create(:reference, application_form: application_form)
 
-      RefereeMailer.reference_request_chaser_email(application_form, reference)
-    end
+    RefereeMailer.reference_request_chaser_email(application_form, reference)
   end
 
   def survey_email
@@ -29,16 +25,5 @@ class RefereeMailerPreview < ActionMailer::Preview
     reference = FactoryBot.build_stubbed(:reference, application_form: application_form)
 
     RefereeMailer.survey_chaser_email(reference)
-  end
-
-private
-
-  def preview_with_rollback &block
-    mail = nil
-    ApplicationForm.transaction do
-      mail = block.call
-      raise ActiveRecord::Rollback, "we don't want to be committing these on QA"
-    end
-    mail
   end
 end


### PR DESCRIPTION
This reverts commit afe20c99ba787b68a4c18856d469cee045ac534b from #1322.

This didn't actually work at all (i.e. records were still being
written to the DB) and the actual fix escapes me right now so I
am backing the change out.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
