### PR TITLE
Refactor chase provider decision flow and TimeLimitCalculator 

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -11,7 +11,7 @@ class TimeLimitConfig
     edit_by: [
       Rule.new(nil, nil, 5),
     ],
-    chase_provider_by: [
+    chase_provider_before_rbd: [
       Rule.new(nil, nil, 20),
     ],
     chase_referee_by: [

--- a/app/services/get_application_forms_waiting_for_provider_decision.rb
+++ b/app/services/get_application_forms_waiting_for_provider_decision.rb
@@ -7,6 +7,6 @@ class GetApplicationFormsWaitingForProviderDecision
   end
 
   def self.chase_provider_time_limit
-    TimeLimitCalculator.new(rule: :chase_provider_before_rbd, effective_date: Time.zone.now).call.second
+    TimeLimitCalculator.new(rule: :chase_provider_before_rbd, effective_date: Time.zone.now).call[:time_in_future]
   end
 end

--- a/app/services/get_application_forms_waiting_for_provider_decision.rb
+++ b/app/services/get_application_forms_waiting_for_provider_decision.rb
@@ -7,6 +7,6 @@ class GetApplicationFormsWaitingForProviderDecision
   end
 
   def self.chase_provider_time_limit
-    TimeLimitCalculator.new(rule: :chase_provider_by, effective_date: Time.zone.now).call.second
+    TimeLimitCalculator.new(rule: :chase_provider_before_rbd, effective_date: Time.zone.now).call.second
   end
 end

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -7,6 +7,6 @@ class GetRefereesToChase
   end
 
   def self.chase_referee_time_limit
-    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: Time.zone.now).call[2]
+    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: Time.zone.now).call[:time_in_past]
   end
 end

--- a/app/services/sandbox_time_limit_calculator.rb
+++ b/app/services/sandbox_time_limit_calculator.rb
@@ -2,6 +2,6 @@ class SandboxTimeLimitCalculator
   def initialize(*); end
 
   def call
-    [0, Time.zone.now]
+    { days: 0, time_in_future: Time.zone.now }
   end
 end

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -20,10 +20,13 @@ class SendApplicationToProvider
 private
 
   def set_reject_by_default
-    days, time = TimeLimitCalculator.new(
+    time_limit = TimeLimitCalculator.new(
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     ).call
+
+    days = time_limit[:days]
+    time = time_limit[:time_in_future]
 
     application_choice.reject_by_default_days = days
     application_choice.reject_by_default_at = time

--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -12,10 +12,13 @@ class SetDeclineByDefault
       application_choices.maximum(:withdrawn_at),
     ].compact.max
 
-    dbd_days, dbd_time = TimeLimitCalculator.new(
+    dbd_time_limit = TimeLimitCalculator.new(
       rule: :decline_by_default,
       effective_date: most_recent_decision_date,
     ).call
+
+    dbd_days = dbd_time_limit[:days]
+    dbd_time = dbd_time_limit[:time_in_future]
 
     application_choices.where(status: 'offer').update_all(
       decline_by_default_at: dbd_time,

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -54,7 +54,7 @@ private
   end
 
   def submit_application_choice(application_choice)
-    _edit_by_days, edit_by_time = time_limit_calculator.call
+    edit_by_time = time_limit_calculator.call[:time_in_future]
     application_choice.edit_by = edit_by_time
     ApplicationStateChange.new(application_choice).submit!
   end

--- a/app/services/time_limit_calculator.rb
+++ b/app/services/time_limit_calculator.rb
@@ -8,7 +8,11 @@ class TimeLimitCalculator
 
   def call
     days = calculate_days
-    [days, calculate_time_in_future(days), calculate_time_in_past(days)]
+    {
+      days: days,
+      time_in_future: calculate_time_in_future(days),
+      time_in_past: calculate_time_in_past(days),
+    }
   end
 
 private

--- a/app/views/provider_mailer/chase_provider_decision.text.erb
+++ b/app/views/provider_mailer/chase_provider_decision.text.erb
@@ -1,10 +1,10 @@
 Dear <%= @application.provider_user_name || 'colleague' %>
 
-# Only <%= TimeLimitConfig.limits_for(:chase_provider_by).first.limit %> working days left to respond
+# Only <%= TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit %> working days left to respond
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
-Log in to Manage teacher training applications to respond within <%= TimeLimitConfig.limits_for(:chase_provider_by).first.limit %> working days:
+Log in to Manage teacher training applications to respond within <%= TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit %> working days:
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
 

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe TimeLimitConfig do
       expect(TimeLimitConfig.limits_for(:edit_by).first.limit).to eq(5)
     end
 
-    it ':chase_provider_by returns a default limit of 20 days' do
-      expect(TimeLimitConfig.limits_for(:chase_provider_by).first.limit).to eq(20)
+    it ':chase_provider_before_rbd returns a default limit of 20 days' do
+      expect(TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit).to eq(20)
     end
   end
 end

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ProviderMailer, type: :mailer do
     end
 
     it 'includes the time limit when we start chasing providers' do
-      expected_days_left = "Only #{TimeLimitConfig.limits_for(:chase_provider_by).first.limit} working days left to respond"
+      expected_days_left = "Only #{TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit} working days left to respond"
       expect(@mail.body.encoded).to include(expected_days_left)
     end
 

--- a/spec/services/get_application_forms_waiting_for_provider_decision_spec.rb
+++ b/spec/services/get_application_forms_waiting_for_provider_decision_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GetApplicationFormsWaitingForProviderDecision do
   let(:current_time) { Time.zone.local(2019, 6, 1, 12, 0, 0) }
+  let(:time_limit_before_rbd) { TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit }
 
   around do |example|
     Timecop.freeze(current_time) do
@@ -17,37 +18,31 @@ RSpec.describe GetApplicationFormsWaitingForProviderDecision do
     )
   end
 
-  it 'returns an application that has not more than 20 working days till RBD date' do
+  it 'returns an application that has not more than the defined limit till RBD date' do
     application_choice = create_application(
       status: 'awaiting_provider_decision',
-      reject_by_default_at: 21.business_days.from_now,
+      reject_by_default_at: time_limit_before_rbd.business_days.from_now,
     )
-
-    Timecop.travel(1.business_days.from_now) do
-      expect(described_class.call).to include application_choice
-    end
+    expect(described_class.call).to include application_choice
   end
 
-  it 'does not return an application that has more than 20 working days till RBD date' do
+  it 'does not return an application that has more than the defined limit till RBD date' do
     application_choice = create_application(
       status: 'awaiting_provider_decision',
-      reject_by_default_at: 22.business_days.from_now,
+      reject_by_default_at: (time_limit_before_rbd + 1).business_days.from_now,
     )
-    Timecop.travel(1.business_days.from_now) do
-      expect(described_class.call).not_to include application_choice
-    end
+
+    expect(described_class.call).not_to include application_choice
   end
 
   it 'does not return an application if it has been chased already' do
     application_choice = create_application(
       status: 'awaiting_provider_decision',
-      reject_by_default_at: 10.business_days.from_now,
+      reject_by_default_at: time_limit_before_rbd.business_days.from_now,
     )
 
     ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)
 
-    Timecop.travel(1.business_days.from_now) do
-      expect(described_class.call).not_to include application_choice
-    end
+    expect(described_class.call).not_to include application_choice
   end
 end

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe SendApplicationToProvider do
 
   it 'sets the `reject_by_default_at` date and `reject_by_default_days`' do
     reject_by_default_at = 20.business_days.from_now.end_of_day
-    time_limit_calculator = instance_double(TimeLimitCalculator, call: [20, reject_by_default_at])
+    time_limit_calculator = instance_double(TimeLimitCalculator, call: { days: 20, time_in_future: reject_by_default_at })
     allow(TimeLimitCalculator).to receive(:new).and_return(time_limit_calculator)
 
     SendApplicationToProvider.new(application_choice: application_choice).call

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe SetDeclineByDefault do
     let(:application_form) { create(:completed_application_form, application_choices_count: 3) }
     let(:choices) { application_form.application_choices }
     let(:now) { Time.zone.local(2019, 11, 26, 12, 0, 0) }
-    let(:time_limit_calculator) { instance_double('TimeLimitCalculator', call: [10, 9.business_days.after(now).end_of_day]) }
+    let(:time_limit_calculator) do
+      instance_double('TimeLimitCalculator',
+                      call: { days: 10, time_in_future: 9.business_days.after(now).end_of_day })
+    end
     let(:call_service) { SetDeclineByDefault.new(application_form: application_form).call }
 
     before { allow(TimeLimitCalculator).to receive(:new).and_return(time_limit_calculator) }

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day, Time.zone.local(2019, 5, 1).end_of_day]
+    expect(calculator.call).to eq(
+      days: 20,
+      time_in_future: Time.zone.local(2019, 7, 1).end_of_day,
+      time_in_past: Time.zone.local(2019, 5, 1).end_of_day,
+    )
   end
 
   it 'returns value for rule with `from_date` when effective date matches rule' do
@@ -31,7 +35,11 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [10, Time.zone.local(2019, 6, 17).end_of_day, Time.zone.local(2019, 5, 16).end_of_day]
+    expect(calculator.call).to eq(
+      days: 10,
+      time_in_future: Time.zone.local(2019, 6, 17).end_of_day,
+      time_in_past: Time.zone.local(2019, 5, 16).end_of_day,
+    )
   end
 
   it 'returns value for default rule rather than one with `from_date` when effective date does not match rule' do
@@ -45,7 +53,11 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [20, Time.zone.local(2019, 7, 1).end_of_day, Time.zone.local(2019, 5, 1).end_of_day]
+    expect(calculator.call).to eq(
+      days: 20,
+      time_in_future: Time.zone.local(2019, 7, 1).end_of_day,
+      time_in_past: Time.zone.local(2019, 5, 1).end_of_day,
+    )
   end
 
   it 'returns value for rule with `to_date` and `from_date` when effective date matches rule' do
@@ -60,7 +72,11 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: Time.zone.now,
     )
-    expect(calculator.call).to eq [5, Time.zone.local(2019, 6, 10).end_of_day, Time.zone.local(2019, 5, 23).end_of_day]
+    expect(calculator.call).to eq(
+      days: 5,
+      time_in_future: Time.zone.local(2019, 6, 10).end_of_day,
+      time_in_past: Time.zone.local(2019, 5, 23).end_of_day,
+    )
   end
 
   it 'returns nil when there is no rule for the given effective date' do
@@ -69,6 +85,8 @@ RSpec.describe TimeLimitCalculator do
       rule: :reject_by_default,
       effective_date: 20.days.ago,
     )
-    expect(calculator.call).to eq [nil, nil, nil]
+    expect(calculator.call).to eq(
+      days: nil, time_in_future: nil, time_in_past: nil,
+    )
   end
 end

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature 'An application is waiting for decision for 20 working days' do
     and_an_application_was_sent_to_provider
     and_i_am_a_provider_user_at_the_course_provider
 
-    when_the_application_is_waiting_for_decision_for_20_working_days
+    when_the_application_is_getting_close_to_the_reject_by_default_date
 
     then_i_should_receive_a_chaser_email_with_a_link_to_the_application
   end
@@ -33,8 +33,9 @@ RSpec.feature 'An application is waiting for decision for 20 working days' do
     create(:provider_users_provider, provider_id: provider_id, provider_user_id: @provider_user.id)
   end
 
-  def when_the_application_is_waiting_for_decision_for_20_working_days
-    Timecop.travel(20.business_days.after(Time.zone.now + 5.minutes)) do
+  def when_the_application_is_getting_close_to_the_reject_by_default_date
+    time_limit_in_buiness_days = TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit
+    Timecop.travel(time_limit_in_buiness_days.days.before(@submitted_application_choice.reject_by_default_at)) do
       SendChaseEmailToProvidersWorker.perform_async
     end
   end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
As discussed in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1290 the time limit the provider get chased at is calculated backwards from `rejectet_by_default_at` date. The previous implementation was tied to the 20 days rule. This PR is intended to remove the hardcoded 20 days and use the `TimeLimitConfig` where possible. The time limit is calculated backwards from the RBD date, which was not clear from the previous implementation. 

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR refactors:
- The flow for `chase provider when an application is waiting for decision`
- The `TimeLimitCalculator` to return a hash and improve readability

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Does this make sense? 

## Link to Trello card
<!-- http://trello.com/123-example-card -->

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
