### PR TITLE
Add feature flag API

### DIFF
--- a/app/controllers/integrations/feature_flags_controller.rb
+++ b/app/controllers/integrations/feature_flags_controller.rb
@@ -1,0 +1,21 @@
+module Integrations
+  class FeatureFlagsController < IntegrationsController
+    def index
+      feature_flags = FeatureFlag::FEATURES.reduce({}) do |features, feature_name|
+        features[feature_name] = {
+          name: feature_name.humanize,
+          active: FeatureFlag.active?(feature_name),
+        }
+
+        features
+      end
+
+      response = {
+        hosting_environment: HostingEnvironment.environment_name,
+        feature_flags: feature_flags,
+      }
+
+      render json: response
+    end
+  end
+end

--- a/app/controllers/integrations/integrations_controller.rb
+++ b/app/controllers/integrations/integrations_controller.rb
@@ -1,21 +1,10 @@
 module Integrations
   class IntegrationsController < ActionController::API
-    include ActionController::HttpAuthentication::Token::ControllerMethods
-
-  private
-
+  protected
     def render_error(name:, message:, status:)
       response = { errors: [{ error: name, message: message }] }
 
       render json: response, status: status
-    end
-
-    def render_unauthorized
-      render_error(
-        name: 'Unauthorized',
-        message: 'Please provide a valid authentication token',
-        status: :unauthorized,
-      )
     end
   end
 end

--- a/app/controllers/integrations/integrations_controller.rb
+++ b/app/controllers/integrations/integrations_controller.rb
@@ -1,6 +1,7 @@
 module Integrations
   class IntegrationsController < ActionController::API
   protected
+
     def render_error(name:, message:, status:)
       response = { errors: [{ error: name, message: message }] }
 

--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -1,5 +1,7 @@
 module Integrations
   class NotifyController < IntegrationsController
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+
     rescue_from ActionController::ParameterMissing, with: :render_unprocessable_entity
 
     def callback
@@ -39,6 +41,14 @@ module Integrations
         name: 'NotFound',
         message: "Could not find a reference with ID: #{reference_id}",
         status: :not_found,
+      )
+    end
+
+    def render_unauthorized
+      render_error(
+        name: 'Unauthorized',
+        message: 'Please provide a valid authentication token',
+        status: :unauthorized,
       )
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,6 +297,7 @@ Rails.application.routes.draw do
 
   namespace :integrations, path: '/integrations' do
     post '/notify/callback' => 'notify#callback'
+    get '/feature-flags' => 'feature_flags#index'
   end
 
   namespace :support_interface, path: '/support' do

--- a/spec/requests/integrations/feature_flags_spec.rb
+++ b/spec/requests/integrations/feature_flags_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /integrations/feature-flags', type: :request do
+  it 'returns the feature flags' do
+    FeatureFlag.activate('pilot_open')
+
+    get '/integrations/feature-flags'
+
+    expect(parsed_response['feature_flags']['pilot_open']['name']).to eql('Pilot open')
+    expect(parsed_response['feature_flags']['pilot_open']['active']).to be(true)
+  end
+
+  def parsed_response
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
## Context

We want to create a dashboard that shows what features are activated where. This will probably live in https://github.com/DFE-Digital/apply-ops-dashboard.

## Changes proposed in this pull request

This adds an API for feature flags to the integrations namespace.

![image](https://user-images.githubusercontent.com/233676/74226605-bef87680-4cb4-11ea-9751-654a571b5c8e.png)

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/zvwGIRy4/991-ongoing-tweak-the-release-process

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
