### PR TITLE
Send candidates who select a provider on the drop down with no courses to Find

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -34,7 +34,6 @@ module CandidateInterface
 
     def pick_provider
       @pick_provider = PickProviderForm.new(code: params.dig(:candidate_interface_pick_provider_form, :code))
-
       if !@pick_provider.valid?
         render :options_for_provider
       elsif @pick_provider.other?

--- a/app/models/candidate_interface/pick_provider_form.rb
+++ b/app/models/candidate_interface/pick_provider_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     validates :code, presence: true
 
     def other?
-      code == 'other'
+      Course.exposed_in_find.pluck(:provider_id).exclude?(Provider.find_by(code: code).id)
     end
 
     def available_providers

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -11,6 +11,10 @@ RSpec.feature 'Selecting a course not on Apply' do
     and_i_click_on_course_choices
     and_i_click_on_add_course
     and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider_without_a_course
+    then_i_see_that_i_should_apply_on_ucas
+
+    when_i_click_on_back
     and_i_choose_a_provider
     and_i_choose_another_course
     then_i_see_that_i_should_apply_on_ucas
@@ -33,6 +37,7 @@ RSpec.feature 'Selecting a course not on Apply' do
     course2 = create(:course, name: 'Secondary', code: 'X123', provider: provider, exposed_in_find: true, open_on_apply: false)
     create(:course_option, site: site, course: course1, vacancy_status: 'B')
     create(:course_option, site: site, course: course2, vacancy_status: 'B')
+    create(:provider, name: 'Provider with no courses', code: 'FAKE')
   end
 
   def and_i_click_on_course_choices
@@ -48,8 +53,17 @@ RSpec.feature 'Selecting a course not on Apply' do
     click_button 'Continue'
   end
 
+  def and_i_choose_a_provider_without_a_course
+    select 'Provider with no courses (FAKE)'
+    click_button 'Continue'
+  end
+
   def then_i_see_that_i_should_apply_on_ucas
     expect(page).to have_content(t('page_titles.not_eligible_yet'))
+  end
+
+  def when_i_click_on_back
+    click_link 'Back'
   end
 
   def and_i_choose_a_provider


### PR DESCRIPTION
## Context

When a user selects a provider that does not have any courses on Find they need to redirected to the apply through UCAS page.

## Changes proposed in this pull request

- Redirect users who meet the above criteria to the apply through UCAS page

Before 

![image](https://user-images.githubusercontent.com/42515961/74231471-8bbae500-4cbe-11ea-8014-e5e349177ce5.png)

![image](https://user-images.githubusercontent.com/42515961/74231492-9aa19780-4cbe-11ea-8a5c-dbed1d54fa04.png)

After

![image](https://user-images.githubusercontent.com/42515961/74231561-c4f35500-4cbe-11ea-9456-7e089fcc3823.png)

## Guidance to review

Check locally with Gorse. They should be able to select a course.

Then check with the University of Brighton. You should see the apply through UCAS page.

## Link to Trello card

https://trello.com/c/Owhx0uVG/889-use-autocomplete-drop-down-to-allow-candidates-to-select-a-provider

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
