### PR TITLE
Fix support interface application detail page

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -50,12 +50,12 @@ class ApplicationReference < ApplicationRecord
   def chase_referee_at
     return unless requested_at
 
-    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: requested_at).call.second
+    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: requested_at).call[:time_in_future]
   end
 
   def replace_referee_at
     return unless requested_at
 
-    TimeLimitCalculator.new(rule: :replace_referee_by, effective_date: requested_at).call.second
+    TimeLimitCalculator.new(rule: :replace_referee_by, effective_date: requested_at).call[:time_in_future]
   end
 end

--- a/spec/system/support_interface/see_individual_application_spec.rb
+++ b/spec/system/support_interface/see_individual_application_spec.rb
@@ -31,6 +31,7 @@ RSpec.feature 'See an application' do
 
   def and_there_are_applications_in_the_system
     @completed_application = create(:completed_application_form, references_count: 2, with_gces: true)
+    SubmitApplication.new(@completed_application).call
     @unsubmitted_application = create(:application_form)
     @application_with_reference = create(:completed_application_form, references_count: 2, with_gces: true)
   end


### PR DESCRIPTION
## Context

This was broken by a merge issue - the `TimeLimitCalculator` interface changed in one branch as two new references to it were introduced in another branch. 

This was found on `qa`. Need to merge this fix before we deploy to `production`. It wasn't covered by system specs so we need to address that as well as fix the issue.

## Changes proposed in this pull request

- Change references to `TimeLimitCalculator` to use new interface in `ApplicationReference#chase_referee_at` and `replace_referee_at`.
- Update system spec that opens this page to include a submitted application to reproduce the issue.

## Guidance to review

- is the usage of `TimeLimitCalculator` correct?

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
