### PR TITLE
Changes to choose a referee page

### DIFF
--- a/app/views/candidate_interface/referees/_intro.html.erb
+++ b/app/views/candidate_interface/referees/_intro.html.erb
@@ -13,7 +13,7 @@
   <li>a teacher at a school where you work or volunteer</li>
   <li>your university tutor or supervisor</li>
   <li>a responsible member of your community who knows you well</li>
-  <li>a supplier or client you've worked with (if you're self-employed)</li>
+  <li>a supplier or client you’ve worked with (if you’re self-employed)</li>
 </ul>
 
 <p class="govuk-body">Referees should not be family members, partners or friends.</p>

--- a/app/views/candidate_interface/referees/_intro.html.erb
+++ b/app/views/candidate_interface/referees/_intro.html.erb
@@ -13,6 +13,7 @@
   <li>a teacher at a school where you work or volunteer</li>
   <li>your university tutor or supervisor</li>
   <li>a responsible member of your community who knows you well</li>
+  <li>a supplier or client you've worked with (if you're self-employed)</li>
 </ul>
 
 <p class="govuk-body">Referees should not be family members, partners or friends.</p>


### PR DESCRIPTION
Added guidance for candidates who are self-employed.

## Context

We've added guidance because self-employed candidates weren't sure who to suggest as referees.

## Changes proposed in this pull request

Additional text.

## Guidance to review

Check additional copy.

## Link to Trello card

https://trello.com/c/ta2maije

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
