### PR TITLE
Implement the correct page title for the new referee form

### DIFF
--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -69,13 +69,13 @@ module CandidateInterface
     end
 
     def redirect_to_dashboard_if_no_references_needed
-      return if ReferenceStatus.new(current_application).still_more_references_needed?
+      return if reference_status.still_more_references_needed?
 
       redirect_to candidate_interface_application_form_path
     end
 
     def redirect_to_confirm_or_show_another_reference_form
-      if ReferenceStatus.new(current_application).needs_to_draft_another_reference?
+      if reference_status.needs_to_draft_another_reference?
         redirect_to action: :new
       else
         redirect_to candidate_interface_confirm_additional_referees_path
@@ -83,9 +83,13 @@ module CandidateInterface
     end
 
     def redirect_to_confirm_if_no_more_reference_needed
-      return if ReferenceStatus.new(current_application).needs_to_draft_another_reference?
+      return if reference_status.needs_to_draft_another_reference?
 
       redirect_to candidate_interface_confirm_additional_referees_path
+    end
+
+    def reference_status
+      @reference_status ||= ReferenceStatus.new(current_application)
     end
   end
 end

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -4,6 +4,8 @@ module CandidateInterface
 
     def new
       redirect_to_confirm_if_no_more_reference_needed
+
+      @page_title = page_title_for_new_page
       @reference = ApplicationReference.new
     end
 
@@ -76,7 +78,7 @@ module CandidateInterface
 
     def redirect_to_confirm_or_show_another_reference_form
       if reference_status.needs_to_draft_another_reference?
-        redirect_to action: :new
+        redirect_to candidate_interface_new_additional_referee_path(second: true)
       else
         redirect_to candidate_interface_confirm_additional_referees_path
       end
@@ -90,6 +92,16 @@ module CandidateInterface
 
     def reference_status
       @reference_status ||= ReferenceStatus.new(current_application)
+    end
+
+    def page_title_for_new_page
+      if params[:second]
+        'Add your second referee'
+      elsif reference_status.number_of_references_that_currently_need_replacing == 2
+        'Add your first referee'
+      else
+        'Add a new referee'
+      end
     end
   end
 end

--- a/app/views/candidate_interface/additional_referees/new.html.erb
+++ b/app/views/candidate_interface/additional_referees/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix('Add a new referee', @reference.errors.any?) %>
+<% content_for :title, title_with_error_prefix(@page_title, @reference.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back') %>
 
 <div class="govuk-grid-row">
@@ -7,7 +7,7 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-xl">
-        Add a new referee
+        <%= @page_title %>
       </h1>
 
       <p class="govuk-body">Contact your referee in advance to check they are:</p>

--- a/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
@@ -57,6 +57,8 @@ RSpec.describe 'Candidate needs to provide a new referee' do
   end
 
   def and_i_fill_in_the_form
+    expect(page).to have_title 'Add a new referee'
+
     fill_in 'Full name', with: 'AO Reference'
     fill_in 'Email address', with: 'betty@example.com'
     fill_in 'What is your relationship to this referee and how long have you known them?', with: 'Just somebody I used to know'

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
@@ -58,6 +58,8 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def and_i_fill_in_the_form
+    expect(page).to have_title 'Add your first referee'
+
     fill_in 'Full name', with: 'AO Reference'
     fill_in 'Email address', with: 'betty@example.com'
     fill_in 'What is your relationship to this referee and how long have you known them?', with: 'Just somebody I used to know'
@@ -65,6 +67,8 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def and_i_fill_in_the_second_form
+    expect(page).to have_title 'Add your second referee'
+
     fill_in 'Full name', with: 'Second Reference'
     fill_in 'Email address', with: 'boppie@example.com'
     fill_in 'What is your relationship to this referee and how long have you known them?', with: 'Just somebody I used to know'


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1279.

## Changes proposed in this pull request

This implements tricky logic to show the correct page title. It's important because the other might be suprised that they have to fill in 2 references, so a hint in the title would help.

## Guidance to review

Any better way of doing this?

## Link to Trello card

https://trello.com/c/oMo8ZCap/761-enable-candidates-to-add-new-referee

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
