### PR TITLE
Add section in "Add a job" page to ask the candidate if they want to add another job

### DIFF
--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -12,9 +12,10 @@ module CandidateInterface
                                   start_date_year: start_date.year,
                                   end_date_month: end_date.month,
                                   end_date_year: end_date.year,
+                                  add_another_job: true,
                                 )
                               else
-                                WorkExperienceForm.new
+                                WorkExperienceForm.new(add_another_job: true)
                               end
     end
 
@@ -22,7 +23,11 @@ module CandidateInterface
       @work_experience_form = WorkExperienceForm.new(work_experience_form_params)
 
       if @work_experience_form.save(current_application)
-        redirect_to candidate_interface_work_history_show_path
+        if @work_experience_form.add_another_job == 'true'
+          redirect_to candidate_interface_work_history_new_path
+        else
+          redirect_to candidate_interface_work_history_show_path
+        end
       else
         render :new
       end
@@ -32,6 +37,7 @@ module CandidateInterface
       work_experience = current_application
         .application_work_experiences.find(work_experience_params[:id])
       @work_experience_form = WorkExperienceForm.build_from_experience(work_experience)
+      @work_experience_form.add_another_job = false
     end
 
     def update
@@ -54,7 +60,7 @@ module CandidateInterface
         .permit(
           :role, :organisation, :details, :working_with_children, :commitment,
           :working_pattern, :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
-          :"end_date(3i)", :"end_date(2i)", :"end_date(1i)"
+          :"end_date(3i)", :"end_date(2i)", :"end_date(1i)", :add_another_job
         )
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) }

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     attr_accessor :role, :organisation, :details, :working_with_children,
                   :commitment, :working_pattern,
                   :start_date_day, :start_date_month, :start_date_year,
-                  :end_date_day, :end_date_month, :end_date_year
+                  :end_date_day, :end_date_month, :end_date_year, :add_another_job
 
     validates :role, :organisation, :details, :working_with_children,
               :commitment,

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -28,9 +28,18 @@
 
 <%= f.govuk_text_area :details, label: { text: t('application_form.work_history.details.label'), size: 'm' }, hint_text: 'Give a brief overview of your role and explain how you developed transferable skills like communication, creativity and organisation', max_words: 150 %>
 
-<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: 'Did this job involve working in a school or with children?', tag: 'span' }, inline: true do %>
+<%= f.govuk_radio_buttons_fieldset :working_with_children, legend: { text: 'Did this job involve working in a school or with children?', tag: 'span' } do %>
   <%= f.govuk_radio_button :working_with_children, true, label: { text: 'Yes' }, link_errors: true %>
   <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
+<% end %>
+
+<% if FeatureFlag.active?('work_breaks') %>
+  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+
+  <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
+    <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>
+    <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, I’ve completed my work history' } %>
+  <% end %>
 <% end %>
 
 <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature 'Entering their work history' do
     and_i_should_see_the_incorrect_date_values
 
     when_i_fill_in_the_job_form
+    and_i_choose_no_to_adding_another_job
     then_i_should_see_my_completed_job
 
     when_i_click_on_delete_entry
@@ -31,11 +32,12 @@ RSpec.feature 'Entering their work history' do
 
     when_i_click_on_add_job
     and_i_fill_in_the_job_form # 5/2014 - 1/2019
-    then_i_should_see_my_completed_job
+    and_i_choose_yes_to_adding_another_job
+    then_i_should_see_the_job_form
 
-    when_i_click_on_add_another_job
-    and_i_fill_in_the_job_form_with_another_job_with_a_break # 3/2019 - current
+    when_i_fill_in_the_job_form_with_another_job_with_a_break # 3/2019 - current
     and_i_do_not_fill_in_end_date
+    and_i_choose_no_to_adding_another_job
     then_i_should_see_my_second_job
     and_i_should_see_the_length_of_the_gap_in_months # 1 months
     and_i_should_be_asked_to_explain_the_break_in_my_work_history
@@ -145,6 +147,16 @@ RSpec.feature 'Entering their work history' do
     fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
 
     choose 'No'
+  end
+
+  def and_i_choose_no_to_adding_another_job
+    choose 'No, I’ve completed my work history'
+
+    click_button t('application_form.work_history.complete_form_button')
+  end
+
+  def and_i_choose_yes_to_adding_another_job
+    choose 'Yes, I want to add another job'
 
     click_button t('application_form.work_history.complete_form_button')
   end
@@ -178,7 +190,7 @@ RSpec.feature 'Entering their work history' do
     when_i_fill_in_the_job_form
   end
 
-  def and_i_fill_in_the_job_form_with_another_job_with_a_break
+  def when_i_fill_in_the_job_form_with_another_job_with_a_break
     scope = 'application_form.work_history'
     fill_in t('role.label', scope: scope), with: 'Chief of Xenomorph Procurement and Research'
     fill_in t('organisation.label', scope: scope), with: 'Weyland-Yutani'
@@ -193,8 +205,6 @@ RSpec.feature 'Entering their work history' do
     fill_in t('details.label', scope: scope), with: 'Gimme Xenomorphs.'
 
     choose 'No'
-
-    click_button t('application_form.work_history.complete_form_button')
   end
 
   def and_i_do_not_fill_in_end_date; end


### PR DESCRIPTION
## Context

When little Ting began working on work history breaks, it seemed like there was no light at the end of the tunnel. But then the Two Pauls came down from Heaven and showed Ting the light.

> It's going to be okay my child. It's doesn't have to be complicated. **_- The Two Pauls_**

See https://trello.com/c/jIWipybM/732-calculate-work-gaps#comment-5e4290ca629e7313c54cd3f1 for the actual story.

This is the first step to actually providing a reason for a work history break.

## Changes proposed in this pull request

This PR adds a section of the "Add a job" page which has radio buttons to ask the candidate if they want to add another job. This is hidden under the `work_breaks` feature flag.

- If they choose "Yes, I want to add another job", then they are redirected to the "Add a job" page. Else, they are taken to the review page.
- If the candidate is on the "Add a job" page, then the "Yes, I want to add another job" is preselected. Else if, the candidate is on the "Edit a job" page, then the "No, I’ve completed my work history" is preselected.

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/74318900-f4b16400-4d75-11ea-995b-a358209d8815.png)

## Guidance to review

Would like help on:

- if there is a nicer way to uniquely identify the radio buttons than using the `id`
- if there is a nicer way to prefill the `add_another_job` attribute to yes or no. Thought there might be a way to do it with formbuilder but couldn't find anything in the documentation

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
