### PR TITLE
Refactor out a system spec specifically for new work history breaks

### DIFF
--- a/spec/system/candidate_interface/candidate_enter_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_enter_work_history_breaks_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering reasons for their work history breaks' do
+  include CandidateHelper
+
+  scenario 'Candidate enters a reason for a work break' do
+    FeatureFlag.activate('work_breaks')
+
+    given_i_am_signed_in
+    and_i_visit_the_site
+
+    when_i_click_on_work_history
+    and_i_choose_i_have_work_for_more_than_5_years
+    and_i_add_a_job_between_march_2019_to_august_2019
+    and_i_add_another_job_between_november_2019_and_now
+    then_i_see_a_two_months_break_between_my_first_job_and_my_second_job
+
+    when_i_click_add_another_job_for_my_break
+    then_i_should_see_the_start_and_end_date_filled_in
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_work_history
+    click_link t('page_titles.work_history')
+  end
+
+  def and_i_choose_i_have_work_for_more_than_5_years
+    choose t('application_form.work_history.more_than_5.label')
+
+    click_button 'Continue'
+  end
+
+  def and_i_add_a_job_between_march_2019_to_august_2019
+    scope = 'application_form.work_history'
+    fill_in t('role.label', scope: scope), with: 'Microsoft Painter'
+    fill_in t('organisation.label', scope: scope), with: 'Department for Education'
+
+    choose 'Full-time'
+
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '3'
+      fill_in 'Year', with: '2019'
+    end
+
+    within('[data-qa="end-date"]') do
+      fill_in 'Month', with: '8'
+      fill_in 'Year', with: '2019'
+    end
+
+    fill_in t('details.label', scope: scope), with: 'I taught others to be pros at MS Paint.'
+
+    choose 'No'
+
+    choose 'Yes, I want to add another job'
+
+    click_button t('application_form.work_history.complete_form_button')
+  end
+
+  def and_i_add_another_job_between_november_2019_and_now
+    scope = 'application_form.work_history'
+    fill_in t('role.label', scope: scope), with: 'Junior Developer'
+    fill_in t('organisation.label', scope: scope), with: 'Department for Education'
+
+    choose 'Full-time'
+
+    within('[data-qa="start-date"]') do
+      fill_in 'Month', with: '11'
+      fill_in 'Year', with: '2019'
+    end
+
+    fill_in t('details.label', scope: scope), with: 'Ship it.'
+
+    choose 'No'
+
+    choose 'No, I’ve completed my work history'
+
+    click_button t('application_form.work_history.complete_form_button')
+  end
+
+  def then_i_see_a_two_months_break_between_my_first_job_and_my_second_job
+    expect(page).to have_content('You have a break in your work history (2 months)')
+  end
+
+  def when_i_click_add_another_job_for_my_break
+    first(:link, t('application_form.work_history.add_another_job')).click
+  end
+
+  def then_i_should_see_the_start_and_end_date_filled_in
+    expect(page).to have_selector("input[value='8']")
+    expect(page).to have_selector("input[value='2019']")
+    expect(page).to have_selector("input[value='11']")
+    expect(page).to have_selector("input[value='2019']")
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Entering their work history' do
   include CandidateHelper
 
   scenario 'Candidate submits their work history' do
-    FeatureFlag.activate('work_breaks')
-
     given_i_am_signed_in
     and_i_visit_the_site
 
@@ -23,7 +21,6 @@ RSpec.feature 'Entering their work history' do
     and_i_should_see_the_incorrect_date_values
 
     when_i_fill_in_the_job_form
-    and_i_choose_no_to_adding_another_job
     then_i_should_see_my_completed_job
 
     when_i_click_on_delete_entry
@@ -32,18 +29,13 @@ RSpec.feature 'Entering their work history' do
 
     when_i_click_on_add_job
     and_i_fill_in_the_job_form # 5/2014 - 1/2019
-    and_i_choose_yes_to_adding_another_job
-    then_i_should_see_the_job_form
+    then_i_should_see_my_completed_job
 
-    when_i_fill_in_the_job_form_with_another_job_with_a_break # 3/2019 - current
+    when_i_click_on_add_another_job
+    and_i_fill_in_the_job_form_with_another_job_with_a_break # 3/2019 - current
     and_i_do_not_fill_in_end_date
-    and_i_choose_no_to_adding_another_job
     then_i_should_see_my_second_job
-    and_i_should_see_the_length_of_the_gap_in_months # 1 months
     and_i_should_be_asked_to_explain_the_break_in_my_work_history
-
-    when_i_click_add_another_job_for_my_break
-    then_i_should_see_the_start_and_end_date_filled_in
 
     given_i_am_on_review_work_history_page
     when_i_click_to_enter_break_explanation
@@ -147,16 +139,6 @@ RSpec.feature 'Entering their work history' do
     fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
 
     choose 'No'
-  end
-
-  def and_i_choose_no_to_adding_another_job
-    choose 'No, I’ve completed my work history'
-
-    click_button t('application_form.work_history.complete_form_button')
-  end
-
-  def and_i_choose_yes_to_adding_another_job
-    choose 'Yes, I want to add another job'
 
     click_button t('application_form.work_history.complete_form_button')
   end
@@ -183,14 +165,14 @@ RSpec.feature 'Entering their work history' do
   end
 
   def when_i_click_on_add_another_job
-    all('a', text: 'Add another job')[1].click
+    click_link 'Add another job'
   end
 
   def and_i_fill_in_the_job_form
     when_i_fill_in_the_job_form
   end
 
-  def when_i_fill_in_the_job_form_with_another_job_with_a_break
+  def and_i_fill_in_the_job_form_with_another_job_with_a_break
     scope = 'application_form.work_history'
     fill_in t('role.label', scope: scope), with: 'Chief of Xenomorph Procurement and Research'
     fill_in t('organisation.label', scope: scope), with: 'Weyland-Yutani'
@@ -205,6 +187,8 @@ RSpec.feature 'Entering their work history' do
     fill_in t('details.label', scope: scope), with: 'Gimme Xenomorphs.'
 
     choose 'No'
+
+    click_button t('application_form.work_history.complete_form_button')
   end
 
   def and_i_do_not_fill_in_end_date; end
@@ -213,23 +197,8 @@ RSpec.feature 'Entering their work history' do
     expect(page).to have_content('Chief of Xenomorph Procurement and Research')
   end
 
-  def and_i_should_see_the_length_of_the_gap_in_months
-    expect(page).to have_content('You have a break in your work history (1 month)')
-  end
-
   def and_i_should_be_asked_to_explain_the_break_in_my_work_history
     expect(page).to have_content(t('application_form.work_history.break.label'))
-  end
-
-  def when_i_click_add_another_job_for_my_break
-    first(:link, t('application_form.work_history.add_another_job')).click
-  end
-
-  def then_i_should_see_the_start_and_end_date_filled_in
-    expect(page).to have_selector("input[value='1']")
-    expect(page).to have_selector("input[value='2019']")
-    expect(page).to have_selector("input[value='3']")
-    expect(page).to have_selector("input[value='2019']")
   end
 
   def given_i_am_on_review_work_history_page


### PR DESCRIPTION
## Context

When slowly adding the feature to enable a candidate to enter a reason for each work history break, we've been adding to the existing `spec/system/candidate_interface/candidate_entering_work_history_spec.rb` system spec. This spec has become quite long and potentially confusing as it mixes new features with the soon to be old way of us collecting a work history break (a single text area).

## Changes proposed in this pull request

This PR extracts the new parts of the work history breaks into a new system spec to make things clearer. 

This means:

- `spec/system/candidate_interface/candidate_entering_work_history_spec.rb` contains the single text box way of entering work history breaks so without the `work_breaks` feature flag activated
- `spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb` contains the new way of entering work history breaks / what we have so far and with the `work_breaks` feature flag activated

## Guidance to review

Is this clearer?

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
