### PR TITLE
Remove referee survey and chase survey emails

### DIFF
--- a/app/mailers/previews/referee_mailer_preview.rb
+++ b/app/mailers/previews/referee_mailer_preview.rb
@@ -13,14 +13,6 @@ class RefereeMailerPreview < ActionMailer::Preview
     RefereeMailer.reference_request_chaser_email(application_form, reference)
   end
 
-  def survey_email
-    RefereeMailer.survey_email(application_form, reference)
-  end
-
-  def survey_chaser_email
-    RefereeMailer.survey_chaser_email(reference)
-  end
-
   def reference_confirmation_email
     RefereeMailer.reference_confirmation_email(application_form, reference)
   end

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -23,27 +23,6 @@ class RefereeMailer < ApplicationMailer
               subject: t('reference_request.subject.chaser', candidate_name: @candidate_name))
   end
 
-  def survey_email(application_form, reference)
-    @name = reference.name
-    @thank_you_message = t('survey_emails.thank_you.referee', candidate_name: application_form.full_name)
-
-    view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: reference.email_address,
-              subject: t('survey_emails.subject.initial'),
-              template_path: 'survey_emails',
-              template_name: 'initial')
-  end
-
-  def survey_chaser_email(reference)
-    @name = reference.name
-
-    view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: reference.email_address,
-              subject: t('survey_emails.subject.chaser'),
-              template_path: 'survey_emails',
-              template_name: 'chaser')
-  end
-
   def reference_confirmation_email(application_form, reference)
     @name = reference.name
     @candidate_name = application_form.full_name

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -70,62 +70,6 @@ RSpec.describe RefereeMailer, type: :mailer do
     end
   end
 
-  describe 'Send survey email' do
-    let(:reference) { build_stubbed(:reference) }
-    let(:application_form) do
-      build_stubbed(
-        :application_form,
-        first_name: 'Elliot',
-        last_name: 'Alderson',
-        application_references: [reference],
-      )
-    end
-
-    context 'when initial email' do
-      let(:mail) { mailer.survey_email(application_form, reference) }
-
-      before { mail.deliver_later }
-
-      it 'sends an email to the provided referee' do
-        expect(mail.to).to include(reference.email_address)
-      end
-
-      it 'sends an email with the correct subject' do
-        expect(mail.subject).to include(t('survey_emails.subject.initial'))
-      end
-
-      it 'sends an email with the correct heading' do
-        expect(mail.body.encoded).to include("Dear #{reference.name}")
-      end
-
-      it 'sends an email with the correct thank you message' do
-        expect(mail.body.encoded).to include(t('survey_emails.thank_you.referee', candidate_name: 'Elliot Alderson'))
-      end
-
-      it 'sends an email with the link to the survey' do
-        expect(mail.body.encoded).to include(t('survey_emails.survey_link'))
-      end
-    end
-
-    context 'when chaser email' do
-      let(:mail) { mailer.survey_chaser_email(reference) }
-
-      before { mail.deliver_later }
-
-      it 'sends an email with the correct subject' do
-        expect(mail.subject).to include(t('survey_emails.subject.chaser'))
-      end
-
-      it 'sends an email with the correct heading' do
-        expect(mail.body.encoded).to include("Dear #{reference.name}")
-      end
-
-      it 'sends an email with the link to the survey' do
-        expect(mail.body.encoded).to include(t('survey_emails.survey_link'))
-      end
-    end
-  end
-
   describe 'Send reference confirmation email' do
     let(:reference) { build_stubbed(:reference) }
     let(:application_form) do

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -38,8 +38,6 @@ RSpec.feature 'Docs' do
       provider_mailer-account_created
       provider_mailer-chase_provider_decision
       referee_mailer-reference_request_chaser_email
-      referee_mailer-survey_chaser_email
-      referee_mailer-survey_email
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

These emails are no longer necessary as when a referee submits a reference they are immediately redirected to a questionnaire to fill out.

## Changes proposed in this pull request

- Remove both emails from the RefereeMailer and PreviewRefereeMailer
- Remove tests and update the docs

## Guidance to review

🤔 Check I got everything I guess?

## Link to Trello card

https://trello.com/c/05nmr4eO/962-checking-emails-in-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
