### PR TITLE
Add interstitial page to warn users that they need to replace references

### DIFF
--- a/app/components/candidate_interface/additional_referees_start_component.html.erb
+++ b/app/components/candidate_interface/additional_referees_start_component.html.erb
@@ -1,0 +1,26 @@
+<h1 class="govuk-heading-xl">
+  <%= title %>
+</h1>
+
+<p class="govuk-body">
+  <% if reference_status.number_of_references_that_currently_need_replacing == 1 %>
+    <%= reason_for_replacement(references_that_need_replacement.first) %>.
+  <% else %>
+    Your referees have not given us a reference:
+    <ul class="govuk-list govuk-list--bullet">
+      <% references_that_need_replacement.each do |ref| %>
+        <li class="govuk-body"><%= reason_for_replacement(ref) %></li>
+      <% end %>
+    </ul>
+  <% end %>
+</p>
+
+<p class="govuk-body">We can’t send your application to your teacher training providers without 2 complete references.</p>
+
+<% if reference_status.number_of_references_that_currently_need_replacing == 1 %>
+  <p> <%= govuk_button_link_to 'Add a new referee', candidate_interface_new_additional_referee_path %></p>
+  <p class="govuk-body"><%= govuk_link_to 'Continue without adding a new referee', candidate_interface_application_complete_path %></p>
+<% else %>
+   <%= govuk_button_link_to 'Add new referees', candidate_interface_new_additional_referee_path %>
+  <p class="govuk-body"><%= govuk_link_to 'Continue without adding new referees', candidate_interface_application_complete_path %></p>
+<% end %>

--- a/app/components/candidate_interface/additional_referees_start_component.rb
+++ b/app/components/candidate_interface/additional_referees_start_component.rb
@@ -1,0 +1,42 @@
+module CandidateInterface
+  class AdditionalRefereesStartComponent < ActionView::Component::Base
+    include ViewHelper
+
+    validates :application_form, presence: true
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+  private
+
+    def reference_status
+      @reference_status ||= ReferenceStatus.new(application_form)
+    end
+
+    def title
+      if reference_status.number_of_references_that_currently_need_replacing == 1
+        'You need to add a new referee'
+      else
+        'You need to add 2 new referees'
+      end
+    end
+
+    def reason_for_replacement(referee)
+      case referee.feedback_status
+      when 'email_bounced'
+        "Our email requesting a reference didn’t reach #{referee.name}"
+      when 'feedback_refused'
+        "#{referee.name} said they won’t give a reference"
+      else
+        "#{referee.name} did not respond to our request"
+      end
+    end
+
+    def references_that_need_replacement
+      @reference_status.references_that_needed_to_be_replaced
+    end
+
+    attr_reader :application_form
+  end
+end

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -9,6 +9,8 @@ module CandidateInterface
       @reference = ApplicationReference.new
     end
 
+    def show; end
+
     def create
       redirect_to_confirm_if_no_more_reference_needed
       reference = current_application.application_references.build(referee_params.merge(replacement: true))

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -3,7 +3,6 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_not_amendable, only: %i[show review]
     before_action :redirect_to_application_form_unless_submitted, only: %i[review_submitted complete submit_success]
 
-
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
       @application_form = current_application

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -21,6 +21,10 @@ module CandidateInterface
       redirect_to candidate_interface_application_form_path if candidate_signed_in?
     end
 
+    def more_reference_needed?
+      ReferenceStatus.new(current_application).still_more_references_needed?
+    end
+
     def show_pilot_holding_page_if_not_open
       return if FeatureFlag.active?('pilot_open')
 

--- a/app/views/candidate_interface/additional_referees/show.html.erb
+++ b/app/views/candidate_interface/additional_referees/show.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::AdditionalRefereesStartComponent, application_form: @current_application %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,8 @@ Rails.application.routes.draw do
 
     get '/apply', to: 'apply_from_find#show', as: :apply_from_find
 
+    get '/interstitial', to: 'sign_in#interstitial', as: :interstitial
+
     scope '/application' do
       get '/' => 'application_form#show', as: :application_form
       get '/edit' => 'application_form#edit', as: :application_edit
@@ -229,8 +231,9 @@ Rails.application.routes.draw do
       end
 
       scope '/new-referee' do
-        get '/' => 'additional_referees#new', as: :new_additional_referee
-        post '/' => 'additional_referees#create'
+        get '/' => 'additional_referees#show', as: :additional_referee
+        get '/new' => 'additional_referees#new', as: :new_additional_referee
+        post '/new' => 'additional_referees#create'
 
         get '/:application_reference_id/edit' => 'additional_referees#edit', as: :edit_additional_referee
         patch '/:application_reference_id/edit' => 'additional_referees#update'

--- a/spec/components/candidate_interface/additional_referees_start_component_spec.rb
+++ b/spec/components/candidate_interface/additional_referees_start_component_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::AdditionalRefereesStartComponent do
+  let(:application_form) { create(:completed_application_form, references_count: 0, with_gces: true) }
+
+  context 'when one referee request failed' do
+    before do
+      create(:reference, :complete, application_form: application_form)
+    end
+
+    it 'has a page content that requests one new referee' do
+      create(:reference, :email_bounced, application_form: application_form)
+      result = render_inline(described_class, application_form: application_form)
+
+      expect(result.css('.govuk-heading-xl').text).to include('You need to add a new referee')
+      expect(result.css('.govuk-button').text).to include('Add a new referee')
+      expect(result.css('.govuk-link').text).to include('Continue without adding a new referee')
+    end
+
+    it 'gives a reason when email bounced' do
+      bounced_referee = create(:reference, :email_bounced, application_form: application_form)
+      result = render_inline(described_class, application_form: application_form)
+
+      expect(result.css('.govuk-body').text).to include("Our email requesting a reference didn’t reach #{bounced_referee.name}.")
+    end
+
+    it 'gives a reason when referee refused to give feedback' do
+      refused_referee = create(:reference, :refused, application_form: application_form)
+      result = render_inline(described_class, application_form: application_form)
+
+      expect(result.css('.govuk-body').text).to include("#{refused_referee.name} said they won’t give a reference.")
+    end
+
+    it 'gives a reason when the feedback is overdue' do
+      late_referee = create(:reference, :requested, application_form: application_form)
+      late_referee.update!(requested_at: Time.zone.now - 30.days)
+      result = render_inline(described_class, application_form: application_form)
+
+      expect(result.css('.govuk-body').text).to include("#{late_referee.name} did not respond to our request.")
+    end
+
+    it 'does not show a reference that does not need replacing' do
+      create(:reference, :email_bounced, application_form: application_form)
+      first_referee = application_form.application_references.first
+
+      result = render_inline(described_class, application_form: application_form)
+      expect(result.css('.govuk-body').text).not_to include(first_referee.name.to_s)
+    end
+  end
+
+  context 'when multiple referee request failed' do
+    before do
+      create(:reference, :email_bounced, application_form: application_form)
+      create(:reference, :refused, application_form: application_form)
+      create(:reference, :complete, application_form: application_form)
+    end
+
+    it 'has a page content that requests new referees' do
+      result = render_inline(described_class, application_form: application_form)
+
+      expect(result.css('.govuk-heading-xl').text).to include('You need to add 2 new referees')
+      expect(result.css('.govuk-button').text).to include('Add new referees')
+      expect(result.css('.govuk-link').text).to include('Continue without adding new referees')
+    end
+
+    it 'gives a reason for all failed referee requests' do
+      first_referee = application_form.application_references.first
+      second_referee = application_form.application_references.second
+      third_referee = application_form.application_references.third
+      result = render_inline(described_class, application_form: application_form)
+
+      expect(result.css('.govuk-body').text).to include('Your referees have not given us a reference:')
+      expect(result.css('.govuk-body').text).to include("Our email requesting a reference didn’t reach #{first_referee.name}")
+      expect(result.css('.govuk-body').text).to include("#{second_referee.name} said they won’t give a reference")
+      expect(result.css('.govuk-body').text).not_to include(third_referee.name.to_s)
+    end
+  end
+end

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::RefereesReviewComponent do
-  let(:application_form) do
-    create(:completed_application_form, references_count: 2)
-  end
-
   context 'when referees are editable' do
     let(:application_form) { create(:completed_application_form, references_count: 2, with_gces: true) }
 

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   include CandidateHelper
 
   scenario "Candidate provides a new referee because 2 didn't respond" do
+    FeatureFlag.activate('pilot_open')
     FeatureFlag.activate('show_new_referee_needed')
 
     given_i_am_signed_in_as_a_candidate
@@ -12,6 +13,9 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
 
     when_i_visit_the_application_dashboard
     then_i_see_that_i_need_new_references
+
+    when_i_visit_the_start_page
+    then_i_see_the_interstitial_page_to_add_new_referees
 
     when_i_click_to_add_a_new_referee
     and_i_fill_in_the_form
@@ -46,15 +50,26 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
   end
 
   def when_i_visit_the_application_dashboard
-    visit candidate_interface_application_form_path
+    visit candidate_interface_application_complete_path
   end
 
   def then_i_see_that_i_need_new_references
     expect(page).to have_content 'You need to give details of 2 new referees'
   end
 
+  def when_i_visit_the_start_page
+    visit candidate_interface_interstitial_path
+  end
+
+  def then_i_see_the_interstitial_page_to_add_new_referees
+    expect(page).to have_content 'You need to add 2 new referees'
+    @application_form.application_references.each do |referee|
+      expect(page).to have_content "#{referee.name} did not respond to our request"
+    end
+  end
+
   def when_i_click_to_add_a_new_referee
-    click_on 'give details of 2 new referees'
+    click_on 'Add new referees'
   end
 
   def and_i_fill_in_the_form


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow candidates to provide an alternative referee if my original referees have not responded *or* have declined. 

## Changes proposed in this pull request
This PR adds the interstitial page that warns candidates when they need to replace references.
The interstitial page should differ if one or two replacement referees needed, using the `AdditionalRefereesStartComponent`. 
### After:
![image](https://user-images.githubusercontent.com/22743709/74355176-68726180-4db4-11ea-94af-80af231ef09d.png)

![image](https://user-images.githubusercontent.com/22743709/74355638-0b2ae000-4db5-11ea-9e3d-bea5a0f12cf3.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
For manual testing: 
- Create an application form with referees needed replacement 
- Log in as a candidate and visit the root page (Make sure the feature flag is on) 
- Visit the application page
You should be redirected to the interstitial page

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/oMo8ZCap/761-enable-candidates-to-add-new-referee

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
