### PR TITLE
Support: split the 'unsubmitted' application process state into two

### DIFF
--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -3,7 +3,7 @@ class PerformanceStatistics
   WITH raw_data AS (
       SELECT
           COUNT(c.id) FILTER (WHERE f.id IS NOT NULL) candidate_forms,
-          SUM(CASE WHEN f.id IS NOT NULL AND f.created_at < f.updated_at THEN 1 ELSE 0 END) candidate_started_form_count,
+          SUM(CASE WHEN f.id IS NOT NULL AND DATE_TRUNC('second', f.updated_at) <> DATE_TRUNC('second', f.created_at) THEN 1 ELSE 0 END) candidate_started_form_count,
           SUM(CASE WHEN f.id IS NOT NULL AND f.submitted_at IS NOT NULL THEN 1 ELSE 0 END) candidate_submitted_form_count
       FROM
           candidates c
@@ -30,8 +30,8 @@ class PerformanceStatistics
           COUNT(f.id) FILTER (WHERE f.id IS NOT NULL) application_forms,
           COUNT(ch.id) FILTER (WHERE f.id IS NOT NULL) application_choices,
           CASE
-            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND f.updated_at = f.created_at THEN ARRAY['0', 'unsubmitted_not_started_form']
-            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND f.updated_at <> f.created_at THEN ARRAY['1', 'unsubmitted_in_progress']
+            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND DATE_TRUNC('second', f.updated_at) = DATE_TRUNC('second', f.created_at) THEN ARRAY['0', 'unsubmitted_not_started_form']
+            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND DATE_TRUNC('second', f.updated_at) <> DATE_TRUNC('second', f.created_at) THEN ARRAY['1', 'unsubmitted_in_progress']
             WHEN 'awaiting_references' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['2', 'awaiting_references']
             WHEN 'application_complete' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['3', 'waiting_to_be_sent']
             WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['4', 'awaiting_provider_decisions']

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -30,17 +30,17 @@ class PerformanceStatistics
           COUNT(f.id) FILTER (WHERE f.id IS NOT NULL) application_forms,
           COUNT(ch.id) FILTER (WHERE f.id IS NOT NULL) application_choices,
           CASE
-            WHEN ARRAY_AGG(DISTINCT ch.status) = '{NULL}' THEN ARRAY['0', 'unsubmitted']
-            WHEN ARRAY_AGG(DISTINCT ch.status) = '{unsubmitted}' THEN ARRAY['0', 'unsubmitted']
-            WHEN 'awaiting_references' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['1', 'awaiting_references']
-            WHEN 'application_complete' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['2', 'waiting_to_be_sent']
-            WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['3', 'awaiting_provider_decisions']
-            WHEN 'offer' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['5', 'awaiting_candidate_response']
-            WHEN 'enrolled' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['8', 'enrolled']
-            WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'recruited']
-            WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['6', 'pending_conditions']
-            WHEN ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_AGG(DISTINCT ch.status), 'withdrawn'), 'rejected'), 'declined'), 'conditions_not_met') = '{}' THEN ARRAY['4', 'ended_without_success']
-            ELSE ARRAY['9', 'unknown_state']
+            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND f.updated_at = f.created_at THEN ARRAY['0', 'unsubmitted_not_started_form']
+            WHEN ARRAY_AGG(DISTINCT ch.status) IN ('{NULL}', '{unsubmitted}') AND f.updated_at <> f.created_at THEN ARRAY['1', 'unsubmitted_in_progress']
+            WHEN 'awaiting_references' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['2', 'awaiting_references']
+            WHEN 'application_complete' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['3', 'waiting_to_be_sent']
+            WHEN 'awaiting_provider_decision' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['4', 'awaiting_provider_decisions']
+            WHEN 'offer' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['6', 'awaiting_candidate_response']
+            WHEN 'enrolled' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['9', 'enrolled']
+            WHEN 'recruited' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['8', 'recruited']
+            WHEN 'pending_conditions' = ANY(ARRAY_AGG(ch.status)) THEN ARRAY['7', 'pending_conditions']
+            WHEN ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_REMOVE(ARRAY_AGG(DISTINCT ch.status), 'withdrawn'), 'rejected'), 'declined'), 'conditions_not_met') = '{}' THEN ARRAY['5', 'ended_without_success']
+            ELSE ARRAY['10', 'unknown_state']
           END status
       FROM
           application_forms f

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -13,10 +13,14 @@ class ProcessState
     end
 
     state :never_signed_in do
-      event :sign_in, transitions_to: :unsubmitted
+      event :sign_in, transitions_to: :unsubmitted_not_started_form
     end
 
-    state :unsubmitted do
+    state :unsubmitted_not_started_form do
+      event :edit_form, transitions_to: :unsubmitted_in_progress
+    end
+
+    state :unsubmitted_in_progress do
       event :submit, transitions_to: :awaiting_references
     end
 

--- a/app/services/process_state.rb
+++ b/app/services/process_state.rb
@@ -63,10 +63,8 @@ class ProcessState
   def state
     if application_form.nil?
       :never_signed_in
-    elsif application_choices.empty?
-      :unsubmitted
-    elsif all_states_are?('unsubmitted')
-      :unsubmitted
+    elsif application_choices.empty? || all_states_are?('unsubmitted')
+      unchanged?(application_form) ? :unsubmitted_not_started_form : :unsubmitted_in_progress
     elsif any_state_is?('awaiting_references')
       :awaiting_references
     elsif any_state_is?('application_complete')
@@ -112,5 +110,9 @@ private
 
   def any_state_is?(state)
     states.include?(state)
+  end
+
+  def unchanged?(application_form)
+    application_form.created_at.to_i == application_form.updated_at.to_i
   end
 end

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -9,9 +9,12 @@ en:
     never_signed_in:
       name: Never signed in
       description: The candidate has signed up but never signed into the service
-    unsubmitted:
-      name: Unsubmitted
-      description: The candidate hasn’t submitted the form yet
+    unsubmitted_not_started_form:
+      name: Haven’t started form
+      description: The candidate has signed in but hasn’t edited the form yet
+    unsubmitted_in_progress:
+      name: Form started but unsubmitted
+      description: The candidate has started editing but hasn’t submitted the form yet
     awaiting_references:
       name: Awaiting references
       description: The candidate has submitted the form. We’ve asked their references for feedback, and are still waiting on one or more of those.
@@ -277,7 +280,12 @@ en:
       by: candidate
       description: ''
 
-    unsubmitted-submit:
+    unsubmitted_not_started_form-edit_form:
+      name: Edit form
+      by: candidate
+      description: ''
+
+    unsubmitted_in_progress-submit:
       name: Submit
       by: candidate
       description: ''

--- a/spec/services/process_state_spec.rb
+++ b/spec/services/process_state_spec.rb
@@ -13,15 +13,23 @@ RSpec.describe ProcessState do
 
       state = ProcessState.new(application_form).state
 
-      expect(state).to be(:unsubmitted)
+      expect(state).to be(:unsubmitted_not_started_form)
     end
 
-    it 'returns unsubmitted with unsubmitted choices' do
+    it 'returns unsubmitted_not_started_form when unsubmitted choices exist but form has not been updated' do
       application_form = build_stubbed(:application_form, application_choices: build_list(:application_choice, 2, status: 'unsubmitted'))
-
       state = ProcessState.new(application_form).state
 
-      expect(state).to be(:unsubmitted)
+      expect(state).to be(:unsubmitted_not_started_form)
+    end
+
+    it 'returns unsubmitted_not_started_form when unsubmitted choices exist but form has been updated' do
+      application_form = build_stubbed(:application_form,
+                                       application_choices: build_list(:application_choice, 2, status: 'unsubmitted'),
+                                       updated_at: Time.zone.now + 1.day)
+      state = ProcessState.new(application_form).state
+
+      expect(state).to be(:unsubmitted_in_progress)
     end
 
     it 'returns awaiting_references when awaiting references for all choices' do


### PR DESCRIPTION
## Context

Within the Support side of things, we have some candidate process documentation and performance statistics. Prior to this PR, there is only 1 state to represent unsubmitted applications. For reporting purposes, it's interesting to differentiate between unsubmitted applications that haven't been modified since creation (i.e. someone has registered to have a look at the application, but hasn't put anything in) vs someone who has put some data in.

## Changes proposed in this pull request

- split the "unsubmitted" state into two states:

in the process documentation:

![image](https://user-images.githubusercontent.com/23801/74364929-0110dd80-4dc5-11ea-921b-a7df3e486f4a.png)

and in the applications/candidates list within the Support interface:

![image](https://user-images.githubusercontent.com/23801/74365021-2b629b00-4dc5-11ea-8e9e-2c93f8c01804.png)

- split the 'unsubmitted' state up into two in the performance reporting on applications:

![image](https://user-images.githubusercontent.com/23801/74365112-551bc200-4dc5-11ea-93e9-a10600ec895c.png)

## Guidance to review

The code defines 'an application has been edited' as having the `updated_at` timestamp not being within the same second as the `created_at` timestamp.

Out of scope of this PR: folding down the candidate and application form reporting on the service performance page (which will be possible and follow shortly after this PR is merged).

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
