### PR TITLE
Send the 'you have an offer' email to candidate

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -76,6 +76,8 @@ class CandidateMailer < ApplicationMailer
     new_offer(application_choice, :decisions_pending)
   end
 
+private
+
   def new_offer(application_choice, template_name)
     @application_choice = application_choice
     @candidate_name = @application_choice.application_form.first_name

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -65,6 +65,12 @@ class CandidateMailer < ApplicationMailer
   end
 
   def new_offer(application_choice)
+    @application_choice = application_choice
+    @candidate_name = @application_choice.application_form.first_name
+    @provider_name = @application_choice.course_option.course.provider.name
+    @course_name = @application_choice.course_option.course.name_and_code
+    @conditions = @application_choice.offer&.dig('conditions') || []
+
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: application_choice.application_form.candidate.email_address,
               subject: t(

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -84,19 +84,17 @@ class CandidateMailer < ApplicationMailer
 
 private
 
-  # TODO: work out whether the are multiple/single offers etc.
-  def new_offer_template_name(_application_choice)
-    # candidate_application_choices = application_choice.application_form.application_choices
-    # number_of_pending_decisions = candidate_application_choices.select(&:awaiting_provider_decision?).count
-    # number_of_offers = candidate_application_choices.select(&:offer?).count
+  def new_offer_template_name(application_choice)
+    candidate_application_choices = application_choice.application_form.application_choices
+    number_of_pending_decisions = candidate_application_choices.select(&:awaiting_provider_decision?).count
+    number_of_offers = candidate_application_choices.select(&:offer?).count
 
-    :single_offer
-    # if number_of_pending_decisions.positive?
-    #   :decisions_pending
-    # elsif number_of_offers > 1
-    #   :multiple_offers
-    # else
-    #   :single_offer
-    # end
+    if number_of_pending_decisions.positive?
+      :decisions_pending
+    elsif number_of_offers > 1
+      :multiple_offers
+    else
+      :single_offer
+    end
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -70,6 +70,9 @@ class CandidateMailer < ApplicationMailer
     @provider_name = @application_choice.course_option.course.provider.name
     @course_name = @application_choice.course_option.course.name_and_code
     @conditions = @application_choice.offer&.dig('conditions') || []
+    @offers = @application_choice.application_form.application_choices.select(&:offer?).map do |offer|
+      "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
+    end
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: application_choice.application_form.candidate.email_address,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -64,7 +64,19 @@ class CandidateMailer < ApplicationMailer
               subject: t("new_referee_request.#{@reason}.subject", referee_name: @referee.name))
   end
 
-  def new_offer(application_choice)
+  def new_offer_single_offer(application_choice)
+    new_offer(application_choice, :single_offer)
+  end
+
+  def new_offer_multiple_offers(application_choice)
+    new_offer(application_choice, :multiple_offers)
+  end
+
+  def new_offer_decisions_pending(application_choice)
+    new_offer(application_choice, :decisions_pending)
+  end
+
+  def new_offer(application_choice, template_name)
     @application_choice = application_choice
     @candidate_name = @application_choice.application_form.first_name
     @provider_name = @application_choice.course_option.course.provider.name
@@ -74,30 +86,16 @@ class CandidateMailer < ApplicationMailer
       "#{offer.course_option.course.name_and_code} at #{offer.course_option.course.provider.name}"
     end
 
-    view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: application_choice.application_form.candidate.email_address,
-              subject: t(
-                "candidate_offer.#{new_offer_template_name(application_choice)}.subject",
-                course_name: application_choice.course_option.course.name_and_code,
-                provider_name: application_choice.course_option.course.provider.name,
-              ),
-              template_path: 'candidate_mailer/new_offer',
-              template_name: new_offer_template_name(application_choice))
-  end
-
-private
-
-  def new_offer_template_name(application_choice)
-    candidate_application_choices = application_choice.application_form.application_choices
-    number_of_pending_decisions = candidate_application_choices.select(&:awaiting_provider_decision?).count
-    number_of_offers = candidate_application_choices.select(&:offer?).count
-
-    if number_of_pending_decisions.positive?
-      :decisions_pending
-    elsif number_of_offers > 1
-      :multiple_offers
-    else
-      :single_offer
-    end
+    view_mail(
+      GENERIC_NOTIFY_TEMPLATE,
+      to: application_choice.application_form.candidate.email_address,
+      subject: t(
+        "candidate_offer.#{template_name}.subject",
+        course_name: application_choice.course_option.course.name_and_code,
+        provider_name: application_choice.course_option.course.provider.name,
+      ),
+      template_path: 'candidate_mailer/new_offer',
+      template_name: template_name,
+    )
   end
 end

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -63,4 +63,34 @@ class CandidateMailer < ApplicationMailer
               to: application_form.candidate.email_address,
               subject: t("new_referee_request.#{@reason}.subject", referee_name: @referee.name))
   end
+
+  def new_offer(application_choice)
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: application_choice.application_form.candidate.email_address,
+              subject: t(
+                "candidate_offer.#{new_offer_template_name(application_choice)}.subject",
+                course_name: application_choice.course_option.course.name_and_code,
+                provider_name: application_choice.course_option.course.provider.name,
+              ),
+              template_path: 'candidate_mailer/new_offer',
+              template_name: new_offer_template_name(application_choice))
+  end
+
+private
+
+  # TODO: work out whether the are multiple/single offers etc.
+  def new_offer_template_name(_application_choice)
+    # candidate_application_choices = application_choice.application_form.application_choices
+    # number_of_pending_decisions = candidate_application_choices.select(&:awaiting_provider_decision?).count
+    # number_of_offers = candidate_application_choices.select(&:offer?).count
+
+    :single_offer
+    # if number_of_pending_decisions.positive?
+    #   :decisions_pending
+    # elsif number_of_offers > 1
+    #   :multiple_offers
+    # else
+    #   :single_offer
+    # end
+  end
 end

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -43,7 +43,7 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.new_referee_request(application_form, reference, reason: :email_bounced)
   end
 
-  def new_offer_without_other_offers
+  def new_offer_single_offer
     course_option = FactoryBot.build_stubbed(:course_option)
     application_choice = application_form.application_choices.build(
       id: 123,
@@ -54,10 +54,10 @@ class CandidateMailerPreview < ActionMailer::Preview
       offered_course_option: course_option,
       decline_by_default_at: 10.business_days.from_now,
     )
-    CandidateMailer.new_offer(application_choice)
+    CandidateMailer.new_offer_single_offer(application_choice)
   end
 
-  def new_offer_with_another_offer
+  def new_offer_multiple_offers
     course_option = FactoryBot.build_stubbed(:course_option)
     application_choice = application_form.application_choices.build(
       id: 123,
@@ -78,10 +78,10 @@ class CandidateMailerPreview < ActionMailer::Preview
       offered_course_option: other_course_option,
       decline_by_default_at: 7.business_days.from_now,
     )
-    CandidateMailer.new_offer(application_choice)
+    CandidateMailer.new_offer_multiple_offers(application_choice)
   end
 
-  def new_offer_with_pending_decisions
+  def new_offer_decisions_pending
     course_option = FactoryBot.build_stubbed(:course_option)
     application_choice = application_form.application_choices.build(
       id: 123,
@@ -98,7 +98,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       course_option: other_course_option,
       status: :awaiting_provider_decision,
     )
-    CandidateMailer.new_offer(application_choice)
+    CandidateMailer.new_offer_decisions_pending(application_choice)
   end
 
 private

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -52,6 +52,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       offer: { conditions: ['DBS check', 'Pass exams'] },
       offered_at: Time.zone.now,
       offered_course_option: course_option,
+      decline_by_default_at: 10.business_days.from_now,
     )
     CandidateMailer.new_offer(application_choice)
   end
@@ -65,6 +66,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       offer: { conditions: ['DBS check', 'Pass exams'] },
       offered_at: Time.zone.now,
       offered_course_option: course_option,
+      decline_by_default_at: 10.business_days.from_now,
     )
     other_course_option = FactoryBot.build_stubbed(:course_option)
     application_form.application_choices.build(
@@ -74,6 +76,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       offer: { conditions: ['Get a degree'] },
       offered_at: Time.zone.now,
       offered_course_option: other_course_option,
+      decline_by_default_at: 7.business_days.from_now,
     )
     CandidateMailer.new_offer(application_choice)
   end
@@ -87,15 +90,13 @@ class CandidateMailerPreview < ActionMailer::Preview
       offer: { conditions: ['DBS check', 'Pass exams'] },
       offered_at: Time.zone.now,
       offered_course_option: course_option,
+      decline_by_default_at: 10.business_days.from_now,
     )
     other_course_option = FactoryBot.build_stubbed(:course_option)
     application_form.application_choices.build(
       id: 456,
       course_option: other_course_option,
       status: :awaiting_provider_decision,
-      offer: { conditions: ['Get a degree'] },
-      offered_at: Time.zone.now,
-      offered_course_option: other_course_option,
     )
     CandidateMailer.new_offer(application_choice)
   end

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -43,10 +43,67 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.new_referee_request(application_form, reference, reason: :email_bounced)
   end
 
+  def new_offer_without_other_offers
+    course_option = FactoryBot.build_stubbed(:course_option)
+    application_choice = application_form.application_choices.build(
+      id: 123,
+      course_option: course_option,
+      status: :offer,
+      offer: { conditions: ['DBS check', 'Pass exams'] },
+      offered_at: Time.zone.now,
+      offered_course_option: course_option,
+    )
+    CandidateMailer.new_offer(application_choice)
+  end
+
+  def new_offer_with_another_offer
+    course_option = FactoryBot.build_stubbed(:course_option)
+    application_choice = application_form.application_choices.build(
+      id: 123,
+      course_option: course_option,
+      status: :offer,
+      offer: { conditions: ['DBS check', 'Pass exams'] },
+      offered_at: Time.zone.now,
+      offered_course_option: course_option,
+    )
+    other_course_option = FactoryBot.build_stubbed(:course_option)
+    application_form.application_choices.build(
+      id: 456,
+      course_option: other_course_option,
+      status: :offer,
+      offer: { conditions: ['Get a degree'] },
+      offered_at: Time.zone.now,
+      offered_course_option: other_course_option,
+    )
+    CandidateMailer.new_offer(application_choice)
+  end
+
+  def new_offer_with_pending_decisions
+    course_option = FactoryBot.build_stubbed(:course_option)
+    application_choice = application_form.application_choices.build(
+      id: 123,
+      course_option: course_option,
+      status: :offer,
+      offer: { conditions: ['DBS check', 'Pass exams'] },
+      offered_at: Time.zone.now,
+      offered_course_option: course_option,
+    )
+    other_course_option = FactoryBot.build_stubbed(:course_option)
+    application_form.application_choices.build(
+      id: 456,
+      course_option: other_course_option,
+      status: :awaiting_provider_decision,
+      offer: { conditions: ['Get a degree'] },
+      offered_at: Time.zone.now,
+      offered_course_option: other_course_option,
+    )
+    CandidateMailer.new_offer(application_choice)
+  end
+
 private
 
   def application_form
-    FactoryBot.build_stubbed(:application_form, first_name: 'Gemma')
+    @application_form ||= FactoryBot.build_stubbed(:application_form, first_name: 'Gemma')
   end
 
   def reference

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -41,7 +41,7 @@ class MakeAnOffer
     application_choice.save!
 
     SetDeclineByDefault.new(application_form: application_choice.application_form).call
-    CandidateMailer.new_offer(application_choice).deliver
+    SendNewOfferEmailToCandidate.new(application_choice: @application_choice).call
     StateChangeNotifier.call(:make_an_offer, application_choice: application_choice)
   rescue Workflow::NoTransitionAllowed
     errors.add(

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -41,6 +41,7 @@ class MakeAnOffer
     application_choice.save!
 
     SetDeclineByDefault.new(application_form: application_choice.application_form).call
+    CandidateMailer.new_offer(application_choice).deliver
     StateChangeNotifier.call(:make_an_offer, application_choice: application_choice)
   rescue Workflow::NoTransitionAllowed
     errors.add(

--- a/app/services/send_new_offer_email_to_candidate.rb
+++ b/app/services/send_new_offer_email_to_candidate.rb
@@ -1,0 +1,30 @@
+class SendNewOfferEmailToCandidate
+  attr_accessor :application_choice
+
+  def initialize(application_choice:)
+    self.application_choice = application_choice
+  end
+
+  def call
+    CandidateMailer.send(
+      "new_offer_#{mail_type(application_choice)}".to_sym,
+      application_choice,
+    ).deliver_later
+  end
+
+private
+
+  def mail_type(application_choice)
+    candidate_application_choices = application_choice.application_form.application_choices
+    number_of_pending_decisions = candidate_application_choices.select(&:awaiting_provider_decision?).count
+    number_of_offers = candidate_application_choices.select(&:offer?).count
+
+    if number_of_pending_decisions.positive?
+      :decisions_pending
+    elsif number_of_offers > 1
+      :multiple_offers
+    else
+      :single_offer
+    end
+  end
+end

--- a/app/services/send_new_offer_email_to_candidate.rb
+++ b/app/services/send_new_offer_email_to_candidate.rb
@@ -10,9 +10,17 @@ class SendNewOfferEmailToCandidate
       "new_offer_#{mail_type(application_choice)}".to_sym,
       application_choice,
     ).deliver_later
+    add_comment_to_audit_trail
   end
 
 private
+
+  def add_comment_to_audit_trail
+    audit_comment =
+      "New offer email sent to candidate #{application_choice.application_form.candidate.email_address} for " +
+      "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}."
+    application_choice.application_form.update!(audit_comment: audit_comment)
+  end
 
   def mail_type(application_choice)
     candidate_application_choices = application_choice.application_form.application_choices

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -1,0 +1,26 @@
+Dear <%= @candidate_name %>,
+
+# You have an offer
+
+Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+
+The provider has set the following condition(s):
+
+<% @conditions.each do |condition| %>
+  - <%= condition %>
+<% end %>
+
+Contact <%= @provider_name %> directly if you have any questions about this.
+
+# Next steps
+
+^Or
+^You can respond to the offer now. If you accept the offer, your other teacher training application(s) will be withdrawn. Sign in to your account if you want to respond:
+
+<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+^You can wait to hear back about your other application(s) before making a decision. When the last decision is in, you’ll have 10 working days to respond.
+

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -14,7 +14,10 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 # Next steps
 
+^You can wait to hear back about your other application(s) before making a decision. When the last decision is in, you’ll have 10 working days to respond.
+
 ^Or
+
 ^You can respond to the offer now. If you accept the offer, your other teacher training application(s) will be withdrawn. Sign in to your account if you want to respond:
 
 <%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
@@ -22,5 +25,3 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 # Give feedback or report a problem
 
 Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
-^You can wait to hear back about your other application(s) before making a decision. When the last decision is in, you’ll have 10 working days to respond.
-

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -12,9 +12,9 @@ The provider has set the following condition(s):
 
 Contact <%= @provider_name %> directly if you have any questions about this.
 
-# Make a decision by <%= @decline_by_default_at %>
+# Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
-You have 10 working days to make a decision. If you don’t reply by <%= @decline_by_default_at %>, your application will be withdrawn. 
+You have 10 working days to make a decision. If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
 
 # Offers you’ve received
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -27,5 +27,4 @@ Sign in to your account to respond:
 
 # Give feedback or report a problem
 
-[becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
-
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -17,7 +17,9 @@ You have 10 working days to make a decision. If you don’t reply by <%= @declin
 
 # Offers you’ve received
 
-((ListCourseNamesAndAssociatedProivderNamesThatThey’veHadOffersFor))
+<% @offers.each do |offer| %>
+  - <%= offer %>
+<% end %>
 
 Sign in to your account to respond:
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -3,6 +3,7 @@ Dear <%= @candidate_name %>,
 # You have an offer
 
 Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+
 The provider has set the following condition(s):
 
 <% @conditions.each do |condition| %>

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -1,0 +1,29 @@
+Dear <%= @candidate_name %>,
+
+# You have an offer
+
+Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+The provider has set the following condition(s):
+
+<% @conditions.each do |condition| %>
+  - <%= condition %>
+<% end %>
+
+Contact <%= @provider_name %> directly if you have any questions about this.
+
+# Make a decision by <%= @decline_by_default_at %>
+
+You have 10 working days to make a decision. If you don’t reply by <%= @decline_by_default_at %>, your application will be withdrawn. 
+
+# Offers you’ve received
+
+((ListCourseNamesAndAssociatedProivderNamesThatThey’veHadOffersFor))
+
+Sign in to your account to respond:
+
+<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
+
+# Give feedback or report a problem
+
+[becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -21,4 +21,4 @@ Sign in to your account to respond:
 
 # Give feedback or report a problem
 
-[becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -1,15 +1,24 @@
-Dear ((CandidateName))
+Dear <%= @candidate_name %>,
 
 # You have an offer
-Congratulations, you have an offer from ((ProviderName)) to study ((Course Name)).
-The provider has set the following condition(s):
-((ConditionsList))
-Contact ((ProviderName)) directly if you have any questions about this.
 
-# Make a decision by ((DBDDate))
-You have 10 working days to make a decision. If you don’t reply by ((DBDDate)), your application will be withdrawn. 
+Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+The provider has set the following condition(s):
+
+<% @conditions.each do |condition| %>
+  - <%= condition %>
+<% end %>
+
+Contact <%= @provider_name %> directly if you have any questions about this.
+
+# Make a decision by <%= @decline_by_default_at %>
+
+You have 10 working days to make a decision. If you don’t reply by <%= @decline_by_default_at %>, your application will be withdrawn. 
+
 Sign in to your account to respond:
-((url))
+
+<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
 
 # Give feedback or report a problem
-Contact us at becomingateacher@digital.education.gov.uk
+
+[becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -3,6 +3,7 @@ Dear <%= @candidate_name %>,
 # You have an offer
 
 Congratulations, you have an offer from <%= @provider_name %> to study <%= @course_name %>.
+
 The provider has set the following condition(s):
 
 <% @conditions.each do |condition| %>

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -12,9 +12,9 @@ The provider has set the following condition(s):
 
 Contact <%= @provider_name %> directly if you have any questions about this.
 
-# Make a decision by <%= @decline_by_default_at %>
+# Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
-You have 10 working days to make a decision. If you don’t reply by <%= @decline_by_default_at %>, your application will be withdrawn. 
+You have 10 working days to make a decision. If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn. 
 
 Sign in to your account to respond:
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -1,0 +1,15 @@
+Dear ((CandidateName))
+
+# You have an offer
+Congratulations, you have an offer from ((ProviderName)) to study ((Course Name)).
+The provider has set the following condition(s):
+((ConditionsList))
+Contact ((ProviderName)) directly if you have any questions about this.
+
+# Make a decision by ((DBDDate))
+You have 10 working days to make a decision. If you don’t reply by ((DBDDate)), your application will be withdrawn. 
+Sign in to your account to respond:
+((url))
+
+# Give feedback or report a problem
+Contact us at becomingateacher@digital.education.gov.uk

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -192,6 +192,14 @@ en:
         candidates must pass a DBS & childen’s barred list check, and
         candidates must pass a fitness to work health check.
 
+        An email is sent to the candidate, the content of which depends
+        on the state of the application, whether there are other offers
+        and whether there are pending decisions from provider.'
+      emails:
+        - candidate_mailer-new_offer_without_other_offers
+        - candidate_mailer-new_offer_with_another_offer
+        - candidate_mailer-new_offer_with_pending_decisions
+
     awaiting_provider_decision-reject:
       name: Provider rejects
       by: provider
@@ -308,7 +316,11 @@ en:
     awaiting_provider_decisions-at_least_one_offer:
       name: At least one offer
       by: provider
-      description: ''
+      description: 'An email is sent to the candidate, the content of which depends on the state of the application, whether there are other offers and whether there are pending decisions from provider.'
+      emails:
+        - candidate_mailer-new_offer_without_other_offers
+        - candidate_mailer-new_offer_with_another_offer
+        - candidate_mailer-new_offer_with_pending_decisions
 
     awaiting_references-references_complete:
       name: All references completed

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -193,12 +193,13 @@ en:
         candidates must pass a fitness to work health check.
 
         An email is sent to the candidate, the content of which depends
-        on the state of the application, whether there are other offers
-        and whether there are pending decisions from provider.'
+        on the state of the other application choices, whether there are
+        other offers and whether there are pending decisions from
+        providers.'
       emails:
-        - candidate_mailer-new_offer_without_other_offers
-        - candidate_mailer-new_offer_with_another_offer
-        - candidate_mailer-new_offer_with_pending_decisions
+        - candidate_mailer-new_offer_single_offer
+        - candidate_mailer-new_offer_multiple_offers
+        - candidate_mailer-new_offer_decisions_pending
 
     awaiting_provider_decision-reject:
       name: Provider rejects
@@ -316,11 +317,7 @@ en:
     awaiting_provider_decisions-at_least_one_offer:
       name: At least one offer
       by: provider
-      description: 'An email is sent to the candidate, the content of which depends on the state of the application, whether there are other offers and whether there are pending decisions from provider.'
-      emails:
-        - candidate_mailer-new_offer_without_other_offers
-        - candidate_mailer-new_offer_with_another_offer
-        - candidate_mailer-new_offer_with_pending_decisions
+      description: ''
 
     awaiting_references-references_complete:
       name: All references completed

--- a/config/locales/new_offer_emails.yml
+++ b/config/locales/new_offer_emails.yml
@@ -1,0 +1,4 @@
+en:
+  candidate_offer:
+    single_offer:
+      subject: "Offer received for %{course_name} at %{provider_name}: make a decision"

--- a/config/locales/new_offer_emails.yml
+++ b/config/locales/new_offer_emails.yml
@@ -4,3 +4,5 @@ en:
       subject: "Offer received for %{course_name} at %{provider_name}: make a decision"
     multiple_offers:
       subject: "Offer received for %{course_name} at %{provider_name}: make a decision"
+    decisions_pending:
+      subject: "Offer received for %{course_name} at %{provider_name}"

--- a/config/locales/new_offer_emails.yml
+++ b/config/locales/new_offer_emails.yml
@@ -2,3 +2,5 @@ en:
   candidate_offer:
     single_offer:
       subject: "Offer received for %{course_name} at %{provider_name}: make a decision"
+    multiple_offers:
+      subject: "Offer received for %{course_name} at %{provider_name}: make a decision"

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -300,6 +300,11 @@ RSpec.describe CandidateMailer, type: :mailer do
         expect(@mail.body.encoded).to include('DBS check')
         expect(@mail.body.encoded).to include('Pass exams')
       end
+
+      it 'sends an email with the correct list of offers' do
+        expect(@mail.body.encoded).to include("#{@application_choice.course_option.course.name} (#{@application_choice.course_option.course.code}) at #{@application_choice.course_option.course.provider.name}")
+        expect(@mail.body.encoded).to include("#{@other_application_choice.course_option.course.name} (#{@other_application_choice.course_option.course.code}) at #{@other_application_choice.course_option.course.provider.name}")
+      end
     end
   end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -230,17 +230,28 @@ RSpec.describe CandidateMailer, type: :mailer do
   describe 'send new offer email to candidate' do
     context 'when there is just a single offer' do
       let(:candidate) { build_stubbed(:candidate) }
-      let(:application_form) { build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE', candidate: candidate) }
+      let(:application_form) { build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE', candidate: candidate, first_name: 'Bob') }
       let(:course_option) { build_stubbed(:course_option) }
       let(:course) { course_option.course }
-      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form, course_option: course_option) }
+      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form, course_option: course_option, offer: { conditions: ['DBS check', 'Pass exams'] }) }
       let(:mail) { mailer.new_offer(application_choice) }
 
       before { mail.deliver_later }
 
-      it 'works' do
+      it 'sends an email with the correct greeting' do
         expect(application_choice.course_option.course).to be_present
         expect(mail.body.encoded).to include('Dear Bob')
+      end
+
+      it 'sends an email with the correct subject' do
+        expect(application_choice.course_option.course).to be_present
+        expect(mail.subject).to include("Offer received for #{application_choice.course_option.course.name} (#{application_choice.course_option.course.code}) at #{application_choice.course_option.course.provider.name}")
+      end
+
+      it 'sends an email with the correct conditions' do
+        expect(application_choice.course_option.course).to be_present
+        expect(mail.body.encoded).to include('DBS check')
+        expect(mail.body.encoded).to include('Pass exams')
       end
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -255,10 +255,10 @@ RSpec.describe CandidateMailer, type: :mailer do
       )
     end
 
-    context 'when there is a single offer' do
+    describe '#new_offer_single_offer' do
       before do
         setup_application
-        @mail = mailer.new_offer(@application_choice)
+        @mail = mailer.new_offer_single_offer(@application_choice)
         @mail.deliver_later
       end
 
@@ -280,7 +280,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
     end
 
-    context 'when there are multiple offers' do
+    describe '#new_offer_multiple_offers' do
       before do
         setup_application
         other_course_option = build_stubbed(:course_option)
@@ -296,7 +296,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         )
         @application_form.id = nil
         @application_form.application_choices = [@application_choice, @other_application_choice]
-        @mail = mailer.new_offer(@application_choice)
+        @mail = mailer.new_offer_multiple_offers(@application_choice)
         @mail.deliver_later
       end
 
@@ -323,7 +323,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
     end
 
-    context 'when there is a different application awaiting provider decision' do
+    describe '#new_offer_decisions_pending' do
       before do
         setup_application
         other_course_option = build_stubbed(:course_option)
@@ -335,7 +335,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         )
         @application_form.id = nil
         @application_form.application_choices = [@application_choice, @other_application_choice]
-        @mail = mailer.new_offer(@application_choice)
+        @mail = mailer.new_offer_decisions_pending(@application_choice)
         @mail.deliver_later
       end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -228,30 +228,47 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe 'send new offer email to candidate' do
-    context 'when there is just a single offer' do
-      let(:candidate) { build_stubbed(:candidate) }
-      let(:application_form) { build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE', candidate: candidate, first_name: 'Bob') }
-      let(:course_option) { build_stubbed(:course_option) }
-      let(:course) { course_option.course }
-      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form, course_option: course_option, offer: { conditions: ['DBS check', 'Pass exams'] }) }
-      let(:mail) { mailer.new_offer(application_choice) }
+    def setup_application
+      @candidate = build_stubbed(:candidate)
+      @application_form = build_stubbed(
+        :application_form,
+        support_reference: 'SUPPORT-REFERENCE',
+        candidate: @candidate,
+        first_name: 'Bob',
+      )
+      course_option = build_stubbed(:course_option)
+      @application_choice = build_stubbed(
+        :application_choice,
+        application_form: @application_form,
+        course_option: course_option,
+        status: :offer,
+        offer: { conditions: ['DBS check', 'Pass exams'] },
+        offered_at: Time.zone.now,
+        offered_course_option: course_option,
+      )
+    end
 
-      before { mail.deliver_later }
+    context 'when there is just a single offer' do
+      before do
+        setup_application
+        @mail = mailer.new_offer(@application_choice)
+        @mail.deliver_later
+      end
 
       it 'sends an email with the correct greeting' do
-        expect(application_choice.course_option.course).to be_present
-        expect(mail.body.encoded).to include('Dear Bob')
+        expect(@application_choice.course_option.course).to be_present
+        expect(@mail.body.encoded).to include('Dear Bob')
       end
 
       it 'sends an email with the correct subject' do
-        expect(application_choice.course_option.course).to be_present
-        expect(mail.subject).to include("Offer received for #{application_choice.course_option.course.name} (#{application_choice.course_option.course.code}) at #{application_choice.course_option.course.provider.name}")
+        expect(@application_choice.course_option.course).to be_present
+        expect(@mail.subject).to include("Offer received for #{@application_choice.course_option.course.name} (#{@application_choice.course_option.course.code}) at #{@application_choice.course_option.course.provider.name}")
       end
 
       it 'sends an email with the correct conditions' do
-        expect(application_choice.course_option.course).to be_present
-        expect(mail.body.encoded).to include('DBS check')
-        expect(mail.body.encoded).to include('Pass exams')
+        expect(@application_choice.course_option.course).to be_present
+        expect(@mail.body.encoded).to include('DBS check')
+        expect(@mail.body.encoded).to include('Pass exams')
       end
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -226,4 +226,22 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
     end
   end
+
+  describe 'send new offer email to candidate' do
+    context 'when there is just a single offer' do
+      let(:candidate) { build_stubbed(:candidate) }
+      let(:application_form) { build_stubbed(:application_form, support_reference: 'SUPPORT-REFERENCE', candidate: candidate) }
+      let(:course_option) { build_stubbed(:course_option) }
+      let(:course) { course_option.course }
+      let(:application_choice) { build_stubbed(:application_choice, application_form: application_form, course_option: course_option) }
+      let(:mail) { mailer.new_offer(application_choice) }
+
+      before { mail.deliver_later }
+
+      it 'works' do
+        expect(application_choice.course_option.course).to be_present
+        expect(mail.body.encoded).to include('Dear Bob')
+      end
+    end
+  end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -306,5 +306,39 @@ RSpec.describe CandidateMailer, type: :mailer do
         expect(@mail.body.encoded).to include("#{@other_application_choice.course_option.course.name} (#{@other_application_choice.course_option.course.code}) at #{@other_application_choice.course_option.course.provider.name}")
       end
     end
+
+    context 'when there is a different application awaiting provider decision' do
+      before do
+        setup_application
+        other_course_option = build_stubbed(:course_option)
+        @other_application_choice = @application_form.application_choices.build(
+          id: 456,
+          application_form: @application_form,
+          course_option: other_course_option,
+          status: :awaiting_provider_decision,
+        )
+        @application_form.id = nil
+        @application_form.application_choices = [@application_choice, @other_application_choice]
+        @mail = mailer.new_offer(@application_choice)
+        @mail.deliver_later
+      end
+
+      it 'sends an email with the correct greeting' do
+        expect(@mail.body.encoded).to include('Dear Bob')
+      end
+
+      it 'sends an email with the correct subject' do
+        expect(@mail.subject).to include("Offer received for #{@application_choice.course_option.course.name} (#{@application_choice.course_option.course.code}) at #{@application_choice.course_option.course.provider.name}")
+      end
+
+      it 'sends an email with the correct conditions' do
+        expect(@mail.body.encoded).to include('DBS check')
+        expect(@mail.body.encoded).to include('Pass exams')
+      end
+
+      it 'sends an email with the correct instructions' do
+        expect(@mail.body.encoded).to include('You can wait to hear back about your other application(s) before making a decision')
+      end
+    end
   end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -228,6 +228,12 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe 'send new offer email to candidate' do
+    around do |example|
+      Timecop.freeze(Time.zone.local(2020, 2, 11)) do
+        example.run
+      end
+    end
+
     def setup_application
       @candidate = build_stubbed(:candidate)
       @application_form = build_stubbed(
@@ -245,6 +251,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         offer: { conditions: ['DBS check', 'Pass exams'] },
         offered_at: Time.zone.now,
         offered_course_option: course_option,
+        decline_by_default_at: 10.business_days.from_now,
       )
     end
 
@@ -261,6 +268,10 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it 'sends an email with the correct subject' do
         expect(@mail.subject).to include("Offer received for #{@application_choice.course_option.course.name} (#{@application_choice.course_option.course.code}) at #{@application_choice.course_option.course.provider.name}")
+      end
+
+      it 'sends an email with the correct decline by default date' do
+        expect(@mail.body.encoded).to include('Make a decision by 25 February 2020')
       end
 
       it 'sends an email with the correct conditions' do
@@ -281,6 +292,7 @@ RSpec.describe CandidateMailer, type: :mailer do
           offer: { conditions: ['Get a degree'] },
           offered_at: Time.zone.now,
           offered_course_option: other_course_option,
+          decline_by_default_at: 5.business_days.from_now,
         )
         @application_form.id = nil
         @application_form.application_choices = [@application_choice, @other_application_choice]
@@ -294,6 +306,10 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it 'sends an email with the correct subject' do
         expect(@mail.subject).to include("Offer received for #{@application_choice.course_option.course.name} (#{@application_choice.course_option.course.code}) at #{@application_choice.course_option.course.provider.name}")
+      end
+
+      it 'sends an email with the correct decline by default date' do
+        expect(@mail.body.encoded).to include('Make a decision by 25 February 2020')
       end
 
       it 'sends an email with the correct conditions' do

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe MakeAnOffer do
         expect(application_choice.offered_at).to eq(Time.zone.now)
       end
     end
+
+    it 'sends an email to the candidate' do
+      application_choice = create(:application_choice, status: :awaiting_provider_decision)
+
+      MakeAnOffer.new(application_choice: application_choice).save
+
+      expect(CandidateMailer.deliveries.count).to be 1
+    end
   end
 
   describe 'validation' do

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MakeAnOffer do
     it 'sends an email to the candidate' do
       application_choice = create(:application_choice, status: :awaiting_provider_decision)
 
-      MakeAnOffer.new(application_choice: application_choice).save
+      MakeAnOffer.new(actor: user, application_choice: application_choice).save
 
       expect(CandidateMailer.deliveries.count).to be 1
     end

--- a/spec/services/send_new_offer_email_to_candidate_spec.rb
+++ b/spec/services/send_new_offer_email_to_candidate_spec.rb
@@ -3,16 +3,13 @@ require 'rails_helper'
 RSpec.describe SendNewOfferEmailToCandidate do
   describe '#call' do
     def setup_application
-      @candidate = build_stubbed(:candidate)
-      @application_form = build_stubbed(
+      @candidate = create(:candidate)
+      @application_form = create(
         :application_form,
-        support_reference: 'SUPPORT-REFERENCE',
         candidate: @candidate,
-        first_name: 'Bob',
       )
-      course_option = build_stubbed(:course_option)
-      @application_choice = @application_form.application_choices.build(
-        id: 123,
+      course_option = create(:course_option)
+      @application_choice = @application_form.application_choices.create(
         application_form: @application_form,
         course_option: course_option,
         status: :offer,
@@ -32,9 +29,11 @@ RSpec.describe SendNewOfferEmailToCandidate do
       end
 
       it 'audits the new offer email', with_audited: true do
-        expected_comment = 'blah'
-        pending 'not implemented yet'
-        expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+        expected_comment =
+          "New offer email sent to candidate #{@application_choice.application_form.candidate.email_address} for " +
+          "#{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.course.provider.name}."
+        described_class.new(application_choice: @application_choice).call
+        expect(@application_choice.application_form.audits.last.comment).to eq(expected_comment)
       end
     end
 
@@ -43,15 +42,13 @@ RSpec.describe SendNewOfferEmailToCandidate do
         mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
         allow(CandidateMailer).to receive(:new_offer_multiple_offers).and_return(mail)
         setup_application
-        other_course_option = build_stubbed(:course_option)
-        @other_application_choice = @application_form.application_choices.build(
+        other_course_option = create(:course_option)
+        @other_application_choice = @application_form.application_choices.create(
           id: 456,
           application_form: @application_form,
           course_option: other_course_option,
           status: :offer,
         )
-        @application_form.id = nil
-        @application_form.application_choices = [@application_choice, @other_application_choice]
       end
 
       it 'sends new offer email for multiple offers case' do
@@ -60,9 +57,11 @@ RSpec.describe SendNewOfferEmailToCandidate do
       end
 
       it 'audits the new offer email', with_audited: true do
-        expected_comment = 'blah'
-        pending 'not implemented yet'
-        expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+        expected_comment =
+          "New offer email sent to candidate #{@application_choice.application_form.candidate.email_address} for " +
+          "#{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.course.provider.name}."
+        described_class.new(application_choice: @application_choice).call
+        expect(@application_choice.application_form.audits.last.comment).to eq(expected_comment)
       end
     end
 
@@ -71,15 +70,12 @@ RSpec.describe SendNewOfferEmailToCandidate do
         mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
         allow(CandidateMailer).to receive(:new_offer_decisions_pending).and_return(mail)
         setup_application
-        other_course_option = build_stubbed(:course_option)
-        @other_application_choice = @application_form.application_choices.build(
-          id: 456,
+        other_course_option = create(:course_option)
+        @other_application_choice = @application_form.application_choices.create(
           application_form: @application_form,
           course_option: other_course_option,
           status: :awaiting_provider_decision,
         )
-        @application_form.id = nil
-        @application_form.application_choices = [@application_choice, @other_application_choice]
       end
 
       it 'sends new offer email for pending decision case' do
@@ -88,9 +84,11 @@ RSpec.describe SendNewOfferEmailToCandidate do
       end
 
       it 'audits the new offer email', with_audited: true do
-        expected_comment = 'blah'
-        pending 'not implemented yet'
-        expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+        expected_comment =
+          "New offer email sent to candidate #{@application_choice.application_form.candidate.email_address} for " +
+          "#{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.course.provider.name}."
+        described_class.new(application_choice: @application_choice).call
+        expect(@application_choice.application_form.audits.last.comment).to eq(expected_comment)
       end
     end
   end

--- a/spec/services/send_new_offer_email_to_candidate_spec.rb
+++ b/spec/services/send_new_offer_email_to_candidate_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe SendNewOfferEmailToCandidate do
+  describe '#call' do
+    def setup_application
+      @candidate = build_stubbed(:candidate)
+      @application_form = build_stubbed(
+        :application_form,
+        support_reference: 'SUPPORT-REFERENCE',
+        candidate: @candidate,
+        first_name: 'Bob',
+      )
+      course_option = build_stubbed(:course_option)
+      @application_choice = @application_form.application_choices.build(
+        id: 123,
+        application_form: @application_form,
+        course_option: course_option,
+        status: :offer,
+      )
+    end
+
+    context 'when there is a single offer' do
+      before do
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        allow(CandidateMailer).to receive(:new_offer_single_offer).and_return(mail)
+        setup_application
+      end
+
+      it 'sends new offer email for single offer case' do
+        described_class.new(application_choice: @application_choice).call
+        expect(CandidateMailer).to have_received(:new_offer_single_offer).with(@application_choice)
+      end
+
+      it 'audits the new offer email', with_audited: true do
+        expected_comment = 'blah'
+        pending 'not implemented yet'
+        expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+      end
+    end
+
+    context 'when there are multiple offers' do
+      before do
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        allow(CandidateMailer).to receive(:new_offer_multiple_offers).and_return(mail)
+        setup_application
+        other_course_option = build_stubbed(:course_option)
+        @other_application_choice = @application_form.application_choices.build(
+          id: 456,
+          application_form: @application_form,
+          course_option: other_course_option,
+          status: :offer,
+        )
+        @application_form.id = nil
+        @application_form.application_choices = [@application_choice, @other_application_choice]
+      end
+
+      it 'sends new offer email for multiple offers case' do
+        described_class.new(application_choice: @application_choice).call
+        expect(CandidateMailer).to have_received(:new_offer_multiple_offers).with(@application_choice)
+      end
+
+      it 'audits the new offer email', with_audited: true do
+        expected_comment = 'blah'
+        pending 'not implemented yet'
+        expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+      end
+    end
+
+    context 'when there are decisions pending' do
+      before do
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        allow(CandidateMailer).to receive(:new_offer_decisions_pending).and_return(mail)
+        setup_application
+        other_course_option = build_stubbed(:course_option)
+        @other_application_choice = @application_form.application_choices.build(
+          id: 456,
+          application_form: @application_form,
+          course_option: other_course_option,
+          status: :awaiting_provider_decision,
+        )
+        @application_form.id = nil
+        @application_form.application_choices = [@application_choice, @other_application_choice]
+      end
+
+      it 'sends new offer email for pending decision case' do
+        described_class.new(application_choice: @application_choice).call
+        expect(CandidateMailer).to have_received(:new_offer_decisions_pending).with(@application_choice)
+      end
+
+      it 'audits the new offer email', with_audited: true do
+        expected_comment = 'blah'
+        pending 'not implemented yet'
+        expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

When a provider makes an offer to a candidate the candidate should be notified as soon as possible so that they know about the offer itself and the deadline for making a decision (decline by default).

## Changes proposed in this pull request

- [x] Add 3 new email templates as specified in requirements - one for a first offer, one for a second/third offer and one for the case where there are pending provider decisions on other offers.
- [x] Add a `new_offer` method to the `CandidateMailer`
- [x] Create a new service to select the correct email depending on the state of other application choices.
- [x] Previews for the 3 new emails
- [x] Update docs in support interface
- [x] Add comment to audit trail

## Guidance to review

- Does having a service to encapsulate the logic around translating the state of the various applications into one of the 3 emails make sense?
- Are the docs correct?
- Did we work out what the preferred method of passing data from the mailer class to a template is? I've just added a bunch of member variables but it's not all that pretty or clever.
- Do the emails look right? Note that the list of conditions and list of offers wasn't really specified in any detail - this is just my interpretation.

With multiple offers:
![image](https://user-images.githubusercontent.com/450843/74414202-d95b5d00-4e38-11ea-8e71-14e1cfedd22f.png)

Without other offers:
![image](https://user-images.githubusercontent.com/450843/74414285-09a2fb80-4e39-11ea-952f-58c923919c1b.png)

With pending decisions:
![image](https://user-images.githubusercontent.com/450843/74414390-41aa3e80-4e39-11ea-835d-65f1a6f85d80.png)

## Link to Trello card

https://trello.com/c/KYYcQe4w/838-email-%F0%9F%8E%89-you-have-an-offer-to-candidate

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
