### PR TITLE
Automate sending the email sent about an overdue reference

### DIFF
--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -3,6 +3,7 @@ class ChaserSent < ApplicationRecord
 
   enum chaser_type: {
     reference_request: 'reference_request',
+    reference_replacement: 'reference_replacement',
     provider_decision_request: 'provider_decision_request',
   }
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -14,6 +14,7 @@ class FeatureFlag
     automated_provider_chaser
     provider_change_response
     send_reference_confirmation_email
+    automated_referee_replacement
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/get_referees_that_need_replacing.rb
+++ b/app/services/get_referees_that_need_replacing.rb
@@ -1,0 +1,8 @@
+class GetRefereesThatNeedReplacing
+  def self.call
+    ApplicationReference
+      .feedback_requested
+      .where.not(id: ChaserSent.reference_replacement.select(:chased_id))
+      .select(&:feedback_overdue?)
+  end
+end

--- a/app/services/send_new_referee_request_email.rb
+++ b/app/services/send_new_referee_request_email.rb
@@ -2,6 +2,8 @@ class SendNewRefereeRequestEmail
   def self.call(application_form:, reference:, reason: :not_responded)
     CandidateMailer.new_referee_request(application_form, reference, reason: reason).deliver
 
+    ChaserSent.create!(chaser_type: :reference_replacement, chased: reference)
+
     candidate_email = application_form.candidate.email_address
     audit_comment = I18n.t("new_referee_request.#{reason}.audit_comment", candidate_email: candidate_email)
     application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)

--- a/app/workers/ask_candidates_for_new_referees_worker.rb
+++ b/app/workers/ask_candidates_for_new_referees_worker.rb
@@ -1,0 +1,15 @@
+class AskCandidatesForNewRefereesWorker
+  include Sidekiq::Worker
+
+  def perform
+    return unless FeatureFlag.active?('automated_referee_replacement')
+
+    GetRefereesThatNeedReplacing.call.each do |reference|
+      SendNewRefereeRequestEmail.call(
+        application_form: reference.application_form,
+        reference: reference,
+        reason: :not_responded,
+      )
+    end
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -14,4 +14,5 @@ class Clock
   every(1.hour, 'DeclineOffersByDefault', at: '**:15') { DeclineOffersByDefaultWorker.perform_async }
   every(1.hour, 'SendChaseEmailToReferees', at: '**:20') { SendChaseEmailToRefereesWorker.perform_async }
   every(1.hour, 'SendChaseEmailToProviders', at: '**:25') { SendChaseEmailToProvidersWorker.perform_async }
+  every(1.hour, 'AskCandidatesForNewReferees', at: '**:30') { AskCandidatesForNewRefereesWorker.perform_async }
 end

--- a/spec/services/get_referees_that_need_replacing_spec.rb
+++ b/spec/services/get_referees_that_need_replacing_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe GetRefereesThatNeedReplacing do
+  describe '.call' do
+    it 'returns referees that were sent their reference email more than 10 days ago and have not already been chased' do
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 11.business_days.ago)
+
+      expect(described_class.call).to include reference
+    end
+
+    it 'only returns application choices which are awaiting references' do
+      create(:reference, :complete, requested_at: 11.business_days.ago)
+
+      expect(described_class.call).to be_empty
+    end
+
+    it 'does not return referees which were sent their reference email less than 5 days ago' do
+      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.business_days.ago)
+
+      expect(described_class.call).to be_empty
+    end
+
+    it 'does not return referees who have already been sent a chase email' do
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 11.business_days.ago)
+
+      SendNewRefereeRequestEmail.call(application_form: reference.application_form, reference: reference, reason: :not_responded)
+
+      expect(described_class.call).to be_empty
+    end
+  end
+end

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe Clockwork do
     { worker: DeclineOffersByDefaultWorker, task: 'DeclineOffersByDefault' },
     { worker: SendChaseEmailToRefereesWorker, task: 'SendChaseEmailToReferees' },
     { worker: SendChaseEmailToProvidersWorker, task: 'SendChaseEmailToProviders' },
+    { worker: AskCandidatesForNewRefereesWorker, task: 'AskCandidatesForNewReferees' },
   ].each do |worker|
     describe 'worker schedule' do
       it 'runs the job every hour' do


### PR DESCRIPTION
##  Context

This automates the email we send to the candidate if their reference hasn’t come back. It uses the existing email, and the `ChaserSent` feature to make sure we don’t send it twice.

## Changes proposed in this pull request

Add the hourly checker to see if there are any overdue references.

**Possibly needs backfill before turning on the feature flag**

## Guidance to review

Note that I’m using `ApplicationReference#feedback_overdue?` instead of a SQL query like we do in the `GetRefereesToChase`. I think this solves duplication, at the cost of some performance of the worker (which we don’t really care about).

## Link to Trello card

https://trello.com/c/ikCWDD9v/785-ref-%F0%9F%98%ACautomate-email-to-candidate-if-no-response-within-10-days

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
