### PR TITLE
Add email for all choices being rejected

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -64,6 +64,20 @@ class CandidateMailer < ApplicationMailer
               subject: t("new_referee_request.#{@reason}.subject", referee_name: @referee.name))
   end
 
+  def all_application_choices_rejected(application_choice)
+    @application = OpenStruct.new(
+      provider_name: application_choice.provider.name,
+      course_name: application_choice.course.name,
+      rejection_reason: application_choice.rejection_reason,
+      candidate_name: application_choice.application_form.first_name,
+      choice_count: application_choice.application_form.application_choices.count,
+    )
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: application_choice.application_form.candidate.email_address,
+              subject: t('application_choice_rejected_email.subject', provider_name: application_choice.provider.name))
+  end
+
   def new_offer_single_offer(application_choice)
     new_offer(application_choice, :single_offer)
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -15,6 +15,7 @@ class FeatureFlag
     provider_change_response
     send_reference_confirmation_email
     automated_referee_replacement
+    candidate_rejected_by_provider_email
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_mailer/all_application_choices_rejected.erb
+++ b/app/views/candidate_mailer/all_application_choices_rejected.erb
@@ -1,0 +1,33 @@
+Dear <%= @application.candidate_name %>,
+
+# Application decision
+
+<% if @application.rejection_reason %>
+
+  <%= @application.provider_name %> has decided not to progress your teacher training application for <%= @application.course_name %> on this occasion. They gave the following feedback:
+
+  <%= @application.rejection_reason %>
+
+<% else %>
+
+  <%= @application.provider_name %> has decided not to progress your teacher training application for <%= @application.course_name %> on this occasion. They declined to give feedback.
+
+<% end %>
+
+Contact <%= @application.provider_name %> directly if you have any questions about this.
+
+# Apply for more courses
+
+You can still apply to more courses this year through UCAS.
+
+Get into Teaching can help you with this. Call them for free on <%= t('application_choice_rejected_email.git.phone_number') %> or chat to an adviser online:
+
+<%= t('application_choice_rejected_email.git.url') %>
+
+# Get feedback from your training provider
+
+If you'd like to apply to the same training <%= 'provider'.pluralize(@application.choice_count) %> again, contact them for advice on improving your application.
+
+# Give feedback or report a problem
+
+Contact us at <%= t('application_choice_rejected_email.bat.url') %>

--- a/config/locales/application_choice_rejected_email.yml
+++ b/config/locales/application_choice_rejected_email.yml
@@ -1,0 +1,8 @@
+en:
+  application_choice_rejected_email:
+    subject: "%{provider_name} has responded: next steps"
+    git:
+      url: https://getintoteaching.education.gov.uk
+      phone_number: 0800 389 2500
+    bat:
+      url: becomingateacher@digital.education.gov.uk

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -204,7 +204,15 @@ en:
     awaiting_provider_decision-reject:
       name: Provider rejects
       by: provider
-      description: The provider rejects the candidate.
+      description:  |
+        The provider rejects the candidate.
+
+        An email is sent to the candidate, the content of which depends
+        on the state of the other application choices, whether all choices
+        have been rejected, whether there are other offers and whether there
+        are pending decisions from providers.
+      emails:
+        - candidate_mailer-all_application_choices_rejected
 
     awaiting_provider_decision-withdraw:
       name: Withdraw


### PR DESCRIPTION
## Context

When a user receives a rejection and all of their course choices have been a rejected they should be sent an email.


## Changes proposed in this pull request

- Add an email to the CandidateMailer

## Guidance to review

Emails 

https://docs.google.com/document/d/1VH_nxuLTiVCkmKhC4eaBpFC61Hd5_Ol1tKwOul-2uUs/edit#heading=h.hz139gcneav5 

This email needs a provider name, course name, candidate name, amount of choices (for pluralisation and rejection reason. I've struggled to get all the below objects associated using build_stubbed. Is there an easier way? The current implementation is a pain for adding it to PreviewCandidateMailer

![image](https://user-images.githubusercontent.com/42515961/74434991-69120300-4e5b-11ea-99f2-f1724a070369.png)

Also, what would happen if a provider refused to give feedback was not covered. I added the following:

![image](https://user-images.githubusercontent.com/42515961/74435110-a2e30980-4e5b-11ea-8cf7-215f0491b0ca.png)

This needs a content review.

## Link to Trello card

https://trello.com/c/22e7C80p/840-email-%F0%9F%99%85%E2%99%80%EF%B8%8F-a-provider-has-rejected-your-application-to-candidate

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
