### PR TITLE
Consolidate and iterate performance reporting

### DIFF
--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -29,3 +29,8 @@
   @include govuk-font($size: 80, $weight: bold);
   display: block;
 }
+
+.app-card__secondary-count {
+  @include govuk-font($size: 48, $weight: bold);
+  display: block;
+}

--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -20,6 +20,11 @@
   color: govuk-colour("white");
 }
 
+.app-card--red {
+  color: govuk-shade(govuk-colour("red"), 30);
+  background: govuk-tint(govuk-colour("red"), 80);
+}
+
 .app-card__count {
   @include govuk-font($size: 80, $weight: bold);
   display: block;

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -23,7 +23,7 @@ class PerformanceStatistics
   FROM
       raw_data".freeze
 
-  APPLICATION_FORM_STATUS_COUNTS_QUERY = "
+  CANDIDATE_QUERY = "
   WITH raw_data AS (
       SELECT
           f.id,
@@ -67,15 +67,15 @@ class PerformanceStatistics
     candidate_counts[key.to_s]
   end
 
-  def application_form_status_counts
-    @application_form_status_counts ||= ActiveRecord::Base
+  def candidate_status_counts
+    @candidate_status_counts ||= ActiveRecord::Base
       .connection
-      .execute(APPLICATION_FORM_STATUS_COUNTS_QUERY)
+      .execute(CANDIDATE_QUERY)
       .to_a
   end
 
-  def application_form_counts_total
-    application_form_status_counts.sum { |row| row['count'].to_i }
+  def candidate_counts_total
+    candidate_status_counts.sum { |row| row['count'].to_i }
   end
 
 private

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -23,28 +23,48 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-quarter">
-    <div class="app-card">
-      <span class="app-card__count"><%= @statistics[:never_signed_in] %></span>
-      <span>never signed in</span>
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <div class="app-card">
+          <span class="app-card__secondary-count"><%= @statistics[:never_signed_in] %></span>
+          <span>never signed in</span>
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <div class="app-card">
+          <span class="app-card__secondary-count"><%= @statistics[:unsubmitted_not_started_form] %></span>
+          <span>not started the form</span>
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <div class="app-card">
+          <span class="app-card__secondary-count"><%= @statistics[:unsubmitted_in_progress] %></span>
+          <span>form in progress</span>
+        </div>
+      </div>
     </div>
   </div>
-  <div class="govuk-grid-column-one-quarter">
-    <div class="app-card">
-      <span class="app-card__count"><%= @statistics.total_candidate_count(only: %i{unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
-      <span>unsubmitted</span>
-    </div>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <div class="app-card app-card--red">
-      <span class="app-card__count"><%= @statistics.total_candidate_count(only: %i{ended_without_success}) %></span>
-      <span>ended w/o success</span>
-    </div>
-  </div>
-  <div class="govuk-grid-column-one-quarter">
-    <div class="app-card app-card--green">
-      <span class="app-card__count"><%= @statistics.total_candidate_count(only: %i{pending_conditions recruited enrolled}) %></span>
-      <span>accepted an offer</span>
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <div class="app-card app-card--red">
+          <span class="app-card__secondary-count"><%= @statistics.total_candidate_count(only: %i{ended_without_success}) %></span>
+          <span>ended w/o success</span>
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <div class="app-card">
+          <span class="app-card__secondary-count"><%= @statistics.total_candidate_count(except: %i{ended_without_success pending_conditions recruited enrolled never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
+          <span>awaiting decisions</span>
+        </div>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <div class="app-card app-card--green">
+          <span class="app-card__secondary-count"><%= @statistics.total_candidate_count(only: %i{pending_conditions recruited enrolled}) %></span>
+          <span>accepted an offer</span>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -34,17 +34,10 @@
   </div>
 </div>
 
-<h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-top-8">Application forms</h2>
-
-<div class="app-card app-card--blue govuk-!-margin-bottom-4">
-  <span class="app-card__count" id="total-application-forms"><%= @statistics.application_form_counts_total %></span>
-  <span>application forms (excluding test users)</span>
-</div>
-
-<div class="govuk-grid-row">
+<div class="govuk-grid-row govuk-!-margin-top-4">
   <div class="govuk-grid-column-full">
     <table class="govuk-table">
-      <caption class="govuk-table__caption">Application form breakdown</caption>
+      <caption class="govuk-table__caption">Candidate breakdown</caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th scope="col" class="govuk-table__header">Status</th>
@@ -54,7 +47,7 @@
       </thead>
 
       <tbody class="govuk-table__body">
-        <% @statistics.application_form_status_counts.each do |row| %>
+        <% @statistics.candidate_status_counts.each do |row| %>
           <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header"><%= t("candidate_flow_application_states.#{row['status']}.name") %></th>
             <td class="govuk-table__cell govuk-table__cell--numeric"><%= row['count'] %></td>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Service performance dashboard' %>
+<% content_for :title, 'Service performance' %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Candidates</h2>
 

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -3,32 +3,32 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27">Candidates</h2>
 
 <div class="app-card app-card--blue govuk-!-margin-bottom-4">
-  <span class="app-card__count" id="total-sign-ups"><%= @statistics[:total_candidate_count] %></span>
+  <span class="app-card__count" id="total-sign-ups"><%= @statistics.total_candidate_count %></span>
   <span>sign ups (excluding test users)</span>
 </div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card">
-      <span class="app-card__count"><%= @statistics[:candidates_signed_up_but_not_signed_in] %></span>
+      <span class="app-card__count"><%= @statistics[:never_signed_in] %></span>
       <span><%= @statistics[:candidates_signed_up_but_not_signed_in] == 1 ? 'hasn’t' : 'haven’t' %> signed in</span>
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card">
-      <span class="app-card__count"><%= @statistics[:candidates_signed_in_but_not_entered_data] %></span>
+      <span class="app-card__count"><%= @statistics[:unsubmitted_not_started_form] %></span>
       <span><%= @statistics[:candidates_signed_in_but_not_entered_data] == 1 ? 'hasn’t' : 'haven’t' %> started</span>
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card">
-      <span class="app-card__count"><%= @statistics[:candidates_with_unsubmitted_forms] %></span>
+      <span class="app-card__count"><%= @statistics[:unsubmitted_in_progress] %></span>
       <span>in progress</span>
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card app-card--green">
-      <span class="app-card__count"><%= @statistics[:candidates_with_submitted_forms] %></span>
+      <span class="app-card__count"><%= @statistics.total_candidate_count(except: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
       <span>submitted</span>
     </div>
   </div>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -7,29 +7,44 @@
   <span>sign ups (excluding test users)</span>
 </div>
 
+<div class="govuk-grid-row govuk-!-margin-bottom-4">
+  <div class="govuk-grid-column-one-half">
+    <div class="app-card">
+      <span class="app-card__count"><%= @statistics.total_candidate_count(only: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
+      <span>in pre-submission</span>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <div class="app-card">
+      <span class="app-card__count"><%= @statistics.total_candidate_count(except: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
+      <span>submitted</span>
+    </div>
+  </div>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card">
       <span class="app-card__count"><%= @statistics[:never_signed_in] %></span>
-      <span><%= @statistics[:candidates_signed_up_but_not_signed_in] == 1 ? 'hasn’t' : 'haven’t' %> signed in</span>
+      <span>never signed in</span>
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card">
-      <span class="app-card__count"><%= @statistics[:unsubmitted_not_started_form] %></span>
-      <span><%= @statistics[:candidates_signed_in_but_not_entered_data] == 1 ? 'hasn’t' : 'haven’t' %> started</span>
+      <span class="app-card__count"><%= @statistics.total_candidate_count(only: %i{unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
+      <span>unsubmitted</span>
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
-    <div class="app-card">
-      <span class="app-card__count"><%= @statistics[:unsubmitted_in_progress] %></span>
-      <span>in progress</span>
+    <div class="app-card app-card--red">
+      <span class="app-card__count"><%= @statistics.total_candidate_count(only: %i{ended_without_success}) %></span>
+      <span>ended w/o success</span>
     </div>
   </div>
   <div class="govuk-grid-column-one-quarter">
     <div class="app-card app-card--green">
-      <span class="app-card__count"><%= @statistics.total_candidate_count(except: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
-      <span>submitted</span>
+      <span class="app-card__count"><%= @statistics.total_candidate_count(only: %i{pending_conditions recruited enrolled}) %></span>
+      <span>accepted an offer</span>
     </div>
   </div>
 </div>

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PerformanceStatistics, type: :model do
-  describe '#application_form_status_counts' do
+  describe '#candidate_status_counts' do
     it 'counts unsubmitted, unstarted applications' do
       application_choice = create(:application_choice, status: 'unsubmitted')
       form = application_choice.application_form
@@ -104,7 +104,7 @@ RSpec.describe PerformanceStatistics, type: :model do
   end
 
   def count_for_process_state(process_state)
-    PerformanceStatistics.new.application_form_status_counts.find { |x| x['status'] == process_state.to_s }['count']
+    PerformanceStatistics.new.candidate_status_counts.find { |x| x['status'] == process_state.to_s }['count']
   end
 
   it 'excludes candidates marked as hidden from reporting' do
@@ -116,7 +116,7 @@ RSpec.describe PerformanceStatistics, type: :model do
     stats = PerformanceStatistics.new
 
     expect(stats[:total_candidate_count]).to eq(1)
-    expect(stats.application_form_counts_total).to eq(1)
+    expect(stats.candidate_counts_total).to eq(1)
   end
 
   it 'excludes candidates without application forms' do
@@ -124,7 +124,7 @@ RSpec.describe PerformanceStatistics, type: :model do
 
     stats = PerformanceStatistics.new
 
-    expect(stats.application_form_counts_total).to eq(0)
+    expect(stats.candidate_counts_total).to eq(0)
   end
 
   it 'breaks down candidates with unsubmitted forms into stages' do

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -2,6 +2,14 @@ require 'rails_helper'
 
 RSpec.describe PerformanceStatistics, type: :model do
   describe '#candidate_status_counts' do
+    it 'counts candidates without application forms' do
+      create(:candidate)
+
+      expect(ProcessState.new(nil).state).to be :never_signed_in
+
+      expect(count_for_process_state(:never_signed_in)).to be(1)
+    end
+
     it 'counts unsubmitted, unstarted applications' do
       application_choice = create(:application_choice, status: 'unsubmitted')
       form = application_choice.application_form
@@ -116,15 +124,6 @@ RSpec.describe PerformanceStatistics, type: :model do
     stats = PerformanceStatistics.new
 
     expect(stats[:total_candidate_count]).to eq(1)
-    expect(stats.candidate_counts_total).to eq(1)
-  end
-
-  it 'excludes candidates without application forms' do
-    create(:candidate)
-
-    stats = PerformanceStatistics.new
-
-    expect(stats.candidate_counts_total).to eq(0)
   end
 
   it 'breaks down candidates with unsubmitted forms into stages' do

--- a/spec/models/performance_statistics_spec.rb
+++ b/spec/models/performance_statistics_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe PerformanceStatistics, type: :model do
-  describe '#candidate_status_counts' do
+  describe '#[]' do
     it 'counts candidates without application forms' do
       create(:candidate)
 
@@ -111,8 +111,22 @@ RSpec.describe PerformanceStatistics, type: :model do
     end
   end
 
+  describe '#total_candidate_count' do
+    it 'optionally filters only on certain process states and excludes certain states' do
+      create(:application_choice, status: 'enrolled')
+      create(:application_choice, status: 'recruited')
+      create(:application_choice, status: 'pending_conditions')
+
+      stats = PerformanceStatistics.new
+
+      expect(stats.total_candidate_count).to eq(3)
+      expect(stats.total_candidate_count(only: %i{enrolled recruited})).to eq(2)
+      expect(stats.total_candidate_count(except: %i{enrolled pending_conditions})).to eq(1)
+    end
+  end
+
   def count_for_process_state(process_state)
-    PerformanceStatistics.new.candidate_status_counts.find { |x| x['status'] == process_state.to_s }['count']
+    PerformanceStatistics.new[process_state]
   end
 
   it 'excludes candidates marked as hidden from reporting' do
@@ -123,32 +137,6 @@ RSpec.describe PerformanceStatistics, type: :model do
 
     stats = PerformanceStatistics.new
 
-    expect(stats[:total_candidate_count]).to eq(1)
-  end
-
-  it 'breaks down candidates with unsubmitted forms into stages' do
-    create(:candidate)
-    create_list(:application_form, 2)
-    create_list(:application_form, 3, updated_at: 3.minutes.from_now) # changed forms
-    create_list(:completed_application_form, 4, updated_at: 3.minutes.from_now)
-
-    stats = PerformanceStatistics.new
-
-    expect(stats[:total_candidate_count]).to eq(10)
-    expect(stats[:candidates_signed_up_but_not_signed_in]).to eq(1)
-    expect(stats[:candidates_signed_in_but_not_entered_data]).to eq(2)
-    expect(stats[:candidates_with_unsubmitted_forms]).to eq(3)
-    expect(stats[:candidates_with_submitted_forms]).to eq(4)
-  end
-
-  it 'avoids double counting generated test data' do
-    form = create(:completed_application_form)
-    form.update_column(:updated_at, form.created_at) # this form is both unchanged but also submitted
-
-    stats = PerformanceStatistics.new
-
-    expect(stats[:total_candidate_count]).to eq(1)
-    expect(stats[:candidates_with_submitted_forms]).to eq(1)
-    expect(stats[:candidates_signed_in_but_not_entered_data]).to eq(0)
+    expect(stats.total_candidate_count).to eq(1)
   end
 end

--- a/spec/system/support_interface/service_performance_spec.rb
+++ b/spec/system/support_interface/service_performance_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'Service performance' do
 
     when_i_visit_the_service_performance_page
     then_i_should_see_the_total_count_of_candidates
-    and_i_should_see_the_total_count_of_application_forms
   end
 
   def given_there_are_candidates_and_application_forms_in_the_system
@@ -19,12 +18,6 @@ RSpec.feature 'Service performance' do
 
   def then_i_should_see_the_total_count_of_candidates
     within '#total-sign-ups' do
-      expect(page).to have_content '3'
-    end
-  end
-
-  def and_i_should_see_the_total_count_of_application_forms
-    within '#total-application-forms' do
       expect(page).to have_content '3'
     end
   end


### PR DESCRIPTION
## Context

The current performance dashboard makes it hard to see what's happening post-submission (how many successful and unsuccessful candidates there are) at a glance.

## Changes proposed in this pull request

Iterate the service performance dashboard:

- consolidate candidate and application form reporting into just candidate reporting, because it's effectively the same thing until Apply 2 is added
- add more focus to how many applications are in pre- and post-submission.
- make it clearer how many applications are in important end-states (offers accepted or unsuccessful)

Before:

![image](https://user-images.githubusercontent.com/23801/74428803-9e195800-4e51-11ea-957c-f7151ff84dee.png)

After:

![image](https://user-images.githubusercontent.com/23801/74521492-6245c780-4f11-11ea-8bc6-c1b2c3ce5154.png)

## Guidance to review

- is the visual design (layout and colours) OK?
- for the top-level metrics, is it clear what the number is from the labels?

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
