### PR TITLE
Add ability to enter a reason for a break

### DIFF
--- a/app/components/break_in_work_history_component.html.erb
+++ b/app/components/break_in_work_history_component.html.erb
@@ -1,10 +1,3 @@
-<section class="app-summary-card govuk-!-margin-bottom-6">
-  <header class="app-summary-card__header">
-    <h3 class="app-summary-card__title">
-      You have a break in your work history (<%= pluralize(work_break.length, 'month') %>)
-    </h3>
-    <div class="app-summary-card__actions">
-      <%= govuk_link_to t('application_form.work_history.add_another_job'), candidate_interface_work_history_new_path(start_date: work_break.start_date, end_date: work_break.end_date) %>
-    </div>
-  </header>
-</section>
+<%= render(SummaryCardComponent, rows: work_break_rows) do %>
+  <%= render(SummaryCardHeaderComponent, title: "Break in work history (#{pluralize(@work_break.length, 'month')})") %>
+<% end %>

--- a/app/components/break_in_work_history_component.rb
+++ b/app/components/break_in_work_history_component.rb
@@ -6,4 +6,32 @@ class BreakInWorkHistoryComponent < ActionView::Component::Base
   def initialize(work_break:)
     @work_break = work_break
   end
+
+  def work_break_rows
+    [reason_row, dates_row]
+  end
+
+private
+
+  def reason_row
+    {
+      key: 'Description',
+      value: @work_break.reason,
+    }
+  end
+
+  def dates_row
+    {
+      key: 'Dates',
+      value: "#{formatted_start_date} - #{formatted_end_date}",
+    }
+  end
+
+  def formatted_start_date
+    @work_break.start_date.to_s(:month_and_year)
+  end
+
+  def formatted_end_date
+    @work_break.end_date.to_s(:month_and_year)
+  end
 end

--- a/app/components/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/break_placeholder_in_work_history_component.html.erb
@@ -1,0 +1,18 @@
+<section class="app-summary-card govuk-!-margin-bottom-6">
+  <header class="app-summary-card__header">
+    <h3 class="app-summary-card__title">
+      You have a break in your work history (<%= pluralize(work_break.length, 'month') %>)
+    </h3>
+
+    <div class="app-summary-card__actions">
+      <ul class="app-summary-card__actions-list">
+        <li class="app-summary-card__actions-list-item">
+          <%= govuk_link_to 'Please explain break', candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date) %>
+        </li>
+        <li class="app-summary-card__actions-list-item">
+          <%= govuk_link_to t('application_form.work_history.add_another_job'), candidate_interface_work_history_new_path(start_date: work_break.start_date, end_date: work_break.end_date) %>
+        </li>
+      </ul>
+    </div>
+  </header>
+</section>

--- a/app/components/break_placeholder_in_work_history_component.rb
+++ b/app/components/break_placeholder_in_work_history_component.rb
@@ -1,0 +1,9 @@
+class BreakPlaceholderInWorkHistoryComponent < ActionView::Component::Base
+  include ViewHelper
+
+  attr_reader :work_break
+
+  def initialize(work_break:)
+    @work_break = work_break
+  end
+end

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -13,6 +13,10 @@
     <% end %>
   <% elsif history[:type] == :break_placeholder %>
     <% if FeatureFlag.active?('work_breaks') %>
+      <%= render(BreakPlaceholderInWorkHistoryComponent, work_break: history[:entry]) %>
+    <% end %>
+  <% elsif history[:type] == :break %>
+    <% if FeatureFlag.active?('work_breaks') %>
       <%= render(BreakInWorkHistoryComponent, work_break: history[:entry]) %>
     <% end %>
   <% end %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -7,7 +7,7 @@ class WorkHistoryReviewComponent < ActionView::Component::Base
     @heading_level = heading_level
     @show_incomplete = show_incomplete
     @missing_error = missing_error
-    @work_history_with_breaks = WorkHistoryWithBreaks.new(@application_form.application_work_experiences).timeline
+    @work_history_with_breaks = WorkHistoryWithBreaks.new(@application_form).timeline
   end
 
   def work_experience_rows(work)

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -52,5 +52,23 @@ module CandidateInterface
         (username == ENV.fetch('BASIC_AUTH_USERNAME')) && (password == ENV.fetch('BASIC_AUTH_PASSWORD'))
       end
     end
+
+    def start_date_field_to_attribute(key)
+      case key
+      when 'start_date(3i)' then 'start_date_day'
+      when 'start_date(2i)' then 'start_date_month'
+      when 'start_date(1i)' then 'start_date_year'
+      else key
+      end
+    end
+
+    def end_date_field_to_attribute(key)
+      case key
+      when 'end_date(3i)' then 'end_date_day'
+      when 'end_date(2i)' then 'end_date_month'
+      when 'end_date(1i)' then 'end_date_year'
+      else key
+      end
+    end
   end
 end

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -48,23 +48,5 @@ module CandidateInterface
           .transform_keys { |key| end_date_field_to_attribute(key) }
           .transform_values(&:strip)
     end
-
-    def start_date_field_to_attribute(key)
-      case key
-      when 'start_date(3i)' then 'start_date_day'
-      when 'start_date(2i)' then 'start_date_month'
-      when 'start_date(1i)' then 'start_date_year'
-      else key
-      end
-    end
-
-    def end_date_field_to_attribute(key)
-      case key
-      when 'end_date(3i)' then 'end_date_day'
-      when 'end_date(2i)' then 'end_date_month'
-      when 'end_date(1i)' then 'end_date_year'
-      else key
-      end
-    end
   end
 end

--- a/app/controllers/candidate_interface/work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/work_history/break_controller.rb
@@ -1,0 +1,44 @@
+module CandidateInterface
+  class WorkHistory::BreakController < CandidateInterfaceController
+    before_action :redirect_to_dashboard_if_not_amendable
+
+    def new
+      @work_break = if params[:start_date] && params[:end_date]
+                      start_date = params[:start_date].to_date
+                      end_date = params[:end_date].to_date
+
+                      WorkHistoryBreakForm.new(
+                        start_date_month: start_date.month,
+                        start_date_year: start_date.year,
+                        end_date_month: end_date.month,
+                        end_date_year: end_date.year,
+                      )
+                    else
+                      WorkHistoryBreakForm.new
+                    end
+    end
+
+    def create
+      @work_break = WorkHistoryBreakForm.new(work_history_break_params)
+
+      if @work_break.save(current_application)
+        redirect_to candidate_interface_work_history_show_path
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def work_history_break_params
+      params.require(:candidate_interface_work_history_break_form)
+        .permit(
+          :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
+          :"end_date(3i)", :"end_date(2i)", :"end_date(1i)", :reason
+        )
+          .transform_keys { |key| start_date_field_to_attribute(key) }
+          .transform_keys { |key| end_date_field_to_attribute(key) }
+          .transform_values(&:strip)
+    end
+  end
+end

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -70,23 +70,5 @@ module CandidateInterface
     def work_experience_params
       params.permit(:id)
     end
-
-    def start_date_field_to_attribute(key)
-      case key
-      when 'start_date(3i)' then 'start_date_day'
-      when 'start_date(2i)' then 'start_date_month'
-      when 'start_date(1i)' then 'start_date_year'
-      else key
-      end
-    end
-
-    def end_date_field_to_attribute(key)
-      case key
-      when 'end_date(3i)' then 'end_date_day'
-      when 'end_date(2i)' then 'end_date_month'
-      when 'end_date(1i)' then 'end_date_year'
-      else key
-      end
-    end
   end
 end

--- a/app/frontend/styles/_summary-card.scss
+++ b/app/frontend/styles/_summary-card.scss
@@ -49,13 +49,14 @@
     white-space: nowrap;
 
     @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      margin-left: govuk-spacing(2);
       text-align: right;
     }
   }
 
-  .app-summary-card__actions-list-item:last-child {
-    margin-right: 0;
-    padding-right: 0;
+  .app-summary-card__actions-list-item:first-child {
+    margin-left: 0;
   }
 
   .app-summary-card__body {

--- a/app/models/application_work_history_break.rb
+++ b/app/models/application_work_history_break.rb
@@ -2,4 +2,8 @@ class ApplicationWorkHistoryBreak < ApplicationRecord
   belongs_to :application_form, touch: true
 
   audited associated_with: :application_form
+
+  def length
+    (end_date.year * 12 + end_date.month) - (start_date.year * 12 + start_date.month) - 1
+  end
 end

--- a/app/models/candidate_interface/work_history_break_form.rb
+++ b/app/models/candidate_interface/work_history_break_form.rb
@@ -13,6 +13,14 @@ module CandidateInterface
 
     validates :reason, presence: true, word_count: { maximum: 400 }
 
+    def save(application_form)
+      return false unless valid?
+
+      application_form.application_work_history_breaks.create!(
+        start_date: start_date, end_date: end_date, reason: reason,
+      )
+    end
+
     def start_date
       valid_or_invalid_start_date(start_date_year, start_date_month)
     end

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -17,8 +17,9 @@ class WorkHistoryWithBreaks
     end
   end
 
-  def initialize(work_history)
-    @work_history = work_history.sort_by(&:start_date)
+  def initialize(application_form)
+    @work_history = application_form.application_work_experiences.sort_by(&:start_date)
+    @existing_breaks = application_form.application_work_history_breaks.sort_by(&:start_date)
     @current_job = nil
   end
 
@@ -50,6 +51,10 @@ private
     { type: :break_placeholder, entry: BreakPlaceholder.new(month_range: month_range) }
   end
 
+  def break_entry(existing_break)
+    { type: :break, entry: existing_break }
+  end
+
   def month_range(start_date:, end_date:)
     (start_date.to_date..end_date.to_date).map(&:beginning_of_month).uniq
   end
@@ -77,11 +82,30 @@ private
       if current_break.last.next_month == month
         current_break << month
       else
-        breaks << break_placeholder_entry(current_break)
+        breaks << break_or_break_placeholder_entry(current_break)
         current_break = [month]
       end
     end
 
-    breaks << break_placeholder_entry(current_break)
+    breaks << break_or_break_placeholder_entry(current_break)
+  end
+
+  def break_or_break_placeholder_entry(current_break)
+    break_placeholder = break_placeholder_entry(current_break)
+
+    existing_break_covering_placeholder = @existing_breaks.select do |existing_break|
+      same_start_date = existing_break.start_date.to_date == break_placeholder[:entry].start_date
+      same_end_date = existing_break.end_date.to_date == break_placeholder[:entry].end_date
+
+      same_start_date && same_end_date
+    end
+
+    if existing_break_covering_placeholder.any?
+      existing_break = existing_break_covering_placeholder.first
+
+      break_entry(existing_break)
+    else
+      break_placeholder
+    end
   end
 end

--- a/app/views/candidate_interface/work_history/break/new.html.erb
+++ b/app/views/candidate_interface/work_history/break/new.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.work_history_break'), @work_break.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @work_break, url: candidate_interface_new_work_history_break_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= t('page_titles.work_history') %></span>
+        <%= t('page_titles.work_history_break') %>
+      </h1>
+
+      <div class="app-work-experience__start-date" data-qa="start-date">
+        <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: 'Start of break', size: 'm', tag: 'span' } %>
+      </div>
+
+      <div class="app-work-experience__end-date" data-qa="end-date">
+        <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: 'End of break', size: 'm', tag: 'span' } %>
+      </div>
+
+      <%= f.govuk_text_area :reason, label: { text: 'Enter reasons for break in work history', size: 'm' }, hint_text: 'For example, parenting or caring responsibilities, unemployment, travel, health, study or other personal reasons', max_words: 400 %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -497,6 +497,7 @@ en:
               invalid: Enter an end date in the correct format
               in_the_future: Enter an end date that is not in the future
             reason:
+              blank: Enter reasons for break in work history
               too_many_words: Reasons for break in work history must be %{count} words or fewer
         candidate_interface/gcse_qualification_details_form:
           attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,7 @@ en:
     address: What is your address?
     work_history: Work history
     work_history_breaks: Tell us about any breaks in your work history
+    work_history_break: Please tell us what you were doing over this period
     add_job: Add job
     degree: Degree
     add_undergraduate_degree: Add undergraduate degree

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,6 +109,9 @@ Rails.application.routes.draw do
         get '/explain-breaks' => 'work_history/breaks#edit', as: :work_history_breaks
         post '/explain-breaks' => 'work_history/breaks#update'
 
+        get '/explain-break/new' => 'work_history/break#new', as: :new_work_history_break
+        post '/explain-break/new' => 'work_history/break#create'
+
         get '/new' => 'work_history/edit#new', as: :work_history_new
         post '/create' => 'work_history/edit#create', as: :work_history_create
 

--- a/spec/components/break_in_work_history_component_spec.rb
+++ b/spec/components/break_in_work_history_component_spec.rb
@@ -1,23 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe BreakInWorkHistoryComponent do
-  let(:work_break) { double }
-
-  before do
-    allow(work_break).to receive(:length).and_return(3)
-    allow(work_break).to receive(:start_date).and_return(Date.new(2020, 1, 1))
-    allow(work_break).to receive(:end_date).and_return(Date.new(2020, 5, 1))
+  let(:february2019) { Time.zone.local(2019, 2, 1) }
+  let(:april2019) { Time.zone.local(2019, 4, 1) }
+  let(:work_break) do
+    build_stubbed(
+      :application_work_history_break,
+      start_date: february2019,
+      end_date: april2019,
+      reason: 'I feel asleep.',
+    )
   end
 
-  it 'renders the component with the break in months' do
+  it 'renders the component with the break in months, reason and dates' do
     result = render_inline(BreakInWorkHistoryComponent, work_break: work_break)
 
-    expect(result.text).to include('You have a break in your work history (3 months)')
-  end
-
-  it 'renders the component with a link to add another job' do
-    result = render_inline(BreakInWorkHistoryComponent, work_break: work_break)
-
-    expect(result.text).to include('Add another job')
+    expect(result.text).to include('Break in work history (1 month)')
+    expect(result.text).to include('I feel asleep.')
+    expect(result.text).to include('February 2019 - April 2019')
   end
 end

--- a/spec/components/break_placeholder_in_work_history_component_spec.rb
+++ b/spec/components/break_placeholder_in_work_history_component_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe BreakPlaceholderInWorkHistoryComponent do
+  let(:work_break) { double }
+
+  before do
+    allow(work_break).to receive(:length).and_return(3)
+    allow(work_break).to receive(:start_date).and_return(Date.new(2020, 1, 1))
+    allow(work_break).to receive(:end_date).and_return(Date.new(2020, 5, 1))
+  end
+
+  it 'renders the component with the break in months' do
+    result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
+
+    expect(result.text).to include('You have a break in your work history (3 months)')
+  end
+
+  it 'renders the component with a link to add another job' do
+    result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
+
+    expect(result.text).to include('Add another job')
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -106,6 +106,12 @@ FactoryBot.define do
     working_pattern { Faker::Lorem.paragraph_by_chars(number: 30) }
   end
 
+  factory :application_work_history_break do
+    start_date { Faker::Date.between(from: 20.years.ago, to: 5.years.ago) }
+    end_date { [Faker::Date.between(from: 4.years.ago, to: Date.today), nil].sample }
+    reason { Faker::Lorem.sentence(word_count: 400) }
+  end
+
   factory :application_volunteering_experience, parent: :application_experience, class: 'ApplicationVolunteeringExperience'
   factory :application_work_experience, parent: :application_experience, class: 'ApplicationWorkExperience'
 

--- a/spec/models/candidate_interface/work_history_break_form_spec.rb
+++ b/spec/models/candidate_interface/work_history_break_form_spec.rb
@@ -1,6 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
+  let(:data) do
+    {
+      start_date: Time.zone.local(2018, 5, 1),
+      end_date: Time.zone.local(2019, 5, 1),
+      reason: Faker::Lorem.sentence(word_count: 400),
+    }
+  end
+
+  let(:form_data) do
+    {
+      start_date_month: data[:start_date].month,
+      start_date_year: data[:start_date].year,
+      end_date_month: data[:end_date].month,
+      end_date_year: data[:end_date].year,
+      reason: data[:reason],
+    }
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:reason) }
 
@@ -11,5 +29,22 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
     it { is_expected.not_to allow_value(long_text).for(:reason) }
 
     include_examples 'validation for a start and end date', 'work_history_break_form'
+  end
+
+  describe '#save' do
+    it 'returns false if not valid' do
+      work_break = CandidateInterface::WorkHistoryBreakForm.new
+
+      expect(work_break.save(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'creates a new work experience if valid' do
+      application_form = create(:application_form)
+      work_break = CandidateInterface::WorkHistoryBreakForm.new(form_data)
+
+      saved_work_break = work_break.save(application_form)
+
+      expect(saved_work_break).to have_attributes(data)
+    end
   end
 end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe WorkHistoryWithBreaks do
     context 'when there are no jobs' do
       it 'returns an empty array' do
         work_history = []
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks).to eq([])
@@ -35,8 +36,9 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns an array containing a hash if the job is current role i.e. end date is nil' do
         job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: nil)
         work_history = [job1]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
@@ -46,8 +48,9 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns an array containing a hash if the job ends at current date' do
         job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: current_date)
         work_history = [job1]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
@@ -57,8 +60,9 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns an array containing a hash for a job and a break if one month break' do
         job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: december2019)
         work_history = [job1]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
@@ -72,8 +76,9 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns an array containing a hash for a job and a break if more than a month break' do
         job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: october2019)
         work_history = [job1]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
@@ -89,8 +94,9 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: december2019)
         job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
         work_history = [job1, job2, job3]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
@@ -104,8 +110,9 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: november2019)
         job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
         work_history = [job1, job2, job3]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(4)
@@ -121,8 +128,9 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
         work_history = [job1, job2, job3]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
@@ -136,8 +144,9 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
         work_history = [job1, job2, job3]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(4)
@@ -153,14 +162,41 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: nil)
         work_history = [job1, job2, job3]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
-        get_work_history_with_breaks = WorkHistoryWithBreaks.new(work_history)
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
         expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
         expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
         expect(work_history_with_breaks[2]).to eq(type: :job, entry: job3)
+      end
+    end
+
+    context 'when an application form already has a break' do
+      it 'returns an array containing hashes for jobs and the existing break' do
+        job1 = build_stubbed(:application_work_experience, start_date: january2019, end_date: february2019)
+        job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
+        work_history = [job1, job2]
+        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+        )
+
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[1][:type]).to eq(:break)
+        expect(work_history_with_breaks[1][:entry].start_date).to eq(february2019)
+        expect(work_history_with_breaks[1][:entry].end_date).to eq(april2019)
+        expect(work_history_with_breaks[1][:entry].length).to eq(1)
+        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job2)
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -16,7 +16,14 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     then_i_see_a_two_months_break_between_my_first_job_and_my_second_job
 
     when_i_click_add_another_job_for_my_break
-    then_i_should_see_the_start_and_end_date_filled_in
+    then_i_see_the_start_and_end_date_filled_in
+
+    given_i_am_on_review_work_history_page
+    when_i_click_to_explain_my_break
+    then_i_see_the_start_and_end_date_filled_in
+
+    when_i_enter_a_reason_for_my_break
+    then_i_can_see_my_reason_on_the_review_page
   end
 
   def given_i_am_signed_in
@@ -92,10 +99,28 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     first(:link, t('application_form.work_history.add_another_job')).click
   end
 
-  def then_i_should_see_the_start_and_end_date_filled_in
+  def then_i_see_the_start_and_end_date_filled_in
     expect(page).to have_selector("input[value='8']")
     expect(page).to have_selector("input[value='2019']")
     expect(page).to have_selector("input[value='11']")
     expect(page).to have_selector("input[value='2019']")
+  end
+
+  def given_i_am_on_review_work_history_page
+    visit candidate_interface_work_history_show_path
+  end
+
+  def when_i_click_to_explain_my_break
+    click_link 'Please explain break'
+  end
+
+  def when_i_enter_a_reason_for_my_break
+    fill_in 'Enter reasons for break in work history', with: 'Painting is tiring.'
+
+    click_button 'Continue'
+  end
+
+  def then_i_can_see_my_reason_on_the_review_page
+    expect(page).to have_content('Painting is tiring.')
   end
 end


### PR DESCRIPTION
## Context

Currently, we are only able to show when breaks occurs in a candidate's work history.

## Changes proposed in this pull request

This PR adds the ability to enter a reason for a work history break and shows the break on the review work history page.

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/74436301-1c7bf700-4e5e-11ea-8867-71807f712fc9.png)

![image](https://user-images.githubusercontent.com/42817036/74436431-5b11b180-4e5e-11ea-9925-70c966f42cb0.png)

## Guidance to review

Review commit by commit as some refactoring has been done.

Should there be a redirect from the `WorkHistory::BreakController` to check that the feature flag is on? Or it's not necessary?

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
