### PR TITLE
Add sandbox mode to the feature flags API

### DIFF
--- a/app/controllers/integrations/feature_flags_controller.rb
+++ b/app/controllers/integrations/feature_flags_controller.rb
@@ -10,6 +10,11 @@ module Integrations
         features
       end
 
+      feature_flags['sandbox_mode'] = {
+        name: 'Sandbox mode',
+        active: HostingEnvironment.sandbox_mode?,
+      }
+
       response = {
         hosting_environment: HostingEnvironment.environment_name,
         feature_flags: feature_flags,

--- a/spec/requests/integrations/feature_flags_spec.rb
+++ b/spec/requests/integrations/feature_flags_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe 'GET /integrations/feature-flags', type: :request do
     expect(parsed_response['feature_flags']['pilot_open']['active']).to be(true)
   end
 
+  it 'tells us when Sandbox mode is on', sandbox: true do
+    get '/integrations/feature-flags'
+    expect(parsed_response['feature_flags']['sandbox_mode']['active']).to be(true)
+  end
+
+  it 'tells us when Sandbox mode is off', sandbox: false do
+    get '/integrations/feature-flags'
+    expect(parsed_response['feature_flags']['sandbox_mode']['active']).to be(false)
+  end
+
   def parsed_response
     JSON.parse(response.body)
   end


### PR DESCRIPTION
Sandbox mode isn't really a feature flag but it does affect the behaviour of environments where it's turned on.

## Context

We forgot to turn off sandbox mode in staging after our testing party,

## Changes proposed in this pull request

Advertise it as a feature flag over the feature_flags API (even though it isn't one)

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
