### PR TITLE
Add ability to delete a work history break

### DIFF
--- a/app/components/break_in_work_history_component.html.erb
+++ b/app/components/break_in_work_history_component.html.erb
@@ -1,3 +1,11 @@
 <%= render(SummaryCardComponent, rows: work_break_rows) do %>
-  <%= render(SummaryCardHeaderComponent, title: "Break in work history (#{pluralize(@work_break.length, 'month')})") %>
+  <%= render(SummaryCardHeaderComponent, title: "Break in work history (#{pluralize(@work_break.length, 'month')})") do %>
+    <% if @editable %>
+      <div class="app-summary-card__actions">
+        <%= link_to candidate_interface_destroy_work_history_break_path(@work_break), class: 'govuk-link' do %>
+          Delete entry <span class="govuk-visually-hidden">for break between <%= formatted_start_date %> and <%= formatted_end_date %></span>
+        <% end %>
+      </div>
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/components/break_in_work_history_component.rb
+++ b/app/components/break_in_work_history_component.rb
@@ -3,12 +3,21 @@ class BreakInWorkHistoryComponent < ActionView::Component::Base
 
   attr_reader :work_break
 
-  def initialize(work_break:)
+  def initialize(work_break:, editable: true)
     @work_break = work_break
+    @editable = editable
   end
 
   def work_break_rows
     [reason_row, dates_row]
+  end
+
+  def formatted_start_date
+    @work_break.start_date.to_s(:month_and_year)
+  end
+
+  def formatted_end_date
+    @work_break.end_date.to_s(:month_and_year)
   end
 
 private
@@ -25,13 +34,5 @@ private
       key: 'Dates',
       value: "#{formatted_start_date} - #{formatted_end_date}",
     }
-  end
-
-  def formatted_start_date
-    @work_break.start_date.to_s(:month_and_year)
-  end
-
-  def formatted_end_date
-    @work_break.end_date.to_s(:month_and_year)
   end
 end

--- a/app/controllers/candidate_interface/work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/work_history/break_controller.rb
@@ -28,7 +28,25 @@ module CandidateInterface
       end
     end
 
+    def confirm_destroy
+      @work_break = current_work_history_break
+    end
+
+    def destroy
+      current_work_history_break.destroy!
+
+      redirect_to candidate_interface_work_history_show_path
+    end
+
   private
+
+    def current_work_history_break
+      current_application.application_work_history_breaks.find(current_work_history_break_id)
+    end
+
+    def current_work_history_break_id
+      params.permit(:id)[:id]
+    end
 
     def work_history_break_params
       params.require(:candidate_interface_work_history_break_form)

--- a/app/views/candidate_interface/work_history/break/confirm_destroy.html.erb
+++ b/app/views/candidate_interface/work_history/break/confirm_destroy.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, t('page_titles.destroy_work_history_break') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_work_history_show_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @work_break, url: candidate_interface_destroy_work_history_break_path(@work_break), method: :post do |f| %>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Work history</span>
+        <%= t('page_titles.destroy_work_history_break') %>
+      </h1>
+
+      <%= f.submit t('application_form.work_history.sure_delete_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', candidate_interface_work_history_show_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,7 @@ en:
     work_history: Work history
     work_history_breaks: Tell us about any breaks in your work history
     work_history_break: Please tell us what you were doing over this period
+    destroy_work_history_break: Are you sure you want to delete this entry?
     add_job: Add job
     degree: Degree
     add_undergraduate_degree: Add undergraduate degree

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,8 @@ Rails.application.routes.draw do
 
         get '/explain-break/new' => 'work_history/break#new', as: :new_work_history_break
         post '/explain-break/new' => 'work_history/break#create'
+        get '/explain-break/delete/:id' => 'work_history/break#confirm_destroy', as: :destroy_work_history_break
+        post '/explain-break/delete/:id' => 'work_history/break#destroy'
 
         get '/new' => 'work_history/edit#new', as: :work_history_new
         post '/create' => 'work_history/edit#create', as: :work_history_create

--- a/spec/components/break_in_work_history_component_spec.rb
+++ b/spec/components/break_in_work_history_component_spec.rb
@@ -19,4 +19,16 @@ RSpec.describe BreakInWorkHistoryComponent do
     expect(result.text).to include('I feel asleep.')
     expect(result.text).to include('February 2019 - April 2019')
   end
+
+  it 'renders the component with a delete link if editable' do
+    result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: true)
+
+    expect(result.text).to include('Delete entry for break between February 2019 and April 2019')
+  end
+
+  it 'renders the component without a delete link if editable is false' do
+    result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: false)
+
+    expect(result.text).not_to include('Delete entry for break between February 2019 and April 2019')
+  end
 end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -198,6 +198,26 @@ RSpec.describe WorkHistoryWithBreaks do
         expect(work_history_with_breaks[1][:entry].length).to eq(1)
         expect(work_history_with_breaks[2]).to eq(type: :job, entry: job2)
       end
+
+      it 'returns an array containing a hash for the existing break if no jobs' do
+        work_history = []
+        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+        )
+
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0][:type]).to eq(:break)
+        expect(work_history_with_breaks[0][:entry].start_date).to eq(february2019)
+        expect(work_history_with_breaks[0][:entry].end_date).to eq(april2019)
+        expect(work_history_with_breaks[0][:entry].length).to eq(1)
+      end
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -24,6 +24,10 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
     when_i_enter_a_reason_for_my_break
     then_i_can_see_my_reason_on_the_review_page
+
+    when_i_click_to_delete_my_break
+    and_i_confirm_i_want_to_delete_my_break
+    then_i_no_longer_see_my_reason_on_the_review_page
   end
 
   def given_i_am_signed_in
@@ -122,5 +126,17 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
   def then_i_can_see_my_reason_on_the_review_page
     expect(page).to have_content('Painting is tiring.')
+  end
+
+  def when_i_click_to_delete_my_break
+    click_link 'Delete entry for break between August 2019 and November 2019'
+  end
+
+  def and_i_confirm_i_want_to_delete_my_break
+    click_button 'Yes I’m sure - delete this entry'
+  end
+
+  def then_i_no_longer_see_my_reason_on_the_review_page
+    expect(page).not_to have_content('Painting is tiring.')
   end
 end


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1360, we added the ability to enter a reason for a work history break.

## Changes proposed in this pull request

This PR:

- fix https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1360#issuecomment-585786083
- add ability to delete a work history break

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/74462466-2dd9f900-4e88-11ea-9735-2f9bfa238b49.png)

![image](https://user-images.githubusercontent.com/42817036/74462493-38948e00-4e88-11ea-8bdd-9ba24f0a0d0a.png)

## Guidance to review

Could the `WorkHistoryWithBreaks` service be refactored better? 🤔 

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
