### PR TITLE
Do not treat sandbox_mode as a feature_flag

### DIFF
--- a/app/controllers/integrations/feature_flags_controller.rb
+++ b/app/controllers/integrations/feature_flags_controller.rb
@@ -10,13 +10,9 @@ module Integrations
         features
       end
 
-      feature_flags['sandbox_mode'] = {
-        name: 'Sandbox mode',
-        active: HostingEnvironment.sandbox_mode?,
-      }
-
       response = {
         hosting_environment: HostingEnvironment.environment_name,
+        sandbox_mode: HostingEnvironment.sandbox_mode?,
         feature_flags: feature_flags,
       }
 

--- a/spec/requests/integrations/feature_flags_spec.rb
+++ b/spec/requests/integrations/feature_flags_spec.rb
@@ -12,12 +12,12 @@ RSpec.describe 'GET /integrations/feature-flags', type: :request do
 
   it 'tells us when Sandbox mode is on', sandbox: true do
     get '/integrations/feature-flags'
-    expect(parsed_response['feature_flags']['sandbox_mode']['active']).to be(true)
+    expect(parsed_response['sandbox_mode']).to be(true)
   end
 
   it 'tells us when Sandbox mode is off', sandbox: false do
     get '/integrations/feature-flags'
-    expect(parsed_response['feature_flags']['sandbox_mode']['active']).to be(false)
+    expect(parsed_response['sandbox_mode']).to be(false)
   end
 
   def parsed_response


### PR DESCRIPTION
We have a feature in the features dashboard which detects when things
are on in only one non-qa environment, and sandbox mode will usually be
in that state. Pass the value as a plain flag instead. Client update: https://github.com/DFE-Digital/apply-ops-dashboard/pull/11 
