### PR TITLE
Implementation of automated all choices rejected email 

### DIFF
--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -20,12 +20,10 @@ class RejectApplication
         rejection_reason: @rejection_reason,
         rejected_at: Time.zone.now,
       )
-      SetDeclineByDefault.new(application_form: @application_choice.application_form).call
-      # New service
       if FeatureFlag.active?('candidate_rejected_by_provider_email')
-        CandidateMailer.all_application_choices_rejected(@application_choice).deliver
-        # SendCandidateRejectionEmail.call(application_choice: @application_choice)
+        SendCandidateRejectionEmail.call(application_choice: @application_choice)
       end
+      SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
   rescue Workflow::NoTransitionAllowed

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -21,6 +21,11 @@ class RejectApplication
         rejected_at: Time.zone.now,
       )
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+      # New service
+      if FeatureFlag.active?('candidate_rejected_by_provider_email')
+        CandidateMailer.all_application_choices_rejected(@application_choice).deliver
+        # SendCandidateRejectionEmail.call(application_choice: @application_choice)
+      end
       StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
   rescue Workflow::NoTransitionAllowed

--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -1,0 +1,14 @@
+class SendCandidateRejectionEmail
+  def self.call(application_choice:)
+    candidate_application_choices = application_choice.application_form.application_choices
+
+    if candidate_application_choices.all?(&:rejected?)
+      CandidateMailer.send(:all_application_choices_rejected, application_choice).deliver_later
+
+      audit_comment =
+        "New rejection email sent to candidate #{application_choice.application_form.candidate.email_address} for " +
+        "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}."
+      application_choice.application_form.update!(audit_comment: audit_comment)
+    end
+  end
+end

--- a/spec/services/send_candidate_rejection_email_spec.rb
+++ b/spec/services/send_candidate_rejection_email_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe SendCandidateRejectionEmail do
+  describe '#call' do
+    let(:application_form) { create(:completed_application_form) }
+    let(:application_choice) {  create(:application_choice, status: :rejected, application_form: application_form) }
+
+    context 'when the candidate has had all of their application choices rejected' do
+      before do
+        mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+        allow(CandidateMailer).to receive(:all_application_choices_rejected).and_return(mail)
+      end
+
+      it 'sends them the all applications rejected email' do
+        described_class.call(application_choice: application_choice)
+        expect(CandidateMailer).to have_received(:all_application_choices_rejected).with(application_choice)
+      end
+
+      it 'audits the rejection email', with_audited: true do
+        expected_comment =
+          "New rejection email sent to candidate #{application_choice.application_form.candidate.email_address} for " +
+          "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}."
+
+        described_class.call(application_choice: application_choice)
+
+        expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.feature 'Receives rejection email' do
+  include CandidateHelper
+
+  scenario 'Receives rejection email' do
+    given_the_pilot_is_open
+    and_candidate_rejected_by_provider_email_is_active
+    and_all_but_one_of_my_application_choices_have_been_rejected
+
+    when_a_provider_rejects_my_last_application
+    then_i_receive_the_all_applications_rejected_email
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_candidate_rejected_by_provider_email_is_active
+    FeatureFlag.activate('candidate_rejected_by_provider_email')
+  end
+
+  def and_all_but_one_of_my_application_choices_have_been_rejected
+    @application_form = create(:completed_application_form)
+    create_list(:application_choice, 2, status: :rejected, application_form: @application_form)
+    @application_choice = create(:application_choice, status: :awaiting_provider_decision, application_form: @application_form)
+  end
+
+  def when_a_provider_rejects_my_last_application
+    RejectApplication.new(application_choice: @application_choice, rejection_reason: 'No experience working with children.').save
+  end
+
+  def then_i_receive_the_all_applications_rejected_email
+    open_email(@application_form.candidate.email_address)
+    expect(current_email.subject).to include(t('application_choice_rejected_email.subject', provider_name: @application_choice.provider.name))
+  end
+end

--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature 'Receives rejection email' do
 
   def then_i_receive_the_all_applications_rejected_email
     open_email(@application_form.candidate.email_address)
+
     expect(current_email.subject).to include(t('application_choice_rejected_email.subject', provider_name: @application_choice.provider.name))
   end
 end


### PR DESCRIPTION
## Context

When a user receives a rejection and all of their course choices have been a rejected they should be sent an email.

The email was created in #1358 

This PR adds automation.

## Changes proposed in this pull request

- Adds the RejectApplication service
- Sends an email if the candidate has had all their applications rejected

## Guidance to review

Steve recently implemented something similar to this for offers. I'll be using his PR as the basis of refactors in subsequent PRs as additional emails are added.


## Link to Trello card

https://trello.com/c/22e7C80p/840-email-%F0%9F%99%85%E2%99%80%EF%B8%8F-a-provider-has-rejected-your-application-to-candidate

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
