### PR TITLE
Sync Provider#region_code from Find API

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -8,6 +8,18 @@ class Provider < ApplicationRecord
   has_many :provider_users, through: :provider_users_providers
   has_many :provider_agreements
 
+  enum region_code: {
+    east_midlands: 'east_midlands',
+    eastern: 'eastern',
+    london: 'london',
+    north_east: 'north_east',
+    north_west: 'north_west',
+    south_east: 'south_east',
+    south_west: 'south_west',
+    west_midlands: 'west_midlands',
+    yorkshire_and_the_humber: 'yorkshire_and_the_humber',
+  }
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -12,10 +12,13 @@ class Provider < ApplicationRecord
     east_midlands: 'east_midlands',
     eastern: 'eastern',
     london: 'london',
+    no_region: 'no_region',
     north_east: 'north_east',
     north_west: 'north_west',
+    scotland: 'scotland',
     south_east: 'south_east',
     south_west: 'south_west',
+    wales: 'wales',
     west_midlands: 'west_midlands',
     yorkshire_and_the_humber: 'yorkshire_and_the_humber',
   }

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -38,7 +38,7 @@ class SyncProviderFromFind
   end
 
   def self.update_provider(provider, find_provider)
-    provider.region_code = find_provider.region_code if find_provider.region_code
+    provider.region_code = find_provider.region_code.strip if find_provider.region_code
     provider.name = find_provider.provider_name if find_provider.provider_name
     provider.save!
   end

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -14,7 +14,7 @@ class SyncProviderFromFind
       .find(provider_code)
       .first
 
-    update_provider_name(provider, find_provider.provider_name)
+    update_provider(provider, find_provider)
 
     find_provider.courses.each do |find_course|
       create_or_update_course(find_course, provider)
@@ -34,6 +34,12 @@ class SyncProviderFromFind
 
   def self.update_provider_name(provider, provider_name)
     provider.name = provider_name
+    provider.save!
+  end
+
+  def self.update_provider(provider, find_provider)
+    provider.region_code = find_provider.region_code if find_provider.region_code
+    provider.name = find_provider.provider_name if find_provider.provider_name
     provider.save!
   end
 

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe SyncProviderFromFind do
   include FindAPIHelper
 
-  describe 'ingesting a new brand provider' do
+  describe 'ingesting a brand new provider' do
     it 'just creates the provider without any courses' do
       stub_find_api_provider_200(
         provider_code: 'ABC',
@@ -142,6 +142,19 @@ RSpec.describe SyncProviderFromFind do
         modes_for_site = course_options.where(site_id: site.id).pluck(:study_mode)
         expect(modes_for_site).to match_array %w[full_time part_time]
       end
+    end
+
+    it 'correctly updates the Provider#region_code' do
+      stub_find_api_provider_200(
+        provider_code: 'ABC',
+        course_code: '9CBA',
+        site_code: 'G',
+        findable: true,
+      )
+
+      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+      expect(@existing_provider.reload.region_code).to eq 'north_west'
     end
   end
 end

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -6,7 +6,8 @@ module FindAPIHelper
     site_code: 'X',
     findable: true,
     study_mode: 'full_time',
-    site_address_line2: 'C/O The Bruntcliffe Academy'
+    site_address_line2: 'C/O The Bruntcliffe Academy',
+    region_code: 'north_west'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -19,6 +20,7 @@ module FindAPIHelper
             'attributes': {
               'provider_name': provider_name,
               'provider_code': provider_code,
+              'region_code': region_code,
             },
             'relationships': {
               'sites': {
@@ -73,7 +75,17 @@ module FindAPIHelper
       )
   end
 
-  def stub_find_api_provider_200_with_accrediting_provider(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', accrediting_provider_code: 'XYZ', accrediting_provider_name: 'Dummy Accrediting Provider', findable: true, study_mode: 'full_time')
+  def stub_find_api_provider_200_with_accrediting_provider(
+    provider_code: 'ABC',
+    provider_name: 'Dummy Provider',
+    course_code: 'X130',
+    site_code: 'X',
+    accrediting_provider_code: 'XYZ',
+    accrediting_provider_name: 'Dummy Accrediting Provider',
+    findable: true,
+    study_mode: 'full_time',
+    region_code: 'north_west'
+  )
     stub_find_api_provider(provider_code)
       .to_return(
         status: 200,
@@ -85,6 +97,7 @@ module FindAPIHelper
             'attributes': {
               'provider_name': provider_name,
               'provider_code': provider_code,
+              'region_code': region_code,
             },
             'relationships': {
               'sites': {
@@ -142,7 +155,14 @@ module FindAPIHelper
       )
   end
 
-  def stub_find_api_provider_200_with_multiple_sites(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', findable: true, study_mode: 'full_time_or_part_time')
+  def stub_find_api_provider_200_with_multiple_sites(
+    provider_code: 'ABC',
+    provider_name: 'Dummy Provider',
+    course_code: 'X130',
+    findable: true,
+    study_mode: 'full_time_or_part_time',
+    region_code: 'north_west'
+  )
     response_hash = {
       status: 200,
       headers: { 'Content-Type': 'application/vnd.api+json' },
@@ -153,6 +173,7 @@ module FindAPIHelper
           'attributes': {
             'provider_name': provider_name,
             'provider_code': provider_code,
+            'region_code': region_code,
           },
           'relationships': {
             'sites': {

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -6,8 +6,8 @@ module FindAPIHelper
     site_code: 'X',
     findable: true,
     study_mode: 'full_time',
-    site_address_line2: 'C/O The Bruntcliffe Academy',
-    region_code: 'north_west'
+    region_code: 'north_west',
+    site_address_line2: 'C/O The Bruntcliffe Academy'
   )
     stub_find_api_provider(provider_code)
       .to_return(


### PR DESCRIPTION
## Context

We want to be able to group Providers by region to make large lists easier to navigate.

## Changes proposed in this pull request

- This PR adds region code to the existing Provider data synchronisation mechanism so that it will be pulled from the Find API by the scheduled background job
- Migration is already deployed. https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1363
- Fix an crash in the synchronisation that doesn't handle nil values for certain Site address fields.

## Guidance to review

- Currently Find only have region_code values for about 25% of their Providers. So this data won't be useful to us until they/we have fixed that. Does it make sense to add this now?

## Link to Trello card

https://trello.com/c/luWz8uHE/975-currently-available-providers-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
