### PR TITLE
Redis persistence in QA and Sandbox

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -110,6 +110,8 @@ stages:
       environment: 'sandbox'
       resourceEnvironmentName: 't02'
       serviceName: 'apply'
+      redisCacheSKU: 'Premium'
+      redisCacheFamily: 'P'
       containerImageReference: '$(imageName):$(build.buildNumber)'
       keyVaultName: 's106t01-shared-kv-01'
       keyVaultResourceGroup: 's106t01-shared-rg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,6 +234,8 @@ stages:
       environment: 'qa'
       resourceEnvironmentName: 'd01'
       serviceName: 'apply'
+      redisCacheSKU: 'Premium'
+      redisCacheFamily: 'P'
       containerImageReference: '$(imageName):$(build.buildNumber)'
       keyVaultName: 's106d01-shared-kv-01'
       keyVaultResourceGroup: 's106d01-shared-rg'


### PR DESCRIPTION
## Context

Several unexpected restarts have been experienced in Redis on the QA and Sandbox environments that has resulted in feature flags being defaulted unexpectedly.

## Changes proposed in this pull request

Upgrade to Premium tier for the QA and Sandbox environments.

**NOTE: Before this PR can be merged into master we will need to delete the Redis instance in QA and then again in Sandbox before next running the release pipeline. This is because of a limitation in the Azure infrastructure that means Redis instances can't be upgraded after they have been created.**

## Guidance to review

N/A

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
