### PR TITLE
Re-align RBD provider email to designs

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -38,12 +38,14 @@ class ProviderMailer < ApplicationMailer
         :course_name_and_code,
         :submitted_at,
         :application_choice,
+        :rbd_days,
       ).new(
         application_choice.application_form.full_name,
         provider_user.full_name,
         application_choice.course.name_and_code,
         application_choice.application_form.submitted_at.to_s(:govuk_date).strip,
         application_choice,
+        application_choice.reject_by_default_days,
     )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -4,11 +4,7 @@ Dear <%= @application.provider_user_name || 'colleague' %>
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
-You did not respond within 40 working days so we rejected the application on your behalf.
-
-You can log in to Manage teacher training applications to check the status of your applications:
-
-<%= provider_interface_application_choice_url(@application.application_choice) %>
+This application has been rejected automatically because you did not respond within 40 working days.
 
 # Give feedback or report a problem
 

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -4,7 +4,7 @@ Dear <%= @application.provider_user_name || 'colleague' %>
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
-This application has been rejected automatically because you did not respond within 40 working days.
+This application has been rejected automatically because you did not respond within <%= @application.rbd_days %> working days.
 
 # Give feedback or report a problem
 

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe ProviderMailer, type: :mailer do
       expect(@mail.body.encoded).to include("on #{submission_date.to_s(:govuk_date).strip}")
     end
 
-    it 'includes a link to the application' do
-      expect(@mail.body.encoded).to include(provider_interface_application_choice_url(application_choice_id: application_choice.id))
+    it 'includes the reject by default days' do
+      expect(@mail.body.encoded).to include('within 123 working days')
     end
   end
 

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'An application has been rejected by default' do
 
     when_the_application_is_rejected_by_default
 
-    then_i_should_receive_an_email_with_a_link_to_the_application
+    then_i_should_receive_an_email
     and_an_audit_comment_has_submitted
   end
 
@@ -37,13 +37,11 @@ RSpec.feature 'An application has been rejected by default' do
     RejectApplicationsByDefaultWorker.new.perform
   end
 
-  def then_i_should_receive_an_email_with_a_link_to_the_application
+  def then_i_should_receive_an_email
     open_email(@provider_user.email_address)
 
     expect(current_email.subject).to include(t('provider_application_rejected_by_default.email.subject',
                                                candidate_name: @application_choice.application_form.full_name))
-
-    expect(current_email.body).to include("http://localhost:3000/provider/applications/#{@application_choice.id}")
   end
 
   def and_an_audit_comment_has_submitted


### PR DESCRIPTION
## Context

[The design of the RBD rejection email to providers](https://docs.google.com/document/d/1VH_nxuLTiVCkmKhC4eaBpFC61Hd5_Ol1tKwOul-2uUs/edit#) has moved on.

## Changes proposed in this pull request

- re-align email to designs
- use the RBD days off the application, instead of hard-coding it in the email template

After:

![image](https://user-images.githubusercontent.com/23801/74532101-384ad000-4f26-11ea-9007-c8af16045f25.png)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
