### PR TITLE
Update work history break content and don't prefill end date if now

### DIFF
--- a/app/components/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/break_placeholder_in_work_history_component.html.erb
@@ -1,16 +1,23 @@
 <section class="app-summary-card govuk-!-margin-bottom-6">
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
-      You have a break in your work history (<%= pluralize(work_break.length, 'month') %>)
+      You have a break in your work history in the last 5 years (<%= pluralize(work_break.length, 'month') %>)
     </h3>
 
     <div class="app-summary-card__actions">
       <ul class="app-summary-card__actions-list">
         <li class="app-summary-card__actions-list-item">
-          <%= govuk_link_to 'Please explain break', candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date) %>
+          <%= link_to candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
+            Please explain break <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
+          <% end %>
         </li>
         <li class="app-summary-card__actions-list-item">
-          <%= govuk_link_to t('application_form.work_history.add_another_job'), candidate_interface_work_history_new_path(start_date: work_break.start_date, end_date: work_break.end_date) %>
+          or
+        </li>
+        <li class="app-summary-card__actions-list-item">
+          <%= link_to candidate_interface_work_history_new_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
+            Add another job <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
+          <% end %>
         </li>
       </ul>
     </div>

--- a/app/components/break_placeholder_in_work_history_component.rb
+++ b/app/components/break_placeholder_in_work_history_component.rb
@@ -6,4 +6,8 @@ class BreakPlaceholderInWorkHistoryComponent < ActionView::Component::Base
   def initialize(work_break:)
     @work_break = work_break
   end
+
+  def between_formatted_dates
+    "between #{@work_break.start_date.to_s(:month_and_year)} and #{@work_break.end_date.to_s(:month_and_year)}"
+  end
 end

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -7,11 +7,13 @@ module CandidateInterface
                                 start_date = params[:start_date].to_date
                                 end_date = params[:end_date].to_date
 
+                                end_date = nil if end_date.month == Time.zone.today.month && end_date.year == Time.zone.today.year
+
                                 WorkExperienceForm.new(
                                   start_date_month: start_date.month,
                                   start_date_year: start_date.year,
-                                  end_date_month: end_date.month,
-                                  end_date_year: end_date.year,
+                                  end_date_month: end_date&.month || '',
+                                  end_date_year: end_date&.year || '',
                                   add_another_job: true,
                                 )
                               else

--- a/spec/components/break_placeholder_in_work_history_component_spec.rb
+++ b/spec/components/break_placeholder_in_work_history_component_spec.rb
@@ -12,12 +12,18 @@ RSpec.describe BreakPlaceholderInWorkHistoryComponent do
   it 'renders the component with the break in months' do
     result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
 
-    expect(result.text).to include('You have a break in your work history (3 months)')
+    expect(result.text).to include('You have a break in your work history in the last 5 years (3 months)')
+  end
+
+  it 'renders the component with a link to explain break' do
+    result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
+
+    expect(result.text).to include('Please explain break between January 2020 and May 2020')
   end
 
   it 'renders the component with a link to add another job' do
     result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
 
-    expect(result.text).to include('Add another job')
+    expect(result.text).to include('Add another job between January 2020 and May 2020')
   end
 end


### PR DESCRIPTION
## Context

Smol tweaks to the work history breaks as per https://trello.com/c/jIWipybM/732-calculate-work-gaps#comment-5e4290ca629e7313c54cd3f1.

## Changes proposed in this pull request

This PR:

- updates the content on a break placeholder and adds an "or" between the two links
- adds visually hidden text to differentiate between "Please explain break" and "Add another job" links for screen readers
- doesn't prefill the end date when a candidate clicks on "Add another job" and the break end date is now

## Screenshot

![image](https://user-images.githubusercontent.com/42817036/74534546-df7e3600-4f2b-11ea-9964-99b837adbbcf.png)

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
