### PR TITLE
Disable NestedGroups cop in spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,10 @@ RSpec/MultipleExpectations:
 RSpec/ContextWording:
   Enabled: false
 
+  RSpec/NestedGroups:
+    Exclude:
+      - 'spec/**/*'
+
 Naming/MethodParameterName:
   AllowedNames:
     - e


### PR DESCRIPTION
## Context

I personally find this cop really annoying in spec files. Thoughts?
