### PR TITLE
Refactor WorkHistoryWithBreaks service

### DIFF
--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -1,23 +1,23 @@
-<% @work_history_with_breaks.each do |history| %>
-  <% if history[:type] == :job %>
-    <%= render(SummaryCardComponent, rows: work_experience_rows(history[:entry]), editable: @editable) do %>
-      <%= render(SummaryCardHeaderComponent, title: history[:entry].role, heading_level: @heading_level, check_icon: history[:entry].working_with_children) do %>
+<% @work_history_with_breaks.each do |entry| %>
+  <% if entry.is_a?(ApplicationWorkExperience) %>
+    <%= render(SummaryCardComponent, rows: work_experience_rows(entry), editable: @editable) do %>
+      <%= render(SummaryCardHeaderComponent, title: entry.role, heading_level: @heading_level, check_icon: entry.working_with_children) do %>
         <% if @editable %>
           <div class="app-summary-card__actions">
-            <%= link_to candidate_interface_work_history_destroy_path(history[:entry].id), class: 'govuk-link' do %>
-              <%= t('application_form.work_history.delete_entry') %><span class="govuk-visually-hidden"><%= generate_action(work: history[:entry]) %></span>
+            <%= link_to candidate_interface_work_history_destroy_path(entry.id), class: 'govuk-link' do %>
+              <%= t('application_form.work_history.delete_entry') %><span class="govuk-visually-hidden"><%= generate_action(work: entry) %></span>
             <% end %>
           </div>
         <% end %>
       <% end %>
     <% end %>
-  <% elsif history[:type] == :break_placeholder %>
+  <% elsif entry.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) %>
     <% if FeatureFlag.active?('work_breaks') %>
-      <%= render(BreakPlaceholderInWorkHistoryComponent, work_break: history[:entry]) %>
+      <%= render(BreakPlaceholderInWorkHistoryComponent, work_break: entry) %>
     <% end %>
-  <% elsif history[:type] == :break %>
+  <% elsif entry.is_a?(ApplicationWorkHistoryBreak) %>
     <% if FeatureFlag.active?('work_breaks') %>
-      <%= render(BreakInWorkHistoryComponent, work_break: history[:entry]) %>
+      <%= render(BreakInWorkHistoryComponent, work_break: entry) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -21,24 +21,25 @@ class WorkHistoryWithBreaks
     @work_history = application_form.application_work_experiences.sort_by(&:start_date)
     @existing_breaks = application_form.application_work_history_breaks.sort_by(&:start_date)
     @current_job = nil
-    @work_history_with_breaks = []
-
-    @work_history.each { |job| @work_history_with_breaks << job_entry(job) }
-    @existing_breaks.each { |existing_break| @work_history_with_breaks << break_entry(existing_break) }
   end
 
   def timeline
-    return @work_history_with_breaks if @work_history.empty?
+    work_history_with_breaks = []
 
-    timeline_in_months = month_range(
-      start_date: @work_history.first.start_date,
-      end_date: Time.zone.now - 1.month,
-    )
-    break_months_in_timeline = remove_working_months(timeline_in_months)
-    breaks = break_entries(break_months_in_timeline)
-    @work_history_with_breaks += breaks if breaks.any?
+    @work_history.each { |job| work_history_with_breaks << job_entry(job) }
+    @existing_breaks.each { |existing_break| work_history_with_breaks << break_entry(existing_break) }
 
-    @work_history_with_breaks.sort_by! { |entry| entry[:entry].start_date }
+    if @work_history.any?
+      timeline_in_months = month_range(
+        start_date: @work_history.first.start_date,
+        end_date: Time.zone.now - 1.month,
+      )
+      break_months_in_timeline = remove_working_months(timeline_in_months)
+      breaks = break_entries(break_months_in_timeline)
+      work_history_with_breaks += breaks if breaks.any?
+    end
+
+    work_history_with_breaks.sort_by(&:start_date)
   end
 
 private

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -26,8 +26,8 @@ class WorkHistoryWithBreaks
   def timeline
     work_history_with_breaks = []
 
-    @work_history.each { |job| work_history_with_breaks << job_entry(job) }
-    @existing_breaks.each { |existing_break| work_history_with_breaks << break_entry(existing_break) }
+    @work_history.each { |job| work_history_with_breaks << job }
+    @existing_breaks.each { |existing_break| work_history_with_breaks << existing_break }
 
     if @work_history.any?
       timeline_in_months = month_range(
@@ -43,18 +43,6 @@ class WorkHistoryWithBreaks
   end
 
 private
-
-  def job_entry(job)
-    { type: :job, entry: job }
-  end
-
-  def break_placeholder_entry(month_range)
-    { type: :break_placeholder, entry: BreakPlaceholder.new(month_range: month_range) }
-  end
-
-  def break_entry(existing_break)
-    { type: :break, entry: existing_break }
-  end
 
   def month_range(start_date:, end_date:)
     (start_date.to_date..end_date.to_date).map(&:beginning_of_month).uniq
@@ -84,7 +72,7 @@ private
         current_break << month
       else
         unless existing_break_covers_break_period?(current_break)
-          breaks << break_placeholder_entry(current_break)
+          breaks << BreakPlaceholder.new(month_range: current_break)
         end
 
         current_break = [month]
@@ -92,22 +80,22 @@ private
     end
 
     unless existing_break_covers_break_period?(current_break)
-      breaks << break_placeholder_entry(current_break)
+      breaks << BreakPlaceholder.new(month_range: current_break)
     end
 
     breaks
   end
 
   def existing_break_covers_break_period?(current_break)
-    existing_break_covering_placeholder = @existing_breaks.select do |existing_break|
-      break_placeholder = break_placeholder_entry(current_break)
+    existing_break_covering_break_period = @existing_breaks.select do |existing_break|
+      break_placeholder = BreakPlaceholder.new(month_range: current_break)
 
-      same_start_date = existing_break.start_date.to_date == break_placeholder[:entry].start_date
-      same_end_date = existing_break.end_date.to_date == break_placeholder[:entry].end_date
+      same_start_date = existing_break.start_date.to_date == break_placeholder.start_date
+      same_end_date = existing_break.end_date.to_date == break_placeholder.end_date
 
       same_start_date && same_end_date
     end
 
-    existing_break_covering_placeholder.any?
+    existing_break_covering_break_period.any?
   end
 end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -219,5 +219,32 @@ RSpec.describe WorkHistoryWithBreaks do
         expect(work_history_with_breaks[0][:entry].length).to eq(1)
       end
     end
+
+    context 'when an application form has multiple breaks' do
+      it 'returns an array of existing breaks and sorted if no jobs' do
+        work_history = []
+        break1 = build_stubbed(:application_work_history_break, start_date: november2019, end_date: current_date)
+        break2 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break1, break2]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+        )
+
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0][:type]).to eq(:break)
+        expect(work_history_with_breaks[0][:entry].start_date).to eq(february2019)
+        expect(work_history_with_breaks[0][:entry].end_date).to eq(april2019)
+        expect(work_history_with_breaks[0][:entry].length).to eq(1)
+        expect(work_history_with_breaks[1][:type]).to eq(:break)
+        expect(work_history_with_breaks[1][:entry].start_date).to eq(november2019)
+        expect(work_history_with_breaks[1][:entry].end_date).to eq(current_date)
+        expect(work_history_with_breaks[1][:entry].length).to eq(2)
+      end
+    end
   end
 end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[0]).to eq(job1)
       end
     end
 
@@ -56,7 +56,7 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
+        expect(work_history_with_breaks[0]).to eq(job1)
       end
     end
 
@@ -70,11 +70,11 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1][:type]).to eq(:break_placeholder)
-        expect(work_history_with_breaks[1][:entry].length).to eq(1)
-        expect(work_history_with_breaks[1][:entry].start_date).to eq(Date.new(2019, 12, 1))
-        expect(work_history_with_breaks[1][:entry].end_date).to eq(Date.new(2020, 2, 1))
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(WorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[1].length).to eq(1)
+        expect(work_history_with_breaks[1].start_date).to eq(Date.new(2019, 12, 1))
+        expect(work_history_with_breaks[1].end_date).to eq(Date.new(2020, 2, 1))
       end
     end
 
@@ -88,9 +88,9 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1][:type]).to eq(:break_placeholder)
-        expect(work_history_with_breaks[1][:entry].length).to eq(3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(WorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[1].length).to eq(3)
       end
     end
 
@@ -106,9 +106,9 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
-        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to eq(job3)
       end
     end
 
@@ -124,11 +124,11 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(4)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
-        expect(work_history_with_breaks[2][:type]).to eq(:break_placeholder)
-        expect(work_history_with_breaks[2][:entry].length).to eq(1)
-        expect(work_history_with_breaks[3]).to eq(type: :job, entry: job3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to be_instance_of(WorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[2].length).to eq(1)
+        expect(work_history_with_breaks[3]).to eq(job3)
       end
     end
 
@@ -144,9 +144,9 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
-        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to eq(job3)
       end
     end
 
@@ -162,11 +162,11 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(4)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1][:type]).to eq(:break_placeholder)
-        expect(work_history_with_breaks[1][:entry].length).to eq(1)
-        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job2)
-        expect(work_history_with_breaks[3]).to eq(type: :job, entry: job3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(WorkHistoryWithBreaks::BreakPlaceholder)
+        expect(work_history_with_breaks[1].length).to eq(1)
+        expect(work_history_with_breaks[2]).to eq(job2)
+        expect(work_history_with_breaks[3]).to eq(job3)
       end
     end
 
@@ -182,9 +182,9 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1]).to eq(type: :job, entry: job2)
-        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job3)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+        expect(work_history_with_breaks[2]).to eq(job3)
       end
     end
 
@@ -205,12 +205,12 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(3)
-        expect(work_history_with_breaks[0]).to eq(type: :job, entry: job1)
-        expect(work_history_with_breaks[1][:type]).to eq(:break)
-        expect(work_history_with_breaks[1][:entry].start_date).to eq(february2019)
-        expect(work_history_with_breaks[1][:entry].end_date).to eq(april2019)
-        expect(work_history_with_breaks[1][:entry].length).to eq(1)
-        expect(work_history_with_breaks[2]).to eq(type: :job, entry: job2)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[1].start_date).to eq(february2019)
+        expect(work_history_with_breaks[1].end_date).to eq(april2019)
+        expect(work_history_with_breaks[1].length).to eq(1)
+        expect(work_history_with_breaks[2]).to eq(job2)
       end
     end
 
@@ -229,10 +229,10 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(1)
-        expect(work_history_with_breaks[0][:type]).to eq(:break)
-        expect(work_history_with_breaks[0][:entry].start_date).to eq(february2019)
-        expect(work_history_with_breaks[0][:entry].end_date).to eq(april2019)
-        expect(work_history_with_breaks[0][:entry].length).to eq(1)
+        expect(work_history_with_breaks[0]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[0].start_date).to eq(february2019)
+        expect(work_history_with_breaks[0].end_date).to eq(april2019)
+        expect(work_history_with_breaks[0].length).to eq(1)
       end
     end
 
@@ -252,14 +252,14 @@ RSpec.describe WorkHistoryWithBreaks do
         work_history_with_breaks = get_work_history_with_breaks.timeline
 
         expect(work_history_with_breaks.count).to eq(2)
-        expect(work_history_with_breaks[0][:type]).to eq(:break)
-        expect(work_history_with_breaks[0][:entry].start_date).to eq(february2019)
-        expect(work_history_with_breaks[0][:entry].end_date).to eq(april2019)
-        expect(work_history_with_breaks[0][:entry].length).to eq(1)
-        expect(work_history_with_breaks[1][:type]).to eq(:break)
-        expect(work_history_with_breaks[1][:entry].start_date).to eq(november2019)
-        expect(work_history_with_breaks[1][:entry].end_date).to eq(current_date)
-        expect(work_history_with_breaks[1][:entry].length).to eq(2)
+        expect(work_history_with_breaks[0]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[0].start_date).to eq(february2019)
+        expect(work_history_with_breaks[0].end_date).to eq(april2019)
+        expect(work_history_with_breaks[0].length).to eq(1)
+        expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[1].start_date).to eq(november2019)
+        expect(work_history_with_breaks[1].end_date).to eq(current_date)
+        expect(work_history_with_breaks[1].length).to eq(2)
       end
     end
   end


### PR DESCRIPTION
## Context

Calculating work history breaks is a bit of a complicated boi and `WorkHistoryWithBreaks` is the service that takes responsibility of returning a candidate's work history with break placeholders (a break without a reason) and existing breaks (a break with a reason).

## Changes proposed in this pull request

This PR refactors `WorkHistoryWithBreaks` service:

- to ensure that existing breaks are sorted
- and its spec to (hopefully) improve readability
- to no longer return a hash with `type` and `entry` key. Just returns the object either `ApplicationWorkExperience`, `ApplicationWorkHistoryBreak` or `WorkHistoryWithBreaks::BreakPlaceholder` and works out the type from the object. Thanks @willmcb!

## Guidance to review

- Review commit by commit
- Is this an improvement?

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
