### PR TITLE
Use coloured tags for feature flag page

### DIFF
--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -4,7 +4,7 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Feature</th>
-      <th class="govuk-table__header">Activated</th>
+      <th class="govuk-table__header">Activated?</th>
       <th class="govuk-table__header">Action</th>
     </tr>
   </thead>
@@ -17,7 +17,11 @@
         </td>
 
         <td class="govuk-table__cell">
-          <%= FeatureFlag.active?(feature_name) ? 'Yes' : 'No' %>
+          <% if FeatureFlag.active?(feature_name) %>
+            <strong class='govuk-tag app-tag--turquoise'>Active</strong>
+          <% else %>
+            <strong class='govuk-tag app-tag--grey'>Inactive</strong>
+          <% end %>
         </td>
 
         <td class="govuk-table__cell">

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Feature flags' do
   end
 
   def then_i_should_see_the_existing_feature_flags
-    expect(page).to have_content 'Pilot open No'
+    expect(page).to have_content 'Pilot open Inactive'
   end
 
   def when_i_activate_the_feature
@@ -38,7 +38,7 @@ RSpec.feature 'Feature flags' do
   end
 
   def then_the_feature_is_activated
-    expect(page).to have_content 'Pilot open Yes'
+    expect(page).to have_content 'Pilot open Active'
     expect(FeatureFlag.active?('pilot_open')).to be true
   end
 
@@ -47,7 +47,7 @@ RSpec.feature 'Feature flags' do
   end
 
   def then_the_feature_is_deactivated
-    expect(page).to have_content 'Pilot open No'
+    expect(page).to have_content 'Pilot open Inactive'
     expect(FeatureFlag.active?('pilot_open')).to be false
   end
 end


### PR DESCRIPTION


## Context

Add colour flags in the feature flag list This makes it easier to differentiate active and inactive features.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/233676/74648343-5fe3a780-5175-11ea-8ea0-d6581d6ddb6c.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

👩‍💻

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
