### PR TITLE
Revert "Bump actionview-component from 1.8.1 to 1.10.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    actionview-component (1.10.0)
+    actionview-component (1.8.1)
     activejob (6.0.2.1)
       activesupport (= 6.0.2.1)
       globalid (>= 0.3.6)


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-postgraduate-teacher-training#1380. The update triggers a crazy amount of deprecation warnings about a new syntax to render components:

```
DEPRECATION WARNING: `render MyComponent, foo: :bar` has been deprecated and will be removed in v2.0.0. Use `render MyComponent.new(foo: :bar)` instead. (called from _app_views_support_interface_sessions_new_html_erb___2247956481588990210_47230903853240 at /home/runner/work/apply-for-postgraduate-teacher-training/apply-for-postgraduate-teacher-training/app/views/support_interface/sessions/new.html.erb:6)
```

Updating this will take some time so let's revert for now.