### PR TITLE
Periodically refresh the service performance screen

### DIFF
--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -102,4 +102,6 @@
   header, footer, .govuk-phase-banner { display: none; }
   .govuk-width-container { max-width: 99%; }
 </style>
+
+<meta http-equiv="refresh" content="60">
 <% end %>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -1,5 +1,9 @@
 <% content_for :title, 'Service performance' %>
 
+<p class='govuk-body'>
+  <%= govuk_link_to 'View in large screen mode', '?screen=1' unless params[:screen] %>
+</p>
+
 <h2 class="govuk-heading-m govuk-!-font-size-27">Candidates</h2>
 
 <div class="app-card app-card--blue govuk-!-margin-bottom-4">
@@ -92,3 +96,10 @@
     </table>
   </div>
 </div>
+
+<% if params[:screen] %>
+<style media="screen">
+  header, footer, .govuk-phase-banner { display: none; }
+  .govuk-width-container { max-width: 99%; }
+</style>
+<% end %>


### PR DESCRIPTION
## Context

The service performance dashboard is displayed on our TV, but isn't periodically updated so the stats never change.

## Changes proposed in this pull request

This adds a 60 second refresh when in "large screen mode". This mode also hides the page furniture and make the screen full-width, so it's nicer on the TV.

![image](https://user-images.githubusercontent.com/233676/74649634-d681a480-5177-11ea-908d-fe6ff38416ed.png)

## Guidance to review

Forgive the inlining of style and javascript - I think this is actually the cleanest and most discoverable way of doing it. 

## Link to Trello card

🚌

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
