### PR TITLE
Add ability to edit a work history break

### DIFF
--- a/app/components/break_in_work_history_component.html.erb
+++ b/app/components/break_in_work_history_component.html.erb
@@ -1,4 +1,4 @@
-<%= render(SummaryCardComponent, rows: work_break_rows) do %>
+<%= render(SummaryCardComponent, rows: work_break_rows, editable: @editable) do %>
   <%= render(SummaryCardHeaderComponent, title: "Break in work history (#{pluralize(@work_break.length, 'month')})") do %>
     <% if @editable %>
       <div class="app-summary-card__actions">

--- a/app/components/break_in_work_history_component.rb
+++ b/app/components/break_in_work_history_component.rb
@@ -26,6 +26,8 @@ private
     {
       key: 'Description',
       value: @work_break.reason,
+      action: "description for break between #{formatted_start_date} and #{formatted_end_date}",
+      change_path: candidate_interface_edit_work_history_break_path(@work_break),
     }
   end
 
@@ -33,6 +35,8 @@ private
     {
       key: 'Dates',
       value: "#{formatted_start_date} - #{formatted_end_date}",
+      action: "dates for break between #{formatted_start_date} and #{formatted_end_date}",
+      change_path: candidate_interface_edit_work_history_break_path(@work_break),
     }
   end
 end

--- a/app/controllers/candidate_interface/work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/work_history/break_controller.rb
@@ -28,6 +28,20 @@ module CandidateInterface
       end
     end
 
+    def edit
+      @work_break = WorkHistoryBreakForm.build_from_break(current_work_history_break)
+    end
+
+    def update
+      @work_break = WorkHistoryBreakForm.new(work_history_break_params)
+
+      if @work_break.update(current_work_history_break)
+        redirect_to candidate_interface_work_history_show_path
+      else
+        render :edit
+      end
+    end
+
     def confirm_destroy
       @work_break = current_work_history_break
     end

--- a/app/models/candidate_interface/work_history_break_form.rb
+++ b/app/models/candidate_interface/work_history_break_form.rb
@@ -13,10 +13,30 @@ module CandidateInterface
 
     validates :reason, presence: true, word_count: { maximum: 400 }
 
+    def self.build_from_break(work_history_break)
+      new(
+        start_date_day: work_history_break.start_date.day,
+        start_date_month: work_history_break.start_date.month,
+        start_date_year: work_history_break.start_date.year,
+        end_date_day: work_history_break.end_date.day,
+        end_date_month: work_history_break.end_date.month,
+        end_date_year: work_history_break.end_date.year,
+        reason: work_history_break.reason,
+      )
+    end
+
     def save(application_form)
       return false unless valid?
 
       application_form.application_work_history_breaks.create!(
+        start_date: start_date, end_date: end_date, reason: reason,
+      )
+    end
+
+    def update(work_break)
+      return false unless valid?
+
+      work_break.update!(
         start_date: start_date, end_date: end_date, reason: reason,
       )
     end

--- a/app/views/candidate_interface/work_history/break/_form.html.erb
+++ b/app/views/candidate_interface/work_history/break/_form.html.erb
@@ -1,0 +1,18 @@
+<%= f.govuk_error_summary %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl"><%= t('page_titles.work_history') %></span>
+  <%= t('page_titles.work_history_break') %>
+</h1>
+
+<div class="app-work-experience__start-date" data-qa="start-date">
+  <%= f.govuk_date_field :start_date, omit_day: true, legend: { text: 'Start of break', size: 'm', tag: 'span' } %>
+</div>
+
+<div class="app-work-experience__end-date" data-qa="end-date">
+  <%= f.govuk_date_field :end_date, omit_day: true, legend: { text: 'End of break', size: 'm', tag: 'span' } %>
+</div>
+
+<%= f.govuk_text_area :reason, label: { text: 'Enter reasons for break in work history', size: 'm' }, hint_text: 'For example, parenting or caring responsibilities, unemployment, travel, health, study or other personal reasons', max_words: 400 %>
+
+<%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/work_history/break/edit.html.erb
+++ b/app/views/candidate_interface/work_history/break/edit.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @work_break, url: candidate_interface_new_work_history_break_path do |f| %>
+    <%= form_with model: @work_break, url: candidate_interface_edit_work_history_break_path, method: :post do |f| %>
       <%= render 'form', f: f %>
     <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,8 @@ Rails.application.routes.draw do
 
         get '/explain-break/new' => 'work_history/break#new', as: :new_work_history_break
         post '/explain-break/new' => 'work_history/break#create'
+        get '/explain-break/edit/:id' => 'work_history/break#edit', as: :edit_work_history_break
+        post '/explain-break/edit/:id' => 'work_history/break#update'
         get '/explain-break/delete/:id' => 'work_history/break#confirm_destroy', as: :destroy_work_history_break
         post '/explain-break/delete/:id' => 'work_history/break#destroy'
 

--- a/spec/components/break_in_work_history_component_spec.rb
+++ b/spec/components/break_in_work_history_component_spec.rb
@@ -20,15 +20,33 @@ RSpec.describe BreakInWorkHistoryComponent do
     expect(result.text).to include('February 2019 - April 2019')
   end
 
-  it 'renders the component with a delete link if editable' do
-    result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: true)
+  context 'when editable' do
+    it 'renders the component with a delete link' do
+      result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: true)
 
-    expect(result.text).to include('Delete entry for break between February 2019 and April 2019')
+      expect(result.text).to include('Delete entry for break between February 2019 and April 2019')
+    end
+
+    it 'renders the component with change links' do
+      result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: true)
+
+      expect(result.text).to include('Change description for break between February 2019 and April 2019')
+      expect(result.text).to include('Change dates for break between February 2019 and April 2019')
+    end
   end
 
-  it 'renders the component without a delete link if editable is false' do
-    result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: false)
+  context 'when not editable' do
+    it 'renders the component without a delete link' do
+      result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: false)
 
-    expect(result.text).not_to include('Delete entry for break between February 2019 and April 2019')
+      expect(result.text).not_to include('Delete entry for break between February 2019 and April 2019')
+    end
+
+    it 'renders the component without change links' do
+      result = render_inline(BreakInWorkHistoryComponent, work_break: work_break, editable: false)
+
+      expect(result.text).not_to include('Change description for break between February 2019 and April 2019')
+      expect(result.text).not_to include('Change dates for break between February 2019 and April 2019')
+    end
   end
 end

--- a/spec/models/candidate_interface/work_history_break_form_spec.rb
+++ b/spec/models/candidate_interface/work_history_break_form_spec.rb
@@ -31,6 +31,17 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
     include_examples 'validation for a start and end date', 'work_history_break_form'
   end
 
+  describe '.build_from_break' do
+    it 'creates an object based on the work history break' do
+      application_work_history_break = build_stubbed(:application_work_history_break, attributes: data)
+      work_break = CandidateInterface::WorkHistoryBreakForm.build_from_break(
+        application_work_history_break,
+      )
+
+      expect(work_break).to have_attributes(form_data)
+    end
+  end
+
   describe '#save' do
     it 'returns false if not valid' do
       work_break = CandidateInterface::WorkHistoryBreakForm.new
@@ -45,6 +56,28 @@ RSpec.describe CandidateInterface::WorkHistoryBreakForm, type: :model do
       saved_work_break = work_break.save(application_form)
 
       expect(saved_work_break).to have_attributes(data)
+    end
+  end
+
+  describe '#update' do
+    it 'returns false if not valid' do
+      work_break = CandidateInterface::WorkHistoryBreakForm.new
+
+      expect(work_break.save(ApplicationForm.new)).to eq(false)
+    end
+
+    it 'updates work history break if valid' do
+      application_work_history_break = create(
+        :application_work_history_break,
+        application_form: create(:application_form),
+        attributes: data,
+      )
+      work_break = CandidateInterface::WorkHistoryBreakForm.new(form_data)
+      work_break.reason = 'Updated reason.'
+
+      work_break.update(application_work_history_break)
+
+      expect(application_work_history_break.reason).to eq('Updated reason.')
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -33,11 +33,15 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     when_i_click_to_explain_my_break_between_august_2019_and_november_2019
     then_i_see_the_start_and_end_date_filled_in_for_my_break_between_august_2019_and_november_2019
 
-    when_i_enter_a_reason_for_my_break
-    then_i_can_see_my_reason_on_the_review_page
+    when_i_enter_a_reason_for_my_break_between_august_2019_and_november_2019
+    then_i_see_my_reason_for_my_break_between_august_2019_and_november_2019_on_the_review_page
 
-    when_i_click_to_delete_my_break
-    and_i_confirm_i_want_to_delete_my_break
+    when_i_click_to_change_my_reason_for_my_break_between_august_2019_and_november_2019
+    and_i_change_my_reason_for_my_break_between_august_2019_and_november_2019
+    then_i_see_my_updated_reason_for_my_break_between_august_2019_and_november_2019_on_the_review_page
+
+    when_i_click_to_delete_my_break_between_august_2019_and_november_2019
+    and_i_confirm_i_want_to_delete_my_break_between_august_2019_and_november_2019
     then_i_no_longer_see_my_reason_on_the_review_page
   end
 
@@ -153,25 +157,39 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     click_link 'Please explain break between August 2019 and November 2019'
   end
 
-  def when_i_enter_a_reason_for_my_break
+  def when_i_enter_a_reason_for_my_break_between_august_2019_and_november_2019
     fill_in 'Enter reasons for break in work history', with: 'Painting is tiring.'
 
     click_button 'Continue'
   end
 
-  def then_i_can_see_my_reason_on_the_review_page
+  def then_i_see_my_reason_for_my_break_between_august_2019_and_november_2019_on_the_review_page
     expect(page).to have_content('Painting is tiring.')
   end
 
-  def when_i_click_to_delete_my_break
+  def when_i_click_to_delete_my_break_between_august_2019_and_november_2019
     click_link 'Delete entry for break between August 2019 and November 2019'
   end
 
-  def and_i_confirm_i_want_to_delete_my_break
+  def and_i_confirm_i_want_to_delete_my_break_between_august_2019_and_november_2019
     click_button 'Yes I’m sure - delete this entry'
   end
 
   def then_i_no_longer_see_my_reason_on_the_review_page
     expect(page).not_to have_content('Painting is tiring.')
+  end
+
+  def when_i_click_to_change_my_reason_for_my_break_between_august_2019_and_november_2019
+    click_link 'Change description for break between August 2019 and November 2019'
+  end
+
+  def and_i_change_my_reason_for_my_break_between_august_2019_and_november_2019
+    fill_in 'Enter reasons for break in work history', with: 'Some updated reason about painting.'
+
+    click_button 'Continue'
+  end
+
+  def then_i_see_my_updated_reason_for_my_break_between_august_2019_and_november_2019_on_the_review_page
+    expect(page).to have_content('Some updated reason about painting.')
   end
 end


### PR DESCRIPTION
## Context

We can currently add and delete a work history break, but a candidate can't update the break once it's entered.

## Changes proposed in this pull request

This PR adds the ability to edit a work history break by adding in "Change" links and edit paths.

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/74653821-e651b680-5180-11ea-87bd-ea64eb80f1a8.png)

![image](https://user-images.githubusercontent.com/42817036/74653872-fbc6e080-5180-11ea-923e-6454f5238e84.png)

![image](https://user-images.githubusercontent.com/42817036/74653844-f2d60f00-5180-11ea-911d-80c256b3bf43.png)

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
