### PR TITLE
Update to only show work history breaks within the last 5 years

### DIFF
--- a/app/components/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/break_placeholder_in_work_history_component.html.erb
@@ -8,7 +8,7 @@
       <ul class="app-summary-card__actions-list">
         <li class="app-summary-card__actions-list-item">
           <%= link_to candidate_interface_new_work_history_break_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
-            Please explain break <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
+            Explain break <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
           <% end %>
         </li>
         <li class="app-summary-card__actions-list-item">
@@ -16,7 +16,7 @@
         </li>
         <li class="app-summary-card__actions-list-item">
           <%= link_to candidate_interface_work_history_new_path(start_date: work_break.start_date, end_date: work_break.end_date), class: 'govuk-link' do %>
-            Add another job <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
+            add another job <span class="govuk-visually-hidden"><%= between_formatted_dates %></span>
           <% end %>
         </li>
       </ul>

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -31,7 +31,7 @@ class WorkHistoryWithBreaks
 
     if @work_history.any?
       timeline_in_months = month_range(
-        start_date: @work_history.first.start_date,
+        start_date: Time.zone.now - 5.years,
         end_date: Time.zone.now - 1.month,
       )
       break_months_in_timeline = remove_working_months(timeline_in_months)

--- a/spec/components/break_placeholder_in_work_history_component_spec.rb
+++ b/spec/components/break_placeholder_in_work_history_component_spec.rb
@@ -18,12 +18,12 @@ RSpec.describe BreakPlaceholderInWorkHistoryComponent do
   it 'renders the component with a link to explain break' do
     result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
 
-    expect(result.text).to include('Please explain break between January 2020 and May 2020')
+    expect(result.text).to include('Explain break between January 2020 and May 2020')
   end
 
   it 'renders the component with a link to add another job' do
     result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
 
-    expect(result.text).to include('Add another job between January 2020 and May 2020')
+    expect(result.text).to include('add another job between January 2020 and May 2020')
   end
 end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe WorkHistoryWithBreaks do
   describe '#timeline' do
+    let(:january2014) { Time.zone.local(2014, 1, 1) }
+    let(:march2014) { Time.zone.local(2014, 3, 1) }
+    let(:october2014) { Time.zone.local(2014, 10, 1) }
+    let(:february2015) { Time.zone.local(2015, 2, 1) }
     let(:january2019) { Time.zone.local(2019, 1, 1) }
     let(:february2019) { Time.zone.local(2019, 2, 1) }
     let(:march2019) { Time.zone.local(2019, 3, 1) }
@@ -34,7 +38,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there is one job with a nil end date i.e. current job' do
       it 'returns the job' do
-        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: nil)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: nil)
         work_history = [job1]
         application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
@@ -48,7 +52,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there is one job that ends at current date i.e. current job' do
       it 'returns the job' do
-        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: current_date)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: current_date)
         work_history = [job1]
         application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
@@ -62,7 +66,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there is one job and a one month break between the end date and current date' do
       it 'returns the job then a break placeholder with a length of one month' do
-        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: december2019)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: december2019)
         work_history = [job1]
         application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
@@ -80,7 +84,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there is one job and more than a month break between the end date and current date' do
       it 'returns the job then a break placeholder with a length of three months' do
-        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: october2019)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: october2019)
         work_history = [job1]
         application_form = build_stubbed(:application_form, application_work_experiences: work_history)
 
@@ -96,7 +100,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there are multiple jobs with no breaks' do
       it 'returns all jobs and sorted by start date' do
-        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: october2019)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: october2019)
         job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: december2019)
         job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
         work_history = [job2, job1, job3]
@@ -114,7 +118,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there is a break between two jobs' do
       it 'returns all jobs with a break inbetween two jobs' do
-        job1 = build_stubbed(:application_work_experience, start_date: september2019, end_date: october2019)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: october2019)
         job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: november2019)
         job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
         work_history = [job1, job2, job3]
@@ -132,9 +136,25 @@ RSpec.describe WorkHistoryWithBreaks do
       end
     end
 
+    context 'when there is a break between two jobs but outside of the last 5 years' do
+      it 'returns all jobs without a break' do
+        job1 = build_stubbed(:application_work_experience, start_date: january2014, end_date: march2014)
+        job2 = build_stubbed(:application_work_experience, start_date: october2014, end_date: current_date)
+        work_history = [job1, job2]
+        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to eq(job2)
+      end
+    end
+
     context 'when the first job is the current job and there is a break between following jobs' do
       it 'returns all jobs without a break as current job covers the break between following jobs' do
-        job1 = build_stubbed(:application_work_experience, start_date: march2019, end_date: nil)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: nil)
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
         work_history = [job1, job2, job3]
@@ -152,7 +172,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there is a break before the current job and a break between following jobs' do
       it 'returns only the break before the current job as current job covers the break between following jobs' do
-        job1 = build_stubbed(:application_work_experience, start_date: january2019, end_date: february2019)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2019)
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
         work_history = [job1, job2, job3]
@@ -172,7 +192,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there is one job that covers the break between following jobs' do
       it 'returns all jobs without a break' do
-        job1 = build_stubbed(:application_work_experience, start_date: january2019, end_date: december2019)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: december2019)
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: nil)
         work_history = [job1, job2, job3]
@@ -190,7 +210,7 @@ RSpec.describe WorkHistoryWithBreaks do
 
     context 'when there are multiple jobs and an existing break' do
       it 'returns all jobs and the existing break and sorted by start date' do
-        job1 = build_stubbed(:application_work_experience, start_date: january2019, end_date: february2019)
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2019)
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
         work_history = [job1, job2]
         break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
     when_i_click_on_work_history
     and_i_choose_i_have_work_for_more_than_5_years
-    and_i_add_a_job_between_march_2019_to_august_2019
+    and_i_add_a_job_between_february_2015_to_august_2019
     and_i_add_another_job_between_november_2019_and_december_2019
     then_i_see_a_two_months_break_between_my_first_job_and_my_second_job
     and_i_see_a_one_month_break_between_my_second_job_and_now
@@ -63,7 +63,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     click_button 'Continue'
   end
 
-  def and_i_add_a_job_between_march_2019_to_august_2019
+  def and_i_add_a_job_between_february_2015_to_august_2019
     scope = 'application_form.work_history'
     fill_in t('role.label', scope: scope), with: 'Microsoft Painter'
     fill_in t('organisation.label', scope: scope), with: 'Department for Education'
@@ -71,8 +71,8 @@ RSpec.feature 'Entering reasons for their work history breaks' do
     choose 'Full-time'
 
     within('[data-qa="start-date"]') do
-      fill_in 'Month', with: '3'
-      fill_in 'Year', with: '2019'
+      fill_in 'Month', with: '2'
+      fill_in 'Year', with: '2015'
     end
 
     within('[data-qa="end-date"]') do

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
   end
 
   def when_i_click_add_another_job_for_my_break_between_august_2019_and_november_2019
-    click_link 'Add another job between August 2019 and November 2019'
+    click_link 'add another job between August 2019 and November 2019'
   end
 
   def then_i_see_the_start_and_end_date_filled_for_adding_another_job_between_august_2019_and_november_2019
@@ -143,7 +143,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
   end
 
   def when_i_click_add_another_job_for_my_break_between_december_2019_and_now
-    click_link 'Add another job between December 2019 and February 2020'
+    click_link 'add another job between December 2019 and February 2020'
   end
 
   def then_i_only_see_the_start_date_filled_in_for_my_break_between_december_2019_and_now
@@ -154,7 +154,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
   end
 
   def when_i_click_to_explain_my_break_between_august_2019_and_november_2019
-    click_link 'Please explain break between August 2019 and November 2019'
+    click_link 'Explain break between August 2019 and November 2019'
   end
 
   def when_i_enter_a_reason_for_my_break_between_august_2019_and_november_2019


### PR DESCRIPTION
## Context

Providers want to know of work history breaks within the last 5 years. Currently, we consider from the start date of the candidate's first job.

## Changes proposed in this pull request

This PR updates to only show work history breaks within the last 5 years by updating the `WorkHistoryWithBreaks` service.

It also does a smol content update which Paul H suggested.

## Screenshots

![image](https://user-images.githubusercontent.com/42817036/74662648-3d13bc00-5192-11ea-9c4d-a36b68b7cd6c.png)

![image](https://user-images.githubusercontent.com/42817036/74662699-4f8df580-5192-11ea-848d-bb7a7b1745f1.png)

## Guidance to review

FYI, I had to update the start dates for some specs for the `WorkHistoryWithBreaks` service to ensure the right number of breaks are returned.

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
