### PR TITLE
Send an email to the candidate when a reference comes in

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -85,6 +85,15 @@ class CandidateMailer < ApplicationMailer
     new_offer(application_choice, :decisions_pending)
   end
 
+  def reference_received(reference)
+    @reference = reference
+    @candidate_name = reference.application_form.first_name
+
+    view_mail(GENERIC_NOTIFY_TEMPLATE,
+              to: reference.application_form.candidate.email_address,
+              subject: I18n.t!('candidate_mailer.reference_received.subject'))
+  end
+
 private
 
   def application_rejected(application_choice, template_name)

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -128,6 +128,10 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_rejected_awaiting_decisions(application_choice)
   end
 
+  def reference_received
+    CandidateMailer.reference_received(reference)
+  end
+
 private
 
   def application_form

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -15,6 +15,7 @@ class FeatureFlag
     send_reference_confirmation_email
     automated_referee_replacement
     candidate_rejected_by_provider_email
+    notify_candidate_of_new_reference
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -10,6 +10,11 @@ class ReceiveReference
   def save!
     ActiveRecord::Base.transaction do
       @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
+
+      if FeatureFlag.active?('notify_candidate_of_new_reference')
+        CandidateMailer.reference_received(@reference).deliver_later
+      end
+
       progress_application_if_enough_references_have_been_submitted
     end
   end

--- a/app/views/candidate_mailer/reference_received.text.erb
+++ b/app/views/candidate_mailer/reference_received.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @candidate_name %>,
+
+# You have a reference
+
+<%= @reference.name %> submitted a reference for your teacher training application.
+
+We’ve attached this to your application form.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -167,6 +167,7 @@ en:
       by: referee
       description: Occurs when 2 referees have provided feedback about the candidate.
       emails:
+        - candidate_mailer-reference_received
         - referee_mailer-reference_confirmation_email
 
     application_complete-send_to_provider:

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -1,0 +1,5 @@
+en:
+  candidate_mailer:
+    reference_received:
+      subject: 'You have a reference for your teacher training application'
+      

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
   scenario 'Referee submits a reference for a candidate' do
     FeatureFlag.activate('training_with_a_disability')
     FeatureFlag.activate('send_reference_confirmation_email')
+    FeatureFlag.activate('notify_candidate_of_new_reference')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application
@@ -24,6 +25,7 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     then_i_see_the_confirmation_page
     and_i_receive_an_email_confirmation
     and_an_audit_comment_is_added
+    and_the_candidate_receives_a_notification
 
     when_i_choose_to_be_contactable
     and_i_click_the_finish_button
@@ -94,6 +96,13 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     expect(@application.audits.last.comment).to eq(
       'Reference confirmation email has been sent to the candidate’s reference: Terri Tudor using terri@example.com.',
     )
+  end
+
+  def and_the_candidate_receives_a_notification
+    open_email(current_candidate.email_address)
+
+    expect(current_email.subject).to end_with('You have a reference for your teacher training application')
+    expect(current_email.body).to have_content('Terri Tudor submitted a reference for your teacher training application')
   end
 
   def then_i_see_the_thank_you_page


### PR DESCRIPTION
## Context

When referees provide a reference we should tell the candidate.

## Changes proposed in this pull request

Add an email and send it when the reference comes in. This is done in a slightly different way from the referee confirmation, which happens inside the controller. We'll refactor that later.

## Guidance to review

I haven't added unit tests to the candidatemailer, because it seems sufficiently testedby the integration test. What do people think?

## Link to Trello card

https://trello.com/c/RP9Njbix

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
