### PR TITLE
Update WorkHistoryWithBreaks to handle overlapping job and existing break

### DIFF
--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -34,9 +34,10 @@ class WorkHistoryWithBreaks
         start_date: Time.zone.now - 5.years,
         end_date: Time.zone.now - 1.month,
       )
-      break_months_in_timeline = remove_working_months(timeline_in_months)
-      breaks = break_entries(break_months_in_timeline)
-      work_history_with_breaks += breaks if breaks.any?
+      break_months_in_timeline = remove_months(timeline: timeline_in_months, entries: @work_history)
+      remaining_months = remove_months(timeline: break_months_in_timeline, entries: @existing_breaks)
+      break_placeholders = break_placeholder_entries(remaining_months)
+      work_history_with_breaks += break_placeholders if break_placeholders.any?
     end
 
     work_history_with_breaks.sort_by(&:start_date)
@@ -48,20 +49,20 @@ private
     (start_date.to_date..end_date.to_date).map(&:beginning_of_month).uniq
   end
 
-  def remove_working_months(timeline_in_months)
-    break_months_in_timeline = timeline_in_months
+  def remove_months(timeline:, entries:)
+    remaining_months_in_timeline = timeline
 
-    @work_history.each do |job|
-      job_end_date = job.end_date.nil? ? Time.zone.now : job.end_date
-      months_in_job_period = month_range(start_date: job.start_date, end_date: job_end_date)
+    entries.each do |entry|
+      entry_end_date = entry.end_date.nil? ? Time.zone.now : entry.end_date
+      months_in_entry_period = month_range(start_date: entry.start_date, end_date: entry_end_date)
 
-      break_months_in_timeline -= months_in_job_period
+      remaining_months_in_timeline -= months_in_entry_period
     end
 
-    break_months_in_timeline
+    remaining_months_in_timeline
   end
 
-  def break_entries(break_months_in_timeline)
+  def break_placeholder_entries(break_months_in_timeline)
     return [] if break_months_in_timeline.empty?
 
     breaks = []
@@ -71,31 +72,11 @@ private
       if current_break.last.next_month == month
         current_break << month
       else
-        unless existing_break_covers_break_period?(current_break)
-          breaks << BreakPlaceholder.new(month_range: current_break)
-        end
-
+        breaks << BreakPlaceholder.new(month_range: current_break)
         current_break = [month]
       end
     end
 
-    unless existing_break_covers_break_period?(current_break)
-      breaks << BreakPlaceholder.new(month_range: current_break)
-    end
-
-    breaks
-  end
-
-  def existing_break_covers_break_period?(current_break)
-    existing_break_covering_break_period = @existing_breaks.select do |existing_break|
-      break_placeholder = BreakPlaceholder.new(month_range: current_break)
-
-      same_start_date = existing_break.start_date.to_date == break_placeholder.start_date
-      same_end_date = existing_break.end_date.to_date == break_placeholder.end_date
-
-      same_start_date && same_end_date
-    end
-
-    existing_break_covering_break_period.any?
+    breaks << BreakPlaceholder.new(month_range: current_break)
   end
 end

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe WorkHistoryWithBreaks do
     let(:march2014) { Time.zone.local(2014, 3, 1) }
     let(:october2014) { Time.zone.local(2014, 10, 1) }
     let(:february2015) { Time.zone.local(2015, 2, 1) }
+    let(:february2016) { Time.zone.local(2016, 2, 1) }
     let(:january2019) { Time.zone.local(2019, 1, 1) }
     let(:february2019) { Time.zone.local(2019, 2, 1) }
     let(:march2019) { Time.zone.local(2019, 3, 1) }
@@ -280,6 +281,30 @@ RSpec.describe WorkHistoryWithBreaks do
         expect(work_history_with_breaks[1].start_date).to eq(november2019)
         expect(work_history_with_breaks[1].end_date).to eq(current_date)
         expect(work_history_with_breaks[1].length).to eq(2)
+      end
+    end
+
+    context 'when there is an existing break that overlaps with a job' do
+      it 'returns the job and existing break, it does not include a break placeholder' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2016)
+        work_history = [job1]
+        break1 = build_stubbed(:application_work_history_break, start_date: february2015, end_date: current_date)
+        breaks = [break1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          application_work_history_breaks: breaks,
+        )
+
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(2)
+        expect(work_history_with_breaks[0]).to eq(job1)
+        expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
+        expect(work_history_with_breaks[1].start_date).to eq(february2015)
+        expect(work_history_with_breaks[1].end_date).to eq(current_date)
+        expect(work_history_with_breaks[1].length).to eq(59)
       end
     end
   end


### PR DESCRIPTION
## Context

Paul H found a bug in work history breaks, if you:

1. Add job between 2007 to 2015
2. Explain the break between 2015 and now
3. Edit job to be until 2016 rather than 2015
4. Break remains (as expected) but a new break placeholder appears (2016 until 2020)

## Changes proposed in this pull request

This PR fixes the above by refactoring and updating the `WorkHistoryWithBreaks` service.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
