### PR TITLE
Change cookie duration

### DIFF
--- a/app/views/content/cookies_candidate.md
+++ b/app/views/content/cookies_candidate.md
@@ -6,4 +6,4 @@ Apply for teacher training cookies may include:
 
 | Name                                                   | Purpose                                        | Expires  |
 | :------------------------------------------------      | :--------------------------------------------- | :------- |
-| \_apply\_for\_postgraduate\_teacher\_training\_session | Used to remember your identity when signed in  | 6 hours  |
+| \_apply\_for\_postgraduate\_teacher\_training\_session | Used to remember your identity when signed in  | 7 days   |

--- a/spec/system/candidate_interface/candidate_content_spec.rb
+++ b/spec/system/candidate_interface/candidate_content_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.feature 'Candidate content' do
+  include ActionView::Helpers::DateHelper
+
   scenario 'Candidate views the content pages' do
     given_i_am_on_the_start_page
     when_i_click_on_accessibility
@@ -34,6 +36,7 @@ RSpec.feature 'Candidate content' do
 
   def then_i_can_see_the_cookie_policy
     expect(page).to have_content(t('page_titles.cookies_candidate'))
+    expect(page).to have_content(distance_of_time_in_words(Devise.timeout_in))
   end
 
   def when_i_click_on_the_privacy_policy


### PR DESCRIPTION
Candidate cookies last 7 days not 6 hours:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/tree/master/config/initializers/devise.rb#L26