### PR TITLE
Update to show work history breaks in years and months

### DIFF
--- a/app/components/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/break_placeholder_in_work_history_component.html.erb
@@ -1,7 +1,7 @@
 <section class="app-summary-card govuk-!-margin-bottom-6">
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
-      You have a break in your work history in the last 5 years (<%= pluralize(work_break.length, 'month') %>)
+      You have a break in your work history in the last 5 years (<%= break_length %>)
     </h3>
 
     <div class="app-summary-card__actions">

--- a/app/components/break_placeholder_in_work_history_component.rb
+++ b/app/components/break_placeholder_in_work_history_component.rb
@@ -10,4 +10,15 @@ class BreakPlaceholderInWorkHistoryComponent < ActionView::Component::Base
   def between_formatted_dates
     "between #{@work_break.start_date.to_s(:month_and_year)} and #{@work_break.end_date.to_s(:month_and_year)}"
   end
+
+  def break_length
+    if @work_break.length <= 12
+      pluralize(@work_break.length, 'month')
+    else
+      years = @work_break.length / 12
+      months = @work_break.length % 12
+
+      "#{pluralize(years, 'year')} and #{pluralize(months, 'month')}"
+    end
+  end
 end

--- a/spec/components/break_placeholder_in_work_history_component_spec.rb
+++ b/spec/components/break_placeholder_in_work_history_component_spec.rb
@@ -9,12 +9,6 @@ RSpec.describe BreakPlaceholderInWorkHistoryComponent do
     allow(work_break).to receive(:end_date).and_return(Date.new(2020, 5, 1))
   end
 
-  it 'renders the component with the break in months' do
-    result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
-
-    expect(result.text).to include('You have a break in your work history in the last 5 years (3 months)')
-  end
-
   it 'renders the component with a link to explain break' do
     result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
 
@@ -25,5 +19,27 @@ RSpec.describe BreakPlaceholderInWorkHistoryComponent do
     result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
 
     expect(result.text).to include('add another job between January 2020 and May 2020')
+  end
+
+  context 'when work history break is less than 12 months' do
+    it 'renders the component with the break in months' do
+      result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
+
+      expect(result.text).to include('You have a break in your work history in the last 5 years (3 months)')
+    end
+  end
+
+  context 'when work history break is more than 12 months' do
+    before do
+      allow(work_break).to receive(:length).and_return(19)
+      allow(work_break).to receive(:start_date).and_return(Date.new(2018, 6, 1))
+      allow(work_break).to receive(:end_date).and_return(Date.new(2020, 2, 1))
+    end
+
+    it 'renders the component with the break in months' do
+      result = render_inline(BreakPlaceholderInWorkHistoryComponent, work_break: work_break)
+
+      expect(result.text).to include('You have a break in your work history in the last 5 years (1 year and 7 months)')
+    end
   end
 end


### PR DESCRIPTION
## Context

Currently, we show the length of work history breaks in months.

## Changes proposed in this pull request

This PR updates the `BreakPlaceholderInWorkHistory` component to display a break that is more than 12 months in years and months.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/42817036/74721083-bfea5480-522e-11ea-9de8-d0648c71abe5.png)

### After

![image](https://user-images.githubusercontent.com/42817036/74721059-b5c85600-522e-11ea-84cb-b817df93e392.png)

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
