### PR TITLE
Tidy up CandidateMailer#new_referee_request

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -44,15 +44,14 @@ class CandidateMailer < ApplicationMailer
               template_name: 'chaser')
   end
 
-  def new_referee_request(application_form, reference, reason: :not_responded)
-    @candidate = application_form.candidate
-    @candidate_name = application_form.first_name
-    @referee = reference
+  def new_referee_request(reference, reason:)
+    @reference = reference
     @reason = reason
 
-    view_mail(GENERIC_NOTIFY_TEMPLATE,
-              to: application_form.candidate.email_address,
-              subject: t("new_referee_request.#{@reason}.subject", referee_name: @referee.name))
+    email_for_candidate(
+      reference.application_form,
+      subject: I18n.t!("candidate_mailer.new_referee_request.#{@reason}.subject", referee_name: @reference.name),
+    )
   end
 
   def application_rejected_all_rejected(application_choice)

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -30,15 +30,15 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def new_referee_request_with_not_responded
-    CandidateMailer.new_referee_request(application_form, reference, reason: :not_responded)
+    CandidateMailer.new_referee_request(reference, reason: :not_responded)
   end
 
   def new_referee_request_with_refused
-    CandidateMailer.new_referee_request(application_form, reference, reason: :refused)
+    CandidateMailer.new_referee_request(reference, reason: :refused)
   end
 
   def new_referee_request_with_email_bounced
-    CandidateMailer.new_referee_request(application_form, reference, reason: :email_bounced)
+    CandidateMailer.new_referee_request(reference, reason: :email_bounced)
   end
 
   def new_offer_single_offer

--- a/app/services/send_new_referee_request_email.rb
+++ b/app/services/send_new_referee_request_email.rb
@@ -1,6 +1,6 @@
 class SendNewRefereeRequestEmail
   def self.call(application_form:, reference:, reason: :not_responded)
-    CandidateMailer.new_referee_request(application_form, reference, reason: reason).deliver
+    CandidateMailer.new_referee_request(reference, reason: reason).deliver
 
     ChaserSent.create!(chaser_type: :reference_replacement, chased: reference)
 

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,8 +1,8 @@
-Dear <%= @candidate_name %>,
+Dear <%= @application_form.first_name %>,
 
 # Give details of a new referee
 
-<%= t("new_referee_request.#{@reason}.explanation", referee_name: @referee.name, referee_email: @referee.email_address) %>
+<%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name, referee_email: @reference.email_address) %>
 
 <% if FeatureFlag.active?('show_new_referee_needed') %>
 Please add a new referee:

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -8,3 +8,18 @@ en:
       subject: Your application is being considered
     chase_reference:
       subject: "%{referee_name} hasn’t given a reference yet"
+    new_referee_request:
+      not_responded:
+        subject: "Give details of a new referee: %{referee_name} hasn’t responded"
+        explanation: |-
+          We haven’t had a reference from %{referee_name}.
+      refused:
+        subject: "%{referee_name} won’t give a reference"
+        explanation: |-
+          %{referee_name} said they won’t give a reference.
+      email_bounced:
+        subject: "Our email didn’t reach %{referee_name}"
+        explanation: |-
+          Our email requesting a reference didn’t reach %{referee_name}.
+
+          We emailed the referee using this address: %{referee_email}

--- a/config/locales/new_referee_request.yml
+++ b/config/locales/new_referee_request.yml
@@ -5,25 +5,14 @@ en:
     confirm_button: Yes - send the email
     success: New referee request sent to candidate
     not_responded:
-      subject: "Give details of a new referee: %{referee_name} hasn’t responded"
-      explanation: |-
-        We haven’t had a reference from %{referee_name}.
       option: Explain the referee has not responded
       audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining non-response.
       confirm_text: We'll send an email to explain that their referee (%{referee_name}) has not responded.
     refused:
-      subject: "%{referee_name} won’t give a reference"
-      explanation: |-
-        %{referee_name} said they won’t give a reference.
       option: Explain the referee won't give a reference
       audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining refusal to provide a reference.
       confirm_text: We'll send an email to explain that their referee (%{referee_name}) won't give a reference.
     email_bounced:
-      subject: "Our email didn’t reach %{referee_name}"
-      explanation: |-
-        Our email requesting a reference didn’t reach %{referee_name}.
-
-        We emailed the referee using this address: %{referee_email}
       option: Explain the referee’s email has bounced
       audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining email bounce.
       confirm_text: We'll send an email to explain their referee's email has bounced.

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -121,24 +121,26 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
   end
 
-  describe 'Send request for new referee email' do
-    let(:reference) { build_stubbed(:reference, name: 'Scott Knowles') }
-    let(:application_form) do
+  describe '.new_referee_request' do
+    let(:reference) do
       build_stubbed(
-        :application_form,
-        first_name: 'Tyrell',
-        last_name: 'Wellick',
-        application_references: [reference],
+        :reference,
+        name: 'Scott Knowles',
+        application_form: build_stubbed(
+          :application_form,
+          first_name: 'Tyrell',
+          last_name: 'Wellick',
+        ),
       )
     end
 
     context 'when referee has not responded' do
-      let(:mail) { mailer.new_referee_request(application_form, reference) }
+      let(:mail) { mailer.new_referee_request(reference, reason: :not_responded) }
 
       before { mail.deliver_later }
 
       it 'sends an email with the correct subject' do
-        expect(mail.subject).to include(t('new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'))
+        expect(mail.subject).to include(t('candidate_mailer.new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'))
       end
 
       it 'sends an email with the correct heading' do
@@ -148,17 +150,17 @@ RSpec.describe CandidateMailer, type: :mailer do
       it 'sends an email saying referee has not responded' do
         explanation = mail.body.encoded.gsub("\r", '')
 
-        expect(explanation).to include(t('new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles'))
+        expect(explanation).to include(t('candidate_mailer.new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles'))
       end
     end
 
     context 'when referee has refused' do
-      let(:mail) { mailer.new_referee_request(application_form, reference, reason: :refused) }
+      let(:mail) { mailer.new_referee_request(reference, reason: :refused) }
 
       before { mail.deliver_later }
 
       it 'sends an email with the correct subject' do
-        expect(mail.subject).to include(t('new_referee_request.refused.subject', referee_name: 'Scott Knowles'))
+        expect(mail.subject).to include(t('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Scott Knowles'))
       end
 
       it 'sends an email with the correct heading' do
@@ -168,17 +170,17 @@ RSpec.describe CandidateMailer, type: :mailer do
       it 'sends an email saying referee has refused' do
         explanation = mail.body.encoded.gsub("\r", '')
 
-        expect(explanation).to include(t('new_referee_request.refused.explanation', referee_name: 'Scott Knowles'))
+        expect(explanation).to include(t('candidate_mailer.new_referee_request.refused.explanation', referee_name: 'Scott Knowles'))
       end
     end
 
     context 'when email address of referee has bounced' do
-      let(:mail) { mailer.new_referee_request(application_form, reference, reason: :email_bounced) }
+      let(:mail) { mailer.new_referee_request(reference, reason: :email_bounced) }
 
       before { mail.deliver_later }
 
       it 'sends an email with the correct subject' do
-        expect(mail.subject).to include(t('new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'))
+        expect(mail.subject).to include(t('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'))
       end
 
       it 'sends an email with the correct heading' do
@@ -188,7 +190,7 @@ RSpec.describe CandidateMailer, type: :mailer do
       it 'sends an email saying referee email bounced' do
         explanation = mail.body.encoded.gsub("\r", '')
 
-        expect(explanation).to include(t('new_referee_request.email_bounced.explanation', referee_name: 'Scott Knowles', referee_email: reference.email_address))
+        expect(explanation).to include(t('candidate_mailer.new_referee_request.email_bounced.explanation', referee_name: 'Scott Knowles', referee_email: reference.email_address))
       end
     end
   end

--- a/spec/requests/integrations/post_notify_callback_spec.rb
+++ b/spec/requests/integrations/post_notify_callback_spec.rb
@@ -130,6 +130,6 @@ RSpec.describe 'Notify Callback - POST /integrations/notify/callback', type: :re
     candidate_email = application_form.candidate.email_address
     open_email(candidate_email)
 
-    expect(current_email.subject).to end_with(t('new_referee_request.email_bounced.subject', referee_name: reference.name))
+    expect(current_email.subject).to end_with(t('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: reference.name))
   end
 end

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -56,7 +56,7 @@ RSpec.feature 'Refusing to give a reference', sidekiq: true do
   def then_an_email_is_sent_to_the_candidate
     open_email(@application.candidate.email_address)
 
-    expect(current_email.subject).to have_content(t('new_referee_request.refused.subject', referee_name: 'Terri Tudor'))
+    expect(current_email.subject).to have_content(t('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Terri Tudor'))
   end
 
   def and_i_should_see_the_thank_you_page


### PR DESCRIPTION
## Context

More refactoring of the CandidateMailer, continuing on from https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1397.

## Changes proposed in this pull request

- Use the shared mail method
- Don’t pass in application_form
- Move I18n keys to candidate_mailer.yml
- Remove default param to make the method call more explicit

## Guidance to review

Anything else I could do?

## Link to Trello card

Related to all the email work going on - this should make it easier to add and update emails.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
