### PR TITLE
Launch expired sign-in link feature

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -33,19 +33,18 @@ module CandidateInterface
         rescue ActiveSupport::MessageEncryptor::InvalidMessage
           redirect_to candidate_interface_sign_in_path && return
         end
-      else
-        @candidate = Candidate.for_email candidate_params[:email_address]
       end
 
-      if @candidate&.persisted?
+      @candidate ||= Candidate.for_email candidate_params[:email_address]
+
+      if @candidate.persisted?
         MagicLinkSignIn.call(candidate: @candidate)
         add_identity_to_log @candidate.id
         redirect_to candidate_interface_check_email_sign_in_path
-      elsif @candidate&.valid?
+      elsif @candidate.valid?
         AuthenticationMailer.sign_in_without_account_email(to: @candidate.email_address).deliver_now
         redirect_to candidate_interface_check_email_sign_in_path
       else
-        @candidate = Candidate.new
         render :new
       end
     end

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -26,16 +26,26 @@ module CandidateInterface
     end
 
     def create
-      @candidate = Candidate.for_email candidate_params[:email_address]
+      if params[:u] && FeatureFlag.active?('improved_expired_token_flow')
+        begin
+          candidate_id = Encryptor.decrypt(params[:u])
+          @candidate = Candidate.find(candidate_id)
+        rescue ActiveSupport::MessageEncryptor::InvalidMessage
+          redirect_to candidate_interface_sign_in_path && return
+        end
+      else
+        @candidate = Candidate.for_email candidate_params[:email_address]
+      end
 
-      if @candidate.persisted?
+      if @candidate&.persisted?
         MagicLinkSignIn.call(candidate: @candidate)
         add_identity_to_log @candidate.id
         redirect_to candidate_interface_check_email_sign_in_path
-      elsif @candidate.valid?
+      elsif @candidate&.valid?
         AuthenticationMailer.sign_in_without_account_email(to: @candidate.email_address).deliver_now
         redirect_to candidate_interface_check_email_sign_in_path
       else
+        @candidate = Candidate.new
         render :new
       end
     end

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -85,12 +85,14 @@ module CandidateInterface
       render_404 unless FeatureFlag.active?('improved_expired_token_flow')
 
       candidate_id = Encryptor.decrypt(params.fetch(:u))
-      candidate = Candidate.find(candidate_id)
-      MagicLinkSignIn.call(candidate: candidate)
-      add_identity_to_log candidate.id
-      redirect_to candidate_interface_check_email_sign_in_path
-    rescue ActiveSupport::MessageEncryptor::InvalidMessage
-      render 'errors/not_found', status: :forbidden
+      if candidate_id
+        candidate = Candidate.find(candidate_id)
+        MagicLinkSignIn.call(candidate: candidate)
+        add_identity_to_log candidate.id
+        redirect_to candidate_interface_check_email_sign_in_path
+      else
+        render 'errors/not_found', status: :forbidden
+      end
     end
 
   private

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -96,7 +96,7 @@ module CandidateInterface
     def expired
       raise unless FeatureFlag.active?('improved_expired_token_flow')
 
-      if params.fetch(:u).blank?
+      if params[:u].blank?
         redirect_to candidate_interface_sign_in_path
         return
       end

--- a/app/services/encryptor.rb
+++ b/app/services/encryptor.rb
@@ -7,5 +7,7 @@ class Encryptor
 
   def self.decrypt(text)
     ENCRYPTOR.decrypt_and_verify(text)
+  rescue ActiveSupport::MessageEncryptor::InvalidMessage
+    false
   end
 end

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -10,7 +10,7 @@
         Sign in links only work for one hour, so you need to request a new one. We'll send this by email.
       </p>
 
-      <%= f.hidden_field :email_address %>
+      <%= hidden_field_tag :u, params[:u] %>
 
       <%= f.govuk_submit t('authentication.expired_token.button') %>
     <% end %>

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @candidate, url: candidate_interface_sign_in_path, method: :post do |f| %>
+    <%= form_with model: @candidate, url: candidate_interface_create_expired_sign_in_path, method: :post do |f| %>
       <h1 class="govuk-heading-xl">
         <%= t('authentication.expired_token.heading') %>
       </h1>

--- a/app/views/candidate_interface/sign_in/expired.html.erb
+++ b/app/views/candidate_interface/sign_in/expired.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @candidate, url: candidate_interface_create_expired_sign_in_path, method: :post do |f| %>
+    <%= form_with url: candidate_interface_create_expired_sign_in_path, method: :post do |f| %>
       <h1 class="govuk-heading-xl">
         <%= t('authentication.expired_token.heading') %>
       </h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
 
     get '/sign-in', to: 'sign_in#new', as: :sign_in
     post '/sign-in', to: 'sign_in#create'
+    post '/sign-in/expired', to: 'sign_in#create_expired', as: :create_expired_sign_in
     get '/sign-in/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_in
     get '/sign-in/expired', to: 'sign_in#expired', as: :expired_sign_in
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
 
     get '/sign-in', to: 'sign_in#new', as: :sign_in
     post '/sign-in', to: 'sign_in#create'
-    post '/sign-in/expired', to: 'sign_in#create_expired', as: :create_expired_sign_in
+    post '/sign-in/expired', to: 'sign_in#create_from_expired_token', as: :create_expired_sign_in
     get '/sign-in/check-email', to: 'sign_in#check_your_email', as: :check_email_sign_in
     get '/sign-in/expired', to: 'sign_in#expired', as: :expired_sign_in
 

--- a/spec/services/encryptor_spec.rb
+++ b/spec/services/encryptor_spec.rb
@@ -6,4 +6,8 @@ RSpec.describe Encryptor do
 
     expect(Encryptor.decrypt(encrypted_data)).to eq('example')
   end
+
+  it 'returns false given an invalid encrypted string' do
+    expect(Encryptor.decrypt('invalid-input')).to be false
+  end
 end

--- a/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Candidate clicks on an expired link', sidekiq: true do
     when_i_visit_the_sign_in_page_with_an_invalid_id_parameter
     then_i_am_taken_to_the_sign_in_page
 
-    when_i_visit_the_expired_sign_in_page_without_id_parameter
+    when_i_visit_the_expired_sign_in_page_without_u_parameter
     then_i_am_taken_to_the_sign_in_page
 
     when_i_fill_in_the_sign_in_form
@@ -73,7 +73,7 @@ RSpec.feature 'Candidate clicks on an expired link', sidekiq: true do
     expect(page).to have_content(t('page_titles.sign_in'))
   end
 
-  def when_i_visit_the_expired_sign_in_page_without_id_parameter
+  def when_i_visit_the_expired_sign_in_page_without_u_parameter
     visit candidate_interface_expired_sign_in_path
   end
 


### PR DESCRIPTION
## Context

This is a follow up to PR https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1233

We want to make it simpler for users that attempt to use an expired token to log in. Since we know who they are we can automatically send an email with a new token.

The original implementation passes a plain user id to an expired page that renders the users email address. This PR ensures that the plain user id replaced by a token and the email is no longer rendered.

## Changes proposed in this pull request

- [x] Replace the candidate `id` param sent to the expired page (`CandidateInterface::SignInController#expired`) with an encrypted id (`u`).
- [x] Remove the `email_address` hidden field from the expired page and replace with the encrypted id (`u`).

Note that these features remain feature flagged and is off on production at this time.

## Guidance to review

- Are the tests sufficient? - I didn't think there was any need to add anything new because the existing system specs cover all the code I touched.
- Does this feature introduce any holes in the authentication process?

## Link to Trello card

https://trello.com/c/LkdIGwhl/887-launch-expired-sign-in-link-feature-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
