### PR TITLE
Don't accidentally create providers when using build_stubbed

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -163,12 +163,12 @@ FactoryBot.define do
   end
 
   factory :provider do
-    initialize_with { Provider.find_or_create_by code: code }
+    initialize_with { Provider.find_or_initialize_by(code: code) }
     code { Faker::Alphanumeric.alphanumeric(number: 3).upcase }
     name { Faker::Educator.university }
 
     trait :with_signed_agreement do
-      after(:build) do |provider|
+      after(:create) do |provider|
         create(:provider_agreement, provider: provider)
       end
     end


### PR DESCRIPTION


## Context

We’re seeing providers appear on QA, caused by the mailer previews. This is because even though we use `build_stubbed`, we override the initializer and do a `find_or_create_by`.

## Changes proposed in this pull request

Fix the issue +  also only create a provider agreement when _creating_ a provider,
because otherwise a provider & agreement will be created anyway.

## Guidance to review

Before:

<img width="1904" alt="Screenshot 2020-02-18 at 09 56 31" src="https://user-images.githubusercontent.com/233676/74724931-0347c180-5235-11ea-9577-2819165016d2.png">

After:

<img width="1904" alt="Screenshot 2020-02-18 at 09 56 42" src="https://user-images.githubusercontent.com/233676/74724947-0b076600-5235-11ea-9198-eba79f912324.png">

## Link to Trello card

https://trello.com/c/yRSmo96F/1658-investigate-providers-with-no-names-on-qa

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
