### PR TITLE
Performance dashboard: clarify wording, card order for post-submission stats

### DIFF
--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -52,15 +52,15 @@
   <div class="govuk-grid-column-one-half">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <div class="app-card app-card--red">
-          <span class="app-card__secondary-count"><%= @statistics.total_candidate_count(only: %i{ended_without_success}) %></span>
-          <span>ended w/o success</span>
+        <div class="app-card">
+          <span class="app-card__secondary-count"><%= @statistics.total_candidate_count(except: %i{ended_without_success pending_conditions recruited enrolled never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
+          <span>still being processed</span>
         </div>
       </div>
       <div class="govuk-grid-column-one-third">
-        <div class="app-card">
-          <span class="app-card__secondary-count"><%= @statistics.total_candidate_count(except: %i{ended_without_success pending_conditions recruited enrolled never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}) %></span>
-          <span>awaiting decisions</span>
+        <div class="app-card app-card--red">
+          <span class="app-card__secondary-count"><%= @statistics.total_candidate_count(only: %i{ended_without_success}) %></span>
+          <span>ended w/o success</span>
         </div>
       </div>
       <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
## Context

The performance dashboard was made better-er in #1359. However it introduced grouping of states that could maybe be made clearer. The 'awaiting decision' card actually includes the candidates who are still awaiting references, as well as those in the cooling-off period, and could be mis-interpreted.

## Changes proposed in this pull request

Reword and re-order a couple of post-submission dashboard cards.

Before:

![image](https://user-images.githubusercontent.com/23801/74726995-57a07080-5238-11ea-9067-e148dfd0b71c.png)

After:

![image](https://user-images.githubusercontent.com/23801/74727018-6129d880-5238-11ea-83f9-40f5c37a0175.png)

## Notes for reviewers

Is the new label clearer?

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
