### PR TITLE
Be less prescriptive within the provider data sharing agreement

### DIFF
--- a/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
+++ b/app/views/provider_interface/provider_agreements/data_sharing_agreement.html.erb
@@ -289,7 +289,7 @@
       <h3 id="section-4-7">Data storage</h3>
       <p>The provider must store shared data securely.</p>
       <p>Data should be encrypted at rest, using modern, full disk encryption such as Windows BitLocker, or Linux/dm-crypt.</p>
-      <p>The data must be retained within the EEA, for example on cloud providers within Europe.</p>
+      <p>The data must be retained in a way that is compliant with EU data protection legislation.</p>
       <p>By signing this agreement, DfE and the provider agree to:</p>
       <ul>
         <li>hold data in strict confidence</li>


### PR DESCRIPTION
## Context

We have received feedback from some providers who feel that they are storing data in a compliant way, but are doing so without actually storing it within the EEA.

[Slack thread](https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1581514639387900)

## Changes proposed in this pull request

Don't prescribe how providers should be storing the data in the DSA.

## Guidance to review

Don't merge until this has been checked with Legal.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
