### PR TITLE
Update API to handle individual work history breaks

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -45,7 +45,7 @@ module VendorApi
           work_experience: {
             jobs: work_experience_jobs,
             volunteering: work_experience_volunteering,
-            work_history_break_explanation: application_form.work_history_breaks,
+            work_history_break_explanation: work_history_breaks,
           },
           offer: offer,
           rejection: get_rejection,
@@ -214,6 +214,25 @@ module VendorApi
         disability: '00',
         ethnicity: '10',
       }
+    end
+
+    def work_history_breaks
+      # With the new feature of adding individual work history breaks, `application_form.work_history_breaks`
+      # is a legacy column. So we'll need to check if an application form has this value first.
+      if application_form.work_history_breaks
+        application_form.work_history_breaks
+      elsif application_form.application_work_history_breaks.any?
+        breaks = application_form.application_work_history_breaks.map do |work_break|
+          start_date = work_break.start_date.to_s(:month_and_year)
+          end_date = work_break.end_date.to_s(:month_and_year)
+
+          "#{start_date} to #{end_date}: #{work_break.reason}"
+        end
+
+        breaks.join("\n\n")
+      else
+        ''
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

On the candidate interface, we've added a new feature (which is currently under a feature flag called `work_breaks`) in which we show breaks that occur in their work history so that a candidate can enter a reason for each individual one. See screenshot below (FYI it shouldn't show the "Tell us about any breaks in your history", this is a bug).

Currently, we have a single text attribute called `work_history_breaks` on an `ApplicationForm` and so the API simply spits this out when presenting an application. But with the new feature we added a new table called `ApplicationWorkHistoryBreaks` which means that an `ApplicationForm` can have many `ApplicationWorkHistoryBreaks`.

![image](https://user-images.githubusercontent.com/42817036/74731384-c8975680-523f-11ea-880f-8f579f60f8f1.png)

## Changes proposed in this pull request

This PR updates the API to return a candidate's work history breaks based on whether or not there is a value for `work_history_breaks` text attribute.

If there is, then use that. Else if there are values for `application_work_history_breaks`, then munge all `application_work_history_breaks` together. Else, return an empty string.

E.g. a munged response will look like this:

```
February 2019 to April 2019: I was watching TV.

September 2019 to December 2019: I was playing games.
```

## Guidance to review

- Are there redundant tests? The code doesn't look at the `work_breaks` feature flag but is it still good to have the tests?
- Are we happy with this response?
- Am I missing anything else?

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
