### PR TITLE
Refactor bug caused by SendCandidateRejectionEmail

### DIFF
--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -7,16 +7,19 @@ class SendCandidateRejectionEmail
 
   def call
     candidate_application_choices = application_choice.application_form.application_choices
-    number_of_pending_decisions = candidate_application_choices.select(&:awaiting_provider_decision?).count
+    number_of_pending_decisions = candidate_application_choices.awaiting_provider_decision.count
+    number_of_offers = candidate_application_choices.offer.count
 
     if candidate_application_choices.all?(&:rejected?)
       CandidateMailer.send(:application_rejected_all_rejected, application_choice).deliver_later
+      add_audit_comment(application_choice)
     elsif number_of_pending_decisions.positive?
       CandidateMailer.send(:application_rejected_awaiting_decisions, application_choice).deliver_later
-    else
+      add_audit_comment(application_choice)
+    elsif number_of_offers.positive?
       CandidateMailer.send(:application_rejected_offers_made, application_choice).deliver_later
+      add_audit_comment(application_choice)
     end
-    add_audit_comment(application_choice)
   end
 
 private

--- a/spec/services/send_candidate_rejection_email_spec.rb
+++ b/spec/services/send_candidate_rejection_email_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SendCandidateRejectionEmail do
       end
     end
 
-    context 'when the candidate receives a rejection and has an offer' do
+    context 'when the candidate receives a rejection and an offer' do
       before do
         create(:application_choice, status: :offer, application_form: application_form)
         allow(CandidateMailer).to receive(:application_rejected_offers_made).and_return(mail)
@@ -55,6 +55,16 @@ RSpec.describe SendCandidateRejectionEmail do
 
       it 'audits the rejection email', with_audited: true do
         expect(application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
+      end
+    end
+
+    context 'when the service receives any other combination of statuses' do
+      before do
+        create(:application_choice, status: :enrolled, application_form: application_form)
+      end
+
+      it 'returns nil' do
+        expect(described_class.new(application_choice: application_choice).call).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
#1313  Context

This SendCandidateRejectionEmail service. is currently triggering sentry errors on QA.

This is due to an else statement failing due to invalid data on QA

## Changes proposed in this pull request

- Refactor the conditional logic to use an elsif statement

## Link to Trello card

https://trello.com/c/22e7C80p/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
