### PR TITLE
Open Apply up to search engines

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -6,7 +6,6 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
-# See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /support


### PR DESCRIPTION
"They tried Googling Apply multiple times but couldn’t find the link."
Candidates have had trouble finding Apply again so they can return to their application.

If we make Apply visible on Google, candidates will be able to find us again and more easily sign in.

- Remove noindex meta tag
- Update robots.txt but disallow /support URLs

https://trello.com/c/Ma1IoQjs/841-sign-in-strategic-review-returning-candidates