### PR TITLE
Deduplicate nationalities in API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -88,7 +88,7 @@ module VendorApi
       [
         application_form.first_nationality,
         application_form.second_nationality,
-      ].map { |n| NATIONALITIES_BY_NAME[n] }.compact
+      ].map { |n| NATIONALITIES_BY_NAME[n] }.compact.uniq
     end
 
     def course_info_for(course_option)

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -200,6 +200,17 @@ RSpec.describe VendorApi::SingleApplicationPresenter do
     end
   end
 
+  describe 'attributes.candidate.nationality' do
+    it 'compacts two nationalities with the same ISO value' do
+      application_form = create(:completed_application_form, :with_completed_references, first_nationality: 'Welsh', second_nationality: 'Scottish')
+      application_choice = create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
+
+      response = VendorApi::SingleApplicationPresenter.new(application_choice).as_json
+
+      expect(response.dig(:attributes, :candidate, :nationality)).to eq %w(GB)
+    end
+  end
+
   describe '#as_json' do
     context 'given a relation that includes application_qualifications' do
       let(:application_choice) do


### PR DESCRIPTION
## Context

A vendor pointed out that entering two countries with the same ISO nationality should not result in two entries in the `nationality` field.

## Changes proposed in this pull request

`uniq`

## Link to Trello card

https://trello.com/c/CdehRRSC/1669-adding-welsh-and-scottish-as-nationalities-results-in-gb-gb-in-the-api

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
