### PR TITLE
Link to course descriptions on Find from providers page

### DIFF
--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -32,7 +32,7 @@
         <div class="govuk-details__text">
           <ul class="govuk-list govuk-list--bullet">
             <% courses.sort_by(&:name).each do |course| %>
-              <li><%= govuk_link_to course.name_and_code, candidate_interface_eligibility_path(providerCode: course.provider.code, courseCode: course.code) %></li>
+              <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
             <% end %>
           </ul>
         </div>


### PR DESCRIPTION
## Context

The current providers page links needs to direct users to the Find course page, but incorrectly links to the Apply ~~dual running~~ eligibility page at the moment.

https://www.apply-for-teacher-training.education.gov.uk/candidate/providers

There is currently no easy way to get to the course details.

## Changes proposed in this pull request

Course links now point to course detail pages on Find.

## Link to Trello card

https://trello.com/c/f4q3RMiT/892-provider-and-course-listing-should-link-to-course-descriptions-on-find-not-the-apply-page
