### PR TITLE
Send candidates a notification when their offer(s) have been declined by default

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -148,6 +148,13 @@ class CandidateMailer < ApplicationMailer
     email_for_candidate(application_form, subject: I18n.t!("chase_candidate_decision_email.subject_#{subject_pluralisation}"))
   end
 
+  def declined_by_default(application_form)
+    @declined_courses = application_form.application_choices.select(&:declined_by_default?)
+    @declined_course_names = @declined_courses.map { |application_choice| "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}" }
+
+    email_for_candidate(application_form, subject: I18n.t!('candidate_mailer.declined_by_default.subject', count: @declined_courses.size))
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -170,6 +170,31 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.reference_received(reference)
   end
 
+  def declined_by_default_multiple_offers
+    application_form = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Harry',
+      application_choices: [
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
+      ],
+    )
+
+    CandidateMailer.declined_by_default(application_form)
+  end
+
+  def declined_by_default_only_one_offer
+    application_form = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Harry',
+      application_choices: [
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
+      ],
+    )
+
+    CandidateMailer.declined_by_default(application_form)
+  end
+
 private
 
   def application_form

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -12,7 +12,9 @@ class DeclineOfferByDefault
         ApplicationStateChange.new(application_choice).decline_by_default!
       end
 
-      CandidateMailer.declined_by_default(application_form).deliver
+      if FeatureFlag.active?('decline_by_default_notification_to_candidate')
+        CandidateMailer.declined_by_default(application_form).deliver
+      end
     end
   end
 end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -11,6 +11,8 @@ class DeclineOfferByDefault
         application_choice.update!(declined_by_default: true, declined_at: Time.zone.now)
         ApplicationStateChange.new(application_choice).decline_by_default!
       end
+
+      CandidateMailer.declined_by_default(application_form).deliver
     end
   end
 end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -1,14 +1,16 @@
 class DeclineOfferByDefault
-  attr_accessor :application_choice
+  attr_accessor :application_form
 
-  def initialize(application_choice:)
-    self.application_choice = application_choice
+  def initialize(application_form:)
+    @application_form = application_form
   end
 
   def call
     ActiveRecord::Base.transaction do
-      application_choice.update(declined_by_default: true, declined_at: Time.zone.now)
-      ApplicationStateChange.new(application_choice).decline_by_default!
+      application_form.application_choices.offer.each do |application_choice|
+        application_choice.update!(declined_by_default: true, declined_at: Time.zone.now)
+        ApplicationStateChange.new(application_choice).decline_by_default!
+      end
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -17,6 +17,7 @@ class FeatureFlag
     candidate_rejected_by_provider_email
     notify_candidate_of_new_reference
     automated_decline_by_default_candidate_chaser
+    decline_by_default_notification_to_candidate
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_mailer/declined_by_default.text.erb
+++ b/app/views/candidate_mailer/declined_by_default.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @application_form.first_name %>,
+
+# <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
+
+We withdrew your application for <%= @declined_course_names.to_sentence %> because you didn’t respond to the <%= 'offer'.pluralize(@declined_course_names.size) %> within <%= @declined_courses.first.decline_by_default_days %> working days.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/workers/decline_offers_by_default_worker.rb
+++ b/app/workers/decline_offers_by_default_worker.rb
@@ -3,9 +3,7 @@ class DeclineOffersByDefaultWorker
 
   def perform
     GetApplicationFormsReadyToDeclineByDefault.call.each do |application_form|
-      application_form.application_choices.offer.each do |application_choice_with_offer|
-        DeclineOfferByDefault.new(application_choice: application_choice_with_offer).call
-      end
+      DeclineOfferByDefault.new(application_form: application_form).call
     end
   end
 end

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -241,6 +241,8 @@ en:
       name: Decline by default
       by: system
       description: The candidate has to respond within 5 days, otherwise the system will decline the offer.
+      emails:
+        - candidate_mailer-declined_by_default
 
     offer-reject:
       name: Provider rescinds offer

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -30,3 +30,7 @@ en:
         subject: "%{provider_name} has made a decision on your application for %{course_name}"
       offers_made:
         subject: "%{provider_name} has responded: make a decision within %{dbd_days} working days"
+    declined_by_default:
+      subject:
+        one: Application withdrawn automatically
+        other: Applications withdrawn automatically

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -610,4 +610,50 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
     end
   end
+
+  describe '.decline_by_default' do
+    context 'when a candidate has 1 offer that was declined' do
+      before do
+        application_form = build_stubbed(
+          :application_form,
+          first_name: 'Fred',
+          application_choices: [
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+          ],
+        )
+
+        @mail = mailer.declined_by_default(application_form)
+      end
+
+      it 'sends an email with the correct subject' do
+        expect(@mail.subject).to include('Application withdrawn automatically')
+      end
+
+      it 'includes the number of business days left to respond' do
+        expect(@mail.body.encoded).to include('10 working days')
+      end
+
+      it 'sends an email with the correct heading' do
+        expect(@mail.body.encoded).to include('Dear Fred')
+      end
+    end
+
+    context 'when a candidate has 2 or 3 offers that were declined' do
+      before do
+        application_form = build_stubbed(
+          :application_form,
+          application_choices: [
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+            build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10),
+          ],
+        )
+
+        @mail = mailer.declined_by_default(application_form)
+      end
+
+      it 'sends an email with the correct subject' do
+        expect(@mail.subject).to include('Applications withdrawn automatically')
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_receives_email_when_an_application_declined_by_default_date_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_email_when_an_application_declined_by_default_date_spec.rb
@@ -11,6 +11,9 @@ RSpec.feature 'An application gets declined by default' do
     when_i_have_an_offer_waiting_for_my_decision
     and_the_time_limit_before_decline_by_default_date_has_been_exceeded
     then_i_receive_an_email_to_make_a_decision
+
+    and_when_the_decline_by_default_limit_has_been_exceeded
+    then_the_application_choice_is_declined
   end
 
   def given_the_pilot_is_open
@@ -23,7 +26,7 @@ RSpec.feature 'An application gets declined by default' do
 
   def when_i_have_an_offer_waiting_for_my_decision
     @application_form = create(:completed_application_form)
-    create(:application_choice, status: :offer, application_form: @application_form, decline_by_default_at: Time.zone.now + 10.days)
+    @application_choice = create(:application_choice, status: :offer, application_form: @application_form, decline_by_default_at: Time.zone.now + 10.days)
   end
 
   def and_the_time_limit_before_decline_by_default_date_has_been_exceeded
@@ -42,5 +45,17 @@ RSpec.feature 'An application gets declined by default' do
     expect(current_email.subject).to include(expected_subject)
 
     expect(current_email.body).to include('http://localhost:3000/candidate/sign-in')
+  end
+
+  def and_when_the_decline_by_default_limit_has_been_exceeded
+    Timecop.travel(30.days.from_now) do
+      DeclineOffersByDefaultWorker.perform_async
+    end
+  end
+
+  def then_the_application_choice_is_declined
+    @application_choice.reload
+
+    expect(@application_choice.reload.status).to eql('declined')
   end
 end

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Decline by default' do
 
     and_when_the_decline_by_default_limit_has_been_exceeded
     then_the_application_choice_is_declined
+    and_the_candidate_receives_an_email
   end
 
   def given_the_pilot_is_open
@@ -57,5 +58,11 @@ RSpec.feature 'Decline by default' do
     @application_choice.reload
 
     expect(@application_choice.reload.status).to eql('declined')
+  end
+
+  def and_the_candidate_receives_an_email
+    open_email(@application_form.candidate.email_address)
+
+    expect(current_email.subject).to include('Application withdrawn automatically')
   end
 end

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature 'Decline by default' do
 
   def and_the_automated_candidate_chaser_is_active
     FeatureFlag.activate('automated_decline_by_default_candidate_chaser')
+    FeatureFlag.activate('decline_by_default_notification_to_candidate')
   end
 
   def when_i_have_an_offer_waiting_for_my_decision

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.feature 'An application gets declined by default' do
+RSpec.feature 'Decline by default' do
   include CourseOptionHelpers
   include CandidateHelper
 
-  scenario 'before the DBD date the candidate receives a chaser email', sidekiq: true do
+  scenario 'An application is declined by default', sidekiq: true do
     given_the_pilot_is_open
     and_the_automated_candidate_chaser_is_active
 


### PR DESCRIPTION
## Context

Candidates have 10 working days to respond to offers, or we'll decline them for them. 

## Changes proposed in this pull request

- Send email when declining by default
- Broaden the feature test from https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1399 to cover the entire journey

## Guidance to review

Per commit it easiest. Email previews:

- https://apply-for-te-reject-by-kvsbl6a.herokuapp.com/rails/mailers/candidate_mailer/declined_by_default_multiple_offers
- https://apply-for-te-reject-by-kvsbl6a.herokuapp.com/rails/mailers/candidate_mailer/declined_by_default_only_one_offer

## Link to Trello card

https://trello.com/c/DtPNK4vW/1043-send-email-to-candidate-when-application-is-rejected-by-default

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
