### PR TITLE
Make Heroku preview apps work more quickly

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "apply-for-teacher-training",
   "scripts": {
-    "postdeploy": "heroku config:set AUTHORISED_HOSTS=${HEROKU_APP_NAME}.herokuapp.com --app ${HEROKU_APP_NAME} && bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
+    "postdeploy": "bundle exec rake db:schema:load && bundle exec rake setup_local_dev_data"
   },
   "env": {
     "AUTHORISED_HOSTS": {

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,4 +112,8 @@ Rails.application.configure do
   HostingEnvironment.authorised_hosts.each do |host|
     config.hosts << host
   end
+
+  if ENV['HEROKU_APP_NAME']
+    config.hosts << "#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
+  end
 end


### PR DESCRIPTION
## Context

Currently we set an environment variable in the post deploy script, which makes the app work. Having to set the env variable in post deploy causes the app to not work until it's restarted.  

## Changes proposed in this pull request

Move the setting of the allowed hosts to the application config, so we don't need the restart.

## Guidance to review



## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
