### PR TITLE
Send notification to provider when candidate accepts

### DIFF
--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -15,6 +15,10 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.chase_provider_decision(provider_user, application_choice)
   end
 
+  def offer_accepted
+    ProviderMailer.offer_accepted(provider_user, application_choice)
+  end
+
 private
 
   def application_choice

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -75,4 +75,25 @@ class ProviderMailer < ApplicationMailer
               to: provider_user.email_address,
               subject: I18n.t!('provider_application_waiting_for_decision.email.subject', candidate_name: @application.candidate_name))
   end
+
+  def offer_accepted(provider_user, application_choice)
+    @application_choice = application_choice
+
+    email_for_provider(
+      provider_user,
+      subject: I18n.t!('provider_mailer.offer_accepted.subject', candidate_name: application_choice.application_form.full_name),
+    )
+  end
+
+private
+
+  def email_for_provider(provider_user, args = {})
+    @provider_user = provider_user
+
+    view_mail(
+      GENERIC_NOTIFY_TEMPLATE,
+      to: provider_user.email_address,
+      subject: args[:subject],
+    )
+  end
 end

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -17,6 +17,12 @@ class AcceptOffer
       end
     end
 
+    if FeatureFlag.active?('offer_accepted_provider_emails')
+      @application_choice.provider.provider_users.each do |provider_user|
+        ProviderMailer.offer_accepted(provider_user, @application_choice).deliver
+      end
+    end
+
     StateChangeNotifier.call(:offer_accepted, application_choice: @application_choice)
   end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -18,6 +18,7 @@ class FeatureFlag
     notify_candidate_of_new_reference
     automated_decline_by_default_candidate_chaser
     decline_by_default_notification_to_candidate
+    offer_accepted_provider_emails
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/provider_mailer/offer_accepted.text.erb
+++ b/app/views/provider_mailer/offer_accepted.text.erb
@@ -1,0 +1,25 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+# Offer accepted
+
+<%= @application_choice.application_form.full_name %> has accepted your offer to study <%= @application_choice.course_option.course.name_and_code %>.
+
+# Tell us when the candidate has met their conditions
+
+Sign in to Manage teacher training applications to update the application status when they’ve met their conditions:
+
+<%= provider_interface_application_choice_url(@application_choice) %>
+
+# Tell us when the candidate has enrolled
+
+Sign in to Manage teacher training applications to update the application status when they’ve enrolled:
+
+<%= provider_interface_application_choice_url(@application_choice) %>
+
+# Update the database of teacher training providers
+
+Enter the candidate’s details into the database of teacher training providers (DTTP) when they’ve started the course.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -270,7 +270,8 @@ en:
       name: Candidate accepts offer
       by: candidate
       description: The candidate can accept the offer. All other application choices will be withdrawn.
-      # https://trello.com/c/Xt431Th8/1025-email-candidate-has-accepted-offer-provider
+      emails:
+        - provider_mailer-offer_accepted
 
     offer-decline:
       name: Candidate declines offer

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -1,0 +1,4 @@
+en:
+  provider_mailer:
+    offer_accepted:
+      subject: '%{candidate_name} has accepted your offer'

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe ProviderMailer, type: :mailer do
                   application_form:
                     build_stubbed(
                       :completed_application_form,
+                      first_name: 'Harry',
+                      last_name: 'Potter',
                    ))
   end
   let(:provider_user) { application_choice.provider.provider_users.first }
@@ -147,6 +149,20 @@ RSpec.describe ProviderMailer, type: :mailer do
     it 'includes a readable RBD date' do
       rbd_date = application_choice.reject_by_default_at
       expect(@mail.body.encoded).to include("by #{rbd_date.to_s(:govuk_date).strip}")
+    end
+  end
+
+  describe '.offer_accepted' do
+    before do
+      @mail = mailer.offer_accepted(provider_user, application_choice)
+    end
+
+    it 'mentions the candidate' do
+      expect(@mail.body.encoded).to include('Harry Potter has accepted your offer')
+    end
+
+    it 'mentions the course' do
+      expect(@mail.body.encoded).to include(application_choice.course.name_and_code)
     end
   end
 end


### PR DESCRIPTION
## Context

When the candidate accepts an offer we need to let the provider know.

## Changes proposed in this pull request

Email provider users when the offer is accepted.

## Guidance to review

https://apply-for-te-provider-e-wdurwi.herokuapp.com/rails/mailers/provider_mailer/offer_accepted

## Link to Trello card

https://trello.com/c/Xt431Th8

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
