### PR TITLE
Handle nil values for Site address lines in course syncing

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -57,11 +57,11 @@ class SyncProviderFromFind
       site = provider.sites.find_or_create_by(code: find_site.code)
 
       site.name = find_site.location_name
-      site.address_line1 = find_site.address1.strip
-      site.address_line2 = find_site.address2.strip
-      site.address_line3 = find_site.address3.strip
-      site.address_line4 = find_site.address4.strip
-      site.postcode = find_site.postcode.strip
+      site.address_line1 = find_site.address1&.strip
+      site.address_line2 = find_site.address2&.strip
+      site.address_line3 = find_site.address3&.strip
+      site.address_line4 = find_site.address4&.strip
+      site.postcode = find_site.postcode&.strip
       site.save!
 
       study_modes = \

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -69,6 +69,31 @@ RSpec.describe SyncProviderFromFind do
       expect(course_option.site.postcode).to eq 'LS27 0LZ'
     end
 
+    it 'correctly handles missing address info' do
+      stub_find_api_provider_200(
+        provider_code: 'ABC',
+        course_code: '9CBA',
+        site_code: 'G',
+        findable: true,
+        site_address_line2: nil,
+      )
+
+      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+      course_option = CourseOption.last
+
+      expect(course_option.course.provider.code).to eq 'ABC'
+      expect(course_option.course.code).to eq '9CBA'
+      expect(course_option.course.exposed_in_find).to be true
+      expect(course_option.course.recruitment_cycle_year).to be FindAPI::RECRUITMENT_CYCLE_YEAR
+      expect(course_option.site.name).to eq 'Main site'
+      expect(course_option.site.address_line1).to eq 'Gorse SCITT'
+      expect(course_option.site.address_line2).to be_nil
+      expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
+      expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
+      expect(course_option.site.postcode).to eq 'LS27 0LZ'
+    end
+
     it 'correctly handles accrediting providers' do
       stub_find_api_provider_200_with_accrediting_provider(
         provider_code: 'ABC',

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -1,5 +1,13 @@
 module FindAPIHelper
-  def stub_find_api_provider_200(provider_code: 'ABC', provider_name: 'Dummy Provider', course_code: 'X130', site_code: 'X', findable: true, study_mode: 'full_time')
+  def stub_find_api_provider_200(
+    provider_code: 'ABC',
+    provider_name: 'Dummy Provider',
+    course_code: 'X130',
+    site_code: 'X',
+    findable: true,
+    study_mode: 'full_time',
+    site_address_line2: 'C/O The Bruntcliffe Academy'
+  )
     stub_find_api_provider(provider_code)
       .to_return(
         status: 200,
@@ -33,7 +41,7 @@ module FindAPIHelper
                 'code': site_code,
                 'location_name': 'Main site',
                 'address1': 'Gorse SCITT ',
-                'address2': 'C/O The Bruntcliffe Academy',
+                'address2': site_address_line2,
                 'address3': 'Bruntcliffe Lane',
                 'address4': 'MORLEY, LEEDS',
                 'postcode': 'LS27 0LZ',


### PR DESCRIPTION
## Context

Course syncing is generating errors on production due to Site addresses being nil in some cases. This is probably due to a recently on-boarded Provider.

## Changes proposed in this pull request

Handle nil Site address lines in the syncing code.

## Guidance to review

- are there any side-effects to this change that I can't see?

## Link to sentry error

https://sentry.io/organizations/dfe-bat/issues/1521782367/?project=1765973&referrer=slack

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
