### PR TITLE
Refactor service to check if user already has the course

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -57,13 +57,16 @@ module CandidateInterface
         service = ExistingCandidateAuthentication.new(candidate: candidate)
         service.execute
 
-        if service.candidate_does_not_have_a_course_from_find?
+        if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
           redirect_to candidate_interface_interstitial_path
-        elsif service.candidate_has_new_course_added?
+        elsif service.candidate_has_already_selected_the_course
+          flash[:warning] = "You have already selected #{course.name_and_code}."
           redirect_to candidate_interface_course_choices_review_path
-        elsif service.candidate_should_choose_site?
+        elsif service.candidate_has_new_course_added
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_should_choose_site
           redirect_to candidate_interface_course_choices_site_path(course.provider.code, course.code)
-        elsif service.candidate_already_has_3_courses?
+        elsif service.candidate_already_has_3_courses
           flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
           redirect_to candidate_interface_course_choices_review_path
         end

--- a/spec/services/candidate_interface/existing_candidate_authentication_spec.rb
+++ b/spec/services/candidate_interface/existing_candidate_authentication_spec.rb
@@ -13,10 +13,10 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service.candidate_already_has_3_courses?).to be_truthy
-        expect(service.candidate_has_new_course_added?).to be_falsey
-        expect(service.candidate_should_choose_site?).to be_falsey
-        expect(service.candidate_does_not_have_a_course_from_find?).to be_falsey
+        expect(service.candidate_already_has_3_courses).to be_truthy
+        expect(service.candidate_has_new_course_added).to be_falsey
+        expect(service.candidate_should_choose_site).to be_falsey
+        expect(service.candidate_does_not_have_a_course_from_find).to be_falsey
         expect(candidate.course_from_find_id).to eq(nil)
       end
 
@@ -27,7 +27,20 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service.candidate_does_not_have_a_course_from_find?).to be(true)
+        expect(service.candidate_does_not_have_a_course_from_find).to be(true)
+      end
+    end
+
+    context 'when the candidate has already submitted their application' do
+      it 'returns candidate_has_submitted_application as true and sets their course_from_find_id to nil' do
+        candidate = create(:candidate, course_from_find_id: 1)
+        create(:completed_application_form, candidate: candidate, application_choices_count: 3)
+
+        service = described_class.new(candidate: candidate)
+        service.execute
+
+        expect(service.candidate_has_submitted_application).to be(true)
+        expect(candidate.course_from_find_id).to eq(nil)
       end
     end
 
@@ -41,10 +54,10 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service.candidate_has_new_course_added?).to be_truthy
-        expect(service.candidate_should_choose_site?).to be_falsey
-        expect(service.candidate_does_not_have_a_course_from_find?).to be_falsey
-        expect(service.candidate_already_has_3_courses?).to be_falsey
+        expect(service.candidate_has_new_course_added).to be_truthy
+        expect(service.candidate_should_choose_site).to be_falsey
+        expect(service.candidate_does_not_have_a_course_from_find).to be_falsey
+        expect(service.candidate_already_has_3_courses).to be_falsey
         expect(candidate.course_from_find_id).to eq(nil)
         expect(candidate.current_application.application_choices.first.course_option_id).to eq(course_options_id)
       end
@@ -59,10 +72,10 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service.candidate_should_choose_site?).to be_truthy
-        expect(service.candidate_has_new_course_added?).to be_falsey
-        expect(service.candidate_does_not_have_a_course_from_find?).to be_falsey
-        expect(service.candidate_already_has_3_courses?).to be_falsey
+        expect(service.candidate_should_choose_site).to be_truthy
+        expect(service.candidate_has_new_course_added).to be_falsey
+        expect(service.candidate_does_not_have_a_course_from_find).to be_falsey
+        expect(service.candidate_already_has_3_courses).to be_falsey
         expect(candidate.course_from_find_id).to eq(nil)
         expect(candidate.current_application.application_choices).not_to be_present
       end
@@ -76,10 +89,25 @@ RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
         service = described_class.new(candidate: candidate)
         service.execute
 
-        expect(service.candidate_does_not_have_a_course_from_find?).to be_truthy
-        expect(service.candidate_has_new_course_added?).to be_falsey
-        expect(service.candidate_should_choose_site?).to be_falsey
-        expect(service.candidate_already_has_3_courses?).to be_falsey
+        expect(service.candidate_does_not_have_a_course_from_find).to be_truthy
+        expect(service.candidate_has_new_course_added).to be_falsey
+        expect(service.candidate_should_choose_site).to be_falsey
+        expect(service.candidate_already_has_3_courses).to be_falsey
+      end
+    end
+
+    context 'when the candidate already has the course as an application choice' do
+      it 'sets the candidates course_from_find_id to nil and sets candidate_has_already_selected_the_course to true' do
+        course = create(:course)
+        candidate = create(:candidate, course_from_find_id: course.id)
+        course_option = create(:course_option, course: course)
+        create(:application_choice, course_option: course_option, application_form: create(:application_form, candidate: candidate))
+
+        service = described_class.new(candidate: candidate)
+        service.execute
+
+        expect(service.candidate_has_already_selected_the_course).to be_truthy
+        expect(candidate.course_from_find_id).to eq(nil)
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'An existing candidate arriving from Find with a course and provider code' do
   include CourseOptionHelpers
-  scenario 'retaining their course selection through the sign up process' do
+  scenario 'candidate is not signed in and retians their course selection' do
     given_the_pilot_is_open
     and_i_am_an_existing_candidate_on_apply
     and_i_have_less_than_3_application_options
@@ -15,6 +15,13 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_should_see_the_course_name_and_code
     and_i_should_see_the_site
     and_my_course_from_find_id_should_be_set_to_nil
+
+    when_i_sign_out
+    and_i_arrive_at_the_sign_up_page_with_the_same_course_params
+    and_i_submit_my_email_address
+    and_click_on_the_magic_link
+    then_i_should_see_the_courses_review_page
+    and_i_should_be_informed_i_have_already_selected_that_course
 
     given_the_course_i_selected_has_multiple_sites
     and_i_am_an_existing_candidate_on_apply
@@ -55,7 +62,8 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_have_less_than_3_application_options
-    application_choice_for_candidate(candidate: @candidate, application_choice_count: 2)
+    application_form = create(:application_form, candidate: @candidate)
+    create(:application_choice, application_form: application_form)
   end
 
   def and_i_have_3_application_options
@@ -80,6 +88,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def and_click_on_the_magic_link
     open_email(@email)
+
     current_email.find_css('a').first.click
   end
 
@@ -138,6 +147,18 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def and_i_should_be_informed_i_already_have_3_courses
     expect(page).to have_content "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course_with_multiple_sites.name_and_code}"
+  end
+
+  def when_i_sign_out
+    click_link 'Sign out'
+  end
+
+  def and_i_arrive_at_the_sign_up_page_with_the_same_course_params
+    visit candidate_interface_sign_up_path providerCode: @course.provider.code, courseCode: @course.code
+  end
+
+  def and_i_should_be_informed_i_have_already_selected_that_course
+    expect(page).to have_content "You have already selected #{@course.name_and_code}."
   end
 
 private


### PR DESCRIPTION
## Context

One of our users submitted an application with duplicate course choices. They used the Apply from Find feature to do so. More investigation in the Slack thread: 

https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1581955325001800

This is caused when a user signs up with a course from find, signs out then follows the same journey via the apply from find page again.


## Changes proposed in this pull request

- Check whether the candidate already has that course in the ExistingCandidateAuthentication
- Raise a flash error telling them they have already selected that course

## Guidance to review

An additional PR will follow which fixes the signed-in user flow

## Link to Trello card

https://trello.com/c/71lG72Y6/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
