### PR TITLE
Fix broken preview when stubbing application choices

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -142,7 +142,7 @@ class CandidateMailer < ApplicationMailer
 
   def chase_candidate_decision(application_form)
     @dbd_date = application_form.application_choices.first.decline_by_default_at.to_s(:govuk_date).strip
-    @application_choices = application_form.application_choices.offer
+    @application_choices = application_form.application_choices.select(&:offer?)
 
     subject_pluralisation = @application_choices.count > 1 ? 'plural' : 'singular'
     email_for_candidate(application_form, subject: I18n.t!("chase_candidate_decision_email.subject_#{subject_pluralisation}"))


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The candidate mailer preview uses stubs to preview an email template, but the current logic in `#chase_candidate_decision` does not work with application choice stubs.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR fixes the way we map application choices

<img width="1202" alt="Screenshot 2020-02-19 at 11 16 14" src="https://user-images.githubusercontent.com/22743709/74829924-f9dc5900-5309-11ea-9351-0a4a234334f8.png">


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
👀 
