### PR TITLE
Use database IDs instead of Course and Provider codes

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -67,7 +67,7 @@ module CandidateInterface
       elsif @pick_course.single_site?
         course_option = CourseOption.where(course_id: @pick_course.course.id).first
 
-        pick_site_for_course(course_code, course_option.id)
+        pick_site_for_course(course_id, course_option.id)
       else
         redirect_to candidate_interface_course_choices_site_path(provider_id: @pick_course.provider_id, course_id: @pick_course.course_id)
       end
@@ -75,16 +75,16 @@ module CandidateInterface
 
     def options_for_site
       @pick_site = PickSiteForm.new(
-        provider_code: params.fetch(:provider_code),
-        course_code: params.fetch(:course_code),
+        provider_id: params.fetch(:provider_id),
+        course_id: params.fetch(:course_id),
       )
     end
 
     def pick_site
-      course_code = params.fetch(:course_code)
+      course_id = params.fetch(:course_id)
       course_option_id = params.dig(:candidate_interface_pick_site_form, :course_option_id)
 
-      pick_site_for_course(course_code, course_option_id)
+      pick_site_for_course(course_id, course_option_id)
     end
 
     def review
@@ -130,11 +130,11 @@ module CandidateInterface
       params.fetch(:candidate_interface_course_chosen_form, {}).permit(:choice)
     end
 
-    def pick_site_for_course(course_code, course_option_id)
+    def pick_site_for_course(course_id, course_option_id)
       @pick_site = PickSiteForm.new(
         application_form: current_application,
-        provider_code: params.fetch(:provider_code),
-        course_code: course_code,
+        provider_id: params.fetch(:provider_id),
+        course_id: course_id,
         course_option_id: course_option_id,
       )
 

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -47,16 +47,16 @@ module CandidateInterface
 
     def options_for_course
       @pick_course = PickCourseForm.new(
-        provider_code: params.fetch(:provider_code),
+        provider_id: params.fetch(:provider_id),
         application_form: current_application,
       )
     end
 
     def pick_course
-      course_code = params.dig(:candidate_interface_pick_course_form, :code)
+      course_id = params.dig(:candidate_interface_pick_course_form, :course_id)
       @pick_course = PickCourseForm.new(
-        provider_code: params.fetch(:provider_code),
-        code: course_code,
+        provider_id: params.fetch(:provider_id),
+        course_id: course_id,
         application_form: current_application,
       )
 
@@ -69,7 +69,7 @@ module CandidateInterface
 
         pick_site_for_course(course_code, course_option.id)
       else
-        redirect_to candidate_interface_course_choices_site_path(provider_code: @pick_course.provider_code, course_code: @pick_course.code)
+        redirect_to candidate_interface_course_choices_site_path(provider_id: @pick_course.provider_id, course_id: @pick_course.course_id)
       end
     end
 

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -33,13 +33,13 @@ module CandidateInterface
     end
 
     def pick_provider
-      @pick_provider = PickProviderForm.new(code: params.dig(:candidate_interface_pick_provider_form, :code))
+      @pick_provider = PickProviderForm.new(provider_id: params.dig(:candidate_interface_pick_provider_form, :provider_id))
       if !@pick_provider.valid?
         render :options_for_provider
       elsif @pick_provider.other?
         redirect_to candidate_interface_course_choices_on_ucas_path
       else
-        redirect_to candidate_interface_course_choices_course_path(provider_code: @pick_provider.code)
+        redirect_to candidate_interface_course_choices_course_path(@pick_provider.provider_id)
       end
     end
 

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -59,7 +59,7 @@ module CandidateInterface
         elsif service.candidate_has_new_course_added
           redirect_to candidate_interface_course_choices_review_path
         elsif service.candidate_should_choose_site
-          redirect_to candidate_interface_course_choices_site_path(course.provider.code, course.code)
+          redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id)
         elsif service.candidate_already_has_3_courses
           flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
           redirect_to candidate_interface_course_choices_review_path

--- a/app/frontend/packs/courses-autocomplete.js
+++ b/app/frontend/packs/courses-autocomplete.js
@@ -2,22 +2,18 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initCoursesAutocomplete = () => {
   try {
-    [
-      "#candidate-interface-pick-course-form-code-field",
-      "#candidate-interface-pick-course-form-code-field-error"
-    ].forEach(id => {
-      const coursesSelect = document.querySelector(id);
+    const id = "#pick-course-form .govuk-select";
+    const coursesSelect = document.querySelector(id);
 
-      if (!coursesSelect) return;
+    if (!coursesSelect) return;
 
-      // Replace "Select a course" with empty string
-      coursesSelect.querySelector("[value='']").innerHTML = "";
+    // Replace "Select a course" with empty string
+    coursesSelect.querySelector("[value='']").innerHTML = "";
 
-      accessibleAutocomplete.enhanceSelectElement({
-        selectElement: coursesSelect,
-        showAllValues: true,
-        confirmOnBlur: false
-      });
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: coursesSelect,
+      showAllValues: true,
+      confirmOnBlur: false
     });
   } catch (err) {
     console.error("Could not enhance courses select:", err);

--- a/app/frontend/packs/providers-autocomplete.js
+++ b/app/frontend/packs/providers-autocomplete.js
@@ -2,22 +2,18 @@ import accessibleAutocomplete from "accessible-autocomplete";
 
 const initProvidersAutocomplete = () => {
   try {
-    [
-      "#candidate-interface-pick-provider-form-code-field",
-      "#candidate-interface-pick-provider-form-code-field-error"
-    ].forEach(id => {
-      const providersSelect = document.querySelector(id);
+    const id = "#pick-provider-form .govuk-select";
+    const providersSelect = document.querySelector(id);
 
-      if (!providersSelect) return;
+    if (!providersSelect) return;
 
-      // Replace "Select a provider" with empty string
-      providersSelect.querySelector("[value='']").innerHTML = "";
+    // Replace "Select a provider" with empty string
+    providersSelect.querySelector("[value='']").innerHTML = "";
 
-      accessibleAutocomplete.enhanceSelectElement({
-        selectElement: providersSelect,
-        showAllValues: true,
-        confirmOnBlur: false
-      });
+    accessibleAutocomplete.enhanceSelectElement({
+      selectElement: providersSelect,
+      showAllValues: true,
+      confirmOnBlur: false
     });
   } catch (err) {
     console.error("Could not enhance providers select:", err);

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -30,7 +30,7 @@ module ViewHelper
   def select_course_options(courses)
     [
       OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_course_form.attributes.code.blank')),
-    ] + courses.map { |course| OpenStruct.new(id: course.code, name: "#{course.name} (#{course.code})") }
+    ] + courses.map { |course| OpenStruct.new(id: course.id, name: "#{course.name} (#{course.code})") }
   end
 
   def select_provider_options(providers)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -36,7 +36,7 @@ module ViewHelper
   def select_provider_options(providers)
     [
       OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_provider_form.attributes.code.blank')),
-    ] + providers.map { |provider| OpenStruct.new(id: provider.code, name: "#{provider.name} (#{provider.code})") }
+    ] + providers.map { |provider| OpenStruct.new(id: provider.id, name: "#{provider.name} (#{provider.code})") }
   end
 
   def submitted_at_date

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -2,8 +2,8 @@ module CandidateInterface
   class PickCourseForm
     include ActiveModel::Model
 
-    attr_accessor :code, :provider_code, :application_form
-    validates :code, presence: true
+    attr_accessor :course_id, :provider_id, :application_form
+    validates :course_id, presence: true
     validate :user_cant_apply_to_same_course_twice
 
     def open_on_apply?
@@ -21,17 +21,17 @@ module CandidateInterface
     end
 
     def course
-      @course ||= provider.courses.find_by!(code: code)
+      @course ||= provider.courses.find(course_id)
     end
 
   private
 
     def provider
-      @provider ||= Provider.find_by!(code: provider_code)
+      @provider ||= Provider.find(provider_id)
     end
 
     def user_cant_apply_to_same_course_twice
-      return if code.blank?
+      return if course_id.blank?
 
       if application_form.application_choices.any? { |application_choice| application_choice.course == course }
         errors[:base] << 'You have already selected this course'

--- a/app/models/candidate_interface/pick_provider_form.rb
+++ b/app/models/candidate_interface/pick_provider_form.rb
@@ -2,11 +2,11 @@ module CandidateInterface
   class PickProviderForm
     include ActiveModel::Model
 
-    attr_accessor :code
-    validates :code, presence: true
+    attr_accessor :provider_id
+    validates :provider_id, presence: true
 
     def other?
-      Course.exposed_in_find.pluck(:provider_id).exclude?(Provider.find_by(code: code).id)
+      Course.exposed_in_find.where(provider_id: provider_id).blank?
     end
 
     def available_providers

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class PickSiteForm
     include ActiveModel::Model
 
-    attr_accessor :application_form, :provider_code, :course_code, :course_option_id
+    attr_accessor :application_form, :provider_id, :course_id, :course_option_id
     validates :course_option_id, presence: true
     validate :candidate_can_only_apply_to_3_courses
 
@@ -25,11 +25,11 @@ module CandidateInterface
     end
 
     def course
-      @course ||= provider.courses.find_by!(code: course_code)
+      @course ||= provider.courses.find(course_id)
     end
 
     def provider
-      @provider ||= Provider.find_by!(code: provider_code)
+      @provider ||= Provider.find(provider_id)
     end
 
     def candidate_can_only_apply_to_3_courses

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -3,10 +3,25 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @pick_course, url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%=
+      form_with(
+        model: @pick_course,
+        url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id]),
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        id: 'pick-course-form'
+      ) do |f|
+    %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select :course_id, select_course_options(@pick_course.available_courses), :id, :name, label: { text: t('page_titles.which_course'), size: 'xl' } %>
+      <%=
+        f.govuk_collection_select(
+          :course_id,
+          select_course_options(@pick_course.available_courses),
+          :id,
+          :name,
+          label: { text: t('page_titles.which_course'), size: 'xl' },
+        )
+      %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -3,25 +3,21 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%=
-      form_with(
-        model: @pick_course,
-        url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id]),
-        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-        id: 'pick-course-form'
-      ) do |f|
-    %>
+    <%= form_with(
+          model: @pick_course,
+          url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id]),
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+          id: 'pick-course-form',
+        ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%=
-        f.govuk_collection_select(
-          :course_id,
-          select_course_options(@pick_course.available_courses),
-          :id,
-          :name,
-          label: { text: t('page_titles.which_course'), size: 'xl' },
-        )
-      %>
+      <%= f.govuk_collection_select(
+            :course_id,
+            select_course_options(@pick_course.available_courses),
+            :id,
+            :name,
+            label: { text: t('page_titles.which_course'), size: 'xl' },
+          ) %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -3,10 +3,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @pick_course, url: candidate_interface_course_choices_course_path(provider_code: params[:provider_code]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @pick_course, url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select :code, select_course_options(@pick_course.available_courses), :id, :name, label: { text: t('page_titles.which_course'), size: 'xl' } %>
+      <%= f.govuk_collection_select :course_id, select_course_options(@pick_course.available_courses), :id, :name, label: { text: t('page_titles.which_course'), size: 'xl' } %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @pick_provider, url: candidate_interface_course_choices_provider_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select :code, select_provider_options(@pick_provider.available_providers), :id, :name, label: { text: t('page_titles.which_provider'), size: 'xl' } do %>
+      <%= f.govuk_collection_select :provider_id, select_provider_options(@pick_provider.available_providers), :id, :name, label: { text: t('page_titles.which_provider'), size: 'xl' } do %>
         <p class="govuk-body">You can
           <%= link_to candidate_interface_providers_path, class: 'govuk-link' do %>
             preview a list of training providers and courses

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -3,10 +3,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @pick_provider, url: candidate_interface_course_choices_provider_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%=
+      form_with(
+        model: @pick_provider,
+        url: candidate_interface_course_choices_provider_path,
+        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        id: 'pick-provider-form'
+      ) do |f|
+    %>
+
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select :provider_id, select_provider_options(@pick_provider.available_providers), :id, :name, label: { text: t('page_titles.which_provider'), size: 'xl' } do %>
+      <%=
+        f.govuk_collection_select(
+          :provider_id,
+          select_provider_options(@pick_provider.available_providers),
+          :id,
+          :name,
+          label: { text: t('page_titles.which_provider'), size: 'xl' },
+        ) do
+      %>
         <p class="govuk-body">You can
           <%= link_to candidate_interface_providers_path, class: 'govuk-link' do %>
             preview a list of training providers and courses

--- a/app/views/candidate_interface/course_choices/options_for_provider.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_provider.html.erb
@@ -3,26 +3,22 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%=
-      form_with(
-        model: @pick_provider,
-        url: candidate_interface_course_choices_provider_path,
-        builder: GOVUKDesignSystemFormBuilder::FormBuilder,
-        id: 'pick-provider-form'
-      ) do |f|
-    %>
+    <%= form_with(
+          model: @pick_provider,
+          url: candidate_interface_course_choices_provider_path,
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+          id: 'pick-provider-form',
+        ) do |f| %>
 
       <%= f.govuk_error_summary %>
 
-      <%=
-        f.govuk_collection_select(
-          :provider_id,
-          select_provider_options(@pick_provider.available_providers),
-          :id,
-          :name,
-          label: { text: t('page_titles.which_provider'), size: 'xl' },
-        ) do
-      %>
+      <%= f.govuk_collection_select(
+            :provider_id,
+            select_provider_options(@pick_provider.available_providers),
+            :id,
+            :name,
+            label: { text: t('page_titles.which_provider'), size: 'xl' },
+          ) do %>
         <p class="govuk-body">You can
           <%= link_to candidate_interface_providers_path, class: 'govuk-link' do %>
             preview a list of training providers and courses

--- a/app/views/candidate_interface/course_choices/options_for_site.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_site.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.which_location'), @pick_site.errors.any?) %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(provider_code: params[:provider_code])) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(provider_id: params[:provider_id])) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @pick_site, url: candidate_interface_course_choices_site_path(provider_code: params[:provider_code], course_code: params[:course_code]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with model: @pick_site, url: candidate_interface_course_choices_site_path(provider_id: params[:provider_id], course_id: params[:course_id]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location') } do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,11 +185,11 @@ Rails.application.routes.draw do
 
         get '/apply-on-ucas' => 'course_choices#ucas', as: :course_choices_on_ucas
 
-        get '/provider/:provider_code/courses' => 'course_choices#options_for_course', as: :course_choices_course
-        post '/provider/:provider_code/courses' => 'course_choices#pick_course'
+        get '/provider/:provider_id/courses' => 'course_choices#options_for_course', as: :course_choices_course
+        post '/provider/:provider_id/courses' => 'course_choices#pick_course'
 
-        get '/provider/:provider_code/courses/:course_code' => 'course_choices#options_for_site', as: :course_choices_site
-        post '/provider/:provider_code/courses/:course_code' => 'course_choices#pick_site'
+        get '/provider/:provider_id/courses/:course_id' => 'course_choices#options_for_site', as: :course_choices_site
+        post '/provider/:provider_id/courses/:course_id' => 'course_choices#pick_site'
 
         get '/review' => 'course_choices#review', as: :course_choices_review
         patch '/review' => 'course_choices#complete', as: :course_choices_complete

--- a/spec/models/candidate_interface/pick_course_form_spec.rb
+++ b/spec/models/candidate_interface/pick_course_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course you can apply to', provider: provider)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course from other provider')
 
-      form = CandidateInterface::PickCourseForm.new(provider_code: provider.code)
+      form = CandidateInterface::PickCourseForm.new(provider_id: provider.id)
 
       expect(form.available_courses.map(&:name)).to eql(['Course not open on apply', 'Course you can apply to'])
     end
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
     let(:provider) { create(:provider, name: 'Royal Academy of Dance', code: 'R55') }
     let(:course) { create(:course, provider: provider, exposed_in_find: true, open_on_apply: true) }
     let(:site) { create(:site, provider: provider) }
-    let(:pick_course_form) { CandidateInterface::PickCourseForm.new(provider_code: provider.code, code: course.code) }
+    let(:pick_course_form) { CandidateInterface::PickCourseForm.new(provider_id: provider.id, course_id: course.id) }
 
     before { create(:course_option, site: site, course: course) }
 

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
@@ -138,7 +138,12 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def then_i_should_see_the_course_choices_site_page
-    expect(page).to have_current_path(candidate_interface_course_choices_site_path(@course_with_multiple_sites.provider.code, @course_with_multiple_sites.code))
+    expect(page).to have_current_path(
+      candidate_interface_course_choices_site_path(
+        @course_with_multiple_sites.provider.id,
+        @course_with_multiple_sites.id,
+      ),
+    )
   end
 
   def then_i_should_see_the_candidate_interface_application_form

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
@@ -60,11 +60,6 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
     click_on t('apply_from_find.apply_button')
   end
 
-  def then_the_url_should_contain_the_course_code_and_provider_code_param
-    expect(page.current_url).to have_content "providerCode=#{@course.provider.code}"
-    expect(page.current_url).to have_content "courseCode=#{@course.code}"
-  end
-
   def when_i_fill_in_the_eligiblity_form_with_yes
     within_fieldset('Are you a citizen of the UK or the EU?') do
       choose 'Yes'

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
@@ -50,7 +50,10 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   end
 
   def when_i_arrive_from_find_to_a_course_that_is_open_on_apply
-    visit candidate_interface_apply_from_find_path providerCode: @course.provider.code, courseCode: @course.code
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
   end
 
   def and_i_click_apply_on_apply
@@ -126,7 +129,12 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   end
 
   def then_i_should_see_the_course_choices_site_page
-    expect(page).to have_current_path(candidate_interface_course_choices_site_path(@course_with_multiple_sites.provider.code, @course_with_multiple_sites.code))
+    expect(page).to have_current_path(
+      candidate_interface_course_choices_site_path(
+        @course_with_multiple_sites.provider.id,
+        @course_with_multiple_sites.id,
+      ),
+    )
   end
 
   def and_i_should_see_an_account_created_flash_message


### PR DESCRIPTION
## Context

In the candidate interface, there are several places where we use codes
to identify Courses and Providers. Certain URL paths contain these
codes, they subsequently end up in the params for the related actions,
and we end up using them in database queries.

The issue with this is that course codes are unique for a provider, but
not unique globally. In cases where a course code is shared between two
providers, this can cause the system to accidentally choose the wrong
course.

## Changes proposed in this pull request

Update route definitions and all related logic so that we use database ids instead of codes to identify Course and Providers.

## Guidance to review

See individual commits for detail.

## Link to Trello card

https://trello.com/c/TU8oMtpf

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
