### PR TITLE
Add ‘Sign in’ link to signed out candidate and provider headers

### DIFF
--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -12,7 +12,9 @@ class NavigationItems
           NavigationItem.new('Sign out', candidate_interface_sign_out_path, false),
         ]
       else
-        []
+        [
+          NavigationItem.new('Sign in', candidate_interface_sign_in_path, false),
+        ]
       end
     end
 
@@ -41,7 +43,9 @@ class NavigationItems
           NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
         ]
       else
-        []
+        [
+          NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
+        ]
       end
     end
 


### PR DESCRIPTION
## Context

Users (both candidates and providers) can’t find the sign in link. On the candidate interface, this is near the bottom of the page, where the big green start button is a distraction. On the provider page, the link is in the masthead, but also obscured by a big start button.

This PR shows a ‘Sign in’ link in the header, for candidate and provider users that are signed out.

## Changes proposed in this pull request

![Apply header](https://user-images.githubusercontent.com/813383/74834297-0fa24c00-5313-11ea-87cc-780a5d13e018.png)
![Manage header](https://user-images.githubusercontent.com/813383/74834300-103ae280-5313-11ea-9a7b-b862c41d3c76.png)