### PR TITLE
Get ready to launcharoo work history breaks!

### DIFF
--- a/app/components/break_in_work_history_component.html.erb
+++ b/app/components/break_in_work_history_component.html.erb
@@ -1,5 +1,5 @@
 <%= render(SummaryCardComponent.new(rows: work_break_rows, editable: @editable)) do %>
-  <%= render(SummaryCardHeaderComponent.new(title: "Break in work history (#{pluralize(@work_break.length, 'month')})")) do %>
+  <%= render(SummaryCardHeaderComponent.new(title: "Break in work history (#{format_months_to_years_and_months(@work_break.length)})")) do %>
     <% if @editable %>
       <div class="app-summary-card__actions">
         <%= link_to candidate_interface_destroy_work_history_break_path(@work_break), class: 'govuk-link' do %>

--- a/app/components/break_placeholder_in_work_history_component.html.erb
+++ b/app/components/break_placeholder_in_work_history_component.html.erb
@@ -1,7 +1,7 @@
 <section class="app-summary-card govuk-!-margin-bottom-6">
   <header class="app-summary-card__header">
     <h3 class="app-summary-card__title">
-      You have a break in your work history in the last 5 years (<%= break_length %>)
+      You have a break in your work history in the last 5 years (<%= format_months_to_years_and_months(@work_break.length) %>)
     </h3>
 
     <div class="app-summary-card__actions">

--- a/app/components/break_placeholder_in_work_history_component.rb
+++ b/app/components/break_placeholder_in_work_history_component.rb
@@ -10,15 +10,4 @@ class BreakPlaceholderInWorkHistoryComponent < ActionView::Component::Base
   def between_formatted_dates
     "between #{@work_break.start_date.to_s(:month_and_year)} and #{@work_break.end_date.to_s(:month_and_year)}"
   end
-
-  def break_length
-    if @work_break.length <= 12
-      pluralize(@work_break.length, 'month')
-    else
-      years = @work_break.length / 12
-      months = @work_break.length % 12
-
-      "#{pluralize(years, 'year')} and #{pluralize(months, 'month')}"
-    end
-  end
 end

--- a/app/components/work_history_review_component.html.erb
+++ b/app/components/work_history_review_component.html.erb
@@ -12,13 +12,11 @@
       <% end %>
     <% end %>
   <% elsif entry.is_a?(WorkHistoryWithBreaks::BreakPlaceholder) %>
-    <% if FeatureFlag.active?('work_breaks') %>
+    <% if show_break_placeholders? %>
       <%= render(BreakPlaceholderInWorkHistoryComponent.new(work_break: entry)) %>
     <% end %>
   <% elsif entry.is_a?(ApplicationWorkHistoryBreak) %>
-    <% if FeatureFlag.active?('work_breaks') %>
-      <%= render(BreakInWorkHistoryComponent.new(work_break: entry)) %>
-    <% end %>
+    <%= render(BreakInWorkHistoryComponent.new(work_break: entry, editable: @editable)) %>
   <% end %>
 <% end %>
 
@@ -26,7 +24,7 @@
   <%= render(SummaryCardComponent.new(rows: no_work_experience_rows, editable: @editable)) %>
 <% end %>
 
-<% if breaks_in_work_history? %>
+<% if show_consolidated_work_history_breaks? %>
   <%= render(SummaryCardComponent.new(rows: break_in_work_history_rows, editable: @editable)) %>
 <% end %>
 

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -44,12 +44,16 @@ class WorkHistoryReviewComponent < ActionView::Component::Base
     ]
   end
 
-  def breaks_in_work_history?
-    CheckBreaksInWorkHistory.call(@application_form)
-  end
-
   def show_missing_banner?
     @show_incomplete
+  end
+
+  def show_consolidated_work_history_breaks?
+    breaks_in_work_history? && (@application_form.work_history_breaks || !FeatureFlag.active?('work_breaks'))
+  end
+
+  def show_break_placeholders?
+    FeatureFlag.active?('work_breaks') && @application_form.work_history_breaks.blank? && @editable
   end
 
 private
@@ -119,5 +123,9 @@ private
     return work.commitment.dasherize.humanize if work.working_pattern.blank?
 
     "#{work.commitment.dasherize.humanize}\n #{work.working_pattern}"
+  end
+
+  def breaks_in_work_history?
+    CheckBreaksInWorkHistory.call(@application_form)
   end
 end

--- a/app/controllers/candidate_interface/work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/work_history/break_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class WorkHistory::BreakController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_not_amendable
+    before_action :redirect_to_review_work_history_if_feature_off
 
     def new
       @work_break = if params[:start_date] && params[:end_date]
@@ -71,6 +72,10 @@ module CandidateInterface
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) }
           .transform_values(&:strip)
+    end
+
+    def redirect_to_review_work_history_if_feature_off
+      redirect_to candidate_interface_work_history_show_path unless FeatureFlag.active?('work_breaks')
     end
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -77,6 +77,16 @@ module ViewHelper
     end
   end
 
+  def format_months_to_years_and_months(number_of_months)
+    duration_parts = ActiveSupport::Duration.build(number_of_months.months).parts
+
+    if duration_parts[:years].positive?
+      "#{pluralize(duration_parts[:years], 'year')} and #{pluralize(duration_parts[:months], 'month')}"
+    else
+      pluralize(number_of_months, 'month')
+    end
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/spec/components/break_in_work_history_component_spec.rb
+++ b/spec/components/break_in_work_history_component_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe BreakInWorkHistoryComponent do
+  let(:january2018) { Time.zone.local(2018, 1, 1) }
   let(:february2019) { Time.zone.local(2019, 2, 1) }
   let(:april2019) { Time.zone.local(2019, 4, 1) }
   let(:work_break) do
@@ -8,16 +9,32 @@ RSpec.describe BreakInWorkHistoryComponent do
       :application_work_history_break,
       start_date: february2019,
       end_date: april2019,
-      reason: 'I feel asleep.',
+      reason: 'I fell asleep.',
     )
   end
 
-  it 'renders the component with the break in months, reason and dates' do
-    result = render_inline(BreakInWorkHistoryComponent.new(work_break: work_break))
+  context 'when work history break is less than 12 months' do
+    it 'renders the component with the break in months, reason and dates' do
+      result = render_inline(BreakInWorkHistoryComponent.new(work_break: work_break))
 
-    expect(result.text).to include('Break in work history (1 month)')
-    expect(result.text).to include('I feel asleep.')
-    expect(result.text).to include('February 2019 - April 2019')
+      expect(result.text).to include('Break in work history (1 month)')
+      expect(result.text).to include('I fell asleep.')
+      expect(result.text).to include('February 2019 - April 2019')
+    end
+  end
+
+  context 'when work history break is more than 12 months' do
+    it 'renders the component with the break in months' do
+      work_break = build_stubbed(
+        :application_work_history_break,
+        start_date: january2018,
+        end_date: april2019,
+        reason: 'I fell asleep.',
+      )
+      result = render_inline(BreakInWorkHistoryComponent.new(work_break: work_break))
+
+      expect(result.text).to include('Break in work history (1 year and 2 months)')
+    end
   end
 
   context 'when editable' do

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe WorkHistoryReviewComponent do
+  let(:february2019) { Time.zone.local(2019, 2, 1) }
+  let(:april2019) { Time.zone.local(2019, 4, 1) }
   let(:data) do
     {
       role: 'Teaching Assistant',
@@ -97,39 +99,111 @@ RSpec.describe WorkHistoryReviewComponent do
 
   context 'when there are breaks in the work history' do
     let(:application_form) do
-      Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
-        create(:application_form) do |form|
-          data[:start_date] = Time.zone.local(2019, 8, 1)
-          data[:end_date] = Time.zone.local(2019, 9, 1)
-          form.application_work_experiences.create(data)
+      create(:application_form) do |form|
+        data[:start_date] = Time.zone.local(2019, 8, 1)
+        data[:end_date] = Time.zone.local(2019, 9, 1)
+        form.application_work_experiences.create(data)
 
-          form.work_history_breaks = 'WE WERE ON A BREAK!'
-        end
+        form.work_history_breaks = 'WE WERE ON A BREAK!'
       end
     end
 
-    context 'when work history breaks are editable' do
+    around do |example|
+      Timecop.freeze(Time.zone.local(2019, 10, 1)) do
+        example.run
+      end
+    end
+
+    context 'when consolidated work history breaks are editable' do
       it 'renders summary card for breaks in the work history' do
-        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
-          result = render_inline(described_class.new(application_form: application_form))
+        result = render(feature_active: false, explanation: 'WE WERE ON A BREAK!')
 
-          expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
-          expect(result.css('.govuk-summary-list__value').to_html).to include('WE WERE ON A BREAK!')
-          expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
-            Rails.application.routes.url_helpers.candidate_interface_work_history_breaks_path,
-          )
-          expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
-        end
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
+        expect(result.css('.govuk-summary-list__value').to_html).to include('WE WERE ON A BREAK!')
+        expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
+          Rails.application.routes.url_helpers.candidate_interface_work_history_breaks_path,
+        )
+        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
       end
     end
 
-    context 'when work history breaks are not editable' do
+    context 'when consolidated work history breaks are not editable' do
       it 'renders component without an edit link' do
-        Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
-          result = render_inline(described_class.new(application_form: application_form, editable: false))
+        result = render(feature_active: false, explanation: 'I was sleeping.', editable: false)
 
-          expect(result.css('.govuk-summary-list__actions').text).not_to include(t('application_form.work_history.break.enter_label'))
-        end
+        expect(result.css('.govuk-summary-list__actions').text).not_to include(t('application_form.work_history.break.change_label'))
+      end
+    end
+
+    context 'when the work breaks feature flag is on, there are existing individual breaks and editable' do
+      it 'renders component with change and delete links' do
+        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break1]
+
+        result = render(feature_active: true, breaks: breaks)
+
+        expect(result.text).to include('Delete entry for break between February 2019 and April 2019')
+        expect(result.text).to include('Change description for break between February 2019 and April 2019')
+        expect(result.text).to include('Change dates for break between February 2019 and April 2019')
+      end
+    end
+
+    context 'when the work breaks feature flag is on, there are existing individual breaks and not editable' do
+      it 'renders component without change and delete links' do
+        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
+        breaks = [break1]
+
+        result = render(feature_active: true, breaks: breaks, editable: false)
+
+        expect(result.text).not_to include('Delete entry for break between February 2019 and April 2019')
+        expect(result.text).not_to include('Change description for break between February 2019 and April 2019')
+        expect(result.text).not_to include('Change dates for break between February 2019 and April 2019')
+      end
+    end
+
+    context 'when the work breaks feature flag is on and consolidated work history breaks has a value' do
+      it 'renders component with consolidated work breaks and without individual breaks' do
+        result = render(feature_active: true, explanation: 'I was sleeping.')
+
+        expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
+        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
+      end
+    end
+
+    context 'when the work breaks feature flag is on and individual breaks are editable' do
+      it 'renders component without break placeholders' do
+        result = render(feature_active: true, editable: true)
+
+        expect(result.css('.app-summary-card__title').text).to include('You have a break in your work history in the last 5 years')
+      end
+    end
+
+    context 'when the work breaks feature flag is on and individual breaks are not editable' do
+      it 'renders component without break placeholders' do
+        result = render(feature_active: true, editable: false)
+
+        expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
+      end
+    end
+
+    context 'when the work breaks feature flag is off and there are no breaks' do
+      it 'renders component with consolidated work breaks and without individual breaks' do
+        result = render(feature_active: false)
+
+        expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
+        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.enter_label'))
+      end
+    end
+
+    context 'when the work breaks feature flag is off and consolidated work history breaks has a value' do
+      it 'renders component with consolidated work breaks and without individual breaks' do
+        result = render(feature_active: false, explanation: 'I was sleeping.')
+
+        expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
+        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
+        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
       end
     end
   end
@@ -159,5 +233,25 @@ RSpec.describe WorkHistoryReviewComponent do
         expect(result.css('.govuk-summary-list__actions').text).not_to include('Change explanation')
       end
     end
+  end
+
+  def render(feature_active: false, explanation: nil, breaks: [], editable: true)
+    if feature_active
+      FeatureFlag.activate('work_breaks')
+    else
+      FeatureFlag.deactivate('work_breaks')
+    end
+
+    data[:start_date] = Time.zone.local(2019, 8, 1)
+    data[:end_date] = Time.zone.local(2019, 9, 1)
+
+    application_form = build_stubbed(
+      :application_form,
+      work_history_breaks: explanation,
+      application_work_history_breaks: breaks,
+      application_work_experiences: [build_stubbed(:application_work_experience, attributes: data)],
+    )
+
+    render_inline(described_class.new(application_form: application_form, editable: editable))
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -10,9 +10,12 @@ RSpec.feature 'Entering reasons for their work history breaks' do
   end
 
   scenario 'Candidate enters a reason for a work break' do
-    FeatureFlag.activate('work_breaks')
-
     given_i_am_signed_in
+    and_the_work_breaks_feature_flag_is_off
+    when_i_visit_the_new_break_page
+    then_i_am_redirected_to_the_review_work_history_page
+
+    given_the_work_breaks_feature_flag_is_on
     and_i_visit_the_site
 
     when_i_click_on_work_history
@@ -47,6 +50,22 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_work_breaks_feature_flag_is_off
+    FeatureFlag.deactivate('work_breaks')
+  end
+
+  def when_i_visit_the_new_break_page
+    visit candidate_interface_new_work_history_break_path
+  end
+
+  def then_i_am_redirected_to_the_review_work_history_page
+    expect(page).to have_current_path(candidate_interface_work_history_show_path)
+  end
+
+  def given_the_work_breaks_feature_flag_is_on
+    FeatureFlag.activate('work_breaks')
   end
 
   def and_i_visit_the_site


### PR DESCRIPTION
## Context

Currently, we only show individual breaks when the `work_breaks` feature flag is on. However, to actually turn this on we have to consider the fact that we will turn on this feature while there are applications in progress i.e. there may be applications that have already used the "old" way of entering work history breaks (the capture-all text box). This means we must - Improvise. Adapt. Overcome!

## Changes proposed in this pull request

This PR does some smol but important things:

- updates the existing breaks component to show the break length in years and months (this was done for the placeholder before but I forgot about existing breaks) and does so by extracting a method into `ViewHelper` and reusing it in `BreakInWorkHistoryComponent`
- redirects to the review work history page if the `work_breaks` feature flag is off when attempting to go to a page to create, edit, etc. an individual break

And then, makes the new feature "backwards-compatible" by taking into consideration whether the feature flag is on and whether there is a value already for `work_history_breaks` (the attribute that stores the capture-all work history breaks in comparison to `application_work_history_breaks` an array of `ApplicationWorkHistoryBreak`s).

It also ensures that change and delete links don't show in Support.

## Guidance to review

- Have a look at `spec/components/work_history_review_component_spec.rb` does the specs make sense? Would highly recommend you also test through the UI make it easier to visualise.
- Does the redirect make sense?
- Is there anything I am missing?

## Link to Trello card

https://trello.com/c/jIWipybM/732-calculate-work-gaps

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
