### PR TITLE
Add clearer page to explain when we send emails

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -23,3 +23,7 @@ linters:
         Enabled: false
       Rails/OutputSafety:
         Enabled: false
+      Layout/ElseAlignment:
+        Enabled: false
+      Layout/IndentationWidth:
+        Enabled: false

--- a/app/components/state_event_explanation_component.html.erb
+++ b/app/components/state_event_explanation_component.html.erb
@@ -4,26 +4,4 @@
 
     This will transition the application to the <%= govuk_link_to "#{human_transitions_to} state", "##{transitions_to}" %>.
   </p>
-
-  <% if development_details %>
-  <p class='govuk-body'>
-    <% if emails_sent_from_event.any? %>
-      Emails sent:
-
-      <ul class='govuk-list govuk-list--bullet'>
-      <% emails_sent_from_event.each do |email| %>
-        <li>
-          <% if Rails.application.config.action_mailer.show_previews %>
-            <%= govuk_link_to email.gsub('-', ' '), "/rails/mailers/" + email.gsub('-', '/') %>
-          <% else %>
-            <%= email.gsub('-', ' ') %>
-          <% end %>
-        </li>
-      <% end %>
-      </ul>
-    <% else %>
-      No emails are sent with this transition.
-    <% end %>
-  </p>
-  <% end %>
 </li>

--- a/app/components/state_event_explanation_component.rb
+++ b/app/components/state_event_explanation_component.rb
@@ -11,14 +11,6 @@ class StateEventExplanationComponent < ActionView::Component::Base
     @namespace = machine.i18n_namespace
   end
 
-  def emails_sent_from_event
-    if I18n.exists?("#{namespace}events.#{from_state}-#{event.name}.emails")
-      I18n.t!("#{namespace}events.#{from_state}-#{event.name}.emails")
-    else
-      []
-    end
-  end
-
   def human_transitions_to
     I18n.t!("#{namespace}application_states.#{transitions_to}.name")
   end

--- a/app/controllers/support_interface/docs_controller.rb
+++ b/app/controllers/support_interface/docs_controller.rb
@@ -3,5 +3,7 @@ module SupportInterface
     def provider_flow; end
 
     def candidate_flow; end
+
+    def when_emails_are_sent; end
   end
 end

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -29,7 +29,7 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.survey_chaser_email(application_form)
   end
 
-  def new_referee_request_with_not_responded
+  def new_referee_request
     CandidateMailer.new_referee_request(reference, reason: :not_responded)
   end
 

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -1,17 +1,19 @@
-<h2 class="govuk-heading-m">Product development</h2>
+<% if current_support_user %>
+  <h2 class="govuk-heading-m">Product development</h2>
 
-<ul class="govuk-footer__inline-list">
-  <li class="govuk-footer__inline-list-item">
-    <%= govuk_link_to 'Provider application flow', support_interface_provider_flow_path %>
-  </li>
+  <ul class="govuk-footer__inline-list">
+    <li class="govuk-footer__inline-list-item">
+      <%= govuk_link_to 'Provider application flow', support_interface_provider_flow_path %>
+    </li>
 
-  <li class="govuk-footer__inline-list-item">
-    <%= govuk_link_to 'Candidate application flow', support_interface_candidate_flow_path %>
-  </li>
+    <li class="govuk-footer__inline-list-item">
+      <%= govuk_link_to 'Candidate application flow', support_interface_candidate_flow_path %>
+    </li>
 
-  <% if Rails.application.config.action_mailer.show_previews %>
-  <li class="govuk-footer__inline-list-item">
-    <%= govuk_link_to 'Mail previews', '/rails/mailers' %>
-  </li>
-  <% end %>
-</ul>
+    <% if Rails.application.config.action_mailer.show_previews %>
+    <li class="govuk-footer__inline-list-item">
+      <%= govuk_link_to 'Mail previews', '/rails/mailers' %>
+    </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -10,6 +10,10 @@
       <%= govuk_link_to 'Candidate application flow', support_interface_candidate_flow_path %>
     </li>
 
+    <li class="govuk-footer__inline-list-item">
+      <%= govuk_link_to 'When emails are sent', support_interface_when_emails_are_sent_path %>
+    </li>
+
     <% if Rails.application.config.action_mailer.show_previews %>
     <li class="govuk-footer__inline-list-item">
       <%= govuk_link_to 'Mail previews', '/rails/mailers' %>

--- a/app/views/support_interface/docs/candidate_flow.html.erb
+++ b/app/views/support_interface/docs/candidate_flow.html.erb
@@ -4,6 +4,7 @@
   <%= render SubNavigationComponent.new(items: [
     { name: 'Provider application flow', url: support_interface_provider_flow_path },
     { name: 'Candidate application flow', url: support_interface_candidate_flow_path, current: true },
+    { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path },
   ]) %>
 <% end %>
 

--- a/app/views/support_interface/docs/provider_flow.html.erb
+++ b/app/views/support_interface/docs/provider_flow.html.erb
@@ -4,6 +4,7 @@
   <%= render SubNavigationComponent.new(items: [
     { name: 'Provider application flow', url: support_interface_provider_flow_path, current: true },
     { name: 'Candidate application flow', url: support_interface_candidate_flow_path },
+    { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path },
   ]) %>
 <% end %>
 

--- a/app/views/support_interface/docs/when_emails_are_sent.html.erb
+++ b/app/views/support_interface/docs/when_emails_are_sent.html.erb
@@ -19,6 +19,28 @@
 
   <h2 class='govuk-heading-l' id='<%= state_name %>'><%= human_state_name %></h2>
 
+  <p class='govuk-body'>
+    <% chaser_emails = I18n.exists?("application_states.#{state_name}.emails") ? I18n.t!("application_states.#{state_name}.emails") : [] %>
+
+    <% if chaser_emails.any? %>
+      In this state we send these chasers:
+
+      <ul class='govuk-list govuk-list--bullet'>
+      <% chaser_emails.each do |email_id| %>
+        <% email_name = email_id.gsub('-', ' ').gsub('candidate_mailer', 'To candidate: ').gsub('referee_mailer', 'To referee: ').gsub('provider_mailer', 'To provider: ') %>
+
+        <li>
+          <% if Rails.application.config.action_mailer.show_previews %>
+            <%= govuk_link_to email_name, '/rails/mailers/' + email_id.gsub('-', '/') %>
+          <% else %>
+            <%= email_name %>
+          <% end %>
+        </li>
+      <% end %>
+      </ul>
+    <% end %>
+  </p>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <ul class="govuk-list">
@@ -26,15 +48,13 @@
 
         <li>
           <p class='govuk-body'>
-            <strong><%= I18n.t!("events.#{state_name}-#{events.first}.name") %></strong> (by <%= I18n.t!("events.#{state_name}-#{events.first}.by") %>)
+            When <strong><%= I18n.t!("events.#{state_name}-#{events.first}.name") %></strong> we send these notifications:
           </p>
 
           <p class='govuk-body'>
             <% emails_sent_from_event = I18n.exists?("events.#{state_name}-#{events.first.name}.emails") ? I18n.t!("events.#{state_name}-#{events.first.name}.emails") : [] %>
 
             <% if emails_sent_from_event.any? %>
-              Emails sent:
-
               <ul class='govuk-list govuk-list--bullet'>
               <% emails_sent_from_event.each do |email_id| %>
                 <% email_name = email_id.gsub('-', ' ').gsub('candidate_mailer', 'To candidate: ').gsub('referee_mailer', 'To referee: ').gsub('provider_mailer', 'To provider: ') %>

--- a/app/views/support_interface/docs/when_emails_are_sent.html.erb
+++ b/app/views/support_interface/docs/when_emails_are_sent.html.erb
@@ -1,0 +1,66 @@
+<%= content_for :title, 'When emails are sent' %>
+
+<% content_for :before_content do %>
+  <%= render SubNavigationComponent.new(items: [
+    { name: 'Provider application flow', url: support_interface_provider_flow_path },
+    { name: 'Candidate application flow', url: support_interface_candidate_flow_path },
+    { name: 'When emails are sent', url: support_interface_when_emails_are_sent_path, current: true },
+  ]) %>
+<% end %>
+
+<style>
+  svg { max-width: 100%; }
+</style>
+
+<% ApplicationStateChange.workflow_spec.states.each do |_, state| %>
+  <% state_name = state.name.to_s %>
+  <% human_state_name = I18n.t!("application_states.#{state_name}.name") %>
+  <% next unless state.events.any? %>
+
+  <h2 class='govuk-heading-l' id='<%= state_name %>'><%= human_state_name %></h2>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <ul class="govuk-list">
+      <% state.events.each do |_, events| %>
+
+        <li>
+          <p class='govuk-body'>
+            <strong><%= I18n.t!("events.#{state_name}-#{events.first}.name") %></strong> (by <%= I18n.t!("events.#{state_name}-#{events.first}.by") %>)
+          </p>
+
+          <p class='govuk-body'>
+            <% emails_sent_from_event = I18n.exists?("events.#{state_name}-#{events.first.name}.emails") ? I18n.t!("events.#{state_name}-#{events.first.name}.emails") : [] %>
+
+            <% if emails_sent_from_event.any? %>
+              Emails sent:
+
+              <ul class='govuk-list govuk-list--bullet'>
+              <% emails_sent_from_event.each do |email_id| %>
+                <% email_name = email_id.gsub('-', ' ').gsub('candidate_mailer', 'To candidate: ').gsub('referee_mailer', 'To referee: ').gsub('provider_mailer', 'To provider: ') %>
+
+                <li>
+                  <% if Rails.application.config.action_mailer.show_previews %>
+                    <%= govuk_link_to email_name, '/rails/mailers/' + email_id.gsub('-', '/') %>
+                  <% else %>
+                    <%= email_name %>
+                  <% end %>
+                </li>
+              <% end %>
+              </ul>
+            <% else %>
+              No emails are sent with this transition.
+            <% end %>
+          </p>
+        </li>
+      <% end %>
+      </ul>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <%= StateDiagram.svg(only_from_state: state_name, machine: ApplicationStateChange) %>
+    </div>
+  </div>
+
+  <hr class='govuk-section-break govuk-section-break--xl govuk-section-break--visible'>
+<% end %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -85,6 +85,10 @@ en:
       description: |
         The candidate submits their application choices with a list of referees. Until 2 references have been received all applications remain in the Awaiting references state.
         The providers don’t see the application at this stage.
+      emails:
+        - candidate_mailer-chase_reference
+        - candidate_mailer-new_referee_request
+        - referee_mailer-reference_request_chaser_email
 
     application_complete:
       name: Waiting to be sent
@@ -102,6 +106,8 @@ en:
 
         When both of these prerequisites are met the application moves to the
         Awaiting provider decision state.
+      emails:
+        - provider_mailer-chase_provider_decision
 
     offer:
       name: Offer made
@@ -112,6 +118,8 @@ en:
 
         We assume that all offers have some conditions, even if there
         are no academic conditions.
+      emails:
+        - candidate_mailer-chase_candidate_decision
 
     recruited:
       name: Recruited
@@ -161,9 +169,6 @@ en:
       emails:
         - candidate_mailer-application_submitted
         - referee_mailer-reference_request_email
-        - referee_mailer-reference_request_chaser_email
-        - candidate_mailer-new_referee_request
-        - candidate_mailer-chase_reference
 
     awaiting_references-references_complete:
       name: References are completed
@@ -180,10 +185,9 @@ en:
       emails:
         - candidate_mailer-application_sent_to_provider
         - provider_mailer-application_submitted
-        - provider_mailer-chase_provider_decision
 
     application_complete-withdraw:
-      name: Withdraw
+      name: Candidate withdraws
       by: candidate
       description: Candidates can withdraw at any time.
 
@@ -205,7 +209,6 @@ en:
         - candidate_mailer-new_offer_single_offer
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending
-        - candidate_mailer-chase_candidate_decision
 
     awaiting_provider_decision-reject:
       name: Provider rejects
@@ -223,7 +226,7 @@ en:
         - candidate_mailer-application_rejected_offers_made
 
     awaiting_provider_decision-withdraw:
-      name: Withdraw
+      name: Candidate withdraws
       by: candidate
       description: |
         The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time.
@@ -288,7 +291,7 @@ en:
       # https://trello.com/c/QNmoQxi1/1027-email-provider-says-candidate-has-not-met-conditions-candidate
 
     pending_conditions-withdraw:
-      name: Withdraw
+      name: Candidate withdraws
       by: candidate
       description: Candidates can withdraw at any time.
 
@@ -298,7 +301,7 @@ en:
       description: ""
 
     recruited-withdraw:
-      name: Withdraw
+      name: Candidate withdraws
       by: candidate
       description: Candidates can withdraw at any time.
 

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -179,7 +179,7 @@ en:
         - referee_mailer-reference_confirmation_email
 
     application_complete-send_to_provider:
-      name: Send to provider
+      name: Application is sent to provider
       by: system
       description: 5 days after submission the application is sent to providers. This is to give candidates the opportunity to edit their application.
       emails:
@@ -232,7 +232,7 @@ en:
         The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time.
 
     awaiting_provider_decision-reject_by_default:
-      name: Reject by default
+      name: Rejected by default
       by: system
       description: |
         An application is rejected by default (RBD) if the provider doesn’t make an offer within 40 working days after they have received an application.
@@ -250,7 +250,7 @@ en:
         - candidate_mailer-new_offer_decisions_pending
 
     offer-decline_by_default:
-      name: Decline by default
+      name: Declined by default
       by: system
       description: The candidate has to respond within 5 days, otherwise the system will decline the offer.
       emails:
@@ -279,13 +279,13 @@ en:
       # https://trello.com/c/jYzNQIaZ/1047-email-a-candidate-has-declined-an-offer-provider
 
     pending_conditions-confirm_conditions_met:
-      name: Confirm conditions are met
+      name: Provider confirms conditions are met
       by: provider
       description: The provider confirms that the candidate has met the conditions set out in the offer.
       # https://trello.com/c/XrlNFh5d/1028-email-provider-says-candidate-has-met-all-conditions-candidate
 
     pending_conditions-conditions_not_met:
-      name: Mark conditions as not met
+      name: Providers marks conditions as not met
       by: provider
       description: The provider says the candidate hasn’t met the conditions set out in the offer.
       # https://trello.com/c/QNmoQxi1/1027-email-provider-says-candidate-has-not-met-conditions-candidate
@@ -296,7 +296,7 @@ en:
       description: Candidates can withdraw at any time.
 
     recruited-confirm_enrolment:
-      name: Confirm enrolment
+      name: Provider confirms enrolment
       by: provider
       description: ""
 
@@ -306,7 +306,7 @@ en:
       description: Candidates can withdraw at any time.
 
     rejected-make_offer:
-      name: Make offer
+      name: Provider makes offer
       by: provider
       description: ""
       emails:

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -161,6 +161,9 @@ en:
       emails:
         - candidate_mailer-application_submitted
         - referee_mailer-reference_request_email
+        - referee_mailer-reference_request_chaser_email
+        - candidate_mailer-new_referee_request
+        - candidate_mailer-chase_reference
 
     awaiting_references-references_complete:
       name: References are completed
@@ -177,6 +180,7 @@ en:
       emails:
         - candidate_mailer-application_sent_to_provider
         - provider_mailer-application_submitted
+        - provider_mailer-chase_provider_decision
 
     application_complete-withdraw:
       name: Withdraw
@@ -201,6 +205,7 @@ en:
         - candidate_mailer-new_offer_single_offer
         - candidate_mailer-new_offer_multiple_offers
         - candidate_mailer-new_offer_decisions_pending
+        - candidate_mailer-chase_candidate_decision
 
     awaiting_provider_decision-reject:
       name: Provider rejects
@@ -236,6 +241,10 @@ en:
       by: provider
       description: |
         The provider is able to update their offer at any time before the candidate has accepted it. An updated offer may have different conditions or be for a different course.
+      emails:
+        - candidate_mailer-new_offer_single_offer
+        - candidate_mailer-new_offer_multiple_offers
+        - candidate_mailer-new_offer_decisions_pending
 
     offer-decline_by_default:
       name: Decline by default
@@ -243,31 +252,40 @@ en:
       description: The candidate has to respond within 5 days, otherwise the system will decline the offer.
       emails:
         - candidate_mailer-declined_by_default
+        # https://trello.com/c/UpGaBWKg/1046-email-application-declined-by-default-as-offer-not-responded-to-within-10-days-provider
 
     offer-reject:
       name: Provider rescinds offer
       by: provider
       description: As long as the candidate hasn’t accepted the offer, the provider can reject the application.
+      emails:
+        - candidate_mailer-application_rejected_all_rejected
+        - candidate_mailer-application_rejected_awaiting_decisions
+        - candidate_mailer-application_rejected_offers_made
 
     offer-accept:
       name: Candidate accepts offer
       by: candidate
       description: The candidate can accept the offer. All other application choices will be withdrawn.
+      # https://trello.com/c/Xt431Th8/1025-email-candidate-has-accepted-offer-provider
 
     offer-decline:
       name: Candidate declines offer
       by: candidate
       description: The candidate can decline the offer.
+      # https://trello.com/c/jYzNQIaZ/1047-email-a-candidate-has-declined-an-offer-provider
 
     pending_conditions-confirm_conditions_met:
       name: Confirm conditions are met
       by: provider
       description: The provider confirms that the candidate has met the conditions set out in the offer.
+      # https://trello.com/c/XrlNFh5d/1028-email-provider-says-candidate-has-met-all-conditions-candidate
 
     pending_conditions-conditions_not_met:
       name: Mark conditions as not met
       by: provider
       description: The provider says the candidate hasn’t met the conditions set out in the offer.
+      # https://trello.com/c/QNmoQxi1/1027-email-provider-says-candidate-has-not-met-conditions-candidate
 
     pending_conditions-withdraw:
       name: Withdraw
@@ -288,14 +306,16 @@ en:
       name: Make offer
       by: provider
       description: ""
+      emails:
+        - candidate_mailer-new_offer_single_offer
+        - candidate_mailer-new_offer_multiple_offers
+        - candidate_mailer-new_offer_decisions_pending
 
   candidate_flow_events:
     not_signed_up-sign_up:
       name: Sign up
       by: candidate
       description: ''
-      emails:
-        - authentication_mailer-sign_up_email
 
     never_signed_in-sign_in:
       name: Sign in

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -333,6 +333,7 @@ Rails.application.routes.draw do
 
     get '/provider-flow', to: 'docs#provider_flow', as: :provider_flow
     get '/candidate-flow', to: 'docs#candidate_flow', as: :candidate_flow
+    get '/when-emails-are-sent', to: 'docs#when_emails_are_sent', as: :when_emails_are_sent
 
     get '/applications' => 'application_forms#index'
     get '/applications/:application_form_id' => 'application_forms#show', as: :application_form

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -37,8 +37,9 @@ RSpec.feature 'Docs' do
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"
     emails_sent = [CandidateMailer, ProviderMailer, RefereeMailer].flat_map { |k| k.public_instance_methods(false).map { |m| "#{k.name.underscore}-#{m}" } }
     documented_application_choice_emails = I18n.t('events').flat_map { |_name, attrs| attrs[:emails] }.compact.uniq
+    documented_chaser_emails = I18n.t('application_states').flat_map { |_name, attrs| attrs[:emails] }.compact.uniq
 
-    emails_documented = documented_application_choice_emails + emails_outside_of_states
+    emails_documented = documented_application_choice_emails + documented_chaser_emails + emails_outside_of_states
 
     expect(emails_documented).to match_array(emails_sent)
   end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -29,24 +29,16 @@ RSpec.feature 'Docs' do
 
   def and_it_contains_documentation_for_all_emails
     emails_outside_of_states = %w[
-      authentication_mailer-sign_in_email
-      authentication_mailer-sign_in_without_account_email
-      candidate_mailer-new_referee_request
-      candidate_mailer-chase_reference
       candidate_mailer-survey_chaser_email
       candidate_mailer-survey_email
-      candidate_mailer-chase_candidate_decision
       provider_mailer-account_created
-      provider_mailer-chase_provider_decision
-      referee_mailer-reference_request_chaser_email
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"
-    emails_sent = [CandidateMailer, ProviderMailer, RefereeMailer, AuthenticationMailer].flat_map { |k| k.public_instance_methods(false).map { |m| "#{k.name.underscore}-#{m}" } }
-    documented_application_choice_emails = I18n.t('events').flat_map { |_name, attrs| attrs[:emails] }.compact
-    documented_application_form_emails = I18n.t('candidate_flow_events').flat_map { |_name, attrs| attrs[:emails] }.compact
+    emails_sent = [CandidateMailer, ProviderMailer, RefereeMailer].flat_map { |k| k.public_instance_methods(false).map { |m| "#{k.name.underscore}-#{m}" } }
+    documented_application_choice_emails = I18n.t('events').flat_map { |_name, attrs| attrs[:emails] }.compact.uniq
 
-    emails_documented = documented_application_choice_emails + documented_application_form_emails + emails_outside_of_states
+    emails_documented = documented_application_choice_emails + emails_outside_of_states
 
     expect(emails_documented).to match_array(emails_sent)
   end


### PR DESCRIPTION
## Context

Currently we have a page that explains states, actions/events and when emails are sent. This is a little too much.

## Changes proposed in this pull request

This pulls out the information about when we send emails into a separate page that just focuses on email. It clears up the state transition page, and makes it clearer when we send emails.

It also separates out chaser emails from notifications. Hopefully it makes sense!

![image](https://user-images.githubusercontent.com/233676/74836523-788bc300-5317-11ea-80f7-0b32370b841a.png)


## Guidance to review

{{ heroku link once up }}

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
