### PR TITLE
Send notification to provider when application is declined by default

### DIFF
--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -19,6 +19,10 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.offer_accepted(provider_user, application_choice)
   end
 
+  def declined_by_default
+    ProviderMailer.declined_by_default(provider_user, application_choice)
+  end
+
 private
 
   def application_choice

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -85,6 +85,14 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def declined_by_default(provider_user, application_choice)
+    @application_choice = application_choice
+    email_for_provider(
+      provider_user,
+      subject: I18n.t!('provider_mailer.decline_by_default.subject', candidate_name: application_choice.application_form.full_name),
+    )
+  end
+
 private
 
   def email_for_provider(provider_user, args = {})

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -10,6 +10,12 @@ class DeclineOfferByDefault
       application_form.application_choices.offer.each do |application_choice|
         application_choice.update!(declined_by_default: true, declined_at: Time.zone.now)
         ApplicationStateChange.new(application_choice).decline_by_default!
+
+        if FeatureFlag.active?('decline_by_default_notification_to_provider')
+          application_choice.provider.provider_users.each do |provider_user|
+            ProviderMailer.declined_by_default(provider_user, application_choice).deliver
+          end
+        end
       end
 
       if FeatureFlag.active?('decline_by_default_notification_to_candidate')

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -19,6 +19,7 @@ class FeatureFlag
     automated_decline_by_default_candidate_chaser
     decline_by_default_notification_to_candidate
     offer_accepted_provider_emails
+    decline_by_default_notification_to_provider
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/provider_mailer/declined_by_default.text.erb
+++ b/app/views/provider_mailer/declined_by_default.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+# Application withdrawn automatically
+
+We withdrew <%= @application_choice.application_form.full_name %>’s application for <%= @application_choice.course.name_and_code %> because they didn’t respond to the offer within <%= @application_choice.decline_by_default_days %> working days.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -255,7 +255,7 @@ en:
       description: The candidate has to respond within 5 days, otherwise the system will decline the offer.
       emails:
         - candidate_mailer-declined_by_default
-        # https://trello.com/c/UpGaBWKg/1046-email-application-declined-by-default-as-offer-not-responded-to-within-10-days-provider
+        - provider_mailer-declined_by_default
 
     offer-reject:
       name: Provider rescinds offer

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -2,3 +2,5 @@ en:
   provider_mailer:
     offer_accepted:
       subject: '%{candidate_name} has accepted your offer'
+    decline_by_default:
+      subject: '%{candidate_name}’s application withdrawn automatically'

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -165,4 +165,15 @@ RSpec.describe ProviderMailer, type: :mailer do
       expect(@mail.body.encoded).to include(application_choice.course.name_and_code)
     end
   end
+
+  describe '.declined_by_default' do
+    before do
+      @mail = mailer.declined_by_default(provider_user, application_choice)
+    end
+
+    it 'includes the course details' do
+      expect(@mail.body.encoded).to include(application_choice.course.name)
+      expect(@mail.body.encoded).to include(application_choice.course.code)
+    end
+  end
 end

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Decline by default' do
     and_when_the_decline_by_default_limit_has_been_exceeded
     then_the_application_choice_is_declined
     and_the_candidate_receives_an_email
+    and_the_provider_receives_an_email
   end
 
   def given_the_pilot_is_open
@@ -24,11 +25,14 @@ RSpec.feature 'Decline by default' do
   def and_the_automated_candidate_chaser_is_active
     FeatureFlag.activate('automated_decline_by_default_candidate_chaser')
     FeatureFlag.activate('decline_by_default_notification_to_candidate')
+    FeatureFlag.activate('decline_by_default_notification_to_provider')
   end
 
   def when_i_have_an_offer_waiting_for_my_decision
-    @application_form = create(:completed_application_form)
+    @application_form = create(:completed_application_form, first_name: 'Harry', last_name: 'Potter')
     @application_choice = create(:application_choice, status: :offer, application_form: @application_form, decline_by_default_at: Time.zone.now + 10.days)
+
+    @provider_user = create(:provider_user, providers: [@application_choice.provider])
   end
 
   def and_the_time_limit_before_decline_by_default_date_has_been_exceeded
@@ -65,5 +69,11 @@ RSpec.feature 'Decline by default' do
     open_email(@application_form.candidate.email_address)
 
     expect(current_email.subject).to include('Application withdrawn automatically')
+  end
+
+  def and_the_provider_receives_an_email
+    open_email(@provider_user.email_address)
+
+    expect(current_email.subject).to include('Harry Potter’s application withdrawn automatically')
   end
 end


### PR DESCRIPTION
## Context

Same as https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1420, but then an email to the provider!

## Changes proposed in this pull request

https://apply-for-te-1046-email-vzw91f.herokuapp.com/rails/mailers/provider_mailer/declined_by_default

## Guidance to review

Similar to the previous ones!

## Link to Trello card

https://trello.com/c/UpGaBWKg/1046-email-application-declined-by-default-as-offer-not-responded-to-within-10-days-provider

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
