### PR TITLE
Email candidate when conditions are met or not met

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -155,6 +155,28 @@ class CandidateMailer < ApplicationMailer
     email_for_candidate(application_form, subject: I18n.t!('candidate_mailer.declined_by_default.subject', count: @declined_courses.size))
   end
 
+  def conditions_met(application_choice)
+    @application_choice = application_choice
+    course = application_choice.course_option.course
+    course_name = "#{course.name_and_code} at #{course.provider.name}"
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.conditions_met.subject', course_name: course_name),
+    )
+  end
+
+  def conditions_not_met(application_choice)
+    @application_choice = application_choice
+    course = application_choice.course_option.course
+    course_name = "#{course.name_and_code} at #{course.provider.name}"
+
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.conditions_not_met.subject', course_name: course_name),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -195,6 +195,14 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.declined_by_default(application_form)
   end
 
+  def conditions_met
+    CandidateMailer.conditions_met(application_choice_with_offer)
+  end
+
+  def conditions_not_met
+    CandidateMailer.conditions_not_met(application_choice_with_offer)
+  end
+
 private
 
   def application_form

--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -8,6 +8,7 @@ class ConditionsNotMet
   def save
     ApplicationStateChange.new(@application_choice).conditions_not_met!
     @application_choice.update!(conditions_not_met_at: Time.zone.now)
+    CandidateMailer.conditions_not_met(@application_choice).deliver
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -8,6 +8,7 @@ class ConfirmOfferConditions
   def save
     ApplicationStateChange.new(@application_choice).confirm_conditions_met!
     @application_choice.update!(recruited_at: Time.zone.now)
+    CandidateMailer.conditions_met(@application_choice).deliver
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/views/candidate_mailer/conditions_met.text.erb
+++ b/app/views/candidate_mailer/conditions_met.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @application_form.first_name %>,
+
+# You’ve met your conditions
+
+Congratulations, <%= @application_choice.course_option.course.provider.name %> has confirmed that you’ve met your conditions for <%= @application_choice.course_option.course.name_and_code %>.
+
+# Next steps
+
+If they haven’t already, <%= @application_choice.course_option.course.provider.name %> should be in contact about enrolling on the course. You can contact them directly if you have any questions about this process.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/conditions_not_met.text.erb
+++ b/app/views/candidate_mailer/conditions_not_met.text.erb
@@ -1,0 +1,11 @@
+Dear <%= @application_form.first_name %>,
+
+# You have not met your conditions
+
+You can’t enrol on <%= @application_choice.course_option.course.name_and_code %> because <%= @application_choice.course_option.course.provider.name %> told us you have not met your conditions.
+
+Get in touch with <%= @application_choice.course_option.course.provider.name %> if you need further advice.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -282,13 +282,15 @@ en:
       name: Provider confirms conditions are met
       by: provider
       description: The provider confirms that the candidate has met the conditions set out in the offer.
-      # https://trello.com/c/XrlNFh5d/1028-email-provider-says-candidate-has-met-all-conditions-candidate
+      emails:
+        - candidate_mailer-conditions_met
 
     pending_conditions-conditions_not_met:
       name: Providers marks conditions as not met
       by: provider
       description: The provider says the candidate hasn’t met the conditions set out in the offer.
-      # https://trello.com/c/QNmoQxi1/1027-email-provider-says-candidate-has-not-met-conditions-candidate
+      emails:
+        - candidate_mailer-conditions_not_met
 
     pending_conditions-withdraw:
       name: Candidate withdraws

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -34,3 +34,7 @@ en:
       subject:
         one: Application withdrawn automatically
         other: Applications withdrawn automatically
+    conditions_met:
+      subject: "You have met your conditions for %{course_name}: next steps"
+    conditions_not_met:
+      subject: "You have not met your conditions for %{course_name}: next steps"

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Confirm conditions met' do
     then_i_get_feedback_that_my_action_succeeded
     and_i_am_back_on_the_application_page
     and_the_candidate_is_recruited
+    and_the_candidate_receives_an_email_notification
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -82,5 +83,10 @@ RSpec.feature 'Confirm conditions met' do
   def and_the_candidate_is_recruited
     expect(@application_choice.reload.recruited?).to be_truthy
     expect(page).to have_content 'Recruited'
+  end
+
+  def and_the_candidate_receives_an_email_notification
+    open_email(@application_choice.application_form.candidate.email_address)
+    expect(current_email.subject).to have_content 'You have met your conditions for'
   end
 end

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -18,6 +18,7 @@ RSpec.feature 'Confirm conditions not met' do
     then_i_get_feedback_that_my_action_succeeded
     and_i_am_back_on_the_application_page
     and_the_application_status_is_conditions_not_met
+    and_the_candidate_receives_an_email_notification
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -40,7 +41,7 @@ RSpec.feature 'Confirm conditions not met' do
   end
 
   def when_i_navigate_to_an_offer_accepted_by_the_candidate
-    course_option = course_option_for_provider_code(provider_code: @provider.code)
+    @course_option = course_option_for_provider_code(provider_code: @provider.code)
     @application_form = create(
       :completed_application_form,
       first_name: 'John',
@@ -49,7 +50,7 @@ RSpec.feature 'Confirm conditions not met' do
     @application_choice = create(
       :application_choice,
       :with_accepted_offer,
-      course_option: course_option,
+      course_option: @course_option,
       application_form: @application_form,
     )
     visit provider_interface_application_choice_path(@application_choice.id)
@@ -82,5 +83,10 @@ RSpec.feature 'Confirm conditions not met' do
   def and_the_application_status_is_conditions_not_met
     expect(@application_choice.reload.conditions_not_met?).to be_truthy
     expect(page).to have_content 'Conditions not met'
+  end
+
+  def and_the_candidate_receives_an_email_notification
+    open_email(@application_choice.application_form.candidate.email_address)
+    expect(current_email.subject).to have_content 'You have not met your conditions for'
   end
 end


### PR DESCRIPTION
## Context

This emails the candidate when the provider has said they met or haven't met the offer conditions.

## Changes proposed in this pull request

See commit - nothing advanced going on here.

## Guidance to review

https://apply-for-te-conditions-fb3ngo.herokuapp.com/rails/mailers/candidate_mailer/conditions_met
https://apply-for-te-conditions-fb3ngo.herokuapp.com/rails/mailers/candidate_mailer/conditions_not_met

## Link to Trello card

Two tickets for the price of 1!

https://trello.com/c/XrlNFh5d https://trello.com/c/QNmoQxi1

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
