### PR TITLE
Email to provider when a candidate has withdrawn application

### DIFF
--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -22,6 +22,10 @@ class ProviderMailerPreview < ActionMailer::Preview
   def declined_by_default
     ProviderMailer.declined_by_default(provider_user, application_choice)
   end
+  
+  def application_withrawn
+    ProviderMailer.application_withrawn(provider_user, application_choice)
+  end
 
 private
 

--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -22,7 +22,7 @@ class ProviderMailerPreview < ActionMailer::Preview
   def declined_by_default
     ProviderMailer.declined_by_default(provider_user, application_choice)
   end
-  
+
   def application_withrawn
     ProviderMailer.application_withrawn(provider_user, application_choice)
   end

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -93,6 +93,15 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def application_withrawn(provider_user, application_choice)
+    @application_choice = application_choice
+
+    email_for_provider(
+      provider_user,
+      subject: I18n.t!('provider_application_withrawnn.email.subject', candidate_name: application_choice.application_form.full_name),
+    )
+  end
+
 private
 
   def email_for_provider(provider_user, args = {})

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -20,6 +20,7 @@ class FeatureFlag
     decline_by_default_notification_to_candidate
     offer_accepted_provider_emails
     decline_by_default_notification_to_provider
+    application_withrawn_provider_email
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -10,10 +10,17 @@ class WithdrawApplication
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
 
       StateChangeNotifier.call(:withdraw, application_choice: application_choice)
+      send_email_notification_to_provider_users(application_choice) if FeatureFlag.active?('application_withrawn_provider_email')
     end
   end
 
 private
 
   attr_reader :application_choice
+
+  def send_email_notification_to_provider_users(application_choice)
+    application_choice.provider.provider_users.each do |provider_user|
+      ProviderMailer.application_withrawn(provider_user, application_choice).deliver
+    end
+  end
 end

--- a/app/views/provider_mailer/application_withrawn.text.erb
+++ b/app/views/provider_mailer/application_withrawn.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+# Application withdrawn
+
+<%= @application_choice.application_form.full_name %> withdrew their application for <%= @application_choice.course_option.course.name_and_code %>.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -190,6 +190,8 @@ en:
       name: Candidate withdraws
       by: candidate
       description: Candidates can withdraw at any time.
+      emails:
+        - provider_mailer-application_withrawn
 
     awaiting_provider_decision-make_offer:
       name: Provider makes offer
@@ -230,6 +232,8 @@ en:
       by: candidate
       description: |
         The candidate makes a withdrawal decision to inform the provider that they no longer want their application to be considered. The candidate can withdraw an application at any time.
+      emails:
+        - provider_mailer-application_withrawn
 
     awaiting_provider_decision-reject_by_default:
       name: Rejected by default
@@ -292,7 +296,7 @@ en:
       description: The provider says the candidate hasn’t met the conditions set out in the offer.
       emails:
         - candidate_mailer-conditions_not_met
-
+        - provider_mailer-application_withrawn
     pending_conditions-withdraw:
       name: Candidate withdraws
       by: candidate
@@ -307,6 +311,8 @@ en:
       name: Candidate withdraws
       by: candidate
       description: Candidates can withdraw at any time.
+      emails:
+        - provider_mailer-application_withrawn
 
     rejected-make_offer:
       name: Provider makes offer

--- a/config/locales/provider_notifications.yml
+++ b/config/locales/provider_notifications.yml
@@ -11,3 +11,6 @@ en:
   provider_application_waiting_for_decision:
     email:
       subject: 'Respond to %{candidate_name}’s application'
+  provider_application_withrawnn:
+    email:
+      subject: '%{candidate_name} withdrew their application'

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -176,4 +176,30 @@ RSpec.describe ProviderMailer, type: :mailer do
       expect(@mail.body.encoded).to include(application_choice.course.code)
     end
   end
+
+  describe 'Send email when the application withdrawn' do
+    before do
+      @mail = mailer.application_withrawn(provider_user, application_choice)
+    end
+
+    it 'sends an email with the correct subject' do
+      expect(@mail.subject).to include(
+        t('provider_application_withrawnn.email.subject',
+          candidate_name: application_choice.application_form.full_name),
+        )
+    end
+
+    it 'addresses the provider user by name' do
+      expect(@mail.body.encoded).to include("Dear #{provider_user.full_name}")
+    end
+
+    it 'includes the candidate name' do
+      expect(@mail.body.encoded).to include(application_choice.application_form.full_name.to_s)
+    end
+
+    it 'includes the course details' do
+      expect(@mail.body.encoded).to include(application_choice.course.name)
+      expect(@mail.body.encoded).to include(application_choice.course.code)
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'A candidate withdraws her application' do
 
   scenario 'successful withdrawal', sidekiq: true do
     given_i_am_signed_in_as_a_candidate
+    and_the_application_withdrawn_provider_email_feature_flag_is_active
     and_i_have_an_application_choice_awaiting_provider_decision
 
     when_i_visit_the_application_dashboard
@@ -14,6 +15,7 @@ RSpec.feature 'A candidate withdraws her application' do
     when_i_click_to_confirm_withdrawal
     then_my_application_should_be_withdrawn
     and_a_slack_notification_is_sent
+    and_the_provider_has_received_an_email
 
     when_i_try_to_visit_the_withdraw_page
     then_i_see_the_page_not_found
@@ -26,6 +28,8 @@ RSpec.feature 'A candidate withdraws her application' do
   def and_i_have_an_application_choice_awaiting_provider_decision
     form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
     @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: form)
+    @provider_user = create(:provider_user)
+    create(:provider_users_provider, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
   end
 
   def when_i_visit_the_application_dashboard
@@ -58,5 +62,14 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def then_i_see_the_page_not_found
     expect(page).to have_content('Page not found')
+  end
+
+  def and_the_application_withdrawn_provider_email_feature_flag_is_active
+    FeatureFlag.activate('application_withrawn_provider_email')
+  end
+
+  def and_the_provider_has_received_an_email
+    open_email(@provider_user.email_address)
+    expect(current_email.subject).to have_content "#{@application_choice.application_form.full_name} withdrew their application"
   end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature 'Docs' do
       candidate_mailer-survey_chaser_email
       candidate_mailer-survey_email
       provider_mailer-account_created
+      provider_mailer-application_withrawn
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -32,7 +32,6 @@ RSpec.feature 'Docs' do
       candidate_mailer-survey_chaser_email
       candidate_mailer-survey_email
       provider_mailer-account_created
-      provider_mailer-application_withrawn
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context
We want to send an email to providers when an application has withdrawn so they are aware of my decision
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request
This PR adds: 
- The `#application_withrawn` email to the provider mailer and template
- Call the mailer when the application has withdrawn
- End-to-end test and preview accordingly

### Preview:
![image](https://user-images.githubusercontent.com/22743709/74855756-04621700-5339-11ea-8d3c-88b6a559886e.png)

<!-- If there are UI changes, please include Before and After screenshots. -->
## Guidance to review
👀 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/KdJ2N1e9/1031-email-candidate-has-withdrawn-application-provider

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
