### PR TITLE
Improve existing content

### DIFF
--- a/app/components/provider_interface/edit_response_options_component.html.erb
+++ b/app/components/provider_interface/edit_response_options_component.html.erb
@@ -4,7 +4,6 @@
     options,
     :value,
     :name,
-    :description,
     legend: { text: 'Choose response' },
   )
 %>

--- a/app/components/provider_interface/edit_response_options_component.rb
+++ b/app/components/provider_interface/edit_response_options_component.rb
@@ -9,8 +9,7 @@ module ProviderInterface
     OPTIONS = [
       OpenStruct.new(
         value: 'different_course',
-        name: 'Offer a different course',
-        description: 'Include any conditions or recommendations',
+        name: 'Offer a different course'
       ),
       OpenStruct.new(
         value: 'withdraw_offer',

--- a/app/components/provider_interface/edit_response_options_component.rb
+++ b/app/components/provider_interface/edit_response_options_component.rb
@@ -9,7 +9,7 @@ module ProviderInterface
     OPTIONS = [
       OpenStruct.new(
         value: 'different_course',
-        name: 'Offer a different course'
+        name: 'Offer a different course',
       ),
       OpenStruct.new(
         value: 'withdraw_offer',

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -50,7 +50,7 @@ module ProviderInterface
       )
 
       if @application_offer.save
-        flash[:success] = 'Application status changed to ‘Offer made’'
+        flash[:success] = 'Offer successfully made to candidate'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,
         )
@@ -77,7 +77,7 @@ module ProviderInterface
         rejection_reason: params.dig(:reject_application, :rejection_reason),
       )
       if @reject_application.save
-        flash[:success] = 'Application status changed to ‘Rejected’'
+        flash[:success] = 'Application successfully rejected'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,
         )
@@ -125,7 +125,7 @@ module ProviderInterface
         offer_withdrawal_reason: params.dig(:withdraw_offer, :offer_withdrawal_reason),
       )
       if @withdraw_offer.save
-        flash[:success] = 'Application status changed to ‘Offer withdrawn’'
+        flash[:success] = 'Offer successfully withdrawn'
         redirect_to provider_interface_application_choice_path(
           application_choice_id: @application_choice.id,
         )

--- a/app/views/provider_interface/conditions/confirm_update.html.erb
+++ b/app/views/provider_interface/conditions/confirm_update.html.erb
@@ -1,41 +1,46 @@
 <% content_for :browser_title, 'Confirm conditions' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
-<%= form_with model: @conditions_form,
-      url: provider_interface_application_choice_update_conditions_path(@application_choice.id),
-      method: :patch do |f| %>
-  <%= f.govuk_error_summary %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-  <h1 class="govuk-heading-xl">
-    <% if @conditions_form.conditions_met? %>
-      Are you sure the candidate met the conditions?
-    <% else %>
-      Are you sure the candidate did not meet the conditions?
+    <%= form_with model: @conditions_form,
+          url: provider_interface_application_choice_update_conditions_path(@application_choice.id),
+          method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <% if @conditions_form.conditions_met? %>
+          Check and confirm conditions have been met
+        <% else %>
+          Check and confirm conditions have not been met
+        <% end %>
+      </h1>
+
+      <%= render SummaryListComponent.new(rows: [
+        { key: 'Candidate name', value: @application_choice.application_form.full_name },
+        { key: 'Course', value: @application_choice.course.name_and_code },
+        { key: 'Preferred location', value: @application_choice.site.name },
+        { key: 'Provider', value: @application_choice.course.provider.name_and_code },
+      ]) %>
+
+      <h2 class="govuk-heading-l">
+        Conditions
+      </h2>
+
+      <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice) %>
+
+      <%= f.hidden_field :conditions_met %>
+
+      <% if @conditions_form.conditions_met? %>
+        <%= f.submit 'Confirm conditions as met', class: 'govuk-button', data: { module: 'govuk-button' } %>
+      <% else %>
+        <%= f.submit 'Confirm conditions as not met', class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <% end %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
     <% end %>
-  </h1>
-
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Candidate name', value: @application_choice.application_form.full_name },
-    { key: 'Course', value: @application_choice.course.name_and_code },
-    { key: 'Preferred location', value: @application_choice.site.name },
-    { key: 'Provider', value: @application_choice.course.provider.name_and_code },
-  ]) %>
-
-  <h2 class="govuk-heading-l">
-    Conditions
-  </h2>
-
-  <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice) %>
-
-  <%= f.hidden_field :conditions_met %>
-
-  <% if @conditions_form.conditions_met? %>
-    <%= f.submit 'Yes I’m sure – they met the conditions', class: 'govuk-button', data: { module: 'govuk-button' } %>
-  <% else %>
-    <%= f.submit 'Yes I’m sure – they did not meet the conditions', class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
-  <% end %>
-
-  <p class="govuk-body">
-    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
-  </p>
-<% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/conditions/confirm_update.html.erb
+++ b/app/views/provider_interface/conditions/confirm_update.html.erb
@@ -33,9 +33,9 @@
       <%= f.hidden_field :conditions_met %>
 
       <% if @conditions_form.conditions_met? %>
-        <%= f.submit 'Confirm conditions as met', class: 'govuk-button', data: { module: 'govuk-button' } %>
+        <%= f.submit 'Confirm they have met your condition', class: 'govuk-button', data: { module: 'govuk-button' } %>
       <% else %>
-        <%= f.submit 'Confirm conditions as not met', class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+        <%= f.submit 'Confirm they have not met your condition', class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
       <% end %>
 
       <p class="govuk-body">

--- a/app/views/provider_interface/conditions/confirm_update.html.erb
+++ b/app/views/provider_interface/conditions/confirm_update.html.erb
@@ -33,9 +33,9 @@
       <%= f.hidden_field :conditions_met %>
 
       <% if @conditions_form.conditions_met? %>
-        <%= f.submit 'Confirm they have met your condition', class: 'govuk-button', data: { module: 'govuk-button' } %>
+        <%= f.submit 'Confirm they have met your conditions', class: 'govuk-button', data: { module: 'govuk-button' } %>
       <% else %>
-        <%= f.submit 'Confirm they have not met your condition', class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+        <%= f.submit 'Confirm they have not met your conditions', class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
       <% end %>
 
       <p class="govuk-body">

--- a/app/views/provider_interface/conditions/edit.html.erb
+++ b/app/views/provider_interface/conditions/edit.html.erb
@@ -1,36 +1,41 @@
 <% content_for :browser_title, 'Confirm conditions' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_path(@application_choice.id)) %>
 
-<%= form_with model: @conditions_form,
-      url: provider_interface_application_choice_confirm_update_conditions_path(@application_choice.id),
-      method: :patch do |f| %>
-  <%= f.govuk_error_summary %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-  <h1 class="govuk-heading-xl">
-    Confirm if the candidate has met all conditions
-  </h1>
+    <%= form_with model: @conditions_form,
+          url: provider_interface_application_choice_confirm_update_conditions_path(@application_choice.id),
+          method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Candidate name', value: @application_choice.application_form.full_name },
-    { key: 'Course', value: @application_choice.course.name_and_code },
-    { key: 'Preferred location', value: @application_choice.site.name },
-    { key: 'Provider', value: @application_choice.course.provider.name_and_code },
-  ]) %>
+      <h1 class="govuk-heading-xl">
+        Confirm if the candidate has met all conditions
+      </h1>
 
-  <h2 class="govuk-heading-l govuk-!-margin-top-8">
-    Conditions
-  </h2>
+      <%= render SummaryListComponent.new(rows: [
+        { key: 'Candidate name', value: @application_choice.application_form.full_name },
+        { key: 'Course', value: @application_choice.course.name_and_code },
+        { key: 'Preferred location', value: @application_choice.site.name },
+        { key: 'Provider', value: @application_choice.course.provider.name_and_code },
+      ]) %>
 
-  <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice) %>
+      <h2 class="govuk-heading-l govuk-!-margin-top-8">
+        Conditions
+      </h2>
 
-  <%= f.govuk_radio_buttons_fieldset :conditions_met, legend: { size: 'm', text: 'Has the candidate met all of the conditions?', tag: 'span' } do %>
-    <%= f.govuk_radio_button :conditions_met, 'yes', label: { text: 'Yes, they’ve met all of the conditions' }, link_errors: true %>
-    <%= f.govuk_radio_button :conditions_met, 'no', label: { text: 'No' } %>
-  <% end %>
+      <%= render ProviderInterface::ConditionsComponent.new(application_choice: @application_choice) %>
 
-  <%= f.govuk_submit 'Continue' %>
+      <%= f.govuk_radio_buttons_fieldset :conditions_met, legend: { size: 'm', text: 'Has the candidate met all of the conditions?', tag: 'span' } do %>
+        <%= f.govuk_radio_button :conditions_met, 'yes', label: { text: 'Yes, they’ve met all of the conditions' }, link_errors: true %>
+        <%= f.govuk_radio_button :conditions_met, 'no', label: { text: 'No' } %>
+      <% end %>
 
-  <p class="govuk-body">
-    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
-  </p>
-<% end %>
+      <%= f.govuk_submit 'Continue' %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -3,35 +3,32 @@
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
 
-<span class="govuk-caption-xl">
-  Application for <%= @application_choice.course.name_and_code %>
-</span>
+<h1 class="govuk-heading-xl">Confirm offer</h1>
 
-<h1 class="govuk-heading-xl">
-  Confirm offer
-</h1>
+<% conditions = capture do %>
+  <% if @application_offer.offer_conditions.empty? %>
+    Unconditional offer
+  <% else %>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @application_offer.offer_conditions.each do |value| %>
+        <li><%= value %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>
+
+<%= render SummaryListComponent.new(rows: [
+  { key: 'Full name', value: @application_choice.application_form.full_name },
+  { key: 'Course', value: @application_choice.course.name_and_code },
+  { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
+  { key: 'Preferred location', value: @application_choice.site.name },
+  { key: 'Conditions', value: conditions },
+]) %>
 
 <%= form_with model: @application_offer, url: provider_interface_application_choice_create_offer_path(@application_choice.id), method: :post do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
-
-      <% conditions = capture do %>
-        <% if @application_offer.offer_conditions.empty? %>
-          Unconditional offer
-        <% else %>
-          <ul class="govuk-list govuk-list--bullet">
-            <% @application_offer.offer_conditions.each do |value| %>
-              <li><%= value %></li>
-            <% end %>
-          </ul>
-        <% end %>
-      <% end %>
-
-      <%= render SummaryListComponent.new(rows: [
-        key: 'Conditions',
-        value: conditions,
-      ]) %>
 
       <p class="govuk-body govuk-!-font-weight-bold">
         Make a note of the conditions you have set.

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -1,32 +1,25 @@
 <% content_for :title, t('page_titles.application') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_reject_path(@application_choice.id)) %>
 
-<span class="govuk-caption-xl">
-  Application for <%= @application_choice.course.name_and_code %>
-</span>
+<h1 class="govuk-heading-xl">Check and confirm rejection</h1>
 
-<h1 class="govuk-heading-xl">
-  Confirm rejection
-</h1>
+<%= render SummaryListComponent.new(rows: [
+  { key: 'Full name', value: @application_choice.application_form.full_name },
+  { key: 'Course', value: @application_choice.course.name_and_code },
+  { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
+  { key: 'Preferred location', value: @application_choice.site.name },
+  { key: 'Reasons for rejection', value: @reject_application.rejection_reason, },
+]) %>
 
 <%= form_with model: @reject_application, url: provider_interface_application_choice_create_reject_path(@application_choice.id), method: :post do |f| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
-
-      <%= render SummaryListComponent.new(rows: [
-        key: 'Reasons for rejection',
-        value: @reject_application.rejection_reason,
-      ]) %>
     </div>
   </div>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">
-        Are you sure you want to reject this application?
-        You can’t undo this action once you confirm.
-      </p>
 
       <%= f.hidden_field :rejection_reason %>
       <%= f.govuk_submit 'Confirm rejection' %>

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -8,7 +8,7 @@
   { key: 'Course', value: @application_choice.course.name_and_code },
   { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
   { key: 'Preferred location', value: @application_choice.site.name },
-  { key: 'Reasons for rejection', value: @reject_application.rejection_reason, },
+  { key: 'Reasons for rejection', value: @reject_application.rejection_reason },
 ]) %>
 
 <%= form_with model: @reject_application, url: provider_interface_application_choice_create_reject_path(@application_choice.id), method: :post do |f| %>

--- a/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
@@ -7,26 +7,21 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    Are you sure you want to withdraw this offer?
+    Check and confirm withdrawal
   </h1>
 
-  <h2 class="govuk-heading-m">Offer details</h2>
   <%= render SummaryListComponent.new(rows: [
     { key: 'Full name', value: @application_choice.application_form.full_name },
     { key: 'Course', value: @application_choice.course.name_and_code },
     { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
     { key: 'Preferred location', value: @application_choice.site.name },
-  ]) %>
-
-  <h2 class="govuk-heading-m">Reasons for withdrawal</h2>
-  <%= render SummaryListComponent.new(rows: [
     { key: 'Reasons for withdrawal', value: @withdraw_offer.offer_withdrawal_reason },
   ]) %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.hidden_field :offer_withdrawal_reason %>
-      <%= f.govuk_submit 'Yes I\'m sure - withdraw offer', warning: true %>
+      <%= f.govuk_submit 'Withdraw offer', warning: true %>
 
       <p class="govuk-body">
         <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>

--- a/app/views/provider_interface/decisions/new_edit_response.html.erb
+++ b/app/views/provider_interface/decisions/new_edit_response.html.erb
@@ -7,9 +7,6 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">
-      Application for <%= @application_choice.course.name_and_code %>
-    </span>
     Change response
   </h1>
 

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -7,9 +7,6 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">
-      Application for <%= @application_choice.course.name_and_code %>
-    </span>
     Conditions of offer
   </h1>
 
@@ -22,7 +19,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_check_boxes_fieldset :standard_conditions, small: true, legend: { text: 'Standard conditions', size: 'm', tag: 'h2' } do %>
+      <%= f.govuk_check_boxes_fieldset :standard_conditions, legend: { text: 'Standard conditions', size: 'm', tag: 'h2' } do %>
           <%= f.govuk_check_box :standard_conditions, 'Fitness to Teach check', label: { text: 'Fitness to Teach check (optional)' } %>
           <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check (optional)' } %>
       <% end %>

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -19,9 +19,9 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_check_boxes_fieldset :standard_conditions, legend: { text: 'Standard conditions', size: 'm', tag: 'h2' } do %>
-          <%= f.govuk_check_box :standard_conditions, 'Fitness to Teach check', label: { text: 'Fitness to Teach check (optional)' } %>
-          <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check (optional)' } %>
+      <%= f.govuk_check_boxes_fieldset :standard_conditions, legend: { text: 'Standard conditions (optional)', size: 'm', tag: 'h2' } do %>
+          <%= f.govuk_check_box :standard_conditions, 'Fitness to Teach check', label: { text: 'Fitness to Teach check' } %>
+          <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check' } %>
       <% end %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -7,9 +7,6 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">
-      Application for <%= @application_choice.course.name_and_code %>
-    </span>
     Reject application
   </h1>
 

--- a/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
@@ -7,9 +7,6 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <span class="govuk-caption-xl">
-      Application for <%= @application_choice.course.name_and_code %>
-    </span>
     Withdraw offer
   </h1>
 

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -6,17 +6,20 @@
     <%= form_with model: @pick_response_form, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <span class="govuk-caption-xl">
-        Application for <%= @application_choice.course.name_and_code %>
-      </span>
-
       <h1 class="govuk-heading-xl">
         Respond to application
       </h1>
 
-      <%- offer_text = 'Make an offer (including any conditions)' %>
+      <%= render SummaryListComponent.new(rows: [
+        { key: 'Full name', value: @application_choice.application_form.full_name },
+        { key: 'Course', value: @application_choice.course.name_and_code },
+        { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
+        { key: 'Preferred location', value: @application_choice.site.name },
+      ]) %>
+
+      <%- offer_text = 'Make an offer' %>
       <%- reject_text = 'Reject application' %>
-      <%= f.govuk_radio_buttons_fieldset :decision, inline: true, legend: { size: 'm', text: '' } do %>
+      <%= f.govuk_radio_buttons_fieldset :decision, legend: { size: 'm', text: 'Choose response' } do %>
         <%= f.govuk_radio_button :decision, 'offer', label: { text: offer_text }, link_errors: true %>
         <%= f.govuk_radio_button :decision, 'reject', label: { text: reject_text } %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,10 +135,14 @@ en:
           attributes:
             conditions_met:
               blank: Please specify if the candidate has met the conditions of the offer
+        withdraw_offer:
+          attributes:
+            offer_withdrawal_reason:
+              blank: Explain why you're withdrawing the offer
         reject_application:
           attributes:
             rejection_reason:
-              blank: Enter feedback for the candidate
+              blank: Explain why you're rejecting the application
   activerecord:
     attributes:
       application_qualification/qualification_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,11 +138,11 @@ en:
         withdraw_offer:
           attributes:
             offer_withdrawal_reason:
-              blank: Explain why you're withdrawing the offer
+              blank: Explain why you’re withdrawing the offer
         reject_application:
           attributes:
             rejection_reason:
-              blank: Explain why you're rejecting the application
+              blank: Explain why you’re rejecting the application
   activerecord:
     attributes:
       application_qualification/qualification_type:

--- a/spec/requests/vendor_api/post_reject_application_spec.rb
+++ b/spec/requests/vendor_api/post_reject_application_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'Vendor API - POST /applications/:application_id/reject', type: :
 
     expect(response).to have_http_status(422)
     expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-    expect(error_response['message']).to eql 'Rejection reason Enter feedback for the candidate'
+    expect(error_response['message']).to eql 'Rejection reason Explain why you’re rejecting the application'
   end
 
   it 'returns not found error when the application was not found' do

--- a/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_met_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Confirm conditions met' do
   end
 
   def and_confirm_my_selection_in_the_next_page
-    click_on 'Yes I’m sure – they met the conditions'
+    click_on 'Confirm they have met your conditions'
   end
 
   def then_i_get_feedback_that_my_action_succeeded

--- a/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
+++ b/spec/system/provider_interface/provider_confirms_conditions_not_met_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Confirm conditions not met' do
   end
 
   def and_confirm_my_selection_in_the_next_page
-    click_on 'Yes I’m sure – they did not meet the conditions'
+    click_on 'Confirm they have not met your conditions'
   end
 
   def then_i_get_feedback_that_my_action_succeeded

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_choose_to_make_an_offer
-    choose 'Make an offer (including any conditions)'
+    choose 'Make an offer'
     click_on 'Continue'
   end
 

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -99,6 +99,6 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_can_see_the_application_has_an_offer_made
-    expect(page).to have_content 'Application status changed to ‘Offer made’'
+    expect(page).to have_content 'Offer successfully made to candidate'
   end
 end

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -84,6 +84,6 @@ RSpec.feature 'Provider rejects application' do
   end
 
   def and_i_can_see_the_application_has_just_been_rejected
-    expect(page).to have_content 'Application status changed to ‘Rejected’'
+    expect(page).to have_content 'Application successfully rejected'
   end
 end

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -107,7 +107,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_can_see_the_application_offer_is_withdrawn
-    expect(page).to have_content 'Application status changed to ‘Offer withdrawn’'
+    expect(page).to have_content 'Offer successfully withdrawn’'
     expect(page).to have_content 'Withdrawn by us'
   end
 end

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -87,13 +87,13 @@ RSpec.feature 'Provider makes an offer' do
         @application_offered.id,
       ),
     )
-    expect(page).to have_content 'Are you sure you want to withdraw this offer?'
+    expect(page).to have_content 'Check and confirm withdrawal'
     expect(page).to have_content 'We are very sorry but...'
     expect(find('#withdraw_offer_offer_withdrawal_reason', visible: false).value).to eq 'We are very sorry but...'
   end
 
   def when_i_confirm_withdrawal_of_the_offer
-    click_on 'Yes I\'m sure - withdraw offer'
+    click_on 'Withdraw offer'
   end
 
   def then_i_am_back_to_the_application_page
@@ -107,7 +107,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def and_i_can_see_the_application_offer_is_withdrawn
-    expect(page).to have_content 'Offer successfully withdrawn’'
+    expect(page).to have_content 'Offer successfully withdrawn'
     expect(page).to have_content 'Withdrawn by us'
   end
 end


### PR DESCRIPTION
## Context

There's a number of little content and style tweaks that have fallen out of alignment with the latest designs. This PR looks to fix all of those.

## Changes to respond offer

Before:
![image](https://user-images.githubusercontent.com/37163/74918753-7a11c580-53c1-11ea-86c6-afa13ea45f31.png)

After:
![image](https://user-images.githubusercontent.com/37163/74918717-69614f80-53c1-11ea-80e0-563f3e438b98.png)

## Changes to conditions page

Before:
![image](https://user-images.githubusercontent.com/37163/74918824-96adfd80-53c1-11ea-9006-f136924251ff.png)

After:
![image](https://user-images.githubusercontent.com/37163/74918853-a0cffc00-53c1-11ea-84b9-11240f717441.png)

## Changes to confirm offer page

Before:
![image](https://user-images.githubusercontent.com/37163/74918956-c826c900-53c1-11ea-8ba9-ce09a962e8d2.png)

After: 
![image](https://user-images.githubusercontent.com/37163/74918991-d70d7b80-53c1-11ea-9fbc-cc3098e1d798.png)

## Changes to reject application page

Before:
![image](https://user-images.githubusercontent.com/37163/74919115-04f2c000-53c2-11ea-8b0c-7d1d80ca72f8.png)

After:
![image](https://user-images.githubusercontent.com/37163/74919140-10de8200-53c2-11ea-80f6-e5b3c81e84d0.png)

## Changes to confirm rejection page

Before:
![image](https://user-images.githubusercontent.com/37163/74919240-353a5e80-53c2-11ea-8960-49aee32cf128.png)

After:
![image](https://user-images.githubusercontent.com/37163/74919255-3bc8d600-53c2-11ea-9c21-98d682b98e42.png)

## Changes to edit response page

Before:
![image](https://user-images.githubusercontent.com/37163/74919522-a11cc700-53c2-11ea-8165-55dd53be7788.png)

After:
![image](https://user-images.githubusercontent.com/37163/74920278-d249c700-53c3-11ea-8d2f-eaa67181b650.png)

## Changes to withdraw page

Before:
![image](https://user-images.githubusercontent.com/37163/74919614-c01b5900-53c2-11ea-9280-c36dd29b8651.png)

After:
![image](https://user-images.githubusercontent.com/37163/74919635-c6a9d080-53c2-11ea-8c90-f72adfa78dc7.png)

## Changes to withdraw confirmation page

Before:
![image](https://user-images.githubusercontent.com/37163/74919694-e214db80-53c2-11ea-8f8e-e4718676bd1f.png)

After:
![image](https://user-images.githubusercontent.com/37163/74927068-ddeebb00-53ce-11ea-8513-44eab582b51b.png)

## Changes to confirming conditions met

Before:
![image](https://user-images.githubusercontent.com/37163/74926908-96682f00-53ce-11ea-8028-5a7300de9a01.png)

After:
![image](https://user-images.githubusercontent.com/37163/74929655-e269a280-53d3-11ea-8750-3729db366b4b.png)

## Changes to confirming conditions not met

Before:
![image](https://user-images.githubusercontent.com/37163/74926946-a4b64b00-53ce-11ea-9765-20648f4d19bc.png)

After:
![image](https://user-images.githubusercontent.com/37163/74929679-ec8ba100-53d3-11ea-8f6c-7359f3ee03f5.png)

## Help needed

- I don't know how to stop the ‘change response’ labels from being bold - fixed thanks to @stevehook 
- I don't know how to change the ‘withdraw offer’ text box error message from ‘can't be blank’ - fixed thanks to @duncanjbrown 

## Link to Trello card

https://trello.com/c/ZoTJfDpi/1682-update-production-content-to-match-prototype-content

