### PR TITLE
Adding a course from find for a signed in candidate

### DIFF
--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class StartPageController < CandidateInterfaceController
     before_action :show_pilot_holding_page_if_not_open
     skip_before_action :authenticate_candidate!
-    before_action :redirect_signed_in_candidate
+    before_action :redirect_to_interstitial_path_if_signed_in
 
     def show; end
 
@@ -29,28 +29,11 @@ module CandidateInterface
 
   private
 
-    def redirect_signed_in_candidate
+    def redirect_to_interstitial_path_if_signed_in
       if current_candidate.present?
         add_course_from_find_id_to_candidate if params[:providerCode].present?
 
-        service = ExistingCandidateAuthentication.new(candidate: current_candidate)
-        service.execute
-
-        if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
-          redirect_to candidate_interface_interstitial_path
-        elsif service.candidate_has_already_selected_the_course
-          flash[:warning] = "You have already selected #{@course.name_and_code}."
-          redirect_to candidate_interface_course_choices_review_path
-        elsif service.candidate_has_new_course_added
-          redirect_to candidate_interface_course_choices_review_path
-        elsif service.candidate_should_choose_site
-          redirect_to candidate_interface_course_choices_site_path(@course.provider.code, @course.code)
-        elsif service.candidate_already_has_3_courses
-          flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course.name_and_code}."
-          redirect_to candidate_interface_course_choices_review_path
-        else
-          redirect_to candidate_interface_application_form_path
-        end
+        redirect_to candidate_interface_interstitial_path
       end
     end
 

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -2,7 +2,7 @@ module CandidateInterface
   class StartPageController < CandidateInterfaceController
     before_action :show_pilot_holding_page_if_not_open
     skip_before_action :authenticate_candidate!
-    before_action :redirect_to_application_if_signed_in
+    before_action :redirect_signed_in_candidate
 
     def show; end
 
@@ -25,6 +25,39 @@ module CandidateInterface
     def eligibility_params
       params.fetch(:candidate_interface_eligibility_form, {}).permit(:eligible_citizen, :eligible_qualifications)
         .transform_values(&:strip)
+    end
+
+  private
+
+    def redirect_signed_in_candidate
+      if current_candidate.present?
+        add_course_from_find_id_to_candidate if params[:providerCode].present?
+
+        service = ExistingCandidateAuthentication.new(candidate: current_candidate)
+        service.execute
+
+        if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
+          redirect_to candidate_interface_interstitial_path
+        elsif service.candidate_has_already_selected_the_course
+          flash[:warning] = "You have already selected #{@course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_has_new_course_added
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_should_choose_site
+          redirect_to candidate_interface_course_choices_site_path(@course.provider.code, @course.code)
+        elsif service.candidate_already_has_3_courses
+          flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        else
+          redirect_to candidate_interface_application_form_path
+        end
+      end
+    end
+
+    def add_course_from_find_id_to_candidate
+      provider = Provider.find_by(code: params[:providerCode])
+      @course = provider.courses.find_by(code: params[:courseCode]) if provider.present?
+      current_candidate.update!(course_from_find_id: @course.id) if @course.present?
     end
   end
 end

--- a/app/services/candidate_interface/add_course_from_find.rb
+++ b/app/services/candidate_interface/add_course_from_find.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class ExistingCandidateAuthentication
+  class AddCourseFromFind
     attr_accessor :candidate,
                   :candidate_already_has_3_courses,
                   :candidate_has_new_course_added,

--- a/spec/services/candidate_interface/add_course_from_find_spec.rb
+++ b/spec/services/candidate_interface/add_course_from_find_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CandidateInterface::ExistingCandidateAuthentication do
+RSpec.describe CandidateInterface::AddCourseFromFind do
   include CourseOptionHelpers
 
   describe '#execute' do

--- a/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_should_be_informed_i_have_already_selected_that_course
 
     given_the_course_i_selected_has_multiple_sites
+    and_i_am_an_existing_candidate_on_apply
     and_i_am_signed_in
     and_i_have_less_than_3_application_options
 
@@ -137,7 +138,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def then_i_should_see_the_course_choices_site_page
-    expect(page).to have_current_path(candidate_interface_course_choices_site_path(@course_with_multiple_sites.provider.code, @course_with_multiple_sites.code))
+    expect(page).to have_current_path(candidate_interface_course_choices_site_path(@course_with_multiple_sites.provider.id, @course_with_multiple_sites.id))
   end
 
   def then_i_should_see_the_candidate_interface_application_form


### PR DESCRIPTION
## Context
**https://trello.com/c/c4ZYOuaI/1010-add-you-selected-a-course-page-into-find-to-apply-journey will be affected by this work**

This PR covers stretch goal 1 of the Trello card. This is to fix adding a course from find for candidates who are already signed in.
 
## Changes proposed in this pull request

- Rework the start page controller to call the ExistingCandidateAuthentication service if the user is signed in and course params are present


## Guidance to review

I think the naming of the ExistingCandidateAuthentication does not really describe what it actually does,  but I can't come up with anything that seems to describe it well.

# Link to Trello card

https://trello.com/c/71lG72Y6/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
