### PR TITLE
Send notification to provider when application is declined

### DIFF
--- a/app/mailers/previews/provider_mailer_preview.rb
+++ b/app/mailers/previews/provider_mailer_preview.rb
@@ -27,6 +27,10 @@ class ProviderMailerPreview < ActionMailer::Preview
     ProviderMailer.application_withrawn(provider_user, application_choice)
   end
 
+  def declined
+    ProviderMailer.declined(provider_user, application_choice)
+  end
+
 private
 
   def application_choice

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -102,6 +102,14 @@ class ProviderMailer < ApplicationMailer
     )
   end
 
+  def declined(provider_user, application_choice)
+    @application_choice = application_choice
+    email_for_provider(
+      provider_user,
+      subject: I18n.t!('provider_mailer.declined.subject', candidate_name: application_choice.application_form.full_name),
+    )
+  end
+
 private
 
   def email_for_provider(provider_user, args = {})

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -7,5 +7,11 @@ class DeclineOffer
     ApplicationStateChange.new(@application_choice).decline!
     @application_choice.update!(declined_at: Time.zone.now)
     StateChangeNotifier.call(:offer_declined, application_choice: @application_choice)
+
+    if FeatureFlag.active?('offer_declined_provider_emails')
+      @application_choice.provider.provider_users.each do |provider_user|
+        ProviderMailer.declined(provider_user, @application_choice).deliver
+      end
+    end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -21,6 +21,7 @@ class FeatureFlag
     offer_accepted_provider_emails
     decline_by_default_notification_to_provider
     application_withrawn_provider_email
+    offer_declined_provider_emails
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/provider_mailer/declined.text.erb
+++ b/app/views/provider_mailer/declined.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @provider_user.full_name || 'colleague' %>
+
+# Offer declined
+
+<%= @application_choice.application_form.full_name %> declined your offer to study <%= @application_choice.course.name_and_code %>.
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -281,7 +281,8 @@ en:
       name: Candidate declines offer
       by: candidate
       description: The candidate can decline the offer.
-      # https://trello.com/c/jYzNQIaZ/1047-email-a-candidate-has-declined-an-offer-provider
+      emails:
+        - provider_mailer-declined
 
     pending_conditions-confirm_conditions_met:
       name: Provider confirms conditions are met

--- a/config/locales/provider_mailer.yml
+++ b/config/locales/provider_mailer.yml
@@ -4,3 +4,5 @@ en:
       subject: '%{candidate_name} has accepted your offer'
     decline_by_default:
       subject: '%{candidate_name}’s application withdrawn automatically'
+    declined:
+      subject: '%{candidate_name} declined an offer'

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -202,4 +202,15 @@ RSpec.describe ProviderMailer, type: :mailer do
       expect(@mail.body.encoded).to include(application_choice.course.code)
     end
   end
+
+  describe '.declined' do
+    before do
+      @mail = mailer.declined(provider_user, application_choice)
+    end
+
+    it 'includes the course details' do
+      expect(@mail.body.encoded).to include(application_choice.course.name)
+      expect(@mail.body.encoded).to include(application_choice.course.code)
+    end
+  end
 end


### PR DESCRIPTION
##  Context

When the candidate declines, this sends an email to the provider users.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

https://apply-for-te-1047-email-keu64w.herokuapp.com/rails/mailers/provider_mailer/declined

## Link to Trello card

https://trello.com/c/jYzNQIaZ

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
