### PR TITLE
Don't try to look up dbd_date on a choice that might not have an offer

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -141,8 +141,8 @@ class CandidateMailer < ApplicationMailer
   end
 
   def chase_candidate_decision(application_form)
-    @dbd_date = application_form.application_choices.first.decline_by_default_at.to_s(:govuk_date).strip
     @application_choices = application_form.application_choices.select(&:offer?)
+    @dbd_date = @application_choices.first.decline_by_default_at.to_s(:govuk_date).strip
 
     subject_pluralisation = @application_choices.count > 1 ? 'plural' : 'singular'
     email_for_candidate(application_form, subject: I18n.t!("chase_candidate_decision_email.subject_#{subject_pluralisation}"))

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -582,6 +582,10 @@ RSpec.describe CandidateMailer, type: :mailer do
       let(:application_form) { create(:completed_application_form) }
 
       before do
+        create(:submitted_application_choice, :awaiting_provider_decision,
+               course_option: course_option_for_provider_code(provider_code: 'GHI'),
+               application_form: application_form)
+
         @first_offer = create(:submitted_application_choice, :with_offer,
                               course_option: course_option_for_provider_code(provider_code: 'ABC'),
                               decline_by_default_at: Time.zone.now,
@@ -590,10 +594,6 @@ RSpec.describe CandidateMailer, type: :mailer do
                                course_option: course_option_for_provider_code(provider_code: 'DEF'),
                                decline_by_default_at: Time.zone.now,
                                application_form: application_form)
-        create(:submitted_application_choice, :awaiting_provider_decision,
-               course_option: course_option_for_provider_code(provider_code: 'GHI'),
-               decline_by_default_at: Time.zone.now,
-               application_form: application_form)
 
         @mail = mailer.chase_candidate_decision(application_form)
       end


### PR DESCRIPTION
## Context

It's possible for an application's first choice not to have a dbd_date on it, but the mailer assumes it does.

Should fix https://sentry.io/organizations/dfe-bat/issues/1523597528/?project=1765973&referrer=slack
