### PR TITLE
Launch expired sign in link feature - for sign up/sign in

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -1,9 +1,6 @@
 class AuthenticationMailer < ApplicationMailer
   def sign_up_email(candidate:, token:)
-    @magic_link = candidate_interface_authenticate_url(
-      token: token,
-      u: Encryptor.encrypt(candidate.id),
-    )
+    @magic_link = candidate_interface_authenticate_url(magic_link_params(token, candidate))
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: candidate.email_address,
@@ -12,10 +9,7 @@ class AuthenticationMailer < ApplicationMailer
   end
 
   def sign_in_email(candidate:, token:)
-    @magic_link = candidate_interface_authenticate_url(
-      token: token,
-      u: Encryptor.encrypt(candidate.id),
-    )
+    @magic_link = candidate_interface_authenticate_url(magic_link_params(token, candidate))
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: candidate.email_address,
@@ -26,5 +20,13 @@ class AuthenticationMailer < ApplicationMailer
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: to,
               subject: t('authentication.sign_in_without_account.email.subject'))
+  end
+
+private
+
+  def magic_link_params(token, candidate)
+    params = { token: token }
+    params[:u] = Encryptor.encrypt(candidate.id) if FeatureFlag.active?('improved_expired_token_flow')
+    params
   end
 end

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -1,6 +1,9 @@
 class AuthenticationMailer < ApplicationMailer
   def sign_up_email(candidate:, token:)
-    @magic_link = "#{candidate_interface_authenticate_url}?token=#{token}"
+    @magic_link = candidate_interface_authenticate_url(
+      token: token,
+      u: Encryptor.encrypt(candidate.id),
+    )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: candidate.email_address,
@@ -9,7 +12,10 @@ class AuthenticationMailer < ApplicationMailer
   end
 
   def sign_in_email(candidate:, token:)
-    @magic_link = "#{candidate_interface_authenticate_url}?token=#{token}"
+    @magic_link = candidate_interface_authenticate_url(
+      token: token,
+      u: Encryptor.encrypt(candidate.id),
+    )
 
     view_mail(GENERIC_NOTIFY_TEMPLATE,
               to: candidate.email_address,

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -19,8 +19,11 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       expect(mail.body.encoded).to include(t('authentication.sign_up.email.subject'))
     end
 
-    it 'sends an email with a magic link' do
-      expect(mail.body.encoded).to include("http://localhost:3000/candidate/authenticate?token=#{token}")
+    it 'sends an email with a magic link and encrypted candidate id' do
+      allow(Encryptor).to receive(:encrypt).and_return('secret')
+      expect(mail.body.encoded).to include(
+        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+      )
     end
 
     it 'sends a request with a Notify reference' do
@@ -46,8 +49,11 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       expect(mail.body.encoded).to include(t('authentication.sign_in.email.subject'))
     end
 
-    it 'sends an email with a magic link' do
-      expect(mail.body.encoded).to include("http://localhost:3000/candidate/authenticate?token=#{token}")
+    it 'sends an email with a magic link and encrypted candidate id' do
+      allow(Encryptor).to receive(:encrypt).and_return('secret')
+      expect(mail.body.encoded).to include(
+        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+      )
     end
   end
 

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -19,11 +19,21 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       expect(mail.body.encoded).to include(t('authentication.sign_up.email.subject'))
     end
 
-    it 'sends an email with a magic link and encrypted candidate id' do
-      allow(Encryptor).to receive(:encrypt).and_return('secret')
+    it 'sends an email with a magic link' do
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/authenticate?token=#{token}",
       )
+    end
+
+    context 'with the improved_expired_token_flow feature flag' do
+      before { FeatureFlag.activate('improved_expired_token_flow') }
+
+      it 'sends an email with a magic link and encrypted candidate id' do
+        allow(Encryptor).to receive(:encrypt).and_return('secret')
+        expect(mail.body.encoded).to include(
+          "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+        )
+      end
     end
 
     it 'sends a request with a Notify reference' do
@@ -49,11 +59,21 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       expect(mail.body.encoded).to include(t('authentication.sign_in.email.subject'))
     end
 
-    it 'sends an email with a magic link and encrypted candidate id' do
-      allow(Encryptor).to receive(:encrypt).and_return('secret')
+    it 'sends an email with a magic link' do
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+        "http://localhost:3000/candidate/authenticate?token=#{token}",
       )
+    end
+
+    context 'with the improved_expired_token_flow feature flag' do
+      before { FeatureFlag.activate('improved_expired_token_flow') }
+
+      it 'sends an email with a magic link and encrypted candidate id' do
+        allow(Encryptor).to receive(:encrypt).and_return('secret')
+        expect(mail.body.encoded).to include(
+          "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
+        )
+      end
     end
   end
 

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate tries to sign up using magic link with an invalid token' do
+  scenario 'Candidate signs in and receives an email inviting them to sign up' do
+    given_the_pilot_is_open
+    and_the_improved_expired_token_flow_feature_flag_is_on
+
+    given_i_am_a_candidate_without_an_account
+
+    when_i_go_to_sign_up
+    and_i_fill_in_the_eligiblity_form_with_yes
+    and_i_submit_my_email_address
+    then_i_receive_an_email_inviting_me_to_sign_up
+
+    when_the_magic_link_token_is_overwritten
+    and_i_click_on_the_link_in_my_email
+    then_i_am_taken_to_the_expired_link_page
+
+    when_i_click_the_button_to_send_me_a_sign_in_email
+    then_i_receive_an_email_inviting_me_to_sign_in
+    and_i_click_on_the_link_in_my_email
+    then_i_am_taken_to_the_sign_up_page
+  end
+
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_improved_expired_token_flow_feature_flag_is_on
+    FeatureFlag.activate('improved_expired_token_flow')
+  end
+
+  def given_i_am_a_candidate_without_an_account
+    @email = "#{SecureRandom.hex}@example.com"
+  end
+
+  def when_i_go_to_sign_up
+    visit '/'
+    click_on 'Start now'
+  end
+
+  def and_i_fill_in_the_eligiblity_form_with_yes
+    within_fieldset('Are you a citizen of the UK or the EU?') do
+      choose 'Yes'
+    end
+
+    within_fieldset('Did you gain all your qualifications at institutions based in the UK?') do
+      choose 'Yes'
+    end
+
+    click_on 'Continue'
+  end
+
+  def and_i_submit_my_email_address
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    check t('authentication.sign_up.accept_terms_checkbox')
+    click_on t('authentication.sign_up.button_continue')
+  end
+
+  def then_i_receive_an_email_inviting_me_to_sign_up
+    open_email(@email)
+    expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
+  end
+
+  def when_the_magic_link_token_is_overwritten
+    Candidate.find_by(email_address: @email).update(magic_link_token: MagicLinkToken.new.raw)
+  end
+
+  def and_i_click_on_the_link_in_my_email
+    current_email.find_css('a').first.click
+  end
+
+  def then_i_am_taken_to_the_expired_link_page
+    expect(page).to have_current_path(candidate_interface_expired_sign_in_path, ignore_query: true)
+  end
+
+  def when_i_click_the_button_to_send_me_a_sign_in_email
+    click_button t('authentication.expired_token.button')
+  end
+
+  def then_i_receive_an_email_inviting_me_to_sign_in
+    open_email(@email)
+    expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
+  end
+
+  def then_i_am_taken_to_the_sign_up_page
+    expect(page).to have_current_path(candidate_interface_application_form_path)
+  end
+end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1403

We have already implemented (behind a feature flag) improved flow for expired magic tokens. This PR extends the same improvements to _invalidated_ tokens, e.g. if a candidate signs up and gets a first magic link, then asks for a second the first is overwritten and therefore invalid.

By using the same encrypted candidate id param that we already have for the simple expire case we can streamline the recovery process in the same way - if we know who you are we can send you an email without prompting for your address again.

## Changes proposed in this pull request

- Include the encrypted candidate id (`u` param) in the magic link
- Adapt `SignInController#authenticate` to attempt to look up by encrypted candidate id if the magic token is invalid and the feature flag is on
- System spec to cover this case

## Guidance to review

- Could this open up holes in the authentication system?
- Are there any other cases that we need to test?

## Link to Trello card

https://trello.com/c/LkdIGwhl/887-launch-expired-sign-in-link-feature-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
