### PR TITLE
Fix broken preview for application_rejected_offers_made

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -92,7 +92,7 @@ class CandidateMailer < ApplicationMailer
   end
 
   def application_rejected_offers_made(application_choice)
-    offers = application_choice.application_form.application_choices.offer
+    offers = application_choice.application_form.application_choices.select(&:offer?)
     decline_by_default_at = offers.map(&:decline_by_default_at).compact.max&.to_s(:govuk_date)
     dbd_days = offers.map(&:decline_by_default_days).max
 


### PR DESCRIPTION
## Context
The candidate mailer preview uses stubs to preview an email template, but the current logic in #application_rejected_offers_made does not work with application choice stubs.

![image](https://user-images.githubusercontent.com/22743709/74948536-59169800-53f4-11ea-9722-af68cf2dcea3.png)


## Changes proposed in this pull request
This PR fixes the way we map offers in CandidateMailer#application_rejected_offers_made 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Does this make sense? 

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
