### PR TITLE
Fix PreviewCandidateMailer awaiting_decisions rejection email

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -72,8 +72,7 @@ class CandidateMailer < ApplicationMailer
   end
 
   def application_rejected_awaiting_decisions(application_choice)
-    @decisions = application_choice.application_form.application_choices.awaiting_provider_decision
-
+    @decisions = application_choice.application_form.application_choices.select(&:awaiting_provider_decision?)
     # We can't use `through:` associations with FactoryBot's `build_stubbed`. Using
     # the association directly instead allows us to use `build_stubbed` in tests
     # and mailer previews.

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -133,15 +133,19 @@ class CandidateMailerPreview < ActionMailer::Preview
   def application_rejected_awaiting_decisions
     provider = FactoryBot.build_stubbed(:provider)
     course = FactoryBot.build_stubbed(:course, provider: provider)
-    application_form = FactoryBot.build_stubbed(:application_form, first_name: 'Tyrell', last_name: 'Wellick')
     course_option = FactoryBot.build_stubbed(:course_option, course: course)
-    FactoryBot.build_stubbed(:application_choice, status: :awaiting_provider_decision, application_form: application_form)
-    application_choice = FactoryBot.build_stubbed(:application_choice,
-                                                  course_option: course_option,
-                                                  application_form: application_form,
-                                                  rejection_reason: 'Not enough experience.')
+    application_form = FactoryBot.build_stubbed(:application_form,
+                                                first_name: 'Tyrell',
+                                                last_name: 'Wellick',
+                                                application_choices: [
+                                                  FactoryBot.build_stubbed(:application_choice, status: :awaiting_provider_decision),
+                                                  FactoryBot.build_stubbed(:application_choice,
+                                                                           course_option: course_option,
+                                                                           status: :rejected,
+                                                                           rejection_reason: 'Not enough experience.'),
+                                                  ])
 
-    CandidateMailer.application_rejected_awaiting_decisions(application_choice)
+    CandidateMailer.application_rejected_awaiting_decisions(application_form.application_choices.last)
   end
 
   def application_rejected_offers_made


### PR DESCRIPTION
## Context

The candidate mailer preview uses stubs to preview an email template, but the current logic in #application_rejected_awaiting_decisions does not work with application choice stubs. (shamelessly stolen from Csaba 😂 )

## Changes proposed in this pull request
Before

![image](https://user-images.githubusercontent.com/42515961/74954154-95e58d80-53fa-11ea-9b13-90976ff177c0.png)

After

![image](https://user-images.githubusercontent.com/42515961/74954235-b1e92f00-53fa-11ea-9e88-c47a8f1487e2.png)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
