### PR TITLE
Fix for applications export

### DIFF
--- a/app/services/support_interface/applications_export.rb
+++ b/app/services/support_interface/applications_export.rb
@@ -51,7 +51,7 @@ module SupportInterface
   private
 
     def last_change_to_form(audits, column)
-      audits.find { |audit| audit.audited_changes.has_key?(column) }&.created_at
+      audits.find { |audit| audit.action == 'update' && audit.audited_changes.has_key?(column) }&.created_at
     end
 
     def relevant_applications

--- a/spec/services/support_interface/applications_export_spec.rb
+++ b/spec/services/support_interface/applications_export_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe SupportInterface::ApplicationsExport do
+RSpec.describe SupportInterface::ApplicationsExport, with_audited: true do
   describe '#applications' do
     it 'returns the correct last changed dates' do
       candidate = create(:candidate, created_at: '2020-01-01')
@@ -12,28 +12,23 @@ RSpec.describe SupportInterface::ApplicationsExport do
         submitted_at: '2020-01-03',
       )
 
-      create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form, updated_at: '2019-01-10')
-      create(:application_choice, status: 'awaiting_provider_decision', application_form: application_form, updated_at: '2020-01-10')
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form, updated_at: Time.zone.now - 1.year)
+      create(:application_choice, :awaiting_provider_decision, application_form: application_form, updated_at: '2020-01-10')
 
-      application_form.update_columns updated_at: '2020-01-04'
+      Timecop.freeze(Time.zone.now + 1.day) do
+        application_form.update! volunteering_experience: 'I have been a volunteer!'
+      end
 
       row = described_class.new.applications.first
 
-      {
-        support_reference: 'PJ9825',
-        process_state: :awaiting_provider_decisions,
-      }.each do |key, value|
-        expect(row[key]).to eql(value)
-      end
-
-      {
-        signed_up_at: '2020-01-01',
-        first_signed_in_at: '2020-01-02',
-        submitted_form_at: '2020-01-03',
-        form_updated_at: '2020-01-04',
-      }.each do |key, value|
-        expect(row[key].to_s).to start_with(value), "#{key}: expected #{row[key]} to match #{value}"
-      end
+      expect(row[:signed_up_at].to_s).to start_with('2020-01-01')
+      expect(row[:first_signed_in_at].to_s).to start_with('2020-01-02')
+      expect(row[:submitted_form_at].to_s).to start_with('2020-01-03')
+      expect(row[:support_reference]).to eql('PJ9825')
+      expect(row[:process_state]).to be(:awaiting_provider_decisions)
+      expect(row[:form_updated_at]).to eql(application_form.updated_at)
+      expect(row[:subject_knowledge_last_updated_at]).to be_nil
+      expect(row[:volunteering_experience_last_updated_at]).to eql(application_form.updated_at)
     end
   end
 end


### PR DESCRIPTION
## Context

The application timings CSV is supposed to show the latest time a column was updated on an application form. However, the method looks at when the column was last updated including the time the record was created. Since all columns are present in the changeset of a create, we basically fall back to the created_at of a application form, making it look like all columns were updated.

## Changes proposed in this pull request

Fix the logic, add better tests.

## Guidance to review

Read the new tests.

## Link to Trello card

https://trello.com/c/dKBwLMPv

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
