### PR TITLE
Fix up declined email to provider

### DIFF
--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -114,6 +114,7 @@ class ProviderMailer < ApplicationMailer
     @application_choice = application_choice
     email_for_provider(
       provider_user,
+      application_choice.application_form,
       subject: I18n.t!('provider_mailer.declined.subject', candidate_name: application_choice.application_form.full_name),
     )
   end


### PR DESCRIPTION
This was merged and conflicts with the changes on https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1433. This is making master fail currently.