### PR TITLE
Link to correct page on Get into teaching

### DIFF
--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -7,17 +7,9 @@
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
       <%= t('apply_from_find.heading') %>
     </h1>
-    <p class="govuk-body">
-      You must apply for this course on UCAS. You’ll need to register with UCAS
-      before you can apply. Visit Get into Teaching for
-      <a class="govuk-link" target="_blank" href="https://getintoteaching.education.gov.uk">
-        guidance on applying for teacher training</a>.
-    </p>
+    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit Get into Teaching for <a class="govuk-link" target="_blank" href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training">guidance on applying for teacher training</a>.</p>
 
-    <p class="govuk-body">
-      When you apply you’ll need these codes for the Choices section of your
-      application form:
-    </p>
+    <p class="govuk-body">When you apply you’ll need these codes for the Choices section of your application form:</p>
 
     <div class="govuk-inset-text">
       <ul class="govuk-list">


### PR DESCRIPTION
## Context

The link to Get into teaching on the ‘Apply for this course on UCAS’ links to the GiT home page, whereas it should link to the specific page about the application process.
