### PR TITLE
Add ok-computer for monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,9 @@ gem 'uk_postcode'
 gem 'business_time'
 gem 'holidays'
 
+# Monitoring
+gem 'okcomputer'
+
 # feature flags
 gem 'rollout'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,6 +278,7 @@ GEM
       shellany (~> 0.0)
     notifications-ruby-client (5.1.1)
       jwt (>= 1.5, < 3)
+    okcomputer (1.18.1)
     omniauth (1.9.0)
       hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
@@ -541,6 +542,7 @@ DEPENDENCIES
   logstash-event
   logstash-logger
   mail-notify
+  okcomputer
   omniauth
   omniauth-rails_csrf_protection
   omniauth_openid_connect

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,7 @@
 class FeatureFlag
   FEATURES = %w[
     pilot_open
+    force_ok_computer_to_fail
     training_with_a_disability
     edit_application
     send_dfe_sign_in_invitations

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,6 @@
+OkComputer.mount_at = 'integrations/monitoring'
+
+OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
+OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100)
+OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100)

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,6 +1,18 @@
+class SimulatedFailureCheck < OkComputer::Check
+  def check
+    if FeatureFlag.active?('force_ok_computer_to_fail')
+      mark_failure
+      mark_message 'force_ok_computer_to_fail is on'
+    else
+      mark_message 'force_ok_computer_to_fail is off'
+    end
+  end
+end
+
 OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
 OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100)
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100)
+OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new


### PR DESCRIPTION
## Context

We could write our own monitoring, but this gem looks ok (computer). It's an engine we mount (here under integrations/monitoring) which provides a nice JSON format for healthchecks. Successful checks return 200. Failed checks return 500.

Supported out of the box are Redis, AR, and sidekiq latency, [amongst other things](https://github.com/sportngin/okcomputer/tree/master/lib/ok_computer/built_in_checks).

If we want to do it ~to~ for ourselves, there is a sensible API for adding [custom checks](https://github.com/sportngin/okcomputer#registering-custom-checks).

## Changes proposed in this pull request

No surprises, hopefully.

the output looks like this. 

![Capture](https://user-images.githubusercontent.com/642279/74960737-c16d7580-5404-11ea-9340-1944f7dcbdeb.PNG)

## Guidance to review

Test by curling `integrations/monitoring/all`. There is also an endpoint without `all` which serves only the "app is serving requests" status and doesn't exercise any of the ~pigs in cages on antibiotics~ databases.

## Link to Trello card

https://trello.com/c/AdpL18Up/1655-add-one-stop-healthcheck-endpoint-to-the-app

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
