### PR TITLE
Refactor mailers to reduce some of the complexity

### DIFF
--- a/app/views/candidate_mailer/_application_rejected_intro.erb
+++ b/app/views/candidate_mailer/_application_rejected_intro.erb
@@ -2,8 +2,8 @@ Dear <%= @application_form.first_name %>,
 
 # Application decision
 
-<%= @intro.provider_name %> has decided not to progress your teacher training application for <%= @intro.course_name %> on this occasion. They gave the following feedback:
+<%= @course.provider.name %> has decided not to progress your teacher training application for <%= @course.name_and_code %> on this occasion. They gave the following feedback:
 
-<%= @intro.rejection_reason %>
+<%= @application_choice.rejection_reason %>
 
-Contact <%= @intro.provider_name %> directly if you have any questions about this.
+Contact <%= @course.provider.name %> directly if you have any questions about this.

--- a/app/views/candidate_mailer/application_rejected_offers_made.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_made.erb
@@ -1,19 +1,19 @@
 <%= render 'application_rejected_intro' %>
 
-# Make a decision about your <%= 'offer'.pluralize(@application.offers.count) %> by <%= @application.decline_by_default_at %>
+# Make a decision about your <%= 'offer'.pluralize(@offers.count) %> by <%= @decline_by_default_at %>
 
-<% if @application.offers.count > 1  %>
+<% if @offers.count > 1  %>
 
 You’ve received the following offers:
-<% @application.offers.each do |offered_application_choice| %>
+<% @offers.each do |offered_application_choice| %>
   - <%= "#{offered_application_choice.course_option.course.name_and_code} at #{offered_application_choice.course_option.course.provider.name}"%>
 <% end %>
 
-If you don’t reply within <%= @application.dbd_days %> working days, your applications will be withdrawn.
+If you don’t reply within <%= @dbd_days %> working days, your applications will be withdrawn.
 
 <% else %>
 
-You now have <%= @application.dbd_days %> working days to make a decision about your offer for a place on <%= @application.offers.first.course.name_and_code %> at <%= @application.offers.first.provider.name%>.
+You now have <%= @dbd_days %> working days to make a decision about your offer for a place on <%= @offers.first.course.name_and_code %> at <%= @offers.first.provider.name%>.
 
 <% end %>
 
@@ -21,7 +21,7 @@ Sign in to your account to respond:
 
 <%= candidate_sign_in_url(@candidate) %>
 
-<% if @application.offers.count > 1  %>
+<% if @offers.count > 1  %>
 
 You can only accept one offer.
 

--- a/app/views/candidate_mailer/application_sent_to_provider.text.erb
+++ b/app/views/candidate_mailer/application_sent_to_provider.text.erb
@@ -2,9 +2,9 @@ Dear <%= @application_form.first_name %>,
 
 # Your application is being considered
 
-Your application is now with your teacher training <%= 'provider'.pluralize(@application.choice_count) %>.
+Your application is now with your teacher training <%= 'provider'.pluralize(@application_form.application_choices.count) %>.
 
-We’ve asked them to make a final decision within <%= @application.reject_by_default_days %> working days.
+We’ve asked them to make a final decision within <%= @application_form.application_choices.first.reject_by_default_days %> working days.
 
 They’ll be in touch with you sooner if they want to arrange an interview.
 

--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application.provider_user_name || 'colleague' %>
+Dear <%= @provider_user_name || 'colleague' %>
 
 # Application rejected automatically
 

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application.provider_user_name || 'colleague' %>
+Dear <%= @provider_user_name || 'colleague' %>
 
 # Application received
 

--- a/app/views/provider_mailer/chase_provider_decision.text.erb
+++ b/app/views/provider_mailer/chase_provider_decision.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @application.provider_user_name || 'colleague' %>
+Dear <%= @provider_user_name || 'colleague' %>
 
 # Only <%= TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit %> working days left to respond
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -492,7 +492,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         @application_choice3 = create(:application_choice,
                                       status: :offer,
                                       application_form: @application_form,
-                                      decline_by_default_at: 8.business_days.from_now,
+                                      decline_by_default_at: 10.business_days.from_now,
                                       decline_by_default_days: 10)
         mail.deliver_later
       end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
I was waiting with the merge of this https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1443 because I tried to remove some of the complexity from the `#application_rejected` emails

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR removes the OpenStruct because I cannot justify the usage of them. 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Do you think this makes sense? Does this help at all? 

## Link to Trello card
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
