### PR TITLE
Candidates can opt out of filling up equality and diversity info

### DIFF
--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -1,0 +1,5 @@
+module CandidateInterface
+  class EqualityAndDiversityController < CandidateInterfaceController
+    def start; end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,6 +22,7 @@ class FeatureFlag
     decline_by_default_notification_to_provider
     application_withrawn_provider_email
     offer_declined_provider_emails
+    equality_and_diversity
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -24,4 +24,8 @@
 
 <%= render 'review', application_form: @application_form, editable: true %>
 
-<%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_application_submit_show_path %>
+<% if FeatureFlag.active?('offer_declined_provider_emails') %>
+  <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>
+<% else %>
+  <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_application_submit_show_path %>
+<% end %>

--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -1,0 +1,16 @@
+<% content_for :title, 'Equality and diversity' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Equality and diversity
+    </h1>
+
+    <p class="govuk-body-l">Your application is now ready to submit. Before you do so, will you complete a 3-minute questionnaire?</p>
+    <p class="govuk-body">This questionnaire is optional and has no impact on the progress of your application.</p>
+    <p class="govuk-body">We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.</p>
+    <p class="govuk-body">Your data will only be shared with training providers when you are enrolled on a course.</p>
+
+    <%= govuk_button_link_to 'Continue without completing questionnaire', candidate_interface_application_submit_show_path %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,6 +249,10 @@ Rails.application.routes.draw do
         get '/confirm' => 'additional_referees#confirm', as: :confirm_additional_referees
         post '/confirm' => 'additional_referees#request_references'
       end
+
+      scope '/equality-and-diversity' do
+        get '/' => 'equality_and_diversity#start', as: :start_equality_and_diversity
+      end
     end
   end
 

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their equality and diversity information' do
+  include CandidateHelper
+
+  scenario 'Candidate submits equality and diversity information' do
+    given_i_am_signed_in
+    and_the_equality_and_diversity_feature_flag_is_active
+    and_i_have_an_application_form_that_is_ready_to_submit
+    and_i_am_on_the_review_page
+
+    when_i_click_on_continue
+    then_i_see_the_equality_and_diversity_page
+
+    when_i_choose_not_to_complete_equality_and_diversity
+    then_i_can_submit_my_application
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_equality_and_diversity_feature_flag_is_active
+    FeatureFlag.activate('offer_declined_provider_emails')
+  end
+
+  def and_i_have_an_application_form_that_is_ready_to_submit
+    @application = create(
+      :completed_application_form,
+      :with_completed_references,
+      candidate: @current_candidate,
+      submitted_at: nil,
+      references_count: 2,
+      with_gces: true,
+    )
+  end
+
+  def and_i_am_on_the_review_page
+    visit candidate_interface_application_review_path
+  end
+
+  def when_i_click_on_continue
+    click_link 'Continue'
+  end
+
+  def then_i_see_the_equality_and_diversity_page
+    expect(page).to have_content('Equality and diversity')
+  end
+
+  def when_i_choose_not_to_complete_equality_and_diversity
+    click_link 'Continue without completing questionnaire'
+  end
+
+  def then_i_can_submit_my_application
+    expect(page).to have_content('Submit application')
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We need to ask users for Equality and Diversity info. As a first slice - Users can opt to provide Equality and Diversity information.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds
- A start page for Equality and Diversity questionnaire and the option to opt to provide Equality and Diversity information
- Feature flag

![image](https://user-images.githubusercontent.com/22743709/75033740-79516000-54a3-11ea-9c00-43aea73f7380.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
