### PR TITLE
Call rejection email outside of transaction

### DIFF
--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -21,11 +21,12 @@ class RejectApplication
         rejected_at: Time.zone.now,
       )
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
-      if FeatureFlag.active?('candidate_rejected_by_provider_email')
-        SendCandidateRejectionEmail.new(application_choice: @application_choice).call
-      end
       StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
+    if FeatureFlag.active?('candidate_rejected_by_provider_email')
+      SendCandidateRejectionEmail.new(application_choice: @application_choice).call
+    end
+    true
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/send_candidate_rejection_email.rb
+++ b/app/services/send_candidate_rejection_email.rb
@@ -12,22 +12,10 @@ class SendCandidateRejectionEmail
 
     if candidate_application_choices.all?(&:rejected?)
       CandidateMailer.send(:application_rejected_all_rejected, application_choice).deliver_later
-      add_audit_comment(application_choice)
     elsif number_of_pending_decisions.positive?
       CandidateMailer.send(:application_rejected_awaiting_decisions, application_choice).deliver_later
-      add_audit_comment(application_choice)
     elsif number_of_offers.positive?
       CandidateMailer.send(:application_rejected_offers_made, application_choice).deliver_later
-      add_audit_comment(application_choice)
     end
-  end
-
-private
-
-  def add_audit_comment(application_choice)
-    audit_comment =
-      "New rejection email sent to candidate #{application_choice.application_form.candidate.email_address} for " +
-      "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}."
-    application_choice.application_form.update!(audit_comment: audit_comment)
   end
 end

--- a/spec/services/send_candidate_rejection_email_spec.rb
+++ b/spec/services/send_candidate_rejection_email_spec.rb
@@ -6,11 +6,6 @@ RSpec.describe SendCandidateRejectionEmail do
     let(:application_choice) { create(:application_choice, status: :rejected, application_form: application_form) }
     let(:mail) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
-    def expected_audit_comment
-      "New rejection email sent to candidate #{application_choice.application_form.candidate.email_address} for " +
-        "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}."
-    end
-
     context 'when the candidate has had all of their application choices rejected' do
       before do
         allow(CandidateMailer).to receive(:application_rejected_all_rejected).and_return(mail)
@@ -19,10 +14,6 @@ RSpec.describe SendCandidateRejectionEmail do
 
       it 'sends them the all applications rejected email' do
         expect(CandidateMailer).to have_received(:application_rejected_all_rejected).with(application_choice)
-      end
-
-      it 'audits the rejection email', with_audited: true do
-        expect(application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
       end
     end
 
@@ -36,10 +27,6 @@ RSpec.describe SendCandidateRejectionEmail do
       it 'sends them the awaiting_decisions email' do
         expect(CandidateMailer).to have_received(:application_rejected_awaiting_decisions).with(application_choice)
       end
-
-      it 'audits the rejection email', with_audited: true do
-        expect(application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
-      end
     end
 
     context 'when the candidate receives a rejection and an offer' do
@@ -51,10 +38,6 @@ RSpec.describe SendCandidateRejectionEmail do
 
       it 'sends them the awaiting_decisions email' do
         expect(CandidateMailer).to have_received(:application_rejected_offers_made).with(application_choice)
-      end
-
-      it 'audits the rejection email', with_audited: true do
-        expect(application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
       end
     end
 


### PR DESCRIPTION
## Context

We think there is a race condition that occurs when we schedule an email for delivery inside this transaction, where the delivery occurs before the transaction has time to finalise and commit the changes to the database. This means that `decline_by_default_at` can be set to nil, which lead to a sentry error in production.

## Changes proposed in this pull request

Remove the audit comment in favour of the new email log.

Move email delivery call outside of transaction.

## Guidance to review

There isn't a good way to test this, because it's a race condition; our tests do not have a realistic queue setup.

## Link to Trello card

No card, tactical fix.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)