### PR TITLE
Remove terms of use line from sign up email

### DIFF
--- a/app/views/authentication_mailer/sign_up_email.text.erb
+++ b/app/views/authentication_mailer/sign_up_email.text.erb
@@ -5,5 +5,3 @@ Click the link below to confirm your email address and go back to the <%= t('ser
 <%= @magic_link %>
 
 You will then be able to save and return to your application.
-
-By signing in, you also agree to the terms of use of the <%= t('service_name.apply') %> service.


### PR DESCRIPTION
## Context

When signing up a candidate they have to check a box to say they agree to the terms of use, so having the `By signing in, you also agree to the terms of use of the Apply for teacher training service.` line in the sign up email is redundant.

## Changes proposed in this pull request

This PR removes the `By signing in, you also agree to the terms of use of the Apply for teacher training service.` line from the sign up email.

### Before

![image](https://user-images.githubusercontent.com/42817036/75140212-5bc00880-56e6-11ea-8aac-24380ee5d8c6.png)

### After

![image](https://user-images.githubusercontent.com/42817036/75140187-5236a080-56e6-11ea-9aca-911cebb92a9e.png)

## Guidance to review

👀 

## Link to Trello card

https://trello.com/c/05nmr4eO/962-checking-emails-in-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
