### PR TITLE
Add ability to choose and update sex for equality and diversity

### DIFF
--- a/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(SummaryCardComponent.new(rows: equality_and_diversity_rows, border: false, editable: @editable)) %>

--- a/app/components/candidate_interface/equality_and_diversity_review_component.rb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.rb
@@ -1,0 +1,23 @@
+module CandidateInterface
+  class EqualityAndDiversityReviewComponent < ActionView::Component::Base
+    def initialize(application_form:, editable: true)
+      @application_form = application_form
+      @editable = editable
+    end
+
+    def equality_and_diversity_rows
+      [sex_row]
+    end
+
+  private
+
+    def sex_row
+      {
+        key: 'Sex',
+        value: @application_form.equality_and_diversity['sex'].capitalize,
+        action: 'sex',
+        change_path: candidate_interface_edit_equality_and_diversity_sex_path,
+      }
+    end
+  end
+end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -1,5 +1,27 @@
 module CandidateInterface
   class EqualityAndDiversityController < CandidateInterfaceController
     def start; end
+
+    def edit_sex
+      @sex = EqualityAndDiversity::SexForm.build_from_application(current_application)
+    end
+
+    def update_sex
+      @sex = EqualityAndDiversity::SexForm.new(sex: sex_param)
+
+      if @sex.save(current_application)
+        redirect_to candidate_interface_review_equality_and_diversity_path
+      else
+        render :edit_sex
+      end
+    end
+
+    def review; end
+
+  private
+
+    def sex_param
+      params.dig(:candidate_interface_equality_and_diversity_sex_form, :sex)
+    end
   end
 end

--- a/app/models/candidate_interface/equality_and_diversity/sex_form.rb
+++ b/app/models/candidate_interface/equality_and_diversity/sex_form.rb
@@ -1,0 +1,21 @@
+module CandidateInterface
+  class EqualityAndDiversity::SexForm
+    include ActiveModel::Model
+
+    attr_accessor :sex
+
+    validates :sex, presence: true
+
+    def self.build_from_application(application_form)
+      sex = application_form.equality_and_diversity ? application_form.equality_and_diversity['sex'] : nil
+
+      new(sex: sex)
+    end
+
+    def save(application_form)
+      return false unless valid?
+
+      application_form.update(equality_and_diversity: { 'sex' => sex })
+    end
+  end
+end

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, 'What is your sex?' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @sex, url: candidate_interface_update_equality_and_diversity_sex_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :sex, legend: { size: 'xl', text: 'What is your sex?' } do %>
+        <div class="govuk-!-margin-top-6">
+          <%= f.govuk_radio_button :sex, :female, label: { text: 'Female' }, link_errors: true %>
+          <%= f.govuk_radio_button :sex, :male, label: { text: 'Male' } %>
+          <%= f.govuk_radio_button :sex, :intersex, label: { text: 'Intersex' } %>
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -1,0 +1,9 @@
+<% content_for :title, 'Check your answers' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_review_path) %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">Equality and diversity</span>
+  Check your answers
+</h1>
+
+<%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>

--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -12,6 +12,10 @@
     <p class="govuk-body">We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.</p>
     <p class="govuk-body">Your data will only be shared with training providers when you are enrolled on a course.</p>
 
-    <%= govuk_button_link_to 'Continue without completing questionnaire', candidate_interface_application_submit_show_path %>
+    <%= govuk_button_link_to 'Continue', candidate_interface_edit_equality_and_diversity_sex_path %>
+
+    <p class="govuk-body">
+      <%= govuk_link_to 'Continue without completing questionnaire', candidate_interface_application_submit_show_path %>
+    </p>
   </div>
 </div>

--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, 'Equality and diversity' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_review_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -550,3 +550,7 @@ en:
             feedback:
               blank: Enter your reference
               too_many_words: Your reference must be %{count} words or fewer
+        candidate_interface/equality_and_diversity/sex_form:
+          attributes:
+            sex:
+              blank: Choose your sex

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -252,6 +252,9 @@ Rails.application.routes.draw do
 
       scope '/equality-and-diversity' do
         get '/' => 'equality_and_diversity#start', as: :start_equality_and_diversity
+        get '/sex' => 'equality_and_diversity#edit_sex', as: :edit_equality_and_diversity_sex
+        post '/sex' => 'equality_and_diversity#update_sex', as: :update_equality_and_diversity_sex
+        get '/review' => 'equality_and_diversity#review', as: :review_equality_and_diversity
       end
     end
   end

--- a/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
+++ b/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EqualityAndDiversityReviewComponent do
+  let(:application_form) do
+    build_stubbed(
+      :application_form,
+      equality_and_diversity: { 'sex' => 'male' },
+    )
+  end
+
+  it 'renders component with correct equality and diversity information' do
+    result = render_inline(described_class.new(application_form: application_form))
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Sex')
+    expect(result.css('.govuk-summary-list__value').text).to include('Male')
+  end
+
+  context 'when editable' do
+    it 'renders the component with change links' do
+      result = render_inline(described_class.new(application_form: application_form, editable: true))
+
+      expect(result.text).to include('Change sex')
+    end
+  end
+
+  context 'when not editable' do
+    it 'renders the component with change links' do
+      result = render_inline(described_class.new(application_form: application_form, editable: false))
+
+      expect(result.text).not_to include('Change sex')
+    end
+  end
+end

--- a/spec/models/candidate_interface/equality_and_diversity/sex_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/sex_form_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EqualityAndDiversity::SexForm, type: :model do
+  describe '#build_from_application' do
+    it 'creates an object based on the application form' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: { 'sex' => 'male' })
+      form = CandidateInterface::EqualityAndDiversity::SexForm.build_from_application(application_form)
+
+      expect(form.sex).to eq('male')
+    end
+
+    it 'returns nil if equality and diversity is nil' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: nil)
+      form = CandidateInterface::EqualityAndDiversity::SexForm.build_from_application(application_form)
+
+      expect(form.sex).to eq(nil)
+    end
+  end
+
+  describe '#save' do
+    let(:application_form) { create(:application_form) }
+
+    context 'when sex is blank' do
+      it 'returns false' do
+        form = CandidateInterface::EqualityAndDiversity::SexForm.new
+
+        expect(form.save(application_form)).to be(false)
+      end
+    end
+
+    context 'when sex has a value' do
+      it 'returns true' do
+        form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'male')
+
+        expect(form.save(application_form)).to be(true)
+      end
+
+      it 'updates the equality and diversity information on the application form' do
+        form = CandidateInterface::EqualityAndDiversity::SexForm.new(sex: 'male')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('sex' => 'male')
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:sex) }
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -14,6 +14,24 @@ RSpec.feature 'Entering their equality and diversity information' do
 
     when_i_choose_not_to_complete_equality_and_diversity
     then_i_can_submit_my_application
+
+    when_i_am_on_the_equality_and_diversity_page
+    and_i_choose_to_complete_equality_and_diversity
+    then_i_am_asked_to_choose_my_sex
+
+    when_i_try_and_submit_without_choosing_my_sex
+    then_i_see_an_error_to_choose_my_sex
+
+    when_i_choose_my_sex
+    and_i_click_on_continue
+    then_i_can_review_my_answer
+
+    when_i_click_change_sex
+    then_i_am_asked_to_choose_my_sex
+
+    when_i_choose_a_different_sex
+    and_i_click_on_continue
+    then_i_can_review_my_updated_sex
   end
 
   def given_i_am_signed_in
@@ -53,5 +71,51 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def then_i_can_submit_my_application
     expect(page).to have_content('Submit application')
+  end
+
+  def when_i_am_on_the_equality_and_diversity_page
+    visit candidate_interface_start_equality_and_diversity_path
+  end
+
+  def and_i_choose_to_complete_equality_and_diversity
+    click_link 'Continue'
+  end
+
+  def then_i_am_asked_to_choose_my_sex
+    expect(page).to have_content('What is your sex?')
+  end
+
+  def when_i_try_and_submit_without_choosing_my_sex
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_to_choose_my_sex
+    expect(page).to have_content('Choose your sex')
+  end
+
+  def when_i_choose_my_sex
+    choose 'Male'
+  end
+
+  def and_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_can_review_my_answer
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('Male')
+  end
+
+  def when_i_click_change_sex
+    click_link 'Change sex'
+  end
+
+  def when_i_choose_a_different_sex
+    choose 'Female'
+  end
+
+  def then_i_can_review_my_updated_sex
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('Female')
   end
 end


### PR DESCRIPTION
## Context

We want to ask candidates for Equality and Diversity information. They can currently opt out of doing this and this slice was done in #1451.

## Changes proposed in this pull request

This PR:

- adds a form object for updating the sex attribute of equality and diversity field of an application
- adds a review component for reviewing and changing the answer

and wraps everything together so that a candidate can choose and update the field.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/75173725-39021400-5727-11ea-9534-54088b305e20.png)

![image](https://user-images.githubusercontent.com/42817036/75173749-428b7c00-5727-11ea-9c2b-0191ae4de0fb.png)

![image](https://user-images.githubusercontent.com/42817036/75173767-4a4b2080-5727-11ea-8f79-76f45c0052d2.png)

## Guidance to review

Would like feedback/help on:

- adding the caption for the `What is your sex?` page. As we are using the formbuilder to render the legend, there doesn't seem to be a way to pass in `Equality and diversity` as a caption. Any way around this? (see below)

<img width="844" alt="Screenshot 2020-02-24 at 17 05 44" src="https://user-images.githubusercontent.com/42817036/75174126-f0972600-5727-11ea-9732-854b7d7da898.png">

- refactoring this:

```ruby
def self.build_from_application(application_form)
  sex = application_form.equality_and_diversity ? application_form.equality_and_diversity['sex'] : nil

  new(sex: sex)
end

```

- review component looks a bit weird because we only have one field

## Link to Trello card

https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
