### PR TITLE
Add go to find page to the add course flow

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -23,9 +23,11 @@ module CandidateInterface
       if @choice_form.chosen_a_course?
         redirect_to candidate_interface_course_choices_provider_path
       else
-        redirect_to 'https://find-postgraduate-teacher-training.education.gov.uk'
+        redirect_to candidate_interface_go_to_find_path
       end
     end
+
+    def go_to_find; end
 
     def options_for_provider
       @pick_provider = PickProviderForm.new

--- a/app/views/candidate_interface/course_choices/go_to_find.html.erb
+++ b/app/views/candidate_interface/course_choices/go_to_find.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, t('page_titles.find_a_course') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_choose_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.find_a_course') %>
+    </h1>
+
+    <p class="govuk-body-l">Search for courses near you on Find postgraduate teacher training.</p>
+
+    <%= govuk_button_link_to 'Start now', 'https://find-postgraduate-teacher-training.education.gov.uk', class: 'govuk-button--start' %>
+
+    <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_complete_path %></p>
+
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
     withdraw_course_choice: Withdrawal
     destroy_course_choice: Are you sure you want to delete this choice?
     have_you_chosen: Have you chosen a course to apply to?
+    find_a_course: Find a course
     which_provider: Which training provider are you applying to?
     which_course: Which course are you applying to?
     which_location: Which location are you applying to?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,8 @@ Rails.application.routes.draw do
         get '/choose' => 'course_choices#have_you_chosen', as: :course_choices_choose
         post '/choose' => 'course_choices#make_choice'
 
+        get '/find_a_course' => 'course_choices#go_to_find', as: :go_to_find
+
         get '/delete/:id' => 'course_choices#confirm_destroy', as: :confirm_destroy_course_choice
         delete '/delete/:id' => 'course_choices#destroy'
 

--- a/spec/system/candidate_interface/candidate_does_not_know_where_they_want_to_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_does_not_know_where_they_want_to_apply_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a course' do
+  include CandidateHelper
+
+  scenario 'Candidate does not know what course to apply for' do
+    given_i_am_signed_in
+
+    when_i_visit_the_site
+    and_i_click_on_course_choices
+    and_i_click_on_add_course
+    and_i_choose_that_i_do_not_know_where_i_want_to_apply
+    then_i_should_be_on_the_find_a_course_page
+
+    when_i_click_start_now
+    then_i_am_sent_to_find
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link 'Course choices'
+  end
+
+  def and_i_click_on_add_course
+    click_link 'Continue'
+  end
+
+  def and_i_choose_that_i_do_not_know_where_i_want_to_apply
+    choose 'No, I need to find a course'
+    click_button 'Continue'
+  end
+
+  def then_i_should_be_on_the_find_a_course_page
+    expect(page).to have_current_path(candidate_interface_go_to_find_path)
+  end
+
+  def when_i_click_start_now
+    click_link 'Start now'
+  end
+
+  def then_i_am_sent_to_find
+    expect(page.current_url).to include('https://find-postgraduate-teacher-training.education.gov.uk')
+  end
+end


### PR DESCRIPTION
## Context

Currently, if a candidate selects that they don't know which course they want to select they are immediately sent to Find. This could be confusing for the user.

## Changes proposed in this pull request

- Add a go_to_find page

![image](https://user-images.githubusercontent.com/42515961/75180595-6dc89800-5734-11ea-9dd5-6ee054bbeb27.png)


## Guidance to review

Designs can be seen here https://bat-design-history.herokuapp.com/apply-teacher-training/pick-a-course#find-a-course---when-course-not-known

## Link to Trello card

https://trello.com/c/xHdcDsRT/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
