### PR TITLE
Set course choices section to incomplete when a course choice is added or deleted

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -106,6 +106,8 @@ module CandidateInterface
         .find(current_course_choice_id)
         .destroy!
 
+      current_application.update!(course_choices_completed: false)
+
       redirect_to candidate_interface_course_choices_index_path
     end
 
@@ -143,6 +145,8 @@ module CandidateInterface
       )
 
       if @pick_site.save
+        current_application.update!(course_choices_completed: false)
+
         redirect_to candidate_interface_course_choices_index_path
       else
         render :options_for_site

--- a/spec/system/candidate_interface/candidate_deletes_course_after_completing_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_course_after_completing_section_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate edits their choice section' do
+  include CandidateHelper
+
+  scenario 'Candidate deletes and adds additonal courses' do
+    given_i_am_signed_in
+    and_i_have_completed_the_course_choice_section
+
+    when_i_visit_the_course_choices_page
+    and_i_click_delete_a_choice
+    and_i_confirm_i_want_to_delete_the_choice
+    and_visit_my_application_page
+    then_the_course_choices_section_should_be_marked_as_incomplete
+
+    given_there_are_courses_to_add
+    and_i_have_added_a_course_and_complete_the_course_choices_section
+
+    when_i_visit_the_course_choices_page
+    and_i_click_on_add_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_a_course_with_a_single_site
+    and_visit_my_application_page
+    then_the_course_choices_section_should_be_marked_as_incomplete
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_completed_the_course_choice_section
+    @application_form = create(:application_form, candidate: @candidate, course_choices_completed: true)
+    create(:application_choice, application_form: @application_form, status: :unsubmitted)
+  end
+
+  def when_i_visit_the_course_choices_page
+    visit candidate_interface_course_choices_review_path
+  end
+
+  def and_i_click_delete_a_choice
+    click_link 'Delete choice'
+  end
+
+  def and_i_confirm_i_want_to_delete_the_choice
+    click_button t('application_form.courses.confirm_delete')
+  end
+
+  def and_visit_my_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def then_the_course_choices_section_should_be_marked_as_incomplete
+    expect(page.text).to include 'Course choices Incomplete'
+  end
+
+  def given_there_are_courses_to_add
+    @course = create(:course, exposed_in_find: true, open_on_apply: true)
+    @course_option = create(:course_option, course: @course, vacancy_status: 'B')
+  end
+
+  def and_i_have_added_a_course_and_complete_the_course_choices_section
+    @application_choice = create(:application_choice, application_form: @application_form, status: :unsubmitted)
+    @application_form.update!(course_choices_completed: true)
+  end
+
+  def and_i_click_on_add_course
+    click_link 'Add another course'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+  end
+
+  def and_i_choose_a_provider
+    select @course.provider.name_and_code
+    click_button 'Continue'
+  end
+
+  def and_i_choose_a_course_with_a_single_site
+    select @course.name_and_code
+    click_button 'Continue'
+  end
+end


### PR DESCRIPTION
## Context

Currently, when the course choices section is marked as complete, the candidate can add or delete courses without it setting the section to incomplete.

This means that a candidate can delete all their course choices and submit their application as our validations only check if all the sections have been completed.

## Changes proposed in this pull request

-  When a candidate adds a new course the application_choices_compelted attribute on the application form is set to false
- When a candidate deletes a course the application_choices_compelted attribute on the application form is set to false

## Guidance to review

This is the first of probably quite a few PRs. After discussion with Theo, anytime a candidate updates something in a section the completed status should default to incomplete.

## Link to Trello card

https://trello.com/c/wrAbxDA8/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
