### PR TITLE
Set degree section to incomplete when one is added, edited or deleted

### DIFF
--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -28,6 +28,8 @@ module CandidateInterface
       @degree = DegreeForm.new(degree_params)
 
       if @degree.update_base(current_application)
+        current_application.update!(degrees_completed: false)
+
         redirect_to candidate_interface_degrees_review_path
       else
         render_new

--- a/app/controllers/candidate_interface/degrees/destroy_controller.rb
+++ b/app/controllers/candidate_interface/degrees/destroy_controller.rb
@@ -11,6 +11,8 @@ module CandidateInterface
         .find(current_degree_id)
         .destroy!
 
+      current_application.update!(degrees_completed: false)
+
       redirect_to candidate_interface_degrees_review_path
     end
 

--- a/app/controllers/candidate_interface/degrees/grade_controller.rb
+++ b/app/controllers/candidate_interface/degrees/grade_controller.rb
@@ -18,6 +18,8 @@ module CandidateInterface
         if award_year_nil?
           redirect_to candidate_interface_degrees_year_path(current_degree_id)
         else
+          current_application.update!(degrees_completed: false)
+
           redirect_to candidate_interface_degrees_review_path
         end
       else

--- a/app/controllers/candidate_interface/degrees/review_controller.rb
+++ b/app/controllers/candidate_interface/degrees/review_controller.rb
@@ -7,9 +7,19 @@ module CandidateInterface
     end
 
     def complete
-      current_application.update!(application_form_params)
+      @application_form = current_application
 
-      redirect_to candidate_interface_application_form_path
+      if @application_form.application_qualifications.degrees.count.zero?
+        flash[:warning] = 'You can’t mark this section complete without adding a degree.'
+
+        @application_form.degrees_completed = false
+
+        render :show
+      else
+        @application_form.update!(application_form_params)
+
+        redirect_to candidate_interface_application_form_path
+      end
     end
 
   private

--- a/app/controllers/candidate_interface/degrees/year_controller.rb
+++ b/app/controllers/candidate_interface/degrees/year_controller.rb
@@ -15,6 +15,8 @@ module CandidateInterface
       @degree = DegreeForm.new(id: current_degree_id, attributes: degree_params)
 
       if @degree.update_year(current_application)
+        current_application.update!(degrees_completed: false)
+
         redirect_to candidate_interface_degrees_review_path
       else
         render :new

--- a/spec/system/candidate_interface/candidate_deletes_and_adds_degree_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_and_adds_degree_after_completing_the_section_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate edits their degree section' do
+  include CandidateHelper
+
+  scenario 'Candidate updates and deletes a degree after completing the degree section' do
+    given_i_am_signed_in
+    and_i_have_completed_the_degree_section
+
+    when_i_visit_the_application_page
+    then_the_degree_section_should_be_marked_as_complete
+
+    when_i_click_the_degree_link
+    and_i_click_to_change_my_undergraduate_degree
+    and_i_change_my_undergraduate_degree
+    and_i_click_on_save_and_continue
+
+    when_i_visit_the_application_page
+    then_the_degree_section_should_be_marked_as_incomplete
+
+    when_i_click_the_degree_link
+    and_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_the_degree_section_should_be_marked_as_complete
+
+    when_i_click_the_degree_link
+    and_i_click_on_delete_degree
+    and_i_confirm_that_i_want_to_delete_my_additional_degree
+
+    when_i_visit_the_application_page
+    then_the_degree_section_should_be_marked_as_incomplete
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_completed_the_degree_section
+    @application_form = create(:application_form, candidate: @candidate)
+    create(:application_qualification, application_form: @application_form, level: :degree)
+    @application_form.update!(degrees_completed: true)
+  end
+
+  def when_i_visit_the_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def then_the_degree_section_should_be_marked_as_complete
+    expect(page.text).to include 'Degree Completed'
+  end
+
+  def when_i_click_the_degree_link
+    click_link 'Degree'
+  end
+
+  def and_visit_my_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_to_change_my_undergraduate_degree
+    page.all('.govuk-summary-list__actions').to_a.first.click_link 'Change qualification'
+  end
+
+  def and_i_change_my_undergraduate_degree
+    fill_in t('application_form.degree.subject.label'), with: 'Wolf'
+    fill_in t('application_form.degree.institution_name.label'), with: 'University of Moon Moon'
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('application_form.degree.base.button')
+  end
+
+  def then_the_degree_section_should_be_marked_as_incomplete
+    expect(page.text).to include 'Degree Incomplete'
+  end
+
+  def and_i_click_on_delete_degree
+    click_link(t('application_form.degree.delete'))
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_additional_degree
+    click_button t('application_form.degree.confirm_delete')
+  end
+
+  def and_i_mark_this_section_as_completed
+    check t('application_form.degree.review.completed_checkbox')
+  end
+
+  def and_i_click_on_continue
+    click_button t('application_form.degree.review.button')
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_degrees_spec.rb
@@ -32,7 +32,14 @@ RSpec.feature 'Entering their degrees' do
     and_i_click_on_save_and_continue
     then_i_can_check_my_undergraduate_degree
 
-    when_i_click_on_continue
+    when_i_click_on_delete_degree
+    and_i_confirm_that_i_want_to_delete_my_degree
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_am_told_i_need_to_add_a_degree_to_complete_the_section
+
+    when_i_readd_my_degree
+    and_i_click_on_continue
     then_i_should_see_the_form_and_the_section_is_not_completed
     when_i_click_on_degree
     then_i_can_check_my_undergraduate_degree
@@ -155,6 +162,10 @@ RSpec.feature 'Entering their degrees' do
     click_button t('application_form.degree.review.button')
   end
 
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
   def then_i_should_see_the_form_and_the_section_is_not_completed
     expect(page).to have_content(t('page_titles.application_form'))
     expect(page).not_to have_css('#degree-badge-id', text: 'Completed')
@@ -166,6 +177,18 @@ RSpec.feature 'Entering their degrees' do
 
   def then_i_see_the_add_another_degree_form
     expect(page).to have_content(t('page_titles.add_another_degree'))
+  end
+
+  def when_i_readd_my_degree
+    when_i_click_on_add_another_degree
+    when_i_fill_in_my_undergraduate_degree_base
+    and_i_click_on_save_and_continue
+
+    when_i_select_the_degree_classification
+    and_i_click_on_save_and_continue
+
+    when_i_fill_in_the_graduation_year
+    and_i_click_on_save_and_continue
   end
 
   def when_i_fill_in_my_additional_degree
@@ -188,6 +211,10 @@ RSpec.feature 'Entering their degrees' do
 
   def and_i_confirm_that_i_want_to_delete_my_additional_degree
     click_button t('application_form.degree.confirm_delete')
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_degree
+    and_i_confirm_that_i_want_to_delete_my_additional_degree
   end
 
   def then_i_can_only_see_my_undergraduate_degree
@@ -265,5 +292,9 @@ RSpec.feature 'Entering their degrees' do
 
   def then_i_can_check_my_answers
     then_i_can_check_my_revised_undergraduate_degree
+  end
+
+  def then_i_am_told_i_need_to_add_a_degree_to_complete_the_section
+    expect(page).to have_content 'You can’t mark this section complete without adding a degree.'
   end
 end


### PR DESCRIPTION
## Context

Currently, when the degree section is marked as complete, the candidate can add, edit or delete degrees without it setting the section to incomplete.

This means that a candidate can delete all their degrees and submit their application as our validations only check if all the sections have been completed.

## Changes proposed in this pull request

-  When a candidate adds, edits or deletes a degree the degrees_attribute on their application form is set to false

## Guidance to review

This is the second PR for this card. The first is #1464  

## Link to Trello card

https://trello.com/c/wrAbxDA8/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
