### PR TITLE
Set other qualifications section to incomplete when edited

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -35,6 +35,8 @@ module CandidateInterface
       @qualification = OtherQualificationForm.new(other_qualification_params)
 
       if @qualification.update(current_application)
+        current_application.update!(other_qualifications_completed: false)
+
         redirect_to candidate_interface_review_other_qualifications_path
       else
         render :edit

--- a/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/destroy_controller.rb
@@ -13,6 +13,8 @@ module CandidateInterface
         .find(current_other_qualification_id)
         .destroy!
 
+      current_application.update!(other_qualifications_completed: false)
+
       redirect_to candidate_interface_review_other_qualifications_path
     end
 

--- a/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualificaitons_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualificaitons_after_completing_the_section_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidates academic and other relevant qualifications' do
+  include CandidateHelper
+
+  scenario 'Candidate updates and deletes qualificaitons in a completed academic and other relevant qualifications section' do
+    given_i_am_signed_in
+    and_i_have_completed_the_other_qualifications_section
+
+    when_i_visit_the_application_page
+    then_the_other_qualificaitons_section_should_be_marked_as_complete
+
+    when_i_click_the_other_qualifications_link
+    and_i_click_to_change_my_qualification
+    and_i_change_my_qualification
+    and_i_click_on_save_and_continue
+
+    when_i_visit_the_application_page
+    then_the_other_qualifications_section_should_not_be_marked_as_complete
+
+    when_i_click_the_other_qualifications_link
+    and_click_on_delete_my_additional_qualification
+    and_i_confirm_that_i_want_to_delete_my_qualification
+
+    when_i_visit_the_application_page
+    then_the_other_qualifications_section_should_not_be_marked_as_complete
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_completed_the_other_qualifications_section
+    @application_form = create(:application_form, candidate: @candidate)
+    create(:application_qualification, application_form: @application_form, level: :other)
+    @application_form.update!(other_qualifications_completed: true)
+  end
+
+  def when_i_visit_the_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def then_the_other_qualificaitons_section_should_be_marked_as_complete
+    expect(page.text).to include 'Academic and other relevant qualifications Completed'
+  end
+
+  def when_i_click_the_other_qualifications_link
+    click_link 'Academic and other relevant qualifications'
+  end
+
+  def and_visit_my_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_to_change_my_qualification
+    page.all('.govuk-summary-list__actions').to_a.first.click_link 'Change'
+  end
+
+  def and_i_change_my_qualification
+    fill_in t('application_form.other_qualification.qualification_type.label'), with: 'A-Level'
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
+    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
+    fill_in t('application_form.other_qualification.grade.label'), with: 'A'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('application_form.degree.base.button')
+  end
+
+  def then_the_other_qualifications_section_should_not_be_marked_as_complete
+    expect(page.text).not_to include 'Academic and other relevant qualifications Complete'
+  end
+
+  def and_i_click_on_delete_degree
+    click_link(t('application_form.degree.delete'))
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_additional_degree
+    click_button t('application_form.degree.confirm_delete')
+  end
+
+  def and_i_mark_this_section_as_completed
+    check t('application_form.degree.review.completed_checkbox')
+  end
+
+  def and_i_click_on_continue
+    click_button t('application_form.degree.review.button')
+  end
+
+  def and_click_on_delete_my_additional_qualification
+    click_link(t('application_form.other_qualification.delete'))
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_qualification
+    click_button t('application_form.other_qualification.confirm_delete')
+  end
+end


### PR DESCRIPTION
## Context

Currently, when the Academic and other relevant qualifications section is marked as complete, the candidate can add, edit or delete qualifications without it setting the section to incomplete.

This means that a candidate can delete all their qualifications and submit their application as our validations only check if all the sections have been completed.

## Changes proposed in this pull request

-  When a candidate adds, edits or deletes a qualification the other_qualifications_completed attribute on their application form is set to false

## Guidance to review

This is the third PR for this card. The first is #1464 and the second is #1466 

## Link to Trello card

https://trello.com/c/wrAbxDA8/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
