### PR TITLE
1665 remove support users

### DIFF
--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -19,6 +19,16 @@ module SupportInterface
       end
     end
 
+    def confirm_destroy
+      @support_user = SupportUser.find(params[:id])
+    end
+
+    def destroy
+      SupportUser.find(params[:id]).destroy!
+      flash[:success] = 'Support user deleted'
+      redirect_to support_interface_support_users_path
+    end
+
   private
 
     def support_user_params

--- a/app/views/support_interface/support_users/confirm_destroy.html.erb
+++ b/app/views/support_interface/support_users/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :before_content, govuk_back_link_to(support_interface_support_users_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @support_user,
+      url: support_interface_destroy_support_user_path(@support_user.id),
+      method: :delete do |f| %>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Support user</span>
+        <%= t('support_interface.support_user.confirm_delete',
+              email: @support_user.email_address) %>
+      </h1>
+
+      <%= f.submit t('support_interface.support_user.delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', support_interface_support_users_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -25,6 +25,7 @@
     <tr class='govuk-table__row'>
       <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Email</th>
       <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>DfE Sign-in UID</th>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Actions</th>
     </tr>
   </thead>
 
@@ -36,6 +37,14 @@
         </td>
         <td class='govuk-table__cell'>
           <%= support_user.dfe_sign_in_uid %>
+        </td>
+        <td class='govuk-table__cell'>
+          <%= link_to(
+                support_interface_confirm_destroy_support_user_path(support_user),
+                class: 'govuk-link',
+          ) do %>
+            Delete user<span class='govuk-visually-hidden'> <%= support_user.email_address %></span>
+          <% end %>
         </td>
       </tr>
     <% end %>

--- a/config/locales/support_interface.yml
+++ b/config/locales/support_interface.yml
@@ -1,0 +1,5 @@
+en:
+  support_interface:
+    support_user:
+      confirm_delete: Are you sure you want to delete support user %{email}?
+      delete: Delete support user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -386,6 +386,9 @@ Rails.application.routes.draw do
     scope '/users' do
       get '/' => 'users#index', as: :users
 
+      get '/delete/:id' => 'support_users#confirm_destroy', as: :confirm_destroy_support_user
+      delete '/delete/:id' => 'support_users#destroy', as: :destroy_support_user
+
       resources :support_users, only: %i[index new create], path: :support
       resources :provider_users, only: %i[index new create edit update], path: :provider
     end

--- a/spec/system/support_interface/remove_support_users_spec.rb
+++ b/spec/system/support_interface/remove_support_users_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Remove a support user' do
+  include DfESignInHelpers
+
+  scenario 'Confirming removal of a support user' do
+    given_i_am_a_support_user
+    and_there_are_some_support_users
+    when_i_visit_the_support_users_page
+    and_i_delete_a_support_user
+    then_i_should_see_a_confirmation_page
+    and_i_confirm_deletion
+    then_the_support_user_is_deleted_from_the_database
+    and_the_support_user_is_not_listed
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_some_support_users
+    @support_users = create_list(:support_user, 2)
+    @deleted_user_email = @support_users.last.email_address
+  end
+
+  def when_i_visit_the_support_users_page
+    visit support_interface_support_users_path
+  end
+
+  def and_i_delete_a_support_user
+    within('.govuk-table__body') do
+      click_on("Delete user #{@deleted_user_email}")
+    end
+  end
+
+  def then_i_should_see_a_confirmation_page
+    expect(page.text).to include("Are you sure you want to delete support user #{@deleted_user_email}?")
+  end
+
+  def and_i_confirm_deletion
+    click_on 'Delete support user'
+  end
+
+  def then_the_support_user_is_deleted_from_the_database
+    expect(SupportUser.find_by_email_address(@deleted_user_email)).to be_nil
+  end
+
+  def and_the_support_user_is_not_listed
+    expect(page.text).not_to include(@deleted_user_email)
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We can onboard support users via the UI but cannot remove them.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Adds delete buttons to the support users index per user. This takes the administrator to a confirmation screen before actual record deletion.

### Before

![image](https://user-images.githubusercontent.com/93511/75339074-b93f8b00-5887-11ea-9df4-d8bb0ff42767.png)


### After

![image](https://user-images.githubusercontent.com/93511/75344442-85b62e00-5892-11ea-8f1e-80bd224f7c9d.png)


(confirmation screen...)

![image](https://user-images.githubusercontent.com/93511/75339330-323ee280-5888-11ea-9e2f-1d09c8c597cb.png)



## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

@tvararu and I discussed putting this behind a feature flag purely to get used to the practice, arguably this feature isn't large enough to warrant it.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

https://trello.com/c/AYxmAxXj/1665-offboarding-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
