### PR TITLE
Link directly to sign in page from provider account created email

### DIFF
--- a/app/views/provider_mailer/account_created.text.erb
+++ b/app/views/provider_mailer/account_created.text.erb
@@ -8,7 +8,7 @@ You will need to use DfE Sign-in to access your applications.
 
 Visit Manage teacher training applications to sign in:
 
-<%= provider_interface_url %>
+<%= provider_interface_sign_in_url %>
 
 # Don’t have a DfE Sign-in account?
 

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe ProviderMailer, type: :mailer do
       expect(@mail.body.encoded).to include("Dear #{@provider_user.full_name}")
     end
 
-    it 'includes a link to the provider home page' do
-      expect(@mail.body.encoded).to include(provider_interface_url)
+    it 'includes a link to the provider sign in page' do
+      expect(@mail.body.encoded).to include(provider_interface_sign_in_path)
     end
   end
 


### PR DESCRIPTION
## Context

Providers still blinded by the big ‘Get started’ button on the provider homepage, when they are directed there to sign in. We should link directly to the sign in page instead.
