### PR TITLE
Allow candidates to say what disabilities they have

### DIFF
--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -28,9 +28,27 @@ module CandidateInterface
       @disability_status = EqualityAndDiversity::DisabilityStatusForm.new(disability_status: disability_status_param)
 
       if @disability_status.save(current_application)
-        redirect_to candidate_interface_review_equality_and_diversity_path
+        if disability_status_param == 'no'
+          redirect_to candidate_interface_review_equality_and_diversity_path
+        else
+          redirect_to candidate_interface_edit_equality_and_diversity_disabilities_path
+        end
       else
         render :edit_disability_status
+      end
+    end
+
+    def edit_disabilities
+      @disabilities = EqualityAndDiversity::DisabilitiesForm.build_from_application(current_application)
+    end
+
+    def update_disabilities
+      @disabilities = EqualityAndDiversity::DisabilitiesForm.new(disabilties_params)
+
+      if @disabilities.save(current_application)
+        redirect_to candidate_interface_review_equality_and_diversity_path
+      else
+        render :edit_disabilities
       end
     end
 
@@ -44,6 +62,10 @@ module CandidateInterface
 
     def disability_status_param
       params.dig(:candidate_interface_equality_and_diversity_disability_status_form, :disability_status)
+    end
+
+    def disabilties_params
+      params.require(:candidate_interface_equality_and_diversity_disabilities_form).permit(:other_disability, disabilities: [])
     end
   end
 end

--- a/app/helpers/checkbox_options_helper.rb
+++ b/app/helpers/checkbox_options_helper.rb
@@ -1,0 +1,11 @@
+module CheckboxOptionsHelper
+  def disabilities_checkboxes
+    CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.map do |id, disability|
+      OpenStruct.new(
+        id: id,
+        name: disability,
+        hint_text: I18n.t("equality_and_diversity.disabilities.#{id}.hint_text"),
+      )
+    end
+  end
+end

--- a/app/models/candidate_interface/equality_and_diversity/disabilities_form.rb
+++ b/app/models/candidate_interface/equality_and_diversity/disabilities_form.rb
@@ -1,0 +1,57 @@
+module CandidateInterface
+  class EqualityAndDiversity::DisabilitiesForm
+    include ActiveModel::Model
+
+    DISABILITIES = [
+      %w[blind Blind],
+      %w[deaf Deaf],
+      ['learning', 'Learning difficulty'],
+      ['long_standing', 'Long-standing illness'],
+      ['mental', 'Mental health condition'],
+      ['physical', 'Physical disability or mobility issue'],
+      ['social', 'Social or communication impairment'],
+    ].freeze
+
+    attr_accessor :disabilities, :other_disability
+
+    validates :disabilities, presence: true
+    validates :other_disability, presence: true, if: :other_disability?
+
+    def self.build_from_application(application_form)
+      return new(disabilities: nil) if application_form.equality_and_diversity.nil?
+
+      list_of_disabilities = DISABILITIES.map { |_, disability| disability }
+      listed, other = application_form.equality_and_diversity['disabilities'].partition { |d| list_of_disabilities.include?(d) }
+
+      if other.any?
+        listed << 'Other'
+
+        new(disabilities: listed, other_disability: other.first)
+      else
+        new(disabilities: listed)
+      end
+    end
+
+    def save(application_form)
+      return false unless valid?
+
+      disabilities << other_disability if disabilities.include?('Other')
+      disabilities.delete('Other')
+
+      if application_form.equality_and_diversity.nil?
+        application_form.update(equality_and_diversity: { 'disabilities' => disabilities })
+      else
+        application_form.equality_and_diversity['disabilities'] = disabilities
+        application_form.save
+      end
+    end
+
+  private
+
+    def other_disability?
+      return false if disabilities.nil?
+
+      disabilities.include?('Other')
+    end
+  end
+end

--- a/app/models/candidate_interface/equality_and_diversity/disability_status_form.rb
+++ b/app/models/candidate_interface/equality_and_diversity/disability_status_form.rb
@@ -19,9 +19,11 @@ module CandidateInterface
 
       if application_form.equality_and_diversity.nil?
         application_form.update(equality_and_diversity: { 'disabilities' => [] })
-      else
+      elsif application_form.equality_and_diversity['disabilities'].nil? || disability_status == 'no'
         application_form.equality_and_diversity['disabilities'] = []
         application_form.save
+      else
+        true
       end
     end
   end

--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, 'Please select all that apply to you' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @disabilities, url: candidate_interface_update_equality_and_diversity_disabilities_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_check_boxes_fieldset :disabilities, legend: { size: 'xl', text: 'Please select all that apply to you' } do %>
+        <div class="govuk-!-margin-top-6">
+          <% disabilities_checkboxes.each do |checkbox| %>
+            <%= f.govuk_check_box :disabilities, checkbox.name, label: { text: checkbox.name, size: 's' }, hint_text: checkbox.hint_text %>
+          <% end %>
+
+          <%= f.govuk_check_box :disabilities, 'Other', label: { text: 'Other', size: 's' } do %>
+            <%= f.govuk_text_field :other_disability, label: { text: 'Describe your disability (optional)' } %>
+          <% end %>
+
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -558,3 +558,9 @@ en:
           attributes:
             disability_status:
               blank: Choose if you have a disability
+        candidate_interface/equality_and_diversity/disabilities_form:
+          attributes:
+            disabilities:
+              blank: Select all disabilities that apply to you
+            other_disability:
+              blank: Describe your disability

--- a/config/locales/equality_and_diversity.yml
+++ b/config/locales/equality_and_diversity.yml
@@ -1,0 +1,18 @@
+en:
+  equality_and_diversity:
+    disabilities:
+      blind:
+        hint_text: (or a serious visual impairment which is not corrected by glasses)
+      deaf:
+        hint_text: (or a serious hearing impairment)
+      learning:
+        hint_text: (for example, dyslexia, dyspraxia or ADHD)
+      long_standing:
+        hint_text: (for example, cancer, HIV, diabetes, chronic heart disease or epilepsy)
+      mental:
+        hint_text: (for example, depression, schizophrenia or anxiety disorder)
+      physical:
+        hint_text: (for example, impaired use of arms or legs, use of a wheelchair or crutches)
+      social: 
+        hint_text: (for example Asperger’s, or another autistic spectrum disorder)
+    

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,8 @@ Rails.application.routes.draw do
         post '/sex' => 'equality_and_diversity#update_sex', as: :update_equality_and_diversity_sex
         get '/disability-status' => 'equality_and_diversity#edit_disability_status', as: :edit_equality_and_diversity_disability_status
         post '/disability-status' => 'equality_and_diversity#update_disability_status', as: :update_equality_and_diversity_disability_status
+        get '/disabilities' => 'equality_and_diversity#edit_disabilities', as: :edit_equality_and_diversity_disabilities
+        post '/disabilities' => 'equality_and_diversity#update_disabilities', as: :update_equality_and_diversity_disabilities
         get '/review' => 'equality_and_diversity#review', as: :review_equality_and_diversity
       end
     end

--- a/spec/helpers/checkbox_options_helper_spec.rb
+++ b/spec/helpers/checkbox_options_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CheckboxOptionsHelper, type: :helper do
+  describe '#disabilities_checkboxes' do
+    it 'return a stuctured list of all listed disabilities' do
+      id, name = CandidateInterface::EqualityAndDiversity::DisabilitiesForm::DISABILITIES.sample
+
+      expect(disabilities_checkboxes).to include(
+        OpenStruct.new(
+          id: id,
+          name: name,
+          hint_text: I18n.t("equality_and_diversity.disabilities.#{id}.hint_text"),
+        ),
+      )
+    end
+  end
+end

--- a/spec/models/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
@@ -1,0 +1,101 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type: :model do
+  describe '.build_from_application' do
+    it 'creates an object based on the application form' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => %w[Blind Deaf] })
+      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+
+      expect(form.disabilities).to eq(%w[Blind Deaf])
+    end
+
+    it 'creates an object with other disability based on the application form' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => ['Blind', 'Deaf', 'Other disability'] })
+      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+
+      expect(form.disabilities).to eq(%w[Blind Deaf Other])
+      expect(form.other_disability).to eq('Other disability')
+    end
+
+    it 'returns nil if equality and diversity is nil' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: nil)
+      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+
+      expect(form.disabilities).to eq(nil)
+    end
+  end
+
+  describe '#save' do
+    let(:application_form) { create(:application_form) }
+
+    context 'when disabilities field is blank' do
+      it 'returns false' do
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new
+
+        expect(form.save(application_form)).to be(false)
+      end
+    end
+
+    context 'when disabilities field has a value' do
+      it 'returns true' do
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind])
+
+        expect(form.save(application_form)).to be(true)
+      end
+
+      it 'updates the equality and diversity information on the application form' do
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind Other], other_disability: 'Other disability')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('disabilities' => ['Blind', 'Other disability'])
+      end
+
+      it 'updates the existing record of equality and diversity information' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind])
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'disabilities' => %w[Blind],
+        )
+      end
+
+      it 'does not update disabilities with other disability if Other is not selected' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind], other_disability: 'Other disability')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'disabilities' => %w[Blind],
+        )
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:disabilities) }
+
+    context 'when other disability is chosen' do
+      it 'validates presence of other disability' do
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Other])
+        error_message = I18n.t('activemodel.errors.models.candidate_interface/equality_and_diversity/disabilities_form.attributes.other_disability.blank')
+
+        form.validate
+
+        expect(form.errors.full_messages_for(:other_disability)).to eq(
+          ["Other disability #{error_message}"],
+        )
+      end
+    end
+
+    context 'when other disability is not chosen' do
+      it 'does not validates presence of other disability' do
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind])
+
+        form.validate
+
+        expect(form.errors).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
@@ -69,6 +69,26 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
           'sex' => 'male', 'disabilities' => [],
         )
       end
+
+      it 'updates the existing disabilities of equality and diversity information' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
+        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'disabilities' => %w(Blind),
+        )
+      end
+
+      it 'resets the disabilities of equality and diversity information if disability status is no' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
+        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'disabilities' => [],
+        )
+      end
     end
   end
 

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -33,12 +33,36 @@ RSpec.feature 'Entering their equality and diversity information' do
     and_i_click_on_continue
     then_i_can_review_my_answers
 
+    when_i_click_change_my_disability
+    then_i_am_asked_if_i_have_a_disability
+
+    when_i_choose_yes_for_having_a_disability
+    and_i_click_on_continue
+    then_i_see_the_disabilities_page
+
+    when_i_try_and_submit_without_ticking_disabilities
+    then_i_see_an_error_to_select_disabilties
+
+    when_i_check_my_disabilities
+    and_i_enter_another_disability
+    and_i_click_on_continue
+    then_i_can_review_my_disabilities
+
     when_i_click_change_sex
     then_i_am_asked_to_choose_my_sex
 
     when_i_choose_a_different_sex
     and_i_click_on_continue
     then_i_can_review_my_updated_sex
+
+    when_i_click_change_my_disability
+    and_i_choose_yes_for_having_a_disability
+    and_i_click_on_continue
+    then_i_see_the_disabilties_i_selected_are_checked
+
+    when_i_change_my_disabilities
+    and_i_click_on_continue
+    then_i_can_review_my_updated_disabilities
   end
 
   def given_i_am_signed_in
@@ -141,5 +165,62 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def when_i_choose_no_for_having_a_disability
     choose 'No'
+  end
+
+  def when_i_click_change_my_disability
+    click_link 'Change disability'
+  end
+
+  def when_i_choose_yes_for_having_a_disability
+    choose 'Yes'
+  end
+
+  def then_i_see_the_disabilities_page
+    expect(page).to have_content('Please select all that apply to you')
+  end
+
+  def when_i_try_and_submit_without_ticking_disabilities
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_to_select_disabilties
+    expect(page).to have_content('Select all disabilities that apply to you')
+  end
+
+  def when_i_check_my_disabilities
+    check 'Blind'
+    check 'Deaf'
+    check 'Other'
+  end
+
+  def and_i_enter_another_disability
+    fill_in 'Describe your disability', with: 'other disability'
+  end
+
+  def then_i_can_review_my_disabilities
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('Male')
+    expect(page).to have_content('Yes (Blind, Deaf and other disability)')
+  end
+
+  def and_i_choose_yes_for_having_a_disability
+    choose 'Yes'
+  end
+
+  def then_i_see_the_disabilties_i_selected_are_checked
+    expect(first('input[type=checkbox][value=Blind]')).to be_checked
+    expect(first('input[type=checkbox][value=Deaf]')).to be_checked
+    expect(first('input[type=checkbox][value=Other]')).to be_checked
+    expect(page).to have_selector("input[value='other disability']")
+  end
+
+  def when_i_change_my_disabilities
+    uncheck 'Blind'
+    uncheck 'Other'
+  end
+
+  def then_i_can_review_my_updated_disabilities
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('Yes (Deaf)')
   end
 end


### PR DESCRIPTION
## Context
Currently, you can only say if you have a disability or not for the equality and diversity monitoring, but not provide details of your disability, see #1463.

## Changes proposed in this pull request
This PR:
- adds a page with a list of disabilities to allow candidates selecting all that apply to them
- adds a form object for updating disabilities

### Screenshots
![image](https://user-images.githubusercontent.com/22743709/75357434-47783900-58a9-11ea-92eb-ee1275cd2195.png)

![image](https://user-images.githubusercontent.com/22743709/75357633-9625d300-58a9-11ea-87d9-9c4866d4a6b3.png)

## Guidance to review

Whether the constant `DISABILITIES` is better placed elsewhere? 

## Link to Trello card
https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
