### PR TITLE
Amend govuk_link_to so that it accepts a block

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,6 +1,8 @@
 module ViewHelper
-  def govuk_link_to(body, url, html_options = {})
+  def govuk_link_to(body, url, html_options = {}, &_block)
     html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
+
+    return link_to(url, html_options) { yield } if block_given?
 
     link_to(body, url, html_options)
   end

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -39,9 +39,9 @@
           <%= support_user.dfe_sign_in_uid %>
         </td>
         <td class='govuk-table__cell'>
-          <%= link_to(
+          <%= govuk_link_to(
+                nil,
                 support_interface_confirm_destroy_support_user_path(support_user),
-                class: 'govuk-link',
           ) do %>
             Delete user<span class='govuk-visually-hidden'> <%= support_user.email_address %></span>
           <% end %>

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -19,6 +19,13 @@ RSpec.describe ViewHelper, type: :helper do
 
       expect(anchor_tag).to eq('<a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://localhost:0103/sheep/baaa">Baaa</a>')
     end
+
+    it 'accepts a block' do
+      anchor_tag = helper.govuk_link_to(nil, 'https://localhost:0103/bee/buzz') do
+        'Buzz'
+      end
+      expect(anchor_tag).to eq('<a class="govuk-link" href="https://localhost:0103/bee/buzz">Buzz</a>')
+    end
   end
 
   describe '#govuk_back_link_to' do


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We discovered in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1469 that `govuk_link_to` does not accept a block argument in the same way that ActionView `link_to` does.

## Changes proposed in this pull request

This PR allows `govuk_link_to` to accept and yield a block. This is useful for more complex link text containing child elements.

Usage:

```ruby
<%= govuk_link_to(nil, root_path) do %>
  This link<span class="govuk-visually-hidden"> contains accessible text</span>
<% end %>
```

renders as:

```html
<a href="/" class="govuk-link">This link<span class="govuk-visually-hidden"> contains accessible text</span></a>
```

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
