### PR TITLE
Add form object to update ethnic group for equality and diversity

### DIFF
--- a/app/models/candidate_interface/equality_and_diversity/ethnic_group_form.rb
+++ b/app/models/candidate_interface/equality_and_diversity/ethnic_group_form.rb
@@ -1,0 +1,28 @@
+module CandidateInterface
+  class EqualityAndDiversity::EthnicGroupForm
+    include ActiveModel::Model
+
+    attr_accessor :ethnic_group
+
+    validates :ethnic_group, presence: true
+
+    def self.build_from_application(application_form)
+      return new(ethnic_group: nil) if application_form.equality_and_diversity.nil?
+      return new(ethnic_group: nil) if application_form.equality_and_diversity['ethnic_group'].nil?
+
+      new(ethnic_group: application_form.equality_and_diversity['ethnic_group'])
+    end
+
+    def save(application_form)
+      return false unless valid?
+
+      if application_form.equality_and_diversity.nil?
+        application_form.update(equality_and_diversity: { 'ethnic_group' => ethnic_group })
+      else
+        application_form.equality_and_diversity['ethnic_group'] = ethnic_group
+        application_form.equality_and_diversity['ethnic_background'] = nil if ethnic_group == 'Prefer not to say'
+        application_form.save
+      end
+    end
+  end
+end

--- a/spec/models/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/ethnic_group_form_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicGroupForm, type: :model do
+  describe '.build_from_application' do
+    context 'when an application form has an ethnic group' do
+      it 'creates a new ethnic group form with ethnic group of the application' do
+        application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British' })
+
+        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.build_from_application(application_form)
+
+        expect(form.ethnic_group).to eq('Asian or Asian British')
+      end
+    end
+
+    it 'returns nil if equality and diversity is nil' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: nil)
+
+      form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.build_from_application(application_form)
+
+      expect(form.ethnic_group).to eq(nil)
+    end
+
+    it 'returns nil if ethnic group field is missing in equality and diversity' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: { 'sex' => 'male' })
+
+      form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.build_from_application(application_form)
+
+      expect(form.ethnic_group).to eq(nil)
+    end
+  end
+
+  describe '#save' do
+    let(:application_form) { create(:application_form) }
+
+    context 'when ethnic group is blank' do
+      it 'returns false' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new
+
+        expect(form.save(application_form)).to be(false)
+      end
+    end
+
+    context 'when ethnic group has a value' do
+      it 'returns true' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Prefer not to say')
+
+        expect(form.save(application_form)).to be(true)
+      end
+
+      it 'updates the equality and diversity information on the application form' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'White')
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'White')
+      end
+
+      it 'updates the existing record of equality and diversity information' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
+        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Black, African, Black British or Caribbean')
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'ethnic_group' => 'Black, African, Black British or Caribbean',
+        )
+      end
+
+      it 'resets the ethnic background of equality and diversity information if ethnic group is "Prefer not to say"' do
+        application_form = create(
+          :application_form,
+          equality_and_diversity: {
+            'sex' => 'male',
+            'ethnic_group' => 'Another ethnic group',
+            'ethnic_background' => 'Arab',
+          },
+        )
+        form = CandidateInterface::EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: 'Prefer not to say')
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'ethnic_group' => 'Prefer not to say', 'ethnic_background' => nil,
+        )
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:ethnic_group) }
+  end
+end


### PR DESCRIPTION
## Context

Currently, we've built the 'What is your sex?', 'Are you disabled?', 'Please select all (disabilities) that apply to you' pages for equality and diversity monitoring. Up next is to add the 'What is your ethnic group?' page.

## Changes proposed in this pull request

This PR adds the form object called `EqualityAndDiversity::EthnicGroupForm` with the usual:

- `.build_from_application` to create the a new `EqualityAndDiversity::EthnicGroupForm` using the values a given `ApplicationForm`
- `#save` to update a given `ApplicationForm` from the value of the instance of `EthnicGroupForm`

## Guidance to review

Very similar to our `EqualityAndDiversity::DisabilityStatusForm`.

## Link to Trello card

https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
