### PR TITLE
Adjust order of states in ApplicationStateChange to fix comparison results

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -14,6 +14,8 @@ class ApplicationStateChange
   #   bundle exec rake generate_state_diagram
   #
   workflow do
+    state :withdrawn
+
     state :unsubmitted do
       event :submit, transitions_to: :awaiting_references
     end
@@ -34,6 +36,10 @@ class ApplicationStateChange
       event :withdraw, transitions_to: :withdrawn
     end
 
+    state :rejected do
+      event :make_offer, transitions_to: :offer
+    end
+
     state :offer do
       event :make_offer, transitions_to: :offer
       event :reject, transitions_to: :rejected
@@ -41,6 +47,8 @@ class ApplicationStateChange
       event :decline, transitions_to: :declined
       event :decline_by_default, transitions_to: :declined
     end
+
+    state :declined
 
     state :pending_conditions do
       event :confirm_conditions_met, transitions_to: :recruited
@@ -56,14 +64,6 @@ class ApplicationStateChange
     end
 
     state :enrolled
-
-    state :rejected do
-      event :make_offer, transitions_to: :offer
-    end
-
-    state :declined
-
-    state :withdrawn
   end
 
   def load_workflow_state


### PR DESCRIPTION
## Context

Statements like the one below produce wrong results because of the order states are declared in `ApplicationStateChange`.

```ruby
  application_state.current_state >= :recruited
```
Example:
![image](https://user-images.githubusercontent.com/107591/75440156-21a76e80-5953-11ea-9bf1-37914c1a97d8.png)

The current app logic is conditions are marked as met (in which case the application state transitions to `recruited`) or not met (which has its own state `conditions_not_met`). In the future, we will be marking individual conditions are met/not met, which means an offer can be withdrawn with conditions in any of the pending/met/not met states, but for now it doesn't make sense to show conditions as met unless a user is either recruited or enrolled.

## Changes proposed in this pull request

See file changes.

## Guidance to review

Visit `/rails/components` and inspect the StatusBoxComponent for the declined state. It should display conditions as 'pending'.

## Link to Trello card

No Trello card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
