### PR TITLE
Pre-check standard conditions for new offers

### DIFF
--- a/app/helpers/checkbox_options_helper.rb
+++ b/app/helpers/checkbox_options_helper.rb
@@ -8,4 +8,13 @@ module CheckboxOptionsHelper
       )
     end
   end
+
+  def standard_conditions_checkboxes
+    MakeAnOffer::STANDARD_CONDITIONS.map do |condition|
+      OpenStruct.new(
+        id: condition,
+        name: condition,
+      )
+    end
+  end
 end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -7,6 +7,7 @@ class MakeAnOffer
 
   MAX_CONDITIONS_COUNT = 20
   MAX_CONDITION_LENGTH = 255
+  STANDARD_CONDITIONS = ['Fitness to Teach check', 'Disclosure and Barring Service (DBS) check'].freeze
 
   validate :validate_course_data
   validate :validate_conditions_max_length
@@ -16,7 +17,7 @@ class MakeAnOffer
     actor:,
     application_choice:,
     offer_conditions: nil,
-    standard_conditions: nil,
+    standard_conditions: STANDARD_CONDITIONS,
     further_conditions: {},
     course_data: nil
   )

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -24,7 +24,7 @@
             standard_conditions_checkboxes,
             :id,
             :name,
-            legend: { text: 'Standard conditions (optional)', size: 'm', tag: 'h2' },
+            legend: { text: 'Standard conditions', size: 'm', tag: 'h2' },
       ) %>
 
       <fieldset class="govuk-fieldset">

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -19,10 +19,13 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_check_boxes_fieldset :standard_conditions, legend: { text: 'Standard conditions (optional)', size: 'm', tag: 'h2' } do %>
-          <%= f.govuk_check_box :standard_conditions, 'Fitness to Teach check', label: { text: 'Fitness to Teach check' } %>
-          <%= f.govuk_check_box :standard_conditions, 'Disclosure and Barring Service (DBS) check', label: { text: 'Disclosure and Barring Service (DBS) check' } %>
-      <% end %>
+      <%= f.govuk_collection_check_boxes(
+            :standard_conditions,
+            standard_conditions_checkboxes,
+            :id,
+            :name,
+            legend: { text: 'Standard conditions (optional)', size: 'm', tag: 'h2' },
+      ) %>
 
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Further conditions (optional)</legend>

--- a/spec/helpers/checkbox_options_helper_spec.rb
+++ b/spec/helpers/checkbox_options_helper_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe CheckboxOptionsHelper, type: :helper do
       )
     end
   end
+
+  describe '#standard_conditions_checkboxes' do
+    it 'returns structured data for standard offer conditions' do
+      expected = MakeAnOffer::STANDARD_CONDITIONS.map do |condition|
+        OpenStruct.new(id: condition, name: condition)
+      end
+
+      expect(standard_conditions_checkboxes).to eq(expected)
+    end
+  end
 end

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Provider makes an offer' do
     and_i_choose_to_make_an_offer
     then_i_see_some_application_info
 
-    when_i_select_standard_reasons
+    and_i_see_standard_reasons_are_checked
     and_i_add_optional_further_conditions
     and_i_click_to_continue
     then_i_am_asked_to_confirm_the_offer
@@ -58,8 +58,9 @@ RSpec.feature 'Provider makes an offer' do
       @application_awaiting_provider_decision.application_form.last_name
   end
 
-  def when_i_select_standard_reasons
-    page.check 'Fitness to Teach check', allow_label_click: true
+  def and_i_see_standard_reasons_are_checked
+    expect(find("input[value='Fitness to Teach check']")).to be_checked
+    expect(find("input[value='Disclosure and Barring Service (DBS) check']")).to be_checked
   end
 
   def and_i_add_optional_further_conditions


### PR DESCRIPTION
## Context

Standard conditions are compulsory for a trainee to start a course and are usually included
in an offer. Providers can choose to omit these conditions but they should be included by default.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Standard conditions are pre-checked when a provider makes a new offer. The provide can omit them by unchecking the condition(s).

<!-- If there are UI changes, please include Before and After screenshots. -->

### Before

![image](https://user-images.githubusercontent.com/93511/75444528-836bd680-595b-11ea-92cb-78569538a608.png)


### After

![image](https://user-images.githubusercontent.com/93511/75444473-66cf9e80-595b-11ea-9d3a-e975f1757619.png)


## Guidance to review

I considered moving the repetition of checkbox values (they are pretty wordy) to a translation file. The use and guidance of translation files is under discussion though, would be happy to hear reviewer's thoughts on this. It would be DRYer to use translations but given these are form checkbox values I wonder if it's the correct use of i18n?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/MpKzZ1HO/1698-make-default-conditions-not-optional-when-making-an-offer-in-the-provider-ui

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
