### PR TITLE
Allow candidates to choose and review their ethnic group

### DIFF
--- a/app/components/candidate_interface/equality_and_diversity_review_component.rb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     end
 
     def equality_and_diversity_rows
-      [sex_row, disabilities_row]
+      [sex_row, disabilities_row, ethnicity_row]
     end
 
   private
@@ -32,6 +32,23 @@ module CandidateInterface
         value: disabilties,
         action: 'disability',
         change_path: candidate_interface_edit_equality_and_diversity_disability_status_path,
+      }
+    end
+
+    def ethnicity_row
+      ethnicity = if @application_form.equality_and_diversity['ethnic_group'] == 'Prefer not to say'
+                    'Prefer not to say'
+                  elsif @application_form.equality_and_diversity['ethnic_background'] == 'Prefer not to say'
+                    @application_form.equality_and_diversity['ethnic_group']
+                  else
+                    "#{@application_form.equality_and_diversity['ethnic_group']} (#{@application_form.equality_and_diversity['ethnic_background']})"
+                  end
+
+      {
+        key: 'Ethnicity',
+        value: ethnicity,
+        action: 'ethnicity',
+        change_path: candidate_interface_edit_equality_and_diversity_ethnic_group_path,
       }
     end
   end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -29,7 +29,7 @@ module CandidateInterface
 
       if @disability_status.save(current_application)
         if disability_status_param == 'no'
-          redirect_to candidate_interface_review_equality_and_diversity_path
+          redirect_to candidate_interface_edit_equality_and_diversity_ethnic_group_path
         else
           redirect_to candidate_interface_edit_equality_and_diversity_disabilities_path
         end
@@ -52,6 +52,20 @@ module CandidateInterface
       end
     end
 
+    def edit_ethnic_group
+      @ethnic_group = EqualityAndDiversity::EthnicGroupForm.build_from_application(current_application)
+    end
+
+    def update_ethnic_group
+      @ethnic_group = EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: ethnic_group_param)
+
+      if @ethnic_group.save(current_application)
+        redirect_to candidate_interface_review_equality_and_diversity_path
+      else
+        render :edit_ethnic_group
+      end
+    end
+
     def review; end
 
   private
@@ -66,6 +80,10 @@ module CandidateInterface
 
     def disabilties_params
       params.require(:candidate_interface_equality_and_diversity_disabilities_form).permit(:other_disability, disabilities: [])
+    end
+
+    def ethnic_group_param
+      params.dig(:candidate_interface_equality_and_diversity_ethnic_group_form, :ethnic_group)
     end
   end
 end

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, 'What is your ethnic group?' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @ethnic_group, url: candidate_interface_update_equality_and_diversity_ethnic_group_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :ethnic_group, legend: { size: 'xl', text: 'What is your ethnic group?' } do %>
+        <div class="govuk-!-margin-top-6">
+          <%= f.govuk_radio_button :ethnic_group, 'Asian or Asian British', label: { text: 'Asian or Asian British', size: 's' }, hint_text: '(includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani)', link_errors: true %>
+          <%= f.govuk_radio_button :ethnic_group, 'Black, African, Black British or Caribbean', label: { text: 'Black, African, Black British or Caribbean', size: 's' }, hint_text: '(includes any Black background)' %>
+          <%= f.govuk_radio_button :ethnic_group, 'Mixed or multiple ethnic groups', label: { text: 'Mixed or multiple ethnic groups', size: 's' }, hint_text: '(includes any Mixed background)' %>
+          <%= f.govuk_radio_button :ethnic_group, 'White', label: { text: 'White', size: 's' }, hint_text: '(includes any White background)' %>
+          <%= f.govuk_radio_button :ethnic_group, 'Another ethnic group', label: { text: 'Another ethnic group', size: 's' }, hint_text: '(includes any other ethnic group, for example, Arab)' %>
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_button :ethnic_group, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,6 +260,8 @@ Rails.application.routes.draw do
         post '/disability-status' => 'equality_and_diversity#update_disability_status', as: :update_equality_and_diversity_disability_status
         get '/disabilities' => 'equality_and_diversity#edit_disabilities', as: :edit_equality_and_diversity_disabilities
         post '/disabilities' => 'equality_and_diversity#update_disabilities', as: :update_equality_and_diversity_disabilities
+        get '/ethnic-group' => 'equality_and_diversity#edit_ethnic_group', as: :edit_equality_and_diversity_ethnic_group
+        post '/ethnic-group' => 'equality_and_diversity#update_ethnic_group', as: :update_equality_and_diversity_ethnic_group
         get '/review' => 'equality_and_diversity#review', as: :review_equality_and_diversity
       end
     end

--- a/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
+++ b/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
@@ -4,25 +4,37 @@ RSpec.describe CandidateInterface::EqualityAndDiversityReviewComponent do
   let(:application_form) do
     build_stubbed(
       :application_form,
-      equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w(no) },
+      equality_and_diversity: { 'sex' => 'male', 'disabilities' => [] },
     )
   end
 
-  context 'when there are disabilities' do
-    it 'renders component with correct equality and diversity information' do
-      application_form.equality_and_diversity = { 'sex' => 'male', 'disabilities' => ['Blind', 'Deaf', 'Learning Difficulties'] }
-
+  context 'when there is a value for sex' do
+    it 'displays the sex' do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.govuk-summary-list__key').text).to include('Sex')
       expect(result.css('.govuk-summary-list__value').text).to include('Male')
+    end
+  end
+
+  context 'when there are disabilities' do
+    it 'displays "Yes" and the disabilities in brackets' do
+      application_form.equality_and_diversity = {
+        'sex' => 'male',
+        'disabilities' => ['Blind', 'Deaf', 'Learning Difficulties'],
+        'ethnic_group' => 'Asian or Asian British',
+        'ethnic_background' => 'Chinese',
+      }
+
+      result = render_inline(described_class.new(application_form: application_form))
+
       expect(result.css('.govuk-summary-list__key').text).to include('Disability')
       expect(result.css('.govuk-summary-list__value').text).to include('Yes (Blind, Deaf and Learning Difficulties)')
     end
   end
 
   context 'when there no disabilities' do
-    it 'renders component with correct equality and diversity information' do
+    it 'displays "No"' do
       application_form.equality_and_diversity = { 'sex' => 'male', 'disabilities' => [] }
 
       result = render_inline(described_class.new(application_form: application_form))
@@ -32,19 +44,72 @@ RSpec.describe CandidateInterface::EqualityAndDiversityReviewComponent do
     end
   end
 
+  context 'when there are values for ethnic group and ethnic background' do
+    it 'displays the ethnic group and ethnic background in brackets' do
+      application_form.equality_and_diversity = {
+        'sex' => 'male',
+        'disabilities' => ['Blind', 'Deaf', 'Learning Difficulties'],
+        'ethnic_group' => 'Asian or Asian British',
+        'ethnic_background' => 'Chinese',
+      }
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Ethnicity')
+      expect(result.css('.govuk-summary-list__value').text).to include('Asian or Asian British (Chinese)')
+    end
+  end
+
+  context 'when the ethnic group is "Prefer not to say"' do
+    it 'displays the ethnic group and ethnic background in brackets' do
+      application_form.equality_and_diversity = {
+        'sex' => 'male',
+        'disabilities' => ['Blind', 'Deaf', 'Learning Difficulties'],
+        'ethnic_group' => 'Prefer not to say',
+      }
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Ethnicity')
+      expect(result.css('.govuk-summary-list__value').text).to include('Prefer not to say')
+      expect(result.css('.govuk-summary-list__value').text).not_to include('()')
+    end
+  end
+
+  context 'when there is a value for ethnic group but ethnic background is "Prefer not to say"' do
+    it 'displays the ethnic group and ethnic background in brackets' do
+      application_form.equality_and_diversity = {
+        'sex' => 'male',
+        'disabilities' => ['Blind', 'Deaf', 'Learning Difficulties'],
+        'ethnic_group' => 'Asian or Asian British',
+        'ethnic_background' => 'Prefer not to say',
+      }
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Ethnicity')
+      expect(result.css('.govuk-summary-list__value').text).to include('Asian or Asian British')
+      expect(result.css('.govuk-summary-list__value').text).not_to include('(Prefer not to say)')
+    end
+  end
+
   context 'when editable' do
-    it 'renders the component with change links' do
+    it 'displays the change links' do
       result = render_inline(described_class.new(application_form: application_form, editable: true))
 
       expect(result.text).to include('Change sex')
+      expect(result.text).to include('Change disability')
+      expect(result.text).to include('Change ethnicity')
     end
   end
 
   context 'when not editable' do
-    it 'renders the component with change links' do
+    it 'does not display the change links' do
       result = render_inline(described_class.new(application_form: application_form, editable: false))
 
       expect(result.text).not_to include('Change sex')
+      expect(result.text).not_to include('Change disability')
+      expect(result.text).not_to include('Change ethnicity')
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -31,6 +31,10 @@ RSpec.feature 'Entering their equality and diversity information' do
 
     when_i_choose_no_for_having_a_disability
     and_i_click_on_continue
+    then_i_am_asked_for_my_ethnic_group
+
+    when_i_choose_that_i_prefer_not_to_say_my_ethnic_group
+    and_i_click_on_continue
     then_i_can_review_my_answers
 
     when_i_click_change_my_disability
@@ -63,6 +67,11 @@ RSpec.feature 'Entering their equality and diversity information' do
     when_i_change_my_disabilities
     and_i_click_on_continue
     then_i_can_review_my_updated_disabilities
+
+    when_i_click_change_ethnic_group
+    and_i_choose_another_ethnic_group
+    and_i_click_on_continue
+    then_i_can_review_my_updated_ethnic_group
   end
 
   def given_i_am_signed_in
@@ -136,6 +145,7 @@ RSpec.feature 'Entering their equality and diversity information' do
     expect(page).to have_content('Check your answers')
     expect(page).to have_content('Male')
     expect(page).to have_content('No')
+    expect(page).to have_content('Prefer not to say')
   end
 
   def when_i_click_change_sex
@@ -165,6 +175,14 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def when_i_choose_no_for_having_a_disability
     choose 'No'
+  end
+
+  def then_i_am_asked_for_my_ethnic_group
+    expect(page).to have_content('What is your ethnic group?')
+  end
+
+  def when_i_choose_that_i_prefer_not_to_say_my_ethnic_group
+    choose 'Prefer not to say'
   end
 
   def when_i_click_change_my_disability
@@ -222,5 +240,18 @@ RSpec.feature 'Entering their equality and diversity information' do
   def then_i_can_review_my_updated_disabilities
     expect(page).to have_content('Check your answers')
     expect(page).to have_content('Yes (Deaf)')
+  end
+
+  def when_i_click_change_ethnic_group
+    click_link 'Change ethnicity'
+  end
+
+  def and_i_choose_another_ethnic_group
+    choose 'White'
+  end
+
+  def then_i_can_review_my_updated_ethnic_group
+    expect(page).to have_content('Check your answers')
+    expect(page).to have_content('White')
   end
 end


### PR DESCRIPTION
## Context
Currently, we've built the 'What is your sex?', 'Are you disabled?', 'Please select all (disabilities) that apply to you' pages for equality and diversity monitoring. Up next is to add the 'What is your ethnic group?' page. The previous PR added the `EthnicGroupForm` #1478

## Changes proposed in this pull request
This PR:
- adds a page to choose an ethnic group
- update the review page to show ethnicity

### Screenshots
![image](https://user-images.githubusercontent.com/22743709/75446733-e19ab880-595f-11ea-85a9-d0ef4822dc24.png)

![image](https://user-images.githubusercontent.com/22743709/75446764-eeb7a780-595f-11ea-85c9-08f86369cb58.png)

## Guidance to review
On the review page, there is a bracket beside the ethnic group in the ethnicity row, this will be fixed once we can record the ethnic background information.

## Link to Trello card
https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
