### PR TITLE
Stop candidate clicking back and submitting section with no course

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -114,10 +114,13 @@ module CandidateInterface
     def complete
       @application_form = current_application
 
-      if @application_form.update(application_form_params)
+      if @application_form.application_choices.count.zero?
+        render :index
+      elsif @application_form.update(application_form_params)
         redirect_to candidate_interface_application_form_path
       else
         @course_choices = current_candidate.current_application.application_choices
+
         render :review
       end
     end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -43,6 +43,9 @@ RSpec.feature 'Selecting a course' do
     and_i_delete_one_of_my_course_choice
     and_i_confirm_that_i_want_to_delete_my_choice
     then_i_no_longer_see_my_course_choice
+
+    when_i_mark_this_section_as_completed
+    and_i_click_continue
   end
 
   def given_i_am_signed_in
@@ -205,5 +208,13 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_no_longer_see_my_course_choice
     expect(page).not_to have_content('Primary (2XT2)')
+  end
+
+  def and_i_click_continue
+    when_i_click_continue
+  end
+
+  def then_i_should_i_should_see_the_course_choice_index_page
+    expect(page).to_have current_path(candidate_interface_course_choices_index_path)
   end
 end


### PR DESCRIPTION
## Context

Currently, a candidate can:

1. Select a course
2. delete the course
3. click on the browser back button twice
4. check complete box
5. complete the course choice section

## Changes proposed in this pull request

- If the candidate tries to complete the course choices section and does not have a course choice, they are redirected to the index page

## Guidance to review

I spoke to Paul and there should be no flash message. The above is the desired flow.

I'm not 100% sure how to test this.

I was going to use visit page.driver.request.env['HTTP_REFERER'] twice to simulate clicking back twice, but when I use it for a second time it returns nil.

## Link to Trello card

https://trello.com/c/wrAbxDA8/950-user-is-able-to-submit-application-by-entering-and-deleting-information

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
