### PR TITLE
1057 Pick Full Time or Part Time Course Options

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -14,11 +14,14 @@ module CandidateInterface
     end
 
     def course_choice_rows(course_choice)
-      [
+      rows = [
         course_row(course_choice),
-        study_mode_row(course_choice),
         location_row(course_choice),
-      ].tap do |r|
+      ]
+
+      rows.insert(1, study_mode_row(course_choice)) if FeatureFlag.active?('choose_study_mode')
+
+      rows.tap do |r|
         r << status_row(course_choice) if @show_status
         r << rejection_reason_row(course_choice) if course_choice.rejection_reason.present?
         r << offer_withdrawal_reason_row(course_choice) if course_choice.offer_withdrawal_reason.present?

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -16,6 +16,7 @@ module CandidateInterface
     def course_choice_rows(course_choice)
       [
         course_row(course_choice),
+        study_mode_row(course_choice),
         location_row(course_choice),
       ].tap do |r|
         r << status_row(course_choice) if @show_status
@@ -55,6 +56,13 @@ module CandidateInterface
       {
         key: 'Location',
         value: "#{course_choice.site.name}\n#{course_choice.site.full_address}",
+      }
+    end
+
+    def study_mode_row(course_choice)
+      {
+        key: 'Full time or part time',
+        value: course_choice.course_option.study_mode.humanize,
       }
     end
 

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -66,6 +66,11 @@ module CandidateInterface
 
       if !@pick_course.open_on_apply?
         redirect_to_ucas
+      elsif @pick_course.both_study_modes_available?
+        redirect_to candidate_interface_course_choices_study_mode_path(
+          @pick_course.provider_id,
+          @pick_course.course_id,
+        )
       elsif @pick_course.single_site?
         course_option = CourseOption.where(course_id: @pick_course.course.id).first
         pick_site_for_course(course_id, course_option.id)
@@ -77,10 +82,35 @@ module CandidateInterface
       end
     end
 
+    def options_for_study_mode
+      @pick_study_mode = PickStudyModeForm.new(
+        provider_id: params.fetch(:provider_id),
+        course_id: params.fetch(:course_id),
+      )
+    end
+
+    def pick_study_mode
+      @pick_study_mode = PickStudyModeForm.new(
+        provider_id: params.fetch(:provider_id),
+        course_id: params.fetch(:course_id),
+        study_mode: params.dig(
+          :candidate_interface_pick_study_mode_form,
+          :study_mode,
+        ),
+      )
+
+      redirect_to candidate_interface_course_choices_site_path(
+        @pick_study_mode.provider_id,
+        @pick_study_mode.course_id,
+        @pick_study_mode.study_mode,
+      )
+    end
+
     def options_for_site
       @pick_site = PickSiteForm.new(
         provider_id: params.fetch(:provider_id),
         course_id: params.fetch(:course_id),
+        study_mode: params.fetch(:study_mode),
       )
     end
 

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -98,6 +98,7 @@ module CandidateInterface
           :study_mode,
         ),
       )
+      render :options_for_study_mode and return unless @pick_study_mode.valid?
 
       redirect_to candidate_interface_course_choices_site_path(
         @pick_study_mode.provider_id,

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -66,7 +66,7 @@ module CandidateInterface
 
       if !@pick_course.open_on_apply?
         redirect_to_ucas
-      elsif @pick_course.both_study_modes_available?
+      elsif @pick_course.both_study_modes_available? && FeatureFlag.active?('choose_study_mode')
         redirect_to candidate_interface_course_choices_study_mode_path(
           @pick_course.provider_id,
           @pick_course.course_id,

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -78,6 +78,7 @@ module CandidateInterface
         redirect_to candidate_interface_course_choices_site_path(
           @pick_course.provider_id,
           @pick_course.course_id,
+          @pick_course.study_mode,
         )
       end
     end

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -28,7 +28,7 @@ module CandidateInterface
         redirect_to candidate_interface_course_choices_review_path
       elsif service.candidate_has_new_course_added
         redirect_to candidate_interface_course_choices_review_path
-      elsif service.candidate_should_choose_study_mode
+      elsif service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
         redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
       elsif service.candidate_should_choose_site
         redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -28,8 +28,10 @@ module CandidateInterface
         redirect_to candidate_interface_course_choices_review_path
       elsif service.candidate_has_new_course_added
         redirect_to candidate_interface_course_choices_review_path
+      elsif service.candidate_should_choose_study_mode
+        redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
       elsif service.candidate_should_choose_site
-        redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id)
+        redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
       elsif service.candidate_already_has_3_courses
         flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
         redirect_to candidate_interface_course_choices_review_path

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -24,6 +24,10 @@ module CandidateInterface
       course.study_mode == 'full_time_or_part_time'
     end
 
+    def study_mode
+      course.study_mode
+    end
+
     def course
       @course ||= provider.courses.find(course_id)
     end

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -21,7 +21,7 @@ module CandidateInterface
     end
 
     def both_study_modes_available?
-      course.study_mode == 'full_time_or_part_time'
+      course.both_study_modes_available?
     end
 
     def study_mode

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -20,6 +20,10 @@ module CandidateInterface
       CourseOption.where(course_id: course.id).one?
     end
 
+    def both_study_modes_available?
+      course.study_mode == 'full_time_or_part_time'
+    end
+
     def course
       @course ||= provider.courses.find(course_id)
     end

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -2,12 +2,16 @@ module CandidateInterface
   class PickSiteForm
     include ActiveModel::Model
 
-    attr_accessor :application_form, :provider_id, :course_id, :course_option_id
+    attr_accessor :application_form, :provider_id, :course_id, :study_mode, :course_option_id
     validates :course_option_id, presence: true
     validate :candidate_can_only_apply_to_3_courses
 
     def available_sites
-      CourseOption.includes(:site).where(course_id: course.id).sort_by { |course_option| course_option.site.name }
+      CourseOption
+        .includes(:site)
+        .where(course_id: course.id)
+        .where(study_mode: study_mode)
+        .sort_by { |course_option| course_option.site.name }
     end
 
     def save

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -7,11 +7,13 @@ module CandidateInterface
     validate :candidate_can_only_apply_to_3_courses
 
     def available_sites
-      CourseOption
-        .includes(:site)
-        .where(course_id: course.id)
-        .where(study_mode: study_mode)
-        .sort_by { |course_option| course_option.site.name }
+      relation = CourseOption.includes(:site).where(course_id: course.id)
+
+      if FeatureFlag.active?('choose_study_mode')
+        relation = relation.where(study_mode: study_mode)
+      end
+
+      relation.sort_by { |course_option| course_option.site.name }
     end
 
     def save

--- a/app/models/candidate_interface/pick_study_mode_form.rb
+++ b/app/models/candidate_interface/pick_study_mode_form.rb
@@ -3,5 +3,6 @@ module CandidateInterface
     include ActiveModel::Model
 
     attr_accessor :provider_id, :course_id, :study_mode
+    validates :study_mode, presence: true
   end
 end

--- a/app/models/candidate_interface/pick_study_mode_form.rb
+++ b/app/models/candidate_interface/pick_study_mode_form.rb
@@ -1,0 +1,7 @@
+module CandidateInterface
+  class PickStudyModeForm
+    include ActiveModel::Model
+
+    attr_accessor :provider_id, :course_id, :study_mode
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -29,4 +29,8 @@ class Course < ApplicationRecord
   def name_and_code
     "#{name} (#{code})"
   end
+
+  def both_study_modes_available?
+    study_mode == 'full_time_or_part_time'
+  end
 end

--- a/app/services/candidate_interface/add_course_from_find.rb
+++ b/app/services/candidate_interface/add_course_from_find.rb
@@ -82,7 +82,7 @@ module CandidateInterface
     end
 
     def course_has_both_study_modes?
-      Course.find(@candidate.course_from_find_id).study_mode == 'full_time_or_part_time'
+      Course.find(@candidate.course_from_find_id).both_study_modes_available?
     end
   end
 end

--- a/app/services/candidate_interface/add_course_from_find.rb
+++ b/app/services/candidate_interface/add_course_from_find.rb
@@ -41,7 +41,7 @@ module CandidateInterface
         add_application_choice
         set_course_from_find_id_to_nil
         @candidate_has_new_course_added = true
-      elsif course_has_both_study_modes?
+      elsif course_has_both_study_modes? && FeatureFlag.active?('choose_study_mode')
         set_course_from_find_id_to_nil
         @candidate_should_choose_study_mode = true
       else

--- a/app/services/candidate_interface/add_course_from_find.rb
+++ b/app/services/candidate_interface/add_course_from_find.rb
@@ -6,7 +6,8 @@ module CandidateInterface
                   :candidate_should_choose_site,
                   :candidate_does_not_have_a_course_from_find,
                   :candidate_has_already_selected_the_course,
-                  :candidate_has_submitted_application
+                  :candidate_has_submitted_application,
+                  :candidate_should_choose_study_mode
 
     def initialize(candidate:)
       @candidate = candidate
@@ -40,6 +41,9 @@ module CandidateInterface
         add_application_choice
         set_course_from_find_id_to_nil
         @candidate_has_new_course_added = true
+      elsif course_has_both_study_modes?
+        set_course_from_find_id_to_nil
+        @candidate_should_choose_study_mode = true
       else
         set_course_from_find_id_to_nil
         @candidate_should_choose_site = true
@@ -75,6 +79,10 @@ module CandidateInterface
       current_course_option_ids = @candidate.current_application.application_choices.map(&:course_option_id)
 
       (potential_course_option_ids_for_course_from_find & current_course_option_ids).present?
+    end
+
+    def course_has_both_study_modes?
+      Course.find(@candidate.course_from_find_id).study_mode == 'full_time_or_part_time'
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,6 +6,7 @@ class FeatureFlag
     automated_referee_chaser
     automated_referee_replacement
     candidate_rejected_by_provider_email
+    choose_study_mode
     confirm_conditions
     decline_by_default_notification_to_candidate
     decline_by_default_notification_to_provider

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,32 +1,32 @@
 class FeatureFlag
   FEATURES = %w[
-    pilot_open
-    force_ok_computer_to_fail
-    training_with_a_disability
-    edit_application
-    send_dfe_sign_in_invitations
-    improved_expired_token_flow
-    work_breaks
-    experimental_api_features
-    confirm_conditions
-    show_new_referee_needed
-    automated_referee_chaser
+    application_withrawn_provider_email
+    automated_decline_by_default_candidate_chaser
     automated_provider_chaser
-    provider_change_response
-    send_reference_confirmation_email
+    automated_referee_chaser
     automated_referee_replacement
     candidate_rejected_by_provider_email
-    notify_candidate_of_new_reference
-    automated_decline_by_default_candidate_chaser
+    confirm_conditions
     decline_by_default_notification_to_candidate
-    offer_accepted_provider_emails
     decline_by_default_notification_to_provider
-    application_withrawn_provider_email
-    offer_declined_provider_emails
-    equality_and_diversity
-    provider_application_filters
-    provider_interface_pagination
     dfe_sign_in_incident
+    edit_application
+    equality_and_diversity
+    experimental_api_features
+    force_ok_computer_to_fail
+    improved_expired_token_flow
+    notify_candidate_of_new_reference
+    offer_accepted_provider_emails
+    offer_declined_provider_emails
+    pilot_open
+    provider_application_filters
+    provider_change_response
+    provider_interface_pagination
+    send_dfe_sign_in_invitations
+    send_reference_confirmation_email
+    show_new_referee_needed
+    training_with_a_disability
+    work_breaks
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -71,7 +71,7 @@ class SyncProviderFromFind
       site.save!
 
       study_modes = \
-        if course.study_mode == 'full_time_or_part_time'
+        if course.both_study_modes_available?
           %i[full_time part_time]
         else
           [course.study_mode]

--- a/app/views/candidate_interface/course_choices/options_for_site.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_site.html.erb
@@ -3,7 +3,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @pick_site, url: candidate_interface_course_choices_site_path(params[:provider_id], params[:course_id]), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+    <%= form_with(
+          model: @pick_site,
+          url: candidate_interface_course_choices_site_path(
+            params[:provider_id], params[:course_id], params[:study_mode]
+          ),
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        ) do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'xl', text: t('page_titles.which_location') } do %>

--- a/app/views/candidate_interface/course_choices/options_for_study_mode.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_study_mode.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.which_study_mode'), @pick_study_mode.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+          model: @pick_study_mode,
+          url: candidate_interface_course_choices_study_mode_path(
+            provider_id: @pick_study_mode.provider_id,
+            course_id: @pick_study_mode.course_id,
+          ),
+          builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+        ) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :study_mode, legend: { size: 'xl', text: t('page_titles.which_study_mode'), tag: 'h2' } do %>
+        <%= f.govuk_radio_button :study_mode, :full_time, label: { text: 'Full time' } %>
+        <%= f.govuk_radio_button :study_mode, :part_time, label: { text: 'Part time' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/options_for_study_mode.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_study_mode.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.which_study_mode'), @pick_study_mode.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(@pick_study_mode.provider_id)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,7 @@ en:
     which_provider: Which training provider are you applying to?
     which_course: Which course are you applying to?
     which_location: Which location are you applying to?
+    which_study_mode: Full time or part time?
     edit_degree: Edit degree
     other_qualification: Academic and other relevant qualifications
     add_other_qualification: Academic and other relevant qualifications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,8 +190,11 @@ Rails.application.routes.draw do
         get '/provider/:provider_id/courses' => 'course_choices#options_for_course', as: :course_choices_course
         post '/provider/:provider_id/courses' => 'course_choices#pick_course'
 
-        get '/provider/:provider_id/courses/:course_id' => 'course_choices#options_for_site', as: :course_choices_site
-        post '/provider/:provider_id/courses/:course_id' => 'course_choices#pick_site'
+        get '/provider/:provider_id/courses/:course_id' => 'course_choices#options_for_study_mode', as: :course_choices_study_mode
+        post '/provider/:provider_id/courses/:course_id' => 'course_choices#pick_study_mode'
+
+        get '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices#options_for_site', as: :course_choices_site
+        post '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices#pick_site'
 
         get '/review' => 'course_choices#review', as: :course_choices_review
         patch '/review' => 'course_choices#complete', as: :course_choices_complete

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -160,6 +160,10 @@ FactoryBot.define do
       open_on_apply { true }
       exposed_in_find { true }
     end
+
+    trait :with_both_study_modes do
+      study_mode { 'full_time_or_part_time' }
+    end
   end
 
   factory :provider do

--- a/spec/models/candidate_interface/pick_course_form_spec.rb
+++ b/spec/models/candidate_interface/pick_course_form_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course you can apply to', provider: provider)
       create(:course, exposed_in_find: true, open_on_apply: true, name: 'Course from other provider')
 
-      form = CandidateInterface::PickCourseForm.new(provider_id: provider.id)
+      form = described_class.new(provider_id: provider.id)
 
       expect(form.available_courses.map(&:name)).to eql(['Course not open on apply', 'Course you can apply to'])
     end
@@ -19,7 +19,7 @@ RSpec.describe CandidateInterface::PickCourseForm do
     let(:provider) { create(:provider, name: 'Royal Academy of Dance', code: 'R55') }
     let(:course) { create(:course, provider: provider, exposed_in_find: true, open_on_apply: true) }
     let(:site) { create(:site, provider: provider) }
-    let(:pick_course_form) { CandidateInterface::PickCourseForm.new(provider_id: provider.id, course_id: course.id) }
+    let(:pick_course_form) { described_class.new(provider_id: provider.id, course_id: course.id) }
 
     before { create(:course_option, site: site, course: course) }
 
@@ -32,6 +32,35 @@ RSpec.describe CandidateInterface::PickCourseForm do
       create(:course_option, site: another_site, course: course)
 
       expect(pick_course_form).not_to be_single_site
+    end
+  end
+
+  describe '#both_study_modes_available?' do
+    let(:provider) { create(:provider) }
+    let(:full_time_course) { create(:course, provider: provider) }
+    let(:part_time_course) {
+      create(:course, provider: provider, study_mode: :part_time)
+    }
+    let(:full_time_or_part_time_course) {
+      create(:course, provider: provider, study_mode: :full_time_or_part_time)
+    }
+
+    let(:form) { described_class.new(provider_id: provider.id) }
+
+    it 'returns false for a full time course' do
+      form.course_id = full_time_course.id
+      expect(form.both_study_modes_available?).to be false
+    end
+
+    it 'returns false for a part time course' do
+      form.course_id = part_time_course.id
+      expect(form.both_study_modes_available?).to be false
+    end
+
+    it 'returns true if both study modes are available' do
+      form.course_id = full_time_or_part_time_course.id
+
+      expect(form.both_study_modes_available?).to be true
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,10 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe Course, type: :model do
-  subject(:course) { create(:course) }
-
   describe 'a valid course' do
+    subject(:course) { create(:course) }
+
     it { is_expected.to validate_presence_of :level }
     it { is_expected.to validate_uniqueness_of(:code).scoped_to(:provider_id) }
+  end
+
+  describe '#both_study_modes_available?' do
+    it 'is true when the study_mode value indicates both modes are available' do
+      course = build_stubbed(:course, study_mode: 'full_time_or_part_time')
+      expect(course.both_study_modes_available?).to be true
+    end
+
+    it 'is false when the study_mode value is a specific mode' do
+      course = build_stubbed(:course, study_mode: 'full_time')
+      expect(course.both_study_modes_available?).to be false
+      course.study_mode = 'part_time'
+      expect(course.both_study_modes_available?).to be false
+    end
   end
 end

--- a/spec/services/candidate_interface/add_course_from_find_spec.rb
+++ b/spec/services/candidate_interface/add_course_from_find_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe CandidateInterface::AddCourseFromFind do
       end
     end
 
+    context 'when the candidate has a course_from_find_id and the course has a choice of study modes' do
+      it 'sets the course_from_find_id to nil and sets the appropriate boolean flag' do
+        course = create(:course, study_mode: :full_time_or_part_time)
+        candidate = create(:candidate, course_from_find_id: course.id)
+
+        service = described_class.new(candidate: candidate)
+        service.execute
+
+        expect(candidate.course_from_find_id).to eq(nil)
+        expect(service.candidate_should_choose_study_mode).to be_truthy
+      end
+    end
+
     context 'when the candidate has a course_from_find_id and the course has multiple sites' do
       it 'sets the course_from_find_id to nil and sets candidate_should_choose_site to true' do
         course = create(:course)

--- a/spec/services/candidate_interface/add_course_from_find_spec.rb
+++ b/spec/services/candidate_interface/add_course_from_find_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe CandidateInterface::AddCourseFromFind do
 
     context 'when the candidate has a course_from_find_id and the course has a choice of study modes' do
       it 'sets the course_from_find_id to nil and sets the appropriate boolean flag' do
+        FeatureFlag.activate('choose_study_mode')
         course = create(:course, study_mode: :full_time_or_part_time)
         candidate = create(:candidate, course_from_find_id: course.id)
 

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
       candidate_interface_course_choices_site_path(
         @course_with_multiple_sites.provider.id,
         @course_with_multiple_sites.id,
+        :full_time,
       ),
     )
   end

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
       candidate_interface_course_choices_site_path(
         @course_with_multiple_sites.provider.id,
         @course_with_multiple_sites.id,
+        :full_time,
       ),
     )
   end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -137,7 +137,6 @@ RSpec.feature 'Selecting a course' do
   def then_i_see_my_completed_course_choice
     expect(page).to have_content('Gorse SCITT')
     expect(page).to have_content('Primary (2XT2)')
-    expect(page).to have_content('Full time')
     expect(page).to have_content('Main site')
     expect(page).to have_content('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, lEEDS, LS27 0LZ')
   end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -72,11 +72,6 @@ RSpec.feature 'Selecting a course' do
       postcode: 'LS8 5DQ'
     )
     multi_site_course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true, open_on_apply: true)
-
-    # TODO: this is a test to check we don't rely on uniqueness of course codes. Replace by a better unit test.
-    clashing_course = create(:course, name: 'A course with the same code, but a different provider', code: '2XT2', exposed_in_find: true, open_on_apply: true)
-    create(:course_option, course: clashing_course)
-
     create(:course_option, site: first_site, course: multi_site_course, vacancy_status: 'B')
     create(:course_option, site: second_site, course: multi_site_course, vacancy_status: 'B')
 

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -137,6 +137,7 @@ RSpec.feature 'Selecting a course' do
   def then_i_see_my_completed_course_choice
     expect(page).to have_content('Gorse SCITT')
     expect(page).to have_content('Primary (2XT2)')
+    expect(page).to have_content('Full time')
     expect(page).to have_content('Main site')
     expect(page).to have_content('Gorse SCITT, C/O The Bruntcliffe Academy, Bruntcliffe Lane, MORLEY, lEEDS, LS27 0LZ')
   end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Selecting a study mode' do
   include CandidateHelper
 
   scenario 'Candidate selects a part time course' do
+    given_choosing_a_study_mode_is_active
     given_i_am_signed_in
     and_there_are_course_options
 
@@ -12,6 +13,10 @@ RSpec.feature 'Selecting a study mode' do
 
     when_i_select_a_site
     then_i_see_my_course_choice
+  end
+
+  def given_choosing_a_study_mode_is_active
+    FeatureFlag.activate('choose_study_mode')
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.feature 'Selecting a study mode' do
+  include CandidateHelper
+
+  scenario 'Candidate selects a part time course' do
+    given_i_am_signed_in
+    and_there_are_course_options
+
+    when_i_select_a_part_time_course
+    then_i_can_only_select_sites_with_a_part_time_course
+
+    when_i_select_a_site
+    then_i_see_my_course_choice
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider)
+
+    @first_site = create(:site, provider: @provider)
+    @second_site = create(:site, provider: @provider)
+
+    @course = create(
+      :course, :with_both_study_modes, :open_on_apply, provider: @provider
+    )
+
+    create(
+      :course_option,
+      site: @first_site,
+      course: @course,
+      study_mode: :part_time,
+    )
+    create(
+      :course_option,
+      site: @second_site,
+      course: @course,
+      study_mode: :full_time,
+    )
+  end
+
+  def when_i_select_a_part_time_course
+    visit candidate_interface_application_form_path
+    click_link 'Course choices'
+    click_link 'Continue'
+
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+
+    select @provider.name
+    click_button 'Continue'
+
+    select @course.name
+    click_button 'Continue'
+
+    choose 'Part time'
+    click_button 'Continue'
+  end
+
+  def then_i_can_only_select_sites_with_a_part_time_course
+    expect(page).to have_text @first_site.name
+    expect(page).not_to have_text @second_site.name
+  end
+
+  def when_i_select_a_site
+    choose @first_site.name
+    click_button 'Continue'
+  end
+
+  def then_i_see_my_course_choice
+    expect(page).to have_text 'Course choices'
+    expect(page).to have_text @course.name
+    expect(page).to have_text 'Part time'
+  end
+end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
@@ -56,6 +56,8 @@ RSpec.feature 'Selecting a study mode' do
     select @course.name
     click_button 'Continue'
 
+    click_button 'Continue'
+    expect(page).to have_text "can't be blank"
     choose 'Part time'
     click_button 'Continue'
   end

--- a/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe 'An existing candidate arriving from Find with course params selects a study mode' do
+  include CourseOptionHelpers
+
+  scenario 'Signed in user with Find course params selects a part time course' do
+    given_the_pilot_is_open
+    and_i_am_an_existing_candidate_on_apply
+    and_the_course_i_selected_has_a_choice_of_study_modes
+    and_i_am_signed_in
+
+    when_i_arrive_at_the_apply_from_find_page_with_course_params
+    and_i_click_apply_on_apply
+    then_i_should_see_the_study_mode_page
+
+    when_i_choose_the_part_time_course
+    then_i_should_see_it_on_my_review_page
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_i_am_an_existing_candidate_on_apply
+    @candidate = create(:candidate)
+  end
+
+  def and_the_course_i_selected_has_a_choice_of_study_modes
+    @course = create(
+      :course,
+      :open_on_apply,
+      :with_both_study_modes,
+      name: 'Potions',
+    )
+    @site = create(:site, provider: @course.provider)
+    create(:course_option, site: @site, course: @course, study_mode: :full_time)
+    create(:course_option, site: @site, course: @course, study_mode: :part_time)
+  end
+
+  def and_i_am_signed_in
+    login_as(@candidate)
+  end
+
+  def when_i_arrive_at_the_apply_from_find_page_with_course_params
+    visit candidate_interface_apply_from_find_path(
+      providerCode: @course.provider.code,
+      courseCode: @course.code,
+    )
+  end
+
+  def and_i_click_apply_on_apply
+    click_on t('apply_from_find.apply_button')
+  end
+
+  def then_i_should_see_the_study_mode_page
+    expect(page).to have_current_path(
+      candidate_interface_course_choices_study_mode_path(
+        @course.provider.id,
+        @course.id,
+      ),
+    )
+  end
+
+  def when_i_choose_the_part_time_course
+    choose 'Part time'
+    click_button 'Continue'
+
+    choose @site.name
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_the_site
+    expect(page).to have_content @site.address_line1
+    expect(page).to have_content @site.address_line2
+    expect(page).to have_content @site.address_line3
+    expect(page).to have_content @site.address_line4
+    expect(page).to have_content @site.postcode
+  end
+
+  def then_i_should_see_it_on_my_review_page
+    expect(page).to have_content "#{@course.name} (#{@course.code})"
+    expect(page).to have_content 'Part time'
+    expect(page).to have_content @site.name
+    expect(page).to have_current_path(candidate_interface_course_choices_review_path)
+  end
+end

--- a/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
 
   scenario 'Signed in user with Find course params selects a part time course' do
     given_the_pilot_is_open
+    given_choosing_a_study_mode_is_active
     and_i_am_an_existing_candidate_on_apply
     and_the_course_i_selected_has_a_choice_of_study_modes
     and_i_am_signed_in
@@ -19,6 +20,10 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
+  end
+
+  def given_choosing_a_study_mode_is_active
+    FeatureFlag.activate('choose_study_mode')
   end
 
   def and_i_am_an_existing_candidate_on_apply

--- a/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_spec.rb
@@ -138,7 +138,13 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def then_i_should_see_the_course_choices_site_page
-    expect(page).to have_current_path(candidate_interface_course_choices_site_path(@course_with_multiple_sites.provider.id, @course_with_multiple_sites.id))
+    expect(page).to have_current_path(
+      candidate_interface_course_choices_site_path(
+        @course_with_multiple_sites.provider.id,
+        @course_with_multiple_sites.id,
+        :full_time,
+      ),
+    )
   end
 
   def then_i_should_see_the_candidate_interface_application_form


### PR DESCRIPTION
## Context

Some courses are available in a part-time study mode. This change adds the ability to select study mode for those courses that present an option.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

- Add a study mode selection page after the candidate has chosen a course.
- Only show this screen if there is actually an option - where there isn't, resolve the study mode for that course automatically and simply display the next step (site selection, or the review page in cases where there's only one site).

Study mode selection page is as follows:

<img width="1237" alt="Screenshot 2020-02-27 at 15 25 36" src="https://user-images.githubusercontent.com/519250/75458216-6b08b580-5975-11ea-8b6f-6b8c16ac8b29.png">

Followed by site selection, filtered to only show sites that support the selected study mode:

<img width="1248" alt="Screenshot 2020-02-27 at 15 32 21" src="https://user-images.githubusercontent.com/519250/75458823-6264af00-5976-11ea-946d-47ebab7e22ba.png">


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

- I'd suggest pulling the branch down and clicking through locally. You may need to change a specific course and its course options to see the new page. Specifically, `Course#study_mode` needs to be `'full_time_or_part_time'`, and it should have at least two course options with different `study_mode` values set (`part_time` and `full_time`).
- Per-commit review may be useful as each commit describes a distinct part of the feature.

**Note** - the site selection functionality shown above should probably be modified so that if only one choice is available, we select this automatically and move the candidate on. This PR is probably large enough as it stands - once reviewed I'll write a followup PR to add this functionality.

## Link to Trello card

https://trello.com/c/JnW7TR8k

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
