### PR TITLE
Add form object to update ethnic background for equality and diversity

### DIFF
--- a/app/models/candidate_interface/equality_and_diversity/ethnic_background_form.rb
+++ b/app/models/candidate_interface/equality_and_diversity/ethnic_background_form.rb
@@ -1,0 +1,46 @@
+module CandidateInterface
+  class EqualityAndDiversity::EthnicBackgroundForm
+    include ActiveModel::Model
+
+    ETHNIC_BACKGROUNDS = {
+      'Asian or Asian British' => %w[Bangladeshi Chinese Indian Pakistani],
+      'Black, African, Black British or Caribbean' => %w[African Carribean],
+      'Mixed or multiple ethnic groups' => ['Asian and White', 'Black African and White', 'Black Caribbean and White'],
+      'White' => ['British, English, Northern Irish, Scottish, or Welsh', 'Irish', 'Irish Traveller or Gypsy'],
+      'Another ethnic group' => %w[Arab],
+    }.freeze
+
+    attr_accessor :ethnic_background, :other_background
+
+    validates :ethnic_background, presence: true
+
+    def self.build_from_application(application_form)
+      group = application_form.equality_and_diversity['ethnic_group']
+      background = application_form.equality_and_diversity['ethnic_background']
+
+      if ETHNIC_BACKGROUNDS[group].include?(background) || background == "Another #{group} background"
+        new(ethnic_background: application_form.equality_and_diversity['ethnic_background'])
+      else
+        new(
+          ethnic_background: "Another #{group} background",
+          other_background: application_form.equality_and_diversity['ethnic_background'],
+        )
+      end
+    end
+
+    def save(application_form)
+      return false unless valid?
+
+      group = application_form.equality_and_diversity['ethnic_group']
+
+      background = ethnic_background == "Another #{group} background" && other_background.present? ? other_background : ethnic_background
+
+      if application_form.equality_and_diversity.nil?
+        application_form.update(equality_and_diversity: { 'ethnic_background' => background })
+      else
+        application_form.equality_and_diversity['ethnic_background'] = background
+        application_form.save
+      end
+    end
+  end
+end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -564,3 +564,7 @@ en:
               blank: Select all disabilities that apply to you
             other_disability:
               blank: Describe your disability
+        candidate_interface/equality_and_diversity/ethnic_background_form:
+          attributes:
+            ethnic_background:
+              blank: Choose your ethnic background

--- a/spec/models/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, type: :model do
+  describe '.build_from_application' do
+    context 'when ethnic background is listed' do
+      it 'creates an object with ethnic background' do
+        application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Chinese' })
+
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+
+        expect(form.ethnic_background).to eq('Chinese')
+        expect(form.other_background).to eq(nil)
+      end
+    end
+
+    context 'when ethnic background is unlisted' do
+      it 'creates an object with ethnic background set to another and other background is ethnic background' do
+        application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Unlisted ethnic background' })
+
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+
+        expect(form.ethnic_background).to eq('Another Asian or Asian British background')
+        expect(form.other_background).to eq('Unlisted ethnic background')
+      end
+    end
+
+    context 'when ethnic background is another background' do
+      it 'creates an object with ethnic background' do
+        application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian or Asian British background' })
+
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+
+        expect(form.ethnic_background).to eq('Another Asian or Asian British background')
+        expect(form.other_background).to eq(nil)
+      end
+    end
+  end
+
+  describe '#save' do
+    let(:application_form) { create(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British' }) }
+
+    context 'when ethnic background field is blank' do
+      it 'returns false' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new
+
+        expect(form.save(application_form)).to be(false)
+      end
+    end
+
+    context 'when ethnic background is listed' do
+      it 'returns true' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Bangladeshi')
+
+        expect(form.save(application_form)).to be(true)
+      end
+
+      it 'updates the application form with the ethnic background value' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Bangladeshi')
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Bangladeshi')
+      end
+
+      it 'updates the existing record of equality and diversity information' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'ethnic_group' => 'Asian or Asian British' })
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Bangladeshi')
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Bangladeshi',
+        )
+      end
+    end
+
+    context 'when ethnic background is another background' do
+      it 'updates the application form with the other background value if other background provided' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian or Asian British background', other_background: 'Unlisted ethnic background')
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Unlisted ethnic background')
+      end
+
+      it 'updates the application form with the ethnic background value if other background is not provided' do
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian or Asian British background', other_background: nil)
+
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian or Asian British background')
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:ethnic_background) }
+  end
+end


### PR DESCRIPTION
## Context

Currently, we've built the 'What is your sex?', 'Are you disabled?', 'Please select all (disabilities) that apply to you' and 'What is your ethnic group?' pages for equality and diversity monitoring. Up next is to add the 'Which of the following best describes your <ethnic group> background?' page.

## Changes proposed in this pull request

This PR adds the form object to update ethnic background for equality and diversity, `EqualityAndDiversity::EthnicBackgroundForm`.

## Guidance to review

- Follow the tests to guide you as it's a bit complex due to the ability to enter another ethnic background as well as leave the text box blank. Also use the prototype to help you.

![Screenshot 2020-02-27 at 17 10 09 1](https://user-images.githubusercontent.com/42817036/75467819-1f113d00-5984-11ea-93c0-409b4e1b4227.png)

- It's quite possible `ETHNIC_BACKGROUNDS` will be and should be moved elsewhere. For now until we hook everything up together, I believe it's fine in the model.
- As I'm away tomorrow and Monday, feel free to jump on this branch or merge this without me.

## Link to Trello card

https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
