### PR TITLE
Change volunteering section to incomplete when edited

### DIFF
--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -10,6 +10,8 @@ module CandidateInterface
       @volunteering_role = VolunteeringRoleForm.new(volunteering_role_params)
 
       if @volunteering_role.save(current_application)
+        current_application.update!(volunteering_completed: false)
+
         redirect_to candidate_interface_review_volunteering_path
       else
         render :new
@@ -25,6 +27,8 @@ module CandidateInterface
       @volunteering_role = VolunteeringRoleForm.new(volunteering_role_params)
 
       if @volunteering_role.update(current_application)
+        current_application.update!(volunteering_completed: false)
+
         redirect_to candidate_interface_review_volunteering_path
       else
         render :edit

--- a/app/controllers/candidate_interface/volunteering/destroy_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/destroy_controller.rb
@@ -13,6 +13,8 @@ module CandidateInterface
         .find(current_volunteering_role_id)
         .destroy!
 
+      current_application.update!(volunteering_completed: false)
+
       redirect_to candidate_interface_review_volunteering_path
     end
 

--- a/spec/system/candidate_interface/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_or_deletes_volunteering_section_after_competing_the_section_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate edits their volunteering section' do
+  include CandidateHelper
+
+  scenario 'Candidate adds or deletes a role after completing the section' do
+    given_i_am_signed_in
+    and_i_have_completed_the_volunteering_section
+
+    when_i_visit_the_application_page
+    then_the_volunteering_section_should_be_marked_as_complete
+
+    when_i_visit_the_review_volunteering_page
+    and_i_click_to_change_my_role
+    and_i_change_my_role
+    and_i_click_on_save_and_continue
+    and_visit_my_application_page
+    then_the_volunteering_section_should_be_marked_as_incomplete
+
+    when_i_visit_the_review_volunteering_page
+    and_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_the_volunteering_section_should_be_marked_as_complete
+
+    when_i_visit_the_review_volunteering_page
+    and_i_click_delete_role
+    and_i_confirm_i_want_to_delete_the_role
+    and_visit_my_application_page
+    then_the_volunteering_section_should_be_marked_as_incomplete
+  end
+
+  def given_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_completed_the_volunteering_section
+    @application_form = create(:application_form, candidate: @candidate)
+    create(:application_volunteering_experience, application_form: @application_form)
+    @application_form.update!(volunteering_completed: true)
+  end
+
+  def when_i_visit_the_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def then_the_volunteering_section_should_be_marked_as_complete
+    expect(page.text).to include 'Volunteering with children and young people Completed'
+  end
+
+  def when_i_visit_the_review_volunteering_page
+    click_link 'Volunteering with children and young people'
+  end
+
+  def and_i_click_to_change_my_role
+    first('.govuk-summary-list__actions').click_link 'Change'
+  end
+
+  def and_i_change_my_role
+    fill_in t('application_form.volunteering.organisation.label'), with: 'Much Wow School'
+  end
+
+  def and_i_click_on_save_and_continue
+    click_button t('application_form.volunteering.complete_form_button')
+  end
+
+  def then_the_volunteering_section_should_be_marked_as_incomplete
+    expect(page.text).to include 'Volunteering with children and young people Incomplete'
+  end
+
+  def and_i_mark_this_section_as_completed
+    check t('application_form.volunteering.review.completed_checkbox')
+  end
+
+  def and_i_click_on_continue
+    click_button t('application_form.volunteering.review.button')
+  end
+
+  def and_visit_my_application_page
+    when_i_visit_the_application_page
+  end
+
+  def and_i_click_delete_role
+    click_link t('application_form.volunteering.delete')
+  end
+
+  def and_i_confirm_i_want_to_delete_the_role
+    click_button t('application_form.volunteering.confirm_delete')
+  end
+end


### PR DESCRIPTION
## Context

Currently, when the volunteering section is marked as complete, the candidate can add, edit or delete roles without it setting the section to incomplete.

## Changes proposed in this pull request

-  When a candidate adds, edits or deletes a role the volunteering_complete attribute on their application form is set to false

## Guidance to review

I spoke to Paul. Filling out this section is not mandatory. 

This is the fourth PR for this card. The first is #1464, the second is #1466 and the third is #1467 

## Link to Trello card

https://trello.com/c/wrAbxDA8/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
