### PR TITLE
Bugfix for use of multiple custom monitoring URL alerts

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -897,7 +897,7 @@
         },
         {
             "apiVersion": "2017-05-10",
-            "name": "availability-test-alerts",
+            "name": "[if(greater(length(parameters('customAvailabilityMonitors')), 0), concat('availability-test-alerts-', split(parameters('customAvailabilityMonitors')[copyIndex('customAlerts')], ':')[0]), 'UNUSED_TEST_ALERTS')]",
             "condition": "[and(greater(length(parameters('customAvailabilityMonitors')), 0), greater(length(parameters('alertRecipientEmails')), 0))]",
             "type": "Microsoft.Resources/deployments",
             "copy": {


### PR DESCRIPTION
## Context

During the deployment yesterday where the availability alerts for Slack were rolled out it was found that if multiple custom monitoring URLs were specified in an environment it resulted in a parsing error in the ARM template due to resource naming duplication.

## Changes proposed in this pull request

Changed to the naming of the availability alert resource deployments to include the alert name as a suffix on each deployment to give them unique names.

## Guidance to review

Update the custom URL availability monitor pipeline variable in DevOps to include multiple URLs to test and run pipeline to confirm.
Evidence of previous runs that I have tested can be seen in the Azure deployment history: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/289869cc-7183-46bd-8131-f673c5eb94ba/resourceGroups/s106d02-apply/deployments

## Link to Trello card

https://trello.com/c/jCAUKIYq/1713-bug-multiple-availability-monitoring-urls

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
