### PR TITLE
Update missing section styles to match error messages

### DIFF
--- a/app/components/section_missing_banner_component.html.erb
+++ b/app/components/section_missing_banner_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-banner<% if @error %> app-banner--warning<% end %> app-banner--missing-section" id="<%= "missing-#{section}-error" %>">
   <div class="app-banner__message">
     <p class="govuk-body" id="<%= "missing-#{section}" %>"><%= @text %></p>
-    <%= link_to t('review_application.complete_section'), @section_path, class: 'govuk-link', aria: { describedby: "missing-#{section}" } %>
+    <%= link_to t('review_application.complete_section'), @section_path, class: 'govuk-link govuk-link--no-visited-state', aria: { describedby: "missing-#{section}" } %>
   </div>
 </div>

--- a/app/frontend/styles/_banner.scss
+++ b/app/frontend/styles/_banner.scss
@@ -11,15 +11,12 @@
   }
 
   &--missing-section {
+    border-width: 0 0 0 $govuk-border-width;
+    padding: govuk-spacing(2);
+    padding-left: govuk-spacing(3);
     @include govuk-responsive-margin(4, "bottom");
 
     .app-banner__message {
-      @include govuk-media-query($from: desktop) {
-        display: flex;
-        justify-content: space-between;
-        align-items: start;
-      }
-
       p {
         @include govuk-typography-weight-bold;
         color: govuk-colour("blue");
@@ -49,8 +46,6 @@
 
 .app-banner__message {
   @include govuk-font($size: 19);
-  display: block;
-  overflow: hidden;
 }
 
 .app-banner__message *:last-child {


### PR DESCRIPTION
- Put the "complete section" link below the error, making it easier to see, especially for zoom text users
- Reduce the visual weight of the banner by removing borders
- Make the messages consistent with the error message style seen on forms (https://design-system.service.gov.uk/components/error-message/)
- Don't use visited link styles on "complete section" links
- Remove overflow hidden so that focus link styles show correctly

| Before | After |
|--|--|
|![Screen Shot 2020-02-28 at 14 40 19](https://user-images.githubusercontent.com/319055/75557665-58a38000-5a38-11ea-9a64-2f3c8601a25c.png)|![Screen Shot 2020-02-28 at 14 39 06](https://user-images.githubusercontent.com/319055/75557655-55a88f80-5a38-11ea-9a4d-c26a7690fb9c.png)|
|![Screen Shot 2020-02-28 at 14 39 51](https://user-images.githubusercontent.com/319055/75557664-580ae980-5a38-11ea-8270-50e810334dc9.png)|![Screen Shot 2020-02-28 at 14 39 19](https://user-images.githubusercontent.com/319055/75557661-56d9bc80-5a38-11ea-86b1-2e2b4cfe8a5f.png)|



