### PR TITLE
Allow candidates to choose and review their ethnic background

### DIFF
--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -46,7 +46,11 @@ module CandidateInterface
       @disabilities = EqualityAndDiversity::DisabilitiesForm.new(disabilties_params)
 
       if @disabilities.save(current_application)
-        redirect_to candidate_interface_review_equality_and_diversity_path
+        if current_application.equality_and_diversity['ethnic_group'].nil?
+          redirect_to candidate_interface_edit_equality_and_diversity_ethnic_group_path
+        else
+          redirect_to candidate_interface_review_equality_and_diversity_path
+        end
       else
         render :edit_disabilities
       end
@@ -60,9 +64,29 @@ module CandidateInterface
       @ethnic_group = EqualityAndDiversity::EthnicGroupForm.new(ethnic_group: ethnic_group_param)
 
       if @ethnic_group.save(current_application)
-        redirect_to candidate_interface_review_equality_and_diversity_path
+        if ethnic_group_param == 'Prefer not to say'
+          redirect_to candidate_interface_review_equality_and_diversity_path
+        else
+          redirect_to candidate_interface_edit_equality_and_diversity_ethnic_background_path
+        end
       else
         render :edit_ethnic_group
+      end
+    end
+
+    def edit_ethnic_background
+      @ethnic_background = EqualityAndDiversity::EthnicBackgroundForm.build_from_application(current_application)
+      @ethnic_group = current_application.equality_and_diversity['ethnic_group']
+    end
+
+    def update_ethnic_background
+      @ethnic_background = EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background_param)
+      @ethnic_group = current_application.equality_and_diversity['ethnic_group']
+
+      if @ethnic_background.save(current_application)
+        redirect_to candidate_interface_review_equality_and_diversity_path
+      else
+        render :edit_ethnic_background
       end
     end
 
@@ -84,6 +108,10 @@ module CandidateInterface
 
     def ethnic_group_param
       params.dig(:candidate_interface_equality_and_diversity_ethnic_group_form, :ethnic_group)
+    end
+
+    def ethnic_background_param
+      params.require(:candidate_interface_equality_and_diversity_ethnic_background_form).permit(:ethnic_background, :other_background)
     end
   end
 end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -1,5 +1,8 @@
 module CandidateInterface
   class EqualityAndDiversityController < CandidateInterfaceController
+    before_action :redirect_to_review_unless_ready_to_submit
+    before_action :redirect_to_review_unless_feature_flag_active
+
     def start; end
 
     def edit_sex
@@ -112,6 +115,18 @@ module CandidateInterface
 
     def ethnic_background_param
       params.require(:candidate_interface_equality_and_diversity_ethnic_background_form).permit(:ethnic_background, :other_background)
+    end
+
+    def redirect_to_review_unless_ready_to_submit
+      redirect_to candidate_interface_application_review_path unless ready_to_submit?
+    end
+
+    def redirect_to_review_unless_feature_flag_active
+      redirect_to candidate_interface_application_review_path unless FeatureFlag.active?('equality_and_diversity')
+    end
+
+    def ready_to_submit?
+      @ready_to_submit ||= CandidateInterface::ApplicationFormPresenter.new(current_application).ready_to_submit?
     end
   end
 end

--- a/app/helpers/ethnic_background_helper.rb
+++ b/app/helpers/ethnic_background_helper.rb
@@ -44,4 +44,8 @@ module EthnicBackgroundHelper
 
     "Which of the following best describes your #{group} background?"
   end
+
+  def equality_and_diversity_caption
+    '<span class="govuk-caption-xl">Equality and diversity</span>'.html_safe
+  end
 end

--- a/app/helpers/ethnic_background_helper.rb
+++ b/app/helpers/ethnic_background_helper.rb
@@ -1,0 +1,47 @@
+module EthnicBackgroundHelper
+  ETHNIC_GROUPS = [
+    'Asian or Asian British',
+    'Black, African, Black British or Caribbean',
+    'Mixed or multiple ethnic groups',
+    'White',
+    'Another ethnic group',
+  ].freeze
+
+  ETHNIC_BACKGROUNDS = {
+      'Asian or Asian British' => %w[Bangladeshi Chinese Indian Pakistani],
+      'Black, African, Black British or Caribbean' => %w[African Carribean],
+      'Mixed or multiple ethnic groups' => ['Asian and White', 'Black African and White', 'Black Caribbean and White'],
+      'White' => ['British, English, Northern Irish, Scottish, or Welsh', 'Irish', 'Irish Traveller or Gypsy'],
+      'Another ethnic group' => %w[Arab],
+    }.freeze
+
+  OTHER_ETHNIC_BACKGROUNDS = {
+    'Asian or Asian British' => ['Another Asian background', 'Your Asian background (optional)'],
+    'Black, African, Black British or Caribbean' => ['Another Black background', 'Your Black background (optional)'],
+    'Mixed or multiple ethnic groups' => ['Another Mixed background', 'Your Mixed background (optional)'],
+    'White' => ['Another White background', 'Your White background (optional)'],
+    'Another ethnic group' => ['Another ethnic background', 'Describe your ethnic background (optional)'],
+  }.freeze
+
+  def ethnic_backgrounds(group)
+    ethnic_backgrounds = ETHNIC_BACKGROUNDS[group].map do |background|
+      OpenStruct.new(
+        label: background,
+        textfield_label: nil,
+      )
+    end
+
+    button_label, textfield_label = OTHER_ETHNIC_BACKGROUNDS[group]
+
+    ethnic_backgrounds << OpenStruct.new(
+      label: button_label,
+      textfield_label: textfield_label,
+    )
+  end
+
+  def ethnic_background_title(group)
+    return 'Which of the following best describes your ethnicity?' if group == 'Another ethnic group'
+
+    "Which of the following best describes your #{group} background?"
+  end
+end

--- a/app/models/candidate_interface/equality_and_diversity/ethnic_group_form.rb
+++ b/app/models/candidate_interface/equality_and_diversity/ethnic_group_form.rb
@@ -16,11 +16,17 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
+      current_ethnic_group = application_form.equality_and_diversity['ethnic_group'] if application_form.equality_and_diversity
+
       if application_form.equality_and_diversity.nil?
         application_form.update(equality_and_diversity: { 'ethnic_group' => ethnic_group })
       else
         application_form.equality_and_diversity['ethnic_group'] = ethnic_group
-        application_form.equality_and_diversity['ethnic_background'] = nil if ethnic_group == 'Prefer not to say'
+
+        if current_ethnic_group
+          application_form.equality_and_diversity['ethnic_background'] = nil if (ethnic_group == 'Prefer not to say') || (current_ethnic_group != ethnic_group)
+        end
+
         application_form.save
       end
     end

--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @disabilities, url: candidate_interface_update_equality_and_diversity_disabilities_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_check_boxes_fieldset :disabilities, legend: { size: 'xl', text: 'Please select all that apply to you' } do %>
+      <%= f.govuk_check_boxes_fieldset :disabilities, legend: { size: 'xl', text: equality_and_diversity_caption + 'Please select all that apply to you' } do %>
         <div class="govuk-!-margin-top-6">
           <% disabilities_checkboxes.each do |checkbox| %>
             <%= f.govuk_check_box :disabilities, checkbox.name, label: { text: checkbox.name, size: 's' }, hint_text: checkbox.hint_text %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, 'Please select all that apply to you' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_disability_status_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @disability_status, url: candidate_interface_update_equality_and_diversity_disability_status_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :disability_status, legend: { size: 'xl', text: 'Are you disabled?' } do %>
+      <%= f.govuk_radio_buttons_fieldset :disability_status, legend: { size: 'xl', text: equality_and_diversity_caption + 'Are you disabled?' } do %>
         <div class="govuk-!-margin-top-6">
           <%= f.govuk_radio_button :disability_status, :yes, label: { text: 'Yes' }, link_errors: true %>
           <%= f.govuk_radio_button :disability_status, :no, label: { text: 'No' } %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, 'Are you disabled?' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_sex_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, ethnic_background_title(@ethnic_group) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_ethnic_group_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -1,0 +1,27 @@
+<% content_for :title, ethnic_background_title(@ethnic_group) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @ethnic_background, url: candidate_interface_update_equality_and_diversity_ethnic_background_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :ethnic_background, legend: { size: 'xl', text: ethnic_background_title(@ethnic_group) } do %>
+        <div class="govuk-!-margin-top-6">
+          <% ethnic_backgrounds(@ethnic_group).each_with_index do |background, i| %>
+              <% if background.textfield_label.nil? %>
+                <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label }, link_errors: i.zero? %>
+              <% else %>
+                <%= f.govuk_radio_button :ethnic_background, background.label, label: { text: background.label } do %>
+                <%= f.govuk_text_field :other_background, label: { text: background.textfield_label } %>
+              <% end %>
+            <% end %>
+          <% end %>
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_button :ethnic_background, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @ethnic_background, url: candidate_interface_update_equality_and_diversity_ethnic_background_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :ethnic_background, legend: { size: 'xl', text: ethnic_background_title(@ethnic_group) } do %>
+      <%= f.govuk_radio_buttons_fieldset :ethnic_background, legend: { size: 'xl', text: equality_and_diversity_caption + ethnic_background_title(@ethnic_group) } do %>
         <div class="govuk-!-margin-top-6">
           <% ethnic_backgrounds(@ethnic_group).each_with_index do |background, i| %>
               <% if background.textfield_label.nil? %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, 'What is your ethnic group?' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_disability_status_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @ethnic_group, url: candidate_interface_update_equality_and_diversity_ethnic_group_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :ethnic_group, legend: { size: 'xl', text: 'What is your ethnic group?' } do %>
+      <%= f.govuk_radio_buttons_fieldset :ethnic_group, legend: { size: 'xl', text: equality_and_diversity_caption + 'What is your ethnic group?' } do %>
         <div class="govuk-!-margin-top-6">
           <%= f.govuk_radio_button :ethnic_group, 'Asian or Asian British', label: { text: 'Asian or Asian British', size: 's' }, hint_text: '(includes any Asian background, for example, Bangladeshi, Chinese, Indian, Pakistani)', link_errors: true %>
           <%= f.govuk_radio_button :ethnic_group, 'Black, African, Black British or Caribbean', label: { text: 'Black, African, Black British or Caribbean', size: 's' }, hint_text: '(includes any Black background)' %>

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, 'What is your sex?' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_start_equality_and_diversity_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -6,7 +6,7 @@
     <%= form_with model: @sex, url: candidate_interface_update_equality_and_diversity_sex_path, method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_radio_buttons_fieldset :sex, legend: { size: 'xl', text: 'What is your sex?' } do %>
+      <%= f.govuk_radio_buttons_fieldset :sex, legend: { size: 'xl', text: equality_and_diversity_caption + 'What is your sex?' } do %>
         <div class="govuk-!-margin-top-6">
           <%= f.govuk_radio_button :sex, :female, label: { text: 'Female' }, link_errors: true %>
           <%= f.govuk_radio_button :sex, :male, label: { text: 'Male' } %>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -7,3 +7,7 @@
 </h1>
 
 <%= render(CandidateInterface::EqualityAndDiversityReviewComponent.new(application_form: @current_application)) %>
+
+<p class="govuk-body">
+  <%= govuk_button_link_to 'Continue', candidate_interface_application_submit_show_path %>
+</p>

--- a/app/views/candidate_interface/equality_and_diversity/review.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :title, 'Check your answers' %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_application_review_path) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_start_equality_and_diversity_path) %>
 
 <h1 class="govuk-heading-xl">
   <span class="govuk-caption-xl">Equality and diversity</span>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -568,3 +568,7 @@ en:
           attributes:
             ethnic_background:
               blank: Choose your ethnic background
+        candidate_interface/equality_and_diversity/ethnic_group_form:
+          attributes:
+            ethnic_group:
+              blank: Choose your ethnic group

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,8 @@ Rails.application.routes.draw do
         post '/disabilities' => 'equality_and_diversity#update_disabilities', as: :update_equality_and_diversity_disabilities
         get '/ethnic-group' => 'equality_and_diversity#edit_ethnic_group', as: :edit_equality_and_diversity_ethnic_group
         post '/ethnic-group' => 'equality_and_diversity#update_ethnic_group', as: :update_equality_and_diversity_ethnic_group
+        get '/ethnic-background' => 'equality_and_diversity#edit_ethnic_background', as: :edit_equality_and_diversity_ethnic_background
+        post '/ethnic-background' => 'equality_and_diversity#update_ethnic_background', as: :update_equality_and_diversity_ethnic_background
         get '/review' => 'equality_and_diversity#review', as: :review_equality_and_diversity
       end
     end

--- a/spec/helpers/ethnic_background_helper_spec.rb
+++ b/spec/helpers/ethnic_background_helper_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe EthnicBackgroundHelper, type: :helper do
+  describe '#ethnic_backgrounds' do
+    let(:group) { EthnicBackgroundHelper::ETHNIC_GROUPS.sample }
+
+    it 'return a stuctured list of all listed ethnic backgrounds' do
+      expected_background = EthnicBackgroundHelper::ETHNIC_BACKGROUNDS[group].sample
+
+      expect(ethnic_backgrounds(group)).to include(
+        OpenStruct.new(
+          label: expected_background,
+          textfield_label: nil,
+        ),
+      )
+    end
+
+    it 'includes a label for the contextual other ethnic background descreption textfield' do
+      expected_other_background = EthnicBackgroundHelper::OTHER_ETHNIC_BACKGROUNDS[group]
+
+      expect(ethnic_backgrounds(group)).to include(
+        OpenStruct.new(
+          label: expected_other_background.first,
+          textfield_label: expected_other_background.second,
+        ),
+      )
+    end
+  end
+
+  describe '#ethnic_background_title' do
+    it 'returns a title for a given ethnic group' do
+      group = 'Asian or Asian British'
+      expect(ethnic_background_title(group)).to include('Which of the following best describes your Asian or Asian British background?')
+    end
+
+    it 'returns the correct title for "Another ethnic group"' do
+      group = 'Another ethnic group'
+      expect(ethnic_background_title(group)).to include('Which of the following best describes your ethnicity?')
+    end
+  end
+end

--- a/spec/models/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/ethnic_background_form_spec.rb
@@ -15,22 +15,35 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
     context 'when ethnic background is unlisted' do
       it 'creates an object with ethnic background set to another and other background is ethnic background' do
-        application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Unlisted ethnic background' })
+        application_form = build_stubbed(:application_form,
+                                         equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Unlisted ethnic background' })
 
         form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
 
-        expect(form.ethnic_background).to eq('Another Asian or Asian British background')
+        expect(form.ethnic_background).to eq('Another Asian background')
         expect(form.other_background).to eq('Unlisted ethnic background')
       end
     end
 
     context 'when ethnic background is another background' do
       it 'creates an object with ethnic background' do
-        application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian or Asian British background' })
+        application_form = build_stubbed(:application_form,
+                                         equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian background' })
 
         form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
 
-        expect(form.ethnic_background).to eq('Another Asian or Asian British background')
+        expect(form.ethnic_background).to eq('Another Asian background')
+        expect(form.other_background).to eq(nil)
+      end
+    end
+
+    context 'when ethnic background is not present' do
+      it 'creates an object with empty ethnic background' do
+        application_form = build_stubbed(:application_form, equality_and_diversity: { 'ethnic_group' => 'Asian or Asian British', 'ethnic_background' => nil })
+
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.build_from_application(application_form)
+
+        expect(form.ethnic_background).to eq(nil)
         expect(form.other_background).to eq(nil)
       end
     end
@@ -76,7 +89,7 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
 
     context 'when ethnic background is another background' do
       it 'updates the application form with the other background value if other background provided' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian or Asian British background', other_background: 'Unlisted ethnic background')
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian background', other_background: 'Unlisted ethnic background')
 
         form.save(application_form)
 
@@ -84,11 +97,11 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm, t
       end
 
       it 'updates the application form with the ethnic background value if other background is not provided' do
-        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian or Asian British background', other_background: nil)
+        form = CandidateInterface::EqualityAndDiversity::EthnicBackgroundForm.new(ethnic_background: 'Another Asian background', other_background: nil)
 
         form.save(application_form)
 
-        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian or Asian British background')
+        expect(application_form.equality_and_diversity).to eq('ethnic_group' => 'Asian or Asian British', 'ethnic_background' => 'Another Asian background')
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -33,6 +33,9 @@ RSpec.feature 'Entering their equality and diversity information' do
     and_i_click_on_continue
     then_i_am_asked_for_my_ethnic_group
 
+    when_i_try_and_submit_without_choosing_my_ethnic_group
+    then_i_see_an_error_to_choose_my_ethnic_group
+
     when_i_choose_that_i_prefer_not_to_say_my_ethnic_group
     and_i_click_on_continue
     then_i_can_review_my_answers
@@ -71,7 +74,15 @@ RSpec.feature 'Entering their equality and diversity information' do
     when_i_click_change_ethnic_group
     and_i_choose_another_ethnic_group
     and_i_click_on_continue
-    then_i_can_review_my_updated_ethnic_group
+    then_i_am_asked_for_my_ethnic_background
+
+    when_i_try_and_submit_without_choosing_my_ethnic_background
+    then_i_see_an_error_to_choose_my_ethnic_background
+
+    when_i_choose_my_ethnic_background
+    and_i_describe_my_other_ethnic_background
+    and_i_click_on_continue
+    then_i_can_review_my_updated_ethnicity
   end
 
   def given_i_am_signed_in
@@ -181,6 +192,14 @@ RSpec.feature 'Entering their equality and diversity information' do
     expect(page).to have_content('What is your ethnic group?')
   end
 
+  def when_i_try_and_submit_without_choosing_my_ethnic_group
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_to_choose_my_ethnic_group
+    expect(page).to have_content('Choose your ethnic group')
+  end
+
   def when_i_choose_that_i_prefer_not_to_say_my_ethnic_group
     choose 'Prefer not to say'
   end
@@ -250,8 +269,28 @@ RSpec.feature 'Entering their equality and diversity information' do
     choose 'White'
   end
 
-  def then_i_can_review_my_updated_ethnic_group
+  def then_i_am_asked_for_my_ethnic_background
+    expect(page).to have_content('Which of the following best describes your White background?')
+  end
+
+  def when_i_try_and_submit_without_choosing_my_ethnic_background
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_to_choose_my_ethnic_background
+    expect(page).to have_content('Choose your ethnic background')
+  end
+
+  def when_i_choose_my_ethnic_background
+    choose 'Another White background'
+  end
+
+  def and_i_describe_my_other_ethnic_background
+    fill_in 'Your White background', with: 'I am Hungarian'
+  end
+
+  def then_i_can_review_my_updated_ethnicity
     expect(page).to have_content('Check your answers')
-    expect(page).to have_content('White')
+    expect(page).to have_content('White (I am Hungarian)')
   end
 end


### PR DESCRIPTION
## Context
Currently, we've built the 'What is your sex?', 'Are you disabled?', 'Please select all (disabilities) that apply to you' pages for equality and diversity monitoring and the 'What is your ethnic group?' page. Up next is to add the 'What is your ethnic background?' The previous PR added the journey to submit the ethnic group information #1481

<!-- Why are you making this change? What might surprise someone about it? -->
## Changes proposed in this pull request
This PR:
- adds a page to choose an ethnic background
- update the review page to show ethnic background
- complete the edit ethnicity flow
- prevent candidates from visiting equality and diversity pages when the application is not ready 
- add caption to equality and diversity page titles as per design

### Screenshots
![image](https://user-images.githubusercontent.com/22743709/75682379-3f474180-5c8d-11ea-9252-4ab2344c521a.png)
![image](https://user-images.githubusercontent.com/22743709/75682444-56862f00-5c8d-11ea-9bbe-3aee06fe2086.png)

## Guidance to review
System tests are a good starting point, otherwise, try to fill up the ethnic group and ethnic background pages. There are quite a lot of possible candidate journeys, not all of them covered in the system tests. Do you think we need more tests around this?
Some of these possible journeys:
- candidate prefer not to say their ethnic group
- candidate say the ethnic group but prefer not to share their ethnic background
- ethnic group and ethnic background changed
- the ethnic group is the same but ethnic background changed
- selected other ethnic background and described
- selected other ethnic background but no description 

## Link to Trello card
https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
