### PR TITLE
Document hotfix deployment instructions

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -42,7 +42,7 @@ stages:
 - stage: deploy_staging
   displayName: 'Deploy - Staging'
   dependsOn: publish_arm_template
-  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_staging, true))
+  condition: and(or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/hotfix')), eq(variables.deploy_staging, true))
   variables:
   - group: APPLY - ENV - Staging
   jobs:
@@ -99,7 +99,7 @@ stages:
 - stage: deploy_sandbox
   displayName: 'Deploy - Sandbox'
   dependsOn: publish_arm_template
-  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_sandbox, true))
+  condition: and(or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/hotfix')), eq(variables.deploy_sandbox, true))
   variables:
   - group: APPLY - ENV - Sandbox
   jobs:
@@ -155,7 +155,7 @@ stages:
 - stage: deploy_production
   displayName: 'Deploy - Production'
   dependsOn: publish_arm_template
-  condition: and(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables.deploy_production, true))
+  condition: and(or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/hotfix')), eq(variables.deploy_production, true))
   variables:
   - group: APPLY - ENV - Production
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,8 +206,8 @@ stages:
         imageName: "$(docker_path):$(Build.BuildNumber)"
 
     - task: Docker@1
-      displayName: Push tagged image (latest) if master
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      displayName: Push tagged image (latest) if master or hotfix
+      condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.SourceBranch'], 'refs/heads/hotfix')))
       inputs:
         command: Push an image
         imageName: "$(docker_path):latest"

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -52,7 +52,7 @@ features 1, 2 and 3, we just want everything up to `D`.
   $ git push origin hotfix
   ```
 
-3. Implement the fix locally raise a PR and get it approved in the
+3. Implement the fix locally, raise a PR and get it approved in the
    normal way. Test it locally or using the Heroku review app that is
    be automatically created.
 4. After the PR is approved don't merge it to `master` straight away.

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -57,7 +57,7 @@ features 1, 2 and 3, we just want everything up to `D`.
    be automatically created.
 4. After the PR is approved don't merge it to `master` straight away.
    First deploy the `hotfix` branch using the [normal deployment
-   procedure](manual-deployment.md) (except picking `HEAD` of the
+   procedure](deployment.md) (except picking `HEAD` of the
    `hotfix` branch rather than a specific SHA on `master` as we normally
    do).
 5. Merge the `hotfix` branch back to `master`. At this point the `hotfix`
@@ -108,5 +108,3 @@ having two main branches. This article describes something close to the
 process that we are following:
 
 https://www.endoflineblog.com/gitflow-considered-harmful
-
-

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -1,0 +1,81 @@
+# Apply for Postgraduate Teacher Training - Hotfix Deployment
+
+## Purpose
+
+This document describes the process of manually deploying a hotfix
+
+### When should this process be used?
+
+Normally deployments to the `staging`, `sandbox` and `production` environments
+happen on a daily (or more frequent) basis and include all changes that
+have been merged into master. A hotfix is a more urgent deployment
+containing typically just one pull request. A hotfix should be performed
+when:
+
+1. The fix is urgent.
+2. There are other changes already merged into master since the last
+   deployment that we don't want to deploy yet perhaps because they are
+   not fully tested.
+
+## Instructions
+
+We assume that we begin in a situation like this:
+
+```
+master        X------1-----2
+               \    /     /
+feature1        ----     /
+                \       /
+feature2         -------
+```
+
+Since last deployed at `X` we've merged two additional features into
+`master`. We urgently need to create a fix that does not include
+features 1 and 2, we just want everything up to `X`.
+
+### Minimum steps that would work...
+
+1. Fetch `master` to your local machine and create a branch from `X`
+   (not `HEAD` as we normally would).
+2. Implement the fix locally raise a PR and get it approved in the
+   normal way. Test it locally or using the Heroku review app that will
+   be automatically created.
+3. Deploy the `hotfix` branch using the normal deployment procedure
+   (except picking `HEAD` of the `hotfix` branch rather than a specific
+   SHA on `master` as we normally do).
+4. Merge the `hotfix` branch back to `master`.
+
+
+Issues that are not addressed here:
+
+- What if we had more than one hotfix on the go at a time? The main
+  problem here would be multiple hotfix branches. If we can stick to
+  just a single hotfix branch then we should be fine. That branch could
+  contain more than one actual fix if needed. We would need to make sure
+  that if a hotfix is initiated that the whole team knows about it.
+- What if we deployed normally again to production after branching
+  `hotfix` but before it was merged? If this happened then it would
+  indicate a failure of communication or a hotfix just taking a long
+  time. In this case it might make more sense to roll the hotfix into
+  the regular release as a normal change and ship it as normal.
+
+
+## References
+
+If you Google something like 'git branching strategy for hotfixes' you
+will find that the top hits point to Gitflow, a popular branching model
+that defines a set of conventions and covers developer feature branches,
+regular releases and hotfixes. It's fairly heavy compared to our current
+model and there are alternatives, four of them are reviewed in this
+article:
+
+https://medium.com/@patrickporto/4-branching-workflows-for-git-30d0aaee7bf
+
+If we want to stay as close as possible to the model that we have at the
+moment we should avoid Gitflow, in particular the idea of having two
+main branches. This article describes something close to the minimum
+steps I've outlined above:
+
+https://www.endoflineblog.com/gitflow-considered-harmful
+
+

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -46,6 +46,20 @@ features 1 and 2, we just want everything up to `X`.
 4. Merge the `hotfix` branch back to `master`.
 
 
+Do we need to tag releases? At the moment we don't really have record of
+which versions shipped and when in the git repository itself. It makes
+sense to tag releases that ship to production so that we have a readily
+available record of that. It would make finding the commit from which a
+hotfix should be branched a little easier.
+
+Should we get into the habit of creating a release branch for normal
+releases? (A release branch is really a generalisation of a hotfix
+branch)
+
+How can we automate step 4 (merging the hotfix back to master)? We want
+to make sure we don't lose any hotfixes in a subsequent deploy.
+
+
 Issues that are not addressed here:
 
 - What if we had more than one hotfix on the go at a time? The main

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This document describes the process of manually deploying a hotfix
+This document describes the process of manually deploying a hotfix.
 
 ### When should this process be used?
 
@@ -35,17 +35,37 @@ Since last deployed at `D` we've merged two additional features into
 `master`. We urgently need to create a fix that does not include
 features 1, 2 and 3, we just want everything up to `D`.
 
-### Minimum steps that would work...
+### Instructions
 
-1. Fetch `master` to your local machine and create a branch from `D`
-   (not `HEAD` as we normally would).
-2. Implement the fix locally raise a PR and get it approved in the
-   normal way. Test it locally or using the Heroku review app that will
+1. Inform the team that a hotfix is being prepared by posting a new
+   thread in Slack to #twd_apply.
+2. Fetch `master` to your local machine and create a branch called
+   `hotfix` from the last deployed commit (not `HEAD` as we normally
+   would). You can specify the last deployed commit using it's SHA and
+   find out which SHA to use on the
+   [ops dashboard](https://apply-ops-dashboard.herokuapp.com/) - just
+   look for the current production version. Push the new branch to Github.
+
+  ```
+  $ git fetch origin master
+  $ git checkout -b hotfix <sha-from-ops-dashboard>
+  $ git push origin hotfix
+  ```
+
+3. Implement the fix locally raise a PR and get it approved in the
+   normal way. Test it locally or using the Heroku review app that is
    be automatically created.
-3. Deploy the `hotfix` branch using the normal deployment procedure
-   (except picking `HEAD` of the `hotfix` branch rather than a specific
-   SHA on `master` as we normally do).
-4. Merge the `hotfix` branch back to `master`.
+4. After the PR is approved don't merge it to `master` straight away.
+   First deploy the `hotfix` branch using the [normal deployment
+   procedure](manual-deployment.md) (except picking `HEAD` of the
+   `hotfix` branch rather than a specific SHA on `master` as we normally
+   do).
+5. Merge the `hotfix` branch back to `master`. At this point the `hotfix`
+   branch should be automatically deleted.
+
+Here is an example of the process where the last 'normal' deployment was
+at `D` and the hotfix was deployed at `H`. After the `hotfix` branch is
+deployed back into `master` it's back to business as usual.
 
 ```
 hotfix             ------------------------------x-x-x-H
@@ -59,54 +79,33 @@ feature2            --x-x-x-x       \      /
 feature3                              -x-x
 ```
 
-### Some questions
-
-Do we need to tag releases? At the moment we don't really have record of
-which versions shipped and when in the git repository itself. It makes
-sense to tag releases that ship to production so that we have a readily
-available record of that. It would make finding the commit from which a
-hotfix should be branched a little easier.
-
-Should we get into the habit of creating a release branch for normal
-releases? (A release branch is really a generalisation of a hotfix
-branch)
-
-How can we automate step 4 (merging the hotfix back to master)? We want
-to make sure we don't lose any hotfixes in a subsequent deploy.
-
-Are there any branch naming or other conventions that we want to follow?
-It would be nice not to have to change the current convention for naming
-feature branches.
-
-Issues that are not addressed here:
-
-#### What if we had more than one hotfix on the go at a time?
-The main problem here would be multiple hotfix branches. If we can stick
-to just a single hotfix branch then we should be fine. That branch could
-contain more than one actual fix if needed. We would need to make sure
-that if a hotfix is initiated that the whole team knows about it.
-
-#### What if we deployed normally again to production after branching `hotfix` but before it was merged?
-If this happened then it would indicate a failure of communication or a
-hotfix just taking a long time. In this case it might make more sense to
-roll the hotfix into the regular release as a normal change and ship it
-as normal.
+### Notes
+- We always use the name `hotfix` to enforce the rule that only
+  ever have one hotfix branch at a time.
+- When starting a hotfix it's important that the rest of the team knows
+  about it so that nobody else starts any other kind of deploy until
+  the hotfix is complete and merged back into `master`.
+- Pushing the new `hotfix` branch to Github at the start of the
+  process (before any fix commits are made) acts as a signal to other
+  developers/systems that a hotfix is in progress.
 
 ## References
 
 If you Google something like 'git branching strategy for hotfixes' you
 will find that the top hits point to Gitflow, a popular branching model
 that defines a set of conventions and covers developer feature branches,
-regular releases and hotfixes. It's fairly heavy compared to our current
-model and there are alternatives, four of them are reviewed in this
-article:
+regular releases and hotfixes:
+
+https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow
+
+Gitflow is fairly heavy compared to our current model and there are
+alternatives, four of them are reviewed in this article:
 
 https://medium.com/@patrickporto/4-branching-workflows-for-git-30d0aaee7bf
 
-If we want to stay as close as possible to the model that we have at the
-moment we should avoid Gitflow, in particular the idea of having two
-main branches. This article describes something close to the minimum
-steps I've outlined above:
+For now we have chosen to avoid Gitflow, in particular the idea of
+having two main branches. This article describes something close to the
+process that we are following:
 
 https://www.endoflineblog.com/gitflow-considered-harmful
 

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -54,7 +54,7 @@ features 1, 2 and 3, we just want everything up to `D`.
 
 3. Implement the fix locally, raise a PR and get it approved in the
    normal way. Test it locally or using the Heroku review app that is
-   be automatically created.
+   automatically created.
 4. After the PR is approved don't merge it to `master` straight away.
    First deploy the `hotfix` branch using the [normal deployment
    procedure](deployment.md) (except picking `HEAD` of the
@@ -65,7 +65,7 @@ features 1, 2 and 3, we just want everything up to `D`.
 
 Here is an example of the process where the last 'normal' deployment was
 at `D` and the hotfix was deployed at `H`. After the `hotfix` branch is
-deployed back into `master` it's back to business as usual.
+merged back into `master` it's back to business as usual.
 
 ```
 hotfix             ------------------------------x-x-x-H
@@ -80,7 +80,7 @@ feature3                              -x-x
 ```
 
 ### Notes
-- We always use the name `hotfix` to enforce the rule that only
+- We always use the name `hotfix` to enforce the rule that we only
   ever have one hotfix branch at a time.
 - When starting a hotfix it's important that the rest of the team knows
   about it so that nobody else starts any other kind of deploy until

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -22,20 +22,22 @@ when:
 We assume that we begin in a situation like this:
 
 ```
-master        X------1-----2
-               \    /     /
-feature1        ----     /
-                \       /
-feature2         -------
+master        ---D--------x-----x--------------x--->
+                  \      /     / \            /
+feature1           -x-x-x     /   \          /
+                   \         /     \        /
+feature2            --x-x-x-x       \      /
+                                     \    /
+feature3                              -x-x
 ```
 
-Since last deployed at `X` we've merged two additional features into
+Since last deployed at `D` we've merged two additional features into
 `master`. We urgently need to create a fix that does not include
-features 1 and 2, we just want everything up to `X`.
+features 1, 2 and 3, we just want everything up to `D`.
 
 ### Minimum steps that would work...
 
-1. Fetch `master` to your local machine and create a branch from `X`
+1. Fetch `master` to your local machine and create a branch from `D`
    (not `HEAD` as we normally would).
 2. Implement the fix locally raise a PR and get it approved in the
    normal way. Test it locally or using the Heroku review app that will
@@ -45,6 +47,19 @@ features 1 and 2, we just want everything up to `X`.
    SHA on `master` as we normally do).
 4. Merge the `hotfix` branch back to `master`.
 
+```
+hotfix             ------------------------------x-x-x-H
+                  /                                     \
+master        ---D--------x-----x--------------x----------->
+                  \      /     / \            /
+feature1           -x-x-x     /   \          /
+                   \         /     \        /
+feature2            --x-x-x-x       \      /
+                                     \    /
+feature3                              -x-x
+```
+
+### Some questions
 
 Do we need to tag releases? At the moment we don't really have record of
 which versions shipped and when in the git repository itself. It makes
@@ -59,20 +74,23 @@ branch)
 How can we automate step 4 (merging the hotfix back to master)? We want
 to make sure we don't lose any hotfixes in a subsequent deploy.
 
+Are there any branch naming or other conventions that we want to follow?
+It would be nice not to have to change the current convention for naming
+feature branches.
 
 Issues that are not addressed here:
 
-- What if we had more than one hotfix on the go at a time? The main
-  problem here would be multiple hotfix branches. If we can stick to
-  just a single hotfix branch then we should be fine. That branch could
-  contain more than one actual fix if needed. We would need to make sure
-  that if a hotfix is initiated that the whole team knows about it.
-- What if we deployed normally again to production after branching
-  `hotfix` but before it was merged? If this happened then it would
-  indicate a failure of communication or a hotfix just taking a long
-  time. In this case it might make more sense to roll the hotfix into
-  the regular release as a normal change and ship it as normal.
+#### What if we had more than one hotfix on the go at a time?
+The main problem here would be multiple hotfix branches. If we can stick
+to just a single hotfix branch then we should be fine. That branch could
+contain more than one actual fix if needed. We would need to make sure
+that if a hotfix is initiated that the whole team knows about it.
 
+#### What if we deployed normally again to production after branching `hotfix` but before it was merged?
+If this happened then it would indicate a failure of communication or a
+hotfix just taking a long time. In this case it might make more sense to
+roll the hotfix into the regular release as a normal change and ship it
+as normal.
 
 ## References
 

--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -41,7 +41,7 @@ features 1, 2 and 3, we just want everything up to `D`.
    thread in Slack to #twd_apply.
 2. Fetch `master` to your local machine and create a branch called
    `hotfix` from the last deployed commit (not `HEAD` as we normally
-   would). You can specify the last deployed commit using it's SHA and
+   would). You can specify the last deployed commit using its SHA and
    find out which SHA to use on the
    [ops dashboard](https://apply-ops-dashboard.herokuapp.com/) - just
    look for the current production version. Push the new branch to Github.

--- a/docs/manual-deployment.md
+++ b/docs/manual-deployment.md
@@ -11,7 +11,7 @@ In the event that code changes are made to the app but the Azure pipelines fail 
 This process assumes that the build and test stage has completed without error and a Docker image has been uploaded to Dockerhub successfully. This process also assumes that no changes are expected to be made to the configuration of the underlying Azure infrastructure hosting the application.
 
 Note that these instructions are for normal deployment. For a hotfix
-deployment, for an urgent fix, please refer to [Hotfix deployment
+deployment, please refer to [Hotfix deployment
 instructions](hotfix-deployment.md).
 
 ## Instructions

--- a/docs/manual-deployment.md
+++ b/docs/manual-deployment.md
@@ -10,6 +10,10 @@ In the event that code changes are made to the app but the Azure pipelines fail 
 
 This process assumes that the build and test stage has completed without error and a Docker image has been uploaded to Dockerhub successfully. This process also assumes that no changes are expected to be made to the configuration of the underlying Azure infrastructure hosting the application.
 
+Note that these instructions are for normal deployment. For a hotfix
+deployment, for an urgent fix, please refer to [Hotfix deployment
+instructions](hotfix-deployment.md).
+
 ## Instructions
 
 **NOTE: Before following the steps below you will need to request an elevation of your rights to the 'contributor' role through PIM in the Azure Portal if working on an app hosted in the test or production subscriptions. Guidance on PIM can be found in the [PIM Guide](pim-guide.md) document. PIM is not required in the development subscription.**


### PR DESCRIPTION
## Context

This is an incident action after the 31 January incident. We want to have an agreed process for deploying hotfixes.

## Changes proposed in this pull request

- [x] Add a new _hotfix deployment_ document that outlines the process and provides instructions.
- [x] Link to the new document from the normal deployment instructions.
- [x] Update the Azure deployment pipeline to permit deployments from a branch called `hotfix`

Beyond the scope of this PR we also need to update the ops dashboard to include a warning when a hotfix deployment is running. Perhaps this could be a simple banner triggered by the presence of a `hotfix` branch in the Github repo? We may also look at tagging releases in the future.

## Guidance to review

- Are the instructions clear? Could they be followed under pressure?
- Any situations that we've not foreseen?

## Link to Trello card

https://trello.com/c/2c9pgmt8/1622-figure-out-how-to-do-a-proper-hotfix-without-deploying-other-stuff-on-master-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
