### PR TITLE
Add guidance to the provider sign in page when DSI has an incident

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,6 +26,7 @@ class FeatureFlag
     equality_and_diversity
     provider_application_filters
     provider_interface_pagination
+    dfe_sign_in_incident
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -4,6 +4,15 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
+    <% if FeatureFlag.active?('dfe_sign_in_incident') %>
+      <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
+          <div class="app-banner__message">
+            <h2 class="govuk-heading-m">You might have problems signing in</h2>
+            <p>Some of our users are having trouble signing in. We’re working on the problem now. If you can’t sign in, try again soon.</p>
+          </div>
+      </div>
+    <% end %>
+
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.sign_in') %>
     </h1>


### PR DESCRIPTION
Because the DSI error page is very unhelpful, warn our users before they
get there. This notice can be toggled via feature flag.

<img width="863" alt="Screenshot 2020-03-02 at 10 44 13" src="https://user-images.githubusercontent.com/642279/75669334-c76c1d80-5c72-11ea-9ec3-6bbfa7cc4eb5.png">

### Context

https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1583141874153800

### Guidance to review

I chose not to include a test...

### Link to Trello card

https://trello.com/c/R1oZNMdc/1717-tell-providers-dfe-sign-in-is-having-an-incident