### PR TITLE
Change other disabilities field to optional

### DIFF
--- a/spec/models/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/disabilities_form_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
       expect(form.other_disability).to eq('Other disability')
     end
 
+    it 'allows other disability to be undisclosed' do
+      application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => %w[Blind Deaf Other] })
+      form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
+
+      expect(form.disabilities).to eq(%w[Blind Deaf Other])
+      expect(form.other_disability).to eq(nil)
+    end
+
     it 'returns nil if equality and diversity is nil' do
       application_form = build_stubbed(:application_form, equality_and_diversity: nil)
       form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.build_from_application(application_form)
@@ -50,6 +58,13 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
         expect(application_form.equality_and_diversity).to eq('disabilities' => ['Blind', 'Other disability'])
       end
 
+      it 'allows other_disability field to be optional' do
+        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind Other], other_disability: '')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq('disabilities' => %w[Blind Other])
+      end
+
       it 'updates the existing record of equality and diversity information' do
         application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male' })
         form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind])
@@ -74,28 +89,5 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilitiesForm, type:
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:disabilities) }
-
-    context 'when other disability is chosen' do
-      it 'validates presence of other disability' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Other])
-        error_message = I18n.t('activemodel.errors.models.candidate_interface/equality_and_diversity/disabilities_form.attributes.other_disability.blank')
-
-        form.validate
-
-        expect(form.errors.full_messages_for(:other_disability)).to eq(
-          ["Other disability #{error_message}"],
-        )
-      end
-    end
-
-    context 'when other disability is not chosen' do
-      it 'does not validates presence of other disability' do
-        form = CandidateInterface::EqualityAndDiversity::DisabilitiesForm.new(disabilities: %w[Blind])
-
-        form.validate
-
-        expect(form.errors).to be_empty
-      end
-    end
   end
 end


### PR DESCRIPTION
## Context
In #1473 we added validation to the `Other disabilities field`, however this meant to be an optional field according to the design.

## Changes proposed in this pull request
This PR:
- change other disabilities field to optional

## Guidance to review
👀 

## Link to Trello card
https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
