### PR TITLE
Prepend candidate name with support reference.

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -7,6 +7,7 @@ class PersonalDetailsComponent < ActionView::Component::Base
            :last_name,
            :phone_number,
            :candidate,
+           :support_reference,
            to: :application_form
 
   delegate :email_address, to: :candidate
@@ -17,6 +18,7 @@ class PersonalDetailsComponent < ActionView::Component::Base
 
   def rows
     [
+      support_reference_row,
       name_row,
       date_of_birth_row,
       nationality_row,
@@ -77,6 +79,13 @@ private
     {
       key: 'Address',
       value: full_address,
+    }
+  end
+
+  def support_reference_row
+    {
+      key: 'Reference',
+      value: support_reference,
     }
   end
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -16,7 +16,10 @@
     <tbody class='govuk-table__body'>
       <% @application_choices.each do |application_choice| %>
       <tr class='govuk-table__row'>
-        <th class='govuk-table__cell'><%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %></th>
+        <td class='govuk-table__cell'>
+          <span class="govuk-caption-m govuk-!-font-size-16"><%= application_choice.application_form.support_reference %></span>
+          <%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %>
+        </td>
         <td class='govuk-table__cell'>
           <% if current_provider_user.providers.size > 1 %>
             <span class='govuk-caption-m govuk-!-font-size-16'>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -14,7 +14,7 @@
 <% end %>
 
 <h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">Application for <%= @application_choice.provider.name_and_code %> - <%= @application_choice.course.name_and_code %></span>
+  <span class="govuk-caption-xl"><%= @application_choice.application_form.support_reference %></span>
   <%= @application_choice.application_form.full_name %>
 </h1>
 

--- a/spec/components/personal_details_component_spec.rb
+++ b/spec/components/personal_details_component_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe PersonalDetailsComponent do
+  let(:application_form) do
+    build_stubbed(
+      :completed_application_form,
+      support_reference: 'AB123',
+      date_of_birth: Date.new(2000, 1, 1),
+    )
+  end
+
+  subject(:result) { render_inline(PersonalDetailsComponent.new(application_form: application_form)) }
+
+  it 'renders component with correct labels' do
+    ['Reference', 'Full name', 'Date of birth', 'Nationality', 'Phone number', 'Email address', 'Address'].each do |key|
+      expect(result.css('.govuk-summary-list__key').text).to include(key)
+    end
+  end
+
+  it 'renders the candidate support reference' do
+    expect(result.css('.govuk-summary-list__value').text).to include('AB123')
+  end
+
+  it 'renders the candidate name' do
+    expect(result.css('.govuk-summary-list__value').text).to include("#{application_form.first_name} #{application_form.last_name}")
+  end
+
+  it 'renders the candidate date of birth' do
+    expect(result.css('.govuk-summary-list__value').text).to include('1 January 2000')
+  end
+
+  it 'renders the candidate nationality' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.first_nationality)
+  end
+
+  it 'renders the candidate phone number' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.phone_number)
+  end
+
+  it 'renders the candidate email address' do
+    expect(result.css('.govuk-summary-list__value').text).to include(application_form.candidate.email_address)
+  end
+
+  it 'renders the candidate address and postcode' do
+    full_address = [
+      application_form.address_line1,
+      application_form.address_line2,
+      application_form.address_line3,
+      application_form.address_line4,
+      application_form.postcode,
+    ].reject(&:blank?).join
+
+    expect(result.css('.govuk-summary-list__value').text).to include(full_address)
+  end
+end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -72,7 +72,9 @@ RSpec.feature 'See applications' do
   alias :when_i_visit_the_provider_page :and_i_visit_the_provider_page
 
   def then_i_should_see_the_applications_from_my_organisation
+    expect(page).to have_content @my_provider_choice1.application_form.support_reference
     expect(page).to have_content @my_provider_choice1.application_form.first_name
+    expect(page).to have_content @my_provider_choice2.application_form.support_reference
     expect(page).to have_content @my_provider_choice2.application_form.first_name
   end
 
@@ -90,7 +92,7 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_be_on_the_application_view_page
-    expect(page).to have_content 'Application for'
+    expect(page).to have_content @my_provider_choice1.application_form.support_reference
     expect(page).to have_content @my_provider_choice1.application_form.first_name
   end
 end


### PR DESCRIPTION
Also add this information to personal details data definition list.
This commit adds a missing spec for PersonalDetailsComponent.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Candidate names are not always unique enough when searching course applications.

## Changes proposed in this pull request

This PR presents the application support reference in the applications list, above the candidate name and similarly in the application details.

We intend to make this reference searchable in future stories

<!-- If there are UI changes, please include Before and After screenshots. -->

### Before


![image](https://user-images.githubusercontent.com/93511/75675869-fccb3800-5c7f-11ea-8bc6-311d0a5f1bc8.png)


![image](https://user-images.githubusercontent.com/93511/75675908-0ce31780-5c80-11ea-8c70-e552dab9e0c1.png)


### After

![image](https://user-images.githubusercontent.com/93511/75675631-6ac32f80-5c7f-11ea-9602-348b1bf2e346.png)

![image](https://user-images.githubusercontent.com/93511/75675676-7d3d6900-5c7f-11ea-87a8-f7b94540aec6.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/zqX9KP70/1638-add-an-id-to-applicationchoices-in-the-provider-ui-applications-index-and-on-the-provider-ui-individual-application-view-%F0%9F%8F%88
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
