### PR TITLE
Update site selection behaviour after choosing study mode

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -101,11 +101,18 @@ module CandidateInterface
       )
       render :options_for_study_mode and return unless @pick_study_mode.valid?
 
-      redirect_to candidate_interface_course_choices_site_path(
-        @pick_study_mode.provider_id,
-        @pick_study_mode.course_id,
-        @pick_study_mode.study_mode,
-      )
+      if @pick_study_mode.single_site_course?
+        pick_site_for_course(
+          @pick_study_mode.course_id,
+          @pick_study_mode.first_site_id,
+        )
+      else
+        redirect_to candidate_interface_course_choices_site_path(
+          @pick_study_mode.provider_id,
+          @pick_study_mode.course_id,
+          @pick_study_mode.study_mode,
+        )
+      end
     end
 
     def options_for_site

--- a/app/models/candidate_interface/pick_study_mode_form.rb
+++ b/app/models/candidate_interface/pick_study_mode_form.rb
@@ -4,5 +4,17 @@ module CandidateInterface
 
     attr_accessor :provider_id, :course_id, :study_mode
     validates :study_mode, presence: true
+
+    def available_sites
+      CourseOption.where(course_id: course_id, study_mode: study_mode)
+    end
+
+    def single_site_course?
+      available_sites.one?
+    end
+
+    def first_site_id
+      available_sites.first&.id
+    end
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -133,7 +133,7 @@ FactoryBot.define do
     provider
 
     code { Faker::Alphanumeric.unique.alphanumeric(number: 1).upcase }
-    name { Faker::Educator.secondary_school }
+    name { Faker::Educator.unique.secondary_school }
     address_line1 { Faker::Address.street_address }
     address_line2 { Faker::Address.city }
     address_line3 { Faker::Address.county }

--- a/spec/models/candidate_interface/pick_study_mode_form_spec.rb
+++ b/spec/models/candidate_interface/pick_study_mode_form_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PickStudyModeForm, type: :model do
+  let!(:course) { create(:course) }
+
+  describe '#available_sites' do
+    it 'returns all sites available for the selected course and study mode' do
+      pt_course_one = create(:course_option, course: course, study_mode: :part_time)
+      pt_course_two = create(:course_option, course: course, study_mode: :part_time)
+      create(:course_option, course: course, study_mode: :full_time)
+
+      form = described_class.new(course_id: course.id, study_mode: :part_time)
+
+      expect(form.available_sites).to eq(
+        [
+          pt_course_one,
+          pt_course_two,
+        ],
+      )
+    end
+  end
+
+  describe 'single_site_course?' do
+    it 'returns true when there is only one available site' do
+      create(:course_option, course: course, study_mode: :full_time)
+
+      form = described_class.new(course_id: course.id, study_mode: :full_time)
+
+      expect(form.single_site_course?).to eq true
+    end
+
+    it 'returns false when there is more than one available site' do
+      create(:course_option, course: course, study_mode: :full_time)
+      create(:course_option, course: course, study_mode: :full_time)
+
+      form = described_class.new(course_id: course.id, study_mode: :full_time)
+
+      expect(form.single_site_course?).to eq false
+    end
+  end
+
+  describe 'first_site_id' do
+    it 'returns the id of the first available site' do
+      course_option = create(:course_option, course: course, study_mode: :full_time)
+
+      form = described_class.new(course_id: course.id, study_mode: :full_time)
+
+      expect(form.first_site_id).to eq course_option.id
+    end
+
+    context 'when there are no sites' do
+      it 'returns nil' do
+        form = described_class.new(course_id: course.id, study_mode: :full_time)
+
+        expect(form.first_site_id).to eq nil
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Selecting a study mode' do
   include CandidateHelper
 
-  scenario 'Candidate selects a part time course' do
+  scenario 'Candidate selects different study modes' do
     given_choosing_a_study_mode_is_active
     given_i_am_signed_in
     and_there_are_course_options
@@ -13,6 +13,56 @@ RSpec.feature 'Selecting a study mode' do
 
     when_i_select_a_site
     then_i_see_my_course_choice
+
+    given_there_is_a_single_site_full_time_course
+    when_i_select_the_single_site_full_time_course
+    then_the_site_is_resolved_automatically_and_i_see_the_course_choice
+  end
+
+  def given_there_is_a_single_site_full_time_course
+    @third_site = create(:site, provider: @provider)
+
+    @single_site_course = create(
+      :course, :with_both_study_modes, :open_on_apply, provider: @provider
+    )
+
+    create(
+      :course_option,
+      site: @third_site,
+      course: @single_site_course,
+      study_mode: :part_time,
+    )
+
+    create(
+      :course_option,
+      site: @third_site,
+      course: @single_site_course,
+      study_mode: :full_time,
+    )
+  end
+
+  def when_i_select_the_single_site_full_time_course
+    visit candidate_interface_application_form_path
+    click_link 'Course choices'
+    click_link 'Add another course'
+
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+
+    select @provider.name
+    click_button 'Continue'
+
+    select @single_site_course.name
+    click_button 'Continue'
+
+    choose 'Full time'
+    click_button 'Continue'
+  end
+
+  def then_the_site_is_resolved_automatically_and_i_see_the_course_choice
+    expect(page).to have_text 'Course choices'
+    expect(page).to have_text @single_site_course.name
+    expect(page).to have_text 'Full time'
   end
 
   def given_choosing_a_study_mode_is_active
@@ -28,6 +78,7 @@ RSpec.feature 'Selecting a study mode' do
 
     @first_site = create(:site, provider: @provider)
     @second_site = create(:site, provider: @provider)
+    @third_site = create(:site, provider: @provider)
 
     @course = create(
       :course, :with_both_study_modes, :open_on_apply, provider: @provider
@@ -42,6 +93,12 @@ RSpec.feature 'Selecting a study mode' do
     create(
       :course_option,
       site: @second_site,
+      course: @course,
+      study_mode: :part_time,
+    )
+    create(
+      :course_option,
+      site: @third_site,
       course: @course,
       study_mode: :full_time,
     )
@@ -69,7 +126,8 @@ RSpec.feature 'Selecting a study mode' do
 
   def then_i_can_only_select_sites_with_a_part_time_course
     expect(page).to have_text @first_site.name
-    expect(page).not_to have_text @second_site.name
+    expect(page).to have_text @second_site.name
+    expect(page).not_to have_text @third_site.name
   end
 
   def when_i_select_a_site

--- a/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -69,17 +69,6 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
   def when_i_choose_the_part_time_course
     choose 'Part time'
     click_button 'Continue'
-
-    choose @site.name
-    click_button 'Continue'
-  end
-
-  def and_i_should_see_the_site
-    expect(page).to have_content @site.address_line1
-    expect(page).to have_content @site.address_line2
-    expect(page).to have_content @site.address_line3
-    expect(page).to have_content @site.address_line4
-    expect(page).to have_content @site.postcode
   end
 
   def then_i_should_see_it_on_my_review_page


### PR DESCRIPTION
## Context

This PR builds on https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1484. The site selection page is redundant if there is only one choice, so we skip the page altogether. This matches behaviour in the course selection action. 

## Changes proposed in this pull request

Skip the site selection page and simply set the single available site as the candidate's application choice.

## Guidance to review

As per #1484 :

I'd suggest pulling the branch down and clicking through locally. You may need to change a specific course and its course options to see the new page. Specifically, `Course#study_mode` needs to be `'full_time_or_part_time'`, and it should have at least two course options with different `study_mode` values set (`part_time` and `full_time`).

## Link to Trello card

https://trello.com/c/JnW7TR8k

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
