### PR TITLE
Don't send ActionController::UnknownFormat errors to Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -3,6 +3,7 @@ Raven.configure do |config|
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
   config.excluded_exceptions += [
     'ActionController::BadRequest',
+    'ActionController::UnknownFormat',
     'ActionController::UnknownHttpMethod',
     'ActionDispatch::Http::Parameters::ParseError',
   ]


### PR DESCRIPTION
## Context

This is actually a user error, we shouldn’t see them in Sentry.

## Changes proposed in this pull request

Ideally we’d return a 400, but this is an easy fix.

## Guidance to review

These should not happen anymore:

https://sentry.io/organizations/dfe-bat/issues/1529664285/?project=1765973&referrer=slack

## Link to Trello card

https://trello.com/c/c1dWLNDX/150-fix-500-error-when-accessing-healthcheck-endpoint-with-a-js-suffix

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
