### PR TITLE
Update wording for training with a disability question

### DIFF
--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -37,7 +37,7 @@ module CandidateInterface
 
     def disability_disclosure_row
       {
-        key: t('application_form.training_with_a_disability.disability_disclosure.label'),
+        key: t('application_form.training_with_a_disability.disability_disclosure.review_label'),
         value: @training_with_a_disability_form.disability_disclosure,
         action: t('application_form.training_with_a_disability.disability_disclosure.change_action'),
         change_path: Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path,

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -15,7 +15,7 @@
 <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
 
 <% if FeatureFlag.active?('training_with_a_disability') %>
-  <h3 class="govuk-heading-m">Training with a disability</h3>
+  <h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
 
   <%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
 <% end %>

--- a/app/views/candidate_interface/application_form/submit_show.html.erb
+++ b/app/views/candidate_interface/application_form/submit_show.html.erb
@@ -34,12 +34,6 @@
       </div>
 
       <%= f.govuk_radio_buttons_fieldset :further_information, legend: { size: 'm', text: t('application_form.further_information.further_information.label') } do %>
-        <p class="govuk-body">
-          Examples of further information include any disability, health or
-          other personal or professional issue you feel is relevant to your
-          application.
-        </p>
-
         <%= f.govuk_radio_button :further_information, true, label: { text: 'Yes' }, link_errors: true do %>
           <%= f.govuk_text_area :further_information_details, label: { text: t('application_form.further_information.further_information_details.label') }, max_words: 300 %>
         <% end %>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -8,16 +8,12 @@
 
       <h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>
 
-      <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person. Please give details of:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>any disability, health or personal issue you feel is relevant</li>
-        <li>special arrangements or assistance you may need</li>
-        <li>dates you are unavailable for interview</li>
-      </ul>
+      <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person.</p>
+      <p class="govuk-body">Give details of any arrangements you might need. Providers can’t always accomodate your preferences.</p>
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label') }, rows: 8, max_words: 200 %>
+          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label'), size: 's' }, hint_text: 'Give a reason if you can', rows: 8, max_words: 200 %>
         <% end %>
 
         <%= f.govuk_radio_button :any_preferences, 'no', label: { text: 'No' } %>

--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -13,13 +13,26 @@
           </h1>
         </legend>
 
-        <p class="govuk-body">It’s a personal choice if you want to inform your training provider of your disability.</p>
-        <p class="govuk-body">The advantage of disclosure is that it enables support and reasonable adjustments to be put in place. In addition, specialist equipment, extra funding and support, can help you achieve your ambition of becoming a teacher.</p>
-        <p class="govuk-body"><%= govuk_link_to 'The Equality Act 2010', 'https://www.gov.uk/guidance/equality-act-2010-guidance' %> and Special Educational Needs and Disability Act 2001, require teacher training providers to ensure they are not discriminating against applicants with disabilities or special educational needs (SEN).</p>
+        <p class="govuk-body">You might benefit from extra support if you’re disabled, have a mental health condition or educational needs.</p>
+        <p class="govuk-body">If you choose to tell us you need support, we’ll let your training provider know. They can then make adjustments so you can attend an interview or do the training.</p>
+        <p class="govuk-body">Examples of support could be:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>organising equipment like a hearing loop or an adapted keyboard</li>
+          <li>putting you in touch with support staff if you have a mental health condition</li>
+          <li>making sure classrooms are wheelchair accessible</li>
+        </ul>
+        <p class="govuk-body">If the help you need is not covered by your provider making adjustments, you might also be able to get support from <%= govuk_link_to 'Access to Work', 'https://www.gov.uk/access-to-work' %>. This could include a grant to help cover the costs of practical support in the workplace.</p>
+        <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
+        <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>. Training providers must not:</p>
+        <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+          <li>organising equipment like a hearing loop or an adapted keyboard</li>
+          <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
+          <li>reject your application because you’re disabled</li>
+        </ul>
 
         <%= f.govuk_radio_buttons_fieldset :disclose_disability, legend: { size: 'm', text: t('application_form.training_with_a_disability.disclose_disability.label') } do %>
           <%= f.govuk_radio_button :disclose_disability, 'yes', label: { text: t('application_form.training_with_a_disability.disclose_disability.yes') } do %>
-            <%= f.govuk_text_area :disability_disclosure, rows: 24, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label') }, max_words: 400 %>
+            <%= f.govuk_text_area :disability_disclosure, rows: 8, label: { text: t('application_form.training_with_a_disability.disability_disclosure.label'), size: 's' }, max_words: 400 %>
           <% end %>
 
           <%= f.govuk_radio_button :disclose_disability, 'no', label: { text: t('application_form.training_with_a_disability.disclose_disability.no') } %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -54,6 +54,10 @@
       { key: 'Study mode', value: @application_choice.course_option.study_mode.humanize },
     ]) %>
 
+    <% if FeatureFlag.active?('training_with_a_disability') %>
+      <h2 class="govuk-heading-m govuk-!-margin-top-8" id="disabilities">Disability and other needs</h2>
+    <% end %>
+
     <h2 class="govuk-heading-m govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
 
     <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -231,14 +231,15 @@ en:
     training_with_a_disability:
       complete_form_button: Continue
       disclose_disability:
-        change_action: whether you want to disclose a disability
-        label: Do you want to disclose a disability?
-        'yes': "Yes"
+        label: Do you want to ask for help to become a teacher?
+        'yes': "Yes, I want to share information about myself so my provider can take steps to support me"
         'no': "No"
+        change_action: whether you want to ask for help
         not_specified: Not entered
       disability_disclosure:
-        label: Tell us about your disability
-        change_action: what you want to tell us about your disability
+        label: Give any relevant information
+        review_label: Relevant information
+        change_action: what information you want to give
       review:
         button: Continue
     volunteering:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,7 +64,7 @@ en:
     becoming_a_teacher: Why do you want to be a teacher?
     subject_knowledge: What do you know about the subject you want to teach?
     interview_preferences: Interview preferences
-    training_with_a_disability: Training with a disability
+    training_with_a_disability: Asking for support if you have a disability or other needs
     volunteering:
       short: Volunteering with children and young people
       long: "Children and young people: volunteering and experience in school"

--- a/spec/components/candidate_interface/training_with_a_disability_review_component_spec.rb
+++ b/spec/components/candidate_interface/training_with_a_disability_review_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::TrainingWithADisabilityReviewComponent do
     it 'renders component with correct values for an disability_disclosure' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.label'))
+      expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.training_with_a_disability.disability_disclosure.review_label'))
       expect(result.css('.govuk-summary-list__value').to_html).to include('I have difficulty climbing stairs')
       expect(result.css('.govuk-summary-list__actions a')[1].attr('href')).to include(Rails.application.routes.url_helpers.candidate_interface_training_with_a_disability_edit_path)
       expect(result.css('.govuk-summary-list__actions').text).to include("Change #{t('application_form.training_with_a_disability.disability_disclosure.change_action')}")


### PR DESCRIPTION
## Context

Updated content on candidate facing form based on user research.

Need to also display the answer(s) to this question in the provider interface.

## Changes proposed in this pull request

Question with updated content:
![Screenshot 2020-03-02 at 17 08 10](https://user-images.githubusercontent.com/813383/75699540-8db60980-5ca8-11ea-8126-e599e1945e61.png)

Reviewing answers to question:
![Screenshot 2020-03-02 at 17 08 23](https://user-images.githubusercontent.com/813383/75699552-91499080-5ca8-11ea-8bb8-d690a7eb86c7.png)

Updated title on application form:
<img width="674" alt="Screenshot 2020-03-02 at 17 08 37" src="https://user-images.githubusercontent.com/813383/75699557-91e22700-5ca8-11ea-983d-44d837680ebf.png">

Updated title on review page:
<img width="1012" alt="Screenshot 2020-03-02 at 17 08 47" src="https://user-images.githubusercontent.com/813383/75699558-927abd80-5ca8-11ea-8b50-4de5ca91cfd9.png">

## Guidance to review

Still need to display the answer to this question on the provider interface.

## Link to Trello card

https://trello.com/c/rzhPkjSp/1099-update-training-with-a-disability-section-with-updated-content
