### PR TITLE
Set the course choice drop downs default value to nil

### DIFF
--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -17,6 +17,7 @@
             :id,
             :name,
             label: { text: t('page_titles.which_course'), size: 'xl' },
+            options: { selected: nil },
           ) %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_provider
     and_i_choose_a_course
     then_i_see_a_message_that_ive_already_chosen_the_course
+    and_the_select_box_has_no_value_selected
 
     given_that_i_am_on_the_course_choices_review_page
     when_i_click_on_add_another_course
@@ -147,6 +148,10 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_see_a_message_that_ive_already_chosen_the_course
     expect(page).to have_css('.govuk-error-summary', text: 'You have already selected this course')
+  end
+
+  def and_the_select_box_has_no_value_selected
+    expect(page.find('#candidate-interface-pick-course-form-course-id-field').value).to eq ''
   end
 
   def given_that_i_am_on_the_course_choices_review_page


### PR DESCRIPTION
## Context

At the moment if a user accidentally readds the same course the select retains the course's name and code.

This means the user has to manually delete the course's name before more options
become available to them.

## Changes proposed in this pull request

- Set the selected value of drop down to nil

Before

![image](https://user-images.githubusercontent.com/42515961/75701274-614fbc80-5cab-11ea-8629-2ef6d46109ed.png)


After 

![image](https://user-images.githubusercontent.com/42515961/75701300-6e6cab80-5cab-11ea-9468-620d73fcbcbb.png)

## Guidance to review

Add a course locally. Attempt to add the same course again.

## Link to Trello card

https://trello.com/c/XaJkYmar/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
