### PR TITLE
Resolve error when candidate edits their course choices after submission

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -146,9 +146,13 @@ module CandidateInterface
     def complete
       @application_form = current_application
 
-      if @application_form.application_choices.count.zero?
-        render :index
-      elsif @application_form.update(application_form_params)
+      render :index if @application_form.application_choices.count.zero?
+
+      if @application_form.submitted?
+        @application_form.application_choices.filter(&:unsubmitted?).each { |choice| SubmitApplicationChoice.new(choice).call }
+      end
+
+      if @application_form.update(application_form_params)
         redirect_to candidate_interface_application_form_path
       else
         @course_choices = current_candidate.current_application.application_choices

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -49,21 +49,7 @@ private
 
   def submit_application
     application_choices.each do |application_choice|
-      submit_application_choice(application_choice)
+      SubmitApplicationChoice.new(application_choice).call
     end
-  end
-
-  def submit_application_choice(application_choice)
-    edit_by_time = time_limit_calculator.call[:time_in_future]
-    application_choice.edit_by = edit_by_time
-    ApplicationStateChange.new(application_choice).submit!
-  end
-
-  def time_limit_calculator
-    klass = HostingEnvironment.sandbox_mode? ? SandboxTimeLimitCalculator : TimeLimitCalculator
-    klass.new(
-      rule: :edit_by,
-      effective_date: application_form.submitted_at,
-    )
   end
 end

--- a/app/services/submit_application_choice.rb
+++ b/app/services/submit_application_choice.rb
@@ -1,0 +1,21 @@
+class SubmitApplicationChoice
+  def initialize(application_choice)
+    @application_choice = application_choice
+  end
+
+  def call
+    edit_by_time = time_limit_calculator.call[:time_in_future]
+    @application_choice.edit_by = edit_by_time
+    ApplicationStateChange.new(@application_choice).submit!
+  end
+
+private
+
+  def time_limit_calculator
+    klass = HostingEnvironment.sandbox_mode? ? SandboxTimeLimitCalculator : TimeLimitCalculator
+    klass.new(
+      rule: :edit_by,
+      effective_date: @application_choice.application_form.submitted_at,
+    )
+  end
+end

--- a/spec/services/submit_application_choice_spec.rb
+++ b/spec/services/submit_application_choice_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe SubmitApplicationChoice do
+  describe 'Submit an application choice', sandbox: false do
+    let(:application_form) { create(:application_form, submitted_at: Time.zone.now) }
+    let(:application_choice) { create(:application_choice, application_form: application_form, status: 'unsubmitted') }
+
+    it 'updates the application choice to Submitted' do
+      SubmitApplicationChoice.new(application_choice).call
+      expect(application_choice).to be_awaiting_references
+    end
+
+    it 'updates the application choice to edit_by date' do
+      days_to_edit = TimeLimitCalculator.new(rule: :edit_by, effective_date: application_form.submitted_at).call[:days]
+      expected_edit_by_day = days_to_edit.business_days.after(application_form.submitted_at).end_of_day
+
+      SubmitApplicationChoice.new(application_choice).call
+      expect(application_choice.edit_by).to eq(expected_edit_by_day)
+    end
+
+    context 'when running in a provider sandbox', sandbox: true do
+      it 'sets the edit_by timestamp to now' do
+        now = Time.zone.local(2019, 11, 11, 15, 0, 0)
+        Timecop.freeze(now) do
+          SubmitApplicationChoice.new(application_choice).call
+
+          expect(application_choice.edit_by).to eq now
+        end
+      end
+    end
+  end
+end

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -9,13 +9,6 @@ RSpec.describe SubmitApplication do
       application_form
     end
 
-    it 'updates the application to Submitted' do
-      application_form = create_application_form
-      SubmitApplication.new(application_form).call
-      expect(application_form.application_choices[0]).to be_awaiting_references
-      expect(application_form.application_choices[1]).to be_awaiting_references
-    end
-
     it 'sets application_form.submitted_at' do
       application_form = create_application_form
       Timecop.freeze(Time.zone.local(2019, 11, 11, 15, 0, 0)) do
@@ -36,18 +29,6 @@ RSpec.describe SubmitApplication do
     end
 
     context 'when running in a provider sandbox', sandbox: true do
-      it 'sets the edit_by timestamp to now' do
-        application_form = create_application_form
-        now = Time.zone.local(2019, 11, 11, 15, 0, 0)
-        Timecop.freeze(now) do
-          SubmitApplication.new(application_form).call
-
-          expect(application_form.submitted_at).to eq now
-          expect(application_form.application_choices[0].edit_by).to eq now
-          expect(application_form.application_choices[1].edit_by).to eq now
-        end
-      end
-
       it 'autocompletes references and pushes status to `awaiting_provider_decision`' do
         application_form = create_application_form
         application_form.application_references << build(:reference, email_address: 'refbot1@example.com')

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -33,6 +33,10 @@ RSpec.feature 'A candidate edits their course choice after submission' do
     given_there_are_course_options
     when_i_add_a_new_course_choice
     then_i_see_the_new_course_choice
+
+    when_i_mark_this_section_as_completed
+    and_i_click_continue
+    then_i_should_see_the_form
   end
 
   def given_the_edit_application_feature_flag_is_on
@@ -154,5 +158,17 @@ RSpec.feature 'A candidate edits their course choice after submission' do
     )
     single_site_course = create(:course, name: 'Dance', code: 'W5X1', provider: another_provider, exposed_in_find: true, open_on_apply: true)
     create(:course_option, site: third_site, course: single_site_course, vacancy_status: 'B')
+  end
+
+  def when_i_mark_this_section_as_completed
+    check t('application_form.courses.complete.completed_checkbox')
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_the_form
+    expect(page).to have_content('Edit your application')
   end
 end


### PR DESCRIPTION
## Context
Deleting a course and adding a new course after submission causes an argument error:
<!-- Why are you making this change? What might surprise someone about it? -->
![image](https://user-images.githubusercontent.com/22743709/75701141-25b4f280-5cab-11ea-922f-a1d6fb713b03.png)
This is because newly created application choices are in an `unsubmitted` state with `edit_by` set to `nil`. They should be in an `awaiting_references` state with `edit_by` set to the correct value.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR resolves the error by setting the `edit_by` date on course choices before completing the course section.

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/u9fFktHo/1048-application-form-errors-when-edit-application-feature-flag-is-on-and-user-edits-their-course-choices

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
