### PR TITLE
Fix spacing on "Tell us what it involves" review

### DIFF
--- a/app/components/volunteering_review_component.rb
+++ b/app/components/volunteering_review_component.rb
@@ -72,7 +72,7 @@ private
   end
 
   def formatted_details(volunteering_role)
-    simple_format(volunteering_role.details)
+    simple_format(volunteering_role.details, class: 'govuk-body')
   end
 
   def formatted_start_date(volunteering_role)

--- a/spec/components/volunteering_review_component_spec.rb
+++ b/spec/components/volunteering_review_component_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe VolunteeringReviewComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.volunteering.review_details.review_label'))
-      expect(result.css('.govuk-summary-list__value').to_html).to include('<p>I interned.</p>')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('<p class="govuk-body">I interned.</p>')
       expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include(
         Rails.application.routes.url_helpers.candidate_interface_edit_volunteering_role_path(volunteering_role),
       )


### PR DESCRIPTION
When using simple_format we need to use `govuk-body` as the paragraph class.

## Before
![Screen Shot 2020-03-02 at 20 52 33](https://user-images.githubusercontent.com/319055/75716922-15f7d700-5cc8-11ea-80a1-8c74e2f3f43e.png)

## After
![Screen Shot 2020-03-02 at 20 52 42](https://user-images.githubusercontent.com/319055/75716938-198b5e00-5cc8-11ea-81a8-3d3d82fef5b0.png)

