### PR TITLE
Fix redirect after changing answer to say no to having disabilities

### DIFF
--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -32,7 +32,11 @@ module CandidateInterface
 
       if @disability_status.save(current_application)
         if disability_status_param == 'no'
-          redirect_to candidate_interface_edit_equality_and_diversity_ethnic_group_path
+          if current_application.equality_and_diversity['ethnic_group'].nil?
+            redirect_to candidate_interface_edit_equality_and_diversity_ethnic_group_path
+          else
+            redirect_to candidate_interface_review_equality_and_diversity_path
+          end
         else
           redirect_to candidate_interface_edit_equality_and_diversity_disabilities_path
         end


### PR DESCRIPTION
## Context

When changing your answer to "No" for the "Are you disabled?" question of the Equality and Diversity questionnaire, you should be redirected to the review page but instead the candidate gets redirected to the ethnic group page.

## Changes proposed in this pull request

This PR fixes the redirect so that the candidate is taken to the review Equality and Diversity page instead of the ethnic group page by checking if the ethnic group field is `nil`.

## Guidance to review

Didn't add a test as we'd have to add to our already quite large system spec. Does that make sense?

## Link to Trello card

https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
