### PR TITLE
1665 Soft delete support users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'omniauth-rails_csrf_protection'
 
 gem 'workflow'
 gem 'audited'
+gem 'discard'
 
 gem 'json-schema'
 gem 'json_api_client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
+    discard (1.2.0)
+      activerecord (>= 4.2, < 7)
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -537,6 +539,7 @@ DEPENDENCIES
   db-query-matchers
   deepsort
   devise
+  discard
   dotenv-rails
   erb_lint
   factory_bot_rails

--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class SupportUsersController < SupportInterfaceController
     def index
-      @support_users = SupportUser.all
+      @support_users = SupportUser.kept
     end
 
     def new
@@ -24,8 +24,8 @@ module SupportInterface
     end
 
     def destroy
-      SupportUser.find(params[:id]).destroy!
-      flash[:success] = 'Support user deleted'
+      SupportUser.find(params[:id]).discard
+      flash[:success] = 'Support user removed'
       redirect_to support_interface_support_users_path
     end
 

--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -12,7 +12,7 @@ class SupportUser < ActiveRecord::Base
     dfe_sign_in_user = DfESignInUser.load_from_session(session)
     return unless dfe_sign_in_user
 
-    SupportUser.find_by(dfe_sign_in_uid: dfe_sign_in_user.dfe_sign_in_uid)
+    SupportUser.kept.find_by(dfe_sign_in_uid: dfe_sign_in_user.dfe_sign_in_uid)
   end
 
 private

--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -1,4 +1,6 @@
 class SupportUser < ActiveRecord::Base
+  include Discard::Model
+
   validates :dfe_sign_in_uid, presence: true
   validates :email_address, presence: true
 

--- a/app/views/support_interface/support_users/confirm_destroy.html.erb
+++ b/app/views/support_interface/support_users/confirm_destroy.html.erb
@@ -7,11 +7,11 @@
       method: :delete do |f| %>
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl">Support user</span>
-        <%= t('support_interface.support_user.confirm_delete',
+        <%= t('support_interface.support_user.confirm_remove',
               email: @support_user.email_address) %>
       </h1>
 
-      <%= f.submit t('support_interface.support_user.delete'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+      <%= f.submit t('support_interface.support_user.remove'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
         <%= govuk_link_to 'Cancel', support_interface_support_users_path %>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -43,7 +43,7 @@
                 nil,
                 support_interface_confirm_destroy_support_user_path(support_user),
           ) do %>
-            Delete user<span class='govuk-visually-hidden'> <%= support_user.email_address %></span>
+            Remove user<span class='govuk-visually-hidden'> <%= support_user.email_address %></span>
           <% end %>
         </td>
       </tr>

--- a/config/locales/support_interface.yml
+++ b/config/locales/support_interface.yml
@@ -1,5 +1,5 @@
 en:
   support_interface:
     support_user:
-      confirm_delete: Are you sure you want to delete support user %{email}?
-      delete: Delete support user
+      confirm_remove: Are you sure you want to remove support user %{email}?
+      remove: Remove support user

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     @support_user ||= SupportUser.new(email_address: 'alice@support.com', dfe_sign_in_uid: 'alice')
   end
 
+  def discarded_support_user
+    @discarded_support_user ||= SupportUser.new(email_address: 'discarded@support.com', dfe_sign_in_uid: 'alice', discarded_at: Time.current)
+  end
+
   def audit
     @audit ||= Audited::Audit.new(
       user: candidate,
@@ -63,6 +67,14 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('1 October 2019 12:10')
     expect(render_result.text).to include('Update Application Form')
     expect(render_result.text).to include('alice@support.com (Support user)')
+  end
+
+  it 'renders an update on application form audit record with a discarded Support User' do
+    audit.user = discarded_support_user
+    audit.action = 'update'
+    expect(render_result.text).to include('1 October 2019 12:10')
+    expect(render_result.text).to include('Update Application Form')
+    expect(render_result.text).to include('discarded@support.com (Support user)')
   end
 
   it 'renders an update application form audit record with the username (rather than a persistent model)' do

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -77,4 +77,12 @@ module DfESignInHelpers
       email_address:  email_address,
     )
   end
+
+  def user_is_a_removed_support_user(email_address:, dfe_sign_in_uid:, discarded_at: Date.new(2020, 1, 1))
+    SupportUser.find_or_create_by!(
+      dfe_sign_in_uid: dfe_sign_in_uid,
+      email_address:  email_address,
+      discarded_at: discarded_at,
+    )
+  end
 end

--- a/spec/system/support_interface/remove_support_users_spec.rb
+++ b/spec/system/support_interface/remove_support_users_spec.rb
@@ -7,10 +7,10 @@ RSpec.feature 'Remove a support user' do
     given_i_am_a_support_user
     and_there_are_some_support_users
     when_i_visit_the_support_users_page
-    and_i_delete_a_support_user
+    and_i_remove_a_support_user
     then_i_should_see_a_confirmation_page
-    and_i_confirm_deletion
-    then_the_support_user_is_deleted_from_the_database
+    and_i_confirm_removal
+    then_the_support_user_is_removed
     and_the_support_user_is_not_listed
   end
 
@@ -20,32 +20,34 @@ RSpec.feature 'Remove a support user' do
 
   def and_there_are_some_support_users
     @support_users = create_list(:support_user, 2)
-    @deleted_user_email = @support_users.last.email_address
+    @removed_user = @support_users.last
+    @removed_user_email = @removed_user.email_address
   end
 
   def when_i_visit_the_support_users_page
     visit support_interface_support_users_path
   end
 
-  def and_i_delete_a_support_user
+  def and_i_remove_a_support_user
     within('.govuk-table__body') do
-      click_on("Delete user #{@deleted_user_email}")
+      click_on("Remove user #{@removed_user_email}")
     end
   end
 
   def then_i_should_see_a_confirmation_page
-    expect(page.text).to include("Are you sure you want to delete support user #{@deleted_user_email}?")
+    expect(page.text).to include("Are you sure you want to remove support user #{@removed_user_email}?")
   end
 
-  def and_i_confirm_deletion
-    click_on 'Delete support user'
+  def and_i_confirm_removal
+    click_on 'Remove support user'
   end
 
-  def then_the_support_user_is_deleted_from_the_database
-    expect(SupportUser.find_by_email_address(@deleted_user_email)).to be_nil
+  def then_the_support_user_is_removed
+    expect(@removed_user.reload.discarded_at).not_to be_nil
+    expect(page.text).to include('Support user removed')
   end
 
   def and_the_support_user_is_not_listed
-    expect(page.text).not_to include(@deleted_user_email)
+    expect(page.text).not_to include(@removed_user_email)
   end
 end

--- a/spec/system/support_interface/removed_support_user_spec.rb
+++ b/spec/system/support_interface/removed_support_user_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe 'A removed support user attempts to authenticate via DfE Sign-in' do
+  include DfESignInHelpers
+
+  scenario 'signing in as removed user' do
+    given_i_have_a_dfe_sign_in_account_and_i_am_a_removed_support_user
+
+    when_i_visit_the_support_interface
+    then_i_should_be_redirected_to_login_page
+    and_i_should_not_see_support_menu
+
+    when_i_sign_in_via_dfe_sign_in
+
+    then_i_should_not_be_authorized
+  end
+
+  def given_i_have_a_dfe_sign_in_account_and_i_am_a_removed_support_user
+    user_exists_in_dfe_sign_in(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc', first_name: 'John')
+    user_is_a_removed_support_user(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
+  end
+
+  def when_i_visit_the_support_interface
+    visit support_interface_applications_path
+  end
+
+  def then_i_should_be_redirected_to_login_page
+    expect(page).to have_current_path support_interface_sign_in_path
+  end
+
+  def and_i_should_not_see_support_menu
+    expect(page).not_to have_link 'Applications'
+    expect(page).not_to have_link 'APITokens'
+    expect(page).not_to have_link 'Vendors'
+  end
+
+  def when_i_sign_in_via_dfe_sign_in
+    click_button 'Sign in using DfE Sign-in'
+  end
+
+  def then_i_should_not_be_authorized
+    expect(page).to have_current_path(auth_dfe_callback_path)
+    expect(page).to have_text 'Your account is not authorized'
+  end
+end


### PR DESCRIPTION
## Context

We currently delete `SupportUser` records which doesn't play nicely with our audit trail. 

See https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1516 for context on why we intend to use the `discard` gem for soft deletion.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR: 

- Introduces the `discard` gem as a lightweight approach to discarding records.
- The `SupportUser` model is configured for soft deletion.
- The support users index action omits discarded users.
- The `SupportUser.load_from_session` authentication method omits discarded users
- Rephrases 'Delete' calls to action to 'Remove' to reflect soft deletion

![image](https://user-images.githubusercontent.com/93511/75798136-0cc14580-5d6e-11ea-9a9d-d3e725e29e48.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/AYxmAxXj/1665-offboarding-from-support


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
