### PR TITLE
Change error message to include course name and code

### DIFF
--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -42,7 +42,7 @@ module CandidateInterface
       return if course_id.blank?
 
       if application_form.application_choices.any? { |application_choice| application_choice.course == course }
-        errors[:base] << 'You have already selected this course'
+        errors[:base] << "You have already added #{course.name_and_code}"
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -150,7 +150,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_see_a_message_that_ive_already_chosen_the_course
-    expect(page).to have_css('.govuk-error-summary', text: 'You have already selected this course')
+    expect(page).to have_css('.govuk-error-summary', text: 'You have already added Primary (2XT2)')
   end
 
   def and_the_select_box_has_no_value_selected


### PR DESCRIPTION
## Context

When a user attempts to add a duplicate course, the courses name and code should be displayed.

## Changes proposed in this pull request

- Show the course name and code in the error message

Before 

![image](https://user-images.githubusercontent.com/42515961/75774642-48491900-5d48-11ea-8ad1-ce7e4f5a4919.png)

After

![image](https://user-images.githubusercontent.com/42515961/75774706-66af1480-5d48-11ea-90e0-40c3ed6123b6.png)

## Link to Trello card

https://trello.com/c/XaJkYmar/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
