### PR TITLE
Render other_uk_qualification_type in qualifications title

### DIFF
--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -4,16 +4,31 @@ class QualificationTitleComponent < ActionView::Component::Base
   end
 
   def qualification_type
-    if @qualification.level == 'gcse' && @qualification.missing_qualification?
-      I18n.t('application_form.gcse.qualification_types_abbreviated.gcse')
-      ApplicationQualification.human_attribute_name('qualification_type.gcse')
-    elsif @qualification.level == 'gcse'
-      ApplicationQualification.human_attribute_name(
-        "qualification_type.#{@qualification.qualification_type}",
-        default: @qualification.qualification_type,
-      )
-    else
-      @qualification.qualification_type
+    if @qualification.level == 'gcse'
+      return type_for_missing_qualification if @qualification.missing_qualification?
+      return type_for_other_uk_qualification if @qualification.other_uk_qualification_type.present?
+
+      return type_for_gcse
     end
+
+    @qualification.qualification_type
+  end
+
+private
+
+  def type_for_missing_qualification
+    I18n.t('application_form.gcse.qualification_types_abbreviated.gcse')
+    ApplicationQualification.human_attribute_name('qualification_type.gcse')
+  end
+
+  def type_for_other_uk_qualification
+    @qualification.other_uk_qualification_type
+  end
+
+  def type_for_gcse
+    ApplicationQualification.human_attribute_name(
+      "qualification_type.#{@qualification.qualification_type}",
+      default: @qualification.qualification_type,
+    )
   end
 end

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -17,7 +17,6 @@ class QualificationTitleComponent < ActionView::Component::Base
 private
 
   def type_for_missing_qualification
-    I18n.t('application_form.gcse.qualification_types_abbreviated.gcse')
     ApplicationQualification.human_attribute_name('qualification_type.gcse')
   end
 

--- a/app/components/qualification_title_component.rb
+++ b/app/components/qualification_title_component.rb
@@ -21,7 +21,8 @@ private
   end
 
   def type_for_other_uk_qualification
-    @qualification.other_uk_qualification_type
+    I18n.t('application_form.gcse.qualification_types.other_uk')
+      .concat(': ', @qualification.other_uk_qualification_type)
   end
 
   def type_for_gcse

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -39,4 +39,18 @@ RSpec.describe QualificationTitleComponent do
 
     expect(result.text).to include('Other UK Maths')
   end
+
+  it 'renders the correct title for an other_uk GCSE equivalent with a specified type' do
+    qualification = build_stubbed(
+      :application_qualification,
+      level: :gcse,
+      qualification_type: 'other_uk',
+      subject: 'maths',
+      other_uk_qualification_type: 'A Level',
+    )
+
+    result = render_inline(described_class.new(qualification: qualification))
+
+    expect(result.text).to include('A Level Maths')
+  end
 end

--- a/spec/components/qualification_title_component_spec.rb
+++ b/spec/components/qualification_title_component_spec.rb
@@ -51,6 +51,6 @@ RSpec.describe QualificationTitleComponent do
 
     result = render_inline(described_class.new(qualification: qualification))
 
-    expect(result.text).to include('A Level Maths')
+    expect(result.text).to include('Other UK qualification: A Level Maths')
   end
 end


### PR DESCRIPTION
## Context

Candidates who choose the 'Other' GCSE qualification type are able to enter an additional value to denote the type, 'A Level' being a common case. 
We should expose this value in the qualification title rather than using the generic formatting of 'Other UK _subject_'.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR adds an additional way of rendering the qualification title text.
If `ApplicationQualification#other_uk_qualification_type` is present we prefer this to the generic `Other UK ...` title.

<!-- If there are UI changes, please include Before and After screenshots. -->

### Before
![image](https://user-images.githubusercontent.com/93511/75783081-d8428f00-5d57-11ea-89c7-fc3a2b3b3b8d.png)

### After
![image](https://user-images.githubusercontent.com/93511/75793232-f95eac00-5d66-11ea-9850-9033be2d7a98.png)

## Guidance to review

The candidate qualification type input fields don't appear to have the conditional validation to enforce the user fills out the 'Other' qualification type, perhaps this is something to iterate. 

The approach here is to only render the specified type if a value for `ApplicationQualification#other_uk_qualification_type` is present. 

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/emBxNMKU/1712-display-otherukqualificationtype-in-provider-and-support-interface

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
