### PR TITLE
Add radio button for providers with twenty or less course choices options

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -53,6 +53,7 @@ module CandidateInterface
         provider_id: params.fetch(:provider_id),
         application_form: current_application,
       )
+      @provider = Provider.find(@pick_course.provider_id)
     end
 
     def pick_course
@@ -62,6 +63,7 @@ module CandidateInterface
         course_id: course_id,
         application_form: current_application,
       )
+      @provider = Provider.find(@pick_course.provider_id)
       render :options_for_course and return unless @pick_course.valid?
 
       if !@pick_course.open_on_apply?

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -53,7 +53,6 @@ module CandidateInterface
         provider_id: params.fetch(:provider_id),
         application_form: current_application,
       )
-      @provider = Provider.find(@pick_course.provider_id)
     end
 
     def pick_course
@@ -63,7 +62,6 @@ module CandidateInterface
         course_id: course_id,
         application_form: current_application,
       )
-      @provider = Provider.find(@pick_course.provider_id)
       render :options_for_course and return unless @pick_course.valid?
 
       if !@pick_course.open_on_apply?

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -11,7 +11,7 @@
         ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <% if @provider.courses.exposed_in_find.count > 20 %>
+      <% if @pick_course.available_courses.count > 20 %>
 
         <%= f.govuk_collection_select(
               :course_id,
@@ -24,15 +24,17 @@
 
       <% else %>
 
-          <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
+        <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
 
-            <div class="govuk-!-margin-top-6">
+          <div class="govuk-!-margin-top-6">
 
-            <% @pick_course.available_courses.each_with_index do |course, i| %>
-              <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, link_errors: i.zero? %>
-            <% end %>
-
+          <% @pick_course.available_courses.each_with_index do |course, i| %>
+            <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, link_errors: i.zero? %>
           <% end %>
+
+          </div>
+
+        <% end %>
 
       <% end %>
 

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -11,14 +11,30 @@
         ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_collection_select(
-            :course_id,
-            select_course_options(@pick_course.available_courses),
-            :id,
-            :name,
-            label: { text: t('page_titles.which_course'), size: 'xl' },
-            options: { selected: nil },
-          ) %>
+      <% if @provider.courses.exposed_in_find.count > 20 %>
+
+        <%= f.govuk_collection_select(
+              :course_id,
+              select_course_options(@pick_course.available_courses),
+              :id,
+              :name,
+              label: { text: t('page_titles.which_course'), size: 'xl' },
+              options: { selected: nil },
+            ) %>
+
+      <% else %>
+
+          <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'xl', text: t('page_titles.which_course') } do %>
+
+            <div class="govuk-!-margin-top-6">
+
+            <% @pick_course.available_courses.each_with_index do |course, i| %>
+              <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, link_errors: i.zero? %>
+            <% end %>
+
+          <% end %>
+
+      <% end %>
 
       <%= f.govuk_submit 'Continue' %>
     <% end %>

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -98,7 +98,7 @@ module CandidateHelper
     select 'Gorse SCITT (1N1)'
     click_button 'Continue'
 
-    select 'Primary (2XT2)'
+    choose 'Primary (2XT2)'
     click_button 'Continue'
 
     check t('application_form.courses.complete.completed_checkbox')

--- a/spec/system/candidate_interface/candidate_deletes_course_after_completing_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_course_after_completing_section_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Candidate edits their choice section' do
   end
 
   def and_i_choose_a_course_with_a_single_site
-    select @course.name_and_code
+    choose @course.name_and_code
     click_button 'Continue'
   end
 end

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -102,7 +102,7 @@ RSpec.feature 'A candidate edits their course choice after submission' do
     click_button 'Continue'
     select 'Gorse SCITT (1N1)'
     click_button 'Continue'
-    select 'Primary (2XT2)'
+    choose 'Primary (2XT2)'
     click_button 'Continue'
     choose 'Main site'
     click_button 'Continue'

--- a/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -72,7 +72,7 @@ RSpec.feature 'Selecting a course not on Apply' do
   end
 
   def and_i_choose_another_course
-    select 'Secondary (X123)'
+    choose 'Secondary (X123)'
     click_button 'Continue'
   end
 end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -229,16 +229,11 @@ RSpec.feature 'Selecting a course' do
   end
 
   def given_the_provider_has_over_twenty_courses
-    create_list(:course, 20, provider: @provider)
+    create_list(:course, 20, provider: @provider, exposed_in_find: true)
   end
 
   def when_i_click_the_continue_link
     click_link 'Continue'
-  end
-
-  def and_i_select_a_course
-    select 'Primary (2XT2)'
-    click_button 'Continue'
   end
 
   def then_the_select_box_has_no_value_selected

--- a/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_provider
     and_i_choose_a_course
     then_i_see_a_message_that_ive_already_chosen_the_course
-    and_the_select_box_has_no_value_selected
 
     given_that_i_am_on_the_course_choices_review_page
     when_i_click_on_add_another_course
@@ -47,6 +46,12 @@ RSpec.feature 'Selecting a course' do
 
     when_i_delete_my_remaining_course_choice
     then_i_should_i_should_see_the_course_choice_index_page
+
+    given_the_provider_has_over_twenty_courses
+    when_i_click_the_continue_link
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    then_the_select_box_has_no_value_selected
   end
 
   def given_i_am_signed_in
@@ -75,9 +80,9 @@ RSpec.feature 'Selecting a course' do
       address_line4: 'West Yorkshire',
       postcode: 'LS8 5DQ'
     )
-    multi_site_course = create(:course, name: 'Primary', code: '2XT2', provider: @provider, exposed_in_find: true, open_on_apply: true)
-    create(:course_option, site: first_site, course: multi_site_course, vacancy_status: 'B')
-    create(:course_option, site: second_site, course: multi_site_course, vacancy_status: 'B')
+    @multi_site_course = create(:course, name: 'Primary', code: '2XT2', provider: @provider, exposed_in_find: true, open_on_apply: true)
+    create(:course_option, site: first_site, course: @multi_site_course, vacancy_status: 'B')
+    create(:course_option, site: second_site, course: @multi_site_course, vacancy_status: 'B')
 
     another_provider = create(:provider, name: 'Royal Academy of Dance', code: 'R55')
     third_site = create(
@@ -121,11 +126,11 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content 'Select a course'
+    expect(page).to have_content "can't be blank"
   end
 
   def and_i_choose_a_course
-    select 'Primary (2XT2)'
+    choose 'Primary (2XT2)'
     click_button 'Continue'
   end
 
@@ -153,10 +158,6 @@ RSpec.feature 'Selecting a course' do
     expect(page).to have_css('.govuk-error-summary', text: 'You have already selected this course')
   end
 
-  def and_the_select_box_has_no_value_selected
-    expect(page.find('#candidate-interface-pick-course-form-course-id-field').value).to eq ''
-  end
-
   def given_that_i_am_on_the_course_choices_review_page
     visit candidate_interface_course_choices_review_path
   end
@@ -167,7 +168,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def and_i_choose_another_course_with_only_one_site
-    select 'Dance (W5X1)'
+    choose 'Dance (W5X1)'
     click_button 'Continue'
   end
 
@@ -225,5 +226,22 @@ RSpec.feature 'Selecting a course' do
 
   def then_i_should_i_should_see_the_course_choice_index_page
     expect(page).to have_current_path(candidate_interface_course_choices_index_path)
+  end
+
+  def given_the_provider_has_over_twenty_courses
+    create_list(:course, 20, provider: @provider)
+  end
+
+  def when_i_click_the_continue_link
+    click_link 'Continue'
+  end
+
+  def and_i_select_a_course
+    select 'Primary (2XT2)'
+    click_button 'Continue'
+  end
+
+  def then_the_select_box_has_no_value_selected
+    expect(page.find('#candidate-interface-pick-course-form-course-id-field').value).to eq ''
   end
 end

--- a/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'Selecting a study mode' do
     select @provider.name
     click_button 'Continue'
 
-    select @single_site_course.name
+    choose @single_site_course.name
     click_button 'Continue'
 
     choose 'Full time'
@@ -115,7 +115,7 @@ RSpec.feature 'Selecting a study mode' do
     select @provider.name
     click_button 'Continue'
 
-    select @course.name
+    choose @course.name
     click_button 'Continue'
 
     click_button 'Continue'


### PR DESCRIPTION
## Context

We currently show an autocomplete for picking a course, whether there is 1 course or 100.

Autocompletes are harder to use than Radios. When there's 20 or less courses (20 is the average number of courses a provider has) we should show them as a list of radio buttons instead.

For lists longer than 20, an autocomplete remains the best option.

The number of courses counted should be the number of available courses (eg those with vacancies)

## Changes proposed in this pull request

- Use radio buttons on the options_for_course page if there are 20 or less available course options

## Guidance to review

- You can use Gorse to test the dropdown
- You can use the University of Chichester to test the radio buttons.

## Link to Trello card

https://trello.com/c/xGUWGWBe/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
