### PR TITLE
Add stubbing of course names in selecting a course study mode spec

### DIFF
--- a/spec/services/support_interface/referee_survey_export_spec.rb
+++ b/spec/services/support_interface/referee_survey_export_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SupportInterface::RefereeSurveyExport do
       reference2 = create(:reference, questionnaire: questionnaire2)
       create(:reference, questionnaire: questionnaire3)
 
-      expect(described_class.new.call).to eq [return_expected_hash(reference1), return_expected_hash(reference2)]
+      expect(described_class.new.call).to match_array([return_expected_hash(reference1), return_expected_hash(reference2)])
     end
   end
 

--- a/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/candidate_selecting_a_course_study_mode_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Selecting a study mode' do
     @third_site = create(:site, provider: @provider)
 
     @single_site_course = create(
-      :course, :with_both_study_modes, :open_on_apply, provider: @provider
+      :course, :with_both_study_modes, :open_on_apply, provider: @provider, name: 'MS Painting'
     )
 
     create(
@@ -81,7 +81,7 @@ RSpec.feature 'Selecting a study mode' do
     @third_site = create(:site, provider: @provider)
 
     @course = create(
-      :course, :with_both_study_modes, :open_on_apply, provider: @provider
+      :course, :with_both_study_modes, :open_on_apply, provider: @provider, name: 'Software Engineering'
     )
 
     create(


### PR DESCRIPTION
## Context

We have a flakey test and it caused Master to fail, see https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=49348&view=ms.vss-test-web.build-test-results-tab&runId=1179756&resultId=100932&paneView=debug.

![image](https://user-images.githubusercontent.com/42817036/75794974-84d93c80-5d69-11ea-936c-ffd840ae73d2.png)

## Changes proposed in this pull request

This PR stubs the name of courses when they are created in the spec to prevent getting an ambiguous match when selecting a course.

## Guidance to review

Does this make sense?

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
