### PR TITLE
Preserve query params when authenticating via DSI

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -40,7 +40,7 @@ module ProviderInterface
     def authenticate_provider_user!
       return if current_provider_user
 
-      session['post_dfe_sign_in_path'] = request.path
+      session['post_dfe_sign_in_path'] = request.fullpath
       redirect_to provider_interface_sign_in_path
     end
 

--- a/app/controllers/support_interface/support_interface_controller.rb
+++ b/app/controllers/support_interface/support_interface_controller.rb
@@ -27,7 +27,7 @@ module SupportInterface
     def authenticate_support_user!
       return if current_support_user
 
-      session['post_dfe_sign_in_path'] = request.path
+      session['post_dfe_sign_in_path'] = request.fullpath
       redirect_to support_interface_sign_in_path
     end
 

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -9,10 +9,12 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
     given_i_am_registered_as_a_provider_user
     and_i_have_a_dfe_sign_in_account
 
-    when_i_visit_the_provider_interface_sign_in_path
+    when_i_visit_the_provider_interface_applications_path
+    then_i_am_redirected_to_the_provider_sign_in_path
     and_i_sign_in_via_dfe_sign_in
 
-    then_i_should_see_my_email_address
+    then_i_am_redirected_to_the_provider_interface_applications_path
+    and_i_should_see_my_email_address
     and_the_timestamp_of_this_sign_in_is_recorded
     and_my_profile_details_are_refreshed
 
@@ -32,15 +34,21 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
     )
   end
 
-  def when_i_visit_the_provider_interface_sign_in_path
-    visit provider_interface_sign_in_path
+  def when_i_visit_the_provider_interface_applications_path
+    visit provider_interface_applications_path(some_key: 'some_value')
+  end
+
+  def then_i_am_redirected_to_the_provider_sign_in_path
+    expect(page).to have_current_path(provider_interface_sign_in_path)
   end
 
   def and_i_sign_in_via_dfe_sign_in
     click_button 'Sign in using DfE Sign-in'
   end
 
-  def then_i_should_be_redirected_to_the_provider_dashboard; end
+  def then_i_am_redirected_to_the_provider_interface_applications_path
+    expect(page).to have_current_path(provider_interface_applications_path(some_key: 'some_value'))
+  end
 
   def and_i_should_see_my_email_address
     expect(page).to have_content('provider@example.com')

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
   scenario 'signing in successfully' do
     given_i_have_a_dfe_sign_in_account_and_support_authorisation
 
-    when_i_visit_the_support_interface
+    when_i_visit_the_support_interface_users_path
     then_i_should_be_redirected_to_login_page
     and_i_should_not_see_support_menu
 
     when_i_sign_in_via_dfe_sign_in
 
-    then_i_should_be_redirected_to_the_support_home_page
+    then_i_should_be_redirected_to_the_support_interface_users_path
     and_i_should_see_my_email_address
     and_my_profile_details_are_refreshed
 
@@ -25,8 +25,8 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
     user_is_a_support_user(email_address: 'user@apply-support.com', dfe_sign_in_uid: 'abc')
   end
 
-  def when_i_visit_the_support_interface
-    visit support_interface_applications_path
+  def when_i_visit_the_support_interface_users_path
+    visit support_interface_users_path(some_key: 'some_value')
   end
 
   def then_i_should_be_redirected_to_login_page
@@ -43,8 +43,8 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
     click_button 'Sign in using DfE Sign-in'
   end
 
-  def then_i_should_be_redirected_to_the_support_home_page
-    expect(page).to have_current_path support_interface_applications_path
+  def then_i_should_be_redirected_to_the_support_interface_users_path
+    expect(page).to have_current_path support_interface_users_path(some_key: 'some_value')
   end
 
   def and_i_should_see_my_email_address


### PR DESCRIPTION
## Context

If a provider bookmarks a URL with a query string and attempts to visit the link before authenticating, they are currently redirected to the requested path after login, but the query string is omitted.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Preserve the path and query string as the redirect destination post-login by storing `request.fullpath` in session.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/eqlxJCjI/1710-preserve-query-params-when-redirecting-dsi-users-to-their-destination-post-login

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
