### PR TITLE
Disable unused and insecure non-SSL port for Redis cache

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -459,9 +459,6 @@
                     "redisCacheCapacity": {
                         "value": "[parameters('redisCacheCapacity')]"
                     },
-                    "enableNonSslPort": {
-                        "value": true
-                    },
                     "dataPersistence": {
                         "value": "aof"
                     },


### PR DESCRIPTION
## Context

This insecurity has been identified following a review of the Azure Security Center recommendations.

## Changes proposed in this pull request

Removed the parameter override for the use of the non-SSL port on the Redis template in the building blocks repo. The result of this is it will use the default value for this parameter in the template which will disable the non-SSL port.
No downtime is incurred by this change to redis because we're already using the SSL port, so we're just disabling unused configuration.

## Guidance to review

New configuration set through this revised template can be see in the DevOps Redis instance:
https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/289869cc-7183-46bd-8131-f673c5eb94ba/resourceGroups/s106d02-apply/providers/Microsoft.Cache/Redis/s106d02-apply-redis/redisConfig

## Link to Trello card

https://trello.com/c/QPs5apoB/1629-review-azure-security-centre-recommendations

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
