### PR TITLE
Rake task to clean data on QA

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,4 +2,3 @@ FIND_BASE_URL=https://api2.publish-teacher-training-courses.service.gov.uk/api/v
 SUPPORT_USERNAME=test
 SUPPORT_PASSWORD=test
 HOSTING_ENVIRONMENT_NAME=development
-DEV_PROVIDERS_TO_SYNC=1N1,2LR,C58

--- a/app/lib/backup_and_restore_support_users.rb
+++ b/app/lib/backup_and_restore_support_users.rb
@@ -1,0 +1,23 @@
+class BackupAndRestoreSupportUsers
+  REDIS_KEY = 'support_users'.freeze
+
+  def self.backup!
+    existing_users = SupportUser.pluck(:email_address, :dfe_sign_in_uid)
+
+    if existing_users.any?
+      Redis.new.set(REDIS_KEY, JSON.generate(existing_users))
+    end
+
+    existing_users.count
+  end
+
+  def self.restore!
+    restored_users = JSON.parse(Redis.new.get(REDIS_KEY))
+
+    restored_users.each do |(email, uid)|
+      SupportUser.find_or_create_by(email_address: email, dfe_sign_in_uid: uid)
+    end
+
+    restored_users.count
+  end
+end

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -12,10 +12,11 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   SupportUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com')
 end
 
-desc 'Sync providers whitelisted in DEV_PROVIDERS_TO_SYNC and open all their courses'
+desc 'Sync some pilot-enabled providers and open all their courses'
 task sync_dev_providers_and_open_courses: :environment do
   puts 'Syncing data from Find...'
-  ENV['DEV_PROVIDERS_TO_SYNC'].split(',').each do |code|
+
+  %w[1N1 2LR C58].each do |code|
     SyncProviderFromFind.call(provider_code: code, sync_courses: true)
   end
 

--- a/lib/tasks/reset_qa.rake
+++ b/lib/tasks/reset_qa.rake
@@ -1,0 +1,32 @@
+desc 'Reset the database to a state with some standard providers and test applications. Preserves existing support users'
+task reset_qa: :environment do
+  raise 'You can’t do this anywhere but QA or development!' unless HostingEnvironment.qa? || Rails.env.development?
+
+  Rake::Task['_reset_qa'].invoke
+end
+
+task _reset_qa: %i[
+  environment
+  backup_support_users
+  truncate_qa_database
+  restore_support_users
+  sync_dev_providers_and_open_courses
+  generate_test_applications
+]
+
+task truncate_qa_database: :environment do
+  raise 'You can’t do this anywhere but QA or development!' unless HostingEnvironment.qa? || Rails.env.development?
+
+  ActiveRecord::Tasks::DatabaseTasks.truncate_all
+  puts 'Truncated database'
+end
+
+task backup_support_users: :environment do
+  backed_up_count = BackupAndRestoreSupportUsers.backup!
+  puts "Backed up #{backed_up_count} support users"
+end
+
+task restore_support_users: :environment do
+  restored_count = BackupAndRestoreSupportUsers.restore!
+  puts "Restored #{restored_count} support users"
+end

--- a/spec/lib/backup_and_restore_support_users_spec.rb
+++ b/spec/lib/backup_and_restore_support_users_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe BackupAndRestoreSupportUsers do
+  it 'backs up and restores support users' do
+    create(:support_user)
+    BackupAndRestoreSupportUsers.backup!
+
+    SupportUser.destroy_all
+    expect(SupportUser.count).to eq 0
+
+    expect { BackupAndRestoreSupportUsers.restore! }
+      .to change { SupportUser.count }.from(0).to(1)
+  end
+
+  context 'when there are no support users in the database' do
+    it 'does not overwrite the backup' do
+      create(:support_user)
+
+      BackupAndRestoreSupportUsers.backup!
+      SupportUser.destroy_all
+      BackupAndRestoreSupportUsers.backup!
+      BackupAndRestoreSupportUsers.restore!
+
+      expect(SupportUser.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
## Context

QA is full of old and incomplete data which makes testing a bit uncertain and causes weird errors.

Provide a way to delete it all and start again.

Considerations:

- we want to preserve support users as it's a pain to create them via the shell. proposed solution: cache existing ones in Redis and restore after deleting the data
- qa runs in `Rails.env.production` so `rake db:reset` is not available for trashing the db. also, we can't run that if there is another connection to the db, which there will be because the app is running. this code directly calls `ActiveRecord`'s `truncate_all` method 😬 

## Changes proposed in this pull request

Refactor the local_dev_data task so we can reuse some of the bits. Add the redis serializing and deserializing. Add the rake task with suitable guards.

## Guidance to review

Rake dependencies are a funny way to order things. Maybe this should be a `bin/` script?
This doesn't trash redis, which might result in some sidekiq errors.


## Link to Trello card

https://trello.com/c/yRSmo96F/1658-investigate-providers-with-no-names-on-qa

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
