### PR TITLE
Tidy up application_qualification factories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,11 @@ RSpec/MultipleExpectations:
 RSpec/ContextWording:
   Enabled: false
 
+# we have a property called "subject" in some factories
+RSpec/EmptyLineAfterSubject:
+  Exclude:
+    - 'spec/factories.rb'
+
 Naming/MethodParameterName:
   AllowedNames:
     - e
@@ -102,3 +107,4 @@ Rails/RakeEnvironment:
 # when dealing with references
 Rails/NotNullColumn:
   Enabled: false
+

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -66,9 +66,9 @@ FactoryBot.define do
 
       after(:build) do |application_form, evaluator|
         if evaluator.with_gces
-          create(:application_qualification, application_form: application_form, subject: 'maths', level: 'gcse', qualification_type: 'GCSE')
-          create(:application_qualification, application_form: application_form, subject: 'english', level: 'gcse', qualification_type: 'GCSE')
-          create(:application_qualification, application_form: application_form, subject: 'science', level: 'gcse', qualification_type: 'GCSE')
+          create(:gcse_qualification, application_form: application_form, subject: 'maths')
+          create(:gcse_qualification, application_form: application_form, subject: 'english')
+          create(:gcse_qualification, application_form: application_form, subject: 'science')
         end
 
         edit_by = if application_form.submitted_at.nil?
@@ -119,7 +119,6 @@ FactoryBot.define do
     level { %w[degree gcse other].sample }
     qualification_type { %w[BA Masters A-Level GCSE].sample }
     subject { Faker::Educator.subject }
-
     grade { %w[first upper_second A B].sample }
     predicted_grade { %w[true false].sample }
     award_year { Faker::Date.between(from: 60.years.ago, to: 3.years.from_now).year }
@@ -127,6 +126,26 @@ FactoryBot.define do
     institution_country { Faker::Address.country_code }
     awarding_body { Faker::Educator.university }
     equivalency_details { Faker::Lorem.paragraph_by_chars(number: 200) }
+
+    factory :gcse_qualification do
+      level { 'gcse' }
+      qualification_type { 'GCSE' }
+      subject { %w[maths english science].sample }
+      grade { %w[A B C].sample }
+      awarding_body { Faker::Educator.secondary_school }
+    end
+
+    factory :degree_qualification do
+      level { 'degree' }
+      qualification_type { %w[BA Masters].sample }
+      grade { %w[first upper_second lower_second third].sample }
+    end
+
+    factory :other_qualification do
+      level { 'other' }
+      qualification_type { %w[Diploma Doctorate NVQ Foundation].sample }
+      grade { %w[pass merit distinction].sample }
+    end
   end
 
   factory :site do

--- a/spec/system/candidate_interface/candidate_deletes_and_adds_degree_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_and_adds_degree_after_completing_the_section_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature 'Candidate edits their degree section' do
 
   def and_i_have_completed_the_degree_section
     @application_form = create(:application_form, candidate: @candidate)
-    create(:application_qualification, application_form: @application_form, level: :degree)
+    create(:degree_qualification, application_form: @application_form)
     @application_form.update!(degrees_completed: true)
   end
 

--- a/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualificaitons_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_and_adds_other_qualificaitons_after_completing_the_section_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Candidates academic and other relevant qualifications' do
 
   def and_i_have_completed_the_other_qualifications_section
     @application_form = create(:application_form, candidate: @candidate)
-    create(:application_qualification, application_form: @application_form, level: :other)
+    create(:other_qualification, application_form: @application_form)
     @application_form.update!(other_qualifications_completed: true)
   end
 

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe 'A Provider viewing an individual application' do
                               english_main_language: true,
                               other_language_details: 'I also speak Spanish and German')
 
-    create_list(:application_qualification, 1, application_form: application_form, level: :degree)
-    create_list(:application_qualification, 2, application_form: application_form, level: :gcse)
-    create_list(:application_qualification, 3, application_form: application_form, level: :other)
+    create_list(:degree_qualification, 1, application_form: application_form)
+    create_list(:gcse_qualification, 2, application_form: application_form)
+    create_list(:other_qualification, 3, application_form: application_form)
 
     create(:application_work_experience,
            application_form: application_form,


### PR DESCRIPTION
## Context

We currently create GCSEs with upper_seconds and degrees with As. As the
test data generation relies on these factories, we end up with
unrealistic data in QA and dev.

## Changes proposed in this pull request

 Make nested factories to create each type of qualification

## Guidance to review

I left in `:application_qualification` — maybe it could go altogether?

## Link to Trello card

This was a quick fix off the back of a Slack chat https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1583318959054400

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
