### PR TITLE
1641 add filtering to the provider ui add components behind feature flag

### DIFF
--- a/app/components/previews/provider_interface/filter_component_preview.rb
+++ b/app/components/previews/provider_interface/filter_component_preview.rb
@@ -3,34 +3,34 @@ module ProviderInterface
     def fully_selected
       render_component_for(path: :provider_interface_applications_path,
                            available_filters: available_filters,
-                           preselected_filters: preselected_filters_full,
+                           applied_filters: applied_filters_full,
                            additional_params: additional_params)
     end
 
     def partially_selected
       render_component_for(path: :provider_interface_applications_path,
                            available_filters: available_filters,
-                           preselected_filters: preselected_filters_partial,
+                           applied_filters: applied_filters_partial,
                            additional_params: additional_params)
     end
 
     def empty
       render_component_for(path: :provider_interface_applications_path,
                            available_filters: available_filters,
-                           preselected_filters: {},
+                           applied_filters: {},
                            additional_params: additional_params)
     end
 
   private
 
-    def render_component_for(path:, available_filters:, preselected_filters:, additional_params:)
+    def render_component_for(path:, available_filters:, applied_filters:, additional_params:)
       render ProviderInterface::FilterComponent.new(path: path,
                                                     available_filters: available_filters,
-                                                    preselected_filters: preselected_filters,
+                                                    applied_filters: applied_filters,
                                                     additional_params: additional_params)
     end
 
-    def preselected_filters_partial
+    def applied_filters_partial
       {
         'status' => {
           'pending-conditions' => 'pending_conditions',
@@ -45,7 +45,7 @@ module ProviderInterface
       }
     end
 
-    def preselected_filters_full
+    def applied_filters_full
       {
         'status' => {
           'pending-conditions' => 'pending_conditions',

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -1,0 +1,31 @@
+<div class="moj-filter__selected">
+
+  <div class="moj-filter__selected-heading">
+
+    <div class="moj-filter__heading-title">
+      <h2 class="govuk-heading-m">Selected filters</h2>
+    </div>
+
+    <div class="moj-filter__heading-action">
+    <p class="govuk-body">
+       <%= link_to "Clear", filtering_page_path(additional_params), class: "govuk-link govuk-link--no-visited-state" %>
+    </p>
+    </div>
+
+  </div>
+
+  <% applied_filters.each do |applied_filters_key, checkbox_config_values| %>
+    <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= applied_filters_key.capitalize %></h3>
+    <ul class="moj-filter-tags">
+    <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
+        <li>
+        <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_value), filtering_page_path(
+          additional_params.merge({ filter_selections: build_tag_url_query_params(
+                                         heading: applied_filters_key,
+                                         tag_value: checkbox_config_key)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+
+</div>

--- a/app/components/provider_interface/current_filters_component.rb
+++ b/app/components/provider_interface/current_filters_component.rb
@@ -1,0 +1,34 @@
+module ProviderInterface
+  class CurrentFiltersComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :applied_filters, :additional_params, :path
+
+    def initialize(path:, available_filters:, applied_filters:, additional_params:)
+      @additional_params = additional_params
+      @applied_filters = applied_filters
+      @available_filters = available_filters
+      @path = path
+    end
+
+    def build_tag_url_query_params(heading:, tag_value:)
+      tag_applied_filters = @applied_filters.clone
+      tag_applied_filters[heading] = @applied_filters[heading].except(tag_value)
+      tag_applied_filters
+    end
+
+    def retrieve_tag_text(heading, lookup_val)
+      @available_filters.each do |available_filter|
+        if available_filter.key(heading)
+          available_filter[:checkbox_config].each do |checkbox_config|
+            return checkbox_config[:text].to_s if checkbox_config.key(lookup_val)
+          end
+        end
+      end
+    end
+
+    def filtering_page_path(*args)
+      send(@path, *args)
+    end
+  end
+end

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -10,38 +10,10 @@
 
       <div class="moj-filter__content">
       <% if applied_filters.any? %>
-        <div class="moj-filter__selected">
-
-          <div class="moj-filter__selected-heading">
-
-            <div class="moj-filter__heading-title">
-              <h2 class="govuk-heading-m">Selected filters</h2>
-            </div>
-
-            <div class="moj-filter__heading-action">
-            <p class="govuk-body">
-               <%= link_to "Clear", filtering_page_path(additional_params), class: "govuk-link govuk-link--no-visited-state" %>
-            </p>
-            </div>
-
-          </div>
-
-          <% applied_filters.each do |applied_filters_key, checkbox_config_values| %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= applied_filters_key.capitalize %></h3>
-            <ul class="moj-filter-tags">
-            <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
-                <li>
-                <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_value), filtering_page_path(
-                  additional_params.merge({ filter_selections: build_tag_url_query_params(
-                                                 heading: applied_filters_key,
-                                                 tag_value: checkbox_config_key,
-                                                 applied_filters: applied_filters)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-
-        </div>
+             <%= render ProviderInterface::CurrentFiltersComponent.new(path: path,
+                                                                       available_filters: available_filters,
+                                                                       applied_filters: applied_filters,
+                                                                       additional_params: additional_params) %>
      <% end %>
 
 

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -1,81 +1,82 @@
-<div class="moj-filter-layout__filter">
-  <div class="moj-filter" tabindex="-1">
-    <div class="moj-filter__header">
-      <div class="moj-filter__header-title">
-        <h2 class="govuk-heading-m">Filter</h2>
-        </div>
-         <div class="moj-filter__header-action">
-        </div>
-    </div>
-
-    <div class="moj-filter__content">
-    <% if preselected_filters.any? %>
-      <div class="moj-filter__selected">
-
-        <div class="moj-filter__selected-heading">
-
-          <div class="moj-filter__heading-title">
-            <h2 class="govuk-heading-m">Selected filters</h2>
+<div class='moj-filter-layout'>
+  <div class="moj-filter-layout__filter">
+    <div class="moj-filter" tabindex="-1">
+      <div class="moj-filter__header">
+        <div class="moj-filter__header-title">
+          <h2 class="govuk-heading-m">Filter</h2>
           </div>
-
-          <div class="moj-filter__heading-action">
-          <p class="govuk-body">
-             <%= link_to "Clear", filtering_page_path(additional_params), class: "govuk-link govuk-link--no-visited-state" %>
-          </p>
+           <div class="moj-filter__header-action">
           </div>
-
-        </div>
-
-        <% preselected_filters.each do |preselected_filters_key, checkbox_config_values| %>
-          <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= preselected_filters_key.capitalize %></h3>
-          <ul class="moj-filter-tags">
-          <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
-              <li>
-              <%= link_to retrieve_tag_text(preselected_filters_key,checkbox_config_value), filtering_page_path(
-                additional_params.merge({ filter: build_tag_url_query_params(
-                                               heading: preselected_filters_key,
-                                               tag_value: checkbox_config_key,
-                                               preselected_filters: preselected_filters)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-
       </div>
-   <% end %>
 
+      <div class="moj-filter__content">
+      <% if preselected_filters.any? %>
+        <div class="moj-filter__selected">
 
-      <div class="moj-filter__options">
-        <form method="get" action=<%= filtering_page_path %>>
-          <%= submit_tag "Apply filters", class: "govuk-button" %>
-          <% additional_params.each do |key, value| %>
-            <input class="govuk-checkboxes__input" id=<%= key %> name=<%= key %> type="hidden" value=<%= value %> %>
+          <div class="moj-filter__selected-heading">
+
+            <div class="moj-filter__heading-title">
+              <h2 class="govuk-heading-m">Selected filters</h2>
+            </div>
+
+            <div class="moj-filter__heading-action">
+            <p class="govuk-body">
+               <%= link_to "Clear", filtering_page_path(additional_params), class: "govuk-link govuk-link--no-visited-state" %>
+            </p>
+            </div>
+
+          </div>
+
+          <% preselected_filters.each do |preselected_filters_key, checkbox_config_values| %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= preselected_filters_key.capitalize %></h3>
+            <ul class="moj-filter-tags">
+            <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
+                <li>
+                <%= link_to retrieve_tag_text(preselected_filters_key,checkbox_config_value), filtering_page_path(
+                  additional_params.merge({ filter: build_tag_url_query_params(
+                                                 heading: preselected_filters_key,
+                                                 tag_value: checkbox_config_key,
+                                                 preselected_filters: preselected_filters)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
+                </li>
+              <% end %>
+            </ul>
           <% end %>
 
+        </div>
+     <% end %>
 
-          <% available_filters.each do |filter_group| %>
-            <div class="govuk-form-group">
-              <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                  <%= filter_group[:heading].capitalize %>
-                </legend>
 
-                <% filter_group[:checkbox_config].each do |checkbox_config| %>
-                  <div class="govuk-checkboxes govuk-checkboxes--small">
-                    <%= render ProviderInterface::FilterCheckboxComponent.new(name: checkbox_config[:name],
-                                                                              text: checkbox_config[:text],
-                                                                              value: checkbox_config[:value],
-                                                                              selected: checkbox_checked?(key_one: filter_group[:heading], key_two: checkbox_config[:name]),
-                                                                              heading: filter_group[:heading].parameterize)
-                     %>
-                  </div>
-                <% end %>
-              </fieldset>
-            </div>
+        <div class="moj-filter__options">
+          <form method="get" action=<%= filtering_page_path %>>
+            <%= submit_tag "Apply filters", class: "govuk-button" %>
+            <% additional_params.each do |key, value| %>
+              <input class="govuk-checkboxes__input" id=<%= key %> name=<%= key %> type="hidden" value=<%= value %> %>
             <% end %>
-        </form>
+
+
+            <% available_filters.each do |filter_group| %>
+              <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                    <%= filter_group[:heading].capitalize %>
+                  </legend>
+
+                  <% filter_group[:checkbox_config].each do |checkbox_config| %>
+                    <div class="govuk-checkboxes govuk-checkboxes--small">
+                      <%= render ProviderInterface::FilterCheckboxComponent.new(name: checkbox_config[:name],
+                                                                                text: checkbox_config[:text],
+                                                                                value: checkbox_config[:value],
+                                                                                selected: checkbox_checked?(key_one: filter_group[:heading], key_two: checkbox_config[:name]),
+                                                                                heading: filter_group[:heading].parameterize)
+                       %>
+                    </div>
+                  <% end %>
+                </fieldset>
+              </div>
+              <% end %>
+          </form>
+        </div>
       </div>
     </div>
   </div>
-</div>
 </div>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -32,7 +32,7 @@
             <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
                 <li>
                 <%= link_to retrieve_tag_text(preselected_filters_key,checkbox_config_value), filtering_page_path(
-                  additional_params.merge({ filter: build_tag_url_query_params(
+                  additional_params.merge({ filter_selections: build_tag_url_query_params(
                                                  heading: preselected_filters_key,
                                                  tag_value: checkbox_config_key,
                                                  preselected_filters: preselected_filters)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -9,7 +9,7 @@
       </div>
 
       <div class="moj-filter__content">
-      <% if preselected_filters.any? %>
+      <% if applied_filters.any? %>
         <div class="moj-filter__selected">
 
           <div class="moj-filter__selected-heading">
@@ -26,16 +26,16 @@
 
           </div>
 
-          <% preselected_filters.each do |preselected_filters_key, checkbox_config_values| %>
-            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= preselected_filters_key.capitalize %></h3>
+          <% applied_filters.each do |applied_filters_key, checkbox_config_values| %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= applied_filters_key.capitalize %></h3>
             <ul class="moj-filter-tags">
             <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
                 <li>
-                <%= link_to retrieve_tag_text(preselected_filters_key,checkbox_config_value), filtering_page_path(
+                <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_value), filtering_page_path(
                   additional_params.merge({ filter_selections: build_tag_url_query_params(
-                                                 heading: preselected_filters_key,
+                                                 heading: applied_filters_key,
                                                  tag_value: checkbox_config_key,
-                                                 preselected_filters: preselected_filters)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
+                                                 applied_filters: applied_filters)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
                 </li>
               <% end %>
             </ul>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -65,7 +65,7 @@
                       <%= render ProviderInterface::FilterCheckboxComponent.new(name: checkbox_config[:name],
                                                                                 text: checkbox_config[:text],
                                                                                 value: checkbox_config[:value],
-                                                                                selected: checkbox_checked?(key_one: filter_group[:heading], key_two: checkbox_config[:name]),
+                                                                                selected: checkbox_checked?(heading: filter_group[:heading], name: checkbox_config[:name]),
                                                                                 heading: filter_group[:heading].parameterize)
                        %>
                     </div>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -1,4 +1,3 @@
-<div class='moj-filter-layout'>
   <div class="moj-filter-layout__filter">
     <div class="moj-filter" tabindex="-1">
       <div class="moj-filter__header">
@@ -79,4 +78,3 @@
       </div>
     </div>
   </div>
-</div>

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -11,8 +11,8 @@ module ProviderInterface
       @additional_params = additional_params
     end
 
-    def checkbox_checked?(key_one:, key_two:)
-      preselected_filters.dig(key_one, key_two) ? true : false
+    def checkbox_checked?(heading:, name:)
+      preselected_filters.dig(heading, name) ? true : false
     end
 
     def build_tag_url_query_params(heading:, tag_value:, preselected_filters:)

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -2,23 +2,23 @@ module ProviderInterface
   class FilterComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :additional_params, :available_filters, :preselected_filters
+    attr_reader :additional_params, :available_filters, :applied_filters
 
-    def initialize(path:, available_filters:, preselected_filters:, additional_params:)
+    def initialize(path:, available_filters:, applied_filters:, additional_params:)
       @path = path
       @available_filters = available_filters
-      @preselected_filters = preselected_filters
+      @applied_filters = applied_filters
       @additional_params = additional_params
     end
 
     def checkbox_checked?(heading:, name:)
-      preselected_filters.dig(heading, name) ? true : false
+      applied_filters.dig(heading, name) ? true : false
     end
 
-    def build_tag_url_query_params(heading:, tag_value:, preselected_filters:)
-      tag_preselected_filters = preselected_filters.clone
-      tag_preselected_filters[heading] = preselected_filters[heading].except(tag_value)
-      tag_preselected_filters
+    def build_tag_url_query_params(heading:, tag_value:, applied_filters:)
+      tag_applied_filters = applied_filters.clone
+      tag_applied_filters[heading] = applied_filters[heading].except(tag_value)
+      tag_applied_filters
     end
 
     def retrieve_tag_text(heading, lookup_val)

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class FilterComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :additional_params, :available_filters, :applied_filters
+    attr_reader :additional_params, :available_filters, :applied_filters, :path
 
     def initialize(path:, available_filters:, applied_filters:, additional_params:)
       @path = path

--- a/app/components/provider_interface/sortable_column_heading_component.html.erb
+++ b/app/components/provider_interface/sortable_column_heading_component.html.erb
@@ -1,9 +1,9 @@
 <% if should_have_sort? %>
   <th scope="col" class="<%= css_class %>" aria-sort="<%= aria_sort_order %>">
-    <%= link_to column_name, url_for(sort_order: toggle_sort_order, sort_by: sort_by, filter_selections: filter_selections), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(sort_order: toggle_sort_order, sort_by: sort_by, filter_selections: filter_selections, filter_visible: filter_visible), class: "app-sort-link" %>
   </th>
 <% else %>
   <th scope="col" class="<%= css_class %>" aria-sort="none">
-    <%= link_to column_name, url_for(sort_order: default_sort_order, sort_by: sort_by, filter_selections: filter_selections), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(sort_order: default_sort_order, sort_by: sort_by, filter_selections: filter_selections, filter_visible: filter_visible), class: "app-sort-link" %>
   </th>
 <% end %>

--- a/app/components/provider_interface/sortable_column_heading_component.html.erb
+++ b/app/components/provider_interface/sortable_column_heading_component.html.erb
@@ -1,9 +1,9 @@
 <% if should_have_sort? %>
   <th scope="col" class="<%= css_class %>" aria-sort="<%= aria_sort_order %>">
-    <%= link_to column_name, url_for(sort_order: toggle_sort_order, sort_by: sort_by), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(sort_order: toggle_sort_order, sort_by: sort_by, filter_selections: filter_selections), class: "app-sort-link" %>
   </th>
 <% else %>
   <th scope="col" class="<%= css_class %>" aria-sort="none">
-    <%= link_to column_name, url_for(sort_order: default_sort_order, sort_by: sort_by), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(sort_order: default_sort_order, sort_by: sort_by, filter_selections: filter_selections), class: "app-sort-link" %>
   </th>
 <% end %>

--- a/app/components/provider_interface/sortable_column_heading_component.rb
+++ b/app/components/provider_interface/sortable_column_heading_component.rb
@@ -2,13 +2,14 @@ module ProviderInterface
   class SortableColumnHeadingComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :column_name, :current_sort_by, :css_class
+    attr_reader :column_name, :current_sort_by, :css_class, :filter_selections
 
-    def initialize(sort_order:, column_name:, current_sort_by:, css_class:)
+    def initialize(sort_order:, column_name:, current_sort_by:, css_class:, filter_selections:)
       @sort_order = sort_order
       @column_name = column_name
       @current_sort_by = current_sort_by
       @css_class = css_class
+      @filter_selections = filter_selections
     end
 
     def default_sort_order

--- a/app/components/provider_interface/sortable_column_heading_component.rb
+++ b/app/components/provider_interface/sortable_column_heading_component.rb
@@ -2,14 +2,15 @@ module ProviderInterface
   class SortableColumnHeadingComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :column_name, :current_sort_by, :css_class, :filter_selections
+    attr_reader :column_name, :current_sort_by, :css_class, :filter_selections, :filter_visible
 
-    def initialize(sort_order:, column_name:, current_sort_by:, css_class:, filter_selections:)
+    def initialize(sort_order:, column_name:, current_sort_by:, css_class:, filter_selections:, filter_visible:)
       @sort_order = sort_order
       @column_name = column_name
       @current_sort_by = current_sort_by
       @css_class = css_class
       @filter_selections = filter_selections
+      @filter_visible = filter_visible
     end
 
     def default_sort_order

--- a/app/components/provider_interface/toggle_filter_component.html.erb
+++ b/app/components/provider_interface/toggle_filter_component.html.erb
@@ -1,6 +1,6 @@
 <div class="moj-action-bar">
   <div class="moj-action-bar__filter">
-    <%= link_to toggle_button_text, url_for(sort_order: sort_order, sort_by: current_sort_by, filter_visible: toggle_filter),
+    <%= link_to toggle_button_text, url_for(sort_order: sort_order, sort_by: current_sort_by, filter_visible: toggle_filter, filter_selections: filter_selections),
       class: "govuk-button govuk-button--secondary", type: "button" %>
   </div>
 </div>

--- a/app/components/provider_interface/toggle_filter_component.html.erb
+++ b/app/components/provider_interface/toggle_filter_component.html.erb
@@ -1,0 +1,6 @@
+<div class="moj-action-bar">
+  <div class="moj-action-bar__filter">
+    <%= link_to toggle_button_text, url_for(sort_order: sort_order, sort_by: current_sort_by, filter_visible: toggle_filter),
+      class: "govuk-button govuk-button--secondary", type: "button" %>
+  </div>
+</div>

--- a/app/components/provider_interface/toggle_filter_component.rb
+++ b/app/components/provider_interface/toggle_filter_component.rb
@@ -2,12 +2,13 @@ module ProviderInterface
   class ToggleFilterComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :sort_order, :current_sort_by, :filter_visible, :filter_options
+    attr_reader :sort_order, :current_sort_by, :filter_visible, :filter_options, :filter_selections
 
-    def initialize(sort_order:, current_sort_by:, filter_visible:)
+    def initialize(sort_order:, current_sort_by:, filter_visible:, filter_selections:)
       @sort_order = sort_order
       @current_sort_by = current_sort_by
       @filter_visible = filter_visible
+      @filter_selections = filter_selections
     end
 
     def toggle_filter

--- a/app/components/provider_interface/toggle_filter_component.rb
+++ b/app/components/provider_interface/toggle_filter_component.rb
@@ -1,0 +1,21 @@
+module ProviderInterface
+  class ToggleFilterComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :sort_order, :current_sort_by, :filter_visible, :filter_options
+
+    def initialize(sort_order:, current_sort_by:, filter_visible:)
+      @sort_order = sort_order
+      @current_sort_by = current_sort_by
+      @filter_visible = filter_visible
+    end
+
+    def toggle_filter
+      @filter_visible.eql?('true') ? 'false' : 'true'
+    end
+
+    def toggle_button_text
+      @filter_visible.eql?('true') ? 'Hide filter' : 'Show filter'
+    end
+  end
+end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -97,7 +97,7 @@ module ProviderInterface
           {
             name: provider.name.parameterize,
             text: provider.name,
-            value: provider.id,
+            value: provider.id.to_s,
           }
         end.uniq!
       }

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -10,7 +10,9 @@ module ProviderInterface
       application_choices = application_choices.page(params[:page] || 1)
 
       if FeatureFlag.active?('provider_application_filters')
-        raise 'feature not implemented yet'
+         @available_filters = available_filters
+         @filter_visible = params[:filter_visible] ||= 'true'
+         @application_choices = application_choices
       else
         @application_choices = application_choices
       end
@@ -29,6 +31,72 @@ module ProviderInterface
         'last-updated' => { 'application_choices.updated_at' => sort_order },
         'name' => { 'last_name' => sort_order, 'first_name' => sort_order },
       }[sort_by]
+    end
+
+    def available_filters
+      [
+        {
+          heading: 'status',
+          checkbox_config: [
+            {
+              name: 'pending-conditions',
+              text: 'Accepted',
+              value: 'pending_conditions',
+            },
+            {
+              name: 'recruited',
+              text: 'Conditions met',
+              value: 'recruited',
+            },
+            {
+              name: 'declined',
+              text: 'Declined',
+              value: 'declined',
+            },
+            {
+              name: 'awaiting-provider-decision',
+              text: 'New',
+              value: 'awaiting_provider_decision',
+            },
+            {
+              name: 'offer',
+              text: 'Offered',
+              value: 'offer',
+            },
+            {
+              name: 'rejected',
+              text: 'Rejected',
+              value: 'rejected',
+            },
+            {
+              name: 'withdrawn',
+              text: 'Application withdrawn',
+              value: 'withdrawn',
+            },
+            {
+              name: 'offer-withdrawn',
+              text: 'Withdrawn by us',
+              value: 'offer_withdrawn',
+            },
+          ],
+ },
+        {
+          heading: 'provider',
+          checkbox_config: [
+            {
+              name: 'somerset-scitt-consortium',
+              text: 'Somerset SCITT consortium',
+              value: '1',
+            },
+            {
+              name: 'the-beach-teaching-school',
+              text: 'The Beach Teaching School',
+              value: '2',
+            },
+
+          ],
+ },
+      ]
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -83,28 +83,27 @@ module ProviderInterface
               value: 'offer_withdrawn',
             },
           ],
-<<<<<<< HEAD
         }
-=======
- },
->>>>>>> Rubocop fixes
       ] << provider_filters_builder(application_choices: application_choices)
     end
 
     def provider_filters_builder(application_choices:)
+      checkbox_config = application_choices.map do |choice|
+        provider = choice.provider
+
+        {
+          name: provider.name.parameterize,
+          text: provider.name,
+          value: provider.id.to_s,
+        }
+      end
+
       provider_filters = {
         heading: 'provider',
-        checkbox_config: application_choices.map do |choice|
-          provider = choice.provider
-          {
-            name: provider.name.parameterize,
-            text: provider.name,
-            value: provider.id.to_s,
-          }
-        end,
+        checkbox_config: checkbox_config.uniq!,
       }
 
-      provider_filters.uniq!
+      provider_filters
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -10,7 +10,7 @@ module ProviderInterface
       application_choices = application_choices.page(params[:page] || 1)
 
       if FeatureFlag.active?('provider_application_filters')
-         @available_filters = available_filters
+         @available_filters = available_filters(application_choices: application_choices)
          @filter_visible =  filter_params[:filter_visible] ||= 'true'
          @filter_selections = filter_params[:filter_selections].to_h ||= {}
          @application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
@@ -39,7 +39,7 @@ module ProviderInterface
       }[sort_by]
     end
 
-    def available_filters
+    def available_filters(application_choices:)
       [
         {
           heading: 'status',
@@ -85,24 +85,23 @@ module ProviderInterface
               value: 'offer_withdrawn',
             },
           ],
- },
-        {
-          heading: 'provider',
-          checkbox_config: [
-            {
-              name: 'somerset-scitt-consortium',
-              text: 'Somerset SCITT consortium',
-              value: '1',
-            },
-            {
-              name: 'the-beach-teaching-school',
-              text: 'The Beach Teaching School',
-              value: '2',
-            },
-
-          ],
- },
-      ]
+ }
+      ] << provider_filters(application_choices: application_choices)
     end
+
+    def provider_filters(application_choices:)
+      {
+        heading: 'provider',
+        checkbox_config: application_choices.map do |choice|
+          provider = choice.provider
+          {
+            name: provider.name.parameterize,
+            text: provider.name,
+            value: provider.id,
+          }
+        end.uniq!
+      }
+    end
+
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -8,13 +8,12 @@ module ProviderInterface
         .order(ordering_arguments(@sort_by, @sort_order))
 
       if FeatureFlag.active?('provider_application_filters')
-         @available_filters = available_filters(application_choices: application_choices)
-         @filter_visible =  filter_params[:filter_visible] ||= 'true'
-         @filter_selections = filter_params[:filter_selections].to_h ||= {}
-         application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
-                                                                          filters: @filter_selections)
+        @available_filters = available_filters(application_choices: application_choices)
+        @filter_visible =  filter_params[:filter_visible] ||= 'true'
+        @filter_selections = filter_params[:filter_selections].to_h ||= {}
+        application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
+                                                                        filters: @filter_selections)
       end
-
       application_choices = application_choices.page(params[:page] || 1)
       @application_choices = application_choices
     end
@@ -24,7 +23,7 @@ module ProviderInterface
         .find(params[:application_choice_id])
     end
 
-  private
+    private
 
     def filter_params
       params.permit(:filter_visible,  filter_selections: {status: {}, provider: {}})
@@ -84,11 +83,11 @@ module ProviderInterface
               value: 'offer_withdrawn',
             },
           ],
- }
-      ] << provider_filters(application_choices: application_choices)
+        }
+      ] << provider_filters_builder(application_choices: application_choices)
     end
 
-    def provider_filters(application_choices:)
+    def provider_filters_builder(application_choices:)
       {
         heading: 'provider',
         checkbox_config: application_choices.map do |choice|

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
     private
 
     def filter_params
-      params.permit(:filter_visible,  filter_selections: {status: {}, provider: {}})
+      params.permit(:filter_visible, filter_selections: { status: {}, provider: {} })
     end
 
     def ordering_arguments(sort_by, sort_order)
@@ -83,12 +83,16 @@ module ProviderInterface
               value: 'offer_withdrawn',
             },
           ],
+<<<<<<< HEAD
         }
+=======
+ },
+>>>>>>> Rubocop fixes
       ] << provider_filters_builder(application_choices: application_choices)
     end
 
     def provider_filters_builder(application_choices:)
-      {
+      provider_filters = {
         heading: 'provider',
         checkbox_config: application_choices.map do |choice|
           provider = choice.provider
@@ -97,9 +101,10 @@ module ProviderInterface
             text: provider.name,
             value: provider.id.to_s,
           }
-        end.uniq!
+        end,
       }
-    end
 
+      provider_filters.uniq!
+    end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -7,17 +7,16 @@ module ProviderInterface
       application_choices = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
         .order(ordering_arguments(@sort_by, @sort_order))
 
-      application_choices = application_choices.page(params[:page] || 1)
-
       if FeatureFlag.active?('provider_application_filters')
          @available_filters = available_filters(application_choices: application_choices)
          @filter_visible =  filter_params[:filter_visible] ||= 'true'
          @filter_selections = filter_params[:filter_selections].to_h ||= {}
-         @application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
+         application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
                                                                           filters: @filter_selections)
-      else
-        @application_choices = application_choices
       end
+
+      application_choices = application_choices.page(params[:page] || 1)
+      @application_choices = application_choices
     end
 
     def show

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -23,7 +23,7 @@ module ProviderInterface
         .find(params[:application_choice_id])
     end
 
-    private
+  private
 
     def filter_params
       params.permit(:filter_visible, filter_selections: { status: {}, provider: {} })
@@ -83,7 +83,7 @@ module ProviderInterface
               value: 'offer_withdrawn',
             },
           ],
-        }
+        },
       ] << provider_filters_builder(application_choices: application_choices)
     end
 

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -14,7 +14,7 @@ module ProviderInterface
          @filter_visible =  filter_params[:filter_visible] ||= 'true'
          @filter_selections = filter_params[:filter_selections].to_h ||= {}
          @application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
-                                                                          status_filters: @filter_selections)
+                                                                          filters: @filter_selections)
       else
         @application_choices = application_choices
       end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -11,8 +11,10 @@ module ProviderInterface
 
       if FeatureFlag.active?('provider_application_filters')
          @available_filters = available_filters
-         @filter_visible = params[:filter_visible] ||= 'true'
-         @application_choices = application_choices
+         @filter_visible =  filter_params[:filter_visible] ||= 'true'
+         @filter_selections = filter_params[:filter_selections].to_h ||= {}
+         @application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
+                                                                          status_filters: @filter_selections)
       else
         @application_choices = application_choices
       end
@@ -24,6 +26,10 @@ module ProviderInterface
     end
 
   private
+
+    def filter_params
+      params.permit(:filter_visible,  filter_selections: {status: {}, provider: {}})
+    end
 
     def ordering_arguments(sort_by, sort_order)
       {

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -11,7 +11,7 @@
 .moj-filter__header {
   background: govuk-colour('white');
   box-shadow: none;
-  border: 1px solid #b1b4b6;
+  border: 1px solid $govuk-border-colour;
   border-bottom: 0;
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
@@ -19,7 +19,7 @@
 
 .moj-filter__selected {
   box-shadow: none;
-  border: 1px solid #b1b4b6;
+  border: 1px solid $govuk-border-colour;
   border-top: 0;
   border-bottom: 0;
   padding-top: govuk-spacing(5);

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -1,0 +1,3 @@
+.govuk-width-container {
+    max-width: 1220px;
+}

--- a/app/frontend/styles/_sortable-table.scss
+++ b/app/frontend/styles/_sortable-table.scss
@@ -11,7 +11,7 @@
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;
-  padding: 0 10px 0 0;
+  padding: 0 15px 0 0;
   position: relative;
   text-align: inherit;
   font-size: 1em;
@@ -32,7 +32,7 @@
 [aria-sort] .app-sort-link:before {
   content: " \25bc";
   position: absolute;
-  right: -1px;
+  right: 0;
   top: 9px;
   font-size: 0.5em;
 }
@@ -40,7 +40,7 @@
 [aria-sort] .app-sort-link:after {
   content: " \25b2";
   position: absolute;
-  right: -1px;
+  right: 0;
   top: 1px;
   font-size: 0.5em;
 }
@@ -54,7 +54,7 @@
   content: " \25b2";
   font-size: .8em;
   position: absolute;
-  right: -5px;
+  right: -2px;
   top: 2px;
 }
 
@@ -62,6 +62,6 @@
   content: " \25bc";
   font-size: .8em;
   position: absolute;
-  right: -5px;
+  right: -2px;
   top: 2px;
 }

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -37,7 +37,9 @@ $govuk-image-url-function: frontend-image-url;
 @import "~@ministryofjustice/frontend/moj/settings/assets";
 @import "~@ministryofjustice/frontend/moj/objects/filter-layout";
 @import "~@ministryofjustice/frontend/moj/components/filter/filter";
+@import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
 @import "_filter";
+@import "_provider";
 
 // Support
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -2,12 +2,12 @@ class FilterApplicationChoicesForProviders
   def self.call(application_choices:, filters:)
     return application_choices if filters.empty?
 
-      if filters[:status] && filters[:provider]
-        return application_choices.where(status: filters[:status].values, 'courses.provider_id' => filters[:provider].values)
-      elsif filters[:status]
-        return application_choices.where(status: filters[:status].values)
-      else
-        application_choices.where('courses.provider_id' => filters[:provider].values)
-      end
+    if filters[:status] && filters[:provider]
+      application_choices.where(status: filters[:status].values, 'courses.provider_id' => filters[:provider].values)
+    elsif filters[:status]
+      application_choices.where(status: filters[:status].values)
+    else
+      application_choices.where('courses.provider_id' => filters[:provider].values)
+    end
   end
 end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -3,7 +3,7 @@ class FilterApplicationChoicesForProviders
     return application_choices if filters.empty?
 
       if filters[:status] && filters[:provider]
-        return application_choices.where(status: page_state.filter_options, 'courses.provider_id' => provider_options)
+        return application_choices.where(status: filters[:status].values, 'courses.provider_id' => filters[:provider].values)
       elsif filters[:status]
         return application_choices.where(status: filters[:status].values)
       else

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -2,6 +2,12 @@ class FilterApplicationChoicesForProviders
   def self.call(application_choices:, filters:)
     return application_choices if filters.empty?
 
-    application_choices.where(status: filters[:status].values)
+      if filters[:status] && filters[:provider]
+        return application_choices.where(status: page_state.filter_options, 'courses.provider_id' => provider_options)
+      elsif filters[:status]
+        return application_choices.where(status: filters[:status].values)
+      else
+        application_choices.where('courses.provider_id' => filters[:provider].values)
+      end
   end
 end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -1,0 +1,7 @@
+class FilterApplicationChoicesForProviders
+  def self.call(application_choices:, status_filters:)
+    return application_choices if status_filters.empty?
+
+    application_choices.where(status: status_filters[:status].values)
+  end
+end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -1,7 +1,7 @@
 class FilterApplicationChoicesForProviders
-  def self.call(application_choices:, status_filters:)
-    return application_choices if status_filters.empty?
+  def self.call(application_choices:, filters:)
+    return application_choices if filters.empty?
 
-    application_choices.where(status: status_filters[:status].values)
+    application_choices.where(status: filters[:status].values)
   end
 end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -77,7 +77,7 @@
 <% end %>
 
 <%= render(PaginatorComponent.new(scope: @application_choices)) %>
-<% elsif @filter_selections.any? %>
+<% elsif @filter_selections %>
      <p class='govuk-body'>No applications for the selected filters.</p>
 <% else %>
   <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 
   <div class='moj-filter-layout__content'>
-    <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @sort_order, current_sort_by: @sort_by, filter_visible: @filter_visible) %>
+    <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @sort_order, current_sort_by: @sort_by, filter_visible: @filter_visible, filter_selections: @filter_selections) %>
     <div class='moj-scrollable-pane'>
       <div class='moj-scrollable-pane__wrapper'>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -2,6 +2,16 @@
 
 <h1 class='govuk-heading-xl'>Applications</h1>
 
+<% if FeatureFlag.active?('provider_application_filters') %>
+
+    <% if @filter_visible.eql?('true') %>
+      <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path, available_filters: @available_filters , preselected_filters: {}, additional_params: {}) %>
+    <% end %>
+
+    <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @sort_order, current_sort_by: @sort_by, filter_visible: @filter_visible) %>
+<% end %>
+
+
 <% if @application_choices.any? %>
   <table class='govuk-table'>
     <thead class='govuk-table__head'>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -59,6 +59,8 @@
 <% end %>
 
 <%= render(PaginatorComponent.new(scope: @application_choices)) %>
+<% elsif @filter_selections.any? %>
+     <p class='govuk-body'>No applications for the selected filters.</p>
 <% else %>
   <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
 <% end %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -4,47 +4,58 @@
 
 <% if FeatureFlag.active?('provider_application_filters') %>
 
-    <% if @filter_visible.eql?('true') %>
-      <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path, available_filters: @available_filters , preselected_filters: {}, additional_params: {}) %>
-    <% end %>
+<div class='moj-filter-layout'>
+  <% if @filter_visible.eql?('true') %>
+    <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path, available_filters: @available_filters , preselected_filters: {}, additional_params: {}) %>
+  <% end %>
 
+  <div class='moj-filter-layout__content'>
     <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @sort_order, current_sort_by: @sort_by, filter_visible: @filter_visible) %>
+    <div class='moj-scrollable-pane'>
+      <div class='moj-scrollable-pane__wrapper'>
+
+      <% end %>
+
+      <% if @application_choices.any? %>
+        <table class='govuk-table'>
+          <thead class='govuk-table__head'>
+            <tr class='govuk-table__row'>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Name', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter') %>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Course', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter') %>
+              <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Last updated', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric') %>
+            </tr>
+          </thead>
+
+          <tbody class='govuk-table__body'>
+            <% @application_choices.each do |application_choice| %>
+              <tr class='govuk-table__row'>
+                <th class='govuk-table__cell'>
+                <span class="govuk-caption-m govuk-!-font-size-16"><%= application_choice.application_form.support_reference %></span>
+                <%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %></th>
+                <td class='govuk-table__cell'>
+                  <% if current_provider_user.providers.size > 1 %>
+                    <span class='govuk-caption-m govuk-!-font-size-16'>
+                      <%= application_choice.provider.name %>
+                    </span>
+                  <% end %>
+
+                  <%= application_choice.course.name_and_code %></td>
+                <td class='govuk-table__cell'><%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %></td>
+                <td class='govuk-table__cell govuk-table__header--numeric'><%= application_choice.updated_at.to_s(:govuk_date_short_month) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+
+        <% if FeatureFlag.active?('provider_application_filters') %>
+        </div>
+    </div>
+  </div>
+</div>
 <% end %>
 
-
-<% if @application_choices.any? %>
-  <table class='govuk-table'>
-    <thead class='govuk-table__head'>
-      <tr class='govuk-table__row'>
-        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Name', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter') %>
-        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Course', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter') %>
-        <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
-        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Last updated', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric') %>
-      </tr>
-    </thead>
-
-    <tbody class='govuk-table__body'>
-      <% @application_choices.each do |application_choice| %>
-      <tr class='govuk-table__row'>
-        <td class='govuk-table__cell'>
-          <span class="govuk-caption-m govuk-!-font-size-16"><%= application_choice.application_form.support_reference %></span>
-          <%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %>
-        </td>
-        <td class='govuk-table__cell'>
-          <% if current_provider_user.providers.size > 1 %>
-            <span class='govuk-caption-m govuk-!-font-size-16'>
-              <%= application_choice.provider.name %>
-            </span>
-          <% end %>
-
-          <%= application_choice.course.name_and_code %></td>
-        <td class='govuk-table__cell'><%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %></td>
-        <td class='govuk-table__cell govuk-table__header--numeric'><%= application_choice.updated_at.to_s(:govuk_date_short_month) %></td>
-      </tr>
-      <% end %>
-    </tbody>
-  </table>
-  <%= render(PaginatorComponent.new(scope: @application_choices)) %>
+<%= render(PaginatorComponent.new(scope: @application_choices)) %>
 <% else %>
   <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
 <% end %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -6,7 +6,10 @@
 
 <div class='moj-filter-layout'>
   <% if @filter_visible.eql?('true') %>
-    <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path, available_filters: @available_filters , preselected_filters: {}, additional_params: {}) %>
+    <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
+                                                      available_filters: @available_filters,
+                                                      preselected_filters: @filter_selections,
+                                                      additional_params: {}) %>
   <% end %>
 
   <div class='moj-filter-layout__content'>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -9,7 +9,8 @@
     <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
                                                       available_filters: @available_filters,
                                                       preselected_filters: @filter_selections,
-                                                      additional_params: {}) %>
+                                                      additional_params: { sort_by: @sort_by,
+                                                                           sort_order: @sort_order }) %>
   <% end %>
 
   <div class='moj-filter-layout__content'>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -23,10 +23,28 @@
         <table class='govuk-table'>
           <thead class='govuk-table__head'>
             <tr class='govuk-table__row'>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Name', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter', filter_selections: @filter_selections) %>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Course', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter', filter_selections: @filter_selections) %>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
+                                                                               column_name: 'Name',
+                                                                               current_sort_by: @sort_by,
+                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                               filter_selections: @filter_selections,
+                                                                               filter_visible: @filter_visible) %>
+
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
+                                                                               column_name: 'Course',
+                                                                               current_sort_by: @sort_by,
+                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                               filter_selections: @filter_selections,
+                                                                               filter_visible: @filter_visible) %>
+
               <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Last updated', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric', filter_selections: @filter_selections) %>
+
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
+                                                                               column_name: 'Last updated',
+                                                                               current_sort_by: @sort_by,
+                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
+                                                                               filter_selections: @filter_selections,
+                                                                               filter_visible: @filter_visible) %>
             </tr>
           </thead>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -23,10 +23,10 @@
         <table class='govuk-table'>
           <thead class='govuk-table__head'>
             <tr class='govuk-table__row'>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Name', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter') %>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Course', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter') %>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Name', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter', filter_selections: @filter_selections) %>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Course', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter', filter_selections: @filter_selections) %>
               <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Last updated', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric') %>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order, column_name: 'Last updated', current_sort_by: @sort_by, css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric', filter_selections: @filter_selections) %>
             </tr>
           </thead>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -8,7 +8,7 @@
   <% if @filter_visible.eql?('true') %>
     <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
                                                       available_filters: @available_filters,
-                                                      preselected_filters: @filter_selections,
+                                                      applied_filters: @filter_selections,
                                                       additional_params: { sort_by: @sort_by,
                                                                            sort_order: @sort_order }) %>
   <% end %>

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     expect(result.text).to include('Selected filters')
   end
 
-  it 'selected filters should include tags that match what has been seleted for' do
+  it 'selected filters should include tags that match what has been selected for' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         preselected_filters: preselected_filters_partial,
@@ -156,7 +156,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   end
 
 
-  it 'selected filters dialogue should not apprer if is nothing filtered for' do
+  it 'selected filters dialogue should not appear if is nothing filtered for' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         preselected_filters: {},

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::FilterComponent do
   let(:path) { :provider_interface_applications_path }
 
-  let(:preselected_filters_partial) do
+  let(:applied_filters_partial) do
     {
       'status' => {
         'pending-conditions' => 'pending_conditions',
@@ -17,7 +17,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     }
   end
 
-  let(:preselected_filters_partial_minus_withdrawn) do
+  let(:applied_filters_partial_minus_withdrawn) do
     {
       'status' => {
         'pending-conditions' => 'pending_conditions',
@@ -107,7 +107,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'marks checkboxes as checked if they have already been pre-selected' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     expect(result.css('#status-pending-conditions').attr('checked').value).to eq('checked')
@@ -123,7 +123,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'on initial load all of the checkboxes are unchecked' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: {},
+                                        applied_filters: {},
                                         additional_params: additional_params)
 
     expect(result.css('#status-pending-conditions').attr('checked')).to eq(nil)
@@ -139,7 +139,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'when filters have been selected filters dialogue to appear' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     expect(result.text).to include('Selected filters')
@@ -148,7 +148,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'selected filters should include tags that match what has been selected for' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     expect(result.css('.moj-filter-tags').text).to include('Accepted', 'New', 'Rejected', 'Application withdrawn', 'The Beach Teaching School')
@@ -159,7 +159,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'selected filters dialogue should not appear if is nothing filtered for' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: {},
+                                        applied_filters: {},
                                         additional_params: additional_params)
 
     expect(result.text).not_to include('Selected filters')
@@ -168,7 +168,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'has a clear button when filters have been selected' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     expect(result.text).to include('Clear')
@@ -177,7 +177,7 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'returns the additional_params as hidden fields' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     expect(result.css('#sort_by').attr('value').value).to eq('desc')
@@ -186,10 +186,10 @@ RSpec.describe ProviderInterface::FilterComponent do
     expect(result.css('#sort_order').attr('type').value).to eq('hidden')
   end
 
-  it 'can return a full text of a preselected_filters value from the available_filters' do
+  it 'can return a full text of a applied_filters value from the available_filters' do
     filter_component = described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     expect(filter_component.retrieve_tag_text('status', 'offer_withdrawn')).to eq('Withdrawn by us')
@@ -199,20 +199,20 @@ RSpec.describe ProviderInterface::FilterComponent do
   it 'can create hash for a tag url that doesn\'t include that tag\'s params' do
     filter_component = described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     hash = filter_component.build_tag_url_query_params(heading: 'status',
                                                tag_value: 'withdrawn',
-                                               preselected_filters: preselected_filters_partial)
+                                               applied_filters: applied_filters_partial)
 
-    expect(hash).to eq(preselected_filters_partial_minus_withdrawn)
+    expect(hash).to eq(applied_filters_partial_minus_withdrawn)
   end
 
   it 'can create a tag url that doesn\'t include that tag\'s values' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
-                                        preselected_filters: preselected_filters_partial,
+                                        applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
     expect(result.css('#tag-rejected').attr('href').value).not_to include('rejected')

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -35,6 +35,13 @@ module DfESignInHelpers
     create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
   end
 
+  def provider_user_exists_in_apply_database_with_multiple_providers
+    provider_one = create(:provider, code: 'ABC', name: 'Example Provider')
+    provider_two = create(:provider, code: 'DEF', name: 'Example Provider')
+    provider_three = create(:provider, code: 'GHI', name: 'Example Provider')
+    create(:provider_user, providers: [provider_one, provider_two, provider_three], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+  end
+
   def fake_dfe_sign_in_auth_hash(email_address:, dfe_sign_in_uid:, first_name:, last_name:)
     {
       'provider' => 'dfe',

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -196,7 +196,6 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_css('.govuk-table__body', text: 'Declined')
   end
 
-
   def when_i_filter_by_provider
     find(:css, '#provider-hoth-teacher-training').set(true)
     find(:css, '#provider-caladan-university').set(true)

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   scenario 'can filter applications by status' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_application_filters_are_active
-    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_see_applications_from_multiple_providers
     and_my_organisation_has_courses_with_applications
     and_i_sign_in_to_the_provider_interface
 
@@ -44,6 +44,14 @@ RSpec.feature 'Providers should be able to filter applications' do
     when_i_sort_by_course
     then_only_rejected_and_offered_applications_should_be_visible
     then_i_do_not_expect_to_see_the_filter_dialogue
+
+    when_i_show_the_filter_dialogue
+    when_i_clear_the_filters
+    then_i_expect_all_applications_to_be_visible
+
+    when_i_filter_by_provider
+    then_i_only_see_applications_for_a_given_provider
+
     and_provider_application_filters_are_deactivated
   end
 
@@ -55,16 +63,24 @@ RSpec.feature 'Providers should be able to filter applications' do
     provider_exists_in_dfe_sign_in
   end
 
-  def and_i_am_permitted_to_see_applications_for_my_provider
-    provider_user_exists_in_apply_database
+  def and_i_am_permitted_to_see_applications_from_multiple_providers
+    provider_user_exists_in_apply_database_with_multiple_providers
   end
 
   def and_my_organisation_has_courses_with_applications
-    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    current_provider = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training')
+    second_provider = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University')
+    third_provider = create(:provider, :with_signed_agreement, code: 'GHI', name: 'University of Arrakis')
 
     course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
     course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
     course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+
+    course_option_four = course_option_for_provider(provider: second_provider, course: create(:course, name: 'Science', provider: second_provider))
+    course_option_five = course_option_for_provider(provider: second_provider, course: create(:course, name: 'History', provider: second_provider))
+
+    course_option_six = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Maths', provider: third_provider))
+    course_option_seven = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Engineering', provider: third_provider))
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
            create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
@@ -77,6 +93,18 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
            create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_four, status: 'offer', application_form:
+           create(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_five, status: 'rejected', application_form:
+           create(:application_form, first_name: 'Paul', last_name: 'Atreides'), updated_at: 5.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_six, status: 'withdrawn', application_form:
+           create(:application_form, first_name: 'Duncan', last_name: 'Idaho'), updated_at: 6.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_seven, status: 'declined', application_form:
+           create(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
   end
 
   def then_i_expect_to_see_the_hide_filter_button
@@ -107,7 +135,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   def then_only_rejected_applications_should_be_visible
     expect(page).to have_css('.govuk-table__body', text: 'Rejected')
     expect(page).not_to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Withdrawn')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
     expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
   end
 
@@ -136,7 +164,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   def then_only_rejected_and_offered_applications_should_be_visible
     expect(page).to have_css('.govuk-table__body', text: 'Rejected')
     expect(page).to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Withdrawn')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
     expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
   end
 
@@ -146,6 +174,29 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def when_i_sort_by_course
     click_link('Course')
+  end
+
+  def when_i_clear_the_filters
+    click_link('Clear')
+  end
+
+  def then_i_expect_all_applications_to_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).to have_css('.govuk-table__body', text: 'Offer')
+    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
+    expect(page).to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+
+  def when_i_filter_by_provider
+    find(:css, '#provider-hoth-teacher-training').set(true)
+    click_button('Apply filters')
+  end
+
+  def then_i_only_see_applications_for_a_given_provider
+    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Caladan University')
+    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
   end
 
   def and_provider_application_filters_are_active

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -1,0 +1,158 @@
+require 'rails_helper'
+
+RSpec.feature 'Providers should be able to filter applications' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'can filter applications by status' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_provider_application_filters_are_active
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_my_organisation_has_courses_with_applications
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_page
+
+    then_i_expect_to_see_the_hide_filter_button
+    then_i_expect_to_see_the_filter_dialogue
+
+    when_i_hide_the_filter_dialogue
+    then_i_do_not_expect_to_see_the_filter_dialogue
+
+    when_i_show_the_filter_dialogue
+    then_i_expect_to_see_the_filter_dialogue
+
+    when_i_filter_for_rejected_applications
+    then_only_rejected_applications_should_be_visible
+    and_the_rejected_tickbox_should_still_be_checked
+
+    when_i_filter_for_applications_that_i_do_not_have
+    then_i_should_see_the_no_filter_results_error_message
+    then_i_expect_to_see_the_hide_filter_button
+    then_i_expect_to_see_the_filter_dialogue
+
+    when_i_filter_for_rejected_and_offered_applications
+    when_i_hide_the_filter_dialogue
+    then_only_rejected_and_offered_applications_should_be_visible
+    when_i_show_the_filter_dialogue
+    then_only_rejected_and_offered_applications_should_be_visible
+
+    when_i_sort_by_name
+    then_only_rejected_and_offered_applications_should_be_visible
+
+    when_i_hide_the_filter_dialogue
+    when_i_sort_by_course
+    then_only_rejected_and_offered_applications_should_be_visible
+    then_i_do_not_expect_to_see_the_filter_dialogue
+    and_provider_application_filters_are_deactivated
+  end
+
+  def when_i_visit_the_provider_page
+    visit provider_interface_path
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_my_organisation_has_courses_with_applications
+    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+
+    course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
+    course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
+    course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
+           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           create(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'rejected', application_form:
+           create(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
+           create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+  end
+
+  def then_i_expect_to_see_the_hide_filter_button
+    expect(page).to have_content('Hide filter')
+  end
+
+  def then_i_expect_to_see_the_filter_dialogue
+    expect(page).to have_button('Apply filters')
+  end
+
+  def when_i_hide_the_filter_dialogue
+    click_link('Hide filter')
+  end
+
+  def then_i_do_not_expect_to_see_the_filter_dialogue
+    expect(page).not_to have_button('Apply filters')
+  end
+
+  def when_i_show_the_filter_dialogue
+    click_link('Show filter')
+  end
+
+  def when_i_filter_for_rejected_applications
+    find(:css, '#status-rejected').set(true)
+    click_button('Apply filters')
+  end
+
+  def then_only_rejected_applications_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Offer')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Withdrawn')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def and_the_rejected_tickbox_should_still_be_checked
+    rejected_checkbox = find(:css, '#status-rejected')
+    expect(rejected_checkbox.checked?).to be(true)
+  end
+
+  def when_i_filter_for_applications_that_i_do_not_have
+    find(:css, '#status-rejected').set(false)
+    find(:css, '#status-pending-conditions').set(true)
+    click_button('Apply filters')
+  end
+
+  def then_i_should_see_the_no_filter_results_error_message
+    expect(page).to have_content('No applications for the selected filters.')
+  end
+
+  def when_i_filter_for_rejected_and_offered_applications
+    find(:css, '#status-pending-conditions').set(false)
+    find(:css, '#status-rejected').set(true)
+    find(:css, '#status-offer').set(true)
+    click_button('Apply filters')
+  end
+
+  def then_only_rejected_and_offered_applications_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).to have_css('.govuk-table__body', text: 'Offer')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Withdrawn')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def when_i_sort_by_name
+    click_link('Name')
+  end
+
+  def when_i_sort_by_course
+    click_link('Course')
+  end
+
+  def and_provider_application_filters_are_active
+    FeatureFlag.activate('provider_application_filters')
+  end
+
+  def and_provider_application_filters_are_deactivated
+    FeatureFlag.deactivate('provider_application_filters')
+  end
+end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'can filter applications by status' do
+  scenario 'can filter applications by status and provider' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_provider_application_filters_are_active
     and_i_am_permitted_to_see_applications_from_multiple_providers
@@ -53,6 +53,9 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_only_see_applications_for_a_given_provider
 
     and_provider_application_filters_are_deactivated
+
+    when_i_visit_the_provider_page
+    then_i_do_not_expect_to_see_the_filter_dialogue
   end
 
   def when_i_visit_the_provider_page

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -24,6 +24,7 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_filter_for_rejected_applications
     then_only_rejected_applications_should_be_visible
+    and_a_rejected_tag_should_be_visible
     and_the_rejected_tickbox_should_still_be_checked
 
     when_i_filter_for_applications_that_i_do_not_have
@@ -51,6 +52,11 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_filter_by_provider
     then_i_only_see_applications_for_a_given_provider
+    then_i_expect_the_relevant_provider_tags_to_be_visible
+
+    when_i_click_to_remove_a_tag
+    then_i_expect_that_tag_not_to_be_visible
+    and_the_remaining_filters_to_still_apply
 
     and_provider_application_filters_are_deactivated
 
@@ -193,12 +199,13 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def when_i_filter_by_provider
     find(:css, '#provider-hoth-teacher-training').set(true)
+    find(:css, '#provider-caladan-university').set(true)
     click_button('Apply filters')
   end
 
   def then_i_only_see_applications_for_a_given_provider
     expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Caladan University')
+    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
     expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
   end
 
@@ -208,5 +215,27 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def and_provider_application_filters_are_deactivated
     FeatureFlag.deactivate('provider_application_filters')
+  end
+
+  def then_i_expect_the_relevant_provider_tags_to_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.moj-filter-tags', text: 'Caladan University')
+  end
+
+  def when_i_click_to_remove_a_tag
+    click_link('Hoth Teacher Training')
+  end
+
+  def then_i_expect_that_tag_not_to_be_visible
+    expect(page).not_to have_css('.moj-filter-tags', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.moj-filter-tags', text: 'Caladan University')
+  end
+
+  def and_the_remaining_filters_to_still_apply
+    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
+  end
+
+  def and_a_rejected_tag_should_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: 'Rejected')
   end
 end


### PR DESCRIPTION
## Context

Third PR as per Theos comment here: #1456 (review)

Splitting up this large PR into smaller chunks

## Guidance to review

Note that the `app/controllers/provider_interface/application_choices_controller.rb` is messy at the moment - everything works but I am going to do another PR and introduce an `ApplicationsPageConfig` model to dry up some of the functionality and make it neater, and deal with things like pagination in a more streamlined way.

## Link to Trello card
https://trello.com/c/wMGLpXGS/1641-add-filtering-to-the-provider-ui

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
