### PR TITLE
Remove send_dfe_sign_in_invitations feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -10,7 +10,6 @@ class FeatureFlag
     pilot_open
     provider_application_filters
     provider_change_response
-    send_dfe_sign_in_invitations
     show_new_referee_needed
     training_with_a_disability
     work_breaks

--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -10,10 +10,8 @@ class InviteProviderUser
   def save_and_invite!
     ActiveRecord::Base.transaction do
       @provider_user.save!
-      if FeatureFlag.active?('send_dfe_sign_in_invitations')
-        invite_user_to_dfe_sign_in
-        send_welcome_email
-      end
+      invite_user_to_dfe_sign_in
+      send_welcome_email
     end
   end
 

--- a/spec/system/provider_interface/provider_sees_empty_state_spec.rb
+++ b/spec/system/provider_interface/provider_sees_empty_state_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'See applications' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider user visits the Provider interface when there are no applications for their provider' do
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_my_training_provider_exists
+    and_another_organisation_has_applications
+
+    when_i_have_been_assigned_to_my_training_provider
+    and_i_sign_in_to_the_provider_interface
+
+    then_i_should_see_no_applications
+  end
+
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_my_training_provider_exists
+    create(:provider, :with_signed_agreement, code: 'ABC')
+  end
+
+  def and_another_organisation_has_applications
+    other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
+
+    @other_provider_choice = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
+  end
+
+  def when_i_have_been_assigned_to_my_training_provider
+    provider_user_exists_in_apply_database
+  end
+  def then_i_should_see_no_applications
+    expect(page).to have_content 'You haven’t received any applications'
+    expect(page).not_to have_selector('.govuk-table')
+  end
+end

--- a/spec/system/provider_interface/provider_sees_empty_state_spec.rb
+++ b/spec/system/provider_interface/provider_sees_empty_state_spec.rb
@@ -33,6 +33,7 @@ RSpec.feature 'See applications' do
   def when_i_have_been_assigned_to_my_training_provider
     provider_user_exists_in_apply_database
   end
+
   def then_i_should_see_no_applications
     expect(page).to have_content 'You haven’t received any applications'
     expect(page).not_to have_selector('.govuk-table')

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -4,17 +4,6 @@ RSpec.feature 'See applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'Provider visits applications when there are none' do
-    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-    and_my_training_provider_exists
-    and_another_organisation_has_applications
-
-    when_i_have_been_assigned_to_my_training_provider
-    and_i_sign_in_to_the_provider_interface
-
-    then_i_should_see_no_applications
-  end
-
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_applications
@@ -59,12 +48,6 @@ RSpec.feature 'See applications' do
     @my_provider_choice2  = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
   end
 
-  def and_another_organisation_has_applications
-    other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
-
-    @other_provider_choice = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
-  end
-
   def and_i_visit_the_provider_page
     visit provider_interface_path
   end
@@ -76,15 +59,6 @@ RSpec.feature 'See applications' do
     expect(page).to have_content @my_provider_choice1.application_form.first_name
     expect(page).to have_content @my_provider_choice2.application_form.support_reference
     expect(page).to have_content @my_provider_choice2.application_form.first_name
-  end
-
-  def then_i_should_see_no_applications
-    expect(page).to have_content 'You haven’t received any applications'
-    expect(page).not_to have_selector('.govuk-table')
-  end
-
-  def but_not_the_applications_from_other_providers
-    expect(page).not_to have_content @other_provider_choice.application_form.first_name
   end
 
   def when_i_click_on_an_application

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -5,8 +5,7 @@ RSpec.feature 'Managing provider users' do
   include DsiAPIHelper
 
   scenario 'creating a new provider user' do
-    given_the_send_dfe_sign_in_invitations_feature_flag_is_on
-    and_dfe_signin_is_configured
+    given_dfe_signin_is_configured
     and_i_am_a_support_user
     and_providers_exist
 
@@ -31,11 +30,7 @@ RSpec.feature 'Managing provider users' do
     then_i_see_that_they_have_been_added_to_that_organisation
   end
 
-  def given_the_send_dfe_sign_in_invitations_feature_flag_is_on
-    FeatureFlag.activate('send_dfe_sign_in_invitations')
-  end
-
-  def and_dfe_signin_is_configured
+  def given_dfe_signin_is_configured
     set_dsi_api_response(success: true)
   end
 


### PR DESCRIPTION
## Context

This feature flag has been enabled in prod for some time and it's now part of the transition team's workflow.

## Changes proposed in this pull request

Remove the flag and associated checks.

## Link to Trello card

Added here https://trello.com/c/h79j49U2/571-clean-up-feature-flags-for-launched-features

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
