### PR TITLE
Remove the experimental_api_features feature flag

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -1,7 +1,6 @@
 module VendorApi
   class TestDataController < VendorApiController
     before_action :check_this_is_a_test_environment
-    before_action :feature_flag_new_endpoints, only: %i[generate clear!]
 
     MAX_COUNT = 100
     DEFAULT_COUNT = 100
@@ -35,12 +34,6 @@ module VendorApi
     end
 
   private
-
-    def feature_flag_new_endpoints
-      if !FeatureFlag.active?('experimental_api_features')
-        render json: {}, status: :not_found
-      end
-    end
 
     def check_this_is_a_test_environment
       if HostingEnvironment.production?

--- a/app/models/vendor_api/open_api_spec.rb
+++ b/app/models/vendor_api/open_api_spec.rb
@@ -9,13 +9,9 @@ module VendorApi
     end
 
     def self.spec
-      if FeatureFlag.active?('experimental_api_features')
-        YAML
-          .load_file('config/vendor-api-v1.yml')
-          .deep_merge(YAML.load_file('config/vendor-api-experimental.yml'))
-      else
-        YAML.load_file('config/vendor-api-v1.yml')
-      end
+      YAML
+        .load_file('config/vendor-api-v1.yml')
+        .deep_merge(YAML.load_file('config/vendor-api-experimental.yml'))
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -13,7 +13,6 @@ class FeatureFlag
     dfe_sign_in_incident
     edit_application
     equality_and_diversity
-    experimental_api_features
     force_ok_computer_to_fail
     improved_expired_token_flow
     notify_candidate_of_new_reference

--- a/spec/models/vendor_api/open_api_spec_spec.rb
+++ b/spec/models/vendor_api/open_api_spec_spec.rb
@@ -2,23 +2,6 @@ require 'rails_helper'
 
 RSpec.describe VendorApi::OpenApiSpec do
   describe '.as_yaml' do
-    it 'can roundtrip with the YAML file on disk' do
-      yaml_on_disk = File.read('config/vendor-api-v1.yml')
-
-      generated_yaml = VendorApi::OpenApiSpec.as_yaml
-
-      expect(yaml_on_disk).to eq(generated_yaml)
-    end
-  end
-
-  it 'does not include /experimental paths' do
-    advertised_paths = VendorApi::OpenApiSpec.as_hash['paths'].keys
-    expect(advertised_paths.filter { |path| path.include?('experimental') }).to be_empty
-  end
-
-  context 'when the experimental_api_features flag is on' do
-    before { FeatureFlag.activate('experimental_api_features') }
-
     it 'includes /experimental paths' do
       advertised_paths = VendorApi::OpenApiSpec.as_hash['paths'].keys
       expect(advertised_paths.filter { |path| path.include?('experimental') }).not_to be_empty

--- a/spec/requests/vendor_api/post_test_data_clear_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_clear_spec.rb
@@ -4,10 +4,6 @@ RSpec.describe 'Vendor API - POST /api/v1/test-data/clear', type: :request do
   include VendorApiSpecHelpers
   include CourseOptionHelpers
 
-  before do
-    FeatureFlag.activate('experimental_api_features')
-  end
-
   it 'clears test data' do
     create(
       :application_choice,

--- a/spec/requests/vendor_api/post_test_data_generate_spec.rb
+++ b/spec/requests/vendor_api/post_test_data_generate_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Vendor API - POST /api/v1/test-data/generate', type: :request do
   include VendorApiSpecHelpers
 
-  before do
-    FeatureFlag.activate('experimental_api_features')
-  end
-
   it 'generates test data' do
     create(:course_option, course: create(:course, :open_on_apply, provider: currently_authenticated_provider))
 


### PR DESCRIPTION
## Context

This feature is on and in use by vendors.

## Changes proposed in this pull request

Permanently enable the "experimental" features in the API.

## Link to Trello card

https://trello.com/c/h79j49U2/571-clean-up-feature-flags-for-launched-features

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
