### PR TITLE
Clean up email feature flags

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -23,9 +23,7 @@ module RefereeInterface
       )
 
       if @reference_form.save
-        if FeatureFlag.active?('send_reference_confirmation_email')
-          SendReferenceConfirmationEmail.call(application_form: @application, reference: reference)
-        end
+        SendReferenceConfirmationEmail.call(application_form: @application, reference: reference)
 
         redirect_to referee_interface_confirmation_path(token: @token_param)
       else

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -17,10 +17,8 @@ class AcceptOffer
       end
     end
 
-    if FeatureFlag.active?('offer_accepted_provider_emails')
-      @application_choice.provider.provider_users.each do |provider_user|
-        ProviderMailer.offer_accepted(provider_user, @application_choice).deliver
-      end
+    @application_choice.provider.provider_users.each do |provider_user|
+      ProviderMailer.offer_accepted(provider_user, @application_choice).deliver
     end
 
     StateChangeNotifier.call(:offer_accepted, application_choice: @application_choice)

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -8,10 +8,8 @@ class DeclineOffer
     @application_choice.update!(declined_at: Time.zone.now)
     StateChangeNotifier.call(:offer_declined, application_choice: @application_choice)
 
-    if FeatureFlag.active?('offer_declined_provider_emails')
-      @application_choice.provider.provider_users.each do |provider_user|
-        ProviderMailer.declined(provider_user, @application_choice).deliver
-      end
+    @application_choice.provider.provider_users.each do |provider_user|
+      ProviderMailer.declined(provider_user, @application_choice).deliver
     end
   end
 end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -10,7 +10,7 @@ class DeclineOfferByDefault
       application_form.application_choices.offer.each do |application_choice|
         application_choice.update!(declined_by_default: true, declined_at: Time.zone.now)
         ApplicationStateChange.new(application_choice).decline_by_default!
-        
+
         application_choice.provider.provider_users.each do |provider_user|
           ProviderMailer.declined_by_default(provider_user, application_choice).deliver
         end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -10,11 +10,9 @@ class DeclineOfferByDefault
       application_form.application_choices.offer.each do |application_choice|
         application_choice.update!(declined_by_default: true, declined_at: Time.zone.now)
         ApplicationStateChange.new(application_choice).decline_by_default!
-
-        if FeatureFlag.active?('decline_by_default_notification_to_provider')
-          application_choice.provider.provider_users.each do |provider_user|
-            ProviderMailer.declined_by_default(provider_user, application_choice).deliver
-          end
+        
+        application_choice.provider.provider_users.each do |provider_user|
+          ProviderMailer.declined_by_default(provider_user, application_choice).deliver
         end
       end
 

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -18,9 +18,7 @@ class DeclineOfferByDefault
         end
       end
 
-      if FeatureFlag.active?('decline_by_default_notification_to_candidate')
-        CandidateMailer.declined_by_default(application_form).deliver
-      end
+      CandidateMailer.declined_by_default(application_form).deliver
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -12,7 +12,6 @@ class FeatureFlag
     experimental_api_features
     force_ok_computer_to_fail
     improved_expired_token_flow
-    offer_accepted_provider_emails
     offer_declined_provider_emails
     pilot_open
     provider_application_filters

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,5 @@
 class FeatureFlag
-  FEATURES = %w[
-    automated_provider_chaser
+  FEATURES = %w[  
     automated_referee_chaser
     automated_referee_replacement
     candidate_rejected_by_provider_email

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,5 @@
 class FeatureFlag
-  FEATURES = %w[  
-    automated_decline_by_default_candidate_chaser
+  FEATURES = %w[
     automated_provider_chaser
     automated_referee_chaser
     automated_referee_replacement

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,5 @@
 class FeatureFlag
-  FEATURES = %w[
-    application_withrawn_provider_email
+  FEATURES = %w[  
     automated_decline_by_default_candidate_chaser
     automated_provider_chaser
     automated_referee_chaser

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,7 +6,6 @@ class FeatureFlag
     candidate_rejected_by_provider_email
     choose_study_mode
     confirm_conditions
-    decline_by_default_notification_to_candidate
     decline_by_default_notification_to_provider
     dfe_sign_in_incident
     edit_application

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,5 @@
 class FeatureFlag
   FEATURES = %w[
-    candidate_rejected_by_provider_email
     choose_study_mode
     confirm_conditions
     dfe_sign_in_incident

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -13,7 +13,6 @@ class FeatureFlag
     provider_change_response
     provider_interface_pagination
     send_dfe_sign_in_invitations
-    send_reference_confirmation_email
     show_new_referee_needed
     training_with_a_disability
     work_breaks

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,5 @@
 class FeatureFlag
-  FEATURES = %w[  
-    automated_referee_chaser
+  FEATURES = %w[
     automated_referee_replacement
     candidate_rejected_by_provider_email
     choose_study_mode

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -12,7 +12,6 @@ class FeatureFlag
     experimental_api_features
     force_ok_computer_to_fail
     improved_expired_token_flow
-    offer_declined_provider_emails
     pilot_open
     provider_application_filters
     provider_change_response

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -12,7 +12,6 @@ class FeatureFlag
     experimental_api_features
     force_ok_computer_to_fail
     improved_expired_token_flow
-    notify_candidate_of_new_reference
     offer_accepted_provider_emails
     offer_declined_provider_emails
     pilot_open

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -6,7 +6,6 @@ class FeatureFlag
     candidate_rejected_by_provider_email
     choose_study_mode
     confirm_conditions
-    decline_by_default_notification_to_provider
     dfe_sign_in_incident
     edit_application
     equality_and_diversity

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,6 +1,5 @@
 class FeatureFlag
   FEATURES = %w[
-    automated_referee_replacement
     candidate_rejected_by_provider_email
     choose_study_mode
     confirm_conditions

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -10,11 +10,7 @@ class ReceiveReference
   def save!
     ActiveRecord::Base.transaction do
       @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
-
-      if FeatureFlag.active?('notify_candidate_of_new_reference')
-        CandidateMailer.reference_received(@reference).deliver_later
-      end
-
+      CandidateMailer.reference_received(@reference).deliver_later
       progress_application_if_enough_references_have_been_submitted
     end
   end

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -23,10 +23,7 @@ class RejectApplication
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
-    if FeatureFlag.active?('candidate_rejected_by_provider_email')
-      SendCandidateRejectionEmail.new(application_choice: @application_choice).call
-    end
-    true
+    SendCandidateRejectionEmail.new(application_choice: @application_choice).call
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -10,7 +10,7 @@ class WithdrawApplication
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
 
       StateChangeNotifier.call(:withdraw, application_choice: application_choice)
-      send_email_notification_to_provider_users(application_choice) if FeatureFlag.active?('application_withrawn_provider_email')
+      send_email_notification_to_provider_users(application_choice)
     end
   end
 

--- a/app/workers/ask_candidates_for_new_referees_worker.rb
+++ b/app/workers/ask_candidates_for_new_referees_worker.rb
@@ -2,8 +2,6 @@ class AskCandidatesForNewRefereesWorker
   include Sidekiq::Worker
 
   def perform
-    return unless FeatureFlag.active?('automated_referee_replacement')
-
     GetRefereesThatNeedReplacing.call.each do |reference|
       SendNewRefereeRequestEmail.call(
         application_form: reference.application_form,

--- a/app/workers/send_chase_email_to_candidates_worker.rb
+++ b/app/workers/send_chase_email_to_candidates_worker.rb
@@ -2,8 +2,6 @@ class SendChaseEmailToCandidatesWorker
   include Sidekiq::Worker
 
   def perform
-    return unless FeatureFlag.active?('automated_decline_by_default_candidate_chaser')
-
     GetApplicationFormsForDeclineByDefaultReminder.call.each do |application|
       SendChaseEmailToCandidate.call(application_form: application)
     end

--- a/app/workers/send_chase_email_to_providers_worker.rb
+++ b/app/workers/send_chase_email_to_providers_worker.rb
@@ -2,8 +2,6 @@ class SendChaseEmailToProvidersWorker
   include Sidekiq::Worker
 
   def perform
-    return unless FeatureFlag.active?('automated_provider_chaser')
-
     GetApplicationFormsWaitingForProviderDecision.call.each do |application_choice|
       SendChaseEmailToProvider.call(application_choice: application_choice)
     end

--- a/app/workers/send_chase_email_to_referees_worker.rb
+++ b/app/workers/send_chase_email_to_referees_worker.rb
@@ -2,8 +2,6 @@ class SendChaseEmailToRefereesWorker
   include Sidekiq::Worker
 
   def perform
-    return unless FeatureFlag.active?('automated_referee_chaser')
-
     GetRefereesToChase.call.each do |reference|
       SendChaseEmailToRefereeAndCandidate.call(application_form: reference.application_form, reference: reference)
     end

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Candidate accepts an offer', sidekiq: true do
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and accepts' do
-    FeatureFlag.activate('offer_accepted_provider_emails')
-
     given_i_am_signed_in
     and_i_have_2_offers_on_my_choices
     and_1_choice_that_is_awaiting_provider_decision

--- a/spec/system/candidate_interface/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_declines_offer_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Candidate declines an offer', sidekiq: true do
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and declines' do
-    FeatureFlag.activate('offer_declined_provider_emails')
-
     given_i_am_signed_in
     and_i_have_an_offer
 

--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Receives rejection email' do
 
   scenario 'Receives rejection email' do
     given_the_pilot_is_open
-    and_candidate_rejected_by_provider_email_is_active
 
     when_all_but_one_of_my_application_choices_have_been_rejected
     and_a_provider_rejects_my_application
@@ -28,10 +27,6 @@ RSpec.feature 'Receives rejection email' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_candidate_rejected_by_provider_email_is_active
-    FeatureFlag.activate('candidate_rejected_by_provider_email')
   end
 
   def when_all_but_one_of_my_application_choices_have_been_rejected

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'A candidate withdraws her application' do
 
   scenario 'successful withdrawal', sidekiq: true do
     given_i_am_signed_in_as_a_candidate
-    and_the_application_withdrawn_provider_email_feature_flag_is_active
     and_i_have_an_application_choice_awaiting_provider_decision
 
     when_i_visit_the_application_dashboard
@@ -62,10 +61,6 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def then_i_see_the_page_not_found
     expect(page).to have_content('Page not found')
-  end
-
-  def and_the_application_withdrawn_provider_email_feature_flag_is_active
-    FeatureFlag.activate('application_withrawn_provider_email')
   end
 
   def and_the_provider_has_received_an_email

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -6,8 +6,7 @@ RSpec.feature 'Decline by default' do
 
   scenario 'An application is declined by default', sidekiq: true do
     given_the_pilot_is_open
-    and_the_automated_candidate_chaser_is_active
-
+    
     when_i_have_an_offer_waiting_for_my_decision
     and_the_time_limit_before_decline_by_default_date_has_been_exceeded
     then_i_receive_an_email_to_make_a_decision
@@ -20,10 +19,6 @@ RSpec.feature 'Decline by default' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_automated_candidate_chaser_is_active
-    FeatureFlag.activate('decline_by_default_notification_to_provider')
   end
 
   def when_i_have_an_offer_waiting_for_my_decision

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Decline by default' do
 
   scenario 'An application is declined by default', sidekiq: true do
     given_the_pilot_is_open
-    
+
     when_i_have_an_offer_waiting_for_my_decision
     and_the_time_limit_before_decline_by_default_date_has_been_exceeded
     then_i_receive_an_email_to_make_a_decision

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature 'Decline by default' do
   end
 
   def and_the_automated_candidate_chaser_is_active
-    FeatureFlag.activate('automated_decline_by_default_candidate_chaser')
     FeatureFlag.activate('decline_by_default_notification_to_candidate')
     FeatureFlag.activate('decline_by_default_notification_to_provider')
   end

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature 'Decline by default' do
   end
 
   def and_the_automated_candidate_chaser_is_active
-    FeatureFlag.activate('decline_by_default_notification_to_candidate')
     FeatureFlag.activate('decline_by_default_notification_to_provider')
   end
 

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'An application is waiting for decision for 20 working days' do
 
   scenario 'the provider receives a chaser email', sidekiq: true do
     FeatureFlag.activate('training_with_a_disability')
-    FeatureFlag.activate('automated_provider_chaser')
 
     given_a_candidate_has_submitted_an_application_form
     and_an_application_was_sent_to_provider

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
   scenario 'Referee submits a reference for a candidate' do
     FeatureFlag.activate('training_with_a_disability')
     FeatureFlag.activate('send_reference_confirmation_email')
-    FeatureFlag.activate('notify_candidate_of_new_reference')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
 
   scenario 'Referee submits a reference for a candidate' do
     FeatureFlag.activate('training_with_a_disability')
-    FeatureFlag.activate('send_reference_confirmation_email')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Referee does not respond in time', sidekiq: true do
 
   scenario 'Emails are sent if a referee does not respond in time' do
     FeatureFlag.activate('training_with_a_disability')
-    FeatureFlag.activate('automated_referee_replacement')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Referee does not respond in time', sidekiq: true do
 
   scenario 'Emails are sent if a referee does not respond in time' do
     FeatureFlag.activate('training_with_a_disability')
-    FeatureFlag.activate('automated_referee_chaser')
     FeatureFlag.activate('automated_referee_replacement')
 
     given_a_candidate_completed_an_application


### PR DESCRIPTION
## Context

We've added a lot of feature flags for the email notifications. We need them removed to keep the application from cluttering. 

## Changes proposed in this pull request

Remove the 12 feature flags 

-  application_withrawn_provider_email
-  automated_decline_by_default_candidate_chaser
-  automated_provider_chaser
-  automated_referee_chaser
-  automated_referee_replacement
-  candidate_rejected_by_provider_email
-  decline_by_default_notification_to_candidate
-  decline_by_default_notification_to_provider
-  notify_candidate_of_new_reference
- offer_accepted_provider_emails
- offer_declined_provider_emails
-  send_reference_confirmation_email

## Guidance to review

Just a sanity check that they've all been removed.

## Link to Trello card

https://trello.com/c/B8seo0Tz/1100-clean-up-feature-flags-for-emails

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
