### PR TITLE
Refactor candidate mailer specs

### DIFF
--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -61,7 +61,6 @@ class CandidateMailerPreview < ActionMailer::Preview
   def new_offer_single_offer
     course_option = FactoryBot.build_stubbed(:course_option)
     application_choice = application_form.application_choices.build(
-      id: 123,
       course_option: course_option,
       status: :offer,
       offer: { conditions: ['DBS check', 'Pass exams'] },
@@ -75,7 +74,6 @@ class CandidateMailerPreview < ActionMailer::Preview
   def new_offer_multiple_offers
     course_option = FactoryBot.build_stubbed(:course_option)
     application_choice = application_form.application_choices.build(
-      id: 123,
       course_option: course_option,
       status: :offer,
       offer: { conditions: ['DBS check', 'Pass exams'] },
@@ -85,7 +83,6 @@ class CandidateMailerPreview < ActionMailer::Preview
     )
     other_course_option = FactoryBot.build_stubbed(:course_option)
     application_form.application_choices.build(
-      id: 456,
       course_option: other_course_option,
       status: :offer,
       offer: { conditions: ['Get a degree'] },
@@ -99,7 +96,6 @@ class CandidateMailerPreview < ActionMailer::Preview
   def new_offer_decisions_pending
     course_option = FactoryBot.build_stubbed(:course_option)
     application_choice = application_form.application_choices.build(
-      id: 123,
       course_option: course_option,
       status: :offer,
       offer: { conditions: ['DBS check', 'Pass exams'] },
@@ -109,7 +105,6 @@ class CandidateMailerPreview < ActionMailer::Preview
     )
     other_course_option = FactoryBot.build_stubbed(:course_option)
     application_form.application_choices.build(
-      id: 456,
       course_option: other_course_option,
       status: :awaiting_provider_decision,
     )

--- a/app/views/candidate_mailer/application_rejected_offers_made.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_made.erb
@@ -13,7 +13,7 @@ If you don’t reply within <%= @dbd_days %> working days, your applications wil
 
 <% else %>
 
-You now have <%= @dbd_days %> working days to make a decision about your offer for a place on <%= @offers.first.course.name_and_code %> at <%= @offers.first.provider.name%>.
+You now have <%= @dbd_days %> working days to make a decision about your offer for a place on <%= @offers.first.course_option.course.name_and_code %> at <%= @offers.first.course_option.course.provider.name%>.
 
 <% end %>
 

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -5,7 +5,7 @@ Dear <%= @application_form.first_name %>,
 You have submitted an application for:
 
 <% @application_form.application_choices.each do |application_choice| %>
-* <%= application_choice.provider.name %> - <%= application_choice.course.name %> (<%= application_choice.course.code %>)
+* <%= application_choice.course_option.course.provider.name %> - <%= application_choice.course_option.course.name %> (<%= application_choice.course_option.course.code %>)
 <% end %>
 
 Your application reference is <%= @application_form.support_reference %>.

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -1,0 +1,183 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer, type: :mailer do
+  include CourseOptionHelpers
+  include ViewHelper
+  include TestHelpers::MailerSetupHelper
+
+  subject(:mailer) { described_class }
+
+  shared_examples 'a mail with subject and content' do |mail, subject, content|
+    let(:email) { described_class.send(mail, @application_choice) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(subject)
+    end
+
+    content.each do |key, expectation|
+      it "sends an email containing the #{key} in the body" do
+        expect(email.body).to include(expectation)
+      end
+    end
+  end
+
+  before do
+    setup_application
+  end
+
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 2, 11)) do
+      example.run
+    end
+  end
+
+  describe 'send new offer email to candidate' do
+    describe '#new_offer_single_offer' do
+      it_behaves_like(
+        'a mail with subject and content', :new_offer_single_offer,
+        'Offer received for Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
+        'heading' => 'Dear Bob',
+        'decline by default date' => 'Make a decision by 25 February 2020',
+        'first_condition' => 'DBS check',
+        'second_condition' => 'Pass exams'
+      )
+    end
+
+    describe '#new_offer_multiple_offers' do
+      before do
+        provider = build_stubbed(:provider, name: 'Falconholt Technical College')
+        other_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
+        @other_application_choice = @application_form.application_choices.build(
+          application_form: @application_form,
+          course_option: other_course_option,
+          status: :offer,
+          offer: { conditions: ['Get a degree'] },
+          offered_at: Time.zone.now,
+          offered_course_option: other_course_option,
+          decline_by_default_at: 5.business_days.from_now,
+        )
+        @application_form.application_choices = [@application_choice, @other_application_choice]
+      end
+
+      it_behaves_like(
+        'a mail with subject and content', :new_offer_multiple_offers,
+        'Offer received for Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
+        'heading' => 'Dear Bob',
+        'decline by default date' => 'Make a decision by 25 February 2020',
+        'first_condition' => 'DBS check',
+        'second_condition' => 'Pass exams',
+        'first_offer' => 'Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
+        'second_offers' => 'Forensic Science (E0FO) at Falconholt Technical College'
+      )
+    end
+
+    describe '#new_offer_decisions_pending' do
+      before do
+        provider = build_stubbed(:provider, name: 'Falconholt Technical College')
+        other_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
+        @other_application_choice = @application_form.application_choices.build(
+          application_form: @application_form,
+          course_option: other_course_option,
+          status: :awaiting_provider_decision,
+        )
+        @application_form.application_choices = [@application_choice, @other_application_choice]
+      end
+
+      it_behaves_like(
+        'a mail with subject and content', :new_offer_decisions_pending,
+        'Offer received for Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
+        'heading' => 'Dear Bob',
+        'first_condition' => 'DBS check',
+        'second_condition' => 'Pass exams',
+        'instructions' => 'You can wait to hear back about your other application(s) before making a decision'
+      )
+    end
+  end
+
+  describe 'application choice rejection emails' do
+    def setup_application
+      provider = build_stubbed(:provider, name: 'Falconholt Technical College')
+      course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Forensic Science', code: 'E0FO', provider: provider))
+      @application_form = build_stubbed(:application_form, first_name: 'Tyrell', last_name: 'Wellick')
+      @application_choice = @application_form.application_choices.build(
+        application_form: @application_form,
+        course_option: course_option,
+        status: :rejected,
+        rejection_reason: 'The application had little detail.',
+      )
+      @application_form.application_choices = [@application_choice]
+    end
+
+    context 'All application choices have been rejected email' do
+      it_behaves_like(
+        'a mail with subject and content', :application_rejected_all_rejected,
+        I18n.t!('candidate_mailer.application_rejected.all_rejected.subject', provider_name: 'Falconholt Technical College'),
+        'heading' => 'Dear Tyrell',
+        'course name and code' => 'Forensic Science (E0FO)',
+        'providers rejection reason' => 'The application had little detail.'
+      )
+    end
+
+    context 'Application rejected and awaiting further decisions' do
+      before do
+        provider = build_stubbed(:provider, name: 'Vertapple University')
+        course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Law', code: 'UFHG', provider: provider))
+        @application_choice_awaiting_provider_decision = @application_form.application_choices.build(
+          application_form: @application_form,
+          course_option: course_option,
+          status: :awaiting_provider_decision,
+          rejection_reason: 'The application had little detail.',
+        )
+      end
+
+      it_behaves_like(
+        'a mail with subject and content', :application_rejected_awaiting_decisions,
+        I18n.t!('candidate_mailer.application_rejected.awaiting_decisions.subject', provider_name: 'Falconholt Technical College', course_name: 'Forensic Science (E0FO)'),
+        'heading' => 'Dear Tyrell',
+        'course name and code' => 'Forensic Science (E0FO)',
+        'courses they are awaiting decisions' => 'Law (UFHG)',
+        'providers they are awaiting decisions' => 'Vertapple University'
+      )
+    end
+
+    context 'Application rejected and one offer has been made' do
+      before do
+        provider = build_stubbed(:provider, name: 'Vertapple University')
+        course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Law', code: 'UFHG', provider: provider))
+        @application_choice_with_offer = @application_form.application_choices.build(
+          application_form: @application_form,
+          course_option: course_option,
+          status: :offer,
+          decline_by_default_at: 10.business_days.from_now,
+          decline_by_default_days: 10,
+        )
+      end
+
+      it_behaves_like(
+        'a mail with subject and content', :application_rejected_offers_made,
+        I18n.t!('candidate_mailer.application_rejected.offers_made.subject', provider_name: 'Falconholt Technical College', dbd_days: 10),
+        'heading' => 'Dear Tyrell',
+        'course name and code' => 'Forensic Science (E0FO)',
+        'other course with an offer ' => 'Law (UFHG)',
+        'other provider they got an offer from' => 'Vertapple University',
+        'their DBD date' => 'Make a decision about your offer by 25 February 2020'
+      )
+    end
+
+    context 'Application rejected and multiple offers has been made' do
+      before do
+        setup_application_form_with_two_offers(@application_form)
+      end
+
+      it_behaves_like(
+        'a mail with subject and content', :application_rejected_offers_made,
+        I18n.t!('candidate_mailer.application_rejected.offers_made.subject', provider_name: 'Falconholt Technical College', dbd_days: 10),
+        'heading' => 'Dear Tyrell',
+        'course name and code' => 'MS Painting (P00)',
+        'first course with offer' => 'Code Refactoring (Z00)',
+        'first course provider with offer' => 'Wen University',
+        'their DBD date' => 'Make a decision about your offers by 25 February 2020'
+      )
+    end
+  end
+end

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe CandidateMailer, type: :mailer do
+  include CourseOptionHelpers
+  include ViewHelper
+
+  subject(:mailer) { described_class }
+
+  describe '.chase_reference' do
+    let(:application_form) { build(:completed_application_form, references_count: 1, with_gces: true) }
+    let(:reference) { application_form.application_references.first }
+    let(:mail) { mailer.chase_reference(reference) }
+
+    it 'sends an email with the correct subject' do
+      expect(mail.subject).to include(I18n.t!('candidate_mailer.chase_reference.subject', referee_name: reference.name))
+    end
+
+    it 'sends an email with the correct heading' do
+      expect(mail.body.encoded).to include("Dear #{application_form.first_name}")
+    end
+
+    it 'sends an email containing the referee email' do
+      expect(mail.body.encoded).to include(reference.email_address)
+    end
+  end
+
+  shared_examples 'a new reference request mail with subject and content' do |reason, subject, content|
+    let(:email) { described_class.send(:new_referee_request, @reference, reason: reason) }
+
+    it 'sends an email with the correct subject' do
+      expect(email.subject).to include(subject)
+    end
+
+    content.each do |key, expectation|
+      it "sends an email containing the #{key} in the body" do
+        expect(email.body).to include(expectation)
+      end
+    end
+  end
+
+  describe '.new_referee_request' do
+    before do
+      @reference = build_stubbed(
+        :reference,
+        name: 'Scott Knowles',
+        email_address: 'ting@canpaint.com',
+        application_form: build_stubbed(:application_form, first_name: 'Tyrell', last_name: 'Wellick'),
+)
+    end
+
+    context 'when referee has not responded' do
+      it_behaves_like('a new reference request mail with subject and content', :not_responded,
+                      I18n.t!('candidate_mailer.new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'),
+                      'heading' => 'Dear Tyrell',
+                      'explanation' => I18n.t!('candidate_mailer.new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles'))
+    end
+
+    context 'when referee has refused' do
+      it_behaves_like('a new reference request mail with subject and content', :refused,
+                      I18n.t!('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Scott Knowles'),
+                      'heading' => 'Dear Tyrell',
+                      'explanation' => I18n.t!('candidate_mailer.new_referee_request.refused.explanation', referee_name: 'Scott Knowles'))
+    end
+
+    context 'when email address of referee has bounced' do
+      it_behaves_like('a new reference request mail with subject and content', :email_bounced,
+                      I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
+                      'heading' => 'Dear Tyrell',
+                      'explanation' => "Our email requesting a reference didn’t reach Scott Knowles.\r\n\r\nWe emailed the referee using this address: ting@canpaint.com")
+    end
+  end
+end

--- a/spec/services/send_new_offer_email_to_candidate_spec.rb
+++ b/spec/services/send_new_offer_email_to_candidate_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe SendNewOfferEmailToCandidate do
         setup_application
         other_course_option = create(:course_option)
         @other_application_choice = @application_form.application_choices.create(
-          id: 456,
           application_form: @application_form,
           course_option: other_course_option,
           status: :offer,

--- a/spec/support/test_helpers/mailer_setup_helper.rb
+++ b/spec/support/test_helpers/mailer_setup_helper.rb
@@ -1,0 +1,50 @@
+module TestHelpers
+  module MailerSetupHelper
+    def setup_application
+      @candidate = build_stubbed(:candidate)
+      @application_form = build_stubbed(
+        :completed_application_form,
+        support_reference: 'SUPPORT-REFERENCE',
+        first_name: 'Bob',
+        candidate: @candidate,
+        references_count: 1,
+      )
+      provider = build_stubbed(:provider, name: 'Brighthurst Technical College')
+      course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Applied Science (Psychology)', code: '3TT5', provider: provider))
+
+      @application_choice = @application_form.application_choices.build(
+        application_form: @application_form,
+        course_option: course_option,
+        status: :offer,
+        offer: { conditions: ['DBS check', 'Pass exams'] },
+        offered_course_option: course_option,
+        decline_by_default_at: 10.business_days.from_now,
+        reject_by_default_days: 10,
+      )
+    end
+
+    def setup_application_form_with_two_offers(application_form)
+      first_provider = build_stubbed(:provider, name: 'Wen University')
+      first_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'MS Painting', code: 'P00', provider: first_provider))
+      first_application_choice_with_offer = application_form.application_choices.build(
+        application_form: application_form,
+        course_option: first_course_option,
+        status: :offer,
+        decline_by_default_at: 10.business_days.from_now,
+        decline_by_default_days: 10,
+      )
+
+      second_provider = build_stubbed(:provider, name: 'Ting University')
+      second_course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Code Refactoring', code: 'Z00', provider: second_provider))
+      second_application_choice_with_offer = application_form.application_choices.build(
+        application_form: application_form,
+        course_option: second_course_option,
+        status: :offer,
+        decline_by_default_at: 10.business_days.from_now,
+        decline_by_default_days: 10,
+      )
+
+      application_form.application_choices = application_form.application_choices + [first_application_choice_with_offer, second_application_choice_with_offer]
+    end
+  end
+end


### PR DESCRIPTION
## Context
The mailer specs are long and we want to refactor them, the candidate mailer is 700 lines long and it has some confusing setup. The previous PR #1515 refactored Provider Mailer specs, but the Candidate Mailer need some cleanup.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR refactors the candidate mailer specs:
- Split the mailer specs into separate files, based on their purpose such as `candidate_mailer_referee_mails_spec`, `candidate_mailer_offers_and_rejections_spec` and the rest of the candidate mails `candidate_mailer_spec`
- Add shared examples to dry out tests
- Add a `MailerSetupHelper` to cut down the duplicate test setups
- Eliminate all the usage of `:create` when stubbing test data 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
As discussed before, we might want to refactor the candidate mailer itself, but cleaning up the candidate mailer specs is good first step regardless. Does the usage of shared examples make sense? 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/Igu4bzNf/132-refactor-tests-or-mailers-to-make-mailer-specs-nicer-medium

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)