### PR TITLE
Fix work break length showing 1 year and 0 months

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -64,8 +64,10 @@ module ViewHelper
   def format_months_to_years_and_months(number_of_months)
     duration_parts = ActiveSupport::Duration.build(number_of_months.months).parts
 
-    if duration_parts[:years].positive?
+    if duration_parts[:years].positive? && duration_parts[:months].positive?
       "#{pluralize(duration_parts[:years], 'year')} and #{pluralize(duration_parts[:months], 'month')}"
+    elsif duration_parts[:years].positive?
+      pluralize(duration_parts[:years], 'year')
     else
       pluralize(number_of_months, 'month')
     end

--- a/spec/components/break_in_work_history_component_spec.rb
+++ b/spec/components/break_in_work_history_component_spec.rb
@@ -13,28 +13,12 @@ RSpec.describe BreakInWorkHistoryComponent do
     )
   end
 
-  context 'when work history break is less than 12 months' do
-    it 'renders the component with the break in months, reason and dates' do
-      result = render_inline(BreakInWorkHistoryComponent.new(work_break: work_break))
+  it 'renders the component with the break length, reason and dates' do
+    result = render_inline(BreakInWorkHistoryComponent.new(work_break: work_break))
 
-      expect(result.text).to include('Break in work history (1 month)')
-      expect(result.text).to include('I fell asleep.')
-      expect(result.text).to include('February 2019 - April 2019')
-    end
-  end
-
-  context 'when work history break is more than 12 months' do
-    it 'renders the component with the break in months' do
-      work_break = build_stubbed(
-        :application_work_history_break,
-        start_date: january2018,
-        end_date: april2019,
-        reason: 'I fell asleep.',
-      )
-      result = render_inline(BreakInWorkHistoryComponent.new(work_break: work_break))
-
-      expect(result.text).to include('Break in work history (1 year and 2 months)')
-    end
+    expect(result.text).to include('Break in work history (1 month)')
+    expect(result.text).to include('I fell asleep.')
+    expect(result.text).to include('February 2019 - April 2019')
   end
 
   context 'when editable' do

--- a/spec/components/break_placeholder_in_work_history_component_spec.rb
+++ b/spec/components/break_placeholder_in_work_history_component_spec.rb
@@ -21,25 +21,9 @@ RSpec.describe BreakPlaceholderInWorkHistoryComponent do
     expect(result.text).to include('add another job between January 2020 and May 2020')
   end
 
-  context 'when work history break is less than 12 months' do
-    it 'renders the component with the break in months' do
-      result = render_inline(BreakPlaceholderInWorkHistoryComponent.new(work_break: work_break))
+  it 'renders the component with the break length' do
+    result = render_inline(BreakPlaceholderInWorkHistoryComponent.new(work_break: work_break))
 
-      expect(result.text).to include('You have a break in your work history in the last 5 years (3 months)')
-    end
-  end
-
-  context 'when work history break is more than 12 months' do
-    before do
-      allow(work_break).to receive(:length).and_return(19)
-      allow(work_break).to receive(:start_date).and_return(Date.new(2018, 6, 1))
-      allow(work_break).to receive(:end_date).and_return(Date.new(2020, 2, 1))
-    end
-
-    it 'renders the component with the break in months' do
-      result = render_inline(BreakPlaceholderInWorkHistoryComponent.new(work_break: work_break))
-
-      expect(result.text).to include('You have a break in your work history in the last 5 years (1 year and 7 months)')
-    end
+    expect(result.text).to include('You have a break in your work history in the last 5 years (3 months)')
   end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -114,4 +114,24 @@ RSpec.describe ViewHelper, type: :helper do
       end
     end
   end
+
+  describe '#format_months_to_years_and_months' do
+    context 'when months is 12 months' do
+      it 'returns years and months' do
+        expect(helper.format_months_to_years_and_months(12)).to eq('1 year')
+      end
+    end
+
+    context 'when months is less than 12 months' do
+      it 'returns just the months' do
+        expect(helper.format_months_to_years_and_months(5)).to eq('5 months')
+      end
+    end
+
+    context 'when months is more than 12 months' do
+      it 'returns just the years and months' do
+        expect(helper.format_months_to_years_and_months(27)).to eq('2 years and 3 months')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

Paul H found a bug. When a work break is exactly 1 year, 2 years, etc we show "1 year and 0 months", it should show "1 year".

## Changes proposed in this pull request

This PR updates `ViewHelper#format_months_to_years_and_months` to only show years and months if there is a positive number of years and months. Tests were also added within the `ViewHelper` spec and removed from the component specs.

### Before

![image](https://user-images.githubusercontent.com/42817036/75965808-3d65c400-5ec1-11ea-88d0-9015f1e8f8c2.png)

### After

![image](https://user-images.githubusercontent.com/42817036/75965872-58383880-5ec1-11ea-9133-bdb7fc547c7b.png)

## Guidance to review

Does moving the specs make sense?

## Link to Trello card

https://trello.com/c/LZg4zEnH/1108-when-a-work-break-is-exactly-a-year-we-show-1-year-and-0-months-it-should-show-1-year

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
