### PR TITLE
Add 'Prefer not to say' option for equality and diversity sex question

### DIFF
--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -11,6 +11,8 @@
           <%= f.govuk_radio_button :sex, :female, label: { text: 'Female' }, link_errors: true %>
           <%= f.govuk_radio_button :sex, :male, label: { text: 'Male' } %>
           <%= f.govuk_radio_button :sex, :intersex, label: { text: 'Intersex' } %>
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_button :sex, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
         </div>
       <% end %>
 


### PR DESCRIPTION
## Context

We should have a 'Prefer not to say' option for the sex question in the Equality and Diversity questionnaire.

## Changes proposed in this pull request

This PR adds 'Prefer not to say' as an option by updating the `edit_sex.html.erb` view.

### Before

![image](https://user-images.githubusercontent.com/42817036/75975851-2dee7700-5ed1-11ea-8b25-5958b2fc358c.png)

### After

![image](https://user-images.githubusercontent.com/42817036/75975822-23cc7880-5ed1-11ea-9af2-939d7307be9a.png)

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
