### PR TITLE
Fix link styles

### DIFF
--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -8,7 +8,7 @@
 
     <p class="govuk-body">
       We couldn’t find the course you’re looking for – there may be a problem with the training provider and/or course code(s).
-      You can still <%= link_to 'proceed to the UCAS application form', UCAS.apply_url %>.
+      You can still <%= govuk_link_to 'proceed to the UCAS application form', UCAS.apply_url %>.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
Show link in correct blue colour on course not found page