### PR TITLE
Remove incorrect email from when_emails_are_sent page

### DIFF
--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -297,11 +297,13 @@ en:
       description: The provider says the candidate hasn’t met the conditions set out in the offer.
       emails:
         - candidate_mailer-conditions_not_met
-        - provider_mailer-application_withrawn
+
     pending_conditions-withdraw:
       name: Candidate withdraws
       by: candidate
       description: Candidates can withdraw at any time.
+      emails:
+        - provider_mailer-application_withrawn
 
     recruited-confirm_enrolment:
       name: Provider confirms enrolment


### PR DESCRIPTION
## Context

We say providers get an `application_withrawn` email on marking conditions not met. This isn't true.

Also, `application_withrawn` contains a typo. Will fix that in a separate PR (sidekiq might have references to it).

## Changes proposed in this pull request

Before

<img width="558" alt="Screenshot 2020-03-05 at 11 27 32" src="https://user-images.githubusercontent.com/642279/75977645-c63a2b00-5ed4-11ea-8730-ee95435b3fe9.png">

After

<img width="536" alt="Screenshot 2020-03-05 at 11 28 14" src="https://user-images.githubusercontent.com/642279/75977651-c89c8500-5ed4-11ea-87e4-c8a0ba717fed.png">

