### PR TITLE
Add prefer not to say choice to disabilities status page

### DIFF
--- a/app/components/candidate_interface/equality_and_diversity_review_component.rb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.rb
@@ -23,6 +23,8 @@ module CandidateInterface
     def disabilities_row
       disabilties = if @application_form.equality_and_diversity['disabilities'].empty?
                       'No'
+                    elsif @application_form.equality_and_diversity['disabilities'].include?('Prefer not to say')
+                      'Prefer not to say'
                     else
                       "Yes (#{@application_form.equality_and_diversity['disabilities'].to_sentence(last_word_connector: ' and ')})"
                     end

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -31,7 +31,7 @@ module CandidateInterface
       @disability_status = EqualityAndDiversity::DisabilityStatusForm.new(disability_status: disability_status_param)
 
       if @disability_status.save(current_application)
-        if disability_status_param == 'no'
+        if disability_status_param == 'no' || disability_status_param == 'Prefer not to say'
           if current_application.equality_and_diversity['ethnic_group'].nil?
             redirect_to candidate_interface_edit_equality_and_diversity_ethnic_group_path
           else

--- a/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
@@ -10,6 +10,8 @@
         <div class="govuk-!-margin-top-6">
           <%= f.govuk_radio_button :disability_status, :yes, label: { text: 'Yes' }, link_errors: true %>
           <%= f.govuk_radio_button :disability_status, :no, label: { text: 'No' } %>
+          <%= f.govuk_radio_divider %>
+          <%= f.govuk_radio_button :disability_status, 'Prefer not to say', label: { text: 'Prefer not to say' } %>
         </div>
       <% end %>
 

--- a/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
+++ b/spec/components/candidate_interface/equality_and_diversity_review_component_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe CandidateInterface::EqualityAndDiversityReviewComponent do
     end
   end
 
+  context 'when the disabilities has value Prefer not to say' do
+    it 'displays "Prefer not to say"' do
+      application_form.equality_and_diversity = { 'sex' => 'male', 'disabilities' => ['Prefer not to say'] }
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Disability')
+      expect(result.css('.govuk-summary-list__value').text).to include('Prefer not to say')
+      expect(result.css('.govuk-summary-list__value').text).not_to include('Yes')
+    end
+  end
+
   context 'when there are values for ethnic group and ethnic background' do
     it 'displays the ethnic group and ethnic background in brackets' do
       application_form.equality_and_diversity = {

--- a/spec/models/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
+++ b/spec/models/candidate_interface/equality_and_diversity/disability_status_form_spec.rb
@@ -2,6 +2,15 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, type: :model do
   describe '.build_from_application' do
+    context 'when an application form disabilities set to: Prefer not to say' do
+      it 'creates an new disability status form with disability status set to Prefer not to say' do
+        application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => ['Prefer not to say'] })
+        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.build_from_application(application_form)
+
+        expect(form.disability_status).to eq('Prefer not to say')
+      end
+    end
+
     context 'when an application form has no disabilities' do
       it 'creates an new disability status form with disability status set to no' do
         application_form = build_stubbed(:application_form, equality_and_diversity: { 'disabilities' => [] })
@@ -83,6 +92,26 @@ RSpec.describe CandidateInterface::EqualityAndDiversity::DisabilityStatusForm, t
       it 'resets the disabilities of equality and diversity information if disability status is no' do
         application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
         form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'no')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'disabilities' => [],
+        )
+      end
+
+      it 'resets the disabilities of equality and diversity information if disability status is Prefer not to say' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => %w[Blind] })
+        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'Prefer not to say')
+        form.save(application_form)
+
+        expect(application_form.equality_and_diversity).to eq(
+          'sex' => 'male', 'disabilities' => ['Prefer not to say'],
+        )
+      end
+
+      it 'resets the disabilities of equality and diversity information if disability status is yes' do
+        application_form = create(:application_form, equality_and_diversity: { 'sex' => 'male', 'disabilities' => ['Prefer not to say'] })
+        form = CandidateInterface::EqualityAndDiversity::DisabilityStatusForm.new(disability_status: 'yes')
         form.save(application_form)
 
         expect(application_form.equality_and_diversity).to eq(


### PR DESCRIPTION
## Context
We should have a 'Prefer not to say' option for the `Are you disabled?` question in the Equality and Diversity questionnaire.

## Changes proposed in this pull request

This PR adds 'Prefer not to say' as an option to `Are you disabled?` page

![image](https://user-images.githubusercontent.com/22743709/75979881-5a0df600-5ed9-11ea-99a4-8d1ab7b9cb55.png)

## Guidance to review

N/A

## Link to Trello card
https://trello.com/c/TTUZPTgz/206-candidates-can-provide-equality-and-diversity-information-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
