### PR TITLE
Remove pagination feature flag

### DIFF
--- a/app/components/paginator_component.rb
+++ b/app/components/paginator_component.rb
@@ -6,7 +6,7 @@ class PaginatorComponent < ActionView::Component::Base
   end
 
   def render?
-    FeatureFlag.active?('provider_interface_pagination') && @scope.total_pages > 1
+    @scope.total_pages > 1
   end
 
   def page_start

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -7,7 +7,7 @@ module ProviderInterface
       application_choices = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
         .order(ordering_arguments(@sort_by, @sort_order))
 
-      application_choices = application_choices.page(params[:page] || 1) if FeatureFlag.active?('provider_interface_pagination')
+      application_choices = application_choices.page(params[:page] || 1)
 
       if FeatureFlag.active?('provider_application_filters')
         raise 'feature not implemented yet'

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,7 +22,6 @@ class FeatureFlag
     pilot_open
     provider_application_filters
     provider_change_response
-    provider_interface_pagination
     send_dfe_sign_in_invitations
     send_reference_confirmation_email
     show_new_referee_needed

--- a/spec/components/paginator_component_spec.rb
+++ b/spec/components/paginator_component_spec.rb
@@ -21,17 +21,7 @@ RSpec.describe PaginatorComponent do
     render_inline(component)
   end
 
-  context 'when the feature flag is OFF' do
-    context 'when we are on the first of two pages' do
-      it 'renders nothing' do
-        expect(rendered_component(current_page: 1, total_count: 29).text).to eq ''
-      end
-    end
-  end
-
-  context 'when the feature flag is ON' do
-    before { FeatureFlag.activate('provider_interface_pagination') }
-
+  context 'pagination behaviour' do
     context 'when there is only one page' do
       it 'renders nothing' do
         expect(rendered_component.text).to eq ''

--- a/spec/system/provider_interface/provider_applications_pagination_spec.rb
+++ b/spec/system/provider_interface/provider_applications_pagination_spec.rb
@@ -6,7 +6,6 @@ RSpec.feature 'Providers should be able to sort applications' do
 
   scenario 'viewing applications one page at a time' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_pagination_feature_is_active
     and_i_am_permitted_to_see_applications_for_my_provider
     and_my_organisation_has_less_than_25_applications
     and_i_sign_in_to_the_provider_interface
@@ -21,18 +20,10 @@ RSpec.feature 'Providers should be able to sort applications' do
     when_i_click_next
     then_i_should_see_page_2
     then_i_should_see_a_paginator_for_page_2
-
-    when_pagination_feature_is_deactivated
-    when_i_visit_the_provider_applications_page
-    then_i_should_not_see_a_paginator
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
-  end
-
-  def and_pagination_feature_is_active
-    FeatureFlag.activate('provider_interface_pagination')
   end
 
   def and_i_am_permitted_to_see_applications_for_my_provider
@@ -101,10 +92,6 @@ RSpec.feature 'Providers should be able to sort applications' do
     expect(page).to have_link('Previous')
     expect(page).to have_link('1')
     expect(page).to have_content('Showing 26 to')
-  end
-
-  def when_pagination_feature_is_deactivated
-    FeatureFlag.deactivate('provider_interface_pagination')
   end
 
   def then_i_should_not_see_a_paginator


### PR DESCRIPTION
## Context

After discussions with Ravi, we (me, Ravi, @duncanjbrown) was decided to remove the feature flag for pagination, as it mean having extra boolean logic to turn it on and off within scoping of the `provider_applications_filter` feature flag. 

We came to the conclusion that it was unlikely that we would ever need to remove pagination and removing the feature flag for pagination would reduce a little of the complexity in `ApplicationChoicesController`

## Changes proposed in this pull request

Remove feature flag for pagination (effectively turning pagination on for provider application choices by default).

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
