### PR TITLE
Export provider data CSV through Support

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -18,6 +18,20 @@ module SupportInterface
       render plain: csv
     end
 
+    def providers_export
+      providers = SupportInterface::ProvidersExport.new.providers
+
+      csv = CSV.generate do |rows|
+        rows << providers.first.keys
+
+        providers.each do |a|
+          rows << a.values
+        end
+      end
+
+      render plain: csv
+    end
+
     def referee_survey
       responses = SupportInterface::RefereeSurveyExport.new.call
 

--- a/app/services/support_interface/providers_export.rb
+++ b/app/services/support_interface/providers_export.rb
@@ -1,0 +1,23 @@
+module SupportInterface
+  class ProvidersExport
+    def providers
+      relevant_providers.map do |provider|
+        {
+          name: provider.name,
+          code: provider.code,
+          agreement_accepted_at: provider.provider_agreements.where.not(accepted_at: nil).first&.accepted_at,
+        }
+      end
+    end
+
+  private
+
+    def relevant_providers
+      Provider
+        .includes(
+          :provider_agreements,
+        )
+        .where(sync_courses: true)
+    end
+  end
+end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -19,6 +19,17 @@
   <%= govuk_link_to 'Download application timings (CSV)', support_interface_application_timings_path %>
 </p>
 
+<h3 class='govuk-heading-m'>Providers</h3>
+
+<p class='govuk-body'>
+  The list of providers that are being synced from the Find service, along
+  with when they signed the data sharing agreement.
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download providers (CSV)', support_interface_providers_export_path %>
+</p>
+
 <h3 class='govuk-heading-m'>Referee survey</h3>
 
 <p class='govuk-body'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -394,6 +394,7 @@ Rails.application.routes.draw do
     get '/performance' => 'performance#index', as: :performance
     get '/performance/application-timings', to: 'performance#application_timings', as: :application_timings
     get '/performance/referee-survey', to: 'performance#referee_survey', as: :referee_survey
+    get '/performance/providers', to: 'performance#providers_export', as: :providers_export
 
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task

--- a/spec/services/support_interface/providers_export_spec.rb
+++ b/spec/services/support_interface/providers_export_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ProvidersExport, with_audited: true do
+  describe '#providers' do
+    it 'returns synced providers and the date they signed the data sharing agreement' do
+      create(:provider, sync_courses: false)
+      provider_without_signed_dsa = create(:provider, sync_courses: true)
+      provider_with_signed_dsa = nil
+      Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
+        provider_with_signed_dsa = create(:provider, :with_signed_agreement, sync_courses: true)
+      end
+
+      providers = described_class.new.providers
+      expect(providers.size).to eq(2)
+
+      expect(providers).to contain_exactly(
+        {
+          name: provider_with_signed_dsa.name,
+          code: provider_with_signed_dsa.code,
+          agreement_accepted_at: Time.zone.local(2019, 10, 1, 12, 0, 0),
+        },
+        {
+          name: provider_without_signed_dsa.name,
+          code: provider_without_signed_dsa.code,
+          agreement_accepted_at: nil,
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Context

We need provider data (including roughly when they were on-boarded) to feed the service dashboard. This is alongside the application exports data introduced in #1240.

## Changes proposed in this pull request

Add another export for provider data to the support interface.

Here's an example:

```csv
name,code,agreement_accepted_at
Gorse SCITT,1N1,2020-02-21 17:33:42 +0000
Oriel High School,2LR,
University of Chichester,C58,
```

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
