### PR TITLE
SPIKE: Provider UI application timeline 

### DIFF
--- a/app/components/provider_interface/application_timeline_component.html.erb
+++ b/app/components/provider_interface/application_timeline_component.html.erb
@@ -1,19 +1,17 @@
 <h2 class="govuk-heading-l">Timeline</h2>
 <div class="app-timeline">
-  <div class="app-timeline__item">
+  <% entries.each do |entry| %>
+    <div class="app-timeline__item">
+      <div class="app-timeline__header">
+        <h2 class="app-timeline__title"><%= entry.action %></h2>
+        <p class="app-timeline__byline">by <%= entry.actor %></p>
+      </div>
 
-    <div class="app-timeline__header">
-      <h2 class="app-timeline__title">Application submitted</h2>
+      <p class="app-timeline__date">
+        <time datetime="<%= entry.date.iso8601 %>"><%= entry.date.to_s(:govuk_date) %></time>
+      </p>
 
-      <p class="app-timeline__byline">by candidate</p>
-
+      <div class="app-timeline__description"></div>
     </div>
-
-    <p class="app-timeline__date">
-    <time datetime="2019-10-10">10 Oct 2019</time>
-    </p>
-
-    <div class="app-timeline__description"></div>
-
-  </div>
+  <% end %>
 </div>

--- a/app/components/provider_interface/application_timeline_component.html.erb
+++ b/app/components/provider_interface/application_timeline_component.html.erb
@@ -1,0 +1,19 @@
+<h2 class="govuk-heading-l">Timeline</h2>
+<div class="app-timeline">
+  <div class="app-timeline__item">
+
+    <div class="app-timeline__header">
+      <h2 class="app-timeline__title">Application submitted</h2>
+
+      <p class="app-timeline__byline">by candidate</p>
+
+    </div>
+
+    <p class="app-timeline__date">
+    <time datetime="2019-10-10">10 Oct 2019</time>
+    </p>
+
+    <div class="app-timeline__description"></div>
+
+  </div>
+</div>

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -1,7 +1,62 @@
 module ProviderInterface
   class ApplicationTimelineComponent < ActionView::Component::Base
+    TimelineEntry = Struct.new(:actor, :action, :date)
+
+    STATUSES_TO_INCLUDE = %w[
+      awaiting_provider_decision
+      rejected
+      offer
+      declined
+      pending_conditions
+      conditions_not_met
+      recruited
+      enrolled
+    ].freeze
+
     def initialize(application_choice:)
       @application_choice = application_choice
+    end
+
+    def entries
+      relevant_audits = @application_choice.audits.where("audited_changes->>'status' IS NOT NULL").order(created_at: :desc)
+
+      relevant_audits.map(&:user)
+      relevant_audits.reduce([]) do |chronology, audit|
+        new_status = Array.wrap(audit.audited_changes['status']).second
+
+        if new_status.present? && timeline_should_include?(new_status)
+          chronology.push(TimelineEntry.new(actor_for(audit), action_for(new_status), audit.created_at))
+        end
+
+        chronology
+      end
+    end
+
+  private
+
+    def timeline_should_include?(status)
+      STATUSES_TO_INCLUDE.include?(status)
+    end
+
+    def actor_for(audit)
+      if audit.user_type == "Candidate"
+        'candidate'
+      else
+        audit.user
+      end
+    end
+
+    def action_for(new_status)
+      {
+        'awaiting_provider_decision' => 'Application submitted',
+        'rejected' => 'Application rejected',
+        'offer' => 'Offer made',
+        'declined' => 'Offer declined',
+        'pending_conditions' => 'Offer accepted',
+        'conditions_not_met' => 'Conditions marked not met',
+        'recruited' => 'Conditions marked met',
+        'enrolled' => 'Candidate enrolled',
+      }.fetch(new_status)
     end
   end
 end

--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -1,0 +1,7 @@
+module ProviderInterface
+  class ApplicationTimelineComponent < ActionView::Component::Base
+    def initialize(application_choice:)
+      @application_choice = application_choice
+    end
+  end
+end

--- a/app/frontend/styles/_timeline.scss
+++ b/app/frontend/styles/_timeline.scss
@@ -1,0 +1,116 @@
+/* ==========================================================================
+   #TIMELINE
+   ========================================================================== */
+
+.app-timeline {
+  margin-bottom: govuk-spacing(4);
+  // overflow: hidden;
+  position: relative;
+
+  &:before {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 5px;
+  }
+
+}
+
+.app-timeline--full {
+  margin-bottom: 0;
+  &:before {
+    height: calc(100% - 75px);
+  }
+}
+
+.app-timeline__item {
+  padding-bottom: govuk-spacing(6);
+  padding-left: govuk-spacing(4);
+  position: relative;
+
+  &:before {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 5px;
+    left: 0;
+    position: absolute;
+    top: govuk-spacing(2);
+    width: 15px;
+  }
+
+}
+
+.app-timeline__item:last-child {
+  &:after {
+    background-color: govuk-colour("blue");
+    content: "";
+    height: 5px;
+    left: -5px;
+    position: absolute;
+    bottom: -10px;
+    width: 15px;
+  }
+}
+
+.app-timeline__title {
+  @include govuk-font($size: 19, $weight: bold);
+  display: inline;
+}
+
+.app-timeline__byline {
+  @include govuk-font($size: 19);
+  color: $govuk-secondary-text-colour;
+  display: inline;
+  margin: 0;
+}
+
+.app-timeline__date {
+  @include govuk-font($size: 16);
+  margin-top: govuk-spacing(1);
+  margin-bottom: 0;
+}
+
+.app-timeline__description {
+  @include govuk-font($size: 19);
+  margin-top: govuk-spacing(4);
+}
+
+/* ==========================================================================
+   #TIMELINE DOCUMENT STYLES – FOR BACKWARDS COMPATIBILITY
+   ========================================================================== */
+
+.app-timeline__documents {
+  list-style: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.app-timeline__document-item {
+  margin-bottom: govuk-spacing(1);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+}
+
+.app-timeline__document-link {
+  // background-image: url(#{$app-images-path}icon-document.svg);
+  background-repeat: no-repeat;
+  background-size: 20px 16px;
+  background-position: 0 50%;
+  padding-left: govuk-spacing(5);
+
+  &:focus {
+    color: govuk-colour("black"); // Focus colour on yellow should really be black.
+  }
+
+  // IE8 does not support box shadow, so use a standard border.
+  @include govuk-if-ie8 {
+    // background-image: url(#{$app-images-path}icon-document.png);
+  }
+
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -38,6 +38,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "~@ministryofjustice/frontend/moj/objects/filter-layout";
 @import "~@ministryofjustice/frontend/moj/components/filter/filter";
 @import "_filter";
+@import "_timeline";
 
 // Support
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -15,6 +15,7 @@ class FeatureFlag
     training_with_a_disability
     work_breaks
     you_selected_a_course_page
+    provider_ui_application_timeline
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -22,6 +22,11 @@
   <div class="govuk-grid-column-two-thirds">
   <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
   </div>
+  <% if FeatureFlag.active?('provider_ui_application_timeline') %>
+    <div class="govuk-grid-column-one-third">
+      <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
+    </div>
+  <% end %>
 </div>
 
 <div class="govuk-grid-row">

--- a/spec/system/provider_interface/provider_sees_empty_state_spec.rb
+++ b/spec/system/provider_interface/provider_sees_empty_state_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'See applications' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider user visits the Provider interface when there are no applications for their provider' do
+    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    and_my_training_provider_exists
+    and_another_organisation_has_applications
+
+    when_i_have_been_assigned_to_my_training_provider
+    and_i_sign_in_to_the_provider_interface
+
+    then_i_should_see_no_applications
+  end
+
+  def given_i_am_a_provider_user_authenticated_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_my_training_provider_exists
+    create(:provider, :with_signed_agreement, code: 'ABC')
+  end
+
+  def and_another_organisation_has_applications
+    other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
+
+    @other_provider_choice = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
+  end
+
+  def when_i_have_been_assigned_to_my_training_provider
+    provider_user_exists_in_apply_database
+  end
+  def then_i_should_see_no_applications
+    expect(page).to have_content 'You haven’t received any applications'
+    expect(page).not_to have_selector('.govuk-table')
+  end
+end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -15,8 +15,10 @@ RSpec.feature 'See applications' do
     and_i_sign_in_to_the_provider_interface
     then_i_should_see_the_applications_from_my_organisation
 
+    given_the_timeline_feature_flag_is_on
     when_i_click_on_an_application
     then_i_should_be_on_the_application_view_page
+    and_i_should_see_the_application_timeline_with_a_submitted_date
   end
 
   def when_my_apply_account_has_been_created
@@ -68,5 +70,15 @@ RSpec.feature 'See applications' do
   def then_i_should_be_on_the_application_view_page
     expect(page).to have_content @my_provider_choice1.application_form.support_reference
     expect(page).to have_content @my_provider_choice1.application_form.first_name
+  end
+
+  def given_the_timeline_feature_flag_is_on
+    FeatureFlag.activate('provider_ui_application_timeline')
+  end
+
+  def and_i_should_see_the_application_timeline_with_a_submitted_date
+    within('.app-timeline') do
+      expect(page).to have_content "Application submitted\nby candidate"
+    end
   end
 end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -4,17 +4,6 @@ RSpec.feature 'See applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  scenario 'Provider visits applications when there are none' do
-    given_i_am_a_provider_user_authenticated_with_dfe_sign_in
-    and_my_training_provider_exists
-    and_another_organisation_has_applications
-
-    when_i_have_been_assigned_to_my_training_provider
-    and_i_sign_in_to_the_provider_interface
-
-    then_i_should_see_no_applications
-  end
-
   scenario 'Provider visits application page' do
     given_i_am_a_provider_user_authenticated_with_dfe_sign_in
     and_my_organisation_has_applications
@@ -59,12 +48,6 @@ RSpec.feature 'See applications' do
     @my_provider_choice2  = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: course_option)
   end
 
-  def and_another_organisation_has_applications
-    other_course_option = course_option_for_provider_code(provider_code: 'ANOTHER_ORG')
-
-    @other_provider_choice = create(:submitted_application_choice, status: 'awaiting_provider_decision', course_option: other_course_option)
-  end
-
   def and_i_visit_the_provider_page
     visit provider_interface_path
   end
@@ -76,15 +59,6 @@ RSpec.feature 'See applications' do
     expect(page).to have_content @my_provider_choice1.application_form.first_name
     expect(page).to have_content @my_provider_choice2.application_form.support_reference
     expect(page).to have_content @my_provider_choice2.application_form.first_name
-  end
-
-  def then_i_should_see_no_applications
-    expect(page).to have_content 'You haven’t received any applications'
-    expect(page).not_to have_selector('.govuk-table')
-  end
-
-  def but_not_the_applications_from_other_providers
-    expect(page).not_to have_content @other_provider_choice.application_form.first_name
   end
 
   def when_i_click_on_an_application


### PR DESCRIPTION
This is a spike into implementing the provider UI application timeline.

**Findings**

This is v doable, but we should consider a couple of upfront refactors:

- test data generation doesn't do right by the audit log. Everything is attributed to the Candidate. Also, everything happens at the same date/time which isn't realistic.
- we still audit provider updates as a string `email@example.com (Provider)`, not a link to a `ProviderUser`, which we ought to turn into a proper association

Incidentally, we bump into the question we faced around logging *transitions* as well as *states*, last seen when we were looking into how we handled an application transitioning between offer and reject (ie withdrawn by provider). There's some manual mapping in the component to accommodate this.

This code also needs to handle VendorApiUsers.

## Link to Trello card

https://trello.com/c/ZvgOpW5Z/1697-implement-the-new-timeline-design-for-applications-on-the-provider-ui-application-page
