### PR TITLE
Allow provider users to modify existing offers (offered course) via the UI

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,22 +1,22 @@
 <% @course_choices.each do |course_choice| %>
   <div class='qa-application-choice-<%= course_choice.id %>'>
   <%= render(SummaryCardComponent.new(rows: course_choice_rows(course_choice), editable: @editable)) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: course_choice.provider.name, heading_level: @heading_level)) do %>
+    <%= render(SummaryCardHeaderComponent.new(title: course_choice.offered_course.provider.name, heading_level: @heading_level)) do %>
       <div class='app-summary-card__actions'>
         <% if course_choice.offer? %>
           <%= link_to candidate_interface_offer_path(course_choice.id), class: 'govuk-link', data: { action: :respond } do %>
             <%= t('application_form.courses.view_and_respond_to_offer') %>
-            <span class="govuk-visually-hidden"> <%= course_choice.course.name_and_code %></span>
+            <span class="govuk-visually-hidden"> <%= course_choice.offered_course.name_and_code %></span>
           <% end %>
         <% elsif withdrawable?(course_choice) %>
           <%= link_to candidate_interface_withdraw_path(course_choice.id), class: 'govuk-link', data: { action: :withdraw } do %>
             <%= t('application_form.courses.withdraw') %>
-            <span class="govuk-visually-hidden"> <%= course_choice.course.name_and_code %></span>
+            <span class="govuk-visually-hidden"> <%= course_choice.offered_course.name_and_code %></span>
           <% end %>
         <% elsif @editable %>
           <%= link_to candidate_interface_confirm_destroy_course_choice_path(course_choice.id), class: 'govuk-link', data: { action: :delete } do %>
             <%= t('application_form.courses.delete') %>
-            <span class="govuk-visually-hidden"> <%= course_choice.course.name_and_code %></span>
+            <span class="govuk-visually-hidden"> <%= course_choice.offered_course.name_and_code %></span>
           <% end %>
         <% end %>
       </div>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -5,7 +5,7 @@ module CandidateInterface
 
     def initialize(application_form:, editable: true, heading_level: 2, show_status: false, show_incomplete: false, missing_error: false)
       @application_form = application_form
-      @course_choices = @application_form.application_choices.includes(:course, :site, :provider).order(id: :asc)
+      @course_choices = @application_form.application_choices.includes(:course, :site, :provider, :offered_course_option).order(id: :asc)
       @editable = editable
       @heading_level = heading_level
       @show_status = show_status
@@ -51,21 +51,21 @@ module CandidateInterface
 
       {
         key: 'Course',
-        value: govuk_link_to("#{course_choice.course.name} (#{course_choice.course.code})", url, target: '_blank', rel: 'noopener'),
+        value: govuk_link_to("#{course_choice.offered_course.name} (#{course_choice.offered_course.code})", url, target: '_blank', rel: 'noopener'),
       }
     end
 
     def location_row(course_choice)
       {
         key: 'Location',
-        value: "#{course_choice.site.name}\n#{course_choice.site.full_address}",
+        value: "#{course_choice.offered_site.name}\n#{course_choice.offered_site.full_address}",
       }
     end
 
     def study_mode_row(course_choice)
       {
         key: 'Full time or part time',
-        value: course_choice.course_option.study_mode.humanize,
+        value: course_choice.offered_option.study_mode.humanize,
       }
     end
 

--- a/app/components/candidate_interface/offer_review_component.rb
+++ b/app/components/candidate_interface/offer_review_component.rb
@@ -22,33 +22,29 @@ module CandidateInterface
     def provider_row
       {
         key: 'Provider',
-        value: @course_choice.course.provider.name,
+        value: @course_choice.offered_course.provider.name,
       }
     end
 
     def course_row
       {
         key: 'Course',
-        value: formatted_course_name_and_code,
+        value: @course_choice.offered_course.name_and_code,
       }
     end
 
     def location_row
       {
         key: 'Location',
-        value: @course_choice.course_option.site.name,
+        value: @course_choice.offered_option.site.name,
       }
     end
 
     def conditions_row
       {
         key: 'Conditions',
-        value: render(OfferConditionsReviewComponent.new(conditions: @course_choice.offer['conditions'], provider: @course_choice.course.provider.name)),
+        value: render(OfferConditionsReviewComponent.new(conditions: @course_choice.offer['conditions'], provider: @course_choice.offered_course.provider.name)),
       }
-    end
-
-    def formatted_course_name_and_code
-      "#{@course_choice.course_option.course.name} (#{@course_choice.course_option.course.code})"
     end
   end
 end

--- a/app/components/previews/provider_interface/offer_summary_list_component_preview.rb
+++ b/app/components/previews/provider_interface/offer_summary_list_component_preview.rb
@@ -1,0 +1,21 @@
+module ProviderInterface
+  class OfferSummaryListComponentPreview < ActionView::Component::Preview
+    def application_choice_with_offer
+      render_component_for choices: ApplicationChoice.where(status: :offer)
+    end
+
+    def application_choice_without_offer
+      render_component_for choices: ApplicationChoice.where(status: :awaiting_provider_decision)
+    end
+
+  private
+
+    def render_component_for(choices:)
+      if !choices.empty?
+        render ProviderInterface::OfferSummaryListComponent.new(application_choice: choices.order('RANDOM()').first)
+      else
+        render template: 'support_interface/docs/missing_test_data'
+      end
+    end
+  end
+end

--- a/app/components/provider_interface/offer_summary_list_component.html.erb
+++ b/app/components/provider_interface/offer_summary_list_component.html.erb
@@ -1,0 +1,2 @@
+<h2 class="govuk-heading-m"><%= header %></h2>
+<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -1,0 +1,38 @@
+module ProviderInterface
+  class OfferSummaryListComponent < ActionView::Component::Base
+    include ViewHelper
+    attr_reader :application_choice, :header
+
+    def initialize(application_choice:, header: 'Your offer')
+      @application_choice = application_choice
+      @header = header
+    end
+
+    def render?
+      application_choice.offer.present? || raise(NoOfferError)
+    end
+
+    def rows
+      [
+        {
+          key: 'Candidate name',
+          value: application_choice.application_form.full_name,
+        },
+        {
+          key: 'Provider',
+          value: application_choice.offered_course.provider.name,
+        },
+        {
+          key: 'Course',
+          value: application_choice.offered_course.name_and_code,
+        },
+        {
+          key: 'Location',
+          value: application_choice.offered_site.name_and_address,
+        },
+      ]
+    end
+
+    class NoOfferError < StandardError; end
+  end
+end

--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -3,6 +3,8 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
+<% if FeatureFlag.active?('provider_change_response') %>
 <p class="govuk-body govuk-!-margin-bottom-0">
   <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
 </p>
+<% end %>

--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -3,10 +3,6 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
-<% if FeatureFlag.active?('provider_change_response') %>
-  <%= govuk_button_link_to 'Change response', provider_interface_application_choice_edit_response_path(application_choice) %>
-<% end %>
-
 <p class="govuk-body govuk-!-margin-bottom-0">
   <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
 </p>

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -26,16 +26,33 @@ module ProviderInterface
           {
             key: 'Provider',
             value: application_choice.offered_course.provider.name,
+            change_path: change_path(:provider),
           },
           {
             key: 'Course',
             value: application_choice.offered_course.name_and_code,
+            change_path: change_path(:course),
           },
           {
             key: 'Location',
             value: application_choice.offered_site.name_and_address,
+            change_path: change_path(:course_option),
           },
         ]
+      end
+
+      def paths
+        Rails.application.routes.url_helpers
+      end
+
+      def change_path(target)
+        return nil unless FeatureFlag.active?('provider_change_response')
+
+        case target
+        when :provider then paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id)
+        when :course then paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id)
+        when :course_option then paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id)
+        end
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -26,17 +26,17 @@ module ProviderInterface
           {
             key: 'Provider',
             value: application_choice.offered_course.provider.name,
-            change_path: change_path(:provider),
+            change_path: change_path(:provider), change_class: 'provider'
           },
           {
             key: 'Course',
             value: application_choice.offered_course.name_and_code,
-            change_path: change_path(:course),
+            change_path: change_path(:course), change_class: 'course'
           },
           {
             key: 'Location',
             value: application_choice.offered_site.name_and_address,
-            change_path: change_path(:course_option),
+            change_path: change_path(:course_option), change_class: 'course_option'
           },
         ]
       end

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -26,17 +26,17 @@ module ProviderInterface
           {
             key: 'Provider',
             value: application_choice.offered_course.provider.name,
-            change_path: change_path(:provider), change_class: 'provider'
+            change_path: change_path(:provider), action: 'training provider'
           },
           {
             key: 'Course',
             value: application_choice.offered_course.name_and_code,
-            change_path: change_path(:course), change_class: 'course'
+            change_path: change_path(:course), action: 'course'
           },
           {
             key: 'Location',
             value: application_choice.offered_site.name_and_address,
-            change_path: change_path(:course_option), change_class: 'course_option'
+            change_path: change_path(:course_option), action: 'location'
           },
         ]
       end

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -17,7 +17,7 @@
       </dd>
 
       <% if row[:change_path] %>
-        <dd class="govuk-summary-list__actions <%= row[:change_class] %>">
+        <dd class="govuk-summary-list__actions">
           <%= link_to row[:change_path], class: 'govuk-link' do %>
             Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
           <% end %>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -17,7 +17,7 @@
       </dd>
 
       <% if row[:change_path] %>
-        <dd class="govuk-summary-list__actions">
+        <dd class="govuk-summary-list__actions <%= row[:change_class] %>">
           <%= link_to row[:change_path], class: 'govuk-link' do %>
             Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
           <% end %>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -26,7 +26,7 @@
         <dd class="govuk-summary-list__actions">
           <%= link_to row[:action], row[:action_path], class: 'govuk-link' %>
         </dd>
-      <% elsif has_action_span? %>
+      <% elsif any_row_has_action_span? %>
         <span class="govuk-summary-list__actions"></span>
       <% end %>
     </div>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -5,8 +5,8 @@ class SummaryListComponent < ActionView::Component::Base
     @rows = rows
   end
 
-  def has_action_span?
-    @rows.select { |row| row.has_key?(:action) }.any?
+  def any_row_has_action_span?
+    @rows.select { |row| row.has_key?(:action) || row.has_key?(:change_path) }.any?
   end
 
 private

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -6,7 +6,7 @@ class SummaryListComponent < ActionView::Component::Base
   end
 
   def any_row_has_action_span?
-    @rows.select { |row| row.has_key?(:action) || row.has_key?(:change_path) }.any?
+    @rows.select { |row| row.has_key?(:action) }.any?
   end
 
 private

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class DecisionsController < ProviderInterfaceController
     before_action :set_application_choice
-    before_action :requires_provider_change_response_feature_flag, only: %i[new_edit_response edit_response new_withdraw_offer confirm_withdraw_offer withdraw_offer]
+    before_action :requires_provider_change_response_feature_flag, only: %i[new_withdraw_offer confirm_withdraw_offer withdraw_offer]
 
     def respond
       @pick_response_form = PickResponseForm.new
@@ -83,23 +83,6 @@ module ProviderInterface
         )
       else
         render action: :new_reject
-      end
-    end
-
-    def new_edit_response
-      @edit_response = EditResponseForm.new
-    end
-
-    def edit_response
-      @edit_response = EditResponseForm.new(
-        edit_response_type: params.dig(:provider_interface_edit_response_form, :edit_response_type),
-      )
-      if @edit_response.valid?
-        redirect_to provider_interface_application_choice_new_withdraw_offer_path(
-          application_choice_id: @application_choice.id,
-        )
-      else
-        render action: :new_edit_response
       end
     end
 

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -1,0 +1,154 @@
+module ProviderInterface
+  class OfferChangesController < ProviderInterfaceController
+    before_action :set_application_choice
+    before_action :requires_provider_change_response_feature_flag
+    before_action :set_change_offer_form
+
+    def edit_provider
+      @change_offer_form.step = :provider
+      set_alternative_providers
+    end
+
+    def edit_course
+      @change_offer_form.step = :course
+      if @change_offer_form.valid?
+        set_alternative_courses
+      else
+        render_providers
+      end
+    end
+
+    def edit_course_option
+      @change_offer_form.step = :course_option
+      if @change_offer_form.valid?
+        set_alternative_course_options
+      else
+        render_courses
+      end
+    end
+
+    def confirm_update
+      @change_offer_form.step = :confirm
+      if @change_offer_form.valid?
+        @future_application_choice = @application_choice.dup
+        @future_application_choice.offered_course_option_id = @change_offer_form.course_option_id
+      elsif @change_offer_form.errors[:provider_id].present?
+        render_providers
+      elsif @change_offer_form.errors[:course_id].present?
+        render_courses
+      else
+        render_course_options
+      end
+    end
+
+    def update
+      @change_offer_form.step = :update
+      if @change_offer_form.complete?
+        raise 'call me!'
+      else
+        raise 'cannot update offer'
+      end
+    end
+
+  private
+
+    def render_providers
+      set_alternative_providers
+      render :edit_provider
+    end
+
+    def render_courses
+      set_alternative_courses
+      render :edit_course
+    end
+
+    def render_course_options
+      set_alternative_course_options
+      render :edit_course_option
+    end
+
+    def requires_provider_change_response_feature_flag
+      raise unless FeatureFlag.active?('provider_change_response')
+    end
+
+    def set_application_choice
+      @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
+        .find(params[:application_choice_id])
+    end
+
+    def set_change_offer_form
+      @change_offer_form = ProviderInterface::ChangeOfferForm.new application_choice: @application_choice,
+                                                                  provider_id: (provider.id if safe_provider?),
+                                                                  course_id: course&.id,
+                                                                  course_option_id: course_option&.id
+    end
+
+    def safe_provider?
+      @safe_provider != nil ? @safe_provider : @safe_provider = current_provider_user.providers.include?(provider) && provider
+    end
+
+    def provider
+      requested_provider || current_provider
+    end
+
+    def current_provider
+      @application_choice.offered_course.provider
+    end
+
+    def requested_provider
+      provider_id = change_offer_params[:provider_id]
+      Provider.find(provider_id) if provider_id.present?
+    end
+
+    def course
+      requested_course || current_course
+    end
+
+    def current_course
+      @application_choice.offered_course
+    end
+
+    def requested_course
+      course_id = change_offer_params[:course_id]
+      Course.find(course_id) if course_id.present?
+    end
+
+    def course_option
+      requested_course_option || current_course_option
+    end
+
+    def current_course_option
+      @application_choice.offered_option
+    end
+
+    def requested_course_option
+      course_option_id = change_offer_params[:course_option_id]
+      CourseOption.find(course_option_id) if course_option_id.present?
+    end
+
+    def set_alternative_providers
+      @alternative_providers = current_provider_user.providers.order(:name)
+    end
+
+    def set_alternative_courses
+      @alternative_courses = Course.where(open_on_apply: true, provider: provider).order(:name)
+    end
+
+    def set_alternative_course_options
+      current_option = @application_choice.offered_option
+      @alternative_course_options = CourseOption.where(
+        course: course,
+        study_mode: current_option.study_mode, # preserving study_mode, for now
+        # TODO: check vacancy_status, e.g. 'B'
+      ).includes(:site).order('sites.name')
+    end
+
+    def change_offer_params
+      begin
+        params.require(:provider_interface_change_offer_form).permit(:provider_id, :course_id, :course_option_id)
+      rescue ActionController::ParameterMissing
+        {}
+      end
+    end
+  end
+end

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -44,7 +44,12 @@ module ProviderInterface
     def update
       @change_offer_form.step = :update
       if @change_offer_form.complete?
-        raise 'call me!'
+        ChangeOffer.new(
+          actor: current_provider_user,
+          application_choice: @application_choice,
+          course_option_id: @change_offer_form.course_option_id,
+        ).save!
+        redirect_to provider_interface_application_choice_path(@application_choice.id)
       else
         raise 'cannot update offer'
       end

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -136,7 +136,11 @@ module ProviderInterface
     end
 
     def set_alternative_courses
-      @alternative_courses = Course.where(open_on_apply: true, provider: provider).order(:name)
+      @alternative_courses = Course.where(
+        open_on_apply: true,
+        provider: provider,
+        study_mode: study_mode_for_alternative_courses,
+      ).order(:name)
     end
 
     def set_alternative_course_options
@@ -146,6 +150,11 @@ module ProviderInterface
         study_mode: current_option.study_mode, # preserving study_mode, for now
         # TODO: check vacancy_status, e.g. 'B'
       ).includes(:site).order('sites.name')
+    end
+
+    def study_mode_for_alternative_courses
+      current_study_mode = @application_choice.offered_option.study_mode
+      [current_study_mode, :full_time_or_part_time]
     end
 
     def change_offer_params

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -43,7 +43,7 @@ module ProviderInterface
 
     def update
       @change_offer_form.step = :update
-      if @change_offer_form.complete?
+      if @change_offer_form.valid?
         ChangeOffer.new(
           actor: current_provider_user,
           application_choice: @application_choice,
@@ -83,13 +83,13 @@ module ProviderInterface
 
     def set_change_offer_form
       @change_offer_form = ProviderInterface::ChangeOfferForm.new application_choice: @application_choice,
-                                                                  provider_id: (provider.id if safe_provider?),
+                                                                  provider_id: (provider.id if allowed_provider?),
                                                                   course_id: course&.id,
                                                                   course_option_id: course_option&.id
     end
 
-    def safe_provider?
-      @safe_provider != nil ? @safe_provider : @safe_provider = current_provider_user.providers.include?(provider) && provider
+    def allowed_provider?
+      current_provider_user.providers.include?(provider)
     end
 
     def provider

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -36,13 +36,15 @@ class ApplicationChoice < ApplicationRecord
     rejected? && !offer_withdrawn_at.nil?
   end
 
+  def offered_option
+    offered_course_option || course_option
+  end
+
   def offered_course
-    offered_option = offered_course_option || course_option
     offered_option.course
   end
 
   def offered_site
-    offered_option = offered_course_option || course_option
     offered_option.site
   end
 

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -20,8 +20,9 @@ module ProviderInterface
     end
 
     validates_each :course_id do |record, attr, _value|
-      if record.step_after?(:course) && (record.course_id.blank? || !course_matches_provider?(record))
-        record.errors.add attr, 'Please select a course'
+      if record.step_after?(:course)
+        record.errors.add attr, 'Please select a course' if record.course_id.blank? || !course_matches_provider?(record)
+        record.errors.add attr, 'Course not open on Apply' if record.course_id.present? && !course_open_on_apply?(record)
       end
     end
 
@@ -32,7 +33,13 @@ module ProviderInterface
     end
 
     def self.course_matches_provider?(record)
-      record.course_id && Course.find(record.course_id).provider.id == record.provider_id
+      course = Course.find(record.course_id) if record.course_id
+      course && record.provider_id && course.provider.id == record.provider_id
+    end
+
+    def self.course_open_on_apply?(record)
+      course = Course.find(record.course_id)
+      course.open_on_apply
     end
 
     def self.course_option_matches_course?(record)

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -16,19 +16,19 @@ module ProviderInterface
     end
 
     validates_each :provider_id do |record, attr, _value|
-      record.errors.add attr, 'Please select a provider' if record.step_after?(:provider) && record.provider_id.blank?
+      record.errors.add attr, :blank if record.step_after?(:provider) && record.provider_id.blank?
     end
 
     validates_each :course_id do |record, attr, _value|
       if record.step_after?(:course)
-        record.errors.add attr, 'Please select a course' if record.course_id.blank? || !course_matches_provider?(record)
-        record.errors.add attr, 'Course not open on Apply' if record.course_id.present? && !course_open_on_apply?(record)
+        record.errors.add attr, :blank if record.course_id.blank? || !course_matches_provider?(record)
+        record.errors.add attr, :not_open_on_apply if record.course_id.present? && !course_open_on_apply?(record)
       end
     end
 
     validates_each :course_option_id do |record, attr, _value|
       if record.step_after?(:course_option) && (record.course_option_id.blank? || !course_option_matches_course?(record))
-        record.errors.add attr, 'Please select an option'
+        record.errors.add attr, :blank
       end
     end
 

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -9,10 +9,10 @@ module ProviderInterface
     # Validation needs to take this into account, e.g. it is fine for course_id to be blank if step == :provider
     #
     STEPS = %i(provider course course_option confirm update).freeze
-    validates :step, presence: true, inclusion: { in: STEPS, message: '%{value} is not a valid option' }
+    validates :step, presence: true, inclusion: { in: STEPS, message: '%{value} is not a valid step' }
 
-    def step_after?(symbol)
-      STEPS.index(step) > STEPS.index(symbol) if step
+    def step_after?(step_symbol)
+      STEPS.index(step) > STEPS.index(step_symbol) if step
     end
 
     validates_each :provider_id do |record, attr, value|

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -1,0 +1,46 @@
+module ProviderInterface
+  class ChangeOfferForm
+    include ActiveModel::Model
+    attr_accessor :application_choice, :step, :provider_id, :course_id, :course_option_id
+
+    validates :application_choice, presence: true
+
+    # This is a form for a multi-step process, in which each step depends on the previous ones.
+    # Validation needs to take this into account, e.g. it is fine for course_id to be blank if step == :provider
+    #
+    STEPS = %i(provider course course_option confirm update).freeze
+    validates :step, presence: true, inclusion: { in: STEPS, message: '%{value} is not a valid option' }
+
+    def step_after?(symbol)
+      STEPS.index(step) > STEPS.index(symbol) if step
+    end
+
+    validates_each :provider_id do |record, attr, _value|
+      record.errors.add attr, 'Please select a provider' if record.step_after?(:provider) && record.provider_id.blank?
+    end
+
+    validates_each :course_id do |record, attr, _value|
+      if record.step_after?(:course) && (record.course_id.blank? || !course_matches_provider?(record))
+        record.errors.add attr, 'Please select a course'
+      end
+    end
+
+    validates_each :course_option_id do |record, attr, _value|
+      if record.step_after?(:course_option) && (record.course_option_id.blank? || !course_option_matches_course?(record))
+        record.errors.add attr, 'Please select an option'
+      end
+    end
+
+    def self.course_matches_provider?(record)
+      record.course_id && Course.find(record.course_id).provider.id == record.provider_id
+    end
+
+    def self.course_option_matches_course?(record)
+      record.course_option_id && CourseOption.find(record.course_option_id).course.id == record.course_id
+    end
+
+    def complete?
+      @course_option_id.present? && valid?
+    end
+  end
+end

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -15,20 +15,20 @@ module ProviderInterface
       STEPS.index(step) > STEPS.index(symbol) if step
     end
 
-    validates_each :provider_id do |record, attr, _value|
-      record.errors.add attr, :blank if record.step_after?(:provider) && record.provider_id.blank?
+    validates_each :provider_id do |record, attr, value|
+      record.errors.add attr, :blank if record.step_after?(:provider) && value.blank?
     end
 
-    validates_each :course_id do |record, attr, _value|
+    validates_each :course_id do |record, attr, value|
       if record.step_after?(:course)
-        record.errors.add attr, :blank if record.course_id.blank? || !course_matches_provider?(record)
-        record.errors.add attr, :not_open_on_apply if record.course_id.present? && !course_open_on_apply?(record)
+        record.errors.add attr, :blank if value.blank? || !course_matches_provider?(record)
+        record.errors.add attr, :not_open_on_apply if value.present? && !course_open_on_apply?(record)
       end
     end
 
-    validates_each :course_option_id do |record, attr, _value|
-      if record.step_after?(:course_option) && (record.course_option_id.blank? || !course_option_matches_course?(record))
-        record.errors.add attr, :blank
+    validates_each :course_option_id do |record, attr, value|
+      if record.step_after?(:course_option)
+        record.errors.add attr, :blank if value.blank? || !course_option_matches_course?(record)
       end
     end
 

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -38,9 +38,5 @@ module ProviderInterface
     def self.course_option_matches_course?(record)
       record.course_option_id && CourseOption.find(record.course_option_id).course.id == record.course_id
     end
-
-    def complete?
-      @course_option_id.present? && valid?
-    end
   end
 end

--- a/app/models/provider_interface/edit_response_form.rb
+++ b/app/models/provider_interface/edit_response_form.rb
@@ -1,9 +1,0 @@
-module ProviderInterface
-  class EditResponseForm
-    include ActiveModel::Model
-
-    attr_accessor :application_choice, :edit_response_type
-    validates :edit_response_type, presence: true
-    validates :edit_response_type, inclusion: { in: %w(withdraw_offer), message: '%{value} is not a valid option' }
-  end
-end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -9,10 +9,12 @@ class ChangeOffer
 
   def save!
     @auth.assert_can_change_offer! application_choice: @application_choice, course_option_id: @course_option_id
-    @application_choice.update!(offered_course_option_id: @course_option_id, offered_at: Time.zone.now)
+    if @course_option_id != @application_choice.offered_option.id
+      @application_choice.update!(offered_course_option_id: @course_option_id, offered_at: Time.zone.now)
 
-    SetDeclineByDefault.new(application_form: @application_choice.application_form).call
-    # TODO: SendChangeOfferEmailToCandidate.new(application_choice: @application_choice).call
-    # TODO: StateChangeNotifier.call(:change_offer, application_choice: application_choice)
+      SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+      # TODO: SendChangeOfferEmailToCandidate.new(application_choice: @application_choice).call
+      # TODO: StateChangeNotifier.call(:change_offer, application_choice: application_choice)
+    end
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -1,0 +1,18 @@
+class ChangeOffer
+  include ActiveModel::Validations
+
+  def initialize(actor:, application_choice:, course_option_id:)
+    @application_choice = application_choice
+    @course_option_id = course_option_id
+    @auth = ProviderAuthorisation.new(actor: actor)
+  end
+
+  def save!
+    @auth.assert_can_change_offer! application_choice: @application_choice, course_option_id: @course_option_id
+    @application_choice.update!(offered_course_option_id: @course_option_id, offered_at: Time.zone.now)
+
+    SetDeclineByDefault.new(application_form: @application_choice.application_form).call
+    # TODO: SendChangeOfferEmailToCandidate.new(application_choice: @application_choice).call
+    # TODO: StateChangeNotifier.call(:change_offer, application_choice: application_choice)
+  end
+end

--- a/app/services/get_application_choices_for_providers.rb
+++ b/app/services/get_application_choices_for_providers.rb
@@ -7,6 +7,7 @@ class GetApplicationChoicesForProviders
     includes = [
       :course,
       :course_option,
+      :offered_course_option,
       :application_form,
       :provider,
       :site,

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -9,8 +9,23 @@ class ProviderAuthorisation
     @actor.is_a?(SupportUser) || @actor.providers.include?(application_choice.course.provider)
   end
 
+  def can_change_offer?(application_choice:, course_option_id:)
+    course_option = CourseOption.find course_option_id
+    if @actor.is_a?(SupportUser)
+      true
+    else
+      authorised_user = @actor.providers.include?(application_choice.course.provider)
+      valid_option = @actor.providers.include?(course_option.course.provider)
+      authorised_user && valid_option
+    end
+  end
+
   def assert_can_make_offer!(application_choice:)
     raise ProviderAuthorisation::NotAuthorisedError, 'assert_can_make_offer!' if !can_make_offer?(application_choice: application_choice)
+  end
+
+  def assert_can_change_offer!(application_choice:, course_option_id:)
+    raise ProviderAuthorisation::NotAuthorisedError, 'assert_can_change_offer!' if !can_change_offer?(application_choice: application_choice, course_option_id: course_option_id)
   end
 
   class NotAuthorisedError < StandardError; end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -20,12 +20,13 @@ class ProviderAuthorisation
     end
   end
 
-  def assert_can_make_offer!(application_choice:)
-    raise ProviderAuthorisation::NotAuthorisedError, 'assert_can_make_offer!' if !can_make_offer?(application_choice: application_choice)
-  end
+  # automatically generates assert_can...! methods e.g. #assert_can_make_offer! for #can_make_offer?
+  instance_methods.select { |m| m.match PERMISSION_METHOD_REGEXP }.each do |method|
+    permission_name = method.to_s.scan(PERMISSION_METHOD_REGEXP).last.first
 
-  def assert_can_change_offer!(application_choice:, course_option_id:)
-    raise ProviderAuthorisation::NotAuthorisedError, 'assert_can_change_offer!' if !can_change_offer?(application_choice: application_choice, course_option_id: course_option_id)
+    define_method("assert_can_#{permission_name}!") do |**keyword_args|
+      raise(ProviderAuthorisation::NotAuthorisedError, method.to_s) unless self.send(method, **keyword_args)
+    end
   end
 
   class NotAuthorisedError < StandardError; end

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -5,7 +5,7 @@
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl govuk-heading-xl">
-    <span class="govuk-caption-xl"><%= @application_choice.provider.name %> - <%= @application_choice.course_option.course.name %> (<%= @application_choice.course_option.course.code %>)</span>
+    <span class="govuk-caption-xl"><%= @application_choice.offered_course.provider.name %> - <%= @application_choice.offered_course.name %> (<%= @application_choice.offered_course.code %>)</span>
     <%= t('page_titles.view_and_respond_to_offer') %>
   </h1>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -19,8 +19,6 @@
     <div class='moj-scrollable-pane'>
       <div class='moj-scrollable-pane__wrapper'>
 
-      <% end %>
-
       <% if @application_choices.any? %>
         <table class='govuk-table'>
           <thead class='govuk-table__head'>
@@ -59,11 +57,11 @@
                 <td class='govuk-table__cell'>
                   <% if current_provider_user.providers.size > 1 %>
                     <span class='govuk-caption-m govuk-!-font-size-16'>
-                      <%= application_choice.provider.name %>
+                      <%= application_choice.offered_course.provider.name %>
                     </span>
                   <% end %>
 
-                  <%= application_choice.course.name_and_code %></td>
+                  <%= application_choice.offered_course.name_and_code %></td>
                 <td class='govuk-table__cell'><%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %></td>
                 <td class='govuk-table__cell govuk-table__header--numeric'><%= application_choice.updated_at.to_s(:govuk_date_short_month) %></td>
               </tr>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -4,76 +4,78 @@
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <% if FeatureFlag.active?('provider_application_filters') %>
+  <div class='moj-filter-layout'>
+    <% if @filter_visible.eql?('true') %>
+      <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
+                                                        available_filters: @available_filters,
+                                                        applied_filters: @filter_selections,
+                                                        additional_params: { sort_by: @sort_by,
+                                                                             sort_order: @sort_order }) %>
+    <% end %>
 
-<div class='moj-filter-layout'>
-  <% if @filter_visible.eql?('true') %>
-    <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
-                                                      available_filters: @available_filters,
-                                                      applied_filters: @filter_selections,
-                                                      additional_params: { sort_by: @sort_by,
-                                                                           sort_order: @sort_order }) %>
-  <% end %>
+    <div class='moj-filter-layout__content'>
+      <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @sort_order, current_sort_by: @sort_by, filter_visible: @filter_visible, filter_selections: @filter_selections) %>
+      <div class='moj-scrollable-pane'>
+        <div class='moj-scrollable-pane__wrapper'>
+<% end %>
 
-  <div class='moj-filter-layout__content'>
-    <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @sort_order, current_sort_by: @sort_by, filter_visible: @filter_visible, filter_selections: @filter_selections) %>
-    <div class='moj-scrollable-pane'>
-      <div class='moj-scrollable-pane__wrapper'>
+<% if @application_choices.any? %>
+  <table class='govuk-table'>
+    <thead class='govuk-table__head'>
+      <tr class='govuk-table__row'>
+        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
+                                                                         column_name: 'Name',
+                                                                         current_sort_by: @sort_by,
+                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                         filter_selections: @filter_selections,
+                                                                         filter_visible: @filter_visible) %>
 
-      <% if @application_choices.any? %>
-        <table class='govuk-table'>
-          <thead class='govuk-table__head'>
-            <tr class='govuk-table__row'>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
-                                                                               column_name: 'Name',
-                                                                               current_sort_by: @sort_by,
-                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               filter_selections: @filter_selections,
-                                                                               filter_visible: @filter_visible) %>
+        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
+                                                                         column_name: 'Course',
+                                                                         current_sort_by: @sort_by,
+                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                         filter_selections: @filter_selections,
+                                                                         filter_visible: @filter_visible) %>
 
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
-                                                                               column_name: 'Course',
-                                                                               current_sort_by: @sort_by,
-                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               filter_selections: @filter_selections,
-                                                                               filter_visible: @filter_visible) %>
+        <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
+ 
+        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
+                                                                         column_name: 'Last updated',
+                                                                         current_sort_by: @sort_by,
+                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
+                                                                         filter_selections: @filter_selections,
+                                                                         filter_visible: @filter_visible) %>
+      </tr>
+    </thead>
+ 
+    <tbody class='govuk-table__body'>
+      <% @application_choices.each do |application_choice| %>
+        <tr class='govuk-table__row'>
+          <th class='govuk-table__cell'>
+            <span class="govuk-caption-m govuk-!-font-size-16"><%= application_choice.application_form.support_reference %></span>
+            <%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %>
+          </th>
+         <td class='govuk-table__cell'>
+           <% if current_provider_user.providers.size > 1 %>
+             <span class='govuk-caption-m govuk-!-font-size-16'>
+               <%= application_choice.offered_course.provider.name %>
+             </span>
+           <% end %>
 
-              <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
-
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
-                                                                               column_name: 'Last updated',
-                                                                               current_sort_by: @sort_by,
-                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
-                                                                               filter_selections: @filter_selections,
-                                                                               filter_visible: @filter_visible) %>
-            </tr>
-          </thead>
-
-          <tbody class='govuk-table__body'>
-            <% @application_choices.each do |application_choice| %>
-              <tr class='govuk-table__row'>
-                <th class='govuk-table__cell'>
-                <span class="govuk-caption-m govuk-!-font-size-16"><%= application_choice.application_form.support_reference %></span>
-                <%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %></th>
-                <td class='govuk-table__cell'>
-                  <% if current_provider_user.providers.size > 1 %>
-                    <span class='govuk-caption-m govuk-!-font-size-16'>
-                      <%= application_choice.offered_course.provider.name %>
-                    </span>
-                  <% end %>
-
-                  <%= application_choice.offered_course.name_and_code %></td>
-                <td class='govuk-table__cell'><%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %></td>
-                <td class='govuk-table__cell govuk-table__header--numeric'><%= application_choice.updated_at.to_s(:govuk_date_short_month) %></td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-
-        <% if FeatureFlag.active?('provider_application_filters') %>
+           <%= application_choice.offered_course.name_and_code %>
+         </td>
+         <td class='govuk-table__cell'><%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %></td>
+         <td class='govuk-table__cell govuk-table__header--numeric'><%= application_choice.updated_at.to_s(:govuk_date_short_month) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+ 
+<% if FeatureFlag.active?('provider_application_filters') %>
         </div>
+      </div>
     </div>
   </div>
-</div>
 <% end %>
 
 <%= render(PaginatorComponent.new(scope: @application_choices)) %>

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -8,12 +8,10 @@
     <%= form_with model: @change_offer_form,
           url: provider_interface_application_choice_change_offer_path(@application_choice.id),
           method: :patch do |f| %>
-      <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :provider_id %>
       <%= f.hidden_field :course_id %>
       <%= f.hidden_field :course_option_id %>
-
       <%= f.govuk_submit 'Change offer' %>
     <% end %>
 

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -20,4 +20,3 @@
     <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
   </div>
 </div>
-

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -1,0 +1,23 @@
+<h1 class="govuk-heading-xl">Check and confirm changes to offer</h2>
+
+<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
+<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @future_application_choice, header: 'Your new offer') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @change_offer_form,
+          url: provider_interface_application_choice_change_offer_path(@application_choice.id),
+          method: :patch do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.hidden_field :provider_id %>
+      <%= f.hidden_field :course_id %>
+      <%= f.hidden_field :course_option_id %>
+
+      <%= f.govuk_submit 'Change offer' %>
+    <% end %>
+
+    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+  </div>
+</div>
+

--- a/app/views/provider_interface/offer_changes/edit_course.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course.html.erb
@@ -1,0 +1,22 @@
+<h1 class="govuk-heading-xl">Choose new course</h2>
+<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @change_offer_form,
+          url: provider_interface_application_choice_change_offer_edit_course_option_path(@application_choice.id),
+          method: :get do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.hidden_field :provider_id %>
+      <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'm', text: 'Select course', tag: 'span' } do %>
+        <% @alternative_courses.each do |course| %>
+          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint_text: nil %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+
+    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer_changes/edit_course.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course.html.erb
@@ -5,7 +5,6 @@
     <%= form_with model: @change_offer_form,
           url: provider_interface_application_choice_change_offer_edit_course_option_path(@application_choice.id),
           method: :get do |f| %>
-      <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :provider_id %>
       <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'm', text: 'Select course', tag: 'span' } do %>

--- a/app/views/provider_interface/offer_changes/edit_course_option.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course_option.html.erb
@@ -5,7 +5,6 @@
     <%= form_with model: @change_offer_form,
           url: provider_interface_application_choice_change_offer_confirmation_path(@application_choice.id),
           method: :get do |f| %>
-      <%= f.govuk_error_summary %>
 
       <%= f.hidden_field :provider_id %>
       <%= f.hidden_field :course_id %>

--- a/app/views/provider_interface/offer_changes/edit_course_option.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course_option.html.erb
@@ -1,0 +1,23 @@
+<h1 class="govuk-heading-xl">Choose new location</h2>
+<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @change_offer_form,
+          url: provider_interface_application_choice_change_offer_confirmation_path(@application_choice.id),
+          method: :get do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.hidden_field :provider_id %>
+      <%= f.hidden_field :course_id %>
+      <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'm', text: 'Select location', tag: 'span' } do %>
+        <% @alternative_course_options.each do |course_option| %>
+          <%= f.govuk_radio_button :course_option_id, course_option.id, label: { text: course_option.site.name }, hint_text: course_option.site.full_address %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+
+    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer_changes/edit_provider.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_provider.html.erb
@@ -1,0 +1,22 @@
+<h1 class="govuk-heading-xl">Change training provider</h2>
+<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with model: @change_offer_form,
+          url: provider_interface_application_choice_change_offer_edit_course_path(@application_choice.id),
+          method: :get do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { size: 'm', text: 'Select alternative provider', tag: 'span' } do %>
+        <% @alternative_providers.each do |provider| %>
+          <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code } %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+
+    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+  </div>
+</div>

--- a/app/views/provider_interface/offer_changes/edit_provider.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_provider.html.erb
@@ -6,7 +6,6 @@
     <%= form_with model: @change_offer_form,
           url: provider_interface_application_choice_change_offer_edit_course_path(@application_choice.id),
           method: :get do |f| %>
-      <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { size: 'm', text: 'Select alternative provider', tag: 'span' } do %>
         <% @alternative_providers.each do |provider| %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -37,9 +37,9 @@
   <h2 class="govuk-heading-l govuk-!-margin-top-8">Course choices</h2>
   <% @application_form.application_choices.includes(:course, :provider, :site).each do |application_choice| %>
     <% rows = [
-      { key: 'Course', value: application_choice.course.name_and_code },
-      { key: 'Provider', value: application_choice.provider.name_and_code },
-      { key: 'Location', value: application_choice.site.name_and_code },
+      { key: 'Course', value: application_choice.offered_course.name_and_code },
+      { key: 'Provider', value: application_choice.offered_course.provider.name_and_code },
+      { key: 'Location', value: application_choice.offered_option.site.name_and_code },
       { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) },
     ] %>
     <% rows << { key: 'Reason for rejection', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>
@@ -47,7 +47,7 @@
     <% rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at %>
 
     <%= render SummaryCardComponent.new(rows: rows) do %>
-      <%= render SummaryCardHeaderComponent.new(title: application_choice.course.name_and_code) %>
+      <%= render SummaryCardHeaderComponent.new(title: application_choice.offered_course.name_and_code) %>
     <% end %>
   <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,12 +137,12 @@ en:
         provider_interface/change_offer_form:
           attributes:
             provider_id:
-              blank: You have not specified a provider
+              blank: You have not chosen an alternative provider
             course_id:
-              blank: You have not specified a course
+              blank: You have not chosen a new course
               not_open_on_apply: Course not open on Apply
             course_option_id:
-              blank: You have not specified a location
+              blank: You have not chosen a new location
         provider_interface/confirm_conditions_form:
           attributes:
             conditions_met:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -137,11 +137,12 @@ en:
         provider_interface/change_offer_form:
           attributes:
             provider_id:
-              blank: You have not specified an alternative provider
+              blank: You have not specified a provider
             course_id:
-              blank: You have not specified an alternative course
+              blank: You have not specified a course
+              not_open_on_apply: Course not open on Apply
             course_option_id:
-              blank: You have not specified an alternative location
+              blank: You have not specified a location
         provider_interface/confirm_conditions_form:
           attributes:
             conditions_met:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -134,6 +134,14 @@ en:
           attributes:
             decision:
               blank: Select if you want to make an offer or reject the application
+        provider_interface/change_offer_form:
+          attributes:
+            provider_id:
+              blank: You have not specified an alternative provider
+            course_id:
+              blank: You have not specified an alternative course
+            course_option_id:
+              blank: You have not specified an alternative location
         provider_interface/confirm_conditions_form:
           attributes:
             conditions_met:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -345,9 +345,6 @@ Rails.application.routes.draw do
     get '/applications/:application_choice_id/offer/change/location' => 'offer_changes#edit_course_option', as: :application_choice_change_offer_edit_course_option
     get '/applications/:application_choice_id/offer/change/confirm' => 'offer_changes#confirm_update', as: :application_choice_change_offer_confirmation
     patch '/applications/:application_choice_id/offer/change' => 'offer_changes#update', as: :application_choice_change_offer
-    get '/applications/:application_choice_id/edit_response' => 'decisions#new_edit_response', as: :application_choice_new_edit_response
-    post '/applications/:application_choice_id/edit_response' => 'decisions#edit_response', as: :application_choice_edit_response
-
     get '/applications/:application_choice_id/offer/new_withdraw' => 'decisions#new_withdraw_offer', as: :application_choice_new_withdraw_offer
     post '/applications/:application_choice_id/offer/confirm_withdraw' => 'decisions#confirm_withdraw_offer', as: :application_choice_confirm_withdraw_offer
     post '/applications/:application_choice_id/offer/withdraw' => 'decisions#withdraw_offer', as: :application_choice_withdraw_offer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,8 +340,14 @@ Rails.application.routes.draw do
     get '/applications/:application_choice_id/conditions' => 'conditions#edit', as: :application_choice_edit_conditions
     patch '/applications/:application_choice_id/conditions/confirm' => 'conditions#confirm_update', as: :application_choice_confirm_update_conditions
     patch '/applications/:application_choice_id/conditions' => 'conditions#update', as: :application_choice_update_conditions
+    get '/applications/:application_choice_id/offer/change/provider' => 'offer_changes#edit_provider', as: :application_choice_change_offer_edit_provider
+    get '/applications/:application_choice_id/offer/change/course' => 'offer_changes#edit_course', as: :application_choice_change_offer_edit_course
+    get '/applications/:application_choice_id/offer/change/location' => 'offer_changes#edit_course_option', as: :application_choice_change_offer_edit_course_option
+    get '/applications/:application_choice_id/offer/change/confirm' => 'offer_changes#confirm_update', as: :application_choice_change_offer_confirmation
+    patch '/applications/:application_choice_id/offer/change' => 'offer_changes#update', as: :application_choice_change_offer
     get '/applications/:application_choice_id/edit_response' => 'decisions#new_edit_response', as: :application_choice_new_edit_response
     post '/applications/:application_choice_id/edit_response' => 'decisions#edit_response', as: :application_choice_edit_response
+
     get '/applications/:application_choice_id/offer/new_withdraw' => 'decisions#new_withdraw_offer', as: :application_choice_new_withdraw_offer
     post '/applications/:application_choice_id/offer/confirm_withdraw' => 'decisions#confirm_withdraw_offer', as: :application_choice_confirm_withdraw_offer
     post '/applications/:application_choice_id/offer/withdraw' => 'decisions#withdraw_offer', as: :application_choice_withdraw_offer

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -276,6 +276,7 @@ FactoryBot.define do
     end
 
     trait :ready_to_send_to_provider do
+      association :application_form, factory: %i[completed_application_form with_completed_references]
       status { :application_complete }
       edit_by { 1.day.ago }
     end
@@ -293,6 +294,7 @@ FactoryBot.define do
     end
 
     trait :with_offer do
+      association :application_form, factory: %i[completed_application_form with_completed_references]
       status { 'offer' }
       decline_by_default_at { Time.zone.now + 7.days }
       decline_by_default_days { 10 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -193,6 +193,14 @@ FactoryBot.define do
     site { association(:site, provider: course.provider) }
 
     vacancy_status { 'both_full_time_and_part_time_vacancies' }
+
+    trait :full_time do
+      study_mode { :full_time }
+    end
+
+    trait :part_time do
+      study_mode { :part_time }
+    end
   end
 
   factory :course do
@@ -209,7 +217,15 @@ FactoryBot.define do
     end
 
     trait :with_both_study_modes do
-      study_mode { 'full_time_or_part_time' }
+      study_mode { :full_time_or_part_time }
+    end
+
+    trait :full_time do
+      study_mode { :full_time }
+    end
+
+    trait :part_time do
+      study_mode { :part_time }
     end
   end
 
@@ -278,10 +294,19 @@ FactoryBot.define do
 
     trait :with_offer do
       status { 'offer' }
-      decline_by_default_at { Time.zone.now + 10.days }
+      decline_by_default_at { Time.zone.now + 7.days }
       decline_by_default_days { 10 }
       offer { { 'conditions' => ['Be cool'] } }
-      offered_at { Time.zone.now }
+      offered_at { Time.zone.now - 3.days }
+    end
+
+    trait :with_modified_offer do
+      with_offer
+
+      after(:build) do |choice, _evaluator|
+        other_course = create(:course, provider: choice.course_option.course.provider)
+        choice.offered_course_option_id = create(:course_option, course: other_course).id
+      end
     end
 
     trait :with_accepted_offer do
@@ -385,6 +410,12 @@ FactoryBot.define do
     email_address { "#{Faker::Name.first_name.downcase}-#{SecureRandom.hex}@example.com" }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
+
+    trait :with_provider do
+      after(:create) do |user, _evaluator|
+        create(:provider).provider_users << user
+      end
+    end
   end
 
   factory :provider_users_provider do

--- a/spec/models/provider_interface/change_offer_form_spec.rb
+++ b/spec/models/provider_interface/change_offer_form_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ChangeOfferForm do
+  include CourseOptionHelpers
+  let(:provider_user) { create(:provider_user, :with_provider) }
+  let(:provider) { provider_user.providers.first }
+  let(:course) { create(:course, :full_time, provider: provider) }
+  let(:course_option) { course_option_for_provider(provider: provider, course: course) }
+  let(:application_choice) { create(:application_choice, :with_modified_offer, course_option: course_option) }
+  let(:form_with_application_choice) { described_class.new(application_choice: application_choice, step: step) }
+
+  def invalid_for_missing(attribute)
+    form_with_application_choice.provider_id = course_option.course.provider.id
+    form_with_application_choice.course_id = course_option.course.id
+    form_with_application_choice.course_option_id = course_option.id
+    form_with_application_choice.send("#{attribute}=".to_sym, nil)
+    expect(form_with_application_choice).to be_invalid
+  end
+
+  describe 'validations common to each step' do
+    it { is_expected.to validate_presence_of(:application_choice) }
+    it { is_expected.to validate_presence_of(:step) }
+  end
+
+  describe 'step: :provider' do
+    let(:step) { :provider }
+    let(:subject) { form_with_application_choice }
+
+    it { is_expected.to be_valid }
+  end
+
+  describe 'step: :course' do
+    let(:step) { :course }
+    let(:subject) { form_with_application_choice }
+
+    it 'is valid when provider_id is set' do
+      form_with_application_choice.provider_id = 'any value'
+      expect(form_with_application_choice).to be_valid
+    end
+
+    %w[provider_id].each do |attribute|
+      it "is invalid when :#{attribute} is missing" do
+        invalid_for_missing attribute
+      end
+    end
+  end
+
+  describe 'step: :course_option' do
+    let(:step) { :course_option }
+    let(:subject) { form_with_application_choice }
+
+    it 'is valid when provider_id and course_id are set and related' do
+      form_with_application_choice.provider_id = course.provider.id
+      form_with_application_choice.course_id = course.id
+      expect(form_with_application_choice).to be_valid
+    end
+
+    %w[provider_id course_id].each do |attribute|
+      it "is invalid when :#{attribute} is missing" do
+        invalid_for_missing attribute
+      end
+    end
+
+    it 'is invalid when provider_id and course_id are set but not related' do
+      form_with_application_choice.provider_id = 458
+      form_with_application_choice.course_id = course.id
+      expect(form_with_application_choice).to be_invalid
+    end
+  end
+
+  describe 'step: :confirm' do
+    let(:step) { :confirm }
+    let(:subject) { form_with_application_choice }
+
+    it 'is valid when provider_id, course_id and course_option_id are all set and related' do
+      form_with_application_choice.provider_id = course_option.course.provider.id
+      form_with_application_choice.course_id = course_option.course.id
+      form_with_application_choice.course_option_id = course_option.id
+      expect(form_with_application_choice).to be_valid
+    end
+
+    %w[provider_id course_id course_option_id].each do |attribute|
+      it "is invalid when :#{attribute} is missing" do
+        invalid_for_missing attribute
+      end
+    end
+
+    it 'is invalid when provider_id, course_id, course_option_id are set but not related' do
+      form_with_application_choice.provider_id = course_option.course.provider.id
+      form_with_application_choice.course_id = course_option.course.id
+      form_with_application_choice.course_option_id = create(:course_option).id
+      expect(form_with_application_choice).to be_invalid
+    end
+  end
+
+  describe 'step: :update' do
+    let(:step) { :update }
+    let(:subject) { form_with_application_choice }
+
+    it 'is valid when provider_id, course_id and course_option_id are all set and related' do
+      form_with_application_choice.provider_id = course_option.course.provider.id
+      form_with_application_choice.course_id = course_option.course.id
+      form_with_application_choice.course_option_id = course_option.id
+      expect(form_with_application_choice).to be_valid
+    end
+
+    %w[provider_id course_id course_option_id].each do |attribute|
+      it "is invalid when :#{attribute} is missing" do
+        invalid_for_missing attribute
+      end
+    end
+  end
+end

--- a/spec/models/provider_interface/change_offer_form_spec.rb
+++ b/spec/models/provider_interface/change_offer_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ProviderInterface::ChangeOfferForm do
   include CourseOptionHelpers
   let(:provider_user) { create(:provider_user, :with_provider) }
   let(:provider) { provider_user.providers.first }
-  let(:course) { create(:course, :full_time, provider: provider) }
+  let(:course) { create(:course, :open_on_apply, provider: provider) }
   let(:course_option) { course_option_for_provider(provider: provider, course: course) }
   let(:application_choice) { create(:application_choice, :with_modified_offer, course_option: course_option) }
   let(:form_with_application_choice) { described_class.new(application_choice: application_choice, step: step) }

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ChangeOffer do
+  include CourseOptionHelpers
+  let(:provider_user) { create(:provider_user, :with_provider) }
+  let(:provider) { provider_user.providers.first }
+  let(:course) { create(:course, :full_time, provider: provider) }
+  let(:course_option) { course_option_for_provider(provider: provider, course: course) }
+  let(:application_choice) { create(:application_choice, :with_modified_offer, course_option: course_option) }
+
+  def service
+    ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option_id: course_option.id)
+  end
+
+  it 'changes offered_course_option_id for the application choice if it is already set' do
+    expect { service.save! }.to change(application_choice, :offered_course_option_id)
+  end
+
+  it 'sets offered_course_option_id for the application choice if it is not already set' do
+    application_choice.update(offered_course_option_id: nil)
+
+    expect { service.save! }.to change(application_choice, :offered_course_option_id)
+  end
+
+  it 'sets the offered_at date for the application_choice' do
+    Timecop.freeze do
+      expect { service.save! }.to change(application_choice, :offered_at).to(Time.zone.now)
+    end
+  end
+
+  it 'resets declined_by_default_at for the application choice' do
+    expect { service.save! && application_choice.reload }.to change(application_choice, :decline_by_default_at)
+  end
+end

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -1,19 +1,19 @@
 module CourseOptionHelpers
   def course_option_for_provider(provider:, course: nil)
-    course ||= create(:course, provider: provider)
+    course ||= create(:course, :open_on_apply, provider: provider)
     site = create(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end
 
   def course_option_for_provider_code(provider_code:)
     provider = create(:provider, :with_signed_agreement, code: provider_code)
-    course = create(:course, provider: provider)
+    course = create(:course, :open_on_apply, provider: provider)
     site = create(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end
 
   def course_option_for_accrediting_provider(provider:, accrediting_provider:)
-    course = create(:course, provider: provider, accrediting_provider: accrediting_provider)
+    course = create(:course, :open_on_apply, provider: provider, accrediting_provider: accrediting_provider)
     site = create(:site, provider: provider)
     create(:course_option, course: course, site: site)
   end

--- a/spec/support/test_helpers/dfe_sign_in_helpers.rb
+++ b/spec/support/test_helpers/dfe_sign_in_helpers.rb
@@ -31,8 +31,9 @@ module DfESignInHelpers
   end
 
   def provider_user_exists_in_apply_database
-    provider = create(:provider, code: 'ABC', name: 'Example Provider')
-    create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    provider_one = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Example Provider')
+    provider_two = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Another Provider')
+    create(:provider_user, providers: [provider_one, provider_two], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
   end
 
   def provider_user_exists_in_apply_database_with_multiple_providers

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider changes an offer' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider changes an offer' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_two_providers
+    and_an_offered_application_choice_exists_for_one_of_my_providers
+    and_another_two_course_options_exist_for_this_provider
+    and_i_sign_in_to_the_provider_interface
+    and_i_view_an_offered_application
+    then_i_cannot_change_the_offer
+
+    when_change_response_feature_is_activated
+    and_i_click_on_change_provider
+    then_i_see_all_my_providers
+
+    when_i_click_on_continue
+    then_i_see_all_courses_for_this_provider
+    and_i_can_change_the_course
+    and_i_see_all_available_locations_for_this_course
+    and_i_can_change_the_location
+
+    when_i_inspect_and_confirm_these_changes
+    then_the_offer_has_new_course_and_location_details
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = Provider.find_by(code: 'ABC')
+  end
+
+  def and_an_offered_application_choice_exists_for_one_of_my_providers
+    @course_option_one = course_option_for_provider_code(provider_code: @provider.code)
+    @application_offered = create(:application_choice, :with_offer, course_option: @course_option_one)
+  end
+
+  def and_another_two_course_options_exist_for_this_provider
+    @course_option_two = course_option_for_provider_code(provider_code: @provider.code)
+    @course_option_three = create(:course_option, course: @course_option_two.course, site: create(:site, provider: @provider))
+  end
+
+  def when_change_response_feature_is_activated
+    FeatureFlag.activate('provider_change_response')
+  end
+
+  def then_i_cannot_change_the_offer
+    first('a', text: 'Change', count: 0)
+  end
+
+  def and_i_view_an_offered_application
+    visit provider_interface_application_choice_path(
+      @application_offered.id,
+    )
+  end
+
+  def and_i_click_on_change_provider
+    visit provider_interface_application_choice_path(@application_offered.id)
+    within('.govuk-summary-list__actions.provider') do
+      click_on 'Change'
+    end
+  end
+
+  def then_i_see_all_my_providers
+    expect(page).to have_content @provider_user.providers.first.name
+    expect(page).to have_content @provider_user.providers.second.name
+  end
+
+  def when_i_click_on_continue
+    click_on 'Continue'
+  end
+
+  def then_i_see_all_courses_for_this_provider
+    @provider.courses.each do |course|
+      expect(page).to have_content course.name_and_code
+    end
+  end
+
+  def and_i_can_change_the_course
+    choose @course_option_two.course.name_and_code
+    click_on 'Continue'
+  end
+
+  def and_i_see_all_available_locations_for_this_course
+    @course_option_two.course.course_options.each do |course_option|
+      expect(page).to have_content course_option.site.name
+    end
+  end
+
+  def and_i_can_change_the_location
+    choose @course_option_three.site.name
+    click_on 'Continue'
+  end
+
+  def when_i_inspect_and_confirm_these_changes
+    expect(page).to have_content @application_offered.application_form.full_name
+
+    expect(page).to have_content @course_option_one.course.name_and_code
+    expect(page).to have_content @course_option_one.site.name_and_address
+
+    expect(page).to have_content @course_option_three.course.name_and_code
+    expect(page).to have_content @course_option_three.site.name_and_address
+
+    click_on 'Change offer'
+  end
+
+  def then_the_offer_has_new_course_and_location_details
+    expect(page).to have_content @course_option_three.course.name_and_code
+    expect(page).to have_content @course_option_three.site.name_and_address
+    expect(@application_offered.reload.offered_option).to eq(@course_option_three)
+  end
+end

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -63,9 +63,7 @@ RSpec.feature 'Provider changes an offer' do
 
   def and_i_click_on_change_provider
     visit provider_interface_application_choice_path(@application_offered.id)
-    within('.govuk-summary-list__actions.provider') do
-      click_on 'Change'
-    end
+    click_on 'Change training provider'
   end
 
   def then_i_see_all_my_providers

--- a/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_withdraws_an_offer_spec.rb
@@ -1,20 +1,19 @@
 require 'rails_helper'
 
-RSpec.feature 'Provider makes an offer' do
+RSpec.feature 'Provider withdraws an offer' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
   scenario 'Provider withdraws an offer' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_an_offered_application_choice_exist_for_my_provider
+    and_an_offered_application_choice_exists_for_my_provider
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
     and_i_view_an_offered_application
-    then_i_cannot_change_response
+    then_i_cannot_withdraw_the_offer
 
     when_change_response_feature_is_activated
-    and_i_change_response_to_an_application
-    and_i_choose_to_withdraw_an_offer
+    and_i_click_on_withdraw_application
     then_i_see_a_form_prompting_for_reasons
 
     when_i_enter_reasons
@@ -30,7 +29,7 @@ RSpec.feature 'Provider makes an offer' do
     provider_exists_in_dfe_sign_in
   end
 
-  def and_an_offered_application_choice_exist_for_my_provider
+  def and_an_offered_application_choice_exists_for_my_provider
     course_option = course_option_for_provider_code(provider_code: 'ABC')
     @application_offered = create(:application_choice, status: 'offer', offered_at: Time.zone.now, course_option: course_option, application_form: create(:completed_application_form, first_name: 'Alice', last_name: 'Wunder'))
   end
@@ -43,8 +42,8 @@ RSpec.feature 'Provider makes an offer' do
     FeatureFlag.activate('provider_change_response')
   end
 
-  def then_i_cannot_change_response
-    first('a', text: 'Change response', count: 0)
+  def then_i_cannot_withdraw_the_offer
+    first('a', text: 'Withdraw offer', count: 0)
   end
 
   def and_i_view_an_offered_application
@@ -53,16 +52,11 @@ RSpec.feature 'Provider makes an offer' do
     )
   end
 
-  def and_i_change_response_to_an_application
+  def and_i_click_on_withdraw_application
     visit provider_interface_application_choice_path(
       @application_offered.id,
     )
-    click_on 'Change response'
-  end
-
-  def and_i_choose_to_withdraw_an_offer
-    choose 'Withdraw offer'
-    click_on 'Continue'
+    click_on 'Withdraw offer'
   end
 
   def then_i_see_a_form_prompting_for_reasons


### PR DESCRIPTION
## Context

While it is possible for vendors to change the offered course through the API, provider users currently cannot make such changes throught the web UI. This PR aims to address this.

## Changes proposed in this pull request

`app/components/provider_interface/status_box_components/offer_component.rb` has been updated to show 'Change' links for provider, course and location, if the relevant feature flag (`provider_change_response`) is active.

This work replaces the previous 'edit response' flow. Changes to offers are done via the 'Change' links, offer withdrawals via a link at the bottom of the status box component.

The new designs allow the provider user to change the provider, as part of modifying the offer, as long as an association between the current user and the new provider exists. Courses are then scoped to the new provider, and locations are scoped to the course. The current logic tries to preserve the `study_mode` (e.g. full-time, part-time) of the original application. Changing `study_mode` is outside the scope of this PR.

Changing the provider is not required. In most cases, provider users will probably just want to change either Course + Location, or just Location, and these flows are also supported.

Previously:
![image](https://user-images.githubusercontent.com/107591/76205310-e0844980-61f1-11ea-8191-b480718aa49f.png)

Now, with `provider_change_response` active:
![image](https://user-images.githubusercontent.com/107591/76205370-fc87eb00-61f1-11ea-9e63-84bc031f82ba.png)

Happy path:

![ezgif com-optimize](https://user-images.githubusercontent.com/107591/76208931-9a7eb400-61f8-11ea-9503-5236d63c23a6.gif)

## Guidance to review

The main new files are: `app/controllers/provider_interface/offer_changes_controller.rb` and `app/models/provider_interface/change_offer_form.rb`.

I've had to update many test helpers and factories because this is new territory (e.g. if courses are not `open_on_apply` they will not show up in the UI, other parts of the provider interface do not check things like that). It seems like our provider UI tests were unaffected by the lack of completed application forms past the :offer stage.

Some more thinking is required around visibility of applications when a provider user is associated with multiple providers, esp. if they can modify offers. Currently, the application is mainly associated with the provider offering the course the candidate has originally applied to, but there may be flows that require changing application_choice ownership when an offer is modified.

This PR also includes code to display the current offered course option instead of the course option the candidate requested, if a provider user has already modified it. Some additional design/UI work may be needed to make it clear the course option has been modified.

## Link to Trello card

[Providers can change the offered course via the UI](https://trello.com/c/Rudw3nXZ)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
