### PR TITLE
Emphasize instruction not to merge immediately in hotfix doc

### DIFF
--- a/docs/hotfix-deployment.md
+++ b/docs/hotfix-deployment.md
@@ -55,7 +55,7 @@ features 1, 2 and 3, we just want everything up to `D`.
 3. Implement the fix locally, raise a PR and get it approved in the
    normal way. Test it locally or using the Heroku review app that is
    automatically created.
-4. After the PR is approved don't merge it to `master` straight away.
+4. After the PR is approved DON'T MERGE IT to `master` straight away.
    First deploy the `hotfix` branch using the [normal deployment
    procedure](deployment.md) (except picking `HEAD` of the
    `hotfix` branch rather than a specific SHA on `master` as we normally


### PR DESCRIPTION
Note that the main reason for this change is to test the hotfix process, however it seems worth emphasising this point - I nearly hit the Merge button first time I tried this.

## Context

This is a doc-only change to test the hotfix process

## Changes proposed in this pull request

Capitalise the _DO NOT MERGE_ straight away instruction.

## Guidance to review

Is this hotfix branched off the most recent deploy? - see https://apply-ops-dashboard.herokuapp.com/

## Link to Trello card

https://trello.com/c/2c9pgmt8/1622-figure-out-how-to-do-a-proper-hotfix-without-deploying-other-stuff-on-master-%F0%9F%8F%88

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
