### PR TITLE
Add 'first' instead of '1st' for referees + change heading size

### DIFF
--- a/app/services/text_ordinalizer.rb
+++ b/app/services/text_ordinalizer.rb
@@ -1,0 +1,18 @@
+class TextOrdinalizer
+  def self.call(value)
+    text_ordinalize(value)
+  end
+
+  class << self
+  private
+
+    def text_ordinalize(value)
+      ordinalize_mapping[value] || value.ordinalize
+    end
+
+    def ordinalize_mapping
+      %w[zeroth first second third fourth fifth sixth seventh
+         eighth ninth tenth]
+    end
+  end
+end

--- a/app/services/text_ordinalizer.rb
+++ b/app/services/text_ordinalizer.rb
@@ -1,4 +1,7 @@
 class TextOrdinalizer
+  ORDINALIZE_MAPPING = %w[zeroth first second third fourth fifth sixth seventh
+                          eighth ninth tenth].freeze
+
   def self.call(value)
     text_ordinalize(value)
   end
@@ -7,12 +10,7 @@ class TextOrdinalizer
   private
 
     def text_ordinalize(value)
-      ordinalize_mapping[value] || value.ordinalize
-    end
-
-    def ordinalize_mapping
-      %w[zeroth first second third fourth fifth sixth seventh
-         eighth ninth tenth]
+      ORDINALIZE_MAPPING[value] || value.ordinalize
     end
   end
 end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -84,7 +84,7 @@
 
     <% if @application_choice.application_form.application_references.any? %>
       <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>
-        <h2 class="govuk-heading-l govuk-!-margin-top-8"><%= "#{(i + 1).ordinalize} reference" %></h2>
+        <h2 class="govuk-heading-m govuk-!-margin-top-8"><%= "#{TextOrdinalizer.call((i + 1)).capitalize} referee" %></h2>
         <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference) %>
       <% end %>
     <% end %>

--- a/spec/services/text_ordinalizer_spec.rb
+++ b/spec/services/text_ordinalizer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe TextOrdinalizer do
+  it 'can return the text value of a number up to ten' do
+    expect(TextOrdinalizer.call(0)).to match('zeroth')
+    expect(TextOrdinalizer.call(1)).to match('first')
+    expect(TextOrdinalizer.call(2)).to match('second')
+    expect(TextOrdinalizer.call(3)).to match('third')
+    expect(TextOrdinalizer.call(4)).to match('fourth')
+    expect(TextOrdinalizer.call(5)).to match('fifth')
+    expect(TextOrdinalizer.call(6)).to match('sixth')
+    expect(TextOrdinalizer.call(7)).to match('seventh')
+    expect(TextOrdinalizer.call(8)).to match('eighth')
+    expect(TextOrdinalizer.call(9)).to match('ninth')
+    expect(TextOrdinalizer.call(10)).to match('tenth')
+  end
+
+  it 'will revert to "Nth" written numbers after ten' do
+    expect(TextOrdinalizer.call(11)).to match('11th')
+  end
+end


### PR DESCRIPTION
## Context

Fixes some discrepancy between app and design.

Referee headings were coming up as '1st reference', '2nd reference' this PR changes this so they read 'First referee', 'Second referee' etc. 

More details in the trello card.

Also changes the `<h2>` tags to govuk mediums rather than large.

## Changes proposed in this pull request

**Before:**
![image](https://user-images.githubusercontent.com/13377553/76082642-c35a3b80-5fa3-11ea-902e-38ec27fb8e75.png)

**After**
<img width="544" alt="Screenshot 2020-03-06 at 12 12 55" src="https://user-images.githubusercontent.com/13377553/76082672-d4a34800-5fa3-11ea-9a49-7c352d05efa9.png">

## Link to Trello card

https://trello.com/c/tU8HFZco/1732-fix-referee-sizing-and-content

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
