### PR TITLE
Export CSV of submitted application choices through Support 

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -18,6 +18,20 @@ module SupportInterface
       render plain: csv
     end
 
+    def submitted_application_choices
+      choices = SupportInterface::ApplicationChoicesExport.new.application_choices
+
+      csv = CSV.generate do |rows|
+        rows << choices.first.keys
+
+        choices.each do |a|
+          rows << a.values
+        end
+      end
+
+      render plain: csv
+    end
+
     def providers_export
       providers = SupportInterface::ProvidersExport.new.providers
 

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -1,0 +1,29 @@
+module SupportInterface
+  class ApplicationChoicesExport
+    def application_choices
+      relevant_applications.flat_map do |application_form|
+        application_form.application_choices.map do |choice|
+          {
+            support_reference: application_form.support_reference,
+            submitted_at: application_form.submitted_at,
+            choice_id: choice.id,
+            provider_code: choice.provider.code,
+            course_code: choice.course.code,
+          }
+        end
+      end
+    end
+
+  private
+
+    def relevant_applications
+      ApplicationForm
+        .includes(
+          :candidate,
+          :application_choices,
+        )
+        .where('candidates.hide_in_reporting' => false)
+        .where.not(submitted_at: nil)
+    end
+  end
+end

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -23,8 +23,8 @@ module SupportInterface
 
     def sent_to_provider_audit_entry(choice:)
       choice
-        .own_and_associated_audits
-        .find_by(audited_changes: { 'status' => %w[application_complete awaiting_provider_decision] })
+        .audits
+        .detect { |entry| entry.audited_changes == { 'status' => %w[application_complete awaiting_provider_decision] } }
     end
 
     def decision_interpretation(choice:)
@@ -55,7 +55,7 @@ module SupportInterface
       ApplicationForm
         .includes(
           :candidate,
-          :application_choices,
+          application_choices: %i[course provider audits],
         )
         .where('candidates.hide_in_reporting' => false)
         .where.not(submitted_at: nil)

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -9,12 +9,19 @@ module SupportInterface
             choice_id: choice.id,
             provider_code: choice.provider.code,
             course_code: choice.course.code,
+            sent_to_provider_at: sent_to_provider_audit_entry(choice: choice)&.created_at,
           }
         end
       end
     end
 
   private
+
+    def sent_to_provider_audit_entry(choice:)
+      choice
+        .own_and_associated_audits
+        .find_by(audited_changes: { 'status' => %w[application_complete awaiting_provider_decision] })
+    end
 
     def relevant_applications
       ApplicationForm

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -10,6 +10,8 @@ module SupportInterface
             provider_code: choice.provider.code,
             course_code: choice.course.code,
             sent_to_provider_at: sent_to_provider_audit_entry(choice: choice)&.created_at,
+            decided_at: choice.offered_at || choice.rejected_at,
+            decision: decision_interpretation(choice: choice),
           }
         end
       end
@@ -21,6 +23,18 @@ module SupportInterface
       choice
         .own_and_associated_audits
         .find_by(audited_changes: { 'status' => %w[application_complete awaiting_provider_decision] })
+    end
+
+    def decision_interpretation(choice:)
+      if choice.offered_at.present?
+        :offered
+      elsif choice.rejected_by_default? && choice.rejected_at.present?
+        :rejected_by_default
+      elsif choice.rejected_at.present?
+        :rejected
+      elsif choice.awaiting_provider_decision?
+        :awaiting_provider
+      end
     end
 
     def relevant_applications

--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -12,6 +12,8 @@ module SupportInterface
             sent_to_provider_at: sent_to_provider_audit_entry(choice: choice)&.created_at,
             decided_at: choice.offered_at || choice.rejected_at,
             decision: decision_interpretation(choice: choice),
+            offer_response: offer_response_interpretation(choice: choice),
+            offer_response_at: choice.accepted_at || choice.declined_at,
           }
         end
       end
@@ -34,6 +36,18 @@ module SupportInterface
         :rejected
       elsif choice.awaiting_provider_decision?
         :awaiting_provider
+      end
+    end
+
+    def offer_response_interpretation(choice:)
+      if choice.accepted_at.present?
+        :accepted
+      elsif choice.declined_by_default? && choice.declined_at.present?
+        :declined_by_default
+      elsif choice.declined_at.present?
+        :declined
+      elsif choice.offer?
+        :awaiting_candidate
       end
     end
 

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -19,6 +19,17 @@
   <%= govuk_link_to 'Download application timings (CSV)', support_interface_application_timings_path %>
 </p>
 
+<h3 class='govuk-heading-m'>Submitted application choices</h3>
+
+<p class='govuk-body'>
+  The submitted application choices export provides data about which courses candidates applied to,
+  as well as info about offers and candidate decisions.
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download submitted application choices (CSV)', support_interface_submitted_application_choices_path %>
+</p>
+
 <h3 class='govuk-heading-m'>Providers</h3>
 
 <p class='govuk-body'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -393,6 +393,7 @@ Rails.application.routes.draw do
 
     get '/performance' => 'performance#index', as: :performance
     get '/performance/application-timings', to: 'performance#application_timings', as: :application_timings
+    get '/performance/submitted-application-choices', to: 'performance#submitted_application_choices', as: :submitted_application_choices
     get '/performance/referee-survey', to: 'performance#referee_survey', as: :referee_survey
     get '/performance/providers', to: 'performance#providers_export', as: :providers_export
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -236,6 +236,18 @@ FactoryBot.define do
       edit_by { 1.day.ago }
     end
 
+    trait :with_rejection do
+      status { 'rejected' }
+      rejection_reason { 'candidate did not meet minimum course entry requirements' }
+      rejected_at { Time.zone.now }
+    end
+
+    trait :with_rejection_by_default do
+      status { 'rejected' }
+      rejected_at { Time.zone.now }
+      rejected_by_default { true }
+    end
+
     trait :with_offer do
       status { 'offer' }
       decline_by_default_at { Time.zone.now + 10.days }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -261,6 +261,19 @@ FactoryBot.define do
       status { 'pending_conditions' }
       accepted_at { Time.zone.now - 2.days }
     end
+
+    trait :with_declined_offer do
+      with_offer
+      status { 'declined' }
+      declined_at { Time.zone.now - 2.days }
+    end
+
+    trait :with_declined_by_default_offer do
+      with_offer
+      status { 'declined' }
+      declined_at { Time.zone.now }
+      declined_by_default { true }
+    end
   end
 
   factory :vendor_api_user do

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           provider_code: submitted_form.application_choices[0].course.provider.code,
           course_code: submitted_form.application_choices[0].course.code,
           sent_to_provider_at: nil,
+          decided_at: nil,
+          decision: nil,
         },
         {
           support_reference: submitted_form.support_reference,
@@ -26,21 +28,57 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           provider_code: submitted_form.application_choices[1].course.provider.code,
           course_code: submitted_form.application_choices[1].course.code,
           sent_to_provider_at: nil,
+          decided_at: nil,
+          decision: nil,
         },
       )
     end
 
-    it 'returns the time that a choice was sent to the provider' do
-      choice = create(:application_choice, :ready_to_send_to_provider)
-      choice.application_form.update(submitted_at: Time.zone.now)
+    context 'for choices that have gone to a provider' do
+      it 'returns the time that a choice was sent to the provider' do
+        choice = create(:application_choice, :ready_to_send_to_provider)
+        choice.application_form.update(submitted_at: Time.zone.now)
 
-      sent_to_provider_at = Time.zone.local(2019, 10, 1, 12, 0, 0)
-      Timecop.freeze(sent_to_provider_at) do
-        SendApplicationToProvider.new(application_choice: choice).call
+        sent_to_provider_at = Time.zone.local(2019, 10, 1, 12, 0, 0)
+        Timecop.freeze(sent_to_provider_at) do
+          SendApplicationToProvider.new(application_choice: choice).call
+        end
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(sent_to_provider_at: sent_to_provider_at)
+        expect(choice_row).to include(decided_at: nil)
+        expect(choice_row).to include(decision: :awaiting_provider)
       end
 
-      choice_row = described_class.new.application_choices.first
-      expect(choice_row).to include(sent_to_provider_at: sent_to_provider_at)
+      it 'returns the decision outcome and time for offers' do
+        decision_time = Time.zone.local(2019, 10, 1, 12, 0, 0)
+        choice = create(:application_choice, :with_offer, offered_at: decision_time)
+        choice.application_form.update(submitted_at: Time.zone.now)
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(decided_at: decision_time)
+        expect(choice_row).to include(decision: :offered)
+      end
+
+      it 'returns the decision outcome and time for rejections' do
+        decision_time = Time.zone.local(2019, 10, 1, 12, 0, 0)
+        choice = create(:application_choice, :with_rejection, rejected_at: decision_time)
+        choice.application_form.update(submitted_at: Time.zone.now)
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(decided_at: decision_time)
+        expect(choice_row).to include(decision: :rejected)
+      end
+
+      it 'returns the decision outcome and time for rejections-by-default' do
+        decision_time = Time.zone.local(2019, 10, 1, 12, 0, 0)
+        choice = create(:application_choice, :with_rejection_by_default, rejected_at: decision_time)
+        choice.application_form.update(submitted_at: Time.zone.now)
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(decided_at: decision_time)
+        expect(choice_row).to include(decision: :rejected_by_default)
+      end
     end
   end
 end

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
+  describe '#application_choices' do
+    it 'returns submitted application choices with timings' do
+      unsubmitted_form = create(:application_form)
+      create(:application_choice, status: :unsubmitted, application_form: unsubmitted_form)
+      submitted_form = create(:completed_application_form, application_choices_count: 2)
+
+      choices = described_class.new.application_choices
+      expect(choices.size).to eq(2)
+
+      expect(choices).to contain_exactly(
+        {
+          support_reference: submitted_form.support_reference,
+          submitted_at: submitted_form.submitted_at,
+          choice_id: submitted_form.application_choices[0].id,
+          provider_code: submitted_form.application_choices[0].course.provider.code,
+          course_code: submitted_form.application_choices[0].course.code,
+        },
+        {
+          support_reference: submitted_form.support_reference,
+          submitted_at: submitted_form.submitted_at,
+          choice_id: submitted_form.application_choices[1].id,
+          provider_code: submitted_form.application_choices[1].course.provider.code,
+          course_code: submitted_form.application_choices[1].course.code,
+        },
+      )
+    end
+  end
+end

--- a/spec/services/support_interface/application_choices_export_spec.rb
+++ b/spec/services/support_interface/application_choices_export_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           sent_to_provider_at: nil,
           decided_at: nil,
           decision: nil,
+          offer_response: nil,
+          offer_response_at: nil,
         },
         {
           support_reference: submitted_form.support_reference,
@@ -30,6 +32,8 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
           sent_to_provider_at: nil,
           decided_at: nil,
           decision: nil,
+          offer_response: nil,
+          offer_response_at: nil,
         },
       )
     end
@@ -78,6 +82,38 @@ RSpec.describe SupportInterface::ApplicationChoicesExport, with_audited: true do
         choice_row = described_class.new.application_choices.first
         expect(choice_row).to include(decided_at: decision_time)
         expect(choice_row).to include(decision: :rejected_by_default)
+      end
+    end
+
+    context 'for choices where the candidate has responded to an offer' do
+      it 'returns the offer decision outcome and time for accepted offers' do
+        decision_time = Time.zone.local(2019, 10, 1, 12, 0, 0)
+        choice = create(:application_choice, :with_accepted_offer, accepted_at: decision_time)
+        choice.application_form.update(submitted_at: Time.zone.now)
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(offer_response_at: decision_time)
+        expect(choice_row).to include(offer_response: :accepted)
+      end
+
+      it 'returns the offer decision outcome and time for declined offers' do
+        decision_time = Time.zone.local(2019, 10, 1, 12, 0, 0)
+        choice = create(:application_choice, :with_declined_offer, declined_at: decision_time)
+        choice.application_form.update(submitted_at: Time.zone.now)
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(offer_response_at: decision_time)
+        expect(choice_row).to include(offer_response: :declined)
+      end
+
+      it 'returns the offer decision outcome and time for declined-by-default offers' do
+        decision_time = Time.zone.local(2019, 10, 1, 12, 0, 0)
+        choice = create(:application_choice, :with_declined_by_default_offer, declined_at: decision_time)
+        choice.application_form.update(submitted_at: Time.zone.now)
+
+        choice_row = described_class.new.application_choices.first
+        expect(choice_row).to include(offer_response_at: decision_time)
+        expect(choice_row).to include(offer_response: :declined_by_default)
       end
     end
   end


### PR DESCRIPTION
## Context

In order to feed the service dashboard, we need an export of submitted application choices, including:

- what course the candidate applied to
- application outcomes and timestamps
- offer decisions and timestamp

This is alongside (but separate from) the exports introduced in #1240 and #1546. All 3 data sets are sufficiently distinct to warrant separate exports.

## Changes proposed in this pull request

Example export:

```
support_reference,submitted_at,choice_id,choice_status,provider_code,course_code,sent_to_provider_at,decision,decided_at,offer_response,offer_response_at
PC3294,2020-01-29 09:53:54 +0000,98,awaiting_provider_decision,ABC,N4Z8,,awaiting_provider,,,
EM1475,2020-01-29 14:01:58 +0000,33,awaiting_provider_decision,ABC,B383,,awaiting_provider,,,
JB5322,2020-01-29 14:09:21 +0000,115,awaiting_provider_decision,ABC,KP7D,,awaiting_provider,,,
YK3727,2020-01-30 14:31:30 +0000,113,awaiting_provider_decision,ABC,S8XJ,,awaiting_provider,,,
GW6186,2020-01-30 15:55:53 +0000,131,offer,ABC,0AXL,,offered,2020-02-21 15:40:17 +0000,awaiting_candidate,
GW6186,2020-01-30 15:55:53 +0000,130,awaiting_provider_decision,ABC,NCXB,,awaiting_provider,,,
GW6186,2020-01-30 15:55:53 +0000,129,awaiting_provider_decision,ABC,W8Q6,,awaiting_provider,,,
YV8261,2020-02-05 22:27:28 +0000,133,awaiting_references,1N1,2398,,,,,
KQ2375,2020-02-05 22:27:29 +0000,134,application_complete,1N1,239G,,,,,
EE5845,2020-02-05 22:27:29 +0000,135,awaiting_provider_decision,1N1,239K,2020-02-05 22:27:29 +0000,awaiting_provider,,,
SU2993,2020-02-05 22:27:30 +0000,137,offer,1N1,2398,2020-02-05 22:27:30 +0000,offered,2020-02-05 22:27:30 +0000,awaiting_candidate,
SU2993,2020-02-05 22:27:30 +0000,136,offer,1N1,239L,2020-02-05 22:27:30 +0000,offered,2020-02-05 22:27:30 +0000,awaiting_candidate,
CK6322,2020-02-05 22:27:30 +0000,139,rejected,C58,Q3X1,2020-02-05 22:27:30 +0000,rejected,2020-02-05 22:27:31 +0000,,
CK6322,2020-02-05 22:27:30 +0000,138,offer,1N1,2396,2020-02-05 22:27:30 +0000,offered,2020-02-05 22:27:30 +0000,awaiting_candidate,
JE7495,2020-02-05 22:27:31 +0000,141,rejected,1N1,2396,2020-02-05 22:27:31 +0000,rejected,2020-02-05 22:27:31 +0000,,
JE7495,2020-02-05 22:27:31 +0000,140,rejected,1N1,23B3,2020-02-05 22:27:31 +0000,rejected,2020-02-05 22:27:31 +0000,,
NM5397,2020-02-05 22:27:31 +0000,142,declined,2LR,2T22,2020-02-05 22:27:32 +0000,offered,2020-02-05 22:27:32 +0000,declined,2020-02-05 22:27:32 +0000
HK3863,2020-02-05 22:27:32 +0000,143,pending_conditions,2LR,2W2W,2020-02-05 22:27:32 +0000,offered,2020-02-05 22:27:32 +0000,accepted,2020-02-05 22:27:32 +0000
XQ7984,2020-02-05 22:27:32 +0000,144,recruited,1N1,239K,2020-02-05 22:27:33 +0000,offered,2020-02-05 22:27:33 +0000,accepted,2020-02-05 22:27:33 +0000
RB9374,2020-02-05 22:27:33 +0000,145,enrolled,1N1,2392,2020-02-05 22:27:33 +0000,offered,2020-02-05 22:27:33 +0000,accepted,2020-02-05 22:27:33 +0000
ZX2847,2020-02-05 22:27:34 +0000,146,withdrawn,C58,2TRC,2020-02-05 22:27:34 +0000,,,,
HK8499,2020-02-06 13:00:15 +0000,149,awaiting_provider_decision,69Q,MDQT,,awaiting_provider,,,
KR7452,2020-02-06 17:04:14 +0000,156,awaiting_provider_decision,4TT,7K1A,,awaiting_provider,,,
```
Example in Excel:

![image](https://user-images.githubusercontent.com/23801/76095370-13dd9300-5fbc-11ea-8084-0f88efa9b078.png)


## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
