### PR TITLE
Prepend Heroku app name to config.hosts

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -8,7 +8,9 @@ module HostingEnvironment
   end
 
   def self.authorised_hosts
-    ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
+    hosts = ENV.fetch('AUTHORISED_HOSTS').split(',').map(&:strip)
+    hosts.prepend "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" if ENV['HEROKU_APP_NAME']
+    hosts
   end
 
   def self.hostname

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,8 +112,4 @@ Rails.application.configure do
   HostingEnvironment.authorised_hosts.each do |host|
     config.hosts << host
   end
-
-  if ENV['HEROKU_APP_NAME']
-    config.hosts << "#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
-  end
 end


### PR DESCRIPTION
## Context

We call `authorised_hosts.first` in `HostingEnvironment#hostname` when `ENV["CUSTOM_HOSTNAME"]` is not defined. On Heroku, `authorised_hosts` always contains `apply-for-teacher-training.herokuapp.com` as the first item in a review app. Because of this, our review apps send magic link emails that tell users to go to `apply-for-teacher-training.herokuapp.com`.

This is a bit annoying, but we can easily work around it by prepending the desired hostname.

## Changes proposed in this pull request

Prepend the Heroku app hostname instead of appending it. Do this in `HostingEnvironment` so we're modifying only one source of truth.

## Guidance to review

Test this by trying to log into the review app. The email you receive should contain a link that works.

## Link to Trello card

Nope.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)