### PR TITLE
Fix flakey contact details spec

### DIFF
--- a/spec/models/candidate_interface/contact_details_form_spec.rb
+++ b/spec/models/candidate_interface/contact_details_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         address_line1: Faker::Address.street_name,
         address_line2: Faker::Address.street_address,
         address_line3: Faker::Address.city,
-        address_line4: Faker::Address.country,
+        address_line4: 'United Kingdom',
         postcode: Faker::Address.postcode,
       }
       application_form = build_stubbed(:application_form, data)
@@ -47,7 +47,7 @@ RSpec.describe CandidateInterface::ContactDetailsForm, type: :model do
         address_line1: Faker::Address.street_name,
         address_line2: Faker::Address.street_address,
         address_line3: Faker::Address.city,
-        address_line4: Faker::Address.country,
+        address_line4: 'United Kingdom',
         postcode: 'bn1 1aa',
       }
       application_form = build(:application_form)


### PR DESCRIPTION
## Context

Faker::Address sometimes returns `British Indian Ocean Territory (Chagos
Archipelago)` which fails our validation for a max length of `50` for `address_line4` because it's `51` characters. Nice.

## Changes proposed in this pull request

Update the test to use `United Kingdom` as the country as that's the main usecase.

## Guidance to review

We've committed to 50 characters max in the vendor API docs, so changing the validation does not seem likely, nor do I think we should in this situation.

Failing spec:

```bash
$ be rspec --seed 1337 ./spec/models/candidate_interface/contact_details_form_spec.rb:45
ℹ️ If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs
Run options: include {:locations=>{"./spec/models/candidate_interface/contact_details_form_spec.rb"=>[45]}}

Randomized with seed 1337

CandidateInterface::ContactDetailsForm
  #save_address
    updates the provided ApplicationForm with the address fields if valid

Finished in 0.88827 seconds (files took 4.32 seconds to load)
1 example, 0 failures

Randomized with seed 1337

Coverage report generated for RSpec to /Users/tvararu/dfe/apply-for-postgraduate-teacher-training/coverage. 213 / 11524 LOC (1.85%) covered.
$ be rspec --seed 38196 ./spec/models/candidate_interface/contact_details_form_spec.rb:45
ℹ️ If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs
Run options: include {:locations=>{"./spec/models/candidate_interface/contact_details_form_spec.rb"=>[45]}}

Randomized with seed 38196

CandidateInterface::ContactDetailsForm
  #save_address
    updates the provided ApplicationForm with the address fields if valid (FAILED - 1)

Failures:

  1) CandidateInterface::ContactDetailsForm#save_address updates the provided ApplicationForm with the address fields if valid
     Failure/Error: expect(contact_details.save_address(application_form)).to eq(true)

       expected: true
            got: false

       (compared using ==)

       Diff:
       @@ -1,2 +1,2 @@
       -true
       +false

     # ./spec/models/candidate_interface/contact_details_form_spec.rb:58:in `block (3 levels) in <top (required)>'

Finished in 0.86374 seconds (files took 4.34 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/models/candidate_interface/contact_details_form_spec.rb:45 # CandidateInterface::ContactDetailsForm#save_address updates the provided ApplicationForm with the address fields if valid

Randomized with seed 38196

Coverage report generated for RSpec to /Users/tvararu/dfe/apply-for-postgraduate-teacher-training/coverage. 178 / 11546 LOC (1.54%) covered.
SimpleCov failed with exit 1
```

Root cause:

```bash
$ be rspec --seed 38196 ./spec/models/candidate_interface/contact_details_form_spec.rb:45
ℹ️ If you change CSS, JS, or Assets - don't forget to run `rake compile_assets` before your test runs
Run options: include {:locations=>{"./spec/models/candidate_interface/contact_details_form_spec.rb"=>[45]}}

Randomized with seed 38196

CandidateInterface::ContactDetailsForm
  #save_address

From: /Users/tvararu/dfe/apply-for-postgraduate-teacher-training/spec/models/candidate_interface/contact_details_form_spec.rb @ line 60 :

    55:
    56:       form_data[:postcode] = 'BN1 1AA'
    57:
    58:       binding.pry
    59:
 => 60:       expect(contact_details.save_address(application_form)).to eq(true)
    61:       expect(application_form).to have_attributes(form_data)
    62:     end
    63:   end
    64:
    65:   describe 'validations' do

[1] pry(#<RSpec::ExampleGroups::CandidateInterfaceContactDetailsForm::SaveAddress>)> contact_details.save_address(application_form)
=> false
[2] pry(#<RSpec::ExampleGroups::CandidateInterfaceContactDetailsForm::SaveAddress>)> contact_details.errors
=> #<ActiveModel::Errors:0x00007ffadbd2c160
 @base=
  #<CandidateInterface::ContactDetailsForm:0x00007ffadbbb63a8
   @address_line1="Mayer Summit",
   @address_line2="779 Cole Islands",
   @address_line3="Wardland",
   @address_line4="British Indian Ocean Territory (Chagos Archipelago)",
   @errors=#<ActiveModel::Errors:0x00007ffadbd2c160 ...>,
   @postcode="bn1 1aa",
   @validation_context=nil>,
 @details={:address_line4=>[{:error=>:too_long, :count=>50}]},
 @messages={:address_line4=>["County must be 50 characters or fewer"]}>
[3] pry(#<RSpec::ExampleGroups::CandidateInterfaceContactDetailsForm::SaveAddress>)> "British Indian Ocean Territory (Chagos Archipelago)".length
  1 Fix flakey contact details spec
=> 51
```

## Link to Trello card

Nope.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)