### PR TITLE
1729-fix-summary-list-so-that-theres-no-gap-unless-at-least-one-row-has-an-action

### DIFF
--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -2,7 +2,7 @@ class SummaryCardComponent < ActionView::Component::Base
   validates :rows, presence: true
 
   def initialize(rows:, border: true, editable: true)
-    @rows = determine_rows(rows, editable)
+    @rows = rows_including_actions_if_editable(rows, editable)
     @border = border
   end
 
@@ -14,7 +14,7 @@ private
 
   attr_reader :rows
 
-  def determine_rows(rows, editable)
+  def rows_including_actions_if_editable(rows, editable)
     rows.map do |row|
       row.tap do |r|
         unless editable

--- a/app/components/summary_card_component.rb
+++ b/app/components/summary_card_component.rb
@@ -20,6 +20,7 @@ private
         unless editable
           r.delete(:change_path)
           r.delete(:action_path)
+          r.delete(:action)
         end
       end
     end

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -26,7 +26,7 @@
         <dd class="govuk-summary-list__actions">
           <%= link_to row[:action], row[:action_path], class: 'govuk-link' %>
         </dd>
-      <% else %>
+      <% elsif has_action_span? %>
         <span class="govuk-summary-list__actions"></span>
       <% end %>
     </div>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -5,6 +5,10 @@ class SummaryListComponent < ActionView::Component::Base
     @rows = rows
   end
 
+  def has_action_span?
+    @rows.select { |row| row.has_key?(:action) }.any?
+  end
+
 private
 
   attr_reader :rows

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -6,7 +6,7 @@ class SummaryListComponent < ActionView::Component::Base
   end
 
   def has_action_span?
-    @rows.select { |row| row.has_key?(:action_path) }.any?
+    @rows.select { |row| row.has_key?(:action) }.any?
   end
 
 private

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -6,7 +6,7 @@ class SummaryListComponent < ActionView::Component::Base
   end
 
   def has_action_span?
-    @rows.select { |row| row.has_key?(:action) }.any?
+    @rows.select { |row| row.has_key?(:action_path) }.any?
   end
 
 private

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe SummaryListComponent do
 
     result = render_inline(SummaryListComponent.new(rows: rows))
 
-    expect(result.to_html.include?('<span class="govuk-summary-list__actions"></span>')).to eq(false)
+    expect(result.to_html).not_to include('<span class="govuk-summary-list__actions"></span>')
   end
 
   it 'does render a span if any row as an action' do
@@ -91,6 +91,6 @@ RSpec.describe SummaryListComponent do
 
     result = render_inline(SummaryListComponent.new(rows: rows))
 
-    expect(result.to_html.include?('<span class="govuk-summary-list__actions"></span>')).to eq(true)
+    expect(result.to_html).to include('<span class="govuk-summary-list__actions"></span>')
   end
 end

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -62,4 +62,35 @@ RSpec.describe SummaryListComponent do
     result = render_inline(SummaryListComponent.new(rows: rows))
     expect(result.css('.govuk-summary-list__value p').to_html).to eq('<p class="govuk-body">Unsafe</p>')
   end
+
+  it 'does not render a span if no row has an action' do
+    rows = [{ key: 'Job',
+             value: ['Teacher', 'Clearcourt High'] },
+            { key: 'Working pattern',
+             value: "Full-time\n Omnis itaque rerum. Velit in ." },
+            { key: 'Description',
+             value: 'Cumque autem veritatis..'  },
+            { key: 'Dates',
+             value: 'May 2003 - November 2019'  }]
+
+    result = render_inline(SummaryListComponent.new(rows: rows))
+
+    expect(result.to_html.include?('<span class="govuk-summary-list__actions"></span>')).to eq(false)
+  end
+
+  it 'does render a span if any row as an action' do
+    rows = [{ key: 'Job',
+             value: ['Teacher', 'Clearcourt High'] },
+            { key: 'Working pattern',
+             value: "Full-time\n Omnis itaque rerum. Velit in ." },
+            { key: 'Description',
+             value: 'Cumque autem veritatis..' },
+            { key: 'Dates',
+             value: 'May 2003 - November 2019',
+             action: 'dates for Teacher, Clearcourt High' }]
+
+    result = render_inline(SummaryListComponent.new(rows: rows))
+
+    expect(result.to_html.include?('<span class="govuk-summary-list__actions"></span>')).to eq(true)
+  end
 end


### PR DESCRIPTION
Changes SummaryListComponent so that if all of the rows that are fed into it have no actions no <span> is output at the end of each row.

If any of the rows have actions the the span is output.

## Changes to UI:

**Before:**
<img width="508" alt="Screenshot 2020-03-09 at 10 57 18" src="https://user-images.githubusercontent.com/13377553/76206929-c435dc00-61f4-11ea-8176-2fbcac45fc71.png">

**After:**
<img width="519" alt="Screenshot 2020-03-09 at 10 55 52" src="https://user-images.githubusercontent.com/13377553/76206802-918be380-61f4-11ea-8a5e-d00163d86a44.png">



## Link to Trello card

https://trello.com/c/2kjPU7Aq/1729-fix-summary-list-so-that-theres-no-gap-unless-at-least-one-row-has-an-action

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
