### PR TITLE
Build add another course flow

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -150,7 +150,21 @@ module CandidateInterface
       redirect_to candidate_interface_course_choices_index_path
     end
 
-    def add_another_course; end
+    def add_another_course
+      @add_another_course = AddAnotherCourseForm.new
+    end
+
+    def add_another_course_selection
+      @additional_courses_allowed = 3 - current_candidate.current_application.application_choices.count
+      @add_another_course = AddAnotherCourseForm.new(add_another_course_params)
+      return render :add_another_course unless @add_another_course.valid?
+
+      if @add_another_course.add_another_course?
+        redirect_to candidate_interface_course_choices_choose_path
+      else
+        redirect_to candidate_interface_application_form_path
+      end
+    end
 
     def complete
       @application_form = current_application
@@ -184,6 +198,10 @@ module CandidateInterface
       params.fetch(:candidate_interface_course_chosen_form, {}).permit(:choice)
     end
 
+    def add_another_course_params
+      params.fetch(:candidate_interface_add_another_course_form, {}).permit(:add_another_course)
+    end
+
     def pick_site_for_course(course_id, course_option_id)
       @pick_site = PickSiteForm.new(
         application_form: current_application,
@@ -194,9 +212,11 @@ module CandidateInterface
 
       if @pick_site.save
         current_application.update!(course_choices_completed: false)
+
         @course_choices = current_candidate.current_application.application_choices
 
-        if @course_choices.count.between?(1, 2)
+        if @course_choices.count.between?(1, 2) && FeatureFlag.active?('add_additional_courses_page')
+          flash[:success] = "You’ve added #{@course_choices.last.course.name_and_code} to your application"
           redirect_to candidate_interface_course_choices_add_another_course_path
         else
           redirect_to candidate_interface_course_choices_index_path

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -150,6 +150,8 @@ module CandidateInterface
       redirect_to candidate_interface_course_choices_index_path
     end
 
+    def add_another_course; end
+
     def complete
       @application_form = current_application
 
@@ -192,8 +194,14 @@ module CandidateInterface
 
       if @pick_site.save
         current_application.update!(course_choices_completed: false)
+        @course_choices = current_candidate.current_application.application_choices
 
-        redirect_to candidate_interface_course_choices_index_path
+        if @course_choices.count.between?(1, 2)
+          redirect_to candidate_interface_course_choices_add_another_course_path
+        else
+          redirect_to candidate_interface_course_choices_index_path
+        end
+
       else
         render :options_for_site
       end

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -151,6 +151,7 @@ module CandidateInterface
     end
 
     def add_another_course
+      @additional_courses_allowed = 3 - current_candidate.current_application.application_choices.count
       @add_another_course = AddAnotherCourseForm.new
     end
 
@@ -212,11 +213,10 @@ module CandidateInterface
 
       if @pick_site.save
         current_application.update!(course_choices_completed: false)
-
         @course_choices = current_candidate.current_application.application_choices
+        flash[:success] = "You’ve added #{@course_choices.last.course.name_and_code} to your application"
 
         if @course_choices.count.between?(1, 2) && FeatureFlag.active?('add_additional_courses_page')
-          flash[:success] = "You’ve added #{@course_choices.last.course.name_and_code} to your application"
           redirect_to candidate_interface_course_choices_add_another_course_path
         else
           redirect_to candidate_interface_course_choices_index_path

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -21,6 +21,8 @@ module CandidateInterface
         if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
           if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
             redirect_to candidate_interface_additional_referee_path
+          elsif current_candidate.current_application.blank_application? && FeatureFlag.active?('before_you_start')
+            redirect_to candidate_interface_before_you_start_path
           else
             redirect_to candidate_interface_application_form_path
           end
@@ -44,6 +46,8 @@ module CandidateInterface
         if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
           if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
             redirect_to candidate_interface_additional_referee_path
+          elsif current_candidate.current_application.blank_application? && FeatureFlag.active?('before_you_start')
+            redirect_to candidate_interface_before_you_start_path
           else
             redirect_to candidate_interface_application_form_path
           end

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -14,36 +14,52 @@ module CandidateInterface
     def interstitial
       course = current_candidate.course_from_find
 
-      service_klass = FeatureFlag.active?('you_selected_a_course_page') ? InterstitialRouteSelector : AddCourseFromFind
-      service = service_klass.new(candidate: current_candidate)
-      service.execute
+      if FeatureFlag.active?('you_selected_a_course_page')
+        service = InterstitialRouteSelector.new(candidate: current_candidate)
+        service.execute
 
-      if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
-        if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
-          redirect_to candidate_interface_additional_referee_path
-        elsif current_candidate.current_application.blank_application? && FeatureFlag.active?('before_you_start')
-          redirect_to candidate_interface_before_you_start_path
-        else
-          redirect_to candidate_interface_application_form_path
+        if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
+          if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
+            redirect_to candidate_interface_additional_referee_path
+          else
+            redirect_to candidate_interface_application_form_path
+          end
+        elsif service.candidate_has_already_selected_the_course
+          flash[:warning] = "You have already selected #{course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_already_has_3_courses
+          flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        elsif !service.candidate_does_not_have_a_course_from_find
+          redirect_to candidate_interface_course_confirm_selection_path(course_id: course.id)
+        elsif service.candidate_should_choose_site
+          redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
+        elsif service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
+          redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
         end
-      elsif service.candidate_has_already_selected_the_course
-        flash[:warning] = "You have already selected #{course.name_and_code}."
-        redirect_to candidate_interface_course_choices_review_path
-      elsif !FeatureFlag.active?('you_selected_a_course_page') && service.candidate_has_new_course_added
-        redirect_to candidate_interface_course_choices_review_path
-      elsif !FeatureFlag.active?('you_selected_a_course_page') && service.candidate_should_choose_site
-        redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
-      elsif !FeatureFlag.active?('you_selected_a_course_page') && service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
-        redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
-      elsif service.candidate_already_has_3_courses
-        flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
-        redirect_to candidate_interface_course_choices_review_path
-      elsif FeatureFlag.active?('you_selected_a_course_page') && !service.candidate_does_not_have_a_course_from_find
-        redirect_to candidate_interface_course_confirm_selection_path(course_id: course.id)
-      elsif FeatureFlag.active?('you_selected_a_course_page') && service.candidate_should_choose_site
-        redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
-      elsif FeatureFlag.active?('you_selected_a_course_page') && service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
-        redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
+      else
+        service = AddCourseFromFind.new(candidate: current_candidate)
+        service.execute
+
+        if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
+          if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
+            redirect_to candidate_interface_additional_referee_path
+          else
+            redirect_to candidate_interface_application_form_path
+          end
+        elsif service.candidate_has_already_selected_the_course
+          flash[:warning] = "You have already selected #{course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_already_has_3_courses
+          flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_has_new_course_added
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_should_choose_site
+          redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
+        elsif service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
+          redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
+        end
       end
     end
 

--- a/app/models/candidate_interface/add_another_course_form.rb
+++ b/app/models/candidate_interface/add_another_course_form.rb
@@ -1,0 +1,12 @@
+module CandidateInterface
+  class AddAnotherCourseForm
+    include ActiveModel::Model
+
+    attr_accessor :add_another_course
+    validates :add_another_course, presence: true
+
+    def add_another_course?
+      add_another_course == 'yes'
+    end
+  end
+end

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     def user_cant_apply_to_same_course_twice
       return if course_id.blank?
 
-      if application_form.application_choices.any? { |application_choice| application_choice.course == course }
+      if application_form.application_choices.includes([:course]).any? { |application_choice| application_choice.course == course }
         errors[:base] << "You have already added #{course.name_and_code}"
       end
     end

--- a/app/services/candidate_interface/add_course_from_find.rb
+++ b/app/services/candidate_interface/add_course_from_find.rb
@@ -37,13 +37,13 @@ module CandidateInterface
       elsif candidate_has_already_selected_the_course?
         set_course_from_find_id_to_nil
         @candidate_has_already_selected_the_course = true
+      elsif course_has_both_study_modes? && FeatureFlag.active?('choose_study_mode')
+        set_course_from_find_id_to_nil
+        @candidate_should_choose_study_mode = true
       elsif course_has_one_site?
         add_application_choice
         set_course_from_find_id_to_nil
         @candidate_has_new_course_added = true
-      elsif course_has_both_study_modes? && FeatureFlag.active?('choose_study_mode')
-        set_course_from_find_id_to_nil
-        @candidate_should_choose_study_mode = true
       else
         set_course_from_find_id_to_nil
         @candidate_should_choose_site = true

--- a/app/services/candidate_interface/interstitial_route_selector.rb
+++ b/app/services/candidate_interface/interstitial_route_selector.rb
@@ -35,11 +35,11 @@ module CandidateInterface
         @candidate_already_has_3_courses = true
       elsif candidate_has_already_selected_the_course?
         @candidate_has_already_selected_the_course = true
-      elsif course_has_one_site?
-        @candidate_has_new_course_added = true
       elsif course_has_both_study_modes? && FeatureFlag.active?('choose_study_mode')
         set_course_from_find_id_to_nil
         @candidate_should_choose_study_mode = true
+      elsif course_has_one_site?
+        @candidate_has_new_course_added = true
       else
         @candidate_should_choose_site = true
       end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,5 +1,6 @@
 class FeatureFlag
   FEATURES = %w[
+    add_additional_courses_page
     banner_about_problems_with_dfe_sign_in
     choose_study_mode
     confirm_conditions

--- a/app/views/candidate_interface/course_choices/add_another_course.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl ">You can choose 2 more courses</h1>
+    <h1 class="govuk-heading-xl ">You can choose <%= @additional_courses_allowed %> more <%= "course".pluralize(@additional_courses_allowed) %></h1>
     <p class="govuk-body">After you submit your application you can’t apply for more courses through this service.</p>
       <%= form_with model: @add_another_course, url: candidate_interface_course_choices_add_another_course_selection_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
         <%= f.govuk_error_summary %>

--- a/app/views/candidate_interface/course_choices/add_another_course.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, title_with_error_prefix('', @add_another_course.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl ">You can choose 2 more courses</h1>
+    <p class="govuk-body">After you submit your application you can’t apply for more courses through this service.</p>
+      <%= form_with model: @add_another_course, url: candidate_interface_course_choices_add_another_course_selection_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+        <%= f.govuk_error_summary %>
+
+        <%= f.govuk_radio_buttons_fieldset :add_another_course, legend: { size: 'xl', text: 'Do you want to add another course?' } do %>
+          <div class="govuk-!-margin-top-6">
+            <%= f.govuk_radio_button :add_another_course, :yes, label: { text: 'Yes, add another course' }, link_errors: true %>
+            <%= f.govuk_radio_button :add_another_course, :no, label: { text: 'No, not at the moment' } %>
+          </div>
+        <% end %>
+
+        <%= f.govuk_submit 'Continue' %>
+      <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/course_choices/add_another_course.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl ">You can choose <%= @additional_courses_allowed %> more <%= "course".pluralize(@additional_courses_allowed) %></h1>
+    <h1 class="govuk-heading-xl ">You can choose <%= @additional_courses_allowed %> more <%= 'course'.pluralize(@additional_courses_allowed) %></h1>
     <p class="govuk-body">After you submit your application you can’t apply for more courses through this service.</p>
       <%= form_with model: @add_another_course, url: candidate_interface_course_choices_add_another_course_selection_path, builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
         <%= f.govuk_error_summary %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,8 @@ Rails.application.routes.draw do
         get '/review' => 'course_choices#review', as: :course_choices_review
         patch '/review' => 'course_choices#complete', as: :course_choices_complete
 
+        get '/add_another_course' => 'course_choices#add_another_course', as: :course_choices_add_another_course
+
         get '/confirm_selection/:course_id' => 'find_course_selections#confirm_selection', as: :course_confirm_selection
         post '/complete_selection/:course_id' => 'find_course_selections#complete_selection', as: :course_complete_selection
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,7 +200,8 @@ Rails.application.routes.draw do
         get '/review' => 'course_choices#review', as: :course_choices_review
         patch '/review' => 'course_choices#complete', as: :course_choices_complete
 
-        get '/add_another_course' => 'course_choices#add_another_course', as: :course_choices_add_another_course
+        get '/another' => 'course_choices#add_another_course', as: :course_choices_add_another_course
+        post '/another' => 'course_choices#add_another_course_selection', as: :course_choices_add_another_course_selection
 
         get '/confirm_selection/:course_id' => 'find_course_selections#confirm_selection', as: :course_confirm_selection
         post '/complete_selection/:course_id' => 'find_course_selections#complete_selection', as: :course_complete_selection

--- a/spec/models/candidate_interface/add_another_course_form_spec.rb
+++ b/spec/models/candidate_interface/add_another_course_form_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::AddAnotherCourseForm, type: :model do
+  let(:form) { described_class.new(add_another_course) }
+  let(:add_another_course) do
+    { 'add_another_course' => 'yes' }
+  end
+
+  it { is_expected.to validate_presence_of(:add_another_course) }
+
+  describe '#add_another_course?' do
+    context 'when the add_another_course value is yes' do
+      it 'returns true' do
+        expect(form.add_another_course?).to be_truthy
+      end
+    end
+
+    context 'when the add_another_course value is no' do
+      let(:add_another_course) do
+        { 'add_another_course' => 'no' }
+      end
+
+      it 'returns false' do
+        expect(form.add_another_course?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -101,6 +101,13 @@ module CandidateHelper
     choose 'Primary (2XT2)'
     click_button 'Continue'
 
+    if FeatureFlag.active?('add_additional_courses_page')
+      choose 'No, not at the moment'
+      click_button 'Continue'
+
+      click_on 'Course choices'
+    end
+
     check t('application_form.courses.complete.completed_checkbox')
     click_button 'Continue'
   end

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -32,6 +32,7 @@ RSpec.feature 'A candidate edits their course choice after submission' do
 
     given_there_are_course_options
     when_i_add_a_new_course_choice
+    and_i_visit_my_course_choices_page
     then_i_see_the_new_course_choice
 
     when_i_mark_this_section_as_completed
@@ -110,6 +111,10 @@ RSpec.feature 'A candidate edits their course choice after submission' do
     click_button 'Continue'
     choose 'Main site'
     click_button 'Continue'
+  end
+
+  def and_i_visit_my_course_choices_page
+    visit candidate_interface_course_choices_review_path
   end
 
   def then_i_see_the_new_course_choice

--- a/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe 'Add additional courses flow' do
     when_i_visit_my_application_page
     and_i_click_on_course_choices
     and_i_click_on_add_course
-    and_i_choose_that_i_know_where_i_want_to_apply
 
-    when_i_choose_a_provider
+    when_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
     and_i_choose_my_first_course_choice
     then_i_should_be_on_the_add_additional_courses_page
     and_i_should_receive_a_message_that_ive_added_the_first_course
@@ -23,12 +23,17 @@ RSpec.describe 'Add additional courses flow' do
 
     when_i_choose_yes
     then_i_should_see_the_have_you_chosen_a_course_page
+
+    when_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_my_second_course_choice
+    then_i_should_be_on_the_add_additional_courses_page
     and_i_should_receive_a_message_that_ive_added_the_second_course
-    # and_i_should_be_told_i_can_add_1_more_courses
-    # and_i_should_be_prompted_to_add_an_additional_course
-    #
+    and_i_should_be_told_i_can_add_1_more_courses
+    and_i_should_be_prompted_to_add_an_additional_course
+
     # when_i_add_a_third_course
-    # then_i_should_be_on_the_add_additional_courses_page
+    # then_i_should_be_on_the_application_page
     # and_i_should_receive_a_message_that_ive_added_the_third_course
   end
 
@@ -60,12 +65,12 @@ RSpec.describe 'Add additional courses flow' do
     click_link 'Continue'
   end
 
-  def and_i_choose_that_i_know_where_i_want_to_apply
+  def when_i_choose_that_i_know_where_i_want_to_apply
     choose 'Yes, I know where I want to apply'
     click_button 'Continue'
   end
 
-  def when_i_choose_a_provider
+  def and_i_choose_a_provider
     select @provider.name_and_code
     click_button 'Continue'
   end
@@ -98,5 +103,18 @@ RSpec.describe 'Add additional courses flow' do
 
   def then_i_should_see_the_have_you_chosen_a_course_page
     expect(page).to have_current_path candidate_interface_course_choices_choose_path
+  end
+
+  def and_i_should_receive_a_message_that_ive_added_the_second_course
+    expect(page).to have_content("You’ve added #{@provider.courses.second.name_and_code} to your application")
+  end
+
+  def and_i_choose_my_second_course_choice
+    choose @provider.courses.second.name_and_code
+    click_button 'Continue'
+  end
+
+  def and_i_should_be_told_i_can_add_1_more_courses
+    expect(page).to have_content('You can choose 1 more course')
   end
 end

--- a/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -17,12 +17,12 @@ RSpec.describe 'Add additional courses flow' do
     when_i_choose_a_provider
     and_i_choose_my_first_course_choice
     then_i_should_be_on_the_add_additional_courses_page
-    # and_i_should_receive_a_message_that_ive_added_the_first_course
-    # and_i_should_be_told_i_can_add_2_more_courses
-    # and_i_should_be_prompted_to_add_an_additional_course
+    and_i_should_receive_a_message_that_ive_added_the_first_course
+    and_i_should_be_told_i_can_add_2_more_courses
+    and_i_should_be_prompted_to_add_an_additional_course
 
-    # when_i_add_an_additional_course
-    # then_i_should_be_on_the_add_additional_courses_page
+    when_i_choose_yes
+    then_i_should_see_the_have_you_chosen_a_course_page
     # and_i_should_receive_a_message_that_ive_added_the_second_course
     # and_i_should_be_told_i_can_add_1_more_courses
     # and_i_should_be_prompted_to_add_an_additional_course
@@ -77,5 +77,26 @@ RSpec.describe 'Add additional courses flow' do
 
   def then_i_should_be_on_the_add_additional_courses_page
     expect(page).to have_current_path candidate_interface_course_choices_add_another_course_path
+  end
+
+  def and_i_should_receive_a_message_that_ive_added_the_first_course
+    expect(page).to have_content("You’ve added #{@provider.courses.first.name_and_code} to your application")
+  end
+
+  def and_i_should_be_told_i_can_add_2_more_courses
+    expect(page).to have_content('You can choose 2 more courses')
+  end
+
+  def and_i_should_be_prompted_to_add_an_additional_course
+    expect(page).to have_content('Do you want to add another course?')
+  end
+
+  def when_i_choose_yes
+    choose 'Yes, add another course'
+    click_on 'Continue'
+  end
+
+  def then_i_should_see_the_have_you_chosen_a_course_page
+    expect(page).to have_current_path candidate_interface_course_choices_choose_path
   end
 end

--- a/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -32,9 +32,14 @@ RSpec.describe 'Add additional courses flow' do
     and_i_should_be_told_i_can_add_1_more_courses
     and_i_should_be_prompted_to_add_an_additional_course
 
-    # when_i_add_a_third_course
-    # then_i_should_be_on_the_application_page
-    # and_i_should_receive_a_message_that_ive_added_the_third_course
+    when_i_choose_yes
+    then_i_should_see_the_have_you_chosen_a_course_page
+
+    when_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_my_third_course_choice
+    then_i_should_be_on_the_course_choice_review_page
+    and_i_should_receive_a_message_that_ive_added_the_third_course
   end
 
   def given_that_add_additional_courses_page_is_active
@@ -102,7 +107,7 @@ RSpec.describe 'Add additional courses flow' do
   end
 
   def then_i_should_see_the_have_you_chosen_a_course_page
-    expect(page).to have_current_path candidate_interface_course_choices_choose_path
+    expect(page).to have_current_path(candidate_interface_course_choices_choose_path)
   end
 
   def and_i_should_receive_a_message_that_ive_added_the_second_course
@@ -116,5 +121,18 @@ RSpec.describe 'Add additional courses flow' do
 
   def and_i_should_be_told_i_can_add_1_more_courses
     expect(page).to have_content('You can choose 1 more course')
+  end
+
+  def and_i_choose_my_third_course_choice
+    choose @provider.courses.third.name_and_code
+    click_button 'Continue'
+  end
+
+  def then_i_should_be_on_the_course_choice_review_page
+    expect(page).to have_current_path(candidate_interface_course_choices_review_path)
+  end
+
+  def and_i_should_receive_a_message_that_ive_added_the_third_course
+    expect(page).to have_content("You’ve added #{@provider.courses.third.name_and_code} to your application")
   end
 end

--- a/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe 'Add additional courses flow' do
+  include CandidateHelper
+
+  scenario 'Candidate is signed in' do
+    given_that_add_additional_courses_page_is_active
+    and_there_are_course_options
+    and_i_am_signed_in
+
+    when_i_visit_my_application_page
+    and_i_click_on_course_choices
+    and_i_click_on_add_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+
+    when_i_choose_a_provider
+    and_i_choose_my_first_course_choice
+    then_i_should_be_on_the_add_additional_courses_page
+    # and_i_should_receive_a_message_that_ive_added_the_first_course
+    # and_i_should_be_told_i_can_add_2_more_courses
+    # and_i_should_be_prompted_to_add_an_additional_course
+
+    # when_i_add_an_additional_course
+    # then_i_should_be_on_the_add_additional_courses_page
+    # and_i_should_receive_a_message_that_ive_added_the_second_course
+    # and_i_should_be_told_i_can_add_1_more_courses
+    # and_i_should_be_prompted_to_add_an_additional_course
+    #
+    # when_i_add_a_third_course
+    # then_i_should_be_on_the_add_additional_courses_page
+    # and_i_should_receive_a_message_that_ive_added_the_third_course
+  end
+
+  def given_that_add_additional_courses_page_is_active
+    FeatureFlag.activate('add_additional_courses_page')
+  end
+
+  def and_there_are_course_options
+    @provider = create(:provider)
+    3.times { create(:course, provider: @provider, exposed_in_find: true) }
+  end
+
+  def and_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_my_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link 'Course choices'
+  end
+
+  def and_i_click_on_add_course
+    click_link 'Continue'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+  end
+
+  def when_i_choose_a_provider
+    select @provider.name_and_code
+    click_button 'Continue'
+  end
+
+  def and_i_choose_my_first_course_choice
+    choose @provider.courses.first.name_and_code
+    click_button 'Continue'
+  end
+
+  def then_i_should_be_on_the_add_additional_courses_page
+    # route to go here
+  end
+end

--- a/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Add additional courses flow' do
   include CandidateHelper
+  include CourseOptionHelpers
 
   scenario 'Candidate is signed in' do
     given_that_add_additional_courses_page_is_active
@@ -37,7 +38,10 @@ RSpec.describe 'Add additional courses flow' do
 
   def and_there_are_course_options
     @provider = create(:provider)
-    3.times { create(:course, provider: @provider, exposed_in_find: true) }
+    create_list(:course, 3, provider: @provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
+    course_option_for_provider(provider: @provider, course: @provider.courses.first)
+    course_option_for_provider(provider: @provider, course: @provider.courses.second)
+    course_option_for_provider(provider: @provider, course: @provider.courses.third)
   end
 
   def and_i_am_signed_in
@@ -72,6 +76,6 @@ RSpec.describe 'Add additional courses flow' do
   end
 
   def then_i_should_be_on_the_add_additional_courses_page
-    # route to go here
+    expect(page).to have_current_path candidate_interface_course_choices_add_another_course_path
   end
 end

--- a/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Add additional courses flow' do
 
     when_i_choose_yes
     then_i_should_see_the_have_you_chosen_a_course_page
-    # and_i_should_receive_a_message_that_ive_added_the_second_course
+    and_i_should_receive_a_message_that_ive_added_the_second_course
     # and_i_should_be_told_i_can_add_1_more_courses
     # and_i_should_be_prompted_to_add_an_additional_course
     #

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_course
     then_i_see_the_address
     and_i_choose_a_location
+    and_i_visit_my_course_choices_page
     then_i_see_my_completed_course_choice
 
     # attempt to add the same course
@@ -33,6 +34,7 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_another_provider
     and_i_choose_another_course_with_only_one_site
+    and_i_visit_my_course_choices_page
     then_i_review_my_second_course_choice
 
     when_i_mark_this_section_as_completed
@@ -141,6 +143,10 @@ RSpec.feature 'Selecting a course' do
   def and_i_choose_a_location
     choose 'Main site'
     click_button 'Continue'
+  end
+
+  def and_i_visit_my_course_choices_page
+    visit candidate_interface_course_choices_review_path
   end
 
   def then_i_see_my_completed_course_choice

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -12,10 +12,12 @@ RSpec.feature 'Selecting a study mode' do
     then_i_can_only_select_sites_with_a_part_time_course
 
     when_i_select_a_site
+    and_i_visit_my_course_choices_page
     then_i_see_my_course_choice
 
     given_there_is_a_single_site_full_time_course_option
     when_i_select_the_single_site_full_time_course
+    and_i_visit_my_course_choices_page
     then_the_site_is_resolved_automatically_and_i_see_the_course_choice
   end
 
@@ -95,6 +97,10 @@ RSpec.feature 'Selecting a study mode' do
   def when_i_select_a_site
     choose @first_site.name
     click_button 'Continue'
+  end
+
+  def and_i_visit_my_course_choices_page
+    visit candidate_interface_course_choices_review_path
   end
 
   def then_i_see_my_course_choice

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
     then_i_should_see_the_study_mode_page
 
     when_i_choose_the_part_time_course
+    and_i_visit_my_course_choices_page
     then_i_should_see_it_on_my_review_page
   end
 
@@ -69,6 +70,10 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
   def when_i_choose_the_part_time_course
     choose 'Part time'
     click_button 'Continue'
+  end
+
+  def and_i_visit_my_course_choices_page
+    visit candidate_interface_course_choices_review_path
   end
 
   def then_i_should_see_it_on_my_review_page


### PR DESCRIPTION
## Context

Candidates should be asked if they want to add additional courses after adding their first or second course.

## Changes proposed in this pull request

- Implement add_another_course page/flow
- Refactors the interstitial action to make it easier to parse

If they can add 2 more courses

![image](https://user-images.githubusercontent.com/42515961/76147624-275d2c80-6096-11ea-8f22-eb2db8afd605.png)

If they can add one more course

![image](https://user-images.githubusercontent.com/42515961/76147634-3f34b080-6096-11ea-95d5-a34abfb74a66.png)

## Guidance to review

This should do several things:

- A flash should show telling the candidate their selected course has been added
- The page should say you can add 2 additional courses if they have 1 course choice
-  The page should say you can add 1 additional course if they have 2 course choices
- If they add a 3rd course they should be redirected to the course choices review page

This should work when arriving from Find or when adding courses via the course choice section.


## Link to Trello card

https://trello.com/c/lgMDVrWk/1090-build-add-another-course-flow

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
