### PR TITLE
Fetch site statuses from Find API

### DIFF
--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -11,6 +11,13 @@ class CourseOption < ApplicationRecord
     part_time: 'part_time',
   }
 
+  enum vacancy_status: {
+    both_full_time_and_part_time_vacancies: 'B',
+    part_time_vacancies: 'P',
+    full_time_vacancies: 'F',
+    no_vacancies: '',
+  }
+
   def validate_providers
     return unless site.present? && course.present?
 

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -12,10 +12,10 @@ class CourseOption < ApplicationRecord
   }
 
   enum vacancy_status: {
-    both_full_time_and_part_time_vacancies: 'B',
-    part_time_vacancies: 'P',
-    full_time_vacancies: 'F',
-    no_vacancies: '',
+    both_full_time_and_part_time_vacancies: 'both_full_time_and_part_time_vacancies',
+    part_time_vacancies: 'part_time_vacancies',
+    full_time_vacancies: 'full_time_vacancies',
+    no_vacancies: 'no_vacancies',
   }
 
   def validate_providers

--- a/app/models/find_api/site_status.rb
+++ b/app/models/find_api/site_status.rb
@@ -1,0 +1,4 @@
+module FindAPI
+  class SiteStatus < FindAPI::Resource
+  end
+end

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -88,7 +88,7 @@ class SyncProviderFromFind
           study_mode: mode,
         )
 
-        course_option.update(vacancy_status: site_status.vac_status)
+        course_option.update!(vacancy_status: site_status.vac_status)
       end
     end
 

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -10,7 +10,7 @@ class SyncProviderFromFind
     # https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/recruitment_cycles/2020/providers/1N1/?include=sites,courses.sites
     find_provider = FindAPI::Provider
       .current_cycle
-      .includes(:sites, courses: [:sites])
+      .includes(:sites, courses: [:sites, site_statuses: [:site]])
       .find(provider_code)
       .first
 
@@ -59,6 +59,8 @@ class SyncProviderFromFind
     end
     course.save!
 
+    site_statuses = find_course.site_statuses
+
     find_course.sites.each do |find_site|
       site = provider.sites.find_or_create_by(code: find_site.code)
 
@@ -70,6 +72,8 @@ class SyncProviderFromFind
       site.postcode = find_site.postcode&.strip
       site.save!
 
+      site_status = site_statuses.find { |ss| ss.site.id == find_site.id }
+
       study_modes = \
         if course.both_study_modes_available?
           %i[full_time part_time]
@@ -78,12 +82,13 @@ class SyncProviderFromFind
         end
 
       study_modes.each do |mode|
-        CourseOption.find_or_create_by(
+        course_option = CourseOption.find_or_create_by(
           site: site,
           course_id: course.id,
           study_mode: mode,
-          vacancy_status: 'B', #TODO: Should this be reflected by `find_course.has_vacancies?`
         )
+
+        course_option.update(vacancy_status: site_status.vac_status)
       end
     end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -165,7 +165,7 @@ FactoryBot.define do
     course
     site { association(:site, provider: course.provider) }
 
-    vacancy_status { 'B' }
+    vacancy_status { 'both_full_time_and_part_time_vacancies' }
   end
 
   factory :course do

--- a/spec/services/candidate_interface/add_course_from_find_spec.rb
+++ b/spec/services/candidate_interface/add_course_from_find_spec.rb
@@ -131,7 +131,7 @@ private
   def create_two_course_options_for_course(course:)
     site = create(:site, provider: course.provider)
     site2 = create(:site, provider: course.provider)
-    create(:course_option, site: site, course: course, vacancy_status: 'B')
-    create(:course_option, site: site2, course: course, vacancy_status: 'B')
+    create(:course_option, site: site, course: course)
+    create(:course_option, site: site2, course: course)
   end
 end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -3,151 +3,153 @@ require 'rails_helper'
 RSpec.describe SyncProviderFromFind do
   include FindAPIHelper
 
-  describe 'ingesting a brand new provider' do
-    it 'just creates the provider without any courses' do
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+  describe '.call' do
+    context 'ingesting a brand new provider' do
+      it 'just creates the provider without any courses' do
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
-      provider = Provider.find_by_code('ABC')
-      expect(provider).to be_present
-      expect(provider.courses).to be_blank
-    end
-  end
-
-  describe 'ingesting an existing provider not configured to sync courses' do
-    before do
-      @existing_provider = create :provider, code: 'ABC', sync_courses: false
-    end
-
-    it 'correctly updates the provider but does not import any courses' do
-      stub_find_api_provider_200(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        site_code: 'G',
-        findable: true,
-      )
-
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
-
-      expect(@existing_provider.reload.courses).to be_blank
-      expect(@existing_provider.reload.name).to eq 'ABC College'
-    end
-  end
-
-  describe 'ingesting an existing provider configured to sync courses, sites and course_options' do
-    before do
-      @existing_provider = create :provider, code: 'ABC', sync_courses: true
-    end
-
-    it 'correctly creates all the entities' do
-      stub_find_api_provider_200(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        site_code: 'G',
-        findable: true,
-      )
-
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
-
-      course_option = CourseOption.last
-
-      expect(course_option.course.provider.code).to eq 'ABC'
-      expect(course_option.course.code).to eq '9CBA'
-      expect(course_option.course.exposed_in_find).to be true
-      expect(course_option.course.recruitment_cycle_year).to be FindAPI::RECRUITMENT_CYCLE_YEAR
-      expect(course_option.site.name).to eq 'Main site'
-      expect(course_option.site.address_line1).to eq 'Gorse SCITT'
-      expect(course_option.site.address_line2).to eq 'C/O The Bruntcliffe Academy'
-      expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
-      expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
-      expect(course_option.site.postcode).to eq 'LS27 0LZ'
-    end
-
-    it 'correctly handles missing address info' do
-      stub_find_api_provider_200(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        site_code: 'G',
-        findable: true,
-        site_address_line2: nil,
-      )
-
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
-
-      course_option = CourseOption.last
-
-      expect(course_option.course.provider.code).to eq 'ABC'
-      expect(course_option.course.code).to eq '9CBA'
-      expect(course_option.course.exposed_in_find).to be true
-      expect(course_option.course.recruitment_cycle_year).to be FindAPI::RECRUITMENT_CYCLE_YEAR
-      expect(course_option.site.name).to eq 'Main site'
-      expect(course_option.site.address_line1).to eq 'Gorse SCITT'
-      expect(course_option.site.address_line2).to be_nil
-      expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
-      expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
-      expect(course_option.site.postcode).to eq 'LS27 0LZ'
-    end
-
-    it 'correctly handles accrediting providers' do
-      stub_find_api_provider_200_with_accrediting_provider(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        site_code: 'G',
-        study_mode: 'full_time',
-        accrediting_provider_code: 'DEF',
-        accrediting_provider_name: 'Test Accrediting Provider',
-      )
-
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
-
-      course_option = CourseOption.last
-
-      expect(course_option.course.accrediting_provider.code).to eq 'DEF'
-      expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
-    end
-
-    it 'stores full_time/part_time information within courses' do
-      stub_find_api_provider_200_with_accrediting_provider(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        study_mode: 'full_time_or_part_time',
-      )
-
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
-
-      course = Provider.find_by_code('ABC').courses.find_by_code('9CBA')
-      expect(course.study_mode).to eq 'full_time_or_part_time'
-    end
-
-    it 'creates the correct number of course_options for sites and study_mode' do
-      stub_find_api_provider_200_with_multiple_sites(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        study_mode: 'full_time_or_part_time',
-      )
-
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
-
-      provider = Provider.find_by_code('ABC')
-      course_options = provider.courses.find_by_code('9CBA').course_options
-
-      expect(course_options.count).to eq 4
-      provider.sites.each do |site|
-        modes_for_site = course_options.where(site_id: site.id).pluck(:study_mode)
-        expect(modes_for_site).to match_array %w[full_time part_time]
+        provider = Provider.find_by_code('ABC')
+        expect(provider).to be_present
+        expect(provider.courses).to be_blank
       end
     end
 
-    it 'correctly updates the Provider#region_code' do
-      stub_find_api_provider_200(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        site_code: 'G',
-        findable: true,
-      )
+    context 'ingesting an existing provider not configured to sync courses' do
+      before do
+        @existing_provider = create :provider, code: 'ABC', sync_courses: false
+      end
 
-      SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+      it 'correctly updates the provider but does not import any courses' do
+        stub_find_api_provider_200(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          site_code: 'G',
+          findable: true,
+        )
 
-      expect(@existing_provider.reload.region_code).to eq 'north_west'
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        expect(@existing_provider.reload.courses).to be_blank
+        expect(@existing_provider.reload.name).to eq 'ABC College'
+      end
+    end
+
+    context 'ingesting an existing provider configured to sync courses, sites and course_options' do
+      before do
+        @existing_provider = create :provider, code: 'ABC', sync_courses: true
+      end
+
+      it 'correctly creates all the entities' do
+        stub_find_api_provider_200(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          site_code: 'G',
+          findable: true,
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        course_option = CourseOption.last
+
+        expect(course_option.course.provider.code).to eq 'ABC'
+        expect(course_option.course.code).to eq '9CBA'
+        expect(course_option.course.exposed_in_find).to be true
+        expect(course_option.course.recruitment_cycle_year).to be FindAPI::RECRUITMENT_CYCLE_YEAR
+        expect(course_option.site.name).to eq 'Main site'
+        expect(course_option.site.address_line1).to eq 'Gorse SCITT'
+        expect(course_option.site.address_line2).to eq 'C/O The Bruntcliffe Academy'
+        expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
+        expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
+        expect(course_option.site.postcode).to eq 'LS27 0LZ'
+      end
+
+      it 'correctly handles missing address info' do
+        stub_find_api_provider_200(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          site_code: 'G',
+          findable: true,
+          site_address_line2: nil,
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        course_option = CourseOption.last
+
+        expect(course_option.course.provider.code).to eq 'ABC'
+        expect(course_option.course.code).to eq '9CBA'
+        expect(course_option.course.exposed_in_find).to be true
+        expect(course_option.course.recruitment_cycle_year).to be FindAPI::RECRUITMENT_CYCLE_YEAR
+        expect(course_option.site.name).to eq 'Main site'
+        expect(course_option.site.address_line1).to eq 'Gorse SCITT'
+        expect(course_option.site.address_line2).to be_nil
+        expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
+        expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
+        expect(course_option.site.postcode).to eq 'LS27 0LZ'
+      end
+
+      it 'correctly handles accrediting providers' do
+        stub_find_api_provider_200_with_accrediting_provider(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          site_code: 'G',
+          study_mode: 'full_time',
+          accrediting_provider_code: 'DEF',
+          accrediting_provider_name: 'Test Accrediting Provider',
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        course_option = CourseOption.last
+
+        expect(course_option.course.accrediting_provider.code).to eq 'DEF'
+        expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
+      end
+
+      it 'stores full_time/part_time information within courses' do
+        stub_find_api_provider_200_with_accrediting_provider(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          study_mode: 'full_time_or_part_time',
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        course = Provider.find_by_code('ABC').courses.find_by_code('9CBA')
+        expect(course.study_mode).to eq 'full_time_or_part_time'
+      end
+
+      it 'creates the correct number of course_options for sites and study_mode' do
+        stub_find_api_provider_200_with_multiple_sites(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          study_mode: 'full_time_or_part_time',
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        provider = Provider.find_by_code('ABC')
+        course_options = provider.courses.find_by_code('9CBA').course_options
+
+        expect(course_options.count).to eq 4
+        provider.sites.each do |site|
+          modes_for_site = course_options.where(site_id: site.id).pluck(:study_mode)
+          expect(modes_for_site).to match_array %w[full_time part_time]
+        end
+      end
+
+      it 'correctly updates the Provider#region_code' do
+        stub_find_api_provider_200(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          site_code: 'G',
+          findable: true,
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+
+        expect(@existing_provider.reload.region_code).to eq 'north_west'
+      end
     end
   end
 end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -16,16 +16,11 @@ RSpec.describe SyncProviderFromFind do
 
     context 'ingesting an existing provider not configured to sync courses' do
       before do
-        @existing_provider = create :provider, code: 'ABC', sync_courses: false
+        @existing_provider = create :provider, code: 'ABC', sync_courses: false, name: 'Foobar College'
       end
 
       it 'correctly updates the provider but does not import any courses' do
-        stub_find_api_provider_200(
-          provider_code: 'ABC',
-          course_code: '9CBA',
-          site_code: 'G',
-          findable: true,
-        )
+        stub_find_api_provider_200(provider_code: 'ABC', findable: true)
 
         SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
@@ -43,14 +38,12 @@ RSpec.describe SyncProviderFromFind do
         stub_find_api_provider_200(
           provider_code: 'ABC',
           course_code: '9CBA',
-          site_code: 'G',
           findable: true,
         )
 
         SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
         course_option = CourseOption.last
-
         expect(course_option.course.provider.code).to eq 'ABC'
         expect(course_option.course.code).to eq '9CBA'
         expect(course_option.course.exposed_in_find).to be true
@@ -67,7 +60,6 @@ RSpec.describe SyncProviderFromFind do
         stub_find_api_provider_200(
           provider_code: 'ABC',
           course_code: '9CBA',
-          site_code: 'G',
           findable: true,
           site_address_line2: nil,
         )
@@ -75,7 +67,6 @@ RSpec.describe SyncProviderFromFind do
         SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
         course_option = CourseOption.last
-
         expect(course_option.course.provider.code).to eq 'ABC'
         expect(course_option.course.code).to eq '9CBA'
         expect(course_option.course.exposed_in_find).to be true
@@ -92,7 +83,6 @@ RSpec.describe SyncProviderFromFind do
         stub_find_api_provider_200_with_accrediting_provider(
           provider_code: 'ABC',
           course_code: '9CBA',
-          site_code: 'G',
           study_mode: 'full_time',
           accrediting_provider_code: 'DEF',
           accrediting_provider_name: 'Test Accrediting Provider',
@@ -101,7 +91,6 @@ RSpec.describe SyncProviderFromFind do
         SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
         course_option = CourseOption.last
-
         expect(course_option.course.accrediting_provider.code).to eq 'DEF'
         expect(course_option.course.accrediting_provider.name).to eq 'Test Accrediting Provider'
       end
@@ -142,7 +131,6 @@ RSpec.describe SyncProviderFromFind do
         stub_find_api_provider_200(
           provider_code: 'ABC',
           course_code: '9CBA',
-          site_code: 'G',
           findable: true,
         )
 

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe SyncProviderFromFind do
         expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
         expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
         expect(course_option.site.postcode).to eq 'LS27 0LZ'
+        expect(course_option.vacancy_status).to eq 'full_time_vacancies'
       end
 
       it 'correctly handles missing address info' do
@@ -77,6 +78,21 @@ RSpec.describe SyncProviderFromFind do
         expect(course_option.site.address_line3).to eq 'Bruntcliffe Lane'
         expect(course_option.site.address_line4).to eq 'MORLEY, LEEDS'
         expect(course_option.site.postcode).to eq 'LS27 0LZ'
+      end
+
+      it 'correctly updates vacancy status for any existing course options' do
+        stub_find_api_provider_200(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          findable: true,
+        )
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        expect(CourseOption.count).to eq 1
+        CourseOption.first.update!(vacancy_status: 'no_vacancies')
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        expect(CourseOption.count).to eq 1
+        expect(CourseOption.first.vacancy_status).to eq 'full_time_vacancies'
       end
 
       it 'correctly handles accrediting providers' do

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -5,13 +5,6 @@ RSpec.describe SyncProviderFromFind do
 
   describe 'ingesting a brand new provider' do
     it 'just creates the provider without any courses' do
-      stub_find_api_provider_200(
-        provider_code: 'ABC',
-        course_code: '9CBA',
-        site_code: 'G',
-        findable: true,
-      )
-
       SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
       provider = Provider.find_by_code('ABC')

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -87,7 +87,7 @@ module CandidateHelper
     @provider = create(:provider, name: 'Gorse SCITT', code: '1N1')
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
     course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider)
-    create(:course_option, site: site, course: course, vacancy_status: 'B')
+    create(:course_option, site: site, course: course)
   end
 
   def candidate_fills_in_course_choices

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -67,6 +67,29 @@ module FindAPIHelper
                     { 'id': '1', 'type': 'sites' },
                   ],
                 },
+                'site_statuses': {
+                  'data': [
+                    { 'id': '222', 'type': 'site_statuses' },
+                  ],
+                },
+              },
+            },
+            {
+              'id': '222',
+              'type': 'site_statuses',
+              'attributes': {
+                'vac_status': 'full_time_vacancies',
+                'publish': 'published',
+                'status': 'running',
+                'has_vacancies?': true,
+              },
+              'relationships': {
+                'site': {
+                  'data': {
+                    'type': 'sites',
+                    'id': '1',
+                  },
+                },
               },
             },
           ],
@@ -329,6 +352,6 @@ private
   def stub_find_api_provider(provider_code)
     stub_request(:get, ENV.fetch('FIND_BASE_URL') +
       'recruitment_cycles/2020' \
-      "/providers/#{provider_code}?include=sites,courses.sites")
+      "/providers/#{provider_code}?include=sites,courses.sites,courses.site_statuses.site")
   end
 end

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -170,6 +170,29 @@ module FindAPIHelper
                     { 'id': '1', 'type': 'sites' },
                   ],
                 },
+                'site_statuses': {
+                  'data': [
+                    { 'id': '222', 'type': 'site_statuses' },
+                  ],
+                },
+              },
+            },
+            {
+              'id': '222',
+              'type': 'site_statuses',
+              'attributes': {
+                'vac_status': 'full_time_vacancies',
+                'publish': 'published',
+                'status': 'running',
+                'has_vacancies?': true,
+              },
+              'relationships': {
+                'site': {
+                  'data': {
+                    'type': 'sites',
+                    'id': '1',
+                  },
+                },
               },
             },
           ],
@@ -257,6 +280,48 @@ module FindAPIHelper
                   { 'id': '1', 'type': 'sites' },
                   { 'id': '2', 'type': 'sites' },
                 ],
+              },
+              'site_statuses': {
+                'data': [
+                  { 'id': '222', 'type': 'site_statuses' },
+                  { 'id': '223', 'type': 'site_statuses' },
+                ],
+              },
+            },
+          },
+          {
+            'id': '222',
+            'type': 'site_statuses',
+            'attributes': {
+              'vac_status': 'full_time_vacancies',
+              'publish': 'published',
+              'status': 'running',
+              'has_vacancies?': true,
+            },
+            'relationships': {
+              'site': {
+                'data': {
+                  'type': 'sites',
+                  'id': '1',
+                },
+              },
+            },
+          },
+          {
+            'id': '223',
+            'type': 'site_statuses',
+            'attributes': {
+              'vac_status': 'full_time_vacancies',
+              'publish': 'published',
+              'status': 'running',
+              'has_vacancies?': true,
+            },
+            'relationships': {
+              'site': {
+                'data': {
+                  'type': 'sites',
+                  'id': '2',
+                },
               },
             },
           },

--- a/spec/system/candidate_interface/candidate_deletes_course_after_completing_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_deletes_course_after_completing_section_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Candidate edits their choice section' do
 
   def given_there_are_courses_to_add
     @course = create(:course, exposed_in_find: true, open_on_apply: true)
-    @course_option = create(:course_option, course: @course, vacancy_status: 'B')
+    @course_option = create(:course_option, course: @course)
   end
 
   def and_i_have_added_a_course_and_complete_the_course_choices_section

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -142,8 +142,8 @@ RSpec.feature 'A candidate edits their course choice after submission' do
       postcode: 'LS8 5DQ'
     )
     multi_site_course = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true, open_on_apply: true)
-    create(:course_option, site: first_site, course: multi_site_course, vacancy_status: 'B')
-    create(:course_option, site: second_site, course: multi_site_course, vacancy_status: 'B')
+    create(:course_option, site: first_site, course: multi_site_course)
+    create(:course_option, site: second_site, course: multi_site_course)
 
     another_provider = create(:provider, name: 'Royal Academy of Dance', code: 'R55')
     third_site = create(
@@ -157,7 +157,7 @@ RSpec.feature 'A candidate edits their course choice after submission' do
       postcode: 'SW11 3RA'
     )
     single_site_course = create(:course, name: 'Dance', code: 'W5X1', provider: another_provider, exposed_in_find: true, open_on_apply: true)
-    create(:course_option, site: third_site, course: single_site_course, vacancy_status: 'B')
+    create(:course_option, site: third_site, course: single_site_course)
   end
 
   def when_i_mark_this_section_as_completed

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_without_selection_page.spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_without_selection_page.spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   def and_the_course_i_selected_only_has_one_site
     @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
     @site = create(:site, provider: @course.provider)
-    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+    create(:course_option, site: @site, course: @course)
   end
 
   def and_i_am_an_existing_candidate_on_apply
@@ -138,8 +138,8 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
     @site2 = create(:site, provider: @course_with_multiple_sites.provider)
-    create(:course_option, site: @site1, course: @course_with_multiple_sites, vacancy_status: 'B')
-    create(:course_option, site: @site2, course: @course_with_multiple_sites, vacancy_status: 'B')
+    create(:course_option, site: @site1, course: @course_with_multiple_sites)
+    create(:course_option, site: @site2, course: @course_with_multiple_sites)
   end
 
   def then_i_should_see_the_course_choices_site_page

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_spec_with_selection_page.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_spec_with_selection_page.rb
@@ -47,15 +47,15 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   def and_the_course_i_selected_only_has_one_site
     @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
     @site = create(:site, provider: @course.provider)
-    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+    create(:course_option, site: @site, course: @course)
   end
 
   def given_the_course_i_selected_has_multiple_sites
     @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
     @site2 = create(:site, provider: @course_with_multiple_sites.provider)
-    create(:course_option, site: @site1, course: @course_with_multiple_sites, vacancy_status: 'B')
-    create(:course_option, site: @site2, course: @course_with_multiple_sites, vacancy_status: 'B')
+    create(:course_option, site: @site1, course: @course_with_multiple_sites)
+    create(:course_option, site: @site2, course: @course_with_multiple_sites)
 
     visit candidate_interface_sign_up_path providerCode: @course_with_multiple_sites.provider.code, courseCode: @course_with_multiple_sites.code
   end

--- a/spec/system/candidate_interface/course_selection/candidate_existing_submitted_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_submitted_user_with_course_params_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   def when_i_arrive_at_the_sign_up_page_with_course_params_with_one_site
     @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
     @site = create(:site, provider: @course.provider)
-    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+    create(:course_option, site: @site, course: @course)
 
     visit candidate_interface_sign_up_path providerCode: @course.provider.code, courseCode: @course.code
   end

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   def and_the_course_i_selected_only_has_one_site
     @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
     @site = create(:site, provider: @course.provider)
-    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+    create(:course_option, site: @site, course: @course)
   end
 
   def and_i_am_an_existing_candidate_on_apply
@@ -169,8 +169,8 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
     @site2 = create(:site, provider: @course_with_multiple_sites.provider)
-    create(:course_option, site: @site1, course: @course_with_multiple_sites, vacancy_status: 'B')
-    create(:course_option, site: @site2, course: @course_with_multiple_sites, vacancy_status: 'B')
+    create(:course_option, site: @site1, course: @course_with_multiple_sites)
+    create(:course_option, site: @site2, course: @course_with_multiple_sites)
   end
 
   def then_i_should_see_the_course_choices_site_page

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -34,15 +34,15 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   def and_the_course_i_selected_only_has_one_site
     @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
     @site = create(:site, provider: @course.provider)
-    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+    create(:course_option, site: @site, course: @course)
   end
 
   def given_the_course_i_selected_has_multiple_sites
     @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
     @site2 = create(:site, provider: @course_with_multiple_sites.provider)
-    create(:course_option, site: @site1, course: @course_with_multiple_sites, vacancy_status: 'B')
-    create(:course_option, site: @site2, course: @course_with_multiple_sites, vacancy_status: 'B')
+    create(:course_option, site: @site1, course: @course_with_multiple_sites)
+    create(:course_option, site: @site2, course: @course_with_multiple_sites)
 
     visit candidate_interface_sign_up_path providerCode: @course_with_multiple_sites.provider.code, courseCode: @course_with_multiple_sites.code
   end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_not_on_apply_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_not_on_apply_spec.rb
@@ -35,8 +35,8 @@ RSpec.feature 'Selecting a course not on Apply' do
     site = create(:site, name: 'Main site', code: '-', provider: provider)
     course1 = create(:course, name: 'Primary', code: '2XT2', provider: provider, exposed_in_find: true, open_on_apply: true)
     course2 = create(:course, name: 'Secondary', code: 'X123', provider: provider, exposed_in_find: true, open_on_apply: false)
-    create(:course_option, site: site, course: course1, vacancy_status: 'B')
-    create(:course_option, site: site, course: course2, vacancy_status: 'B')
+    create(:course_option, site: site, course: course1)
+    create(:course_option, site: site, course: course2)
     create(:provider, name: 'Provider with no courses', code: 'FAKE')
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -81,8 +81,8 @@ RSpec.feature 'Selecting a course' do
       postcode: 'LS8 5DQ'
     )
     @multi_site_course = create(:course, name: 'Primary', code: '2XT2', provider: @provider, exposed_in_find: true, open_on_apply: true)
-    create(:course_option, site: first_site, course: @multi_site_course, vacancy_status: 'B')
-    create(:course_option, site: second_site, course: @multi_site_course, vacancy_status: 'B')
+    create(:course_option, site: first_site, course: @multi_site_course)
+    create(:course_option, site: second_site, course: @multi_site_course)
 
     another_provider = create(:provider, name: 'Royal Academy of Dance', code: 'R55')
     third_site = create(
@@ -96,7 +96,7 @@ RSpec.feature 'Selecting a course' do
       postcode: 'SW11 3RA'
     )
     single_site_course = create(:course, name: 'Dance', code: 'W5X1', provider: another_provider, exposed_in_find: true, open_on_apply: true)
-    create(:course_option, site: third_site, course: single_site_course, vacancy_status: 'B')
+    create(:course_option, site: third_site, course: single_site_course)
   end
 
   def when_i_visit_the_site

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   def and_the_course_i_selected_only_has_one_site
     @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
     @site = create(:site, provider: @course.provider)
-    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+    create(:course_option, site: @site, course: @course)
   end
 
   def and_i_am_an_existing_candidate_on_apply
@@ -161,8 +161,8 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
     @site2 = create(:site, provider: @course_with_multiple_sites.provider)
-    create(:course_option, site: @site1, course: @course_with_multiple_sites, vacancy_status: 'B')
-    create(:course_option, site: @site2, course: @course_with_multiple_sites, vacancy_status: 'B')
+    create(:course_option, site: @site1, course: @course_with_multiple_sites)
+    create(:course_option, site: @site2, course: @course_with_multiple_sites)
   end
 
   def then_i_should_see_the_course_choices_site_page

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_without_selection_page_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_without_selection_page_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   def and_the_course_i_selected_only_has_one_site
     @course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
     @site = create(:site, provider: @course.provider)
-    create(:course_option, site: @site, course: @course, vacancy_status: 'B')
+    create(:course_option, site: @site, course: @course)
   end
 
   def and_i_am_an_existing_candidate_on_apply
@@ -133,8 +133,8 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     @course_with_multiple_sites = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Herbology')
     @site1 = create(:site, provider: @course_with_multiple_sites.provider)
     @site2 = create(:site, provider: @course_with_multiple_sites.provider)
-    create(:course_option, site: @site1, course: @course_with_multiple_sites, vacancy_status: 'B')
-    create(:course_option, site: @site2, course: @course_with_multiple_sites, vacancy_status: 'B')
+    create(:course_option, site: @site1, course: @course_with_multiple_sites)
+    create(:course_option, site: @site2, course: @course_with_multiple_sites)
   end
 
   def then_i_should_see_the_course_choices_site_page


### PR DESCRIPTION
## Context

We want to stop candidates from applying to courses that are full, so that they don't waste time on their application unnecessarily. The first step in doing so is to retrieve data from the Find API which tells us the vacancy status of a given course/site choice.

## Changes proposed in this pull request

Update the SyncProviderFromFind rake task to pull in and persist the required data. See commits for more detail.

## Guidance to review

- A per-commit review will step through the precursory refactors followed by the described changes.
- Testing locally, run `bundle exec rake sync_dev_providers_and_open_courses`. Inspecting your database, records in `course_options` should be populated with a `vacancy_status` value that matches the enum declaration in the CourseOption model.

## Link to Trello card

https://trello.com/c/LAh0iGIc

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
