### PR TITLE
Prevent a candidate from entering a future date for a start date

### DIFF
--- a/app/helpers/date_validation_helper.rb
+++ b/app/helpers/date_validation_helper.rb
@@ -35,6 +35,13 @@ module DateValidationHelper
     end
   end
 
+  def start_date_before_current_year_and_month
+    if start_date.year > Time.zone.today.year || \
+        start_date.year == Time.zone.today.year && start_date.month > Time.zone.today.month
+      errors.add(:start_date, :in_the_future)
+    end
+  end
+
   def end_date_before_current_year_and_month
     if end_date.year > Time.zone.today.year || \
         end_date.year == Time.zone.today.year && end_date.month > Time.zone.today.month
@@ -44,6 +51,10 @@ module DateValidationHelper
 
   def start_date_and_end_date_valid?
     end_date.is_a?(Date) && start_date.is_a?(Date)
+  end
+
+  def start_date_valid?
+    start_date.is_a?(Date)
   end
 
   def end_date_valid?

--- a/app/helpers/date_validation_helper.rb
+++ b/app/helpers/date_validation_helper.rb
@@ -36,15 +36,13 @@ module DateValidationHelper
   end
 
   def start_date_before_current_year_and_month
-    if start_date.year > Time.zone.today.year || \
-        start_date.year == Time.zone.today.year && start_date.month > Time.zone.today.month
+    if start_date > Time.zone.today
       errors.add(:start_date, :in_the_future)
     end
   end
 
   def end_date_before_current_year_and_month
-    if end_date.year > Time.zone.today.year || \
-        end_date.year == Time.zone.today.year && end_date.month > Time.zone.today.month
+    if end_date > Time.zone.today
       errors.add(:end_date, :in_the_future)
     end
   end

--- a/app/models/candidate_interface/volunteering_role_form.rb
+++ b/app/models/candidate_interface/volunteering_role_form.rb
@@ -17,6 +17,7 @@ module CandidateInterface
     validates :details, word_count: { maximum: 150 }
 
     validate :start_date_valid
+    validate :start_date_before_current_year_and_month, if: :start_date_valid?
     validate :end_date_valid, unless: :end_date_blank?
     validate :end_date_before_current_year_and_month, if: :end_date_valid?
     validate :start_date_before_end_date, if: :start_date_and_end_date_valid?

--- a/app/models/candidate_interface/work_experience_form.rb
+++ b/app/models/candidate_interface/work_experience_form.rb
@@ -15,6 +15,7 @@ module CandidateInterface
     validates :working_with_children, inclusion: { in: %w(true false) }
 
     validate :start_date_valid
+    validate :start_date_before_current_year_and_month, if: :start_date_valid?
     validate :end_date_valid, unless: :end_date_blank?
     validate :end_date_before_current_year_and_month, if: :end_date_valid?
     validate :start_date_before_end_date, if: :start_date_and_end_date_valid?

--- a/app/models/candidate_interface/work_history_break_form.rb
+++ b/app/models/candidate_interface/work_history_break_form.rb
@@ -7,6 +7,7 @@ module CandidateInterface
                   :end_date_day, :end_date_month, :end_date_year, :reason
 
     validate :start_date_valid
+    validate :start_date_before_current_year_and_month, if: :start_date_valid?
     validate :end_date_valid
     validate :end_date_before_current_year_and_month, if: :end_date_valid?
     validate :start_date_before_end_date, if: :start_date_and_end_date_valid?

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -495,6 +495,7 @@ en:
             start_date:
               invalid: Enter a start date in the correct format
               before: Enter a start date that is before the end date
+              in_the_future: Enter a start date that is not in the future
             end_date:
               invalid: Enter an end date in the correct format
               in_the_future: Enter an end date that is not in the future

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -484,6 +484,7 @@ en:
             start_date:
               invalid: Enter a start date in the correct format
               before: Enter a start date that is before the end date
+              in_the_future: Enter a start date that is not in the future
             end_date:
               invalid: Enter an end date in the correct format
               in_the_future: Enter an end date that is not in the future

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -540,6 +540,7 @@ en:
             start_date:
               invalid: Enter a start date in the correct format
               before: Enter a start date that is before the end date
+              in_the_future: Enter a start date that is not in the future
             end_date:
               invalid: Enter an end date in the correct format, for example 5 2019
               in_the_future: Enter an end date that is not in the future

--- a/spec/support/candidate_interface/shared_examples/start_date_validation.rb
+++ b/spec/support/candidate_interface/shared_examples/start_date_validation.rb
@@ -23,6 +23,20 @@ RSpec.shared_examples 'validation for a start date' do |error_scope|
       )
     end
 
+    it 'is invalid if the date is after the time now' do
+      Timecop.freeze(Time.zone.local(2020, 1, 1)) do
+        form = described_class.new(
+          start_date_month: '12', start_date_year: '2021',
+        )
+
+        form.validate
+
+        expect(form.errors.full_messages_for(:start_date)).to eq(
+          ["Start date #{t("activemodel.errors.models.candidate_interface/#{error_scope}.attributes.start_date.in_the_future")}"],
+        )
+      end
+    end
+
     it 'is valid if the date is equal to the end date' do
       form = described_class.new(
         start_date_month: '5', start_date_year: '2018',


### PR DESCRIPTION
## Context

A candidate was able to submit their application despite including a role where the start date was in the future (April 2020).

## Changes proposed in this pull request

This PR adds validation to prevent a start date being in the future for: adding a job, volunteering and work history break.

### After

![image](https://user-images.githubusercontent.com/42817036/76202079-3229d580-61ec-11ea-8cbd-5bfed06e3786.png)

## Guidance to review

FYI: The card specified that adding a job and volunteering but validation was also added for work history breaks.

## Link to Trello card

https://trello.com/c/Nqdbr71A/1116-dev-bug-user-added-future-date-as-start-date-%F0%9F%90%9B

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
