### PR TITLE
Add feature flag for suitability to work with children

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -11,6 +11,7 @@ class FeatureFlag
     provider_application_filters
     provider_change_response
     show_new_referee_needed
+    suitability_to_work_with_children
     training_with_a_disability
     work_breaks
     you_selected_a_course_page

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -51,6 +51,11 @@
             <%= render(TaskListItemComponent.new(text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path)) %>
           </li>
         <% end %>
+        <% if FeatureFlag.active?('suitability_to_work_with_children') %>
+          <li class="app-task-list__item">
+            <%= govuk_link_to t('page_titles.suitability_to_work_with_children'), '#' %>
+          </li>
+        <% end %>
     </ul>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,7 @@ en:
     subject_knowledge: What do you know about the subject you want to teach?
     interview_preferences: Interview preferences
     training_with_a_disability: Asking for support if you have a disability or other needs
+    suitability_to_work_with_children: Declaring any safeguarding issues
     volunteering:
       short: Volunteering with children and young people
       long: "Unpaid experience working with children and other volunteering"

--- a/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their suitability to work with children' do
+  include CandidateHelper
+
+  scenario 'Candidate declares any safeguarding issues' do
+    given_i_am_signed_in
+    and_the_suitability_to_work_with_children_feature_flag_is_off
+    when_i_visit_the_site
+    then_i_dont_see_declaring_any_safeguarding_issues
+
+    given_the_suitability_to_work_with_children_feature_flag_is_on
+    when_i_visit_the_site
+    then_i_see_declaring_any_safeguarding_issues
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def and_the_suitability_to_work_with_children_feature_flag_is_off
+    FeatureFlag.deactivate('suitability_to_work_with_children')
+  end
+
+  def then_i_dont_see_declaring_any_safeguarding_issues
+    expect(page).not_to have_content('Declaring any safeguarding issues')
+  end
+
+  def given_the_suitability_to_work_with_children_feature_flag_is_on
+    FeatureFlag.activate('suitability_to_work_with_children')
+  end
+
+  def then_i_see_declaring_any_safeguarding_issues
+    expect(page).to have_content(t('page_titles.suitability_to_work_with_children'))
+  end
+end


### PR DESCRIPTION
## Context

We want candidates to supply information about criminal convictions so that their application can properly assessed by providers.

## Changes proposed in this pull request

This PR is a first slice of adding in this feature which is just to add a feature flag for it and show a link to the `Declaring any safeguarding issues` section (currently doesn't link to anything).

### Screenshot

<img width="1278" alt="Screenshot 2020-03-09 at 11 00 10" src="https://user-images.githubusercontent.com/42817036/76207148-27c00980-61f5-11ea-8612-cd8bc7f93dd5.png">

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/61j2wqUR/1072-suitability-to-work-with-children-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
