### PR TITLE
Show disability disclosure in the provider interface

### DIFF
--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,0 +1,2 @@
+<h2 class="govuk-heading-m govuk-!-margin-top-8" id="disabilities">Disability and other needs</h2>
+<p class="govuk-body"><%= disability_disclosure %></p>

--- a/app/components/provider_interface/training_with_disability_component.rb
+++ b/app/components/provider_interface/training_with_disability_component.rb
@@ -1,0 +1,19 @@
+module ProviderInterface
+  class TrainingWithDisabilityComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def render?
+      application_form.disclose_disability? && @application_form.disability_disclosure.present?
+    end
+
+    def disability_disclosure
+      @application_form.disability_disclosure
+    end
+  end
+end

--- a/app/components/provider_interface/training_with_disability_component.rb
+++ b/app/components/provider_interface/training_with_disability_component.rb
@@ -9,7 +9,7 @@ module ProviderInterface
     end
 
     def render?
-      application_form.disclose_disability? && @application_form.disability_disclosure.present?
+      application_form.disclose_disability? && disability_disclosure.present?
     end
 
     def disability_disclosure

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -55,7 +55,7 @@
     ]) %>
 
     <% if FeatureFlag.active?('training_with_a_disability') %>
-      <%= render TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
+      <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
     <% end %>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-8" id="qualifications">Qualifications</h2>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -55,7 +55,7 @@
     ]) %>
 
     <% if FeatureFlag.active?('training_with_a_disability') %>
-      <h2 class="govuk-heading-m govuk-!-margin-top-8" id="disabilities">Disability and other needs</h2>
+      <%= render TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
     <% end %>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-8" id="qualifications">Qualifications</h2>

--- a/spec/components/provider_interface/training_with_disability_component_spec.rb
+++ b/spec/components/provider_interface/training_with_disability_component_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::TrainingWithDisabilityComponent do
+  it 'renders nothing if `#disclose_disability` is false' do
+    application_form = instance_double(
+      ApplicationForm,
+      disclose_disability?: false,
+      disability_disclosure: 'I am hard of hearing',
+    )
+    result = render_inline(described_class.new(application_form: application_form))
+    expect(result.text).to eq ''
+  end
+
+  it 'renders nothing if `#disclose_disability` is true but there is no disclosure' do
+    application_form = instance_double(
+      ApplicationForm,
+      disclose_disability?: true,
+      disability_disclosure: '',
+    )
+    result = render_inline(described_class.new(application_form: application_form))
+    expect(result.text).to eq ''
+  end
+
+  it 'renders heading and disclosure if `#disclose_disability` is true' do
+    application_form = instance_double(
+      ApplicationForm,
+      disclose_disability?: true,
+      disability_disclosure: 'I am hard of hearing',
+    )
+    result = render_inline(described_class.new(application_form: application_form))
+    expect(result.text).to include('Disability and other needs')
+    expect(result.text).to include('I am hard of hearing')
+  end
+end


### PR DESCRIPTION
## Context

Disability and other needs only shows a heading. We need to show the disability disclosure iff the candidate has asked for it to be shared.

## Changes proposed in this pull request

- Add simple component that renders the disability disclosure section (just a heading and paragraph) if the candidate opted in.
- Use the existing `training_with_a_disability` feature flag to control this.
- Update existing system spec

![image](https://user-images.githubusercontent.com/450843/76219976-99588180-620e-11ea-8a45-8b6e05d878d6.png)



## Guidance to review

- Nothing is rendered when the candidate did not opt-in or the feature flag is inactive.

## Link to Trello card

https://trello.com/c/xgdpUQrr/1730-disability-and-other-needs-only-shows-a-heading

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
