### PR TITLE
Set GCSE sections to incomplete if no year or grade is present

### DIFF
--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -106,15 +106,15 @@ module CandidateInterface
     end
 
     def maths_gcse_completed?
-      @application_form.maths_gcse.present?
+      gcse_completed?(@application_form.maths_gcse)
     end
 
     def english_gcse_completed?
-      @application_form.english_gcse.present?
+      gcse_completed?(@application_form.english_gcse)
     end
 
     def science_gcse_completed?
-      @application_form.science_gcse.present?
+      gcse_completed?(@application_form.science_gcse)
     end
 
     def other_qualifications_completed?
@@ -165,6 +165,16 @@ module CandidateInterface
       volunteering_experience_is_set = [true, false].include?(@application_form.volunteering_experience)
 
       volunteering_completed? || volunteering_added? || volunteering_experience_is_set
+    end
+
+    def gcse_completed?(gcse)
+      if gcse.present?
+        if gcse.qualification_type != 'missing'
+          gcse.grade.present? && gcse.award_year.present?
+        else
+          true
+        end
+      end
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -17,6 +17,13 @@ RSpec.feature 'Candidate entering GCSE details' do
     and_i_click_save_and_continue
     then_i_see_add_grade_page
 
+    when_i_visit_the_candidate_application_page
+    then_the_maths_gcse_should_be_incomplete
+
+    when_i_click_on_the_maths_gcse_link
+    and_i_select_gcse_option
+    and_i_click_save_and_continue
+
     when_i_fill_in_the_grade
     and_i_click_save_and_continue
     then_i_see_add_year_page
@@ -64,6 +71,10 @@ RSpec.feature 'Candidate entering GCSE details' do
     choose('GCSE')
   end
 
+  def and_i_select_gcse_option
+    when_i_select_gcse_option
+  end
+
   def when_i_select_gce_option
     choose('GCE O Level')
   end
@@ -76,6 +87,10 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   def when_i_visit_the_candidate_application_page
     visit '/candidate/application'
+  end
+
+  def then_the_maths_gcse_should_be_incomplete
+    expect(page).to have_content 'Maths GCSE or equivalent Incomplete'
   end
 
   def then_i_see_the_add_gcse_maths_page
@@ -160,5 +175,9 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   def i_see_the_maths_gcse_is_completed
     expect(page).to have_css('#maths-gcse-or-equivalent-badge-id', text: 'Completed')
+  end
+
+  def when_i_click_on_the_maths_gcse_link
+    and_i_click_on_the_maths_gcse_link
   end
 end


### PR DESCRIPTION
## Context

If a user:

1. Clicks on add GCSE
2. Clicks the GCSE option
3. Navigates back to their application form

The Maths GCSE section will be marked as complete despite them not having added a grade or year awarded.

## Changes proposed in this pull request

- If they have selected they have a qualification check that the grade and year awarded attributes are present

## Link to Trello card

https://trello.com/c/wrAbxDA8/950-user-is-able-to-submit-application-by-entering-and-deleting-information

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
