### PR TITLE
Add button to render an application as PDF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ FROM ruby:2.6.5-alpine AS common-build-env
 
 ARG APP_HOME=/app
 ARG BUILD_PACKAGES="build-base"
-ARG DEV_PACKAGES="postgresql-dev git nodejs yarn graphviz"
+ARG DEV_PACKAGES="postgresql-dev git nodejs yarn graphviz ttf-ubuntu-font-family"
 ARG RUBY_PACKAGES="tzdata"
 ARG bundleWithout=""
 
 ENV BUNDLER_VERSION="2.0.2"
 ENV BUNDLE_PATH="/gems"
 ENV BUNDLE_WITHOUT=${bundleWithout}
+ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine
 
 RUN apk update && \
     apk upgrade && \
@@ -80,6 +81,7 @@ ENV RAILS_ENV=production
 ENV BUNDLE_WITHOUT=${bundleWithout}
 ENV BUNDLE_PATH="/gems"
 ENV BUNDLER_VERSION="2.0.2"
+ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine
 
 WORKDIR $APP_HOME
 

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'ruby-graphviz'
 gem 'kaminari'
 
 # PDF generation
-gem 'wkhtmltopdf-binary'
+gem ENV['WKHTMLTOPDF_GEM'] || 'wkhtmltopdf-binary'
 gem 'pdfkit'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,10 @@ gem 'ruby-graphviz'
 
 gem 'kaminari'
 
+# PDF generation
+gem 'wkhtmltopdf-binary'
+gem 'pdfkit'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.4)
       ast (~> 2.4.0)
+    pdfkit (0.8.4.1)
     pg (1.2.3)
     pry (0.13.0)
       coderay (~> 1.1)
@@ -503,6 +504,7 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
+    wkhtmltopdf-binary (0.12.5.4)
     workflow (2.0.2)
     xpath (3.2.0)
       nokogiri (~> 1.8)
@@ -550,6 +552,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   openapi3_parser (= 0.8.0)
+  pdfkit
   pg (~> 1.2.3)
   pry
   pry-byebug
@@ -577,6 +580,7 @@ DEPENDENCIES
   web-console (>= 3.3.0)
   webmock
   webpacker
+  wkhtmltopdf-binary
   workflow
 
 RUBY VERSION

--- a/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.html.erb
+++ b/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.html.erb
@@ -1,3 +1,3 @@
 <%= render SummaryListComponent.new(rows: rows) %>
 
-<%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
+<%= govuk_button_link_to 'Respond to application', provider_interface_application_choice_respond_path(application_choice), class: 'govuk-!-margin-bottom-0 app-!-print-display-none' %>

--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -4,7 +4,7 @@
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
 <% if FeatureFlag.active?('provider_change_response') %>
-<p class="govuk-body govuk-!-margin-bottom-0">
+<p class="govuk-body govuk-!-margin-bottom-0 app-!-print-display-none">
   <%= govuk_link_to 'Withdraw offer', provider_interface_application_choice_new_withdraw_offer_path(@application_choice.id) %>
 </p>
 <% end %>

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -3,5 +3,5 @@
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 
 <% if FeatureFlag.active?('confirm_conditions') %>
-  <%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0' %>
+  <%= govuk_button_link_to 'Confirm conditions', provider_interface_application_choice_edit_conditions_path(application_choice), class: 'govuk-!-margin-bottom-0  app-!-print-display-none' %>
 <% end %>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -18,13 +18,13 @@
 
       <% if row[:change_path] %>
         <dd class="govuk-summary-list__actions">
-          <%= link_to row[:change_path], class: 'govuk-link' do %>
+          <%= link_to row[:change_path], class: 'govuk-link app-!-print-display-none' do %>
             Change<span class="govuk-visually-hidden"> <%= row[:action] %></span>
           <% end %>
         </dd>
       <% elsif row[:action_path] %>
         <dd class="govuk-summary-list__actions">
-          <%= link_to row[:action], row[:action_path], class: 'govuk-link' %>
+          <%= link_to row[:action], row[:action_path], class: 'govuk-link app-!-print-display-none' %>
         </dd>
       <% elsif any_row_has_action_span? %>
         <span class="govuk-summary-list__actions"></span>

--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -7,16 +7,4 @@
   .govuk-breadcrumbs {
     display: none;
   }
-
-  .app-print-link {
-    display: none;
-  }
-}
-
-.app-print-link {
-  display: none;
-}
-
-.js-enabled .app-print-link {
-  display: block;
 }

--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -7,6 +7,10 @@
   .govuk-breadcrumbs {
     display: none;
   }
+
+  .app-print-link {
+    display: none;
+  }
 }
 
 .app-print-link {

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -19,7 +19,7 @@
       <span class="govuk-caption-xl"><%= @application_choice.application_form.support_reference %></span>
       <%= @application_choice.application_form.full_name %>
     </h1>
-    <p class="app-print-link app-!-print-display-none">
+    <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
       <%= govuk_link_to(
         'Download application (PDF)',
         provider_interface_application_choice_path(@application_choice.id, format: :pdf),

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -13,23 +13,30 @@
   </div>
 <% end %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl"><%= @application_choice.application_form.support_reference %></span>
-  <%= @application_choice.application_form.full_name %>
-</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
+      <span class="govuk-caption-xl"><%= @application_choice.application_form.support_reference %></span>
+      <%= @application_choice.application_form.full_name %>
+    </h1>
+    <p class="app-print-link app-!-print-display-none">
+      <%= govuk_link_to(
+        'Download application (PDF)',
+        provider_interface_application_choice_path(@application_choice.id, format: :pdf),
+        download: @application_choice.application_form.support_reference
+      ) %>
+    </p>
+  </div>
+</div>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
+  <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
   </div>
 </div>
 
-<div class="govuk-grid-row app-print-link app-!-print-display-none">
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_link_to('View as PDF', provider_interface_application_choice_path(@application_choice.id, format: :pdf)) %>
-  </div>
-</div>
-
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Application</h2>
 
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -21,9 +21,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
-    <div class="app-!-print-display-none">
-      <%= govuk_link_to('Print this page', 'javascript:window.print();', class: 'app-print-link__link') %>
-    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row app-print-link app-!-print-display-none">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_link_to('View as PDF', provider_interface_application_choice_path(@application_choice.id, format: :pdf)) %>
+  </div>
+</div>
 
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Application</h2>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,6 @@ module ApplyForPostgraduateTeacherTraining
 
     config.active_job.queue_adapter = :sidekiq
 
-    config.middleware.use PDFKit::Middleware, { print_media_type: true }, only: [%r[^/provider/applications/\d+]]
+    config.middleware.use PDFKit::Middleware, { print_media_type: true }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,21 +1,21 @@
 require_relative 'boot'
 
-require "rails"
+require 'rails'
 # Pick the frameworks you want:
-require "active_model/railtie"
-require "active_job/railtie"
-require "active_record/railtie"
-require "action_controller/railtie"
-require "action_mailer/railtie"
-require "action_view/railtie"
+require 'active_model/railtie'
+require 'active_job/railtie'
+require 'active_record/railtie'
+require 'action_controller/railtie'
+require 'action_mailer/railtie'
+require 'action_view/railtie'
 
-require "action_view/component"
+require 'action_view/component'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-require "./app/lib/hosting_environment"
+require './app/lib/hosting_environment'
 
 module ApplyForPostgraduateTeacherTraining
   class Application < Rails::Application
@@ -33,10 +33,10 @@ module ApplyForPostgraduateTeacherTraining
 
     config.exceptions_app = self.routes
 
-    config.action_mailer.preview_path = "#{Rails.root}/app/mailers/previews"
+    config.action_mailer.preview_path = Rails.root.join('app/mailers/previews')
     config.action_mailer.show_previews = Rails.env.development? || HostingEnvironment.qa? || HostingEnvironment.review?
 
-    config.action_view_component.preview_path = "#{Rails.root}/app/components/previews"
+    config.action_view_component.preview_path = Rails.root.join('/app/components/previews')
     config.action_view_component.show_previews = Rails.env.development? || HostingEnvironment.qa? || HostingEnvironment.review?
 
     config.time_zone = 'London'

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ Bundler.require(*Rails.groups)
 
 require './app/lib/hosting_environment'
 
+require 'pdfkit'
+
 module ApplyForPostgraduateTeacherTraining
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -46,5 +48,7 @@ module ApplyForPostgraduateTeacherTraining
     config.action_view.raise_on_missing_translations = true
 
     config.active_job.queue_adapter = :sidekiq
+
+    config.middleware.use PDFKit::Middleware, { print_media_type: true }, only: [%r[^/provider/applications/\d+]]
   end
 end

--- a/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider sees an application as PDF' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'viewing application in PDF format' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_sign_in_to_the_provider_interface
+    and_an_application_exists
+
+    when_i_visit_the_provider_application_page
+    and_i_click_the_pdf_link
+    then_i_should_see_the_application_choice_in_pdf_format
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_an_application_exists
+    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+    @course_option = course_option_for_provider(
+      provider: current_provider,
+      course: create(:course, name: 'Alchemy', provider: current_provider),
+    )
+
+    @application_form = create(:application_form, first_name: 'Sheila', last_name: 'Jones')
+
+    @application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: @course_option,
+      status: 'offer',
+      application_form: @application_form,
+      offered_at: 1.day.ago,
+      updated_at: 1.day.ago,
+    )
+  end
+
+  def when_i_visit_the_provider_application_page
+    visit provider_interface_application_choice_path(@application_choice.id)
+  end
+
+  def and_i_click_the_pdf_link
+    click_on 'View as PDF'
+  end
+
+  def then_i_should_see_the_application_choice_in_pdf_format
+    expect(page.driver.response.status).to eq(200)
+    expect(page.driver.response.content_type).to eq('application/pdf')
+    expect(page.driver.response.length).to be > 0
+  end
+end

--- a/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Provider sees an application as PDF' do
   end
 
   def and_i_click_the_pdf_link
-    click_on 'View as PDF'
+    click_on 'Download application (PDF)'
   end
 
   def then_i_should_see_the_application_choice_in_pdf_format


### PR DESCRIPTION
## Context

Providers often need to retain application details as files or in print.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds 'Download application (PDF)' link to provider application page which responds with a file download of the application in PDF format. 
`pdf-kit` gem is configured as middleware, generates the candidate application as an embedded PDF.

NOTE: This PR has been reworked after some team discussion, we decided to remove the javascript print link and replace with a link to PDF.

<!-- If there are UI changes, please include Before and After screenshots. -->

### After

![image](https://user-images.githubusercontent.com/93511/77440650-73230c00-6de0-11ea-9a94-2c4920114165.png)



## Guidance to review

- Does the PDF link work for you? Can you print, download and save the PDF?
- Are all application action buttons (Change, Respond etc.) and links hidden in print/PDF format?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/5QZJlM2b/1778-pdf-generation-button

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
