### PR TITLE
Add form object for declaring safeguarding issues

### DIFF
--- a/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
+++ b/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
@@ -6,5 +6,15 @@ module CandidateInterface
 
     validates :share_safeguarding_issues, presence: true
     validates :safeguarding_issues, word_count: { maximum: 400 }
+
+    def save(application_form)
+      return false unless valid?
+
+      if share_safeguarding_issues == 'Yes' && safeguarding_issues.present?
+        application_form.update(safeguarding_issues: safeguarding_issues)
+      else
+        application_form.update(safeguarding_issues: share_safeguarding_issues)
+      end
+    end
   end
 end

--- a/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
+++ b/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
@@ -7,6 +7,19 @@ module CandidateInterface
     validates :share_safeguarding_issues, presence: true
     validates :safeguarding_issues, word_count: { maximum: 400 }
 
+    def self.build_from_application(application_form)
+      if (application_form.safeguarding_issues == 'Yes') || (application_form.safeguarding_issues == 'No')
+        new(share_safeguarding_issues: application_form.safeguarding_issues)
+      elsif application_form.safeguarding_issues.present?
+        new(
+          share_safeguarding_issues: 'Yes',
+          safeguarding_issues: application_form.safeguarding_issues,
+        )
+      else
+        new(share_safeguarding_issues: nil, safeguarding_issues: nil)
+      end
+    end
+
     def save(application_form)
       return false unless valid?
 

--- a/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
+++ b/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
@@ -1,0 +1,10 @@
+module CandidateInterface
+  class SafeguardingIssuesDeclarationForm
+    include ActiveModel::Model
+
+    attr_accessor :share_safeguarding_issues, :safeguarding_issues
+
+    validates :share_safeguarding_issues, presence: true
+    validates :safeguarding_issues, word_count: { maximum: 400 }
+  end
+end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -573,3 +573,9 @@ en:
           attributes:
             ethnic_group:
               blank: Choose your ethnic group
+        candidate_interface/safeguarding_issues_declaration_form:
+          attributes:
+            share_safeguarding_issues:
+              blank: Choose if you want to share any safeguarding issues
+            safeguarding_issues:
+              too_many_words: Safeguarding issues must be %{count} words or fewer

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -41,6 +41,7 @@ FactoryBot.define do
       work_history_explanation { Faker::Lorem.paragraph_by_chars(number: 600) }
       work_history_breaks { Faker::Lorem.paragraph_by_chars(number: 400) }
       volunteering_experience { [true, false, nil].sample }
+      safeguarding_issues { 'I have a criminal conviction.' }
 
       # Checkboxes to mark a section as complete
       course_choices_completed { true }

--- a/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
+++ b/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
@@ -1,6 +1,89 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :model do
+  describe '#save' do
+    let(:application_form) { create(:application_form) }
+
+    context 'when sharing safeguarding issues is blank' do
+      it 'returns false' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new
+
+        expect(form.save(application_form)).to be(false)
+      end
+    end
+
+    context 'when sharing safeguarding issues is "No"' do
+      it 'returns true' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(share_safeguarding_issues: 'No')
+
+        expect(form.save(application_form)).to be(true)
+      end
+
+      it 'updates safeguarding issues of the application form to "No"' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(share_safeguarding_issues: 'No')
+
+        form.save(application_form)
+
+        expect(application_form.safeguarding_issues).to eq('No')
+      end
+    end
+
+    context 'when sharing safeguarding issues is "Yes" but no details provided' do
+      it 'returns true' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+          share_safeguarding_issues: 'Yes',
+          safeguarding_issues: '',
+        )
+
+        expect(form.save(application_form)).to be(true)
+      end
+
+      it 'updates safeguarding issues of the application form to provided issues if empty string' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+          share_safeguarding_issues: 'Yes',
+          safeguarding_issues: '',
+        )
+
+        form.save(application_form)
+
+        expect(application_form.safeguarding_issues).to eq('Yes')
+      end
+
+      it 'updates safeguarding issues of the application form to provided issues if nil' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+          share_safeguarding_issues: 'Yes',
+          safeguarding_issues: nil,
+        )
+
+        form.save(application_form)
+
+        expect(application_form.safeguarding_issues).to eq('Yes')
+      end
+    end
+
+    context 'when sharing safeguarding issues is "Yes" and details provided' do
+      it 'returns true' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+          share_safeguarding_issues: 'Yes',
+          safeguarding_issues: 'I have a criminal conviction.',
+        )
+
+        expect(form.save(application_form)).to be(true)
+      end
+
+      it 'updates safeguarding issues of the application form to provided issues' do
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.new(
+          share_safeguarding_issues: 'Yes',
+          safeguarding_issues: 'I have a criminal conviction.',
+        )
+
+        form.save(application_form)
+
+        expect(application_form.safeguarding_issues).to eq('I have a criminal conviction.')
+      end
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:share_safeguarding_issues) }
 

--- a/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
+++ b/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
@@ -1,6 +1,52 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :model do
+  describe '.build_from_application' do
+    context 'when safeguarding issues does not have a value' do
+      it 'creates an object based on the application form' do
+        application_form = build_stubbed(:application_form, safeguarding_issues: nil)
+
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+
+        expect(form.share_safeguarding_issues).to eq(nil)
+        expect(form.safeguarding_issues).to eq(nil)
+      end
+    end
+
+    context 'when safeguarding issues has a value of "Yes"' do
+      it 'creates an object based on the application form' do
+        application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+
+        expect(form.share_safeguarding_issues).to eq('Yes')
+        expect(form.safeguarding_issues).to eq(nil)
+      end
+    end
+
+    context 'when safeguarding issues has a value of "No"' do
+      it 'creates an object based on the application form' do
+        application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
+
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+
+        expect(form.share_safeguarding_issues).to eq('No')
+        expect(form.safeguarding_issues).to eq(nil)
+      end
+    end
+
+    context 'when safeguarding issues has details' do
+      it 'creates an object based on the application form' do
+        application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+
+        form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+
+        expect(form.share_safeguarding_issues).to eq('Yes')
+        expect(form.safeguarding_issues).to eq('I have a criminal conviction.')
+      end
+    end
+  end
+
   describe '#save' do
     let(:application_form) { create(:application_form) }
 

--- a/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
+++ b/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:share_safeguarding_issues) }
+
+    valid_text = Faker::Lorem.sentence(word_count: 400)
+    invalid_text = Faker::Lorem.sentence(word_count: 401)
+
+    it { is_expected.to allow_value(valid_text).for(:safeguarding_issues) }
+    it { is_expected.not_to allow_value(invalid_text).for(:safeguarding_issues) }
+  end
+end


### PR DESCRIPTION
## Context

We want candidates to supply information about criminal convictions so that their application can properly assessed by providers.

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1564, we added a feature flag and in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1568, we added a migration for storing safeguarding issues.

## Changes proposed in this pull request

This PR adds the form object for declaring safeguarding issues called `SafeguardingIssuesDeclarationForm` and the usual `#save` and `.build_from_application` methods.

## Guidance to review

- What do you think about the name of the form? Could be `SafeguardingDeclarationForm`, `SafeguardingIssuesForm` or `SafeguardingForm` etc.

## Link to Trello card

https://trello.com/c/61j2wqUR/1072-suitability-to-work-with-children-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
