### PR TITLE
Don’t insist on uniqueness for first_ or last_names in test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -14,8 +14,8 @@ module TestApplications
   def self.create_application(states:, courses_to_apply_to: nil)
     raise ZeroCoursesPerApplicationError.new('You can\'t have zero courses per application') unless states.any?
 
-    first_name = Faker::Name.unique.first_name
-    last_name = Faker::Name.unique.last_name
+    first_name = Faker::Name.first_name
+    last_name = Faker::Name.last_name
     candidate = FactoryBot.create(
       :candidate,
       email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",


### PR DESCRIPTION
It is very unlikely that we will see the same
first_name/last_name combination in any case as there are 5162
first_names available and 471 last_names.

## Context

Tribal saw 500s on bulk creation of test applications: https://sentry.io/organizations/dfe-bat/issues/1555912584/?project=1765973&referrer=slack

## Changes proposed in this pull request

Remove the uniqueness constraint on `first_names` and `last_names` in `TestApplications`


## Link to Trello card

https://trello.com/c/Z7j3YLqI/1746-fix-fakeruniquegeneratorretrylimitexceeded-errors-when-vendors-try-to-generate-large-numbers-of-applications-in-the-sandbox

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
