### PR TITLE
Prevent application choice from being withdrawable during the edit period

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -29,7 +29,7 @@ module CandidateInterface
     end
 
     def withdrawable?(course_choice)
-      ApplicationStateChange.new(course_choice).can_withdraw?
+      ApplicationStateChange.new(course_choice).can_withdraw? && course_choice.edit_by < Time.zone.now
     end
 
     def any_withdrawable?

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -215,6 +215,7 @@ FactoryBot.define do
 
     status { ApplicationStateChange.valid_states.sample }
     personal_statement { 'hello' }
+    edit_by { Time.zone.now }
 
     factory :submitted_application_choice do
       status { 'awaiting_provider_decision' }

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -48,8 +48,8 @@ RSpec.feature 'A candidate edits their course choice after submission' do
   end
 
   def and_i_have_a_completed_application
-    form = create(:completed_application_form, :with_completed_references, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16))
-    @application_choice = create(:application_choice, status: :awaiting_references, edit_by: Time.zone.local(2019, 12, 20), application_form: form)
+    form = create(:completed_application_form, :with_completed_references, references_count: 2, candidate: current_candidate, submitted_at: Time.zone.local(2019, 12, 16), with_gces: true)
+    @application_choice = create(:application_choice, status: :application_complete, edit_by: Time.zone.local(2019, 12, 20), application_form: form)
   end
 
   def when_i_visit_the_application_dashboard


### PR DESCRIPTION
The previous bug fix introduced a weird behaviour in certain cases #1508. When a candidate edits an application choice while the application is still in the edit period, but already received references, the application choice has the option of `withdraw` rather than `delete` even though that application has not sent to providers. 

## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Update the review component to show withdraw only when an application exceeded the `edit_by` date(therefore sent to provider)

## Changes proposed in this pull request

### Before
![image](https://user-images.githubusercontent.com/22743709/76228481-b1cd9980-6218-11ea-973d-d8f20166915c.png)

### After
![image](https://user-images.githubusercontent.com/22743709/76228608-dde91a80-6218-11ea-9d6f-7fa81d43e692.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/u9fFktHo/1048-application-form-errors-when-edit-application-feature-flag-is-on-and-user-edits-their-course-choices

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
