### PR TITLE
Add a more complete work history to test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -37,7 +37,7 @@ module TestApplications
       application_form = FactoryBot.create(
         :completed_application_form,
         application_choices_count: 0,
-        work_experiences_count: 1,
+        full_work_history: true,
         volunteering_experiences_count: 1,
         references_count: 2,
         with_gces: true,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,6 +56,7 @@ FactoryBot.define do
         references_count { 0 }
         references_state { :requested }
         with_gces { false }
+        full_work_history { false }
       end
 
       trait :with_completed_references do
@@ -78,8 +79,6 @@ FactoryBot.define do
                   end
 
         create_list(:application_choice, evaluator.application_choices_count, application_form: application_form, status: 'awaiting_references', edit_by: edit_by)
-        create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)
-        create_list(:application_volunteering_experience, evaluator.volunteering_experiences_count, application_form: application_form)
         create_list(:reference, evaluator.references_count, evaluator.references_state, application_form: application_form)
         # The application_form validates the length of this collection when
         # it is created, which is BEFORE we create the references here.
@@ -91,6 +90,34 @@ FactoryBot.define do
         if evaluator.references_count > 0
           application_form.application_references.reload
         end
+
+        if evaluator.full_work_history
+          first_start_date = rand(63..70).months.ago
+          first_end_date = rand(50..58).months.ago
+          second_start_date = rand(36..47).months.ago
+          second_end_date = rand(6..12).months.ago
+          create(
+            :application_work_experience,
+            application_form: application_form,
+            start_date: first_start_date,
+            end_date: first_end_date,
+          )
+          create(
+            :application_work_history_break,
+            application_form: application_form,
+            start_date: first_end_date,
+            end_date: second_start_date,
+          )
+          create(
+            :application_work_experience,
+            application_form: application_form,
+            start_date: second_start_date,
+            end_date: second_end_date,
+          )
+        else
+          create_list(:application_work_experience, evaluator.work_experiences_count, application_form: application_form)
+        end
+        create_list(:application_volunteering_experience, evaluator.volunteering_experiences_count, application_form: application_form)
       end
     end
   end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -39,4 +39,16 @@ RSpec.describe TestApplications do
       expect(choices.count).to eq(1)
     end
   end
+
+  describe 'full work history' do
+    it 'creates applications with work experience as well as explained and unexplained breaks' do
+      create(:course_option, course: create(:course, :open_on_apply))
+
+      choices = TestApplications.create_application(states: %i[awaiting_provider_decision])
+
+      expect(choices.count).to eq(1)
+      expect(choices.first.application_form.application_work_experiences.count).to eq(2)
+      expect(choices.first.application_form.application_work_history_breaks.count).to eq(1)
+    end
+  end
 end


### PR DESCRIPTION
## Context

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1562 extends the provider interface to display explained and unexplained breaks in work history. It includes new components with previews. To properly exercise these components in previews we need each work history to include work experience, explained and unexplained breaks.

## Changes proposed in this pull request

Adjust factories and `TestApplications` to generate a more complete work history.

## Guidance to review

- Does this cover everything we need to see in work experience?

## Link to Trello card

https://trello.com/c/ZOkPYTd7/1479-show-work-breaks-calculated-breaks-and-reasons

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
