### PR TITLE
1741 un remove support users

### DIFF
--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -1,7 +1,7 @@
 module SupportInterface
   class SupportUsersController < SupportInterfaceController
     def index
-      @support_users = SupportUser.kept
+      @support_users = params[:removed] == 'true' ? SupportUser.discarded : SupportUser.kept
     end
 
     def new
@@ -22,10 +22,17 @@ module SupportInterface
     def confirm_destroy
       @support_user = SupportUser.find(params[:id])
     end
+    alias confirm_restore confirm_destroy
 
     def destroy
       SupportUser.find(params[:id]).discard
       flash[:success] = 'Support user removed'
+      redirect_to support_interface_support_users_path
+    end
+
+    def restore
+      SupportUser.find(params[:id]).undiscard
+      flash[:success] = 'Support user restored'
       redirect_to support_interface_support_users_path
     end
 

--- a/app/helpers/support_users_helper.rb
+++ b/app/helpers/support_users_helper.rb
@@ -1,0 +1,9 @@
+module SupportUsersHelper
+  def support_user_account_management_path(support_user)
+    if support_user.discarded?
+      support_interface_confirm_restore_support_user_path(support_user)
+    else
+      support_interface_confirm_destroy_support_user_path(support_user)
+    end
+  end
+end

--- a/app/views/support_interface/support_users/confirm_restore.html.erb
+++ b/app/views/support_interface/support_users/confirm_restore.html.erb
@@ -1,0 +1,21 @@
+<% content_for :before_content, govuk_back_link_to(support_interface_support_users_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @support_user,
+      url: support_interface_restore_support_user_path(@support_user.id),
+      method: :delete do |f| %>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl">Support user</span>
+        <%= t('support_interface.support_user.confirm_restore',
+              email: @support_user.email_address) %>
+      </h1>
+
+      <%= f.submit t('support_interface.support_user.restore'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', support_interface_support_users_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -51,3 +51,5 @@
     <% end %>
   </tbody>
 </table>
+
+<%= govuk_link_to 'Restore a removed user', support_interface_support_users_path(removed: true) unless params[:removed] == 'true' %>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -39,11 +39,12 @@
           <%= support_user.dfe_sign_in_uid %>
         </td>
         <td class='govuk-table__cell'>
-          <%= govuk_link_to(
-                nil,
-                support_interface_confirm_destroy_support_user_path(support_user),
-          ) do %>
-            Remove user<span class='govuk-visually-hidden'> <%= support_user.email_address %></span>
+          <%
+              link_action = support_user.discarded? ? 'Restore' : 'Remove'
+              link_path = support_user_account_management_path(support_user)
+          -%>
+          <%= govuk_link_to(nil, link_path) do %>
+            <%= link_action %> user<span class='govuk-visually-hidden'> <%= support_user.email_address %></span>
           <% end %>
         </td>
       </tr>

--- a/config/locales/support_interface.yml
+++ b/config/locales/support_interface.yml
@@ -2,4 +2,6 @@ en:
   support_interface:
     support_user:
       confirm_remove: Are you sure you want to remove support user %{email}?
+      confirm_restore: Are you sure you want to restore support user %{email}?
       remove: Remove support user
+      restore: Restore support user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -405,6 +405,8 @@ Rails.application.routes.draw do
 
       get '/delete/:id' => 'support_users#confirm_destroy', as: :confirm_destroy_support_user
       delete '/delete/:id' => 'support_users#destroy', as: :destroy_support_user
+      get '/restore/:id' => 'support_users#confirm_restore', as: :confirm_restore_support_user
+      delete '/restore/:id' => 'support_users#restore', as: :restore_support_user
 
       resources :support_users, only: %i[index new create], path: :support
       resources :provider_users, only: %i[index new create edit update], path: :provider

--- a/spec/helpers/support_users_helper_spec.rb
+++ b/spec/helpers/support_users_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe SupportUsersHelper, type: :helper do
+  describe '#support_user_account_management_path' do
+    context 'for a support user' do
+      it 'returns the path to remove a support user' do
+        support_user = instance_double(SupportUser, id: 12345, discarded?: false)
+        path = helper.support_user_account_management_path(support_user)
+        expect(path).to eq(support_interface_confirm_destroy_support_user_path(support_user))
+      end
+    end
+
+    context 'for a discarded support user' do
+      it 'returns the path to restore a support user' do
+        support_user = instance_double(SupportUser, id: 12345, discarded?: true)
+        path = helper.support_user_account_management_path(support_user)
+        expect(path).to eq(support_interface_confirm_restore_support_user_path(support_user))
+      end
+    end
+  end
+end

--- a/spec/system/support_interface/remove_and_restore_a_support_user_spec.rb
+++ b/spec/system/support_interface/remove_and_restore_a_support_user_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Remove and restore support user' do
   end
 
   def when_i_visit_the_removed_support_users_page
-    visit support_interface_support_users_path(removed: true)
+    click_on 'Restore a removed user'
   end
 
   def and_i_restore_a_support_user

--- a/spec/system/support_interface/remove_and_restore_a_support_user_spec.rb
+++ b/spec/system/support_interface/remove_and_restore_a_support_user_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature 'Remove a support user' do
+RSpec.feature 'Remove and restore support user' do
   include DfESignInHelpers
 
-  scenario 'Confirming removal of a support user' do
+  scenario 'Confirming removal of a support user then restoring the user' do
     given_i_am_a_support_user
     and_there_are_some_support_users
     when_i_visit_the_support_users_page
@@ -12,6 +12,12 @@ RSpec.feature 'Remove a support user' do
     and_i_confirm_removal
     then_the_support_user_is_removed
     and_the_support_user_is_not_listed
+
+    when_i_visit_the_removed_support_users_page
+    and_i_restore_a_support_user
+    and_i_confirm_restoring
+    then_the_support_user_is_restored
+    and_the_support_user_is_listed
   end
 
   def given_i_am_a_support_user
@@ -49,5 +55,28 @@ RSpec.feature 'Remove a support user' do
 
   def and_the_support_user_is_not_listed
     expect(page.text).not_to include(@removed_user_email)
+  end
+
+  def when_i_visit_the_removed_support_users_page
+    visit support_interface_support_users_path(removed: true)
+  end
+
+  def and_i_restore_a_support_user
+    within('.govuk-table__body') do
+      click_on("Restore user #{@removed_user_email}")
+    end
+  end
+
+  def and_i_confirm_restoring
+    click_on 'Restore support user'
+  end
+
+  def then_the_support_user_is_restored
+    expect(@removed_user.reload.discarded_at).to be_nil
+    expect(page.text).to include('Support user restored')
+  end
+
+  def and_the_support_user_is_listed
+    expect(page.text).to include(@removed_user_email)
   end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

We soft-delete users when removing them. We have no way of restoring these records.

## Changes proposed in this pull request

This PR introduces the routes, actions and views to restore support users.

<!-- If there are UI changes, please include Before and After screenshots. -->

### After

![image](https://user-images.githubusercontent.com/93511/76235544-24dc0d80-6223-11ea-82d3-7da78afdf096.png)

![image](https://user-images.githubusercontent.com/93511/76235091-894a9d00-6222-11ea-992a-3d701fdbd3e4.png)

![image](https://user-images.githubusercontent.com/93511/76235601-38877400-6223-11ea-9511-570d83176528.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/MyvZas23/1741-un-remove-support-users

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
