### PR TITLE
Make providers application_choices page wider without affecting rest of app

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -1,5 +1,5 @@
 <header class="govuk-header <%= classes %>" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container">
+  <div class="govuk-header__container govuk-width-container<%= wide ? " app-width-container--wide" : "" %>">
     <div class="govuk-header__logo">
       <%= link_to 'https://gov.uk', class: 'govuk-header__link govuk-header__link--homepage' do %>
         <span class="govuk-header__logotype">

--- a/app/components/header_component.rb
+++ b/app/components/header_component.rb
@@ -1,10 +1,11 @@
 class HeaderComponent < ActionView::Component::Base
-  attr_reader :navigation_items, :service_url, :service_name, :classes
+  attr_reader :navigation_items, :service_url, :service_name, :classes, :wide
 
-  def initialize(navigation_items:, service_name:, service_url:, classes: '')
+  def initialize(navigation_items:, service_name:, service_url:, classes: '', wide: false)
     @navigation_items = navigation_items
     @service_name     = service_name
     @service_url      = service_url
     @classes          = classes
+    @wide             = wide
   end
 end

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -1,3 +1,5 @@
-.govuk-width-container {
+@include govuk-media-query($from: wide) {
+  .app-width-container--wide {
     max-width: 1220px;
+  }
 }

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -10,6 +10,13 @@ $moj-images-path: '~@ministryofjustice/frontend/moj/assets/images/';
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
+$govuk-breakpoints: (
+  mobile:  320px,
+  tablet:  641px,
+  desktop: 769px,
+  wide:    1300px
+);
+
 @import "~govuk-frontend/govuk/all";
 @import "_autocomplete";
 @import "_banner";

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="govuk-footer govuk-footer--app app-!-print-display-none" role="contentinfo">
-  <div class="govuk-width-container">
+  <div class="govuk-width-container<%= yield(:page_width) == "wide" ? " app-width-container--wide" : "" %>">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <% case try(:current_namespace) %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,27 +3,32 @@
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_candidate_interface(current_candidate, controller))) %>
+                                 navigation_items: NavigationItems.for_candidate_interface(current_candidate, controller),
+                                 wide: yield(:page_width) == "wide")) %>
 <% when 'support_interface' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_support_interface(current_support_user, controller))) %>
+                                 navigation_items: NavigationItems.for_support_interface(current_support_user, controller),
+                                 wide: yield(:page_width) == "wide")) %>
 <% when 'provider_interface' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user))) %>
+                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user),
+                                 wide: yield(:page_width) == "wide")) %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_api_docs(controller))) %>
+                                 navigation_items: NavigationItems.for_api_docs(controller),
+                                 wide: yield(:page_width) == "wide")) %>
 <% else %>
   <% components_url = '/rails/components' if request.path.match(/^\/rails\/components/) %>
   <% components_name = 'ActionView::Component Previews' if request.path.match(/^\/rails\/components/) %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: components_name || try(:service_name),
                                  service_url: components_url || try(:service_url),
-                                 navigation_items: [])) %>
+                                 navigation_items: [],
+                                 wide: yield(:page_width) == "wide")) %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <div class="govuk-width-container">
+  <div class="govuk-width-container<%= yield(:page_width) == "wide" ? " app-width-container--wide" : "" %>">
     <%= render 'layouts/phase_banner' %>
 
     <%= yield(:before_content) %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, 'Applications' %>
+<% content_for :page_width, 'wide' %>
 
 <h1 class='govuk-heading-xl'>Applications</h1>
 


### PR DESCRIPTION
## Context

The `application_choices` index page now can optionally display a set of filters on the left which require a wider layout to look right at the moment.

This was previously done by overriding the main `govuk-width-container` class which has the undesirable effect of affecting the width of every other page in the application, as well as not looking great on breakpoints between ~800px and ~1240px.

## Changes proposed in this pull request

- Add new `app-width-container--wide` override class, remove previous `govuk-width-container` declaration
- Use new class in header, body, and footer when a `page_width` variable is set to `"wide"`

## Guidance to review

I think the filters component deserves some more attention separately, as it doesn't behave nicely when scaling down to mobile and back. This can be carded up on its own.

Before:

![Screenshot 2020-03-09 at 17 17 27](https://user-images.githubusercontent.com/1650875/76240398-11cd3b80-622b-11ea-9027-77de94d4b049.png)

After:

![Screenshot 2020-03-09 at 17 17 17](https://user-images.githubusercontent.com/1650875/76240408-15f95900-622b-11ea-80dd-f715d1a8e496.png)

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)