### PR TITLE
Add ability to declare any safeguarding issues

### DIFF
--- a/app/components/safeguarding_review_component.html.erb
+++ b/app/components/safeguarding_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(SummaryCardComponent.new(rows: safeguarding_rows, editable: @editable)) %>

--- a/app/components/safeguarding_review_component.rb
+++ b/app/components/safeguarding_review_component.rb
@@ -1,0 +1,32 @@
+class SafeguardingReviewComponent < ActionView::Component::Base
+  def initialize(application_form:, editable: true)
+    @safeguarding = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
+    @editable = editable
+  end
+
+  def safeguarding_rows
+    [sharing_safeguarding_issues_row, relevant_information_row].compact
+  end
+
+private
+
+  def sharing_safeguarding_issues_row
+    {
+      key: 'Do you want to share any information which could have an impact on your application?',
+      value: @safeguarding.share_safeguarding_issues,
+      action: 'if you want to share any safeguarding issues',
+      change_path: candidate_interface_edit_safeguarding_path,
+    }
+  end
+
+  def relevant_information_row
+    return if @safeguarding.share_safeguarding_issues == 'No'
+
+    {
+      key: 'Relevant information',
+      value: @safeguarding.safeguarding_issues || 'Not entered',
+      action: 'relevant information for safeguarding issues',
+      change_path: candidate_interface_edit_safeguarding_path,
+    }
+  end
+end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -1,0 +1,32 @@
+module CandidateInterface
+  class SafeguardingController < CandidateInterfaceController
+    before_action :redirect_to_application_form_unless_feature_flag_active
+
+    def show; end
+
+    def edit
+      @safeguarding = SafeguardingIssuesDeclarationForm.build_from_application(current_application)
+    end
+
+    def update
+      @safeguarding = SafeguardingIssuesDeclarationForm.new(safeguarding_params)
+
+      if @safeguarding.save(current_application)
+        redirect_to candidate_interface_review_safeguarding_path
+      else
+        render :edit
+      end
+    end
+
+  private
+
+    def safeguarding_params
+      params.require(:candidate_interface_safeguarding_issues_declaration_form)
+        .permit(:share_safeguarding_issues, :safeguarding_issues)
+    end
+
+    def redirect_to_application_form_unless_feature_flag_active
+      redirect_to candidate_interface_application_form_path unless FeatureFlag.active?('suitability_to_work_with_children')
+    end
+  end
+end

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -53,7 +53,7 @@
         <% end %>
         <% if FeatureFlag.active?('suitability_to_work_with_children') %>
           <li class="app-task-list__item">
-            <%= govuk_link_to t('page_titles.suitability_to_work_with_children'), '#' %>
+            <%= govuk_link_to t('page_titles.suitability_to_work_with_children'), candidate_interface_edit_safeguarding_path %>
           </li>
         <% end %>
     </ul>

--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -1,0 +1,48 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.suitability_to_work_with_children'), @safeguarding.errors.any?)%>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @safeguarding, url: candidate_interface_edit_safeguarding_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.suitability_to_work_with_children') %>
+      </h1>
+
+      <p class="govuk-body">
+        Teacher training providers need to check that it’s safe for you to work
+        with children and young people.
+      </p>
+
+      <p class="govuk-body">
+        As well as confirming your identity and your right to work in the UK,
+        providers will check:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your criminal record in the UK (they'll do an enhanced <%= govuk_link_to 'DBS check', 'https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks', target: '_blank' %>) and abroad where relevant</li>
+        <li>whether you’ve been banned from teaching or working with children</li>
+        <li>your professional behaviour, such as whether you've been removed from teacher training and what your referees say about you</li>
+      </ul>
+
+      <p class="govuk-body">
+        Tell your provider about any potential safeguarding issues, such as
+        offences, cautions, reprimands and final warnings. They can give advice
+        about whether this will affect your application.
+      </p>
+
+      <p class="govuk-body">A criminal conviction won’t necessarily stop you becoming a teacher.</p>
+
+      <%= f.govuk_radio_buttons_fieldset :share_safeguarding_issues, legend: { size: 'm', text: 'Do you want to share any safeguarding issues?' } do %>
+        <%= f.govuk_radio_button :share_safeguarding_issues, 'Yes', label: { text: 'Yes, I want to share something' }, hint_text: 'Talk to your provider directly or tell us about it here. This won’t stop you from submitting your application.' do %>
+          <%= f.govuk_text_area :safeguarding_issues, rows: 8, label: { text: 'Give any relevant information', size: 's' }, max_words: 400 %>
+        <% end %>
+
+        <%= f.govuk_radio_button :share_safeguarding_issues, 'No', label: { text: 'No' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, t('page_titles.suitability_to_work_with_children') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+
+<h1 class="govuk-heading-xl">
+  <%= t('page_titles.suitability_to_work_with_children') %>
+</h1>
+
+<%= render(SafeguardingReviewComponent.new(application_form: @current_application)) %>
+
+<p class="govuk-body">
+  <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,6 +273,12 @@ Rails.application.routes.draw do
         post '/ethnic-background' => 'equality_and_diversity#update_ethnic_background', as: :update_equality_and_diversity_ethnic_background
         get '/review' => 'equality_and_diversity#review', as: :review_equality_and_diversity
       end
+
+      scope '/safeguarding' do
+        get '/' => 'safeguarding#edit', as: :edit_safeguarding
+        post '/' => 'safeguarding#update'
+        get '/review' => 'safeguarding#show', as: :review_safeguarding
+      end
     end
   end
 

--- a/spec/components/safeguarding_review_component_spec.rb
+++ b/spec/components/safeguarding_review_component_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.describe SafeguardingReviewComponent do
+  context 'when safeguarding issues has a value of "Yes"' do
+    it 'displays "Yes" for sharing safeguarding issues and "Not entered" for relevant information' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+
+      result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
+
+      expect(result.text).to include('Do you want to share any information which could have an impact on your application?')
+      expect(result.text).to include('Yes')
+      expect(result.text).to include('Relevant information')
+      expect(result.text).to include('Not entered')
+    end
+  end
+
+  context 'when safeguarding issues has a value of "No"' do
+    it 'displays "No" for sharing safeguarding issues and "Not entered" for relevant information' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
+
+      result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
+
+      expect(result.text).to include('Do you want to share any information which could have an impact on your application?')
+      expect(result.text).to include('No')
+      expect(result.text).not_to include('Relevant information')
+    end
+  end
+
+  context 'when safeguarding issues has details' do
+    it 'displays "Yes" for sharing safeguarding issues and the details for relevant information' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+
+      result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
+
+      expect(result.text).to include('Do you want to share any information which could have an impact on your application?')
+      expect(result.text).to include('Yes')
+      expect(result.text).to include('Relevant information')
+      expect(result.text).to include('I have a criminal conviction.')
+    end
+  end
+
+  context 'when editable' do
+    it 'renders the component with change links' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+
+      result = render_inline(SafeguardingReviewComponent.new(application_form: application_form, editable: true))
+
+      expect(result.text).to include('Change if you want to share any safeguarding issues')
+      expect(result.text).to include('Change relevant information for safeguarding issues')
+    end
+  end
+
+  context 'when not editable' do
+    it 'renders the component without change links' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+
+      result = render_inline(SafeguardingReviewComponent.new(application_form: application_form, editable: false))
+
+      expect(result.text).not_to include('Change if you want to share any safeguarding issues')
+      expect(result.text).not_to include('Change relevant information for safeguarding issues')
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -9,9 +9,27 @@ RSpec.feature 'Entering their suitability to work with children' do
     when_i_visit_the_site
     then_i_dont_see_declaring_any_safeguarding_issues
 
+    when_i_visit_the_declaring_any_safeguarding_issues_form
+    then_i_see_the_application_form
+
     given_the_suitability_to_work_with_children_feature_flag_is_on
     when_i_visit_the_site
     then_i_see_declaring_any_safeguarding_issues
+
+    when_i_click_on_declaring_any_safeguarding_issues
+    then_i_see_declaring_any_safeguarding_issues_form
+
+    when_i_choose_yes
+    and_enter_relevant_information
+    and_i_click_on_continue
+    then_i_see_my_relevant_information
+
+    when_i_click_to_change_sharing_safeguarding_issues
+    then_i_see_declaring_any_safeguarding_issues_form
+
+    when_i_choose_no
+    and_i_click_on_continue
+    then_i_see_my_updated_answer
   end
 
   def given_i_am_signed_in
@@ -30,11 +48,57 @@ RSpec.feature 'Entering their suitability to work with children' do
     expect(page).not_to have_content('Declaring any safeguarding issues')
   end
 
+  def when_i_visit_the_declaring_any_safeguarding_issues_form
+    visit candidate_interface_edit_safeguarding_path
+  end
+
+  def then_i_see_the_application_form
+    expect(page).to have_content('Your application')
+  end
+
   def given_the_suitability_to_work_with_children_feature_flag_is_on
     FeatureFlag.activate('suitability_to_work_with_children')
   end
 
   def then_i_see_declaring_any_safeguarding_issues
     expect(page).to have_content(t('page_titles.suitability_to_work_with_children'))
+  end
+
+  def when_i_click_on_declaring_any_safeguarding_issues
+    click_link t('page_titles.suitability_to_work_with_children')
+  end
+
+  def then_i_see_declaring_any_safeguarding_issues_form
+    expect(page).to have_content('Do you want to share any safeguarding issues?')
+  end
+
+  def when_i_choose_yes
+    choose 'Yes'
+  end
+
+  def and_enter_relevant_information
+    fill_in 'Give any relevant information', with: 'I have a criminal conviction.'
+  end
+
+  def and_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_my_relevant_information
+    expect(page).to have_content(t('page_titles.suitability_to_work_with_children'))
+    expect(page).to have_content('I have a criminal conviction.')
+  end
+
+  def when_i_click_to_change_sharing_safeguarding_issues
+    click_link 'Change if you want to share any safeguarding issues'
+  end
+
+  def when_i_choose_no
+    choose 'No'
+  end
+
+  def then_i_see_my_updated_answer
+    expect(page).to have_content(t('page_titles.suitability_to_work_with_children'))
+    expect(page).to have_content('No')
   end
 end


### PR DESCRIPTION
## Context

We want candidates to supply information about criminal convictions so that their application can properly assessed by providers.

Previous PRs:

- #1564 - added a feature flag
- #1568 - added a migration for storing safeguarding issues
- https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1573 - added the form object

## Changes proposed in this pull request

This PR allows a candidate to declare any safeguarding issues by creating the view with the form and allowing them to review and/or change their answer.

### Screenshots

![image](https://user-images.githubusercontent.com/42817036/76243317-10ead880-6230-11ea-8f38-8ec0dac56f99.png)

![image](https://user-images.githubusercontent.com/42817036/76243149-c701f280-622f-11ea-9099-e736f34011b5.png)

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/61j2wqUR/1072-suitability-to-work-with-children-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
