### PR TITLE
Allow support users to cancel references

### DIFF
--- a/app/components/candidate_interface/additional_referees_start_component.rb
+++ b/app/components/candidate_interface/additional_referees_start_component.rb
@@ -28,6 +28,8 @@ module CandidateInterface
         "Our email requesting a reference didn’t reach #{referee.name}"
       when 'feedback_refused'
         "#{referee.name} said they won’t give a reference"
+      when 'cancelled'
+        "We've cancelled the reference request for #{referee.name}"
       else
         "#{referee.name} did not respond to our request"
       end

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -93,7 +93,7 @@ module CandidateInterface
         reference.feedback_overdue? ? :red : :blue
       when 'feedback_provided'
         :green
-      when 'feedback_refused', 'feedback_overdue', 'email_bounced'
+      when 'feedback_refused', 'feedback_overdue', 'email_bounced', 'cancelled'
         :red
       end
     end

--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,5 +1,11 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: @title)) %>
+    <%= render(SummaryCardHeaderComponent.new(title: @title)) do %>
+      <div class='app-summary-card__actions'>
+        <%= link_to support_interface_cancel_reference_path(@reference), class: 'govuk-link' do %>
+          Cancel reference<span class="govuk-visually-hidden"> for <%= @reference.name %></span>
+        <% end %>
+      </div>
+    <% end %>
   <% end %>
 </div>

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -1,0 +1,14 @@
+module SupportInterface
+  class ReferencesController < SupportInterfaceController
+    def cancel
+      @reference = ApplicationReference.find(params[:reference_id])
+    end
+
+    def confirm_cancel
+      reference = ApplicationReference.find(params[:reference_id])
+      reference.update!(feedback_status: 'cancelled')
+      flash[:success] = 'Reference was cancelled'
+      redirect_to support_interface_application_form_path(reference.application_form)
+    end
+  end
+end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -17,6 +17,7 @@ class ApplicationReference < ApplicationRecord
   audited associated_with: :application_form
 
   enum feedback_status: {
+    cancelled: 'cancelled',
     not_requested_yet: 'not_requested_yet',
     feedback_requested: 'feedback_requested',
     feedback_provided: 'feedback_provided',

--- a/app/services/reference_status.rb
+++ b/app/services/reference_status.rb
@@ -21,8 +21,9 @@ class ReferenceStatus
     refused = application_references.select(&:feedback_refused?)
     bounced = application_references.select(&:email_bounced?)
     ignored = application_references.select(&:feedback_overdue?)
+    cancelled = application_references.select(&:cancelled?)
 
-    refused + bounced + ignored
+    refused + bounced + ignored + cancelled
   end
 
 private

--- a/app/views/support_interface/references/cancel.html.erb
+++ b/app/views/support_interface/references/cancel.html.erb
@@ -1,0 +1,38 @@
+<% content_for :browser_title, 'Cancel reference' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@reference.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Are you sure you want to cancel this reference?
+    </h1>
+
+    <p class="govuk-body">
+      Cancelling a reference will:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>prevent this referee from providing a reference</li>
+      <li>allow the candidate to provide a replacement referee</li>
+    </ul>
+
+    <p class="govuk-body">
+      Cancelling a reference does <strong>not send email notifications</strong>.
+    </p>
+
+    <%= render(SummaryCardComponent.new(rows: [
+    {
+      key: 'Reference name',
+      value: @reference.name,
+    },
+    {
+      key: 'Reference email address',
+      value: @reference.email_address,
+    },
+    ])) %>
+
+    <%= form_with model: @reference, url: support_interface_cancel_reference_path(@reference), method: :post do |f| %>
+      <%= f.govuk_submit 'Cancel reference', warning: true %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -178,6 +178,7 @@ en:
               blank: Tell us about the referee’s relationship to you and how long they’ve known you
               too_many_words: Relationship to referee must be %{count} words or fewer
             feedback_status:
+              cancelled: Cancelled
               not_requested_yet: Not requested yet
               feedback_requested: Feedback requested
               feedback_provided: Feedback provided

--- a/config/locales/reference.yml
+++ b/config/locales/reference.yml
@@ -1,11 +1,13 @@
 en:
   reference_status:
+    cancelled: 'Cancelled'
     not_requested_yet: 'Not requested yet'
     feedback_requested: 'Requested'
     feedback_provided: 'Feedback provided'
     feedback_refused: 'Declined'
     email_bounced: 'Email bounced'
   candidate_reference_status:
+    cancelled: 'Cancelled'
     not_requested_yet: 'Not requested yet'
     feedback_requested: 'Awaiting response'
     feedback_provided: 'Reference given'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -376,6 +376,9 @@ Rails.application.routes.draw do
     get '/send-survey-email/:application_form_id' => 'survey_emails#show', as: :survey_emails
     post '/send-survey-email/:application_form_id' => 'survey_emails#deliver'
 
+    get '/references/:reference_id/cancel' => 'references#cancel', as: :cancel_reference
+    post '/references/:reference_id/cancel' => 'references#confirm_cancel'
+
     get '/tokens' => 'api_tokens#index', as: :api_tokens
     post '/tokens' => 'api_tokens#create'
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -346,6 +346,12 @@ FactoryBot.define do
       requested_at { Time.zone.now }
     end
 
+    trait :cancelled do
+      feedback_status { 'cancelled' }
+      feedback { nil }
+      requested_at { Time.zone.now }
+    end
+
     trait :requested do
       feedback_status { 'feedback_requested' }
       feedback { nil }

--- a/spec/models/candidate_interface/pick_study_mode_form_spec.rb
+++ b/spec/models/candidate_interface/pick_study_mode_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::PickStudyModeForm, type: :model do
 
       form = described_class.new(course_id: course.id, study_mode: :part_time)
 
-      expect(form.available_sites).to eq(
+      expect(form.available_sites).to match_array(
         [
           pt_course_one,
           pt_course_two,

--- a/spec/services/reference_status_spec.rb
+++ b/spec/services/reference_status_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe ReferenceStatus do
       expect(status.needs_to_draft_another_reference?).to be(true)
     end
 
+    it 'knows if cancelled referees need to be replaced' do
+      application_form = create(:application_form)
+      create(:reference, :complete, application_form: application_form)
+      cancelled = create(:reference, :cancelled, application_form: application_form)
+
+      status = ReferenceStatus.new(application_form.reload)
+
+      expect(status.still_more_references_needed?).to be(true)
+      expect(status.references_that_needed_to_be_replaced).to match_array([cancelled])
+      expect(status.needs_to_draft_another_reference?).to be(true)
+    end
+
     it 'knows if referees need to be replaced if we are waiting for the other one' do
       application_form = create(:application_form)
       create(:reference, :requested, application_form: application_form)

--- a/spec/system/support_interface/cancel_reference_spec.rb
+++ b/spec/system/support_interface/cancel_reference_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.feature 'Cancelling references' do
+  include DfESignInHelpers
+
+  scenario 'Support agent cancels reference' do
+    given_i_am_a_support_user
+    and_there_is_an_application
+    and_i_visit_the_application
+
+    when_i_click_to_cancel_the_reference
+    and_i_confirm_i_really_want_to_cancel_the_reference
+    then_the_reference_is_cancelled
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_an_application
+    @application_with_reference = create(:completed_application_form)
+    create(:reference, :requested, name: 'Harry', application_form: @application_with_reference)
+  end
+
+  def and_i_visit_the_application
+    visit support_interface_application_form_path(@application_with_reference)
+  end
+
+  def when_i_click_to_cancel_the_reference
+    click_on 'Cancel reference for Harry'
+  end
+
+  def and_i_confirm_i_really_want_to_cancel_the_reference
+    click_on 'Cancel reference'
+  end
+
+  def then_the_reference_is_cancelled
+    expect(page).to have_content 'Reference was cancelled'
+    expect(page).to have_content 'Cancelled'
+  end
+end


### PR DESCRIPTION
## Context

We've had 2 support requests from people who've filled in an incorrect email address for references. Not all incorrect emails bounce, so they would have to wait 10 days before adding a replacement referee.

This adds a "cancel reference" button, so we can manually remove the reference request. This allows candidates to provide a replacement. It doesn't email the candidate because this often happens via a Zendesk conversation anyway.

## Changes proposed in this pull request

Given this application with references that haven't come in:

![image](https://user-images.githubusercontent.com/233676/76254693-d2abe400-6244-11ea-80f6-f781ae7f4159.png)

We can click on 'Cancel reference' and get the confirm screen:

![image](https://user-images.githubusercontent.com/233676/76254731-e0fa0000-6244-11ea-9af6-1581af73b1d7.png)

This will change the status of the reference to 'cancelled':

![image](https://user-images.githubusercontent.com/233676/76254788-f66f2a00-6244-11ea-873a-d4e2e6bc5254.png)

Which will require the candidate to add a replacement:

![image](https://user-images.githubusercontent.com/233676/76254950-38986b80-6245-11ea-99e0-02cdb5aae821.png)


## Guidance to review

Does it make sense? I don't think we need any checks, eg to prevent cancellation of a provided reference, because it might come in handy (eg someone filling in a bogus reference).

## Link to Trello card

https://trello.com/c/5rQqoe5P/1148-support-change-2x-referees-email-address

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
