### PR TITLE
Clearer feature flag name

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,8 +1,8 @@
 class FeatureFlag
   FEATURES = %w[
+    banner_about_problems_with_dfe_sign_in
     choose_study_mode
     confirm_conditions
-    dfe_sign_in_incident
     edit_application
     equality_and_diversity
     force_ok_computer_to_fail

--- a/app/views/provider_interface/sessions/new.html.erb
+++ b/app/views/provider_interface/sessions/new.html.erb
@@ -4,7 +4,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <% if FeatureFlag.active?('dfe_sign_in_incident') %>
+    <% if FeatureFlag.active?('banner_about_problems_with_dfe_sign_in') %>
       <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
           <div class="app-banner__message">
             <h2 class="govuk-heading-m">You might have problems signing in</h2>


### PR DESCRIPTION
## Context

PR #1495 introduced a feature-toggled banner to show to provider users when DfE Sign-in was down. However, the feature flag name isn't self-explanatory when skimming down the flags on the Features page.

## Changes proposed in this pull request

Before (slightly unfortunate wording on the button):

![image](https://user-images.githubusercontent.com/23801/76262962-a351a300-6255-11ea-897c-cb72bf5dc38e.png)

After:

![image](https://user-images.githubusercontent.com/23801/76263212-34287e80-6256-11ea-8468-3f9e3d25b308.png)

## Guidance to review

It should be OK to rename the flag because it's turned off in production?

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
