### PR TITLE
Link audit entries to provider users rather than just email addresses

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -23,6 +23,8 @@ module SupportInterface
         "#{audit.user.email_address} (Vendor API)"
       elsif audit.user_type == 'SupportUser'
         "#{audit.user.email_address} (Support user)"
+      elsif audit.user_type == 'ProviderUser'
+        "#{audit.user.email_address} (Provider user)"
       elsif audit.username.present?
         audit.username
       else

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -3,7 +3,6 @@ module ProviderInterface
     include LogQueryParams
 
     before_action :authenticate_provider_user!
-    around_action :set_audit_username
     before_action :add_identity_to_log
     before_action :check_data_sharing_agreements
 
@@ -17,21 +16,13 @@ module ProviderInterface
 
     helper_method :current_provider_user, :dfe_sign_in_user
 
-  private
-
-    def set_audit_username
-      Audited.audit_class.as_user(audit_username) do
-        yield
-      end
-    end
-
-    def audit_username
-      current_provider_user ? "#{current_provider_user.email_address} (Provider)" : nil
-    end
-
     def current_provider_user
       @current_provider_user != nil ? @current_provider_user : @current_provider_user = (ProviderUser.load_from_session(session) || false)
     end
+
+    alias :audit_user :current_provider_user
+
+  protected
 
     def dfe_sign_in_user
       DfESignInUser.load_from_session(session)

--- a/app/services/fix_provider_audits.rb
+++ b/app/services/fix_provider_audits.rb
@@ -1,0 +1,25 @@
+class FixProviderAudits
+  def initialize
+    @provider_users = {}
+  end
+
+  def call
+    Audited::Audit.where("username like '%(Provider)'").find_each do |audit|
+      email_address = email_address_from(audit)
+      provider_user = find_provider_user_by(email_address)
+      audit.update(user: provider_user) if provider_user
+    end
+  end
+
+private
+
+  def find_provider_user_by(email_address)
+    @provider_users[email_address] ||= ProviderUser.find_by(email_address: email_address)
+    @provider_users[email_address]
+  end
+
+  def email_address_from(audit)
+    match = audit.username.match(/(^.*) \(Provider\)/)
+    match[1] if match
+  end
+end

--- a/lib/tasks/fix_provider_audits.rake
+++ b/lib/tasks/fix_provider_audits.rake
@@ -1,0 +1,4 @@
+desc 'Fix audit records that refer to a provider email rather than provider ID'
+task fix_provider_audits: :environment do
+  FixProviderAudits.new.call
+end

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -77,6 +77,14 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('discarded@support.com (Support user)')
   end
 
+  it 'renders an update on application form audit record with a Provider User' do
+    audit.user = provider_user
+    audit.action = 'update'
+    expect(render_result.text).to include('1 October 2019 12:10')
+    expect(render_result.text).to include('Update Application Form')
+    expect(render_result.text).to include('jim@example.com (Provider user)')
+  end
+
   it 'renders an update application form audit record with the username (rather than a persistent model)' do
     audit.user = nil
     audit.username = 'SYSTEM'

--- a/spec/requests/provider_interface/audit_trail_spec.rb
+++ b/spec/requests/provider_interface/audit_trail_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Provider interface - audit trail', type: :request, with_audited:
     allow(ProviderUser).to receive(:load_from_session)
       .and_return(
         ProviderUser.new(
+          id: 123,
           email_address: 'alice@example.com',
           dfe_sign_in_uid: 'ABCDEF',
           providers: [application_choice.course.provider],
@@ -28,6 +29,7 @@ RSpec.describe 'Provider interface - audit trail', type: :request, with_audited:
       ), params: { offer_conditions: '["must be clever"]' }
     }.to(change { application_choice.audits.count })
 
-    expect(application_choice.audits.last.username).to eq 'alice@example.com (Provider)'
+    expect(application_choice.audits.last.user_id).to eq 123
+    expect(application_choice.audits.last.user_type).to eq 'ProviderUser'
   end
 end

--- a/spec/services/fix_provider_audits_spec.rb
+++ b/spec/services/fix_provider_audits_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe FixProviderAudits do
+  it 'updates a legacy provider audit entry when there is a matching provider user' do
+    provider_user = create :provider_user, email_address: 'bob@example.com'
+    audit = Audited::Audit.create(
+      username: 'bob@example.com (Provider)',
+    )
+    described_class.new.call
+    expect(audit.reload.user_id).to eq provider_user.id
+    expect(audit.user_type).to eq 'ProviderUser'
+    expect(audit.username).to be_nil
+  end
+
+  it 'does nothing to a legacy provider audit entry that does not match provider user' do
+    audit = Audited::Audit.create(
+      username: 'bob@example.com (Provider)',
+    )
+    described_class.new.call
+    expect(audit.reload.user_id).to be_nil
+    expect(audit.user_type).to be_nil
+    expect(audit.username).to eq 'bob@example.com (Provider)'
+  end
+
+  it 'does nothing to a non legacy provider audit entry' do
+    support_user = create :support_user, email_address: 'ted@example.com'
+    audit = Audited::Audit.create(
+      user: support_user,
+      username: nil,
+    )
+    described_class.new.call
+    expect(audit.reload.user_id).to eq support_user.id
+    expect(audit.user_type).to eq 'SupportUser'
+    expect(audit.username).to be_nil
+  end
+end


### PR DESCRIPTION
## Context

At the moment we only record the email of the provider user. If we want to get eg the person's name we need to look the provider user up by email is unreliable and awkward.

## Changes proposed in this pull request

- [x] Attribute provider audit actions to the current provider user instead of the email address
- [x] Update existing audit trail entries

## Guidance to review

- Is a rake task the right way to implement the upgrade? (I don't think it belongs in a migration because the data volume is pretty much unbounded so I'd be concerned about how long it takes).
- Not sure how to flag up 'manual post-deployment' tasks. Elsewhere I've seen release notes used to list things that the deployers need to do. Should we have a standard section on the Trello card?
- Another thing worth flagging is that the rake task and associated service can and should be deleted after they've served their purpose to avoid unnecessary code bloat. Should we just add a new Trello card?

## Link to Trello card

https://trello.com/c/urHsv4dj/1742-make-provider-auditing-associate-actions-with-provideruser-records

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
