### PR TITLE
Show a course full page if selecting a course with no vacancies

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -66,7 +66,7 @@ module CandidateInterface
 
       if !@pick_course.open_on_apply?
         redirect_to_ucas
-      elsif @pick_course.full?
+      elsif @pick_course.full? && FeatureFlag.active?('check_full_courses')
         redirect_to candidate_interface_course_choices_full_path(
           @pick_course.provider_id,
           @pick_course.course_id,

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -66,6 +66,11 @@ module CandidateInterface
 
       if !@pick_course.open_on_apply?
         redirect_to_ucas
+      elsif @pick_course.full?
+        redirect_to candidate_interface_course_choices_full_path(
+          @pick_course.provider_id,
+          @pick_course.course_id,
+        )
       elsif @pick_course.both_study_modes_available? && FeatureFlag.active?('choose_study_mode')
         redirect_to candidate_interface_course_choices_study_mode_path(
           @pick_course.provider_id,
@@ -81,6 +86,10 @@ module CandidateInterface
           @pick_course.study_mode,
         )
       end
+    end
+
+    def full
+      @course = Course.find(params[:course_id])
     end
 
     def options_for_study_mode

--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -28,6 +28,10 @@ module CandidateInterface
       course.study_mode
     end
 
+    def full?
+      course.full?
+    end
+
     def course
       @course ||= provider.courses.find(course_id)
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -33,4 +33,8 @@ class Course < ApplicationRecord
   def both_study_modes_available?
     study_mode == 'full_time_or_part_time'
   end
+
+  def full?
+    course_options.all?(&:no_vacancies?)
+  end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -3,6 +3,7 @@ class FeatureFlag
     add_additional_courses_page
     banner_about_problems_with_dfe_sign_in
     choose_study_mode
+    check_full_courses
     confirm_conditions
     edit_application
     equality_and_diversity

--- a/app/views/candidate_interface/course_choices/full.html.erb
+++ b/app/views/candidate_interface/course_choices/full.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, t('page_titles.full_course') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_course_choices_course_path(@course.provider)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.full_course') %>
+    </h1>
+
+    <p class="govuk-body">The course '<%= @course.name_and_code %>' is full.</p>
+    <p class="govuk-body">You can:</p>
+    <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-8">
+      <li>
+        <%= link_to(
+          'choose another course',
+          candidate_interface_course_choices_course_path(@course.provider),
+          class: 'govuk-link'
+        ) %>
+      </li>
+      <li>
+        contact
+        <%= govuk_link_to(
+          @course.provider.name,
+          "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-contact"
+        ) %>
+      to see if the course will re-open or discuss alternatives
+      </li>
+    </ul>
+
+    <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_form_path %></p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,6 +48,7 @@ en:
     destroy_degree: Are you sure you want to delete this degree?
     choosing_courses: Choosing your courses
     course_choices: Course choices
+    full_course: You cannot apply to this course because it has no vacancies
     withdraw_course_choice: Withdrawal
     destroy_course_choice: Are you sure you want to delete this choice?
     have_you_chosen: Have you chosen a course to apply to?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,8 @@ Rails.application.routes.draw do
         get '/provider/:provider_id/courses/:course_id' => 'course_choices#options_for_study_mode', as: :course_choices_study_mode
         post '/provider/:provider_id/courses/:course_id' => 'course_choices#pick_study_mode'
 
+        get '/provider/:provider_id/courses/:course_id/full' => 'course_choices#full', as: :course_choices_full
+
         get '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices#options_for_site', as: :course_choices_site
         post '/provider/:provider_id/courses/:course_id/:study_mode' => 'course_choices#pick_site'
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -21,4 +21,36 @@ RSpec.describe Course, type: :model do
       expect(course.both_study_modes_available?).to be false
     end
   end
+
+  describe '#full?' do
+    subject(:course) { create(:course) }
+
+    context 'when there are no course options' do
+      it 'returns true' do
+        expect(course.full?).to be true
+      end
+    end
+
+    context 'when a subset of course options have vacancies' do
+      before do
+        create(:course_option, course: course, vacancy_status: 'full_time_vacancies')
+        create(:course_option, course: course, vacancy_status: 'no_vacancies')
+      end
+
+      it 'returns false' do
+        expect(course.full?).to be false
+      end
+    end
+
+    context 'when no course options have vacancies' do
+      before do
+        create(:course_option, course: course, vacancy_status: 'no_vacancies')
+        create(:course_option, course: course, vacancy_status: 'no_vacancies')
+      end
+
+      it 'returns false' do
+        expect(course.full?).to be true
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Selecting a full course' do
   include CandidateHelper
 
   scenario 'Candidate selects a full course' do
+    given_check_full_courses_is_active
     given_i_am_signed_in
     and_there_is_a_full_course
     when_i_select_the_full_course
@@ -12,6 +13,10 @@ RSpec.describe 'Selecting a full course' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def given_check_full_courses_is_active
+    FeatureFlag.activate('check_full_courses')
   end
 
   def and_there_is_a_full_course

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Selecting a full course' do
+  include CandidateHelper
+
+  scenario 'Candidate selects a full course' do
+    given_i_am_signed_in
+    and_there_is_a_full_course
+    when_i_select_the_full_course
+    then_i_see_a_page_telling_me_i_cannot_apply
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_is_a_full_course
+    @course = create(:course, :open_on_apply)
+
+    create(:course_option, course: @course, vacancy_status: 'no_vacancies')
+  end
+
+  def when_i_select_the_full_course
+    visit candidate_interface_application_form_path
+    click_link 'Course choices'
+    click_link 'Continue'
+
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+
+    select @course.provider.name
+    click_button 'Continue'
+
+    choose @course.name
+    click_button 'Continue'
+  end
+
+  def then_i_see_a_page_telling_me_i_cannot_apply
+    expect(page).to have_text('You cannot apply to this course because it has no vacancies')
+    expect(page).to have_text("The course '#{@course.name_and_code}' is full")
+  end
+end


### PR DESCRIPTION


## Context

When a course has no vacancies in any of its course options, we want to show a page which informs the user of this fact. This is part of a wider piece of work to prevent candidates wasting time on applications to unavailable courses.

## Changes proposed in this pull request

- Add a Course#full? method which checks if any course options have
  vacancies.
- Add the course full page, including links to the Provider contact
  details.
- Update course selection to show this page if the selected course is
  full.

### The course full page

<img width="875" alt="Screenshot 2020-03-10 at 12 00 49" src="https://user-images.githubusercontent.com/519250/76310655-1fd09a00-62c7-11ea-9b9f-fd065fd9e18b.png">


## Guidance to review

- If testing locally or on the review app, navigate to /candidate/application/courses/provider/1/courses/1/full (replacing the IDs as appropriate). This will show the newly introduced page.
- Testing the logical checks will require DB changes. Specifically, a course must have all its course options updated with `vacancy_status: 'no_vacancies'`.

## Link to Trello card

https://trello.com/c/LAh0iGIc/348-dev-stop-candidates-adding-full-courses-to-their-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
