### PR TITLE
Add ability to view completion and review safeguarding section upon submission

### DIFF
--- a/app/components/safeguarding_review_component.html.erb
+++ b/app/components/safeguarding_review_component.html.erb
@@ -1,1 +1,5 @@
-<%= render(SummaryCardComponent.new(rows: safeguarding_rows, editable: @editable)) %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent.new(section: :safeguarding, section_path: candidate_interface_edit_safeguarding_path, error: @missing_error)) %>
+<% else %>
+  <%= render(SummaryCardComponent.new(rows: safeguarding_rows, editable: @editable)) %>
+<% end %>

--- a/app/components/safeguarding_review_component.rb
+++ b/app/components/safeguarding_review_component.rb
@@ -1,11 +1,16 @@
 class SafeguardingReviewComponent < ActionView::Component::Base
-  def initialize(application_form:, editable: true)
+  def initialize(application_form:, editable: true, missing_error: false)
     @safeguarding = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
     @editable = editable
+    @missing_error = missing_error
   end
 
   def safeguarding_rows
     [sharing_safeguarding_issues_row, relevant_information_row].compact
+  end
+
+  def show_missing_banner?
+    !@safeguarding.valid? && @editable
   end
 
 private

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -159,6 +159,10 @@ module CandidateInterface
       @application_form.application_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
     end
 
+    def safeguarding_completed?
+      @application_form.safeguarding_issues.present?
+    end
+
   private
 
     def show_review_volunteering?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -19,6 +19,7 @@ module CandidateInterface
         ([:training_with_a_disability, training_with_a_disability_completed?] if FeatureFlag.active?('training_with_a_disability')),
         [:work_experience, work_experience_completed?],
         [:volunteering, volunteering_completed?],
+        ([:safeguarding, safeguarding_completed?] if FeatureFlag.active?('suitability_to_work_with_children')),
 
         # "Qualifications" section
         [:degrees, degrees_completed?],

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -28,6 +28,12 @@
 
 <%= render(VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
 
+<% if FeatureFlag.active?('suitability_to_work_with_children') %>
+  <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
+
+  <%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
+<% end %>
+
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
 <h3 class="govuk-heading-m">Degree(s)</h3>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -46,16 +46,16 @@
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent.new(text: t('page_titles.volunteering.short'), completed: @application_form_presenter.volunteering_completed?, path: @application_form_presenter.volunteering_path)) %>
       </li>
-        <% if FeatureFlag.active?('training_with_a_disability') %>
-          <li class="app-task-list__item">
-            <%= render(TaskListItemComponent.new(text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path)) %>
-          </li>
-        <% end %>
-        <% if FeatureFlag.active?('suitability_to_work_with_children') %>
-          <li class="app-task-list__item">
-            <%= govuk_link_to t('page_titles.suitability_to_work_with_children'), candidate_interface_edit_safeguarding_path %>
-          </li>
-        <% end %>
+      <% if FeatureFlag.active?('training_with_a_disability') %>
+        <li class="app-task-list__item">
+          <%= render(TaskListItemComponent.new(text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path)) %>
+        </li>
+      <% end %>
+      <% if FeatureFlag.active?('suitability_to_work_with_children') %>
+        <li class="app-task-list__item">
+          <%= render(TaskListItemComponent.new(text: t('page_titles.suitability_to_work_with_children'), completed: @application_form_presenter.safeguarding_completed?, path: @application_form_presenter.safeguarding_completed? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path)) %>
+        </li>
+      <% end %>
     </ul>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">

--- a/config/locales/review_application.yml
+++ b/config/locales/review_application.yml
@@ -32,3 +32,5 @@ en:
       incomplete: Volunteering with children and young people is not marked as completed
     work_experience:
       incomplete: Work history is not marked as completed
+    safeguarding:
+      incomplete: Safeguarding information not entered

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -257,6 +257,24 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#safeguarding_completed?' do
+    it 'returns false if safeguarding issues is nil' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: nil)
+
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.safeguarding_completed?).to eq(false)
+    end
+
+    it 'returns true if safeguarding issues has a value' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.safeguarding_completed?).to eq(true)
+    end
+  end
+
   describe '#work_experience_path' do
     it 'returns the length path if no work experience' do
       application_form = build(:completed_application_form, work_experiences_count: 0, work_history_explanation: '')

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -4,6 +4,7 @@ module CandidateHelper
     personal_details
     contact_details
     training_with_a_disability
+    safeguarding
     work_experience
     volunteering
     degrees
@@ -22,6 +23,7 @@ module CandidateHelper
 
   def candidate_completes_application_form
     given_courses_exist
+    and_the_suitability_to_work_with_children_feature_flag_is_on
     create_and_sign_in_candidate
     visit candidate_interface_application_form_path
 
@@ -45,6 +47,9 @@ module CandidateHelper
     candidate_fills_in_disability_info
     click_button t('application_form.training_with_a_disability.complete_form_button')
     click_link t('application_form.training_with_a_disability.review.button')
+
+    click_link t('page_titles.suitability_to_work_with_children')
+    candidate_fills_in_safeguarding_issues
 
     click_link t('page_titles.degree')
     candidate_fills_in_their_degree
@@ -88,6 +93,10 @@ module CandidateHelper
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
     course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider)
     create(:course_option, site: site, course: course)
+  end
+
+  def and_the_suitability_to_work_with_children_feature_flag_is_on
+    FeatureFlag.activate('suitability_to_work_with_children')
   end
 
   def candidate_fills_in_course_choices
@@ -171,6 +180,15 @@ module CandidateHelper
   def candidate_fills_in_disability_info
     choose t('application_form.training_with_a_disability.disclose_disability.yes')
     fill_in t('application_form.training_with_a_disability.disability_disclosure.label'), with: 'I have difficulty climbing stairs'
+  end
+
+  def candidate_fills_in_safeguarding_issues
+    choose 'Yes'
+    fill_in 'Give any relevant information', with: 'I have a criminal conviction.'
+
+    click_button 'Continue'
+
+    click_link 'Continue'
   end
 
   def candidate_fills_in_work_experience

--- a/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -30,6 +30,9 @@ RSpec.feature 'Entering their suitability to work with children' do
     when_i_choose_no
     and_i_click_on_continue
     then_i_see_my_updated_answer
+
+    when_i_click_on_continue
+    then_i_see_the_section_is_completed
   end
 
   def given_i_am_signed_in
@@ -45,7 +48,7 @@ RSpec.feature 'Entering their suitability to work with children' do
   end
 
   def then_i_dont_see_declaring_any_safeguarding_issues
-    expect(page).not_to have_content('Declaring any safeguarding issues')
+    expect(page).not_to have_content(t('page_titles.suitability_to_work_with_children'))
   end
 
   def when_i_visit_the_declaring_any_safeguarding_issues_form
@@ -100,5 +103,13 @@ RSpec.feature 'Entering their suitability to work with children' do
   def then_i_see_my_updated_answer
     expect(page).to have_content(t('page_titles.suitability_to_work_with_children'))
     expect(page).to have_content('No')
+  end
+
+  def when_i_click_on_continue
+    click_link 'Continue'
+  end
+
+  def then_i_see_the_section_is_completed
+    expect(page).to have_css('#declaring-any-safeguarding-issues-badge-id', text: 'Completed')
   end
 end

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
   scenario 'sees everything missing from the current state' do
     given_i_am_signed_in
     and_the_training_with_a_disability_feature_flag_is_on
+    and_the_suitability_to_work_with_children_feature_flag_is_on
 
     when_i_visit_the_review_application_page
     then_i_should_be_able_to_click_through_and_complete_each_section_but_science_gcse
@@ -20,6 +21,10 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   def and_the_training_with_a_disability_feature_flag_is_on
     FeatureFlag.activate('training_with_a_disability')
+  end
+
+  def and_the_suitability_to_work_with_children_feature_flag_is_on
+    FeatureFlag.activate('suitability_to_work_with_children')
   end
 
   def when_i_visit_the_review_application_page

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     and_i_can_see_my_personal_details
     and_i_can_see_my_contact_details
     and_i_can_see_my_disability_disclosure
+    and_i_can_see_my_safeguarding_issues
     and_i_can_see_my_volunteering_roles
     and_i_can_see_my_degree
     and_i_can_see_my_gcses
@@ -54,6 +55,10 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
     FeatureFlag.activate('training_with_a_disability')
   end
 
+  def and_the_suitability_to_work_with_children_feature_flag_is_on
+    FeatureFlag.activate('suitability_to_work_with_children')
+  end
+
   def when_i_have_completed_my_application
     candidate_completes_application_form
   end
@@ -91,6 +96,11 @@ RSpec.feature 'Candidate submits the application', sidekiq: true do
   def and_i_can_see_my_disability_disclosure
     expect(page).to have_content 'Yes'
     expect(page).to have_content 'I have difficulty climbing stairs'
+  end
+
+  def and_i_can_see_my_safeguarding_issues
+    expect(page).to have_content 'Yes'
+    expect(page).to have_content 'I have a criminal conviction.'
   end
 
   def and_i_can_see_my_volunteering_roles


### PR DESCRIPTION
## Context

We want candidates to supply information about criminal convictions so that their application can properly assessed by providers.

Previous PRs:

#1564 - added a feature flag
#1568 - added a migration for storing safeguarding issues
#1573 - added the form object
#1582 - added ability to choose and enter any safeguarding issues

## Changes proposed in this pull request

This PR adds the ability to see if the safeguarding section is completed and review the section when checking before application submission.

### Screenshots

<img width="1920" alt="Screenshot 2020-03-10 at 12 00 05" src="https://user-images.githubusercontent.com/42817036/76310483-c7999800-62c6-11ea-8c3d-8f53dbd9cb94.png">

<img width="740" alt="Screenshot 2020-03-10 at 12 09 52" src="https://user-images.githubusercontent.com/42817036/76311162-3deaca00-62c8-11ea-9611-46850f5907fc.png">

## Guidance to review

- Bits and bobs done here and there to do this so recommend review commit by commit.
- Turned the `suitability_to_work_with_children` feature flag on in the `spec/support/test_helpers/candidate_helper.rb` otherwise it meant I would have to update each spec that uses `candidate_completes_application_form`. However, for `training_with_a_disability` we turn that feature flag on for each spec that used it. Which makes more sense?
- Error message isn't great but will check with Emma tomorrow as she wants to review content for this section.

## Link to Trello card

https://trello.com/c/61j2wqUR/1072-suitability-to-work-with-children-build

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
