### PR TITLE
Update content from 'Interview preferences' to 'Interview needs'

### DIFF
--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -8,12 +8,32 @@
 
       <h1 class="govuk-heading-xl"><%= t('page_titles.interview_preferences') %></h1>
 
-      <p class="govuk-body">Your interview will usually take place over the course of a day and you will need to attend in person.</p>
-      <p class="govuk-body">Give details of any arrangements you might need. Providers can’t always accomodate your preferences.</p>
+      <p class="govuk-body">
+        Interviews usually take place over the course of a day.
+        You'll need to attend in person.
+      </p>
+
+      <p class="govuk-body">
+        Training providers might not have much flexibility when setting a date
+        and time for interview.
+      </p>
+
+      <p class="govuk-body">
+        If there's a reason why you need some flexibility you can tell us about
+        it here.
+      </p>
+
+      <p class="govuk-body">For example:</p>
+
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
+        <li>you have commitments such as employment or caring responsibilities</li>
+        <li>you'll be travelling a long way to get to the interview</li>
+        <li>you'll need some adjustments because you're disabled</li>
+      </ul>
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>
         <%= f.govuk_radio_button :any_preferences, 'yes', label: { text: 'Yes' }, link_errors: true do %>
-          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label'), size: 's' }, hint_text: 'Give a reason if you can', rows: 8, max_words: 200 %>
+          <%= f.govuk_text_area :interview_preferences, label: { text: t('application_form.personal_statement.interview_preferences.yes_label') }, rows: 8, max_words: 200 %>
         <% end %>
 
         <%= f.govuk_radio_button :any_preferences, 'no', label: { text: 'No' } %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -222,11 +222,11 @@ en:
         label: Tell us what you know about the subject you want to teach
         complete_form_button: Continue
       interview_preferences:
-        key: Interview preferences
-        change_action: interview preferences
-        label: Do you have any preferences for your interview?
+        key: Interview needs
+        change_action: interview needs
+        label: Do you have any interview needs?
         complete_form_button: Save and continue
-        yes_label: What are your interview preferences?
+        yes_label: What are your interview needs?
         no_value: None
     training_with_a_disability:
       complete_form_button: Continue

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,7 +63,7 @@ en:
     destroy_other_qualification: Are you sure you want to delete this qualification?
     becoming_a_teacher: Why do you want to be a teacher?
     subject_knowledge: What do you know about the subject you want to teach?
-    interview_preferences: Interview preferences
+    interview_preferences: Interview needs
     training_with_a_disability: Asking for support if you have a disability or other needs
     suitability_to_work_with_children: Declaring any safeguarding issues
     volunteering:

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -67,7 +67,7 @@ module CandidateHelper
     click_link 'What do you know about the subject you want to teach?'
     candidate_fills_in_subject_knowledge
 
-    click_link 'Interview preferences'
+    click_link t('page_titles.interview_preferences')
     candidate_fills_in_interview_preferences
 
     candidate_provides_two_referees

--- a/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
@@ -82,6 +82,6 @@ RSpec.feature 'Entering interview preferences' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#interview-preferences-badge-id', text: 'Completed')
+    expect(page).to have_css('#interview-needs-badge-id', text: 'Completed')
   end
 end


### PR DESCRIPTION
## Context

We want to provide more accurate guidance about interview needs.

## Changes proposed in this pull request

This PR updates the content about interviews:

- change from 'Interview preferences' to 'Interview needs'
- update main content on the form
- update the labels for 'Yes' on the form

### Screenshots

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/42817036/76323033-0b4acc80-62dc-11ea-9d35-40250ecddfa2.png)|![image](https://user-images.githubusercontent.com/42817036/76322774-b60ebb00-62db-11ea-89d6-b0c3dcbb0ff6.png)|
|![image](https://user-images.githubusercontent.com/42817036/76323001-fec67400-62db-11ea-96b0-922d68a1123c.png)|![image](https://user-images.githubusercontent.com/42817036/76322949-ece4d100-62db-11ea-8035-9687e33130db.png)|

## Guidance to review

Anything I've missed? (https://bat-design-history.netlify.com/apply-for-teacher-training/interview-needs)

## Link to Trello card

https://trello.com/c/zcFLtedQ/1138-dev-update-content-for-interview-needs

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
