### PR TITLE
Never notify Slack when creating a test application

### DIFF
--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -4,30 +4,20 @@ class GenerateTestApplications
   def perform
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
-    without_slack_message_sending do
-      TestApplications.create_application states: [:unsubmitted]
-      TestApplications.create_application states: [:awaiting_references]
-      TestApplications.create_application states: [:application_complete]
-      TestApplications.create_application states: [:awaiting_provider_decision] * 3
-      TestApplications.create_application states: [:offer] * 2
-      TestApplications.create_application states: %i[offer rejected]
-      TestApplications.create_application states: [:rejected] * 2
-      TestApplications.create_application states: [:offer_withdrawn]
-      TestApplications.create_application states: [:declined]
-      TestApplications.create_application states: [:accepted]
-      TestApplications.create_application states: [:accepted_no_conditions]
-      TestApplications.create_application states: [:recruited]
-      TestApplications.create_application states: [:conditions_not_met]
-      TestApplications.create_application states: [:enrolled]
-      TestApplications.create_application states: [:withdrawn]
-    end
-  end
-
-private
-
-  def without_slack_message_sending
-    RequestStore.store[:disable_slack_messages] = true
-    yield
-    RequestStore.store[:disable_slack_messages] = false
+    TestApplications.create_application states: [:unsubmitted]
+    TestApplications.create_application states: [:awaiting_references]
+    TestApplications.create_application states: [:application_complete]
+    TestApplications.create_application states: [:awaiting_provider_decision] * 3
+    TestApplications.create_application states: [:offer] * 2
+    TestApplications.create_application states: %i[offer rejected]
+    TestApplications.create_application states: [:rejected] * 2
+    TestApplications.create_application states: [:offer_withdrawn]
+    TestApplications.create_application states: [:declined]
+    TestApplications.create_application states: [:accepted]
+    TestApplications.create_application states: [:accepted_no_conditions]
+    TestApplications.create_application states: [:recruited]
+    TestApplications.create_application states: [:conditions_not_met]
+    TestApplications.create_application states: [:enrolled]
+    TestApplications.create_application states: [:withdrawn]
   end
 end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -22,4 +22,14 @@ RSpec.describe GenerateTestApplications do
       'enrolled',
     )
   end
+
+  it 'does not notify Slack', sidekiq: true do
+    ClimateControl.modify(STATE_CHANGE_SLACK_URL: 'https://example.com') do
+      slack_request = stub_request(:post, 'https://example.com')
+
+      GenerateTestApplications.new.perform
+
+      expect(slack_request).not_to have_been_made
+    end
+  end
 end


### PR DESCRIPTION

## Context

So far applications created via the `GenerateTestApplications` service have had their slack notifications suppressed. This didn’t apply to applications created via the sandbox, which made the #twd_apply_test channel very noisy when vendors created hundreds of applications.

## Changes proposed in this pull request

Push the restriction down into `TestApplications` so it’s always applied for mass-generated data.

## Guidance to review

The spec is a bit gnarly because the actual sending of Slack notifications depends on two circumstances: an env var and `Sidekiq::Testing.inline!` being enabled. I manually tested the opposite assertion and saw the spec fail.

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
