### PR TITLE
Add error prefix to page titles of equality and diversity forms

### DIFF
--- a/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disabilities.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Please select all that apply to you' %>
+<% content_for :title, title_with_error_prefix('Please select all that apply to you', @disabilities.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_disability_status_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_disability_status.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Are you disabled?' %>
+<% content_for :title, title_with_error_prefix('Are you disabled?', @disability_status.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_sex_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_background.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, ethnic_background_title(@ethnic_group) %>
+<% content_for :title, title_with_error_prefix(ethnic_background_title(@ethnic_group), @ethnic_background.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_ethnic_group_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_ethnic_group.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'What is your ethnic group?' %>
+<% content_for :title, title_with_error_prefix('What is your ethnic group?', @ethnic_group.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_edit_equality_and_diversity_disability_status_path) %>
 
 <div class="govuk-grid-row">

--- a/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/edit_sex.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'What is your sex?' %>
+<% content_for :title, title_with_error_prefix('What is your sex?', @sex.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_equality_and_diversity_path) %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

When an error occurs on all equality and diversity forms, we don't prefix the page title with "Error:". We should as this is an accessibility issue and was previously pointed out in our DAC Report.

## Changes proposed in this pull request

This PR prefixes all the forms that are part of the equality and diversity questionnaire:

1. "Error: What is your sex? - Apply for teacher training - GOV.UK"
2. "Error: Are you disabled? - Apply for teacher training - GOV.UK"
3. "Error: Please select all that apply to you - Apply for teacher training - GOV.UK"
4. "Error: What is your ethnic group? - Apply for teacher training - GOV.UK"
5. "Error: Which of the following best describes your <ethnic group> background? - Apply for teacher training - GOV.UK"

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/76335411-6684bb00-62ec-11ea-8fca-f55a45ca9b3c.png)

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/Vfodcv7X/1147-prefix-error-to-the-page-title-for-equality-and-diversity-forms

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
