### PR TITLE
1641 add filtering to the provider ui refactor

### DIFF
--- a/app/components/previews/provider_interface/filter_component_preview.rb
+++ b/app/components/previews/provider_interface/filter_component_preview.rb
@@ -4,30 +4,30 @@ module ProviderInterface
       render_component_for(path: :provider_interface_applications_path,
                            available_filters: available_filters,
                            applied_filters: applied_filters_full,
-                           additional_params: additional_params)
+                           params_for_current_state: params_for_current_state)
     end
 
     def partially_selected
       render_component_for(path: :provider_interface_applications_path,
                            available_filters: available_filters,
                            applied_filters: applied_filters_partial,
-                           additional_params: additional_params)
+                           params_for_current_state: params_for_current_state)
     end
 
     def empty
       render_component_for(path: :provider_interface_applications_path,
                            available_filters: available_filters,
                            applied_filters: {},
-                           additional_params: additional_params)
+                           params_for_current_state: params_for_current_state)
     end
 
   private
 
-    def render_component_for(path:, available_filters:, applied_filters:, additional_params:)
+    def render_component_for(path:, available_filters:, applied_filters:, params_for_current_state:)
       render ProviderInterface::FilterComponent.new(path: path,
                                                     available_filters: available_filters,
                                                     applied_filters: applied_filters,
-                                                    additional_params: additional_params)
+                                                    params_for_current_state: params_for_current_state)
     end
 
     def applied_filters_partial
@@ -129,7 +129,7 @@ module ProviderInterface
       ]
     end
 
-    def additional_params
+    def params_for_current_state
       {
         sort_by: 'desc',
         sort_order: 'last-updated',

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -8,7 +8,7 @@
 
     <div class="moj-filter__heading-action">
     <p class="govuk-body">
-       <%= link_to "Clear", filtering_page_path(additional_params), class: "govuk-link govuk-link--no-visited-state" %>
+       <%= link_to "Clear", filtering_page_path(additional_params.except(:filter_selections)), class: "govuk-link govuk-link--no-visited-state" %>
     </p>
     </div>
 
@@ -19,10 +19,10 @@
     <ul class="moj-filter-tags">
     <% checkbox_config_values.each do |checkbox_config_name, _| %>
         <li>
-          <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_name),
-                                        filtering_page_path({filter_selections: build_tag_url_query_params(
+          <%= link_to retrieve_tag_text(applied_filters_key, checkbox_config_name),
+                                        filtering_page_path(additional_params.merge({filter_selections: build_tag_url_query_params(
                                                                                 heading: applied_filters_key,
-                                                                                tag_value: checkbox_config_name)}.merge(additional_params)),
+                                                                                tag_value: checkbox_config_name)})),
                                         class: "moj-filter__tag", id: "tag-#{checkbox_config_name}" %>
         </li>
       <% end %>

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -19,10 +19,11 @@
     <ul class="moj-filter-tags">
     <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
         <li>
-        <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_value), filtering_page_path(
-          additional_params.merge({ filter_selections: build_tag_url_query_params(
-                                         heading: applied_filters_key,
-                                         tag_value: checkbox_config_key)})), class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
+          <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_value),
+                                        filtering_page_path({filter_selections: build_tag_url_query_params(
+                                                                                heading: applied_filters_key,
+                                                                                tag_value: checkbox_config_key)}.merge(additional_params)),
+                                        class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
         </li>
       <% end %>
     </ul>

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -8,7 +8,7 @@
 
     <div class="moj-filter__heading-action">
     <p class="govuk-body">
-       <%= link_to "Clear", filtering_page_path(additional_params.except(:filter_selections)), class: "govuk-link govuk-link--no-visited-state" %>
+       <%= link_to "Clear", filtering_page_path(params_for_current_state.except(:filter_selections)), class: "govuk-link govuk-link--no-visited-state" %>
     </p>
     </div>
 
@@ -20,7 +20,7 @@
     <% checkbox_config_values.each do |checkbox_config_name, _| %>
         <li>
           <%= link_to retrieve_tag_text(applied_filters_key, checkbox_config_name),
-                                        filtering_page_path(additional_params.merge({filter_selections: build_tag_url_query_params(
+                                        filtering_page_path(params_for_current_state.merge({filter_selections: build_tag_url_query_params(
                                                                                 heading: applied_filters_key,
                                                                                 tag_value: checkbox_config_name)})),
                                         class: "moj-filter__tag", id: "tag-#{checkbox_config_name}" %>

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -17,13 +17,13 @@
   <% applied_filters.each do |applied_filters_key, checkbox_config_values| %>
     <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= applied_filters_key.capitalize %></h3>
     <ul class="moj-filter-tags">
-    <% checkbox_config_values.each do |checkbox_config_key, checkbox_config_value| %>
+    <% checkbox_config_values.each do |checkbox_config_name, _| %>
         <li>
-          <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_value),
+          <%= link_to retrieve_tag_text(applied_filters_key,checkbox_config_name),
                                         filtering_page_path({filter_selections: build_tag_url_query_params(
                                                                                 heading: applied_filters_key,
-                                                                                tag_value: checkbox_config_key)}.merge(additional_params)),
-                                        class: "moj-filter__tag", id: "tag-#{checkbox_config_value}" %>
+                                                                                tag_value: checkbox_config_name)}.merge(additional_params)),
+                                        class: "moj-filter__tag", id: "tag-#{checkbox_config_name}" %>
         </li>
       <% end %>
     </ul>

--- a/app/components/provider_interface/current_filters_component.rb
+++ b/app/components/provider_interface/current_filters_component.rb
@@ -2,10 +2,10 @@ module ProviderInterface
   class CurrentFiltersComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :applied_filters, :additional_params, :path
+    attr_reader :applied_filters, :params_for_current_state, :path
 
-    def initialize(path:, available_filters:, applied_filters:, additional_params:)
-      @additional_params = additional_params
+    def initialize(path:, available_filters:, applied_filters:, params_for_current_state:)
+      @params_for_current_state = params_for_current_state
       @applied_filters = applied_filters
       @available_filters = available_filters
       @path = path

--- a/app/components/provider_interface/filter_checkbox_component.html.erb
+++ b/app/components/provider_interface/filter_checkbox_component.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-checkboxes__item">
-  <input class="govuk-checkboxes__input" id=<%= "#{heading}-#{name}" %> name=<%= "filter_selections[#{heading}][#{name}]" %> value=<%= "#{value}" %> type="checkbox", <%= "checked" if selected %> >
+  <input class="govuk-checkboxes__input" id=<%= "#{heading}-#{text.parameterize}" %> name=<%= "filter_selections[#{heading}][#{name}]" %> type="checkbox", <%= "checked" if selected %> >
   <label class="govuk-label govuk-checkboxes__label" for=<%= "#{heading}-#{name}" %>>
     <%= text %>
   </label>

--- a/app/components/provider_interface/filter_checkbox_component.rb
+++ b/app/components/provider_interface/filter_checkbox_component.rb
@@ -2,12 +2,11 @@ module ProviderInterface
   class FilterCheckboxComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :name, :text, :value, :selected, :heading
+    attr_reader :name, :text, :selected, :heading
 
-    def initialize(name:, text:, value:, selected:, heading:)
+    def initialize(name:, text:, selected:, heading:)
       @name = name
       @text = text
-      @value = value
       @selected = selected
       @heading = heading
     end

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -26,25 +26,27 @@
 
 
             <% available_filters.each do |filter_group| %>
-              <div class="govuk-form-group">
-                <fieldset class="govuk-fieldset">
-                  <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                    <%= filter_group[:heading].capitalize %>
-                  </legend>
+              <% unless filter_group[:checkbox_config].size <= 1 %>
+                <div class="govuk-form-group">
+                  <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                      <%= filter_group[:heading].capitalize %>
+                    </legend>
 
-                  <% filter_group[:checkbox_config].each do |checkbox_config| %>
-                    <div class="govuk-checkboxes govuk-checkboxes--small">
-                      <%= render ProviderInterface::FilterCheckboxComponent.new(name: checkbox_config[:name],
-                                                                                text: checkbox_config[:text],
-                                                                                value: checkbox_config[:value],
-                                                                                selected: checkbox_checked?(heading: filter_group[:heading], name: checkbox_config[:name]),
-                                                                                heading: filter_group[:heading].parameterize)
-                       %>
-                    </div>
-                  <% end %>
-                </fieldset>
-              </div>
-              <% end %>
+                    <% filter_group[:checkbox_config].each do |checkbox_config| %>
+                      <div class="govuk-checkboxes govuk-checkboxes--small">
+                        <%= render ProviderInterface::FilterCheckboxComponent.new(name: checkbox_config[:name],
+                                                                                  text: checkbox_config[:text],
+                                                                                  value: checkbox_config[:value],
+                                                                                  selected: checkbox_checked?(heading: filter_group[:heading], name: checkbox_config[:name]),
+                                                                                  heading: filter_group[:heading].parameterize)
+                         %>
+                      </div>
+                    <% end %>
+                  </fieldset>
+                </div>
+            <% end %>
+          <% end %>
           </form>
         </div>
       </div>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -13,14 +13,14 @@
              <%= render ProviderInterface::CurrentFiltersComponent.new(path: path,
                                                                        available_filters: available_filters,
                                                                        applied_filters: applied_filters,
-                                                                       additional_params: additional_params) %>
+                                                                       params_for_current_state: params_for_current_state) %>
      <% end %>
 
 
         <div class="moj-filter__options">
           <form method="get" action=<%= filtering_page_path %>>
             <%= submit_tag "Apply filters", class: "govuk-button" %>
-            <% additional_params.except(:filter_selections).each do |key, value| %>
+            <% params_for_current_state.except(:filter_selections).each do |key, value| %>
               <input class="govuk-checkboxes__input" id=<%= key %> name=<%= key %> type="hidden" value=<%= value %> %>
             <% end %>
 

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -20,7 +20,7 @@
         <div class="moj-filter__options">
           <form method="get" action=<%= filtering_page_path %>>
             <%= submit_tag "Apply filters", class: "govuk-button" %>
-            <% additional_params.each do |key, value| %>
+            <% additional_params.except(:filter_selections).each do |key, value| %>
               <input class="govuk-checkboxes__input" id=<%= key %> name=<%= key %> type="hidden" value=<%= value %> %>
             <% end %>
 

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -37,7 +37,6 @@
                       <div class="govuk-checkboxes govuk-checkboxes--small">
                         <%= render ProviderInterface::FilterCheckboxComponent.new(name: checkbox_config[:name],
                                                                                   text: checkbox_config[:text],
-                                                                                  value: checkbox_config[:value],
                                                                                   selected: checkbox_checked?(heading: filter_group[:heading], name: checkbox_config[:name]),
                                                                                   heading: filter_group[:heading].parameterize)
                          %>

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -2,13 +2,13 @@ module ProviderInterface
   class FilterComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :additional_params, :available_filters, :applied_filters, :path
+    attr_reader :params_for_current_state, :available_filters, :applied_filters, :path
 
-    def initialize(path:, available_filters:, applied_filters:, additional_params:)
+    def initialize(path:, available_filters:, applied_filters:, params_for_current_state:)
       @path = path
       @available_filters = available_filters
       @applied_filters = applied_filters
-      @additional_params = additional_params
+      @params_for_current_state = params_for_current_state
     end
 
     def checkbox_checked?(heading:, name:)

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -15,22 +15,6 @@ module ProviderInterface
       applied_filters.dig(heading, name) ? true : false
     end
 
-    def build_tag_url_query_params(heading:, tag_value:, applied_filters:)
-      tag_applied_filters = applied_filters.clone
-      tag_applied_filters[heading] = applied_filters[heading].except(tag_value)
-      tag_applied_filters
-    end
-
-    def retrieve_tag_text(heading, lookup_val)
-      available_filters.each do |available_filter|
-        if available_filter.key(heading)
-          available_filter[:checkbox_config].each do |checkbox_config|
-            return checkbox_config[:text].to_s if checkbox_config.key(lookup_val)
-          end
-        end
-      end
-    end
-
     def filtering_page_path(*args)
       send(@path, *args)
     end

--- a/app/components/provider_interface/sortable_column_heading_component.html.erb
+++ b/app/components/provider_interface/sortable_column_heading_component.html.erb
@@ -1,9 +1,9 @@
 <% if should_have_sort? %>
   <th scope="col" class="<%= css_class %>" aria-sort="<%= aria_sort_order %>">
-    <%= link_to column_name, url_for(sort_order: toggle_sort_order, sort_by: sort_by, filter_selections: filter_selections, filter_visible: filter_visible), class: "app-sort-link" %>
+    <%= link_to column_name, url_for({sort_order: toggle_sort_order, sort_by: sort_by}.merge(additional_params)), class: "app-sort-link" %>
   </th>
 <% else %>
   <th scope="col" class="<%= css_class %>" aria-sort="none">
-    <%= link_to column_name, url_for(sort_order: default_sort_order, sort_by: sort_by, filter_selections: filter_selections, filter_visible: filter_visible), class: "app-sort-link" %>
+    <%= link_to column_name, url_for({sort_order: default_sort_order, sort_by: sort_by}.merge(additional_params)), class: "app-sort-link" %>
   </th>
 <% end %>

--- a/app/components/provider_interface/sortable_column_heading_component.html.erb
+++ b/app/components/provider_interface/sortable_column_heading_component.html.erb
@@ -1,9 +1,9 @@
 <% if should_have_sort? %>
   <th scope="col" class="<%= css_class %>" aria-sort="<%= aria_sort_order %>">
-    <%= link_to column_name, url_for({sort_order: toggle_sort_order, sort_by: sort_by}.merge(additional_params)), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(additional_params.merge({sort_order: toggle_sort_order, sort_by: sort_by})), class: "app-sort-link" %>
   </th>
 <% else %>
   <th scope="col" class="<%= css_class %>" aria-sort="none">
-    <%= link_to column_name, url_for({sort_order: default_sort_order, sort_by: sort_by}.merge(additional_params)), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(additional_params.merge({sort_order: default_sort_order, sort_by: sort_by})), class: "app-sort-link" %>
   </th>
 <% end %>

--- a/app/components/provider_interface/sortable_column_heading_component.html.erb
+++ b/app/components/provider_interface/sortable_column_heading_component.html.erb
@@ -1,9 +1,9 @@
 <% if should_have_sort? %>
   <th scope="col" class="<%= css_class %>" aria-sort="<%= aria_sort_order %>">
-    <%= link_to column_name, url_for(additional_params.merge({sort_order: toggle_sort_order, sort_by: sort_by})), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(params_for_current_state.merge({sort_order: toggle_sort_order, sort_by: sort_by})), class: "app-sort-link" %>
   </th>
 <% else %>
   <th scope="col" class="<%= css_class %>" aria-sort="none">
-    <%= link_to column_name, url_for(additional_params.merge({sort_order: default_sort_order, sort_by: sort_by})), class: "app-sort-link" %>
+    <%= link_to column_name, url_for(params_for_current_state.merge({sort_order: default_sort_order, sort_by: sort_by})), class: "app-sort-link" %>
   </th>
 <% end %>

--- a/app/components/provider_interface/sortable_column_heading_component.rb
+++ b/app/components/provider_interface/sortable_column_heading_component.rb
@@ -2,15 +2,14 @@ module ProviderInterface
   class SortableColumnHeadingComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :column_name, :current_sort_by, :css_class, :filter_selections, :filter_visible
+    attr_reader :column_name, :current_sort_by, :css_class, :additional_params
 
-    def initialize(sort_order:, column_name:, current_sort_by:, css_class:, filter_selections:, filter_visible:)
+    def initialize(sort_order:, column_name:, current_sort_by:, css_class:, additional_params:)
       @sort_order = sort_order
       @column_name = column_name
       @current_sort_by = current_sort_by
       @css_class = css_class
-      @filter_selections = filter_selections
-      @filter_visible = filter_visible
+      @additional_params = additional_params
     end
 
     def default_sort_order

--- a/app/components/provider_interface/sortable_column_heading_component.rb
+++ b/app/components/provider_interface/sortable_column_heading_component.rb
@@ -2,14 +2,14 @@ module ProviderInterface
   class SortableColumnHeadingComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :column_name, :current_sort_by, :css_class, :additional_params
+    attr_reader :column_name, :current_sort_by, :css_class, :params_for_current_state
 
-    def initialize(sort_order:, column_name:, current_sort_by:, css_class:, additional_params:)
+    def initialize(sort_order:, column_name:, current_sort_by:, css_class:, params_for_current_state:)
       @sort_order = sort_order
       @column_name = column_name
       @current_sort_by = current_sort_by
       @css_class = css_class
-      @additional_params = additional_params
+      @params_for_current_state = params_for_current_state
     end
 
     def default_sort_order

--- a/app/components/provider_interface/toggle_filter_component.html.erb
+++ b/app/components/provider_interface/toggle_filter_component.html.erb
@@ -1,6 +1,6 @@
 <div class="moj-action-bar">
   <div class="moj-action-bar__filter">
-    <%= link_to toggle_button_text, url_for(additional_params.merge({filter_visible: toggle_filter})),
+    <%= link_to toggle_button_text, url_for(params_for_current_state.merge({filter_visible: toggle_filter})),
       class: "govuk-button govuk-button--secondary", type: "button" %>
   </div>
 </div>

--- a/app/components/provider_interface/toggle_filter_component.html.erb
+++ b/app/components/provider_interface/toggle_filter_component.html.erb
@@ -1,6 +1,6 @@
 <div class="moj-action-bar">
   <div class="moj-action-bar__filter">
-    <%= link_to toggle_button_text, url_for(sort_order: sort_order, sort_by: current_sort_by, filter_visible: toggle_filter, filter_selections: filter_selections),
+    <%= link_to toggle_button_text, url_for({filter_visible: toggle_filter}.merge(additional_params)),
       class: "govuk-button govuk-button--secondary", type: "button" %>
   </div>
 </div>

--- a/app/components/provider_interface/toggle_filter_component.html.erb
+++ b/app/components/provider_interface/toggle_filter_component.html.erb
@@ -1,6 +1,6 @@
 <div class="moj-action-bar">
   <div class="moj-action-bar__filter">
-    <%= link_to toggle_button_text, url_for({filter_visible: toggle_filter}.merge(additional_params)),
+    <%= link_to toggle_button_text, url_for(additional_params.merge({filter_visible: toggle_filter})),
       class: "govuk-button govuk-button--secondary", type: "button" %>
   </div>
 </div>

--- a/app/components/provider_interface/toggle_filter_component.rb
+++ b/app/components/provider_interface/toggle_filter_component.rb
@@ -2,13 +2,11 @@ module ProviderInterface
   class ToggleFilterComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :sort_order, :current_sort_by, :filter_visible, :filter_options, :filter_selections
+    attr_reader :filter_visible, :additional_params
 
-    def initialize(sort_order:, current_sort_by:, filter_visible:, filter_selections:)
-      @sort_order = sort_order
-      @current_sort_by = current_sort_by
+    def initialize(filter_visible:, additional_params:)
       @filter_visible = filter_visible
-      @filter_selections = filter_selections
+      @additional_params = additional_params
     end
 
     def toggle_filter

--- a/app/components/provider_interface/toggle_filter_component.rb
+++ b/app/components/provider_interface/toggle_filter_component.rb
@@ -2,11 +2,11 @@ module ProviderInterface
   class ToggleFilterComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :filter_visible, :additional_params
+    attr_reader :filter_visible, :params_for_current_state
 
-    def initialize(filter_visible:, additional_params:)
+    def initialize(filter_visible:, params_for_current_state:)
       @filter_visible = filter_visible
-      @additional_params = additional_params
+      @params_for_current_state = params_for_current_state
     end
 
     def toggle_filter

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,21 +1,18 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     def index
-      @sort_order = params[:sort_order].eql?('asc') ? 'asc' : 'desc'
-      @sort_by = params[:sort_by].presence || 'last-updated'
-
       application_choices = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
-        .order(ordering_arguments(@sort_by, @sort_order))
+
+      @page_state = ProviderApplicationsPageState.new(params: params, application_choices: application_choices)
 
       if FeatureFlag.active?('provider_application_filters')
-        @available_filters = available_filters(application_choices: application_choices)
-        @filter_visible =  filter_params[:filter_visible] ||= 'true'
-        @filter_selections = filter_params[:filter_selections].to_h ||= {}
+        @filter_visible = @page_state.filter_visible
+        @filter_selections = @page_state.filter_selections
         application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
                                                                         filters: @filter_selections)
       end
       application_choices = application_choices.page(params[:page] || 1)
-      @application_choices = application_choices
+      @application_choices = application_choices.order(@page_state.applications_odering_query)
     end
 
     def show
@@ -29,81 +26,5 @@ module ProviderInterface
       params.permit(:filter_visible, filter_selections: { status: {}, provider: {} })
     end
 
-    def ordering_arguments(sort_by, sort_order)
-      {
-        'course' => { 'courses.name' => sort_order },
-        'last-updated' => { 'application_choices.updated_at' => sort_order },
-        'name' => { 'last_name' => sort_order, 'first_name' => sort_order },
-      }[sort_by]
-    end
-
-    def available_filters(application_choices:)
-      [
-        {
-          heading: 'status',
-          checkbox_config: [
-            {
-              name: 'pending-conditions',
-              text: 'Accepted',
-              value: 'pending_conditions',
-            },
-            {
-              name: 'recruited',
-              text: 'Conditions met',
-              value: 'recruited',
-            },
-            {
-              name: 'declined',
-              text: 'Declined',
-              value: 'declined',
-            },
-            {
-              name: 'awaiting-provider-decision',
-              text: 'New',
-              value: 'awaiting_provider_decision',
-            },
-            {
-              name: 'offer',
-              text: 'Offered',
-              value: 'offer',
-            },
-            {
-              name: 'rejected',
-              text: 'Rejected',
-              value: 'rejected',
-            },
-            {
-              name: 'withdrawn',
-              text: 'Application withdrawn',
-              value: 'withdrawn',
-            },
-            {
-              name: 'offer-withdrawn',
-              text: 'Withdrawn by us',
-              value: 'offer_withdrawn',
-            },
-          ],
-        },
-      ] << provider_filters_builder(application_choices: application_choices)
-    end
-
-    def provider_filters_builder(application_choices:)
-      checkbox_config = application_choices.map do |choice|
-        provider = choice.provider
-
-        {
-          name: provider.name.parameterize,
-          text: provider.name,
-          value: provider.id.to_s,
-        }
-      end
-
-      provider_filters = {
-        heading: 'provider',
-        checkbox_config: checkbox_config.uniq!,
-      }
-
-      provider_filters
-    end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -17,6 +17,5 @@ module ProviderInterface
       @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
         .find(params[:application_choice_id])
     end
-
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -10,7 +10,7 @@ module ProviderInterface
                                                                         filters: @page_state.filter_selections)
       end
       application_choices = application_choices.page(params[:page] || 1)
-      @application_choices = application_choices.order(@page_state.applications_odering_query)
+      @application_choices = application_choices.order(@page_state.applications_ordering_query)
     end
 
     def show

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -6,10 +6,8 @@ module ProviderInterface
       @page_state = ProviderApplicationsPageState.new(params: params, application_choices: application_choices)
 
       if FeatureFlag.active?('provider_application_filters')
-        @filter_visible = @page_state.filter_visible
-        @filter_selections = @page_state.filter_selections
         application_choices = FilterApplicationChoicesForProviders.call(application_choices: application_choices,
-                                                                        filters: @filter_selections)
+                                                                        filters: @page_state.filter_selections)
       end
       application_choices = application_choices.page(params[:page] || 1)
       @application_choices = application_choices.order(@page_state.applications_odering_query)
@@ -18,12 +16,6 @@ module ProviderInterface
     def show
       @application_choice = GetApplicationChoicesForProviders.call(providers: current_provider_user.providers)
         .find(params[:application_choice_id])
-    end
-
-  private
-
-    def filter_params
-      params.permit(:filter_visible, filter_selections: { status: {}, provider: {} })
     end
 
   end

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -20,6 +20,15 @@ module ProviderInterface
       }[@sort_by]
     end
 
+    def to_h
+      {
+        sort_order: @sort_order,
+        sort_by: @sort_by,
+        filter_visible: @filter_visible,
+        filter_selections: @filter_selections,
+      }
+    end
+
   private
 
     def calculate_filter_visibility

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -1,0 +1,120 @@
+module ProviderInterface
+  class ProviderApplicationsPageState
+    attr_accessor :sort_order, :sort_by, :available_filters, :filter_visible, :filter_selections
+
+    def initialize(params:, application_choices:)
+      @params = params
+      @application_choices = application_choices
+      @sort_order = calculate_sort_order
+      @sort_by = calculate_sort_by
+      @available_filters = calculate_available_filters
+      @filter_visible =  calculate_filter_visibility
+      @filter_selections = calculate_filter_selections
+    end
+
+    def applications_odering_query
+      {
+        'course' => { 'courses.name' => @sort_order },
+        'last-updated' => { 'application_choices.updated_at' => @sort_order },
+        'name' => { 'last_name' => @sort_order, 'first_name' => @sort_order },
+      }[@sort_by]
+    end
+
+  private
+
+    def calculate_filter_visibility
+      @params[:filter_visible] ||= 'true'
+    end
+
+    def calculate_filter_selections
+      filter_params[:filter_selections].to_h ||= {}
+    end
+
+    def filter_params
+      @params.permit(:filter_visible, filter_selections: { status: {}, provider: {} })
+    end
+
+    def calculate_sort_order
+      @params[:sort_order].eql?('asc') ? 'asc' : 'desc'
+    end
+
+    def calculate_sort_by
+      @params[:sort_by].presence || 'last-updated'
+    end
+
+
+    def calculate_available_filters
+      status_filters << provider_filters_builder
+    end
+
+    def status_filters
+      [
+        {
+          heading: 'status',
+          checkbox_config: [
+            {
+              name: 'pending-conditions',
+              text: 'Accepted',
+              value: 'pending_conditions',
+            },
+            {
+              name: 'recruited',
+              text: 'Conditions met',
+              value: 'recruited',
+            },
+            {
+              name: 'declined',
+              text: 'Declined',
+              value: 'declined',
+            },
+            {
+              name: 'awaiting-provider-decision',
+              text: 'New',
+              value: 'awaiting_provider_decision',
+            },
+            {
+              name: 'offer',
+              text: 'Offered',
+              value: 'offer',
+            },
+            {
+              name: 'rejected',
+              text: 'Rejected',
+              value: 'rejected',
+            },
+            {
+              name: 'withdrawn',
+              text: 'Application withdrawn',
+              value: 'withdrawn',
+            },
+            {
+              name: 'offer-withdrawn',
+              text: 'Withdrawn by us',
+              value: 'offer_withdrawn',
+            },
+          ],
+        },
+      ]
+    end
+
+    def provider_filters_builder
+      checkbox_config = @application_choices.map do |choice|
+        provider = choice.provider
+
+        {
+          name: provider.name.parameterize,
+          text: provider.name,
+          value: provider.id.to_s,
+        }
+      end
+
+      provider_filters = {
+        heading: 'provider',
+        checkbox_config: checkbox_config.uniq!,
+      }
+
+      provider_filters
+    end
+
+  end
+end

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -53,44 +53,36 @@ module ProviderInterface
           heading: 'status',
           checkbox_config: [
             {
-              name: 'pending-conditions',
               text: 'Accepted',
-              value: 'pending_conditions',
+              name: 'pending_conditions',
             },
             {
-              name: 'recruited',
               text: 'Conditions met',
-              value: 'recruited',
+              name: 'recruited',
             },
             {
-              name: 'declined',
               text: 'Declined',
-              value: 'declined',
+              name: 'declined',
             },
             {
-              name: 'awaiting-provider-decision',
               text: 'New',
-              value: 'awaiting_provider_decision',
+              name: 'awaiting_provider_decision',
             },
             {
-              name: 'offer',
               text: 'Offered',
-              value: 'offer',
+              name: 'offer',
             },
             {
-              name: 'rejected',
               text: 'Rejected',
-              value: 'rejected',
+              name: 'rejected',
             },
             {
-              name: 'withdrawn',
               text: 'Application withdrawn',
-              value: 'withdrawn',
+              name: 'withdrawn',
             },
             {
-              name: 'offer-withdrawn',
               text: 'Withdrawn by us',
-              value: 'offer_withdrawn',
+              name: 'offer_withdrawn',
             },
           ],
         },
@@ -102,9 +94,8 @@ module ProviderInterface
         provider = choice.provider
 
         {
-          name: provider.name.parameterize,
           text: provider.name,
-          value: provider.id.to_s,
+          name: provider.id.to_s,
         }
       end
 

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -12,7 +12,7 @@ module ProviderInterface
       @filter_selections = calculate_filter_selections
     end
 
-    def applications_odering_query
+    def applications_ordering_query
       {
         'course' => { 'courses.name' => @sort_order },
         'last-updated' => { 'application_choices.updated_at' => @sort_order },

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -23,7 +23,7 @@ module ProviderInterface
   private
 
     def calculate_filter_visibility
-      @params[:filter_visible] ||= 'true'
+      filter_params[:filter_visible] ||= 'true'
     end
 
     def calculate_filter_selections

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -42,7 +42,6 @@ module ProviderInterface
       @params[:sort_by].presence || 'last-updated'
     end
 
-
     def calculate_available_filters
       status_filters << provider_filters_builder
     end
@@ -106,6 +105,5 @@ module ProviderInterface
 
       provider_filters
     end
-
   end
 end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -3,11 +3,11 @@ class FilterApplicationChoicesForProviders
     return application_choices if filters.empty?
 
     if filters[:status] && filters[:provider]
-      application_choices.where(status: filters[:status].values, 'courses.provider_id' => filters[:provider].values)
+      application_choices.where(status: filters[:status].keys, 'courses.provider_id' => filters[:provider].keys)
     elsif filters[:status]
-      application_choices.where(status: filters[:status].values)
+      application_choices.where(status: filters[:status].keys)
     else
-      application_choices.where('courses.provider_id' => filters[:provider].values)
+      application_choices.where('courses.provider_id' => filters[:provider].keys)
     end
   end
 end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -32,15 +32,15 @@
                                                                                column_name: 'Name',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               filter_selections: @page_state.filter_selections,
-                                                                               filter_visible: @page_state.filter_visible) %>
+                                                                               additional_params: { filter_selections: @page_state.filter_selections,
+                                                                                                    filter_visible: @page_state.filter_visible }) %>
 
               <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
                                                                                column_name: 'Course',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               filter_selections: @page_state.filter_selections,
-                                                                               filter_visible: @page_state.filter_visible) %>
+                                                                               additional_params: { filter_selections: @page_state.filter_selections,
+                                                                                                    filter_visible: @page_state.filter_visible }) %>
 
 
               <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
@@ -49,8 +49,8 @@
                                                                                column_name: 'Last updated',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
-                                                                               filter_selections: @page_state.filter_selections,
-                                                                               filter_visible: @page_state.filter_visible) %>
+                                                                               additional_params: { filter_selections: @page_state.filter_selections,
+                                                                                                    filter_visible: @page_state.filter_visible }) %>
             </tr>
           </thead>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -10,15 +10,12 @@
     <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
                                                       available_filters: @page_state.available_filters,
                                                       applied_filters: @page_state.filter_selections,
-                                                      additional_params: { sort_by: @page_state.sort_by,
-                                                                           sort_order: @page_state.sort_order }) %>
+                                                      additional_params: @page_state.to_h) %>
   <% end %>
 
   <div class='moj-filter-layout__content'>
     <%= render ProviderInterface::ToggleFilterComponent.new(filter_visible: @page_state.filter_visible,
-                                                            additional_params: { sort_order: @page_state.sort_order,
-                                                                                sort_by: @page_state.sort_by,
-                                                                                filter_selections: @page_state.filter_selections }) %>
+                                                            additional_params: @page_state.to_h) %>
     <div class='moj-scrollable-pane'>
       <div class='moj-scrollable-pane__wrapper'>
 
@@ -32,15 +29,13 @@
                                                                                column_name: 'Name',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               additional_params: { filter_selections: @page_state.filter_selections,
-                                                                                                    filter_visible: @page_state.filter_visible }) %>
+                                                                               additional_params: @page_state.to_h) %>
 
               <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
                                                                                column_name: 'Course',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               additional_params: { filter_selections: @page_state.filter_selections,
-                                                                                                    filter_visible: @page_state.filter_visible }) %>
+                                                                               additional_params: @page_state.to_h) %>
 
 
               <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
@@ -49,8 +44,7 @@
                                                                                column_name: 'Last updated',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
-                                                                               additional_params: { filter_selections: @page_state.filter_selections,
-                                                                                                    filter_visible: @page_state.filter_visible }) %>
+                                                                               additional_params: @page_state.to_h) %>
             </tr>
           </thead>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -4,50 +4,55 @@
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <% if FeatureFlag.active?('provider_application_filters') %>
-  <div class='moj-filter-layout'>
-    <% if @filter_visible.eql?('true') %>
-      <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
-                                                        available_filters: @available_filters,
-                                                        applied_filters: @filter_selections,
-                                                        additional_params: { sort_by: @sort_by,
-                                                                             sort_order: @sort_order }) %>
-    <% end %>
 
-    <div class='moj-filter-layout__content'>
-      <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @sort_order, current_sort_by: @sort_by, filter_visible: @filter_visible, filter_selections: @filter_selections) %>
-      <div class='moj-scrollable-pane'>
-        <div class='moj-scrollable-pane__wrapper'>
-<% end %>
+<div class='moj-filter-layout'>
+  <% if @page_state.filter_visible.eql?('true') %>
+    <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
+                                                      available_filters: @page_state.available_filters,
+                                                      applied_filters: @page_state.filter_selections,
+                                                      additional_params: { sort_by: @page_state.sort_by,
+                                                                           sort_order: @page_state.sort_order }) %>
+  <% end %>
 
-<% if @application_choices.any? %>
-  <table class='govuk-table'>
-    <thead class='govuk-table__head'>
-      <tr class='govuk-table__row'>
-        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
-                                                                         column_name: 'Name',
-                                                                         current_sort_by: @sort_by,
-                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                         filter_selections: @filter_selections,
-                                                                         filter_visible: @filter_visible) %>
+  <div class='moj-filter-layout__content'>
+    <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @page_state.sort_order,
+                                                            current_sort_by: @page_state.sort_by,
+                                                            filter_visible: @page_state.filter_visible,
+                                                            filter_selections: @page_state.filter_selections) %>
+    <div class='moj-scrollable-pane'>
+      <div class='moj-scrollable-pane__wrapper'>
 
-        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
-                                                                         column_name: 'Course',
-                                                                         current_sort_by: @sort_by,
-                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                         filter_selections: @filter_selections,
-                                                                         filter_visible: @filter_visible) %>
+      <% end %>
 
-        <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
- 
-        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @sort_order,
-                                                                         column_name: 'Last updated',
-                                                                         current_sort_by: @sort_by,
-                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
-                                                                         filter_selections: @filter_selections,
-                                                                         filter_visible: @filter_visible) %>
-      </tr>
-    </thead>
- 
+      <% if @application_choices.any? %>
+        <table class='govuk-table'>
+          <thead class='govuk-table__head'>
+            <tr class='govuk-table__row'>
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
+                                                                               column_name: 'Name',
+                                                                               current_sort_by: @page_state.sort_by,
+                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                               filter_selections: @page_state.filter_selections,
+                                                                               filter_visible: @page_state.filter_visible) %>
+
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
+                                                                               column_name: 'Course',
+                                                                               current_sort_by: @page_state.sort_by,
+                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                               filter_selections: @page_state.filter_selections,
+                                                                               filter_visible: @page_state.filter_visible) %>
+
+              <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
+
+              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
+                                                                               column_name: 'Last updated',
+                                                                               current_sort_by: @page_state.sort_by,
+                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
+                                                                               filter_selections: @page_state.filter_selections,
+                                                                               filter_visible: @page_state.filter_visible) %>
+            </tr>
+          </thead>
+
     <tbody class='govuk-table__body'>
       <% @application_choices.each do |application_choice| %>
         <tr class='govuk-table__row'>
@@ -70,7 +75,7 @@
       <% end %>
     </tbody>
   </table>
- 
+
 <% if FeatureFlag.active?('provider_application_filters') %>
         </div>
       </div>
@@ -79,7 +84,7 @@
 <% end %>
 
 <%= render(PaginatorComponent.new(scope: @application_choices)) %>
-<% elsif @filter_selections %>
+<% elsif @page_state.filter_selections %>
      <p class='govuk-body'>No applications for the selected filters.</p>
 <% else %>
   <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -42,6 +42,7 @@
                                                                                filter_selections: @page_state.filter_selections,
                                                                                filter_visible: @page_state.filter_visible) %>
 
+
               <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
 
               <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
@@ -84,7 +85,7 @@
 <% end %>
 
 <%= render(PaginatorComponent.new(scope: @application_choices)) %>
-<% elsif @page_state.filter_selections %>
+<% elsif @page_state.filter_selections.any? %>
      <p class='govuk-body'>No applications for the selected filters.</p>
 <% else %>
   <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -10,12 +10,12 @@
     <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
                                                       available_filters: @page_state.available_filters,
                                                       applied_filters: @page_state.filter_selections,
-                                                      additional_params: @page_state.to_h) %>
+                                                      params_for_current_state: @page_state.to_h) %>
   <% end %>
 
   <div class='moj-filter-layout__content'>
     <%= render ProviderInterface::ToggleFilterComponent.new(filter_visible: @page_state.filter_visible,
-                                                            additional_params: @page_state.to_h) %>
+                                                            params_for_current_state: @page_state.to_h) %>
     <div class='moj-scrollable-pane'>
       <div class='moj-scrollable-pane__wrapper'>
 
@@ -29,13 +29,13 @@
                                                                                column_name: 'Name',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               additional_params: @page_state.to_h) %>
+                                                                               params_for_current_state: @page_state.to_h) %>
 
               <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
                                                                                column_name: 'Course',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               additional_params: @page_state.to_h) %>
+                                                                               params_for_current_state: @page_state.to_h) %>
 
 
               <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
@@ -44,7 +44,7 @@
                                                                                column_name: 'Last updated',
                                                                                current_sort_by: @page_state.sort_by,
                                                                                css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
-                                                                               additional_params: @page_state.to_h) %>
+                                                                               params_for_current_state: @page_state.to_h) %>
             </tr>
           </thead>
 

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -15,10 +15,10 @@
   <% end %>
 
   <div class='moj-filter-layout__content'>
-    <%= render ProviderInterface::ToggleFilterComponent.new(sort_order: @page_state.sort_order,
-                                                            current_sort_by: @page_state.sort_by,
-                                                            filter_visible: @page_state.filter_visible,
-                                                            filter_selections: @page_state.filter_selections) %>
+    <%= render ProviderInterface::ToggleFilterComponent.new(filter_visible: @page_state.filter_visible,
+                                                            additional_params: { sort_order: @page_state.sort_order,
+                                                                                sort_by: @page_state.sort_by,
+                                                                                filter_selections: @page_state.filter_selections }) %>
     <div class='moj-scrollable-pane'>
       <div class='moj-scrollable-pane__wrapper'>
 

--- a/spec/components/provider_interface/current_filters_component_spec.rb
+++ b/spec/components/provider_interface/current_filters_component_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
     ]
   end
 
-  let(:additional_params) do
+  let(:params_for_current_state) do
     {
       sort_by: 'desc',
       sort_order: 'last-updated',
@@ -108,7 +108,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.css('.moj-filter-tags').text).to include('Accepted', 'New', 'Rejected', 'Application withdrawn', 'The Beach Teaching School')
     expect(result.css('.moj-filter-tags').text).not_to include('Declined', 'Conditions met', 'Somerset SCITT consortium')
@@ -118,7 +118,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.text).to include('Clear')
   end
@@ -127,7 +127,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
     filter_component = described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(filter_component.retrieve_tag_text('status', 'offer_withdrawn')).to eq('Withdrawn by us')
     expect(filter_component.retrieve_tag_text('provider', '2')).to eq('The Beach Teaching School')
@@ -137,7 +137,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
     filter_component = described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     hash = filter_component.build_tag_url_query_params(heading: 'status',
                                                tag_value: 'withdrawn')
@@ -149,7 +149,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.css('#tag-rejected').attr('href').value).not_to include('rejected')
     expect(result.css('#tag-rejected').attr('href').value).to include('2')

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe ProviderInterface::FilterComponent do
   let(:applied_filters_partial) do
     {
       'status' => {
-        'pending-conditions' => 'pending_conditions',
-        'awaiting-provider-decision' => 'awaiting_provider_decision',
-        'offer' => 'offer',
-        'rejected' => 'rejected',
-        'withdrawn' => 'withdrawn',
+        'pending_conditions' => 'on',
+        'awaiting_provider_decision' => 'on',
+        'offer' => 'on',
+        'rejected' => 'on',
+        'withdrawn' => 'on',
       }, 'provider' => {
-          'the-beach-teaching-school' => '2',
+          '2' => 'on',
         }
     }
   end
@@ -20,12 +20,12 @@ RSpec.describe ProviderInterface::FilterComponent do
   let(:applied_filters_partial_minus_withdrawn) do
     {
       'status' => {
-        'pending-conditions' => 'pending_conditions',
-        'awaiting-provider-decision' => 'awaiting_provider_decision',
-        'offer' => 'offer',
-        'rejected' => 'rejected',
+        'pending_conditions' => 'on',
+        'awaiting_provider_decision' => 'on',
+        'offer' => 'on',
+        'rejected' => 'on',
       }, 'provider' => {
-          'the-beach-teaching-school' => '2',
+          '2' => 'on',
         }
     }
   end
@@ -37,44 +37,36 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'status',
         checkbox_config: [
           {
-            name: 'pending-conditions',
             text: 'Accepted',
-            value: 'pending_conditions',
+            name: 'pending_conditions',
           },
           {
-            name: 'recruited',
             text: 'Conditions met',
-            value: 'recruited',
+            name: 'recruited',
           },
           {
-            name: 'declined',
             text: 'Declined',
-            value: 'declined',
+            name: 'declined',
           },
           {
-            name: 'awaiting-provider-decision',
             text: 'New',
-            value: 'awaiting_provider_decision',
+            name: 'awaiting_provider_decision',
           },
           {
-            name: 'offer',
             text: 'Offered',
-            value: 'offer',
+            name: 'offer',
           },
           {
-            name: 'rejected',
             text: 'Rejected',
-            value: 'rejected',
+            name: 'rejected',
           },
           {
-            name: 'withdrawn',
             text: 'Application withdrawn',
-            value: 'withdrawn',
+            name: 'withdrawn',
           },
           {
-            name: 'offer-withdrawn',
             text: 'Withdrawn by us',
-            value: 'offer_withdrawn',
+            name: 'offer_withdrawn',
           },
         ],
       },
@@ -82,14 +74,12 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'provider',
         checkbox_config: [
           {
-            name: 'somerset-scitt-consortium',
             text: 'Somerset SCITT consortium',
-            value: '1',
+            name: '1',
           },
           {
-            name: 'the-beach-teaching-school',
             text: 'The Beach Teaching School',
-            value: '2',
+            name: '2',
           },
 
         ],
@@ -103,14 +93,12 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'status',
         checkbox_config: [
           {
-            name: 'pending-conditions',
             text: 'Accepted',
-            value: 'pending_conditions',
+            name: 'pending_conditions',
           },
           {
-            name: 'offer-withdrawn',
             text: 'Withdrawn by us',
-            value: 'offer_withdrawn',
+            name: 'offer_withdrawn',
           },
         ],
       },
@@ -118,9 +106,8 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'provider',
         checkbox_config: [
           {
-            name: 'somerset-scitt-consortium',
             text: 'Somerset SCITT consortium',
-            value: '1',
+            name: '1',
           },
         ],
        },
@@ -140,12 +127,13 @@ RSpec.describe ProviderInterface::FilterComponent do
                                         applied_filters: applied_filters_partial,
                                         additional_params: additional_params)
 
-    expect(result.css('#status-pending-conditions').attr('checked').value).to eq('checked')
+
+    expect(result.css('#status-accepted').attr('checked').value).to eq('checked')
     expect(result.css('#status-recruited').attr('checked')).to eq(nil)
     expect(result.css('#status-declined').attr('checked')).to eq(nil)
-    expect(result.css('#status-awaiting-provider-decision').attr('checked').value).to eq('checked')
+    expect(result.css('#status-new').attr('checked').value).to eq('checked')
     expect(result.css('#status-rejected').attr('checked').value).to eq('checked')
-    expect(result.css('#status-withdrawn').attr('checked').value).to eq('checked')
+    expect(result.css('#status-application-withdrawn').attr('checked').value).to eq('checked')
     expect(result.css('#provider-somerset-scitt-consortium').attr('checked')).to eq(nil)
     expect(result.css('#provider-the-beach-teaching-school').attr('checked').value).to eq('checked')
   end
@@ -156,12 +144,12 @@ RSpec.describe ProviderInterface::FilterComponent do
                                         applied_filters: {},
                                         additional_params: additional_params)
 
-    expect(result.css('#status-pending-conditions').attr('checked')).to eq(nil)
+    expect(result.css('#status-accepted').attr('checked')).to eq(nil)
     expect(result.css('#status-recruited').attr('checked')).to eq(nil)
     expect(result.css('#status-declined').attr('checked')).to eq(nil)
-    expect(result.css('#status-awaiting-provider-decision').attr('checked')).to eq(nil)
+    expect(result.css('#status-new').attr('checked')).to eq(nil)
     expect(result.css('#status-rejected').attr('checked')).to eq(nil)
-    expect(result.css('#status-withdrawn').attr('checked')).to eq(nil)
+    expect(result.css('#status-application-withdrawn').attr('checked')).to eq(nil)
     expect(result.css('#provider-somerset-scitt-consortium').attr('checked')).to eq(nil)
     expect(result.css('#provider-the-beach-teaching-school').attr('checked')).to eq(nil)
   end

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     ]
   end
 
-  let(:additional_params) do
+  let(:params_for_current_state) do
     {
       sort_by: 'desc',
       sort_order: 'last-updated',
@@ -125,7 +125,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
 
     expect(result.css('#status-accepted').attr('checked').value).to eq('checked')
@@ -142,7 +142,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: {},
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.css('#status-accepted').attr('checked')).to eq(nil)
     expect(result.css('#status-recruited').attr('checked')).to eq(nil)
@@ -158,7 +158,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.text).to include('Selected filters')
   end
@@ -167,17 +167,17 @@ RSpec.describe ProviderInterface::FilterComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: {},
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.text).not_to include('Selected filters')
   end
 
 
-  it 'returns the additional_params as hidden fields' do
+  it 'returns the params_for_current_state as hidden fields' do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters,
                                         applied_filters: applied_filters_partial,
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.css('#sort_by').attr('value').value).to eq('desc')
     expect(result.css('#sort_order').attr('value').value).to eq('last-updated')
@@ -189,7 +189,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     result = render_inline described_class.new(path: path,
                                         available_filters: available_filters_only_one_provider,
                                         applied_filters: {},
-                                        additional_params: additional_params)
+                                        params_for_current_state: params_for_current_state)
 
     expect(result.to_html).not_to include('Provider')
     expect(result.to_html).to include('Status')

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -97,6 +97,36 @@ RSpec.describe ProviderInterface::FilterComponent do
     ]
   end
 
+  let(:available_filters_only_one_provider) do
+    [
+      {
+        heading: 'status',
+        checkbox_config: [
+          {
+            name: 'pending-conditions',
+            text: 'Accepted',
+            value: 'pending_conditions',
+          },
+          {
+            name: 'offer-withdrawn',
+            text: 'Withdrawn by us',
+            value: 'offer_withdrawn',
+          },
+        ],
+      },
+      {
+        heading: 'provider',
+        checkbox_config: [
+          {
+            name: 'somerset-scitt-consortium',
+            text: 'Somerset SCITT consortium',
+            value: '1',
+          },
+        ],
+       },
+    ]
+  end
+
   let(:additional_params) do
     {
       sort_by: 'desc',
@@ -165,5 +195,15 @@ RSpec.describe ProviderInterface::FilterComponent do
     expect(result.css('#sort_order').attr('value').value).to eq('last-updated')
     expect(result.css('#sort_by').attr('type').value).to eq('hidden')
     expect(result.css('#sort_order').attr('type').value).to eq('hidden')
+  end
+
+  it 'does not render a filter if there is only one possible filter in a filter_group' do
+    result = render_inline described_class.new(path: path,
+                                        available_filters: available_filters_only_one_provider,
+                                        applied_filters: {},
+                                        additional_params: additional_params)
+
+    expect(result.to_html).not_to include('Provider')
+    expect(result.to_html).to include('Status')
   end
 end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -155,7 +155,7 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def when_i_filter_for_applications_that_i_do_not_have
     find(:css, '#status-rejected').set(false)
-    find(:css, '#status-pending-conditions').set(true)
+    find(:css, '#status-accepted').set(true)
     click_button('Apply filters')
   end
 
@@ -164,9 +164,9 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def when_i_filter_for_rejected_and_offered_applications
-    find(:css, '#status-pending-conditions').set(false)
+    find(:css, '#status-accepted').set(false)
     find(:css, '#status-rejected').set(true)
-    find(:css, '#status-offer').set(true)
+    find(:css, '#status-offered').set(true)
     click_button('Apply filters')
   end
 


### PR DESCRIPTION
## Context

Forth PR as per Theos comment here: #1456 (review)

Refactor of solution to clean up controller and way that the filter_config is encapsulated.

Also reduced amount of information in the filter_config - now just takes `name:` and `text:` values in hash to compute what it should look like. See  `ProvidersApplicationPageState` for implementation of this (note the config hash has been moved here from the `ApplicationChoicesController` and somewhat adapted as per the above.

## Guidance for review

- haven't added unit tests for the `ProvidersApplicationPageState` class as I had in original PR as I think the system specs are pretty comprehensive - happy to write some though if you think this would be valuable.

## Link to Trello card
https://trello.com/c/wMGLpXGS/1641-add-filtering-to-the-provider-ui

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
