### PR TITLE
Correct capitalisation for service name

### DIFF
--- a/config/locales/apply_from_find.yml
+++ b/config/locales/apply_from_find.yml
@@ -5,4 +5,4 @@ en:
     apply_button: Apply through the new service
     find_button: Find postgraduate teacher training
     heading_not_found: We couldn’t find the course you’re looking for
-    account_created_message: 'Your apply for teacher training account has been created'
+    account_created_message: 'Your Apply for teacher training account has been created'


### PR DESCRIPTION
## Context

Service name should be capitalised in registration message.

## Link to Trello card

https://trello.com/c/sRrOATPQ/910-apply-capitalisation-on-registration
