### PR TITLE
Allow referees to confirm or amend their relationship with the candidate

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -14,6 +14,27 @@ module RefereeInterface
       @reference_form = ReferenceFeedbackForm.new(reference: reference)
     end
 
+    def relationship
+      redirect_to referee_interface_reference_feedback_path(token: @token_param) unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
+
+      @application = reference.application_form
+      @relationship = reference.relationship
+      @relationship_form = ReferenceRelationshipForm.build_from_reference(reference: reference)
+    end
+
+    def confirm_relationship
+      @application = reference.application_form
+      @relationship = reference.relationship
+      @relationship_form = ReferenceRelationshipForm.new(relationship_params)
+      @relationship_form.candidate = reference.application_form.full_name
+
+      if @relationship_form.save(reference)
+        redirect_to referee_interface_reference_feedback_path(token: @token_param)
+      else
+        render :relationship
+      end
+    end
+
     def submit_feedback
       @application = reference.application_form
 
@@ -110,6 +131,11 @@ module RefereeInterface
         :safe_to_work_with_children_explanation, :consent_to_be_contacted,
         :consent_to_be_contacted_details
       )
+    end
+
+    def relationship_params
+      params.require(:referee_interface_reference_relationship_form)
+            .permit(:relationship_correction, :relationship_confirmation)
     end
   end
 end

--- a/app/models/referee_interface/reference_relationship_form.rb
+++ b/app/models/referee_interface/reference_relationship_form.rb
@@ -1,0 +1,28 @@
+module RefereeInterface
+  class ReferenceRelationshipForm
+    include ActiveModel::Model
+    attr_accessor :relationship_confirmation, :relationship_correction, :candidate
+
+    validates :relationship_confirmation, presence: true
+    validate :presence_of_relationship_correction
+
+    def self.build_from_reference(reference:)
+      relationship_confirmation = reference.relationship_correction.blank? ? 'yes' : 'no' unless reference.relationship_correction.nil?
+      new(relationship_confirmation: relationship_confirmation, relationship_correction: reference.relationship_correction, candidate: reference.application_form.full_name)
+    end
+
+    def save(application_reference)
+      return false unless valid?
+
+      application_reference.update!(relationship_correction: relationship_correction)
+    end
+
+    def presence_of_relationship_correction
+      return if relationship_confirmation.nil?
+      return if relationship_confirmation == 'yes' || relationship_correction.present?
+
+      relationship_correction_blank = I18n.t('activemodel.errors.models.referee_interface/reference_relationship_form.attributes.relationship_correction.blank', candidate: candidate)
+      errors.add(:relationship_correction, relationship_correction_blank)
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -18,6 +18,7 @@ class FeatureFlag
     you_selected_a_course_page
     before_you_start
     provider_interface_work_breaks
+    referee_confirm_relationship_and_safeguarding
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, "Confirm how you know #{@application.full_name}" %>
+
+<%= form_with model: @relationship_form, url: referee_interface_confirm_relationship_path(token: @token_param), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Confirm how you know <%= @application.full_name %></h1>
+
+      <p class="govuk-body"><%= @application.full_name %> describes your relationship as follows:</p>
+      <p class="govuk-inset-text"><%= @relationship %></p>
+
+      <%= f.govuk_radio_buttons_fieldset :relationship_confirmation, legend: { text: 'Is this correct?' } do %>
+          <%= f.govuk_radio_button :relationship_confirmation, :yes, label: { text: 'Yes' }, link_errors: true %>
+          <%= f.govuk_radio_button :relationship_confirmation, :no, label: { text: 'No' } do %>
+            <%= f.govuk_text_area :relationship_correction, label: { text: "Tell us what your relationship is to #{@application.full_name} and how long you’ve known them" }, max_words: 50, rows: 5 %>
+          <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/referee_mailer/reference_request_email.text.erb
+++ b/app/views/referee_mailer/reference_request_email.text.erb
@@ -4,7 +4,7 @@ Dear <%= @reference.name %>,
 
 Please use the link below to give a reference as soon as possible.
 
-<%= referee_interface_reference_feedback_url(token: @unhashed_token) %>
+<%= referee_interface_reference_relationship_url(token: @unhashed_token) %>
 
 If you won’t give <%= @candidate_name %> a reference, please let us know by clicking the link below.
 

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -582,3 +582,9 @@ en:
               blank: Choose if you want to share any safeguarding issues
             safeguarding_issues:
               too_many_words: Safeguarding issues must be %{count} words or fewer
+        referee_interface/reference_relationship_form:
+          attributes:
+            relationship_confirmation:
+              blank: Choose if the described relationship is correct
+            relationship_correction:
+              blank: "Enter your relationship to %{candidate}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -286,7 +286,10 @@ Rails.application.routes.draw do
   end
 
   namespace :referee_interface, path: '/reference' do
-    get '/' => 'reference#feedback', as: :reference_feedback
+    get '/' => 'reference#relationship', as: :reference_relationship
+    patch '/confirm-relationship' => 'reference#confirm_relationship', as: :confirm_relationship
+
+    get '/feedback' => 'reference#feedback', as: :reference_feedback
 
     get '/confirmation' => 'reference#confirmation', as: :confirmation
     patch '/confirmation' => 'reference#submit_feedback', as: :submit_feedback

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RefereeMailer, type: :mailer do
     it 'sends an email with a link to the reference form' do
       mail.deliver_now
       body = mail.body.encoded
-      expect(body).to include(referee_interface_reference_feedback_url(token: ''))
+      expect(body).to include(referee_interface_reference_relationship_url(token: ''))
     end
 
     it 'sends a request with a Notify reference' do

--- a/spec/models/referee_interface/reference_relationship_form_spec.rb
+++ b/spec/models/referee_interface/reference_relationship_form_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
+  describe '#build_from_application' do
+    it 'creates an object based on the application reference' do
+      reference = build_stubbed(:reference, relationship_correction: 'Leader of the MS Paint course')
+      form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+
+      expect(form.relationship_correction).to eq('Leader of the MS Paint course')
+    end
+
+    context 'when there is no relationship_correction' do
+      it 'sets the relationship_confirmation true' do
+        reference = build_stubbed(:reference, relationship_correction: '')
+        form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+
+        expect(form.relationship_confirmation).to eq('yes')
+      end
+    end
+
+    context 'when there is a relationship_correction' do
+      it 'sets the relationship_confirmation false' do
+        reference = build_stubbed(:reference, relationship_correction: 'She did not attend my MS Paint course')
+        form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+
+        expect(form.relationship_confirmation).to eq('no')
+      end
+    end
+
+    context 'when there is a relationship_correction is nil' do
+      it 'sets the relationship_confirmation nil' do
+        reference = build_stubbed(:reference)
+        form = RefereeInterface::ReferenceRelationshipForm.build_from_reference(reference: reference)
+
+        expect(form.relationship_confirmation).to eq(nil)
+      end
+    end
+  end
+
+  describe '#save' do
+    let(:application_reference) { create(:reference) }
+
+    context 'when relationship_confirmation is blank' do
+      it 'return false' do
+        form = RefereeInterface::ReferenceRelationshipForm.new
+
+        expect(form.save(application_reference)).to be(false)
+      end
+    end
+
+    context 'when relationship_correction has a value' do
+      it 'updates the application reference with the correction' do
+        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'no', relationship_correction: 'I dont know this person')
+
+        form.save(application_reference)
+
+        expect(application_reference.relationship_correction).to eq('I dont know this person')
+      end
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:relationship_confirmation) }
+
+    context 'when other relationship_confirmation has value "no"' do
+      it 'validates presence of relationship_correction' do
+        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'no', candidate: 'Tim Tamagotchi')
+        expected_error_message = I18n.t('activemodel.errors.models.referee_interface/reference_relationship_form.attributes.relationship_correction.blank', candidate: 'Tim Tamagotchi')
+
+        form.validate
+
+        expect(form.errors.full_messages_for(:relationship_correction)).to eq(
+          ["Relationship correction #{expected_error_message}"],
+        )
+      end
+
+      it 'does not show error when there is relationship_correction' do
+        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_correction: 'Fixed')
+        form.validate
+
+        expect(form.errors.full_messages_for(:relationship_correction)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
 
   scenario 'Referee submits a reference for a candidate' do
     FeatureFlag.activate('training_with_a_disability')
+    FeatureFlag.activate('referee_confirm_relationship_and_safeguarding')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application
@@ -14,6 +15,17 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     then_i_see_page_not_found
 
     when_i_click_on_the_link_within_the_email
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+
+    when_i_click_on_continue
+    then_i_can_see_an_error_to_confirm_my_relationship_with_the_candidate
+
+    when_i_confirm_that_the_described_relationship_is_not_correct
+    and_i_click_on_continue
+    then_i_can_see_an_error_to_enter_my_relationship_with_the_candidate
+
+    when_i_confirm_that_the_described_relationship_is_correct
+    and_i_click_on_continue
     then_i_see_the_reference_comment_page
     and_i_see_the_list_of_the_courses_the_candidate_applied_to
 
@@ -62,6 +74,34 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
 
   def when_i_click_on_the_link_within_the_email
     current_email.click_link(@reference_feedback_url)
+  end
+
+  def then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+  end
+
+  def when_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_can_see_an_error_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content('Choose if the described relationship is correct')
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_not_correct
+    choose 'No'
+  end
+
+  def then_i_can_see_an_error_to_enter_my_relationship_with_the_candidate
+    expect(page).to have_content("Enter your relationship to #{@application.full_name}")
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_correct
+    choose 'Yes'
+  end
+
+  def and_i_click_on_continue
+    click_button 'Continue'
   end
 
   def then_i_see_the_reference_comment_page


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow referees to confirm and correct their relationship with the candidate. And allow the referees to say whether the applicant is a suitable candidate to work with children so that a provider can properly assess their application. This a second slice of reworking the referee flow, the previous PR added a migration to store these data #1577. 

## Changes proposed in this pull request
This PR adds:
- A `RefereeRelationshipForm` to update relationship details
- The relationship page to confirm their relationship with the candidate or submit a correction

### The new page
![image](https://user-images.githubusercontent.com/22743709/76341605-34c42200-62f5-11ea-9667-95cdfead8069.png)

![image](https://user-images.githubusercontent.com/22743709/76341694-4e656980-62f5-11ea-9d5e-23f3ff88e03f.png)




## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I've noticed that the current reference page is a single page, therefore the review page doesn't exist yet. I tried to complete a smol slice of the new reference flow, by adding the `confirm relationship` page before the existing feedback page. Does this make sense? 

## Link to Trello card
https://trello.com/c/QlKuThen/1130-build-referee-view-of-candidate-working-with-children

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
