### PR TITLE
Update interview needs to use smart quotes

### DIFF
--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -10,7 +10,7 @@
 
       <p class="govuk-body">
         Interviews usually take place over the course of a day.
-        You'll need to attend in person.
+        You’ll need to attend in person.
       </p>
 
       <p class="govuk-body">
@@ -19,7 +19,7 @@
       </p>
 
       <p class="govuk-body">
-        If there's a reason why you need some flexibility you can tell us about
+        If there’s a reason why you need some flexibility you can tell us about
         it here.
       </p>
 
@@ -27,8 +27,8 @@
 
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
         <li>you have commitments such as employment or caring responsibilities</li>
-        <li>you'll be travelling a long way to get to the interview</li>
-        <li>you'll need some adjustments because you're disabled</li>
+        <li>you’ll be travelling a long way to get to the interview</li>
+        <li>you’ll need some adjustments because you’re disabled</li>
       </ul>
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1592, we updated the content for interview needs but didn't use smart quotes for some bits.

## Changes proposed in this pull request

This PR updates the content to use smart quotes.

## Guidance to review

👀 Have I missed anywhere else?

## Link to Trello card

https://trello.com/c/zcFLtedQ/1138-dev-update-content-for-interview-needs

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
