### PR TITLE
Simplify CourseOption vacancy_status enum

### DIFF
--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -12,9 +12,7 @@ class CourseOption < ApplicationRecord
   }
 
   enum vacancy_status: {
-    both_full_time_and_part_time_vacancies: 'both_full_time_and_part_time_vacancies',
-    part_time_vacancies: 'part_time_vacancies',
-    full_time_vacancies: 'full_time_vacancies',
+    vacancies: 'vacancies',
     no_vacancies: 'no_vacancies',
   }
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -192,7 +192,7 @@ FactoryBot.define do
     course
     site { association(:site, provider: course.provider) }
 
-    vacancy_status { 'both_full_time_and_part_time_vacancies' }
+    vacancy_status { 'vacancies' }
 
     trait :full_time do
       study_mode { :full_time }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Course, type: :model do
 
     context 'when a subset of course options have vacancies' do
       before do
-        create(:course_option, course: course, vacancy_status: 'full_time_vacancies')
+        create(:course_option, course: course, vacancy_status: 'vacancies')
         create(:course_option, course: course, vacancy_status: 'no_vacancies')
       end
 


### PR DESCRIPTION
## Context

This enum currently uses the site vacancy status values provided by the
Find API. Those values are:

  - both_full_time_and_part_time_vacancies
  - full_time_vacancies
  - part_time_vacancies
  - no_vacancies

While Find stores these values at the Site level, in Apply we have the
concept of a CourseOption. Because this is a specific permutation of
course, study_mode, and site, we can get away with a simpler set of
descriptors:

  - vacancies
  - no_vacancies

## Changes proposed in this pull request


  - Update the enum as described above
  - Implement a CourseOption method that translates the detailed
    descriptions from Find and persists one of the two simpler statuses
  - Invoke this method from the SyncProviderFromFind service.

## Guidance to review

- The use of a two-value enum rather than a boolean flag is kind of lame, but I've gone with this as it's the simpler change - it doesn't involve any database modifications and can be updated easily if we decide to adopt a different set of status values.

## Link to Trello card

https://trello.com/c/LAh0iGIc

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
