### PR TITLE
Move task to sync providers to Tasks

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -9,11 +9,6 @@ module SupportInterface
       @provider_agreement = ProviderAgreement.data_sharing_agreements.for_provider(@provider).last
     end
 
-    def sync
-      SyncAllFromFind.perform_async
-      redirect_to action: 'index'
-    end
-
     def open_all_courses
       update_provider('Successfully updated all courses') { |provider| OpenProviderCourses.new(provider: provider).call }
     end

--- a/app/controllers/support_interface/tasks_controller.rb
+++ b/app/controllers/support_interface/tasks_controller.rb
@@ -8,6 +8,10 @@ module SupportInterface
         GenerateTestApplications.perform_async
         flash[:success] = 'Scheduled job to generate test applications - this might take a while!'
         redirect_to support_interface_tasks_path
+      when 'sync_providers'
+        SyncAllFromFind.perform_async
+        flash[:success] = 'Scheduled job to sync providers - this might take a while!'
+        redirect_to support_interface_tasks_path
       when 'create_vendor_providers'
         GenerateVendorProviders.call
         flash[:success] = 'Created test providers for vendors'

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, 'Providers' %>
 
-<%= form_tag support_interface_providers_sync_path, method: :post do %>
-  <%= submit_tag('Sync Providers from Find', class: 'govuk-button') %>
-<% end %>
-
 <p class="govuk-body">
   Course options: <%= CourseOption.all.size %>
 </p>

--- a/app/views/support_interface/tasks/index.html.erb
+++ b/app/views/support_interface/tasks/index.html.erb
@@ -1,5 +1,13 @@
 <% content_for :title, 'Tasks' %>
 
+<div>
+  <h2 class='govuk-heading-m'>Sync providers</h2>
+  <div class='govuk-body'>
+    Download providers from Find.
+  </div>
+  <%= button_to 'Sync Providers from Find', support_interface_run_task_path('sync_providers'), class: 'govuk-button' %>
+</div>
+
 <% unless HostingEnvironment.production? %>
   <div>
     <h2 class='govuk-heading-m'>Test applications</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -397,7 +397,6 @@ Rails.application.routes.draw do
     post '/tokens' => 'api_tokens#create'
 
     get '/providers' => 'providers#index', as: :providers
-    post '/providers/sync' => 'providers#sync'
     get '/providers/:provider_id' => 'providers#show', as: :provider
     post '/providers/:provider_id' => 'providers#open_all_courses'
     post '/providers/:provider_id/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -7,9 +7,11 @@ RSpec.feature 'See providers' do
   scenario 'User visits providers page' do
     given_i_am_a_support_user
     and_providers_are_configured_to_be_synced
-    when_i_visit_the_providers_page
+    when_i_visit_the_tasks_page
     and_i_click_the_sync_button
     then_requests_to_find_should_be_made
+
+    when_i_visit_the_providers_page
     and_i_should_see_the_updated_list_of_providers
 
     when_i_click_on_a_provider
@@ -35,8 +37,8 @@ RSpec.feature 'See providers' do
     sign_in_as_support_user
   end
 
-  def when_i_visit_the_providers_page
-    visit support_interface_providers_path
+  def when_i_visit_the_tasks_page
+    visit support_interface_tasks_path
   end
 
   def and_providers_are_configured_to_be_synced
@@ -101,6 +103,10 @@ RSpec.feature 'See providers' do
     expect(@request1).to have_been_made
     expect(@request2).to have_been_made
     expect(@request3).to have_been_made
+  end
+
+  def when_i_visit_the_providers_page
+    visit support_interface_providers_path
   end
 
   def and_i_should_see_the_updated_list_of_providers


### PR DESCRIPTION
##  Context

I'm doing some cleanup of the providers in the support UI. 

## Changes proposed in this pull request

Move the "Sync Providers" button to the tasks page.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
