### PR TITLE
Add print link to application details page

### DIFF
--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -12,3 +12,11 @@
     display: none;
   }
 }
+
+.app-print-link {
+  display: none;
+}
+
+.js-enabled .app-print-link {
+  display: block;
+}

--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -7,10 +7,6 @@
   .govuk-breadcrumbs {
     display: none;
   }
-
-  .app-print-link {
-    display: none;
-  }
 }
 
 .app-print-link {

--- a/app/frontend/styles/_print-helpers.scss
+++ b/app/frontend/styles/_print-helpers.scss
@@ -7,4 +7,8 @@
   .govuk-breadcrumbs {
     display: none;
   }
+
+  .app-print-link {
+    display: none;
+  }
 }

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -24,6 +24,12 @@
   </div>
 </div>
 
+<div class="govuk-grid-row app-print-link">
+  <div class="govuk-grid-column-two-thirds">
+    <%= govuk_link_to('Print this page', 'javascript:window.print();', class: 'app-print-link__link') %>
+  </div>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Application</h2>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -24,7 +24,7 @@
   </div>
 </div>
 
-<div class="govuk-grid-row app-print-link">
+<div class="govuk-grid-row app-print-link app-!-print-display-none">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_link_to('Print this page', 'javascript:window.print();', class: 'app-print-link__link') %>
   </div>

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -187,4 +187,8 @@ RSpec.describe 'A Provider viewing an individual application' do
   def and_i_should_see_the_disability_disclosure
     expect(page).to have_content 'I am hard of hearing'
   end
+
+  def and_i_should_see_a_link_to_print_this_page
+    expect(page).to have_link 'Print this page'
+  end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a 'Print this page' link to the application details page below the status component.

<!-- If there are UI changes, please include Before and After screenshots. -->

### After 

![image](https://user-images.githubusercontent.com/93511/76416759-98049180-6393-11ea-9ef0-8e8197fd3e3f.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/u1uNpPE3/1688-create-button-to-print-applications

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
