### PR TITLE
Separate synced providers from others

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -1,7 +1,11 @@
 module SupportInterface
   class ProvidersController < SupportInterfaceController
     def index
-      @providers = Provider.includes(:sites, :courses).order(:name)
+      @providers = Provider.where(sync_courses: true).includes(:sites, :courses).order(:name)
+    end
+
+    def other_providers
+      @providers = Provider.where(sync_courses: false).order(:name)
     end
 
     def show

--- a/app/views/support_interface/providers/index.html.erb
+++ b/app/views/support_interface/providers/index.html.erb
@@ -1,8 +1,11 @@
-<% content_for :title, 'Providers' %>
+<% content_for :title, 'Synced providers' %>
 
-<p class="govuk-body">
-  Course options: <%= CourseOption.all.size %>
-</p>
+<% content_for :before_content do %>
+  <%= render SubNavigationComponent.new(items: [
+    { name: 'Synced providers', url: support_interface_providers_path, current: true },
+    { name: 'Other providers', url: support_interface_other_providers_path },
+  ]) %>
+<% end %>
 
 <table class='govuk-table'>
   <thead class='govuk-table__head'>
@@ -20,11 +23,8 @@
           <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
         </td>
         <td class='govuk-table__cell'>
-          <% if provider.sync_courses? %>
-            <%= pluralize provider.courses.size, 'course' %> (<%= provider.courses.open_on_apply.size %> on DfE Apply)
-          <% else %>
-            Not synced from Find
-          <% end %>
+          <%= pluralize provider.courses.size, 'course' %><br/>
+          <%= provider.courses.open_on_apply.size %> on DfE Apply
         </td>
         <td class='govuk-table__cell'>
           <%= provider.sites.size %>

--- a/app/views/support_interface/providers/other_providers.html.erb
+++ b/app/views/support_interface/providers/other_providers.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, 'Other providers' %>
+
+<% content_for :before_content do %>
+  <%= render SubNavigationComponent.new(items: [
+    { name: 'Synced providers', url: support_interface_providers_path },
+    { name: 'Other providers', url: support_interface_other_providers_path, current: true },
+  ]) %>
+<% end %>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header govuk-!-width-one-half'>Provider Name</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @providers.each do |provider| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'>
+          <%= govuk_link_to provider.name_and_code, support_interface_provider_path(provider) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -400,6 +400,7 @@ Rails.application.routes.draw do
     post '/tokens' => 'api_tokens#create'
 
     get '/providers' => 'providers#index', as: :providers
+    get '/providers/other' => 'providers#other_providers', as: :other_providers
     get '/providers/:provider_id' => 'providers#show', as: :provider
     post '/providers/:provider_id' => 'providers#open_all_courses'
     post '/providers/:provider_id/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'See provider course syncing' do
   scenario 'User switches sync courses on Provider' do
     given_i_am_a_support_user
     and_a_provider_exists
-    when_i_visit_the_providers_page
+    when_i_visit_the_other_providers_page
     then_i_see_that_the_provider_is_not_configured_to_sync_courses
 
     when_i_click_on_a_provider
@@ -28,12 +28,13 @@ RSpec.feature 'See provider course syncing' do
     create :provider, code: 'ABC', name: 'ABC College'
   end
 
-  def when_i_visit_the_providers_page
+  def when_i_visit_the_other_providers_page
     visit support_interface_providers_path
+    click_link 'Other providers'
   end
 
   def then_i_see_that_the_provider_is_not_configured_to_sync_courses
-    expect(page).to have_content('Not synced from Find')
+    expect(page).to have_content('ABC College')
   end
 
   def when_i_click_on_a_provider
@@ -77,6 +78,7 @@ RSpec.feature 'See provider course syncing' do
   end
 
   def then_i_see_that_a_course_has_been_synced
-    expect(page).to have_content('1 course (0 on DfE Apply)')
+    expect(page).to have_content('1 course')
+    expect(page).to have_content('0 on DfE Apply')
   end
 end


### PR DESCRIPTION
## Context

We currently have a list of all providers in the system, which is quite big. The most important distinction is whether or not they are synced.

## Changes proposed in this pull request

Split the providers into 2 pages.

### Before

![image](https://user-images.githubusercontent.com/233676/76418614-d8194380-6396-11ea-8930-5de5d822f8c8.png)

### After

![image](https://user-images.githubusercontent.com/233676/76418560-be77fc00-6396-11ea-813a-2b0a56f59782.png)

![image](https://user-images.githubusercontent.com/233676/76418580-c899fa80-6396-11ea-93a1-354d0bfa9652.png)


## Guidance to review



## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
