### PR TITLE
Make test application generation spread events out over time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,6 @@ group :test do
   gem 'capybara-email'
   gem 'climate_control'
   gem 'launchy'
-  gem 'timecop'
   gem 'guard-rspec'
   gem 'webmock'
   gem 'simplecov', require: false
@@ -105,4 +104,5 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'bullet'
+  gem 'timecop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -71,8 +71,6 @@ gem 'ruby-graphviz'
 
 gem 'kaminari'
 
-gem 'timecop'
-
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'
@@ -95,6 +93,7 @@ group :test do
   gem 'clockwork-test'
   gem 'deepsort'
   gem 'rspec-benchmark'
+  gem 'timecop'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ gem 'ruby-graphviz'
 
 gem 'kaminari'
 
+gem 'timecop'
+
 group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.3'
@@ -104,5 +106,4 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'bullet'
-  gem 'timecop'
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -12,143 +12,143 @@ module TestApplications
   end
 
   def self.create_application(states:, courses_to_apply_to: nil)
-    Timecop.freeze(rand(30..60).days.ago)
+    Timecop.freeze(rand(30..60).days.ago) do
+      raise ZeroCoursesPerApplicationError.new('You can\'t have zero courses per application') unless states.any?
 
-    raise ZeroCoursesPerApplicationError.new('You can\'t have zero courses per application') unless states.any?
-
-    first_name = Faker::Name.first_name
-    last_name = Faker::Name.last_name
-    candidate = FactoryBot.create(
-      :candidate,
-      email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
-    )
-
-    courses_to_apply_to ||= Course.joins(:course_options)
-      .open_on_apply
-
-    courses_to_apply_to = courses_to_apply_to.sample(states.count)
-
-    # it does not make sense to apply to the same course multiple times
-    # in the course of the same application, and it’s forbidden in the UI.
-    # Throw an exception if we try to do that here.
-    if courses_to_apply_to.count < states.count
-      raise NotEnoughCoursesError.new("Not enough distinct courses to generate a #{states.count}-course application")
-    end
-
-    Audited.audit_class.as_user(candidate) do
-      application_form = FactoryBot.create(
-        :completed_application_form,
-        application_choices_count: 0,
-        full_work_history: true,
-        volunteering_experiences_count: 1,
-        references_count: 2,
-        with_gces: true,
-        submitted_at: nil,
-        candidate: candidate,
-        first_name: first_name,
-        last_name: last_name,
+      first_name = Faker::Name.first_name
+      last_name = Faker::Name.last_name
+      candidate = FactoryBot.create(
+        :candidate,
+        email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
       )
 
-      application_choices = courses_to_apply_to.map do |course|
-        FactoryBot.create(
-          :application_choice,
-          status: 'unsubmitted',
-          course_option: course.course_options.first,
-          application_form: application_form,
-          personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
+      courses_to_apply_to ||= Course.joins(:course_options)
+        .open_on_apply
+
+      courses_to_apply_to = courses_to_apply_to.sample(states.count)
+
+      # it does not make sense to apply to the same course multiple times
+      # in the course of the same application, and it’s forbidden in the UI.
+      # Throw an exception if we try to do that here.
+      if courses_to_apply_to.count < states.count
+        raise NotEnoughCoursesError.new("Not enough distinct courses to generate a #{states.count}-course application")
+      end
+
+      Audited.audit_class.as_user(candidate) do
+        fast_forward(1..2)
+        application_form = FactoryBot.create(
+          :completed_application_form,
+          application_choices_count: 0,
+          full_work_history: true,
+          volunteering_experiences_count: 1,
+          references_count: 2,
+          with_gces: true,
+          submitted_at: nil,
+          candidate: candidate,
+          first_name: first_name,
+          last_name: last_name,
         )
-      end
 
-      return if states.include? :unsubmitted
-
-      without_slack_message_sending do
-        SubmitApplication.new(application_form).call
-        return if states.include? :awaiting_references
-
-        Timecop.travel(Time.zone.now + rand(1..2).days)
-        application_form.application_references.each do |reference|
-          reference.relationship_correction = [nil, Faker::Lorem.sentence].sample
-          reference.safeguarding_concerns = [nil, Faker::Lorem.sentence].sample
-
-          Timecop.travel(Time.zone.now + rand(1..2).days)
-
-          ReceiveReference.new(
-            reference: reference,
-            feedback: 'You are awesome',
-          ).save!
+        application_choices = courses_to_apply_to.map do |course|
+          FactoryBot.create(
+            :application_choice,
+            status: 'unsubmitted',
+            course_option: course.course_options.first,
+            application_form: application_form,
+            personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
+          )
         end
-        return if states.include? :application_complete
 
-        application_choices.map(&:reload)
+        return if states.include? :unsubmitted
 
-        states.zip(application_choices).each do |state, application_choice|
-          put_application_choice_in_state(application_choice, state)
+        fast_forward(1..2)
+        without_slack_message_sending do
+          SubmitApplication.new(application_form).call
+          return if states.include? :awaiting_references
+
+          application_form.application_references.each do |reference|
+            reference.relationship_correction = [nil, Faker::Lorem.sentence].sample
+            reference.safeguarding_concerns = [nil, Faker::Lorem.sentence].sample
+
+            fast_forward(1..2)
+
+            ReceiveReference.new(
+              reference: reference,
+              feedback: 'You are awesome',
+            ).save!
+          end
+          return if states.include? :application_complete
+
+          application_choices.map(&:reload)
+
+          states.zip(application_choices).each do |state, application_choice|
+            put_application_choice_in_state(application_choice, state)
+          end
         end
-      end
 
-      application_choices
+        application_choices
+      end
     end
-  ensure
-    Timecop.return
   end
 
   def self.put_application_choice_in_state(choice, state)
-    Timecop.travel(Time.zone.now + rand(7..10).days)
+    # This is only supposed to happen after 7 days, but SendApplicationToProvider
+    fast_forward(7..10)
     SendApplicationToProvider.new(application_choice: choice).call
     choice.update(edit_by: Time.zone.now)
     return if state == :awaiting_provider_decision
 
     if state == :offer
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
     elsif state == :rejected
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
     elsif state == :offer_withdrawn
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       WithdrawOffer.new(application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
     elsif state == :declined
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       DeclineOffer.new(application_choice: choice).save!
     elsif state == :accepted
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
     elsif state == :accepted_no_conditions
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: []).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
     elsif state == :conditions_not_met
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check', 'Complete course']).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       ConditionsNotMet.new(application_choice: choice).save
     elsif state == :recruited
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       ConfirmOfferConditions.new(application_choice: choice).save
     elsif state == :enrolled
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       ConfirmOfferConditions.new(application_choice: choice).save
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       ConfirmEnrolment.new(application_choice: choice).save
     elsif state == :withdrawn
-      Timecop.travel(Time.zone.now + rand(1..3).days)
+      fast_forward(1..3)
       WithdrawApplication.new(application_choice: choice).save!
     end
   end
@@ -161,5 +161,9 @@ module TestApplications
     RequestStore.store[:disable_slack_messages] = true
     yield
     RequestStore.store[:disable_slack_messages] = false
+  end
+
+  def self.fast_forward(range)
+    Timecop.travel(Time.zone.now + rand(range).days)
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -98,9 +98,8 @@ module TestApplications
   end
 
   def self.put_application_choice_in_state(choice, state)
-    fast_forward(7..10)
+    travel_to(choice.edit_by) if choice.edit_by > Time.zone.now
     SendApplicationToProvider.new(application_choice: choice).call
-    choice.update(edit_by: Time.zone.now)
     return if state == :awaiting_provider_decision
 
     if state == :offer

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -98,7 +98,6 @@ module TestApplications
   end
 
   def self.put_application_choice_in_state(choice, state)
-    # This is only supposed to happen after 7 days, but SendApplicationToProvider
     fast_forward(7..10)
     SendApplicationToProvider.new(application_choice: choice).call
     choice.update(edit_by: Time.zone.now)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,6 +1,11 @@
+require 'active_support/testing/time_helpers'
+require 'sidekiq/testing'
+
 module TestApplications
   class NotEnoughCoursesError < RuntimeError; end
   class ZeroCoursesPerApplicationError < RuntimeError; end
+
+  extend ActiveSupport::Testing::TimeHelpers
 
   def self.generate_for_provider(provider:, courses_per_application:, count:)
     1.upto(count).flat_map do
@@ -12,83 +17,84 @@ module TestApplications
   end
 
   def self.create_application(states:, courses_to_apply_to: nil)
-    Timecop.freeze(rand(30..60).days.ago) do
-      raise ZeroCoursesPerApplicationError.new('You can\'t have zero courses per application') unless states.any?
+    travel_to rand(30..60).days.ago
+    raise ZeroCoursesPerApplicationError.new('You can\'t have zero courses per application') unless states.any?
 
-      first_name = Faker::Name.first_name
-      last_name = Faker::Name.last_name
-      candidate = FactoryBot.create(
-        :candidate,
-        email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
+    first_name = Faker::Name.first_name
+    last_name = Faker::Name.last_name
+    candidate = FactoryBot.create(
+      :candidate,
+      email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
+    )
+
+    courses_to_apply_to ||= Course.joins(:course_options)
+      .open_on_apply
+
+    courses_to_apply_to = courses_to_apply_to.sample(states.count)
+
+    # it does not make sense to apply to the same course multiple times
+    # in the course of the same application, and it’s forbidden in the UI.
+    # Throw an exception if we try to do that here.
+    if courses_to_apply_to.count < states.count
+      raise NotEnoughCoursesError.new("Not enough distinct courses to generate a #{states.count}-course application")
+    end
+
+    Audited.audit_class.as_user(candidate) do
+      fast_forward(1..2)
+      application_form = FactoryBot.create(
+        :completed_application_form,
+        application_choices_count: 0,
+        full_work_history: true,
+        volunteering_experiences_count: 1,
+        references_count: 2,
+        with_gces: true,
+        submitted_at: nil,
+        candidate: candidate,
+        first_name: first_name,
+        last_name: last_name,
       )
 
-      courses_to_apply_to ||= Course.joins(:course_options)
-        .open_on_apply
-
-      courses_to_apply_to = courses_to_apply_to.sample(states.count)
-
-      # it does not make sense to apply to the same course multiple times
-      # in the course of the same application, and it’s forbidden in the UI.
-      # Throw an exception if we try to do that here.
-      if courses_to_apply_to.count < states.count
-        raise NotEnoughCoursesError.new("Not enough distinct courses to generate a #{states.count}-course application")
-      end
-
-      Audited.audit_class.as_user(candidate) do
-        fast_forward(1..2)
-        application_form = FactoryBot.create(
-          :completed_application_form,
-          application_choices_count: 0,
-          full_work_history: true,
-          volunteering_experiences_count: 1,
-          references_count: 2,
-          with_gces: true,
-          submitted_at: nil,
-          candidate: candidate,
-          first_name: first_name,
-          last_name: last_name,
+      application_choices = courses_to_apply_to.map do |course|
+        FactoryBot.create(
+          :application_choice,
+          status: 'unsubmitted',
+          course_option: course.course_options.first,
+          application_form: application_form,
+          personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
         )
-
-        application_choices = courses_to_apply_to.map do |course|
-          FactoryBot.create(
-            :application_choice,
-            status: 'unsubmitted',
-            course_option: course.course_options.first,
-            application_form: application_form,
-            personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
-          )
-        end
-
-        return if states.include? :unsubmitted
-
-        fast_forward(1..2)
-        without_slack_message_sending do
-          SubmitApplication.new(application_form).call
-          return if states.include? :awaiting_references
-
-          application_form.application_references.each do |reference|
-            reference.relationship_correction = [nil, Faker::Lorem.sentence].sample
-            reference.safeguarding_concerns = [nil, Faker::Lorem.sentence].sample
-
-            fast_forward(1..2)
-
-            ReceiveReference.new(
-              reference: reference,
-              feedback: 'You are awesome',
-            ).save!
-          end
-          return if states.include? :application_complete
-
-          application_choices.map(&:reload)
-
-          states.zip(application_choices).each do |state, application_choice|
-            put_application_choice_in_state(application_choice, state)
-          end
-        end
-
-        application_choices
       end
+
+      return if states.include? :unsubmitted
+
+      fast_forward(1..2)
+      without_slack_message_sending do
+        SubmitApplication.new(application_form).call
+        return if states.include? :awaiting_references
+
+        application_form.application_references.each do |reference|
+          reference.relationship_correction = [nil, Faker::Lorem.sentence].sample
+          reference.safeguarding_concerns = [nil, Faker::Lorem.sentence].sample
+
+          fast_forward(1..2)
+
+          ReceiveReference.new(
+            reference: reference,
+            feedback: 'You are awesome',
+          ).save!
+        end
+        return if states.include? :application_complete
+
+        application_choices.map(&:reload)
+
+        states.zip(application_choices).each do |state, application_choice|
+          put_application_choice_in_state(application_choice, state)
+        end
+      end
+
+      application_choices
     end
+  ensure
+    travel_back
   end
 
   def self.put_application_choice_in_state(choice, state)
@@ -164,6 +170,6 @@ module TestApplications
   end
 
   def self.fast_forward(range)
-    Timecop.travel(Time.zone.now + rand(range).days)
+    travel_to(Time.zone.now + rand(range).days)
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -102,47 +102,48 @@ module TestApplications
     SendApplicationToProvider.new(application_choice: choice).call
     return if state == :awaiting_provider_decision
 
-    if state == :offer
+    case state
+    when :offer
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-    elsif state == :rejected
+    when :rejected
       fast_forward(1..3)
       RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
-    elsif state == :offer_withdrawn
+    when :offer_withdrawn
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       fast_forward(1..3)
       WithdrawOffer.new(application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
-    elsif state == :declined
+    when :declined
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       fast_forward(1..3)
       DeclineOffer.new(application_choice: choice).save!
-    elsif state == :accepted
+    when :accepted
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-    elsif state == :accepted_no_conditions
+    when :accepted_no_conditions
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: []).save
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-    elsif state == :conditions_not_met
+    when :conditions_not_met
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check', 'Complete course']).save
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
       fast_forward(1..3)
       ConditionsNotMet.new(application_choice: choice).save
-    elsif state == :recruited
+    when :recruited
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
       fast_forward(1..3)
       ConfirmOfferConditions.new(application_choice: choice).save
-    elsif state == :enrolled
+    when :enrolled
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       fast_forward(1..3)
@@ -151,7 +152,7 @@ module TestApplications
       ConfirmOfferConditions.new(application_choice: choice).save
       fast_forward(1..3)
       ConfirmEnrolment.new(application_choice: choice).save
-    elsif state == :withdrawn
+    when :withdrawn
       fast_forward(1..3)
       WithdrawApplication.new(application_choice: choice).save!
     end

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -4,20 +4,22 @@ class GenerateTestApplications
   def perform
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
-    TestApplications.create_application states: [:unsubmitted]
-    TestApplications.create_application states: [:awaiting_references]
-    TestApplications.create_application states: [:application_complete]
-    TestApplications.create_application states: [:awaiting_provider_decision] * 3
-    TestApplications.create_application states: [:offer] * 2
-    TestApplications.create_application states: %i[offer rejected]
-    TestApplications.create_application states: [:rejected] * 2
-    TestApplications.create_application states: [:offer_withdrawn]
-    TestApplications.create_application states: [:declined]
-    TestApplications.create_application states: [:accepted]
-    TestApplications.create_application states: [:accepted_no_conditions]
-    TestApplications.create_application states: [:recruited]
-    TestApplications.create_application states: [:conditions_not_met]
-    TestApplications.create_application states: [:enrolled]
-    TestApplications.create_application states: [:withdrawn]
+    Sidekiq::Testing.inline! do
+      TestApplications.create_application states: [:unsubmitted]
+      TestApplications.create_application states: [:awaiting_references]
+      TestApplications.create_application states: [:application_complete]
+      TestApplications.create_application states: [:awaiting_provider_decision] * 3
+      TestApplications.create_application states: [:offer] * 2
+      TestApplications.create_application states: %i[offer rejected]
+      TestApplications.create_application states: [:rejected] * 2
+      TestApplications.create_application states: [:offer_withdrawn]
+      TestApplications.create_application states: [:declined]
+      TestApplications.create_application states: [:accepted]
+      TestApplications.create_application states: [:accepted_no_conditions]
+      TestApplications.create_application states: [:recruited]
+      TestApplications.create_application states: [:conditions_not_met]
+      TestApplications.create_application states: [:enrolled]
+      TestApplications.create_application states: [:withdrawn]
+    end
   end
 end

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -1,3 +1,5 @@
+require 'sidekiq/testing'
+
 desc 'Delete and create test data, including courses and options'
 task generate_test_data: :environment do
   GenerateTestData.new(100).generate

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -5,5 +5,7 @@ end
 
 desc 'Generate test applications for existing providers'
 task generate_test_applications: :environment do
-  GenerateTestApplications.new.perform
+  Sidekiq::Testing.inline! do
+    GenerateTestApplications.new.perform
+  end
 end

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -7,7 +7,5 @@ end
 
 desc 'Generate test applications for existing providers'
 task generate_test_applications: :environment do
-  Sidekiq::Testing.inline! do
-    GenerateTestApplications.new.perform
-  end
+  GenerateTestApplications.new.perform
 end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -10,6 +10,20 @@ RSpec.describe TestApplications do
     expect(choices.count).to eq(2)
   end
 
+  it 'creates a realistic timeline' do
+    courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+    application_choice = TestApplications.create_application(states: %i[enrolled], courses_to_apply_to: courses_we_want).first
+
+    application_form = application_choice.application_form
+    candidate = application_form.candidate
+    expect(application_choice.created_at - candidate.created_at).to be >= 1.day
+    expect(application_form.submitted_at - application_choice.created_at).to be >= 1.day
+    expect(application_choice.offered_at - application_form.submitted_at).to be >= 1.day
+    expect(application_choice.accepted_at - application_choice.offered_at).to be >= 1.day
+    expect(application_choice.enrolled_at - application_choice.accepted_at).to be >= 1.day
+  end
+
   it 'throws an exception if there aren’t enough courses to apply to' do
     expect {
       TestApplications.create_application(states: %i[offer])


### PR DESCRIPTION
## Context

At the moment an application is created, submitted, receives references, is offered/accepted/enrolled etc all at the same moment. The data is useless for testing the timeline, sorting by date, etc.

## Changes proposed in this pull request

- [x] Go back to a semi-random start point then fast forward time by a few days at a time between lifecycle steps.
- [x] Inline all Sidekiq jobs triggered by the test data generator so that they get done at the 'right' time.
- [x] Using built-in Rails test helpers for time travel rather than Timecop so as not to introduce another production dependency.

## Guidance to review

- Is `ActiveSupport::Testing::TimeHelpers` OK to use outside tests? Is it ok in production?

## Link to Trello card

https://trello.com/c/Vn06dsBl/1744-make-test-application-generation-spread-events-out-over-time
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
