### PR TITLE
Fix missing section errors not showing when equality and diversity feature flag is on

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -32,7 +32,11 @@ module CandidateInterface
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
 
       if @application_form_presenter.ready_to_submit?
-        @further_information_form = FurtherInformationForm.new
+        if FeatureFlag.active?('equality_and_diversity')
+          redirect_to candidate_interface_start_equality_and_diversity_path
+        else
+          @further_information_form = FurtherInformationForm.new
+        end
       else
         @errors = @application_form_presenter.section_errors
 

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -24,8 +24,4 @@
 
 <%= render 'review', application_form: @application_form, editable: true %>
 
-<% if FeatureFlag.active?('equality_and_diversity') %>
-  <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>
-<% else %>
-  <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_application_submit_show_path %>
-<% end %>
+<%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_application_submit_show_path %>

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
     given_i_am_signed_in
     and_the_training_with_a_disability_feature_flag_is_on
     and_the_suitability_to_work_with_children_feature_flag_is_on
+    and_the_equality_and_diversity_feature_flag_is_on
 
     when_i_visit_the_review_application_page
     then_i_should_be_able_to_click_through_and_complete_each_section_but_science_gcse
@@ -25,6 +26,10 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   def and_the_suitability_to_work_with_children_feature_flag_is_on
     FeatureFlag.activate('suitability_to_work_with_children')
+  end
+
+  def and_the_equality_and_diversity_feature_flag_is_on
+    FeatureFlag.activate('equality_and_diversity')
   end
 
   def when_i_visit_the_review_application_page


### PR DESCRIPTION
## Context

The error summary on the "Review your application" page doesn't show when the `equality_and_diversity` feature flag is on which shows the sections that aren't complete.

## Changes proposed in this pull request

This PR ensures that the missing section errors shows up by moving the redirect to the `ApplicationFormController` instead of linking to the equality and diversity start page in the view.

## Guidance to review

Try it using the Heroku preview app to submit an incomplete with the `equality_and_diversity` feature flag on and you should see the error summary, something like:

![image](https://user-images.githubusercontent.com/42817036/76421790-1e24d600-639c-11ea-8cc2-0a078bfb9d8b.png)

## Link to Trello card

https://trello.com/c/EfbebMO0/1151-fix-error-summary-not-showing-on-the-review-your-application-when-equality-and-diversity-feature-is-on

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
