### PR TITLE
Redis minimum TLS version change

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -465,6 +465,9 @@
                     "redisCacheCapacity": {
                         "value": "[parameters('redisCacheCapacity')]"
                     },
+                    "minimumTlsVersion": {
+                        "value": "1.2"
+                    },
                     "dataPersistence": {
                         "value": "aof"
                     },


### PR DESCRIPTION
## Context

On 31st March MS will be removing support for TLS versions 1.0 and 1.1 and will force all users to use version 1.2 as the minimum. This change is to pre-emptively make this change ourselves in a more controlled manner.

This is a service impacting change. The change will actually be made manually through the portal during a quiet period of operation and then this change will be merged in to ensure the templates persist the minimum TLS version advertised by the Redis cache.

## Changes proposed in this pull request

Override default value of `minimumTlsVersion` in building block template from version 1.0 to version 1.2

## Guidance to review

N/A

## Link to Trello card

https://trello.com/c/9amwxUUS/1607-set-default-minimum-tls-version-to-12-on-redis-cache

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
