### PR TITLE
Allow referees to submit safeguarding concerns about the candidate

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -9,11 +9,6 @@ module RefereeInterface
 
     layout 'application'
 
-    def feedback
-      @application = reference.application_form
-      @reference_form = ReferenceFeedbackForm.new(reference: reference)
-    end
-
     def relationship
       redirect_to referee_interface_reference_feedback_path(token: @token_param) unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
 
@@ -29,10 +24,32 @@ module RefereeInterface
       @relationship_form.candidate = reference.application_form.full_name
 
       if @relationship_form.save(reference)
-        redirect_to referee_interface_reference_feedback_path(token: @token_param)
+        redirect_to referee_interface_safeguarding_path(token: @token_param)
       else
         render :relationship
       end
+    end
+
+    def safeguarding
+      @application = reference.application_form
+      @safeguarding_form = ReferenceSafeguardingForm.build_from_reference(reference: reference)
+    end
+
+    def confirm_safeguarding
+      @application = reference.application_form
+      @safeguarding_form = ReferenceSafeguardingForm.new(safeguarding_params)
+      @safeguarding_form.candidate = reference.application_form.full_name
+
+      if @safeguarding_form.save(reference)
+        redirect_to referee_interface_reference_feedback_path(token: @token_param)
+      else
+        render :safeguarding
+      end
+    end
+
+    def feedback
+      @application = reference.application_form
+      @reference_form = ReferenceFeedbackForm.new(reference: reference)
     end
 
     def submit_feedback
@@ -136,6 +153,11 @@ module RefereeInterface
     def relationship_params
       params.require(:referee_interface_reference_relationship_form)
             .permit(:relationship_correction, :relationship_confirmation)
+    end
+
+    def safeguarding_params
+      params.require(:referee_interface_reference_safeguarding_form)
+            .permit(:any_safeguarding_concerns, :safeguarding_concerns)
     end
   end
 end

--- a/app/models/referee_interface/reference_relationship_form.rb
+++ b/app/models/referee_interface/reference_relationship_form.rb
@@ -14,7 +14,9 @@ module RefereeInterface
     def save(application_reference)
       return false unless valid?
 
-      application_reference.update!(relationship_correction: relationship_correction)
+      correction = relationship_confirmation == 'yes' ? '' : relationship_correction
+
+      application_reference.update!(relationship_correction: correction)
     end
 
     def presence_of_relationship_correction

--- a/app/models/referee_interface/reference_safeguarding_form.rb
+++ b/app/models/referee_interface/reference_safeguarding_form.rb
@@ -1,0 +1,47 @@
+module RefereeInterface
+  class ReferenceSafeguardingForm
+    include ActiveModel::Model
+    attr_accessor :any_safeguarding_concerns, :safeguarding_concerns, :candidate
+
+    validate :presentce_of_any_safeguarding_concerns
+    validate :presentce_of_safeguarding_concerns
+
+    def self.build_from_reference(reference:)
+      any_safeguarding_concerns = reference.safeguarding_concerns.blank? ? 'no' : 'yes' unless reference.safeguarding_concerns.nil?
+
+      new(any_safeguarding_concerns: any_safeguarding_concerns, safeguarding_concerns: reference.safeguarding_concerns)
+    end
+
+    def save(application_reference)
+      return false unless valid?
+
+      concerns = any_safeguarding_concerns == 'no' ? '' : safeguarding_concerns
+      application_reference.update!(safeguarding_concerns: concerns)
+    end
+
+  private
+
+    def presentce_of_any_safeguarding_concerns
+      return if any_safeguarding_concerns.present?
+
+      any_safeguarding_concerns_blank =
+        I18n.t(
+          'activemodel.errors.models.referee_interface/reference_safeguarding_form.attributes.any_safeguarding_concerns.blank',
+          candidate: candidate,
+        )
+      errors.add(:any_safeguarding_concerns, any_safeguarding_concerns_blank)
+    end
+
+    def presentce_of_safeguarding_concerns
+      return unless any_safeguarding_concerns == 'yes'
+      return if safeguarding_concerns.present?
+
+      safeguarding_concerns_blank =
+        I18n.t(
+          'activemodel.errors.models.referee_interface/reference_safeguarding_form.attributes.safeguarding_concerns.blank',
+          candidate: candidate,
+        )
+      errors.add(:safeguarding_concerns, safeguarding_concerns_blank)
+    end
+  end
+end

--- a/app/models/referee_interface/reference_safeguarding_form.rb
+++ b/app/models/referee_interface/reference_safeguarding_form.rb
@@ -3,8 +3,8 @@ module RefereeInterface
     include ActiveModel::Model
     attr_accessor :any_safeguarding_concerns, :safeguarding_concerns, :candidate
 
-    validate :presentce_of_any_safeguarding_concerns
-    validate :presentce_of_safeguarding_concerns
+    validate :presence_of_any_safeguarding_concerns
+    validate :presence_of_safeguarding_concerns
 
     def self.build_from_reference(reference:)
       any_safeguarding_concerns = reference.safeguarding_concerns.blank? ? 'no' : 'yes' unless reference.safeguarding_concerns.nil?
@@ -21,7 +21,7 @@ module RefereeInterface
 
   private
 
-    def presentce_of_any_safeguarding_concerns
+    def presence_of_any_safeguarding_concerns
       return if any_safeguarding_concerns.present?
 
       any_safeguarding_concerns_blank =
@@ -32,7 +32,7 @@ module RefereeInterface
       errors.add(:any_safeguarding_concerns, any_safeguarding_concerns_blank)
     end
 
-    def presentce_of_safeguarding_concerns
+    def presence_of_safeguarding_concerns
       return unless any_safeguarding_concerns == 'yes'
       return if safeguarding_concerns.present?
 

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -1,4 +1,7 @@
 <% content_for :title, "Give a teacher training reference for #{@application.full_name}" %>
+<% if FeatureFlag.active?('referee_confirm_relationship_and_safeguarding') %>
+  <% content_for :before_content, govuk_back_link_to(referee_interface_safeguarding_path(token: @token_param)) %>
+<% end %>
 
 <%= form_with model: @reference_form, url: referee_interface_submit_feedback_path(token: @token_param), method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/referee_interface/reference/safeguarding.html.erb
+++ b/app/views/referee_interface/reference/safeguarding.html.erb
@@ -1,0 +1,20 @@
+<% content_for :title, "Do you know of any reason why #{@application.full_name} should not work with children?" %>
+<% content_for :before_content, govuk_back_link_to(referee_interface_reference_relationship_path(token: @token_param)) %>
+
+<%= form_with model: @safeguarding_form, url: referee_interface_confirm_safeguarding_path(token: @token_param), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= f.govuk_radio_buttons_fieldset :any_safeguarding_concerns, legend: { size: 'xl', text: "Do you know of any reason why #{@application.full_name} should not work with children?" } do %>
+        <div class="govuk-!-margin-top-6">
+          <%= f.govuk_radio_button :any_safeguarding_concerns, :no, label: { text: 'No' }, link_errors: true %>
+          <%= f.govuk_radio_button :any_safeguarding_concerns, :yes, label: { text: 'Yes' } do %>
+            <%= f.govuk_text_area :safeguarding_concerns, label: { text: "Tell us why you think #{@application.full_name} should not work with children"}, max_words: 150, rows: 5 %>
+          <% end %>
+        <div>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -588,3 +588,9 @@ en:
               blank: Choose if the described relationship is correct
             relationship_correction:
               blank: "Enter your relationship to %{candidate}"
+        referee_interface/reference_safeguarding_form:
+          attributes:
+            any_safeguarding_concerns:
+              blank: Select if you know of any reason why %{candidate} should not work with children
+            safeguarding_concerns:
+              blank: Enter a reason why %{candidate} should not work with children

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -291,6 +291,9 @@ Rails.application.routes.draw do
     get '/' => 'reference#relationship', as: :reference_relationship
     patch '/confirm-relationship' => 'reference#confirm_relationship', as: :confirm_relationship
 
+    get '/safeguarding' => 'reference#safeguarding', as: :safeguarding
+    patch '/confirm-safeguarding' => 'reference#confirm_safeguarding', as: :confirm_safeguarding
+
     get '/feedback' => 'reference#feedback', as: :reference_feedback
 
     get '/confirmation' => 'reference#confirmation', as: :confirmation

--- a/spec/models/referee_interface/reference_relationship_form_spec.rb
+++ b/spec/models/referee_interface/reference_relationship_form_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
       end
     end
 
-    context 'when relationship_correction has a value' do
+    context 'when relationship_confirmation has value "no"' do
       it 'updates the application reference with the correction' do
         form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'no', relationship_correction: 'I dont know this person')
 
@@ -57,12 +57,22 @@ RSpec.describe RefereeInterface::ReferenceRelationshipForm, type: :model do
         expect(application_reference.relationship_correction).to eq('I dont know this person')
       end
     end
+
+    context 'when relationship_confirmation has value "yes' do
+      it 'resets the relationship_correction' do
+        form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'yes')
+
+        form.save(application_reference)
+
+        expect(application_reference.relationship_correction).to eq('')
+      end
+    end
   end
 
   describe 'validations' do
     it { is_expected.to validate_presence_of(:relationship_confirmation) }
 
-    context 'when other relationship_confirmation has value "no"' do
+    context 'when relationship_confirmation has value "no"' do
       it 'validates presence of relationship_correction' do
         form = RefereeInterface::ReferenceRelationshipForm.new(relationship_confirmation: 'no', candidate: 'Tim Tamagotchi')
         expected_error_message = I18n.t('activemodel.errors.models.referee_interface/reference_relationship_form.attributes.relationship_correction.blank', candidate: 'Tim Tamagotchi')

--- a/spec/models/referee_interface/reference_safeguarding_form_spec.rb
+++ b/spec/models/referee_interface/reference_safeguarding_form_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::ReferenceSafeguardingForm, type: :model do
+  describe '.build_from_application' do
+    it 'creates an object based on the application reference' do
+      reference = build_stubbed(:reference, safeguarding_concerns: 'Very unreliable')
+      form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+
+      expect(form.safeguarding_concerns).to eq('Very unreliable')
+    end
+
+    context 'when safeguarding concern is blank' do
+      it 'sets the any_safeguarding_concerns attribute to no' do
+        reference = build_stubbed(:reference, safeguarding_concerns: '')
+        form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+
+        expect(form.any_safeguarding_concerns).to eq('no')
+      end
+    end
+
+    context 'when safeguarding concern has a value' do
+      it 'sets the any_safeguarding_concerns attribute to yes' do
+        reference = build_stubbed(:reference, safeguarding_concerns: 'Very unreliable')
+        form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+
+        expect(form.any_safeguarding_concerns).to eq('yes')
+      end
+    end
+
+    context 'when safeguarding concern is nil' do
+      it 'sets the any_safeguarding_concerns attribute to nil' do
+        reference = build_stubbed(:reference, safeguarding_concerns: nil)
+        form = RefereeInterface::ReferenceSafeguardingForm.build_from_reference(reference: reference)
+
+        expect(form.any_safeguarding_concerns).to eq(nil)
+      end
+    end
+  end
+
+  describe '#save' do
+    let(:application_reference) { create(:reference) }
+
+    context 'when any_safeguarding_concerns is blank' do
+      it 'return false' do
+        form = RefereeInterface::ReferenceSafeguardingForm.new
+
+        expect(form.save(application_reference)).to be(false)
+      end
+    end
+
+    context 'when any_safeguarding_concerns has value "no"' do
+      it 'updates the safeguarding_concerns' do
+        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: 'no')
+        form.save(application_reference)
+
+        expect(application_reference.safeguarding_concerns).to eq('')
+      end
+    end
+
+    context 'when any_safeguarding_concerns has value "yes"' do
+      it 'updates the safeguarding_concerns' do
+        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: 'yes', safeguarding_concerns: 'rude')
+        form.save(application_reference)
+
+        expect(application_reference.safeguarding_concerns).to eq('rude')
+      end
+    end
+  end
+
+  describe 'validations' do
+    it 'validate presence of any_safeguarding_concerns' do
+      form = RefereeInterface::ReferenceSafeguardingForm.new(candidate: 'Donald Trump')
+      expected_error_message = 'Select if you know of any reason why Donald Trump should not work with children'
+
+      form.validate
+
+      expect(form.errors.full_messages_for(:any_safeguarding_concerns)).to eq(
+        ["Any safeguarding concerns #{expected_error_message}"],
+      )
+    end
+
+    context 'when other any_safeguarding_concerns is nil or has value "no"' do
+      it 'does not validate presence of safeguarding_concerns' do
+        any_safeguarding_concerns = [nil, 'no'].sample
+        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: any_safeguarding_concerns)
+        form.validate
+
+        expect(form.errors.full_messages_for(:safeguarding_concerns)).to be_empty
+      end
+    end
+
+    context 'when both any_safeguarding_concerns and safeguarding_concerns present' do
+      it 'does not show error messages' do
+        form = RefereeInterface::ReferenceSafeguardingForm.new(any_safeguarding_concerns: 'yes', safeguarding_concerns: 'rude')
+
+        form.validate
+
+        expect(form.errors.full_messages_for(:any_safeguarding_concerns)).to be_empty
+        expect(form.errors.full_messages_for(:safeguarding_concerns)).to be_empty
+      end
+    end
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -18,13 +18,24 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
 
     when_i_click_on_continue
-    then_i_can_see_an_error_to_confirm_my_relationship_with_the_candidate
+    then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
 
     when_i_confirm_that_the_described_relationship_is_not_correct
     and_i_click_on_continue
-    then_i_can_see_an_error_to_enter_my_relationship_with_the_candidate
+    then_i_see_an_error_to_enter_my_relationship_with_the_candidate
 
     when_i_confirm_that_the_described_relationship_is_correct
+    and_i_click_on_continue
+    then_i_see_the_safeguarding_page
+
+    when_i_click_on_continue
+    then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
+
+    when_i_choose_the_candidate_is_not_suitable_for_working_with_children
+    and_i_click_on_continue
+    then_i_see_an_error_to_enter_my_safeguarding_concerns
+
+    when_i_choose_the_candidate_is_suitable_for_working_with_children
     and_i_click_on_continue
     then_i_see_the_reference_comment_page
     and_i_see_the_list_of_the_courses_the_candidate_applied_to
@@ -84,7 +95,7 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     click_button 'Continue'
   end
 
-  def then_i_can_see_an_error_to_confirm_my_relationship_with_the_candidate
+  def then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
     expect(page).to have_content('Choose if the described relationship is correct')
   end
 
@@ -92,12 +103,32 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     choose 'No'
   end
 
-  def then_i_can_see_an_error_to_enter_my_relationship_with_the_candidate
+  def then_i_see_an_error_to_enter_my_relationship_with_the_candidate
     expect(page).to have_content("Enter your relationship to #{@application.full_name}")
   end
 
   def when_i_confirm_that_the_described_relationship_is_correct
     choose 'Yes'
+  end
+
+  def then_i_see_the_safeguarding_page
+    expect(page).to have_content("Do you know of any reason why #{@application.full_name} should not work with children?")
+  end
+
+  def then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
+    expect(page).to have_content("Select if you know of any reason why #{@application.full_name} should not work with children")
+  end
+
+  def when_i_choose_the_candidate_is_not_suitable_for_working_with_children
+    choose 'Yes'
+  end
+
+  def then_i_see_an_error_to_enter_my_safeguarding_concerns
+    expect(page).to have_content("Enter a reason why #{@application.full_name} should not work with children")
+  end
+
+  def when_i_choose_the_candidate_is_suitable_for_working_with_children
+    choose 'No'
   end
 
   def and_i_click_on_continue


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow the referees to say whether the applicant is a suitable candidate to work with children so that a provider can properly assess their application. This the third slice of reworking the referee flow, the previous PR added the `Confirm relationship` page  #1598. 

## Changes proposed in this pull request
This PR adds:
- A `ReferenceSafeguardingForm` to update safeguarding concerns
- The safeguarding page to allow the referees submitting a reason why the candidate should not work with children

### The new page
![image](https://user-images.githubusercontent.com/22743709/76433142-d312bf00-63ab-11ea-8730-4424962f4517.png)

![image](https://user-images.githubusercontent.com/22743709/76433173-ddcd5400-63ab-11ea-9c72-1a7e34d52933.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Reviewing commit-by-commit can be helpful

## Link to Trello card
https://trello.com/c/QlKuThen/1130-build-referee-view-of-candidate-working-with-children

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
