### PR TITLE
Don't send Redis::CannotConnectError to Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -6,5 +6,6 @@ Raven.configure do |config|
     'ActionController::UnknownFormat',
     'ActionController::UnknownHttpMethod',
     'ActionDispatch::Http::Parameters::ParseError',
+    'Redis::CannotConnectError',
   ]
 end


### PR DESCRIPTION

## Context

We now have a healthcheck that verifies that we can connect to Redis, so we don't need these Sentry alerts anymore.

## Changes proposed in this pull request

Filter all Redis::CannotConnectError when sending to Sentry.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
