### PR TITLE
Update interview needs to conditionally show disability bullet point

### DIFF
--- a/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/edit.html.erb
@@ -28,7 +28,10 @@
       <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-7">
         <li>you have commitments such as employment or caring responsibilities</li>
         <li>you’ll be travelling a long way to get to the interview</li>
-        <li>you’ll need some adjustments because you’re disabled</li>
+
+        <% unless FeatureFlag.active?('training_with_a_disability') %>
+          <li>you’ll need some adjustments because you’re disabled</li>
+        <% end %>
       </ul>
 
       <%= f.govuk_radio_buttons_fieldset :any_preferences, legend: { size: 'm', text: t('application_form.personal_statement.interview_preferences.label'), tag: 'span' } do %>


### PR DESCRIPTION
## Context

Paul L mentioned that the ‘you’ll need some adjustments because you’re disabled’ example should not be shown if the "Training with a disability feature" flag is enabled. There's a wider discussion about this but for now we'll make it conditional.

## Changes proposed in this pull request

This PR updates the interview needs section to conditionally show disability adjustments bullet point based on whether or not the `training_with_a_disability` feature flag is on.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/zcFLtedQ/1138-dev-update-content-for-interview-needs

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
