### PR TITLE
Tweak referee guidance for candidates

### DIFF
--- a/app/views/candidate_interface/referees/_intro.html.erb
+++ b/app/views/candidate_interface/referees/_intro.html.erb
@@ -1,31 +1,10 @@
-<p class="govuk-body">We’ll submit your application to your training provider once we receive <%= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %> references for you. Choose referees who’ll endorse your:</p>
+<p class="govuk-body">We’ll submit your application to your training provider once we receive <%= ApplicationForm::MINIMUM_COMPLETE_REFERENCES %> references for you. These need to be from different people. Choose referees who can endorse your:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>teaching passion and potential</li>
   <li>suitability to work with children</li>
   <li>academic abilities</li>
   <li>reliability and professionalism</li>
 </ul>
-<p class="govuk-body">Suitable referees include:</p>
-
-<ul class="govuk-list govuk-list--bullet">
-  <li>your current line manager at work</li>
-  <li>previous employers</li>
-  <li>a teacher at a school where you work or volunteer</li>
-  <li>your university tutor or supervisor</li>
-  <li>a supplier or client you’ve worked with (if you’re self-employed)</li>
-</ul>
-
-<p class="govuk-body">Referees should not be family members, partners or friends. Training providers will only accept character references if there’s also an academic or professional reference. </p>
-<p class="govuk-body">If you’re not sure if your referees are suitable, contact your provider to discuss this.</p>
-<div class="govuk-warning-text govuk-!-margin-bottom-4">
-  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">Warning</span>
-    We won’t contact your referees until you submit your application
-  </strong>
-</div>
-
-<p class="govuk-body">If your referees don’t respond, we’ll get back in touch with you to ask for a replacement.</p>
 
 <p class="govuk-body">
   <%= govuk_button_link_to 'Continue', candidate_interface_new_referee_path %>


### PR DESCRIPTION
## Context

Our guidance needs to be brought in line with the prototype

https://apply-beta-prototype.herokuapp.com/application/L67RP/references

## Changes proposed in this pull request

Before

![image](https://user-images.githubusercontent.com/42515961/76506738-92ff1b00-6443-11ea-858d-5ef043c7c49d.png)

After

![image](https://user-images.githubusercontent.com/42515961/76506782-a27e6400-6443-11ea-965c-cb1f8232911f.png)

## Link to Trello card

https://trello.com/c/wwoQFSeB/1146-dev-iterate-candidate-select-type-of-referee

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
