### PR TITLE
Display course options & vacancy status in support UI

### DIFF
--- a/app/components/support_interface/course_choices_table_component.html.erb
+++ b/app/components/support_interface/course_choices_table_component.html.erb
@@ -1,0 +1,27 @@
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header'>ID</th>
+      <th scope='col' class='govuk-table__header'>Course</th>
+      <th scope='col' class='govuk-table__header'>Vacancy status</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% course_rows.each do |course_option| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'><%= course_option.id %></td>
+        <td class='govuk-table__cell'><%= govuk_link_to(course_option.course.name_and_code, support_interface_course_path(course_option.course)) %> - <%= course_option.study_mode.humanize %> at <%= course_option.site.name %></td>
+        <td class='govuk-table__cell'>
+          <% if course_option.vacancies? %>
+            <%= render TagComponent.new(text: 'Vacancies', type: 'green') %>
+          <% elsif course_option.no_vacancies? %>
+            <%= render TagComponent.new(text: 'No vacancies', type: 'red') %>
+          <% else %>
+            <%= render TagComponent.new(text: '(unknown)', type: 'grey') %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/components/support_interface/course_choices_table_component.rb
+++ b/app/components/support_interface/course_choices_table_component.rb
@@ -1,0 +1,13 @@
+module SupportInterface
+  class CourseChoicesTableComponent < ActionView::Component::Base
+    include ViewHelper
+
+    def initialize(course_options:)
+      @course_options = course_options
+    end
+
+    def course_rows
+      @course_options.sort_by { |course_option| course_option.course.name }
+    end
+  end
+end

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -11,6 +11,7 @@ module SupportInterface
     def show
       @provider = Provider.includes(:courses, :sites).find(params[:provider_id])
       @provider_agreement = ProviderAgreement.data_sharing_agreements.for_provider(@provider).last
+      @course_options = @provider.course_options.includes(:course, :site)
     end
 
     def open_all_courses

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -44,6 +44,7 @@
   <thead class='govuk-table__head'>
     <tr class='govuk-table__row'>
       <th scope='col' class='govuk-table__header'>Name</th>
+      <th scope='col' class='govuk-table__header'>Address</th>
     </tr>
   </thead>
 
@@ -51,6 +52,7 @@
     <% @provider.sites.each do |site| %>
       <tr class='govuk-table__row'>
         <td class='govuk-table__cell'><%= site.name_and_code %></td>
+        <td class='govuk-table__cell'><%= site.full_address %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -38,6 +38,9 @@
   <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses)) %>
 <% end %>
 
+<h2 class='govuk-heading-l'>Course choices & vacancies</h2>
+<%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>
+
 <h2 class='govuk-heading-l'>Sites (<%= @provider.sites.size %>)</h2>
 
 <table class='govuk-table'>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -30,11 +30,11 @@
   <% end %>
 <% end %>
 
-<h2 class='govuk-heading-m'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.open_on_apply.size %> on DfE Apply)</h2>
+<h2 class='govuk-heading-l'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.open_on_apply.size %> on DfE Apply)</h2>
 <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accrediting_provider))) %>
 
 <% if @provider.accredited_courses.any? %>
-  <h2 class='govuk-heading-m'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
+  <h2 class='govuk-heading-l'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
   <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses)) %>
 <% end %>
 

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -125,7 +125,7 @@ RSpec.feature 'See providers' do
   end
 
   def when_i_click_on_a_course
-    click_link 'ABC-1'
+    first('table').click_link('ABC-1')
   end
 
   def then_i_see_the_course_information
@@ -144,6 +144,7 @@ RSpec.feature 'See providers' do
 
   def then_i_see_the_updated_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
+    expect(page).to have_content 'Vacancies'
     expect(page).to have_content '1 course (1 on DfE Apply)'
     expect(page).to have_content 'Accredited body'
     expect(page).to have_content 'University of Chester'


### PR DESCRIPTION
## Context

We're now syncing the vacancy status for courses, which will prevent candidates from applying to courses that are full.

## Changes proposed in this pull request

This adds a list of course options & vacancy status to the support UI. It also serves as a better view into what different choices exist for a provider.

## Guidance to review

Long-ass screenshot alert:

![image](https://user-images.githubusercontent.com/233676/76512946-736cf000-644d-11ea-9c2e-f2ce6ddb3d60.png)


## Link to Trello card

https://trello.com/c/yBDnIoUS

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
