### PR TITLE
Add provider to dev sync list

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -16,7 +16,7 @@ desc 'Sync some pilot-enabled providers and open all their courses'
 task sync_dev_providers_and_open_courses: :environment do
   puts 'Syncing data from Find...'
 
-  %w[1N1 2LR C58].each do |code|
+  %w[1N1 2LR C58 C85].each do |code|
     SyncProviderFromFind.call(provider_code: code, sync_courses: true)
   end
 


### PR DESCRIPTION


## Context

Current providers on QA don't have the mix of full-time/part-time course options that we need to adequately test study mode selection.

## Changes proposed in this pull request

Add C85 (Coventry University). It has both full time and part time study
modes for the course B408 (Biology).

## Guidance to review

- Run the rake task locally and check the above provider/course are present in the db.

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
