### PR TITLE
Edit course table to add description and remove redundant columns

### DIFF
--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -10,7 +10,6 @@
   'Recruitment cycle year' => @course.recruitment_cycle_year,
   'Last updated' => @course.updated_at.to_s(:govuk_date_and_time),
   'Study modes' => @course.study_mode.humanize,
-  'Qualification' => @course.qualification,
   'Financial support' => @course.financial_support,
 })) %>
 

--- a/db/migrate/20200312110616_add_description_to_course_and_remove_qualificaiton.rb
+++ b/db/migrate/20200312110616_add_description_to_course_and_remove_qualificaiton.rb
@@ -1,0 +1,17 @@
+class AddDescriptionToCourseAndRemoveQualificaiton < ActiveRecord::Migration[6.0]
+  def up
+    change_table :courses, bulk: true do |t|
+      t.string :description
+      t.remove :apply_from_date
+      t.remove :qualification
+    end
+  end
+
+  def down
+    change_table :courses, bulk: true do |t|
+      t.remove :description
+      t.datetime :apply_from_date
+      t.string :qualification
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_11_164517) do
+ActiveRecord::Schema.define(version: 2020_03_12_110616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -203,11 +203,10 @@ ActiveRecord::Schema.define(version: 2020_03_11_164517) do
     t.boolean "open_on_apply", default: false, null: false
     t.integer "recruitment_cycle_year", null: false
     t.string "study_mode", limit: 1, default: "F", null: false
-    t.string "qualification"
     t.string "financial_support"
     t.datetime "start_date"
-    t.datetime "apply_from_date"
     t.string "course_length"
+    t.string "description"
     t.index ["code"], name: "index_courses_on_code"
     t.index ["exposed_in_find", "open_on_apply"], name: "index_courses_on_exposed_in_find_and_open_on_apply"
     t.index ["provider_id", "code"], name: "index_courses_on_provider_id_and_code", unique: true


### PR DESCRIPTION
## Context

The description attribute is a combination of qualification, study type and funding type. As we only need to show this we don't need their qualification in a separate column.

Apply from date is not needed

## Changes proposed in this pull request

- Add course description
- Remove apply from date column from the courses table
- Remove qualification

## Link to Trello card

https://trello.com/c/D4sPmcZI/1106-dev-display-additional-course-info-on-summary-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
