### PR TITLE
Actually fail when brakeman detects issues

### DIFF
--- a/brakeman.yml
+++ b/brakeman.yml
@@ -1,0 +1,3 @@
+---
+pager: false
+quiet: true

--- a/brakeman.yml
+++ b/brakeman.yml
@@ -1,3 +1,7 @@
 ---
 pager: false
 quiet: true
+skip_checks:
+  # This Check issues a lot of false positives because it thinks that
+  # our component calls `Render` use user input.
+  - CheckRender

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -28,7 +28,7 @@ end
 
 desc 'Run brakeman'
 task :brakeman do
-  sh 'bundle exec brakeman'
+  sh 'bundle exec brakeman -c brakeman.yml'
 end
 
 desc 'Run rubocop'

--- a/lib/tasks/testing.rake
+++ b/lib/tasks/testing.rake
@@ -28,8 +28,7 @@ end
 
 desc 'Run brakeman'
 task :brakeman do
-  require 'brakeman'
-  Brakeman.run(app_path: '.', print_report: true)
+  sh 'bundle exec brakeman'
 end
 
 desc 'Run rubocop'


### PR DESCRIPTION
## Context

We are currently running brakeman as part of the build, but when it finds issues we do nothing! This is because `Brakeman.run` in rake will only return something, and not alter the exit code of the rake task. This means that CI won't know something is up.

## Changes proposed in this pull request

- Fail on CI when brakeman detects issues 
- Fix the outstanding issue by ignoring it (it's a false positive)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
