### PR TITLE
References relationship confirmation and safeguarding concerns in Provider view

### DIFF
--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -6,6 +6,8 @@ module ProviderInterface
              :name,
              :email_address,
              :relationship,
+             :relationship_confirmation,
+             :relationship_correction,
              to: :reference
 
     def initialize(reference:)
@@ -17,6 +19,7 @@ module ProviderInterface
         name_row,
         email_address_row,
         relationship_row,
+        relationship_confirmation_or_correction_row,
         feedback_row,
       ].compact
     end
@@ -44,6 +47,15 @@ module ProviderInterface
       }
     end
 
+    def relationship_confirmation_or_correction_row
+#      return unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
+
+      {
+        key: 'Relationship confirmed by referee?',
+        value: confirmation_or_correction,
+      }
+    end
+
     def feedback_row
       if feedback
         {
@@ -51,6 +63,12 @@ module ProviderInterface
           value: feedback,
         }
       end
+    end
+
+    def confirmation_or_correction
+      return relationship_correction if relationship_correction.present?
+
+      'Yes'
     end
 
     attr_reader :reference

--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -8,6 +8,7 @@ module ProviderInterface
              :relationship,
              :relationship_confirmation,
              :relationship_correction,
+             :safeguarding_concerns,
              to: :reference
 
     def initialize(reference:)
@@ -19,7 +20,8 @@ module ProviderInterface
         name_row,
         email_address_row,
         relationship_row,
-        relationship_confirmation_or_correction_row,
+        relationship_confirmation_row,
+        safeguarding_row,
         feedback_row,
       ].compact
     end
@@ -47,12 +49,21 @@ module ProviderInterface
       }
     end
 
-    def relationship_confirmation_or_correction_row
-#      return unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
+    def relationship_confirmation_row
+      return unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
 
       {
         key: 'Relationship confirmed by referee?',
-        value: confirmation_or_correction,
+        value: relationship_correction || 'Yes',
+      }
+    end
+
+    def safeguarding_row
+      return unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
+
+      {
+        key: 'Does the referee know of any reason why this candidate should not work with children?',
+        value: safeguarding_concerns || 'No',
       }
     end
 
@@ -63,12 +74,6 @@ module ProviderInterface
           value: feedback,
         }
       end
-    end
-
-    def confirmation_or_correction
-      return relationship_correction if relationship_correction.present?
-
-      'Yes'
     end
 
     attr_reader :reference

--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -39,7 +39,7 @@ module ProviderInterface
 
     def relationship_row
       {
-        key: 'Relationship to candidate',
+        key: 'Relationship between candidate and referee',
         value: relationship,
       }
     end

--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -21,7 +21,9 @@ module ProviderInterface
         email_address_row,
         relationship_row,
         relationship_confirmation_row,
+        relationship_correction_row,
         safeguarding_row,
+        safeguarding_concerns_row,
         feedback_row,
       ].compact
     end
@@ -50,20 +52,38 @@ module ProviderInterface
     end
 
     def relationship_confirmation_row
-      return unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
+      return unless referee_relationship_and_safeguarding_feature_enabled?
 
       {
         key: 'Relationship confirmed by referee?',
-        value: relationship_correction || 'Yes',
+        value: relationship_correction.present? ? 'No' : 'Yes',
+      }
+    end
+
+    def relationship_correction_row
+      return unless referee_relationship_and_safeguarding_feature_enabled? && relationship_correction.present?
+
+      {
+        key: 'Relationship amended by referee',
+        value: relationship_correction,
       }
     end
 
     def safeguarding_row
-      return unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
+      return unless referee_relationship_and_safeguarding_feature_enabled?
 
       {
         key: 'Does the referee know of any reason why this candidate should not work with children?',
-        value: safeguarding_concerns || 'No',
+        value: safeguarding_concerns.present? ? 'Yes' : 'No',
+      }
+    end
+
+    def safeguarding_concerns_row
+      return unless referee_relationship_and_safeguarding_feature_enabled? && safeguarding_concerns.present?
+
+      {
+        key: 'Reason(s) given by referee why this candidate should not work with children',
+        value: safeguarding_concerns,
       }
     end
 
@@ -74,6 +94,10 @@ module ProviderInterface
           value: feedback,
         }
       end
+    end
+
+    def referee_relationship_and_safeguarding_feature_enabled?
+      FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
     end
 
     attr_reader :reference

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -64,6 +64,9 @@ module TestApplications
         return if states.include? :awaiting_references
 
         application_form.application_references.each do |reference|
+          reference.relationship_correction = [nil, Faker::Lorem.sentence].sample
+          reference.safeguarding_concerns = [nil, Faker::Lorem.sentence].sample
+
           ReceiveReference.new(
             reference: reference,
             feedback: 'You are awesome',

--- a/spec/components/provider_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/reference_with_feedback_component_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
+  describe '#rows' do
+    let(:reference) { build(:reference, feedback: 'A valuable unit of work') }
+
+    subject(:component) { described_class.new(reference: reference) }
+
+    it 'contains a name row' do
+      row = component.rows.first
+      expect(row[:key]).to eq('Name')
+      expect(row[:value]).to eq(reference.name)
+    end
+
+    it 'contains an email address row' do
+      row = component.rows.second
+      expect(row[:key]).to eq('Email address')
+      expect(row[:value]).to eq(reference.email_address)
+    end
+
+    it 'contains a relationship row' do
+      row = component.rows.third
+      expect(row[:key]).to eq('Relationship between candidate and referee')
+      expect(row[:value]).to eq(reference.relationship)
+    end
+
+    it 'contains a confirmation row' do
+      expect(component.rows.fourth[:key]).to eq('Relationship confirmed by referee?')
+    end
+
+    it 'affirms the referee relationship when uncorrected' do
+      expect(component.rows.fourth[:value]).to eq('Yes')
+    end
+
+    it 'contains a correction as the row value when corrected' do
+      reference.relationship_correction = 'This is not correct'
+      expect(component.rows.fourth[:value]).to eq('This is not correct')
+    end
+
+    it 'contains a feedback row' do
+      row = component.rows.last
+      expect(row[:key]).to eq('Reference')
+      expect(row[:value]).to eq(reference.feedback)
+    end
+  end
+end

--- a/spec/components/provider_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/reference_with_feedback_component_spec.rb
@@ -39,7 +39,13 @@ RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
 
       it 'contains a correction as the row value when corrected' do
         reference.relationship_correction = 'This is not correct'
-        expect(component.rows.fourth[:value]).to eq('This is not correct')
+
+        expect(component.rows.fourth[:value]).to eq('No')
+
+        correction_row = component.rows.fifth
+
+        expect(correction_row[:key]).to eq('Relationship amended by referee')
+        expect(correction_row[:value]).to eq('This is not correct')
       end
     end
 
@@ -56,7 +62,14 @@ RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
 
       it 'contains safeguarding concerns where present' do
         reference.safeguarding_concerns = 'Is a big bad wolf, has posed as elderly grandparent.'
-        expect(component.rows.fifth[:value]).to eq(reference.safeguarding_concerns)
+        expect(component.rows.fifth[:value]).to eq('Yes')
+
+        safeguarding_concerns_row = component.rows[5]
+
+        expect(safeguarding_concerns_row[:key]).to eq(
+          'Reason(s) given by referee why this candidate should not work with children',
+        )
+        expect(safeguarding_concerns_row[:value]).to eq(reference.safeguarding_concerns)
       end
     end
 


### PR DESCRIPTION
## Context

We now ask referees for corrections about their relationship with the candidate.
Likewise we ask for reasons on safeguarding if applicable.

See https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1612 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1598

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR exposes the relationship corrections and safeguarding concerns text in the candidate references as presented to the provider.

[Also adds samples of these fields to test data](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/48faece1eb9a47cd39b9704f9adf2f927db137ba).
### Before

![image](https://user-images.githubusercontent.com/93511/76533725-67465a00-6470-11ea-9b65-fb53ddc1d24f.png)


### After

![image](https://user-images.githubusercontent.com/93511/76533670-539af380-6470-11ea-8027-c02239124935.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/tPjkXoN4/1759-%F0%9F%8F%88-references-provider-view
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
