### PR TITLE
Add a page that lists all the courses that are full

### DIFF
--- a/app/controllers/support_interface/course_options_controller.rb
+++ b/app/controllers/support_interface/course_options_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class CourseOptionsController < SupportInterfaceController
+    def index
+      @course_options = CourseOption.where('vacancy_status != ?', 'vacancies').includes(:course, :site)
+    end
+  end
+end

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -23,7 +23,7 @@ class NavigationItems
         [
           NavigationItem.new('Candidates', support_interface_candidates_path, is_active(current_controller, %w[candidates import_references])),
           NavigationItem.new('API Tokens', support_interface_tokens_path, is_active(current_controller, 'api_tokens')),
-          NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, 'providers')),
+          NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses])),
           NavigationItem.new('Features', support_interface_feature_flags_path, is_active(current_controller, 'feature_flags')),
           NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, 'performance')),
           NavigationItem.new('Tasks', support_interface_tasks_path, is_active(current_controller, 'tasks')),

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -25,7 +25,7 @@ class NavigationItems
           NavigationItem.new('API Tokens', support_interface_tokens_path, is_active(current_controller, 'api_tokens')),
           NavigationItem.new('Providers', support_interface_providers_path, is_active(current_controller, %w[providers courses])),
           NavigationItem.new('Features', support_interface_feature_flags_path, is_active(current_controller, 'feature_flags')),
-          NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, 'performance')),
+          NavigationItem.new('Performance', support_interface_performance_path, is_active(current_controller, %w[performance course_options])),
           NavigationItem.new('Tasks', support_interface_tasks_path, is_active(current_controller, 'tasks')),
           NavigationItem.new('Users', support_interface_users_path, is_active(current_controller, 'users')),
           NavigationItem.new(current_support_user.email_address, nil, false),

--- a/app/views/layouts/support_layout.html.erb
+++ b/app/views/layouts/support_layout.html.erb
@@ -1,4 +1,8 @@
 <% content_for :content do %>
+  <% if yield(:context).present? %>
+    <span class="govuk-caption-xl"><%= yield :context %></span>
+  <% end %>
+
   <% if yield(:title).present? %>
     <h1 class='govuk-heading-xl'><%= yield :title %></h1>
   <% end %>

--- a/app/views/support_interface/course_options/index.html.erb
+++ b/app/views/support_interface/course_options/index.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, 'Course options without vacancies' %>
+
+<%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :context, @course.provider.name_and_code %>
 <% content_for :title, @course.name_and_code %>
+<% content_for :before_content, govuk_back_link_to(support_interface_provider_path(@course.provider), 'Back to provider') %>
 
 <h2 class='govuk-heading-m'>Course info</h2>
 

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :context, @course.provider.name_and_code %>
 <% content_for :title, @course.name_and_code %>
 
 <h2 class='govuk-heading-m'>Course info</h2>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -2,9 +2,10 @@
 
 <h2 class='govuk-heading-l'>Dashboards</h2>
 
-<p class='govuk-body'>
-  <%= govuk_link_to 'Performance dashboard', integrations_performance_path %> (public)
-</p>
+<ul class='govuk-body'>
+  <li><%= govuk_link_to 'Performance dashboard', integrations_performance_path %> (public)</li>
+  <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
+</ul>
 
 <h2 class='govuk-heading-l'>Downloads for analysis</h2>
 

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, @provider.name_and_code %>
+<% content_for :before_content, govuk_back_link_to(support_interface_providers_path, 'Back to providers') %>
 
 <%= render(SupportInterface::ProviderSyncCoursesToggleComponent.new(provider: @provider)) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -408,6 +408,8 @@ Rails.application.routes.draw do
     post '/providers/:provider_id' => 'providers#open_all_courses'
     post '/providers/:provider_id/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing
 
+    get '/course-options' => 'course_options#index', as: :course_options
+
     get '/courses/:course_id' => 'courses#show', as: :course
     post '/courses/:course_id' => 'courses#update'
 

--- a/spec/system/support_interface/full_courses_spec.rb
+++ b/spec/system/support_interface/full_courses_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Full courses' do
+  include DfESignInHelpers
+
+  scenario 'View all course options that are full' do
+    given_i_am_a_support_user
+    and_there_are_courses_without_vacancies
+    when_i_visit_the_course_options_page
+    then_i_see_the_list_of_course_options
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_courses_without_vacancies
+    create(:course_option, vacancy_status: 'no_vacancies')
+  end
+
+  def when_i_visit_the_course_options_page
+    visit support_interface_course_options_path
+  end
+
+  def then_i_see_the_list_of_course_options
+    expect(page).to have_content 'No vacancies'
+  end
+end


### PR DESCRIPTION
## Context

We now sync the vacancy status of courses (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1561) to prevent applications to full courses (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1590). We surface the courses that are full by provider (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1624), but not across the system.

## Changes proposed in this pull request

Add a page with all courses that are full. It's a quick thing to properly test the courses-full features on production.

![image](https://user-images.githubusercontent.com/233676/76539835-34549400-6479-11ea-8e79-cea35e69dc49.png)

It's in the performance section because I couldn't think of anything better.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/yBDnIoUS

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
