### PR TITLE
Allow referees to review their answers before submitting a reference

### DIFF
--- a/app/components/referee_interface/reference_review_component.html.erb
+++ b/app/components/referee_interface/reference_review_component.html.erb
@@ -1,0 +1,1 @@
+<%= render(SummaryCardComponent.new(rows: reference_rows, border: false, editable: @editable)) %>

--- a/app/components/referee_interface/reference_review_component.rb
+++ b/app/components/referee_interface/reference_review_component.rb
@@ -1,0 +1,48 @@
+module RefereeInterface
+  class ReferenceReviewComponent < ActionView::Component::Base
+    def initialize(reference:, token_param: nil, editable: true)
+      @reference = reference
+      @editable = editable
+      @token_param = token_param
+    end
+
+    def reference_rows
+      [relationship, safeguarding_concerns, reference]
+    end
+
+  private
+
+    def relationship
+      {
+        key: 'Relationship',
+        value: relationship_value,
+        action: 'relationship',
+        change_path: referee_interface_reference_relationship_path(token: @token_param),
+      }
+    end
+
+    def safeguarding_concerns
+      {
+        key: 'Concerns about candidate working with children',
+        value: @reference.safeguarding_concerns.presence || 'No',
+        action: 'concerns about candidate working with children',
+        change_path: referee_interface_safeguarding_path(token: @token_param),
+      }
+    end
+
+    def reference
+      {
+        key: 'Reference',
+        value: @reference.feedback,
+        action: 'reference',
+        change_path: referee_interface_reference_feedback_path(token: @token_param),
+      }
+    end
+
+    def relationship_value
+      return 'Confirmed by referee' if @reference.relationship_correction.blank?
+
+      "Amended by referee to: #{@reference.relationship_correction}"
+    end
+  end
+end

--- a/app/models/referee_interface/reference_feedback_form.rb
+++ b/app/models/referee_interface/reference_feedback_form.rb
@@ -13,10 +13,14 @@ module RefereeInterface
     def save
       return unless valid?
 
-      ReceiveReference.new(
-        reference: reference,
-        feedback: feedback,
-      ).save!
+      if FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
+        reference.update!(feedback: feedback)
+      else
+        ReceiveReference.new(
+          reference: reference,
+          feedback: feedback,
+        ).save!
+      end
 
       true
     end

--- a/app/models/referee_interface/reference_relationship_form.rb
+++ b/app/models/referee_interface/reference_relationship_form.rb
@@ -5,6 +5,7 @@ module RefereeInterface
 
     validates :relationship_confirmation, presence: true
     validate :presence_of_relationship_correction
+    validates :relationship_correction, word_count: { maximum: 50 }
 
     def self.build_from_reference(reference:)
       relationship_confirmation = reference.relationship_correction.blank? ? 'yes' : 'no' unless reference.relationship_correction.nil?
@@ -13,6 +14,7 @@ module RefereeInterface
 
     def save(application_reference)
       return false unless valid?
+
 
       correction = relationship_confirmation == 'yes' ? '' : relationship_correction
 

--- a/app/models/referee_interface/reference_safeguarding_form.rb
+++ b/app/models/referee_interface/reference_safeguarding_form.rb
@@ -5,6 +5,7 @@ module RefereeInterface
 
     validate :presence_of_any_safeguarding_concerns
     validate :presence_of_safeguarding_concerns
+    validates :safeguarding_concerns, word_count: { maximum: 150 }
 
     def self.build_from_reference(reference:)
       any_safeguarding_concerns = reference.safeguarding_concerns.blank? ? 'no' : 'yes' unless reference.safeguarding_concerns.nil?

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Give a teacher training reference for #{@application.full_name}" %>
+<% content_for :title, title_with_error_prefix("Give a teacher training reference for #{@application.full_name}", @reference_form.errors.any?) %>
 <% if FeatureFlag.active?('referee_confirm_relationship_and_safeguarding') %>
   <% content_for :before_content, govuk_back_link_to(referee_interface_safeguarding_path(token: @token_param)) %>
 <% end %>
@@ -43,7 +43,11 @@
 
       <%= f.govuk_text_area :feedback, label: { text: 'Your reference', size: 'm' }, max_words: 300, rows: 15 %>
 
-      <%= f.govuk_submit t('reference_form.confirm') %>
+      <% if FeatureFlag.active?('referee_confirm_relationship_and_safeguarding') %>
+         <%= f.govuk_submit 'Continue' %>
+      <% else %>
+        <%= f.govuk_submit t('reference_form.confirm') %>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/referee_interface/reference/relationship.html.erb
+++ b/app/views/referee_interface/reference/relationship.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Confirm how you know #{@application.full_name}" %>
+<% content_for :title, title_with_error_prefix("Confirm how you know #{@application.full_name}", @relationship_form.errors.any?) %>
 
 <%= form_with model: @relationship_form, url: referee_interface_confirm_relationship_path(token: @token_param), method: :patch do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/referee_interface/reference/review.html.erb
+++ b/app/views/referee_interface/reference/review.html.erb
@@ -1,0 +1,17 @@
+<% content_for :title, 'Check your answers before submitting your reference' %>
+<% content_for :before_content, govuk_back_link_to(referee_interface_reference_feedback_path(token: @token_param)) %>
+
+<%= form_with url: referee_interface_submit_reference_path(token: @token_param), method: :patch do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">
+        Check your answers before submitting your reference
+      </h1>
+      <%= render(RefereeInterface::ReferenceReviewComponent.new(reference: @reference, token_param: @token_param)) %>
+
+      <p class="govuk-body">
+        <%= f.govuk_submit t('reference_form.confirm') %>
+      </p>
+    </div>
+  </div>
+<% end %>

--- a/app/views/referee_interface/reference/safeguarding.html.erb
+++ b/app/views/referee_interface/reference/safeguarding.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Do you know of any reason why #{@application.full_name} should not work with children?" %>
+<% content_for :title, title_with_error_prefix("Do you know of any reason why #{@application.full_name} should not work with children?", @safeguarding_form.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(referee_interface_reference_relationship_path(token: @token_param)) %>
 
 <%= form_with model: @safeguarding_form, url: referee_interface_confirm_safeguarding_path(token: @token_param), method: :patch do |f| %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -588,9 +588,17 @@ en:
               blank: Choose if the described relationship is correct
             relationship_correction:
               blank: "Enter your relationship to %{candidate}"
+              too_many_words: Your description must be %{count} words or fewer
         referee_interface/reference_safeguarding_form:
           attributes:
             any_safeguarding_concerns:
               blank: Select if you know of any reason why %{candidate} should not work with children
             safeguarding_concerns:
               blank: Enter a reason why %{candidate} should not work with children
+              too_many_words: Your reason must be %{count} words or fewer
+        referee_interface/reference_feedback_form:
+          attributes:
+            feedback: 
+              blank: Enter your reference
+              too_many_words: Your reference must be %{count} words or fewer
+              

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,6 +299,9 @@ Rails.application.routes.draw do
     get '/confirmation' => 'reference#confirmation', as: :confirmation
     patch '/confirmation' => 'reference#submit_feedback', as: :submit_feedback
 
+    get '/review' => 'reference#review', as: :reference_review
+    patch '/submit' => 'reference#submit_reference', as: :submit_reference
+
     patch '/questionnaire' => 'reference#submit_questionnaire', as: :submit_questionnaire
     get '/finish' => 'reference#finish', as: :finish
 

--- a/spec/components/referee_interface/reference_review_component_spec.rb
+++ b/spec/components/referee_interface/reference_review_component_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::ReferenceReviewComponent do
+  context 'when there is no relationship correction' do
+    let(:reference) { build_stubbed(:reference, relationship_correction: '') }
+
+    it 'displays that the relationship is confirmed' do
+      result = render_inline(described_class.new(reference: reference))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Relationship')
+      expect(result.css('.govuk-summary-list__value').text).to include('Confirmed by referee')
+    end
+  end
+
+  context 'when there is a relationship correction' do
+    let(:reference) { build_stubbed(:reference, relationship_correction: 'meh') }
+
+    it 'displays the correction' do
+      result = render_inline(described_class.new(reference: reference))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Relationship')
+      expect(result.css('.govuk-summary-list__value').text).to include('Amended by referee to: meh')
+    end
+  end
+
+  context 'when there is no safeguarding concern' do
+    let(:reference) { build_stubbed(:reference, safeguarding_concerns: '') }
+
+    it 'displays that there are no concerns about safeguarding' do
+      result = render_inline(described_class.new(reference: reference))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Concerns about candidate working with children')
+      expect(result.css('.govuk-summary-list__value').text).to include('No')
+    end
+  end
+
+  context 'when there are safeguarding concerns' do
+    let(:reference) { build_stubbed(:reference, safeguarding_concerns: 'very very concerned') }
+
+    it 'displays the safeguarding concerns' do
+      result = render_inline(described_class.new(reference: reference))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Concerns about candidate working with children')
+      expect(result.css('.govuk-summary-list__value').text).to include('very very concerned')
+    end
+  end
+
+  context 'when there is reference' do
+    let(:reference) { build_stubbed(:reference, feedback: 'best MS paint artist in the world') }
+
+    it 'displays the safeguarding concerns' do
+      result = render_inline(described_class.new(reference: reference))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Reference')
+      expect(result.css('.govuk-summary-list__value').text).to include('best MS paint artist in the world')
+    end
+  end
+
+  context 'when editable' do
+    it 'displays the change links' do
+      result = render_inline(described_class.new(reference: build_stubbed(:reference)))
+
+      expect(result.text).to include('Change relationship')
+      expect(result.text).to include('Change concerns about candidate working with children')
+      expect(result.text).to include('Change reference')
+    end
+  end
+
+  context 'when not editable' do
+    it 'does not display the change links' do
+      result = render_inline(described_class.new(reference: build_stubbed(:reference), editable: false))
+
+      expect(result.text).not_to include('Change relationship')
+      expect(result.text).not_to include('Change concerns about candidate working with children')
+      expect(result.text).not_to include('Change reference')
+    end
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -41,6 +41,9 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     and_i_see_the_list_of_the_courses_the_candidate_applied_to
 
     when_i_fill_in_the_reference_field
+    and_i_click_on_continue
+    then_i_see_the_reference_review_page
+
     and_i_click_the_submit_reference_button
     then_i_see_am_told_i_submittted_my_refernce
     then_i_see_the_confirmation_page

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -5,57 +5,28 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
 
   scenario 'Referee submits a reference for a candidate' do
     FeatureFlag.activate('training_with_a_disability')
-    FeatureFlag.activate('referee_confirm_relationship_and_safeguarding')
 
     given_a_candidate_completed_an_application
     when_the_candidate_submits_the_application
     then_i_receive_an_email_with_a_magic_link
-
     when_i_try_to_access_the_reference_page_with_invalid_token
     then_i_see_page_not_found
 
     when_i_click_on_the_link_within_the_email
-    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
-
-    when_i_click_on_continue
-    then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
-
-    when_i_confirm_that_the_described_relationship_is_not_correct
-    and_i_click_on_continue
-    then_i_see_an_error_to_enter_my_relationship_with_the_candidate
-
-    when_i_confirm_that_the_described_relationship_is_correct
-    and_i_click_on_continue
-    then_i_see_the_safeguarding_page
-
-    when_i_click_on_continue
-    then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
-
-    when_i_choose_the_candidate_is_not_suitable_for_working_with_children
-    and_i_click_on_continue
-    then_i_see_an_error_to_enter_my_safeguarding_concerns
-
-    when_i_choose_the_candidate_is_suitable_for_working_with_children
-    and_i_click_on_continue
     then_i_see_the_reference_comment_page
     and_i_see_the_list_of_the_courses_the_candidate_applied_to
 
     when_i_fill_in_the_reference_field
-    and_i_click_on_continue
-    then_i_see_the_reference_review_page
-
     and_i_click_the_submit_reference_button
     then_i_see_am_told_i_submittted_my_refernce
     then_i_see_the_confirmation_page
     and_i_receive_an_email_confirmation
     and_an_audit_comment_is_added
     and_the_candidate_receives_a_notification
-
     when_i_choose_to_be_contactable
     and_i_click_the_finish_button
     then_i_see_the_thank_you_page
     and_i_am_told_i_will_be_contacted
-
     when_i_retry_to_edit_the_feedback
     then_i_see_the_thank_you_page
   end
@@ -90,48 +61,8 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     current_email.click_link(@reference_feedback_url)
   end
 
-  def then_i_am_asked_to_confirm_my_relationship_with_the_candidate
-    expect(page).to have_content("Confirm how you know #{@application.full_name}")
-  end
-
   def when_i_click_on_continue
     click_button 'Continue'
-  end
-
-  def then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
-    expect(page).to have_content('Choose if the described relationship is correct')
-  end
-
-  def when_i_confirm_that_the_described_relationship_is_not_correct
-    choose 'No'
-  end
-
-  def then_i_see_an_error_to_enter_my_relationship_with_the_candidate
-    expect(page).to have_content("Enter your relationship to #{@application.full_name}")
-  end
-
-  def when_i_confirm_that_the_described_relationship_is_correct
-    choose 'Yes'
-  end
-
-  def then_i_see_the_safeguarding_page
-    expect(page).to have_content("Do you know of any reason why #{@application.full_name} should not work with children?")
-  end
-
-  def then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
-    expect(page).to have_content("Select if you know of any reason why #{@application.full_name} should not work with children")
-  end
-
-  def when_i_choose_the_candidate_is_not_suitable_for_working_with_children
-    choose 'Yes'
-  end
-
-  def then_i_see_an_error_to_enter_my_safeguarding_concerns
-    expect(page).to have_content("Enter a reason why #{@application.full_name} should not work with children")
-  end
-
-  def when_i_choose_the_candidate_is_suitable_for_working_with_children
-    choose 'No'
   end
 
   def and_i_click_on_continue

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -1,0 +1,251 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true do
+  include CandidateHelper
+
+  scenario 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do
+    FeatureFlag.activate('training_with_a_disability')
+
+    given_a_candidate_completed_an_application
+    and_the_confirm_relationship_and_safeguarding_feature_flag_is_active
+    when_the_candidate_submits_the_application
+    then_i_receive_an_email_with_a_magic_link
+
+    when_i_try_to_access_the_reference_page_with_invalid_token
+    then_i_see_page_not_found
+
+    when_i_click_on_the_link_within_the_email
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+
+    when_i_click_on_continue
+    then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
+
+    when_i_confirm_that_the_described_relationship_is_not_correct
+    and_i_click_on_continue
+    then_i_see_an_error_to_enter_my_relationship_with_the_candidate
+
+    when_i_confirm_that_the_described_relationship_is_correct
+    and_i_click_on_continue
+    then_i_see_the_safeguarding_page
+
+    when_i_click_on_continue
+    then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
+
+    when_i_choose_the_candidate_is_not_suitable_for_working_with_children
+    and_i_click_on_continue
+    then_i_see_an_error_to_enter_my_safeguarding_concerns
+
+    when_i_choose_the_candidate_is_suitable_for_working_with_children
+    and_i_click_on_continue
+    then_i_see_the_reference_comment_page
+    and_i_see_the_list_of_the_courses_the_candidate_applied_to
+
+    when_i_fill_in_the_reference_field
+    and_i_click_on_continue
+    then_i_see_the_reference_review_page
+
+    when_i_click_change_relationship
+    and_i_amend_the_relationship
+    and_i_click_on_continue
+    then_i_can_review_the_amended_relationship
+
+    when_i_click_change_safeguarding_concerns
+    and_i_amend_the_safeguarding_concerns
+    and_i_click_on_continue
+    then_i_can_review_the_amended_safeguarding_concerns
+
+    and_i_click_the_submit_reference_button
+    then_i_see_am_told_i_submittted_my_refernce
+    then_i_see_the_confirmation_page
+    and_i_receive_an_email_confirmation
+    and_an_audit_comment_is_added
+    and_the_candidate_receives_a_notification
+
+    when_i_choose_to_be_contactable
+    and_i_click_the_finish_button
+    then_i_see_the_thank_you_page
+    and_i_am_told_i_will_be_contacted
+
+    when_i_retry_to_edit_the_feedback
+    then_i_see_the_thank_you_page
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def and_the_confirm_relationship_and_safeguarding_feature_flag_is_active
+    FeatureFlag.activate('referee_confirm_relationship_and_safeguarding')
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+  end
+
+  def then_i_receive_an_email_with_a_magic_link
+    open_email('terri@example.com')
+
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
+    @token = Rack::Utils.parse_query(URI(matches.captures.first).query)['token']
+    @reference_feedback_url = matches.captures.first unless matches.nil?
+
+    expect(@reference_feedback_url).not_to be_nil
+  end
+
+  def when_i_try_to_access_the_reference_page_with_invalid_token
+    visit referee_interface_reference_feedback_path(token: 'invalid-token')
+  end
+
+  def then_i_see_page_not_found
+    expect(page).to have_content('Page not found')
+  end
+
+  def when_i_click_on_the_link_within_the_email
+    current_email.click_link(@reference_feedback_url)
+  end
+
+  def then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+  end
+
+  def when_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content('Choose if the described relationship is correct')
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_not_correct
+    choose 'No'
+  end
+
+  def then_i_see_an_error_to_enter_my_relationship_with_the_candidate
+    expect(page).to have_content("Enter your relationship to #{@application.full_name}")
+  end
+
+  def when_i_confirm_that_the_described_relationship_is_correct
+    choose 'Yes'
+  end
+
+  def then_i_see_the_safeguarding_page
+    expect(page).to have_content("Do you know of any reason why #{@application.full_name} should not work with children?")
+  end
+
+  def then_i_see_an_error_to_choose_if_i_know_any_safeguarding_concerns
+    expect(page).to have_content("Select if you know of any reason why #{@application.full_name} should not work with children")
+  end
+
+  def when_i_choose_the_candidate_is_not_suitable_for_working_with_children
+    choose 'Yes'
+  end
+
+  def then_i_see_an_error_to_enter_my_safeguarding_concerns
+    expect(page).to have_content("Enter a reason why #{@application.full_name} should not work with children")
+  end
+
+  def when_i_choose_the_candidate_is_suitable_for_working_with_children
+    choose 'No'
+  end
+
+  def and_i_click_on_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_reference_comment_page
+    expect(page).to have_content("Give a teacher training reference for #{@application.full_name}")
+  end
+
+  def when_i_fill_in_the_reference_field
+    fill_in 'Your reference', with: 'This is a reference for the candidate.'
+  end
+
+  def then_i_see_the_reference_review_page
+    expect(page).to have_content('Check your answers before submitting your reference')
+  end
+
+  def when_i_click_change_relationship
+    click_link 'Change relationship'
+  end
+
+  def and_i_amend_the_relationship
+    choose 'No'
+    fill_in "Tell us what your relationship is to #{@application.full_name} and how long you’ve known them", with: 'he is not my friend'
+  end
+
+  def then_i_can_review_the_amended_relationship
+    expect(page).to have_content('Amended by referee to: he is not my friend')
+  end
+
+  def when_i_click_change_safeguarding_concerns
+    click_link 'Change concerns about candidate working with children'
+  end
+
+  def and_i_amend_the_safeguarding_concerns
+    choose 'Yes'
+    fill_in "Tell us why you think #{@application.full_name} should not work with children", with: 'telling dirty jokes'
+  end
+
+  def then_i_can_review_the_amended_safeguarding_concerns
+    expect(page).to have_content('telling dirty jokes')
+  end
+
+  def and_i_click_the_submit_reference_button
+    click_button t('reference_form.confirm')
+  end
+
+  def and_i_click_the_finish_button
+    click_button t('questionnaire_form.confirm')
+  end
+
+  def then_i_see_am_told_i_submittted_my_refernce
+    expect(page).to have_content("Your reference for #{@application.full_name}")
+  end
+
+  def and_i_receive_an_email_confirmation
+    open_email('terri@example.com')
+
+    expect(current_email.subject).to have_content(t('reference_confirmation_email.subject', candidate_name: @application.full_name))
+  end
+
+  def and_an_audit_comment_is_added
+    expect(@application.audits.last.comment).to eq(
+      'Reference confirmation email has been sent to the candidate’s reference: Terri Tudor using terri@example.com.',
+    )
+  end
+
+  def and_the_candidate_receives_a_notification
+    open_email(current_candidate.email_address)
+
+    expect(current_email.subject).to end_with('You have a reference for your teacher training application')
+    expect(current_email.body).to have_content('Terri Tudor submitted a reference for your teacher training application')
+  end
+
+  def then_i_see_the_thank_you_page
+    expect(page).to have_content('Thank you')
+  end
+
+  def and_i_am_told_i_will_be_contacted
+    expect(page).to have_content('Our user research team will contact you shortly')
+  end
+
+  def when_i_retry_to_edit_the_feedback
+    visit @reference_feedback_url
+  end
+
+  def and_i_see_the_list_of_the_courses_the_candidate_applied_to
+    @application.application_choices.each do |application_choice|
+      expect(page).to have_content(application_choice.course.name)
+      expect(page).to have_content(application_choice.site.name)
+    end
+  end
+
+  def then_i_see_the_confirmation_page
+    expect(page).to have_current_path(referee_interface_confirmation_path(token: @token))
+  end
+
+  def when_i_choose_to_be_contactable
+    choose t('questionnaire_form.consent_to_be_contacted')
+    fill_in 'Please let us know when you’re available', with: 'anytime 012345 678900'
+  end
+end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We want to allow referees to review their answers before submitting a reference so the correct information about their relationship to the candidate and their suitability to work with children is accurate, before it's submitted alongside their application.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR:
- Adds a `ReferenceReviewComponent` to show the reference before submission
- Updates the ReferenceFeedbackForm to use the feature flag when saving a feedback
- Splits out the new `referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec`  from the existing `referee_can_submit_a_reference_for_candidate_spec` to make sure we don't break the old behaviour
- Add error messages and error prefixes to relationship/safeguarding and feedback pages


### Review page:
![image](https://user-images.githubusercontent.com/22743709/76544822-982e8b00-6480-11ea-9126-2bc51b30ff55.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Turn on the `Referee confirm relationship and safeguarding` and try to submit a reference, then try to edit your answers.

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/Xa3dxxWC/1159-dev-referee-check-your-answers

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
