### PR TITLE
[Tech debt] Stub data where possible in component tests

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -14,6 +14,7 @@ class ApplicationForm < ApplicationRecord
   has_many :application_work_history_breaks
 
   MINIMUM_COMPLETE_REFERENCES = 2
+  DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
 
   enum phase: {
     apply_1: 'apply_1',
@@ -74,7 +75,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def all_provider_decisions_made?
-    application_choices.any? && application_choices.where(status: %w[awaiting_references application_complete awaiting_provider_decision]).empty?
+    application_choices.any? && (application_choices.map(&:status) & DECISION_PENDING_STATUSES).empty?
   end
 
   def all_choices_withdrawn?

--- a/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
+++ b/spec/components/candidate_interface/becoming_a_teacher_review_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::BecomingATeacherReviewComponent do
-  let(:application_form) { create(:completed_application_form) }
+  let(:application_form) { build_stubbed(:completed_application_form) }
 
   context 'when becoming a teacher is editable' do
     it 'renders SummaryCardComponent with valid becoming a teacher' do

--- a/spec/components/candidate_interface/degrees_review_component_spec.rb
+++ b/spec/components/candidate_interface/degrees_review_component_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::DegreesReviewComponent do
-  let(:application_form) { create(:application_form) }
-  let!(:degree1) do
-    application_form.application_qualifications.create(
-      level: 'degree',
+  let(:application_form) { build_stubbed(:application_form) }
+  let(:degree1) do
+    build_stubbed(
+      :degree_qualification,
       qualification_type: 'BA',
       subject: 'Woof',
       institution_name: 'University of Doge',
@@ -14,7 +14,8 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     )
   end
   let(:degree2) do
-    {
+    build_stubbed(
+      :degree_qualification,
       level: 'degree',
       qualification_type: 'BA',
       subject: 'Meow',
@@ -22,7 +23,13 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
       grade: 'First',
       predicted_grade: true,
       award_year: '2010',
-    }
+    )
+  end
+
+  let(:application_qualifications) { ActiveRecordRelationStub.new(ApplicationQualification, [degree1], scopes: [:degrees]) }
+
+  before do
+    allow(application_form).to receive(:application_qualifications).and_return(application_qualifications)
   end
 
   context 'when degrees are editable' do
@@ -63,7 +70,9 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
 
     it 'renders component with correct values for a predicted grade' do
-      application_form.application_qualifications.create(degree2)
+      allow(application_form).to receive(:application_qualifications).and_return(
+        ActiveRecordRelationStub.new(ApplicationQualification, [degree1, degree2], scopes: [:degrees]),
+      )
 
       result = render_inline(described_class.new(application_form: application_form))
 
@@ -72,14 +81,18 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
 
     it 'renders component with correct values for an other grade' do
-      application_form.application_qualifications.create(
-        level: 'degree',
+      degree3 = build_stubbed(
+        :degree_qualification,
         qualification_type: 'BA',
         subject: 'Hoot',
         institution_name: 'University of Owl',
         grade: 'Distinction',
         predicted_grade: false,
         award_year: '2010',
+      )
+
+      allow(application_form).to receive(:application_qualifications).and_return(
+        ActiveRecordRelationStub.new(ApplicationQualification, [degree3], scopes: [:degrees]),
       )
 
       result = render_inline(described_class.new(application_form: application_form))
@@ -89,7 +102,9 @@ RSpec.describe CandidateInterface::DegreesReviewComponent do
     end
 
     it 'renders component with correct values for multiple degrees' do
-      application_form.application_qualifications.create(degree2)
+      allow(application_form).to receive(:application_qualifications).and_return(
+        ActiveRecordRelationStub.new(ApplicationQualification, [degree1, degree2], scopes: [:degrees]),
+      )
 
       result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
+++ b/spec/components/candidate_interface/other_qualifications_review_component_spec.rb
@@ -1,9 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
-  let(:application_form) { create(:application_form) }
-  let!(:qualification1) do
-    application_form.application_qualifications.create(
+  let(:application_form) { build_stubbed(:application_form) }
+  let(:qualification1) do
+    build_stubbed(
+      :application_qualification,
       level: 'other',
       qualification_type: 'A-Level',
       subject: 'Making Doggo Sounds',
@@ -13,11 +14,18 @@ RSpec.describe CandidateInterface::OtherQualificationsReviewComponent do
       award_year: '2012',
     )
   end
-  let!(:qualification2) do
-    application_form.application_qualifications.create(
+  let(:qualification2) do
+    build_stubbed(
+      :application_qualification,
       level: 'other',
       qualification_type: 'A-Level',
       subject: 'Making Cat Sounds',
+    )
+  end
+
+  before do
+    allow(application_form).to receive(:application_qualifications).and_return(
+      ActiveRecordRelationStub.new(ApplicationQualification, [qualification1, qualification2], scopes: [:other]),
     )
   end
 

--- a/spec/components/candidate_interface/personal_details_review_component_spec.rb
+++ b/spec/components/candidate_interface/personal_details_review_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::PersonalDetailsReviewComponent do
-  let(:application_form) { create(:completed_application_form) }
+  let(:application_form) { build_stubbed(:completed_application_form) }
 
   context 'when personal details are editable' do
     it 'renders SummaryCardComponent with valid personal details' do

--- a/spec/components/candidate_interface/subject_knowledge_review_component_spec.rb
+++ b/spec/components/candidate_interface/subject_knowledge_review_component_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SubjectKnowledgeReviewComponent do
-  let(:application_form) { create(:completed_application_form) }
+  let(:application_form) { build_stubbed(:completed_application_form) }
 
   context 'when subject knowledge is editable' do
     it 'renders SummaryCardComponent with valid becoming a teacher' do

--- a/spec/support/active_record_relation_stub.rb
+++ b/spec/support/active_record_relation_stub.rb
@@ -1,0 +1,23 @@
+class ActiveRecordRelationStub
+  attr_reader :records
+  alias to_a records
+
+  # @param model_klass [ActiveRecord::Base] the stubbing association's class
+  # @param records [Array] list of records the association holds
+  # @param scopes [Array] list of stubbed scopes
+  def initialize(model_klass, records, scopes: [])
+    @records = records
+
+    scopes.each do |scope|
+      fail NotImplementedError, scope unless model_klass.respond_to?(scope)
+
+      define_singleton_method(scope) do
+        self
+      end
+    end
+  end
+
+  def order(_hash)
+    records
+  end
+end


### PR DESCRIPTION
## Context

Component specs shouldn't care if the underlying data is stored in the db. 
Stubbing this data should improve test suite speed.

## Speed improvement:

Master: `rspec spec/components/candidate_interface/`

_Finished in 5.93 seconds (files took 3.99 seconds to load)_

This branch:  `rspec spec/components/candidate_interface/`

_Finished in 4.99 seconds (files took 3.94 seconds to load)_
 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Use `FactoryBot#build_stubbed` over `FactoryBot#create` in component specs, this PR deals with the easier to convert candidate component specs.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/OEjmIn3C/135-the-tests-are-becoming-slow-high

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
