### PR TITLE
Add additional information to radio buttons on course selection page

### DIFF
--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -29,7 +29,7 @@
           <div class="govuk-!-margin-top-6">
 
           <% @pick_course.available_courses.each_with_index do |course, i| %>
-            <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, link_errors: i.zero? %>
+            <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint_text: course.description, link_errors: i.zero? %>
           <% end %>
 
           </div>

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -12,6 +12,7 @@ RSpec.feature 'Selecting a course' do
     and_i_click_on_add_course
     and_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
+    then_i_should_see_a_course_and_its_description
 
     when_submit_without_choosing_a_course
     then_i_should_see_an_error
@@ -121,6 +122,11 @@ RSpec.feature 'Selecting a course' do
   def and_i_choose_a_provider
     select 'Gorse SCITT (1N1)'
     click_button 'Continue'
+  end
+
+  def then_i_should_see_a_course_and_its_description
+    expect(page).to have_content(@multi_site_course.name_and_code)
+    expect(page).to have_content(@multi_site_course.description)
   end
 
   def when_submit_without_choosing_a_course


### PR DESCRIPTION
## Context

Candidates need to be able to:
1. See more information about the course they are selecting
2. Easily distinguish between similar course ie. one is part-time and one is full time

## Changes proposed in this pull request

Before

![image](https://user-images.githubusercontent.com/42515961/76544757-7cc38000-6480-11ea-8ff7-734a92523deb.png)


After

![image](https://user-images.githubusercontent.com/42515961/76549789-eb0c4080-6488-11ea-8a88-119aca77b559.png)


## Guidance to review

None really.

## Link to Trello card

https://trello.com/c/88LNlgb8/

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
