### PR TITLE
Add ability to use link in initial and chaser reference request emails

### DIFF
--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -51,7 +51,8 @@ class ApplicationReference < ApplicationRecord
 
   def self.find_by_unhashed_token(unhashed_token)
     hashed_token = Devise.token_generator.digest(ApplicationReference, :hashed_sign_in_token, unhashed_token)
-    find_by(hashed_sign_in_token: hashed_token)
+
+    find_by(hashed_sign_in_token: hashed_token) || ReferenceToken.find_by(hashed_token: hashed_token)&.application_reference
   end
 
   def chase_referee_at

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -403,6 +403,12 @@ FactoryBot.define do
     end
   end
 
+  factory :reference_token do
+    association :application_reference, factory: :reference
+
+    hashed_token { '1234567890' }
+  end
+
   factory :support_user do
     dfe_sign_in_uid { SecureRandom.uuid }
     email_address { "#{Faker::Name.first_name.downcase}@example.com" }

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -118,4 +118,55 @@ RSpec.describe ApplicationReference, type: :model do
       expect(reference.reference_tokens.first.hashed_token).to eq('new_hashed_token')
     end
   end
+
+  describe '.find_by_unhashed_token' do
+    before do
+      devise_token_generator = instance_double(Devise::TokenGenerator)
+      allow(Devise).to receive(:token_generator).and_return(devise_token_generator)
+      allow(devise_token_generator).to receive(:digest)
+        .with(ApplicationReference, :hashed_sign_in_token, 'unhashed_token')
+        .and_return('hashed_token')
+    end
+
+    context 'when the unhashed token does not match an unhashed sign in token on a reference' do
+      it 'returns nil' do
+        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
+
+        expect(reference).to eq(nil)
+      end
+    end
+
+    context 'when the unhashed token matches an unhashed sign in token on a reference' do
+      it 'returns the reference' do
+        create(:reference, name: 'Chandler Bing', hashed_sign_in_token: 'hashed_token')
+        create(:reference, name: 'Monica Geller-Bing', hashed_sign_in_token: 'another_hashed_token')
+
+        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
+
+        expect(reference.name).to eq('Chandler Bing')
+      end
+    end
+
+    context 'when the unhashed token can be found in the reference token table' do
+      it 'returns the reference' do
+        chandler = create(:reference, name: 'Chandler Bing')
+        create(:reference_token, application_reference: chandler, hashed_token: 'hashed_token')
+
+        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
+
+        expect(reference.name).to eq('Chandler Bing')
+      end
+    end
+
+    context 'when the unhashed token can be found in the reference token table and on a reference' do
+      it 'returns the reference' do
+        chandler = create(:reference, name: 'Chandler Bing', hashed_sign_in_token: 'hashed_token')
+        create(:reference_token, application_reference: chandler, hashed_token: 'hashed_token')
+
+        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
+
+        expect(reference.name).to eq('Chandler Bing')
+      end
+    end
+  end
 end

--- a/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
+++ b/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.feature 'Referee can use sign in link in the initial and chaser email', sidekiq: true do
+  scenario 'Referee clicks sign in links on the initial and chaser reference request emails' do
+    given_the_confirm_relationship_and_safeguarding_feature_flag_is_active
+    and_i_am_a_referee_of_an_submitted_application
+    and_i_received_the_initial_reference_request_email
+    when_i_click_on_the_link_within_the_email
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+
+    given_i_received_the_chaser_reference_request_email
+    when_i_click_on_the_link_within_the_email
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+  end
+
+  def given_the_confirm_relationship_and_safeguarding_feature_flag_is_active
+    FeatureFlag.activate('referee_confirm_relationship_and_safeguarding')
+  end
+
+  def and_i_am_a_referee_of_an_submitted_application
+    @reference = create(:reference, :requested)
+    @application = create(:completed_application_form, application_references: [@reference])
+  end
+
+  def and_i_received_the_initial_reference_request_email
+    RefereeMailer.reference_request_email(@application, @reference).deliver_now
+  end
+
+  def when_i_click_on_the_link_within_the_email
+    open_email(@reference.email_address)
+
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
+    reference_feedback_url = matches.captures.first unless matches.nil?
+
+    current_email.click_link(reference_feedback_url)
+  end
+
+  def then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+  end
+
+  def given_i_received_the_chaser_reference_request_email
+    RefereeMailer.reference_request_chaser_email(@application, @reference).deliver_now
+  end
+end


### PR DESCRIPTION
## Context

In #1617, we added a new table `ReferenceToken` and in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1634, we backfilled reference tokens and created a new one when refreshing sign in token for a reference.

## Changes proposed in this pull request

This PR allows a referee to use the sign in link on the initial reference request email and on the chaser email by:

- updating `ApplicationReference.find_by_unhashed_token` to also check the `ReferenceToken` table if the referee has an associated token there.

## Guidance to review

What do you think of having a separate system spec for this? The other existing ones where quite long already so going with a new one seemed necessary.

## Link to Trello card

https://trello.com/c/Io6avau8/1119-dev-improve-user-journey-when-referees-click-on-their-first-email-after-a-chaser-has-been-sent

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
