### PR TITLE
Swap two columns in the application choices CSV export

### DIFF
--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -5,8 +5,8 @@ module SupportInterface
         application_form.application_choices.map do |choice|
           {
             support_reference: application_form.support_reference,
-            submitted_at: application_form.submitted_at,
             choice_id: choice.id,
+            submitted_at: application_form.submitted_at,
             choice_status: choice.status,
             provider_code: choice.provider.code,
             course_code: choice.course.code,


### PR DESCRIPTION
## Context

We have a data pipeline which feeds our service dashboard using this data. The pipeline is a bit brittle/difficult to change and relies on `choice_id` coming before `submitted_at`, and it's easier to make the change in the export than in the pipeline.

Previous work: #1546, #1554, #1581

## Changes proposed in this pull request

Swap two columns around in the export.

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
