### PR TITLE
Disambiguate courses with the same name in the courses dropdown

### DIFF
--- a/app/helpers/select_options_helper.rb
+++ b/app/helpers/select_options_helper.rb
@@ -8,7 +8,7 @@ module SelectOptionsHelper
   def select_course_options(courses)
     [
       OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_course_form.attributes.code.blank')),
-    ] + courses.map { |course| OpenStruct.new(id: course.id, name: "#{course.name} (#{course.code})") }
+    ] + courses.map { |course| OpenStruct.new(id: course.id, name: course.name) }
   end
 
   def select_provider_options(providers)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -26,8 +26,24 @@ class Course < ApplicationRecord
     full_time_or_part_time: 'B',
   }
 
+  def name_and_description
+    "#{name} #{description}"
+  end
+
+  def name_and_provider
+    "#{name} #{accrediting_provider&.name}"
+  end
+
   def name_and_code
     "#{name} (#{code})"
+  end
+
+  def name_code_and_description
+    "#{name} (#{code}) – #{description}"
+  end
+
+  def name_code_and_provider
+    "#{name} (#{code}) – #{accrediting_provider&.name}"
   end
 
   def both_study_modes_available?

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -11,11 +11,11 @@
         ) do |f| %>
       <%= f.govuk_error_summary %>
 
-      <% if @pick_course.available_courses.count > 20 %>
+      <% if @pick_course.radio_available_courses.count > 20 %>
 
         <%= f.govuk_collection_select(
               :course_id,
-              select_course_options(@pick_course.available_courses),
+              select_course_options(@pick_course.dropdown_available_courses),
               :id,
               :name,
               label: { text: t('page_titles.which_course'), size: 'xl' },
@@ -28,7 +28,7 @@
 
           <div class="govuk-!-margin-top-6">
 
-          <% @pick_course.available_courses.each_with_index do |course, i| %>
+          <% @pick_course.radio_available_courses.each_with_index do |course, i| %>
             <%= f.govuk_radio_button :course_id, course.id, label: { text: "#{course.name} (#{course.code})" }, hint_text: course.description, link_errors: i.zero? %>
           <% end %>
 

--- a/spec/models/candidate_interface/pick_course_form_spec.rb
+++ b/spec/models/candidate_interface/pick_course_form_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::PickCourseForm do
-  describe '#available_courses' do
+  describe '#radio_available_courses' do
     it 'returns courses that candidates can choose from' do
       provider = create(:provider, name: 'School with courses')
       create(:course, exposed_in_find: false, open_on_apply: true, name: 'Course not shown in Find', provider: provider)
@@ -11,7 +11,87 @@ RSpec.describe CandidateInterface::PickCourseForm do
 
       form = described_class.new(provider_id: provider.id)
 
-      expect(form.available_courses.map(&:name)).to eql(['Course not open on apply', 'Course you can apply to'])
+      expect(form.radio_available_courses.map(&:name)).to eql(['Course not open on apply', 'Course you can apply to'])
+    end
+  end
+
+  describe '#dropdown_available_courses' do
+    context 'with no ambiguous courses' do
+      it 'returns each courses name and code' do
+        provider = create(:provider)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: '789', description: 'PGCE with QTS full time', provider: provider)
+
+        form = described_class.new(provider_id: provider.id)
+
+        expect(form.dropdown_available_courses.map(&:name)).to eql(['English (789)', 'Maths (123)'])
+      end
+    end
+
+    context 'when courses have ambiguous names and different descriptions' do
+      it 'adds the course description to the name of the course' do
+        provider = create(:provider)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: '789', description: 'PGCE with QTS full time', provider: provider)
+
+        form = described_class.new(provider_id: provider.id)
+
+        expect(form.dropdown_available_courses.map(&:name)).to eql(['English (789)', 'Maths (123) – PGCE full time', 'Maths (456) – PGCE with QTS full time'])
+      end
+    end
+
+    context 'when courses have ambiguous names and the same description' do
+      it 'adds the accrediting provider name to the the name of the course' do
+        provider = create(:provider)
+        provider2 = create(:provider, name: 'BIG SCITT')
+        provider3 = create(:provider, name: 'EVEN BIGGER SCITT')
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accrediting_provider: provider2)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accrediting_provider: provider3)
+
+        form = described_class.new(provider_id: provider.id)
+
+        expect(form.dropdown_available_courses.map(&:name)).to eql(['Maths (123) – BIG SCITT', 'Maths (456) – EVEN BIGGER SCITT'])
+      end
+    end
+
+    context 'when courses have the same accrediting provider and different descriptions' do
+      it 'prioritises showing the description over the accrediting provider name' do
+        provider = create(:provider)
+        provider2 = create(:provider, name: 'BIG SCITT')
+        provider3 = create(:provider, name: 'EVEN BIGGER SCITT')
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider, accrediting_provider: provider2)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accrediting_provider: provider3)
+
+        form = described_class.new(provider_id: provider.id)
+
+        expect(form.dropdown_available_courses.map(&:name)).to eql(['Maths (123) – PGCE full time', 'Maths (456) – PGCE with QTS full time'])
+      end
+    end
+
+    context 'with multiple ambigious names' do
+      it 'returns the correct values' do
+        provider = create(:provider)
+        provider2 = create(:provider, name: 'BIG SCITT')
+        provider3 = create(:provider, name: 'EVEN BIGGER SCITT')
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE full time', provider: provider, accrediting_provider: provider2)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accrediting_provider: provider2)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '789', description: 'PGCE with QTS full time', provider: provider, accrediting_provider: provider3)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A01', description: 'PGCE full time', provider: provider, accrediting_provider: provider3)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A02', description: 'PGCE with QTS full time', provider: provider, accrediting_provider: provider2)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'English', code: 'A03', description: 'PGCE with QTS full time', provider: provider, accrediting_provider: provider3)
+
+        form = described_class.new(provider_id: provider.id)
+
+        expect(form.dropdown_available_courses.map(&:name)).to eql(
+          ['English (A01) – PGCE full time',
+           'English (A02) – BIG SCITT',
+           'English (A03) – EVEN BIGGER SCITT',
+           'Maths (123) – PGCE full time',
+           'Maths (456) – BIG SCITT',
+           'Maths (789) – EVEN BIGGER SCITT'],
+         )
+      end
     end
   end
 


### PR DESCRIPTION
## Context

Courses have a description on Find (such as "PCGE full time") and an accredited body (such as "Big SCITT"). When a course has the same name as another course, it usually has a different course description or accredited body. We should surface these.

## Changes proposed in this pull request

On the course dropdown:
- Adds the description if a provider has two courses with the same name
- Adds the accrediting provider if two courses have the same name and description

## Guidance to review

After:

![Screenshot 2020-03-25 at 17 03 52](https://user-images.githubusercontent.com/1650875/77564436-a20db080-6eba-11ea-887d-4df7fabd1b82.png)


## Link to Trello card

https://trello.com/c/OnwPZPWa/854-dev-disambiguate-courses-in-autocomplete-and-course-listing-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
