### PR TITLE
Scrub equality and diversity audit data

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -112,5 +112,5 @@ class ApplicationForm < ApplicationRecord
     updated_at == created_at
   end
 
-  audited
+  audited except: :equality_and_diversity
 end

--- a/db/migrate/20200315091931_scrub_equality_and_diversity_audits.rb
+++ b/db/migrate/20200315091931_scrub_equality_and_diversity_audits.rb
@@ -1,0 +1,17 @@
+class ScrubEqualityAndDiversityAudits < ActiveRecord::Migration[6.0]
+  def up
+    # See https://www.postgresql.org/docs/current/functions-json.html
+    Audited::Audit.where(
+      # in this field       get this key            as jsonb
+      "(audited_changes -> 'equality_and_diversity')::jsonb" +
+      # audited saves changes as pairs of [before, after], get index 1 (after)
+      '->1' +
+      # do any of these strings exist as top-level keys?
+      " ?| array['sex', 'disabilities', 'ethnic_group', 'ethnic_background']",
+    ).destroy_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_13_124507) do
+ActiveRecord::Schema.define(version: 2020_03_15_091931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## Context

We discovered that we were exposing this data to support users via the audit log.

## Changes proposed in this pull request

Scrub equality and diversity audit data with a data migration.

Prevent it from being saved in the future by marking it as an excepted field.

## Guidance to review

Check the migration, no tests for the `except` because we'd be testing the library itself.

Tested this locally, here's how if you want to as well:

- Enable equality and diversity feature flag
- Log in with an unsubmitted but complete application
- Go to submit, fill in one equality and diversity field
- Check that it's in the audit log for that form
- Checkout to this branch
- Run pending migrations
- Check that the audit log is scrubbed
- Fill in another equality and diversity field
- Check that it's not in the audit log

## Link to Trello card

Ship it.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)