### PR TITLE
Add test to ensure that initial reference request email works after chaser is sent

### DIFF
--- a/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
+++ b/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
@@ -5,11 +5,14 @@ RSpec.feature 'Referee can use sign in link in the initial and chaser email', si
     given_the_confirm_relationship_and_safeguarding_feature_flag_is_active
     and_i_am_a_referee_of_an_submitted_application
     and_i_received_the_initial_reference_request_email
-    when_i_click_on_the_link_within_the_email
+    when_i_click_on_the_link_within_the_initial_email
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
 
     given_i_received_the_chaser_reference_request_email
-    when_i_click_on_the_link_within_the_email
+    when_i_click_on_the_link_within_the_chaser_email
+    then_i_am_asked_to_confirm_my_relationship_with_the_candidate
+
+    when_i_click_on_the_link_within_the_initial_email
     then_i_am_asked_to_confirm_my_relationship_with_the_candidate
   end
 
@@ -26,13 +29,10 @@ RSpec.feature 'Referee can use sign in link in the initial and chaser email', si
     RefereeMailer.reference_request_email(@application, @reference).deliver_now
   end
 
-  def when_i_click_on_the_link_within_the_email
+  def when_i_click_on_the_link_within_the_initial_email
     open_email(@reference.email_address)
 
-    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
-    reference_feedback_url = matches.captures.first unless matches.nil?
-
-    current_email.click_link(reference_feedback_url)
+    click_sign_in_link(current_emails.first)
   end
 
   def then_i_am_asked_to_confirm_my_relationship_with_the_candidate
@@ -41,5 +41,18 @@ RSpec.feature 'Referee can use sign in link in the initial and chaser email', si
 
   def given_i_received_the_chaser_reference_request_email
     RefereeMailer.reference_request_chaser_email(@application, @reference).deliver_now
+  end
+
+  def when_i_click_on_the_link_within_the_chaser_email
+    open_email(@reference.email_address)
+
+    click_sign_in_link(current_emails.second)
+  end
+
+  def click_sign_in_link(email)
+    matches = email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
+    reference_feedback_url = matches.captures.first unless matches.nil?
+
+    email.click_link(reference_feedback_url)
   end
 end


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1638, we added the ability use the link in initial and chaser reference request emails. Although, a test in the system spec was missing as noted by @tvararu https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1638#discussion_r392297270.

## Changes proposed in this pull request

This PR ensures that the initial reference request email works after the chaser reference request email is sent.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/Io6avau8/1119-dev-improve-user-journey-when-referees-click-on-their-first-email-after-a-chaser-has-been-sent

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
