### PR TITLE
1752 search applications by candidate name in provider interface

### DIFF
--- a/app/components/previews/provider_interface/filter_component_preview.rb
+++ b/app/components/previews/provider_interface/filter_component_preview.rb
@@ -67,7 +67,7 @@ module ProviderInterface
       [
         {
           heading: 'status',
-          checkbox_config: [
+          input_config: [
             {
               name: 'pending-conditions',
               text: 'Accepted',
@@ -112,7 +112,7 @@ module ProviderInterface
  },
         {
           heading: 'provider',
-          checkbox_config: [
+          input_config: [
             {
               name: 'somerset-scitt-consortium',
               text: 'Somerset SCITT consortium',

--- a/app/components/previews/provider_interface/filter_component_preview.rb
+++ b/app/components/previews/provider_interface/filter_component_preview.rb
@@ -69,41 +69,49 @@ module ProviderInterface
           heading: 'status',
           input_config: [
             {
+              type: 'checkbox',
               name: 'pending-conditions',
               text: 'Accepted',
               value: 'pending_conditions',
             },
             {
+              type: 'checkbox',
               name: 'recruited',
               text: 'Conditions met',
               value: 'recruited',
             },
             {
+              type: 'checkbox',
               name: 'declined',
               text: 'Declined',
               value: 'declined',
             },
             {
+              type: 'checkbox',
               name: 'awaiting-provider-decision',
               text: 'New',
               value: 'awaiting_provider_decision',
             },
             {
+              type: 'checkbox',
               name: 'offer',
               text: 'Offered',
               value: 'offer',
             },
             {
+              type: 'checkbox',
               name: 'rejected',
               text: 'Rejected',
               value: 'rejected',
             },
             {
+              type: 'checkbox',
               name: 'withdrawn',
               text: 'Application withdrawn',
               value: 'withdrawn',
             },
             {
+              type: 'checkbox',
               name: 'offer-withdrawn',
               text: 'Withdrawn by us',
               value: 'offer_withdrawn',
@@ -114,11 +122,13 @@ module ProviderInterface
           heading: 'provider',
           input_config: [
             {
+              type: 'checkbox',
               name: 'somerset-scitt-consortium',
               text: 'Somerset SCITT consortium',
               value: '1',
             },
             {
+              type: 'checkbox',
               name: 'the-beach-teaching-school',
               text: 'The Beach Teaching School',
               value: '2',

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -14,16 +14,16 @@
 
   </div>
 
-  <% applied_filters.each do |applied_filters_key, checkbox_config_values| %>
+  <% applied_filters.each do |applied_filters_key, input_config_values| %>
     <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= applied_filters_key.capitalize %></h3>
     <ul class="moj-filter-tags">
-    <% checkbox_config_values.each do |checkbox_config_name, _| %>
+    <% input_config_values.each do |input_config_name, _| %>
         <li>
-          <%= link_to retrieve_tag_text(applied_filters_key, checkbox_config_name),
+          <%= link_to retrieve_tag_text(applied_filters_key, input_config_name),
                                         filtering_page_path(params_for_current_state.merge({filter_selections: build_tag_url_query_params(
                                                                                 heading: applied_filters_key,
-                                                                                tag_value: checkbox_config_name)})),
-                                        class: "moj-filter__tag", id: "tag-#{checkbox_config_name}" %>
+                                                                                tag_value: input_config_name)})),
+                                        class: "moj-filter__tag", id: "tag-#{input_config_name}" %>
         </li>
       <% end %>
     </ul>

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -15,7 +15,11 @@
   </div>
 
   <% applied_filters.each do |applied_filters_key, input_config_values| %>
-    <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= applied_filters_key.capitalize %></h3>
+    <% if applied_filters_key.eql?('search') %>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-0">Candidate's name</h3>
+    <% else %>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= applied_filters_key.capitalize %></h3>
+    <% end %>
     <ul class="moj-filter-tags">
     <% input_config_values.each do |input_config_name, _| %>
         <li>

--- a/app/components/provider_interface/current_filters_component.rb
+++ b/app/components/provider_interface/current_filters_component.rb
@@ -20,8 +20,8 @@ module ProviderInterface
     def retrieve_tag_text(heading, lookup_val)
       @available_filters.each do |available_filter|
         if available_filter.key(heading)
-          available_filter[:checkbox_config].each do |checkbox_config|
-            return checkbox_config[:text].to_s if checkbox_config.key(lookup_val)
+          available_filter[:input_config].each do |input_config|
+            return input_config[:text].to_s if input_config.key(lookup_val)
           end
         end
       end

--- a/app/components/provider_interface/current_filters_component.rb
+++ b/app/components/provider_interface/current_filters_component.rb
@@ -19,7 +19,7 @@ module ProviderInterface
 
     def retrieve_tag_text(heading, lookup_val)
       if heading.eql?('search')
-        return @applied_filters[:search][:candidates_name]
+        @applied_filters[:search][:candidates_name]
       else
         @available_filters.each do |available_filter|
           if available_filter.key(heading)

--- a/app/components/provider_interface/current_filters_component.rb
+++ b/app/components/provider_interface/current_filters_component.rb
@@ -19,7 +19,7 @@ module ProviderInterface
 
     def retrieve_tag_text(heading, lookup_val)
       if heading.eql?('search')
-        @applied_filters[:search][:candidates_name]
+        return @applied_filters[:search][:candidates_name]
       else
         @available_filters.each do |available_filter|
           if available_filter.key(heading)

--- a/app/components/provider_interface/current_filters_component.rb
+++ b/app/components/provider_interface/current_filters_component.rb
@@ -18,10 +18,14 @@ module ProviderInterface
     end
 
     def retrieve_tag_text(heading, lookup_val)
-      @available_filters.each do |available_filter|
-        if available_filter.key(heading)
-          available_filter[:input_config].each do |input_config|
-            return input_config[:text].to_s if input_config.key(lookup_val)
+      if heading.eql?('search')
+        @applied_filters[:search][:candidates_name]
+      else
+        @available_filters.each do |available_filter|
+          if available_filter.key(heading)
+            available_filter[:input_config].each do |input_config|
+              return input_config[:text].to_s if input_config.key(lookup_val)
+            end
           end
         end
       end

--- a/app/components/provider_interface/filter_checkbox_component.html.erb
+++ b/app/components/provider_interface/filter_checkbox_component.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-checkboxes__item">
-  <input class="govuk-checkboxes__input" id=<%= "#{heading}-#{text.parameterize}" %> name=<%= "filter_selections[#{heading}][#{name}]" %> type="checkbox", <%= "checked" if selected %> >
+  <input class="govuk-checkboxes__input" id=<%= "#{heading}-#{text.parameterize}" %> name=<%= "filter_selections[#{heading}][#{name}]" %> type="checkbox" <%= "checked" if selected %> >
   <label class="govuk-label govuk-checkboxes__label" for=<%= "#{heading}-#{text.parameterize}" %>>
     <%= text %>
   </label>

--- a/app/components/provider_interface/filter_checkbox_component.html.erb
+++ b/app/components/provider_interface/filter_checkbox_component.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-checkboxes__item">
   <input class="govuk-checkboxes__input" id=<%= "#{heading}-#{text.parameterize}" %> name=<%= "filter_selections[#{heading}][#{name}]" %> type="checkbox", <%= "checked" if selected %> >
-  <label class="govuk-label govuk-checkboxes__label" for=<%= "#{heading}-#{name}" %>>
+  <label class="govuk-label govuk-checkboxes__label" for=<%= "#{heading}-#{text.parameterize}" %>>
     <%= text %>
   </label>
 </div>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -26,18 +26,18 @@
 
 
             <% available_filters.each do |filter_group| %>
-              <% unless filter_group[:checkbox_config].size <= 1 %>
+              <% unless filter_group[:input_config].size <= 1 %>
                 <div class="govuk-form-group">
                   <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                       <%= filter_group[:heading].capitalize %>
                     </legend>
 
-                    <% filter_group[:checkbox_config].each do |checkbox_config| %>
+                    <% filter_group[:input_config].each do |input_config| %>
                       <div class="govuk-checkboxes govuk-checkboxes--small">
-                        <%= render ProviderInterface::FilterCheckboxComponent.new(name: checkbox_config[:name],
-                                                                                  text: checkbox_config[:text],
-                                                                                  selected: checkbox_checked?(heading: filter_group[:heading], name: checkbox_config[:name]),
+                        <%= render ProviderInterface::FilterCheckboxComponent.new(name: input_config[:name],
+                                                                                  text: input_config[:text],
+                                                                                  selected: checkbox_checked?(heading: filter_group[:heading], name: input_config[:name]),
                                                                                   heading: filter_group[:heading].parameterize)
                          %>
                       </div>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -28,33 +28,28 @@
             <% available_filters.each do |filter_group| %>
                 <div class="govuk-form-group">
                   <fieldset class="govuk-fieldset">
-                    <% if filter_group[:heading].parameterize.eql?('candidate-s-name') %>
+
+                    <% if is_candidates_name_search_field?(filter_group) || form_group_fields_greater_than_one?(filter_group) %>
                       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                         <%= filter_group[:heading].capitalize %>
                       </legend>
-                    <% elsif filter_group[:input_config].size > 1 %>
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                          <%= filter_group[:heading].capitalize %>
-                        </legend>
                     <% end %>
 
                     <% filter_group[:input_config].each do |input_config| %>
-                      <% if input_config[:type].eql?('checkbox') %>
-                        <% if filter_group[:input_config].size > 1 %>
-                            <div class="govuk-checkboxes govuk-checkboxes--small">
-                              <%= render ProviderInterface::FilterCheckboxComponent.new(name: input_config[:name],
-                                                                                        text: input_config[:text],
-                                                                                        selected: checkbox_checked?(heading: filter_group[:heading],
-                                                                                                                    name: input_config[:name]),
-                                                                                        heading: filter_group[:heading].parameterize)
-                               %>
-                            </div>
-                        <% end %>
-                      <% elsif filter_group[:heading].parameterize.eql?('candidate-s-name')  %>
+                      <% if is_candidates_name_search_field?(filter_group) %>
                         <%= render ProviderInterface::FilterSearchComponent.new(name: input_config[:name],
                                                                                 type: input_config[:type],
                                                                                 heading: filter_group[:heading],
                                                                                 value: applied_filters.fetch(:search, {}).fetch(:candidates_name, "")) %>
+                      <% elsif form_group_fields_greater_than_one?(filter_group) %>
+                         <div class="govuk-checkboxes govuk-checkboxes--small">
+                           <%= render ProviderInterface::FilterCheckboxComponent.new(name: input_config[:name],
+                                                                                     text: input_config[:text],
+                                                                                     selected: checkbox_checked?(heading: filter_group[:heading],
+                                                                                                                 name: input_config[:name]),
+                                                                                     heading: filter_group[:heading].parameterize)
+                           %>
+                        </div>
                       <% end %>
                     <% end %>
                   </fieldset>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -44,7 +44,9 @@
                             </div>
                         <% end %>
                       <% elsif input_config[:type].eql?('search') %>
-                        <%= render ProviderInterface::FilterSearchComponent.new(name: input_config[:name], text: input_config[:text]) %>
+                        <%= render ProviderInterface::FilterSearchComponent.new(name: input_config[:name],
+                                                                                type: input_config[:type],
+                                                                                heading: filter_group[:heading]) %>
                       <% end %>
                     <% end %>
                   </fieldset>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -26,7 +26,6 @@
 
 
             <% available_filters.each do |filter_group| %>
-              <% unless filter_group[:input_config].size <= 1 %>
                 <div class="govuk-form-group">
                   <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
@@ -34,17 +33,22 @@
                     </legend>
 
                     <% filter_group[:input_config].each do |input_config| %>
-                      <div class="govuk-checkboxes govuk-checkboxes--small">
-                        <%= render ProviderInterface::FilterCheckboxComponent.new(name: input_config[:name],
-                                                                                  text: input_config[:text],
-                                                                                  selected: checkbox_checked?(heading: filter_group[:heading], name: input_config[:name]),
-                                                                                  heading: filter_group[:heading].parameterize)
-                         %>
-                      </div>
+                      <% if input_config[:type].eql?('checkbox') %>
+                        <% unless filter_group[:input_config].size <= 1 %>
+                            <div class="govuk-checkboxes govuk-checkboxes--small">
+                              <%= render ProviderInterface::FilterCheckboxComponent.new(name: input_config[:name],
+                                                                                        text: input_config[:text],
+                                                                                        selected: checkbox_checked?(heading: filter_group[:heading], name: input_config[:name]),
+                                                                                        heading: filter_group[:heading].parameterize)
+                               %>
+                            </div>
+                        <% end %>
+                      <% elsif input_config[:type].eql?('search') %>
+                        <%= render ProviderInterface::FilterSearchComponent.new(name: input_config[:name], text: input_config[:text]) %>
+                      <% end %>
                     <% end %>
                   </fieldset>
                 </div>
-            <% end %>
           <% end %>
           </form>
         </div>

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -28,22 +28,29 @@
             <% available_filters.each do |filter_group| %>
                 <div class="govuk-form-group">
                   <fieldset class="govuk-fieldset">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                      <%= filter_group[:heading].capitalize %>
-                    </legend>
+                    <% if filter_group[:heading].parameterize.eql?('candidate-s-name') %>
+                      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                        <%= filter_group[:heading].capitalize %>
+                      </legend>
+                    <% elsif filter_group[:input_config].size > 1 %>
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                          <%= filter_group[:heading].capitalize %>
+                        </legend>
+                    <% end %>
 
                     <% filter_group[:input_config].each do |input_config| %>
                       <% if input_config[:type].eql?('checkbox') %>
-                        <% unless filter_group[:input_config].size <= 1 %>
+                        <% if filter_group[:input_config].size > 1 %>
                             <div class="govuk-checkboxes govuk-checkboxes--small">
                               <%= render ProviderInterface::FilterCheckboxComponent.new(name: input_config[:name],
                                                                                         text: input_config[:text],
-                                                                                        selected: checkbox_checked?(heading: filter_group[:heading], name: input_config[:name]),
+                                                                                        selected: checkbox_checked?(heading: filter_group[:heading],
+                                                                                                                    name: input_config[:name]),
                                                                                         heading: filter_group[:heading].parameterize)
                                %>
                             </div>
                         <% end %>
-                      <% elsif input_config[:type].eql?('search') %>
+                      <% elsif filter_group[:heading].parameterize.eql?('candidate-s-name')  %>
                         <%= render ProviderInterface::FilterSearchComponent.new(name: input_config[:name],
                                                                                 type: input_config[:type],
                                                                                 heading: filter_group[:heading],

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -46,7 +46,8 @@
                       <% elsif input_config[:type].eql?('search') %>
                         <%= render ProviderInterface::FilterSearchComponent.new(name: input_config[:name],
                                                                                 type: input_config[:type],
-                                                                                heading: filter_group[:heading]) %>
+                                                                                heading: filter_group[:heading],
+                                                                                value: applied_filters.fetch(:search, {}).fetch(:candidates_name, "")) %>
                       <% end %>
                     <% end %>
                   </fieldset>

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -26,6 +26,5 @@ module ProviderInterface
     def form_group_fields_greater_than_one?(filter_group)
       filter_group[:input_config].size > 1
     end
-
   end
 end

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -18,5 +18,14 @@ module ProviderInterface
     def filtering_page_path(*args)
       send(@path, *args)
     end
+
+    def is_candidates_name_search_field?(filter_group)
+      filter_group[:heading].parameterize.eql?('candidate-s-name')
+    end
+
+    def form_group_fields_greater_than_one?(filter_group)
+      filter_group[:input_config].size > 1
+    end
+
   end
 end

--- a/app/components/provider_interface/filter_search_component.html.erb
+++ b/app/components/provider_interface/filter_search_component.html.erb
@@ -1,0 +1,1 @@
+<input class="govuk-input" id=<% name.parameterize %> name="keywords" type="text" value="">

--- a/app/components/provider_interface/filter_search_component.html.erb
+++ b/app/components/provider_interface/filter_search_component.html.erb
@@ -1,1 +1,1 @@
-<input class="govuk-input" id=<%= name.parameterize %> name=<%= "filter_selections[#{type}][#{name}]" %> type="text" >
+<input class="govuk-input" id=<%= name.parameterize %> name=<%= "filter_selections[#{type}][#{name}]" %> type="text" value="<%= value %>" >

--- a/app/components/provider_interface/filter_search_component.html.erb
+++ b/app/components/provider_interface/filter_search_component.html.erb
@@ -1,1 +1,1 @@
-<input class="govuk-input" id=<% name.parameterize %> name="keywords" type="text" value="">
+<input class="govuk-input" id=<%= name.parameterize %> name=<%= "filter_selections[#{type}][#{name}]" %> type="text" value="">

--- a/app/components/provider_interface/filter_search_component.html.erb
+++ b/app/components/provider_interface/filter_search_component.html.erb
@@ -1,1 +1,1 @@
-<input class="govuk-input" id=<%= name.parameterize %> name=<%= "filter_selections[#{type}][#{name}]" %> type="text" value="">
+<input class="govuk-input" id=<%= name.parameterize %> name=<%= "filter_selections[#{type}][#{name}]" %> type="text" >

--- a/app/components/provider_interface/filter_search_component.rb
+++ b/app/components/provider_interface/filter_search_component.rb
@@ -1,0 +1,12 @@
+module ProviderInterface
+  class FilterSearchComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :name, :text
+
+    def initialize(name:, text:)
+      @name = name
+      @text = text
+    end
+  end
+end

--- a/app/components/provider_interface/filter_search_component.rb
+++ b/app/components/provider_interface/filter_search_component.rb
@@ -2,12 +2,13 @@ module ProviderInterface
   class FilterSearchComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :name, :type, :heading
+    attr_reader :name, :type, :heading, :value
 
-    def initialize(name:, type:, heading:)
+    def initialize(name:, type:, heading:, value:)
       @name = name
       @type = type
       @heading = heading
+      @value = value
     end
   end
 end

--- a/app/components/provider_interface/filter_search_component.rb
+++ b/app/components/provider_interface/filter_search_component.rb
@@ -2,11 +2,12 @@ module ProviderInterface
   class FilterSearchComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :name, :text
+    attr_reader :name, :type, :heading
 
-    def initialize(name:, text:)
+    def initialize(name:, type:, heading:)
       @name = name
-      @text = text
+      @type = type
+      @heading = heading
     end
   end
 end

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -1,0 +1,19 @@
+module ProviderInterface
+  class SafeguardingDeclarationComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_reader :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def render?
+      application_form.disclose_disability? && disability_disclosure.present?
+    end
+
+    def disability_disclosure
+      @application_form.disability_disclosure
+    end
+  end
+end

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -36,7 +36,14 @@ module ProviderInterface
     end
 
     def calculate_filter_selections
-      filter_params[:filter_selections].to_h ||= {}
+      filter_selections = filter_params[:filter_selections].to_h ||= {}
+      remove_candiates_name_search_if_empty(filter_selections)
+    end
+
+    def remove_candiates_name_search_if_empty(filter_selections)
+      return filter_selections if filter_selections.empty?
+      filter_selections.delete(:search) if filter_selections.fetch(:search,{}).fetch(:candidates_name, "") == ""
+      filter_selections
     end
 
     def filter_params

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -136,7 +136,7 @@ module ProviderInterface
 
       provider_filters = {
         heading: 'provider',
-        input_config: input_config.uniq!,
+        input_config: input_config.uniq,
       }
 
       provider_filters

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -63,57 +63,57 @@ module ProviderInterface
             type: 'search',
             text: '',
             name: 'candidates_name',
-          }]
-        }
+          }],
+        },
       ]
     end
 
     def status_filters
-        {
-          heading: 'status',
-          input_config: [
-            {
-              type: 'checkbox',
-              text: 'Accepted',
-              name: 'pending_conditions',
-            },
-            {
-              type: 'checkbox',
-              text: 'Conditions met',
-              name: 'recruited',
-            },
-            {
-              type: 'checkbox',
-              text: 'Declined',
-              name: 'declined',
-            },
-            {
-              type: 'checkbox',
-              text: 'New',
-              name: 'awaiting_provider_decision',
-            },
-            {
-              type: 'checkbox',
-              text: 'Offered',
-              name: 'offer',
-            },
-            {
-              type: 'checkbox',
-              text: 'Rejected',
-              name: 'rejected',
-            },
-            {
-              type: 'checkbox',
-              text: 'Application withdrawn',
-              name: 'withdrawn',
-            },
-            {
-              type: 'checkbox',
-              text: 'Withdrawn by us',
-              name: 'offer_withdrawn',
-            },
-          ],
-        }
+      {
+        heading: 'status',
+        input_config: [
+          {
+            type: 'checkbox',
+            text: 'Accepted',
+            name: 'pending_conditions',
+          },
+          {
+            type: 'checkbox',
+            text: 'Conditions met',
+            name: 'recruited',
+          },
+          {
+            type: 'checkbox',
+            text: 'Declined',
+            name: 'declined',
+          },
+          {
+            type: 'checkbox',
+            text: 'New',
+            name: 'awaiting_provider_decision',
+          },
+          {
+            type: 'checkbox',
+            text: 'Offered',
+            name: 'offer',
+          },
+          {
+            type: 'checkbox',
+            text: 'Rejected',
+            name: 'rejected',
+          },
+          {
+            type: 'checkbox',
+            text: 'Application withdrawn',
+            name: 'withdrawn',
+          },
+          {
+            type: 'checkbox',
+            text: 'Withdrawn by us',
+            name: 'offer_withdrawn',
+          },
+        ],
+      }
     end
 
     def provider_filters_builder

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -55,11 +55,24 @@ module ProviderInterface
       status_filters << provider_filters_builder
     end
 
+    def search_filters
+      [
+        {
+          heading: 'candidate\'s name',
+          input_config: [{
+            type: 'search',
+            text: '',
+            name: 'candidates_name',
+          }]
+        }
+      ]
+    end
+
     def status_filters
       [
         {
           heading: 'status',
-          checkbox_config: [
+          input_config: [
             {
               text: 'Accepted',
               name: 'pending_conditions',
@@ -98,7 +111,7 @@ module ProviderInterface
     end
 
     def provider_filters_builder
-      checkbox_config = @application_choices.map do |choice|
+      input_config = @application_choices.map do |choice|
         provider = choice.provider
 
         {
@@ -109,7 +122,7 @@ module ProviderInterface
 
       provider_filters = {
         heading: 'provider',
-        checkbox_config: checkbox_config.uniq!,
+        input_config: input_config.uniq!,
       }
 
       provider_filters

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -42,7 +42,8 @@ module ProviderInterface
 
     def remove_candiates_name_search_if_empty(filter_selections)
       return filter_selections if filter_selections.empty?
-      filter_selections.delete(:search) if filter_selections.fetch(:search,{}).fetch(:candidates_name, "") == ""
+
+      filter_selections.delete(:search) if filter_selections.fetch(:search, {}).fetch(:candidates_name, '') == ''
       filter_selections
     end
 

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -52,7 +52,7 @@ module ProviderInterface
     end
 
     def calculate_available_filters
-      status_filters << provider_filters_builder
+      search_filters << status_filters << provider_filters_builder
     end
 
     def search_filters
@@ -69,45 +69,51 @@ module ProviderInterface
     end
 
     def status_filters
-      [
         {
           heading: 'status',
           input_config: [
             {
+              type: 'checkbox',
               text: 'Accepted',
               name: 'pending_conditions',
             },
             {
+              type: 'checkbox',
               text: 'Conditions met',
               name: 'recruited',
             },
             {
+              type: 'checkbox',
               text: 'Declined',
               name: 'declined',
             },
             {
+              type: 'checkbox',
               text: 'New',
               name: 'awaiting_provider_decision',
             },
             {
+              type: 'checkbox',
               text: 'Offered',
               name: 'offer',
             },
             {
+              type: 'checkbox',
               text: 'Rejected',
               name: 'rejected',
             },
             {
+              type: 'checkbox',
               text: 'Application withdrawn',
               name: 'withdrawn',
             },
             {
+              type: 'checkbox',
               text: 'Withdrawn by us',
               name: 'offer_withdrawn',
             },
           ],
-        },
-      ]
+        }
     end
 
     def provider_filters_builder
@@ -115,6 +121,7 @@ module ProviderInterface
         provider = choice.provider
 
         {
+          type: 'checkbox',
           text: provider.name,
           name: provider.id.to_s,
         }

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -43,7 +43,7 @@ module ProviderInterface
     def remove_candiates_name_search_if_empty(filter_selections)
       return filter_selections if filter_selections.empty?
 
-      filter_selections.delete(:search) if filter_selections.fetch(:search, {}).fetch(:candidates_name, '') == ''
+      filter_selections.delete(:search) if filter_selections.dig(:search, :candidates_name) == ''
       filter_selections
     end
 

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -40,7 +40,7 @@ module ProviderInterface
     end
 
     def filter_params
-      @params.permit(:filter_visible, filter_selections: { status: {}, provider: {} })
+      @params.permit(:filter_visible, filter_selections: { search: {}, status: {}, provider: {} })
     end
 
     def calculate_sort_order

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -27,7 +27,7 @@ class FilterApplicationChoicesForProviders
     end
 
     def search_exists?(filters)
-      filters.fetch(:search, {}).fetch(:candidates_name, "").empty? ? false : true
+      filters.fetch(:search, {}).fetch(:candidates_name, '').empty? ? false : true
     end
 
     def create_filter_query(application_choices, filters)
@@ -37,6 +37,5 @@ class FilterApplicationChoicesForProviders
       filtered_application_choices = status(filtered_application_choices, filters) if filters[:status]
       filtered_application_choices
     end
-
   end
 end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -9,7 +9,7 @@ class FilterApplicationChoicesForProviders
   private
 
     def prepare_search_array(search_terms)
-      search_terms.downcase.gsub(/\W /, '').split
+      search_terms.downcase.split.map { |name| "%#{name}%"}
     end
 
     def search(application_choices, candidates_name)

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -2,9 +2,7 @@ class FilterApplicationChoicesForProviders
   def self.call(application_choices:, filters:)
     return application_choices if filters.empty?
 
-    applied_filters = calculate_applied_filters(filters)
-
-    create_filter_query(application_choices, applied_filters, filters)
+    create_filter_query(application_choices, filters)
   end
 
   class << self
@@ -36,11 +34,11 @@ class FilterApplicationChoicesForProviders
       search_terms.downcase.gsub(/\W /, '').split
     end
 
-    def create_filter_query(application_choices, applied_filters, filters)
+    def create_filter_query(application_choices, filters)
       filtered_application_choices = application_choices
-      filtered_application_choices = search(filtered_application_choices) if search_exists?(filters)
-      filtered_application_choices = provider(filtered_application_choices) if filters[:provider]
-      filtered_application_choices = status(filtered_application_choices) if filters[:status]
+      filtered_application_choices = search(filtered_application_choices, filters) if search_exists?(filters)
+      filtered_application_choices = provider(filtered_application_choices, filters) if filters[:provider]
+      filtered_application_choices = status(filtered_application_choices, filters) if filters[:status]
       filtered_application_choices
     end
 

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -28,14 +28,6 @@ class FilterApplicationChoicesForProviders
       application_choices.where('courses.provider_id' => filters[:provider].keys)
     end
 
-    def calculate_applied_filters(filters)
-      search = search_exists?(filters)
-      status = filters[:status] ? true : false
-      provider = filters[:provider] ? true : false
-
-      [search, status, provider]
-    end
-
     def search_exists?(filters)
       filters.fetch(:search, {}).fetch(:candidates_name, "").empty? ? false : true
     end
@@ -45,46 +37,12 @@ class FilterApplicationChoicesForProviders
     end
 
     def create_filter_query(application_choices, applied_filters, filters)
-      candidates_name = filters[:search][:candidates_name] if search_exists?(filters)
-
-      case applied_filters
-      when options[:provider]
-        return provider(application_choices, filters)
-
-      when options[:status]
-        return status(application_choices, filters)
-
-      when options[:status_and_provider]
-        return provider(status(application_choices, filters), filters)
-
-      when options[:search]
-        return search(application_choices, candidates_name)
-
-      when options[:search_and_provider]
-        return provider(search(application_choices, candidates_name), filters)
-
-      when options[:search_and_status]
-        return search(status(application_choices, filters), candidates_name)
-
-      when options[:search_status_and_provider]
-        return provider(search(application_choices, candidates_name), filters)
-      else
-        return application_choices
-      end
+      filtered_application_choices = application_choices
+      filtered_application_choices = search(filtered_application_choices) if search_exists?(filters)
+      filtered_application_choices = provider(filtered_application_choices) if filters[:provider]
+      filtered_application_choices = status(filtered_application_choices) if filters[:status]
+      filtered_application_choices
     end
 
-    def options
-      # mirrors a three variable boolean truth table
-      # minus all false as this is caught by default
-      {
-        provider: [false, false, true],
-        status: [false, true, false],
-        status_and_provider: [false, true, true],
-        search: [true, false, false],
-        search_and_provider: [true, false, true],
-        search_and_status: [true, true, false],
-        search_status_and_provider: [true, true, true],
-      }
-    end
   end
 end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -2,7 +2,11 @@ class FilterApplicationChoicesForProviders
   def self.call(application_choices:, filters:)
     return application_choices if filters.empty?
 
-    if filters[:status] && filters[:provider]
+    if filters[:search]
+       search_array = prepare_search_array(filters[:search][:candidates_name])
+       application_choices.where("first_name ILIKE ANY (array[?])", search_array)
+         .or(application_choices.where("last_name ILIKE ANY (array[?])", search_array))
+    elsif filters[:status] && filters[:provider]
       application_choices.where(status: filters[:status].keys, 'courses.provider_id' => filters[:provider].keys)
     elsif filters[:status]
       application_choices.where(status: filters[:status].keys)
@@ -10,4 +14,10 @@ class FilterApplicationChoicesForProviders
       application_choices.where('courses.provider_id' => filters[:provider].keys)
     end
   end
+
+ def self.prepare_search_array(search_terms)
+   search_terms.downcase.gsub(/\W /, '').split
+ end
 end
+
+

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -30,13 +30,9 @@ class FilterApplicationChoicesForProviders
       filters.fetch(:search, {}).fetch(:candidates_name, "").empty? ? false : true
     end
 
-    def prepare_search_array(search_terms)
-      search_terms.downcase.gsub(/\W /, '').split
-    end
-
     def create_filter_query(application_choices, filters)
       filtered_application_choices = application_choices
-      filtered_application_choices = search(filtered_application_choices, filters) if search_exists?(filters)
+      filtered_application_choices = search(filtered_application_choices, filters[:search][:candidates_name]) if search_exists?(filters)
       filtered_application_choices = provider(filtered_application_choices, filters) if filters[:provider]
       filtered_application_choices = status(filtered_application_choices, filters) if filters[:status]
       filtered_application_choices

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -14,20 +14,6 @@ class FilterApplicationChoicesForProviders
       search_terms.downcase.gsub(/\W /, '').split
     end
 
-    def options
-      # mirrors a three variable boolean truth table
-      # minus all false as this is caught by default
-      {
-        provider: [false, false, true],
-        status: [false, true, false],
-        status_and_provider: [false, true, true],
-        search: [true, false, false],
-        search_and_provider: [true, false, true],
-        search_and_status: [true, true, false],
-        search_status_and_provider: [true, true, true],
-      }
-    end
-
     def search(application_choices, candidates_name)
       search_array = prepare_search_array(candidates_name)
       application_choices.where('first_name ILIKE ANY (array[?])', search_array)
@@ -52,6 +38,10 @@ class FilterApplicationChoicesForProviders
 
     def search_exists?(filters)
       filters.fetch(:search, {}).fetch(:candidates_name, "").empty? ? false : true
+    end
+
+    def prepare_search_array(search_terms)
+      search_terms.downcase.gsub(/\W /, '').split
     end
 
     def create_filter_query(application_choices, applied_filters, filters)
@@ -81,6 +71,20 @@ class FilterApplicationChoicesForProviders
       else
         return application_choices
       end
+    end
+
+    def options
+      # mirrors a three variable boolean truth table
+      # minus all false as this is caught by default
+      {
+        provider: [false, false, true],
+        status: [false, true, false],
+        status_and_provider: [false, true, true],
+        search: [true, false, false],
+        search_and_provider: [true, false, true],
+        search_and_status: [true, true, false],
+        search_status_and_provider: [true, true, true],
+      }
     end
   end
 end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -2,22 +2,87 @@ class FilterApplicationChoicesForProviders
   def self.call(application_choices:, filters:)
     return application_choices if filters.empty?
 
-    if filters[:search]
-       search_array = prepare_search_array(filters[:search][:candidates_name])
-       application_choices.where("first_name ILIKE ANY (array[?])", search_array)
-         .or(application_choices.where("last_name ILIKE ANY (array[?])", search_array))
-    elsif filters[:status] && filters[:provider]
-      application_choices.where(status: filters[:status].keys, 'courses.provider_id' => filters[:provider].keys)
-    elsif filters[:status]
-      application_choices.where(status: filters[:status].keys)
-    else
-      application_choices.where('courses.provider_id' => filters[:provider].keys)
-    end
+    applied_filters = calculate_applied_filters(filters)
+
+    create_filter_query(application_choices, applied_filters, filters)
   end
 
- def self.prepare_search_array(search_terms)
-   search_terms.downcase.gsub(/\W /, '').split
- end
+  class << self
+  private
+
+    def prepare_search_array(search_terms)
+      search_terms.downcase.gsub(/\W /, '').split
+    end
+
+    def options
+      # mirrors a three variable boolean truth table
+      # minus all false as this is caught by guard clause
+      {
+        provider: [false, false, true],
+        status: [false, true, false],
+        status_and_provider: [false, true, true],
+        search: [true, false, false],
+        search_and_provider: [true, false, true],
+        search_and_status: [true, true, false],
+        search_status_and_provider: [true, true, true],
+      }
+    end
+
+    def search(application_choices, candidates_name)
+      search_array = prepare_search_array(candidates_name)
+      application_choices.where('first_name ILIKE ANY (array[?])', search_array)
+        .or(application_choices.where('last_name ILIKE ANY (array[?])', search_array))
+    end
+
+    def status(application_choices, filters)
+      application_choices.where(status: filters[:status].keys)
+    end
+
+    def provider(application_choices, filters)
+      application_choices.where('courses.provider_id' => filters[:provider].keys)
+    end
+
+    def calculate_applied_filters(filters)
+      search = search_exists?(filters)
+      status = filters[:status] ? true : false
+      provider = filters[:provider] ? true : false
+
+      [search, status, provider]
+    end
+
+    def search_exists?(filters)
+      filters.fetch(:search, {}).fetch(:candidates_name, "").empty? ? false : true
+    end
+
+    def create_filter_query(application_choices, applied_filters, filters)
+      case applied_filters
+      when options[:provider]
+        return provider(application_choices, filters)
+
+      when options[:status]
+        return status(application_choices, filters)
+
+      when options[:status_and_provider]
+        return provider(status(application_choices, filters), filters)
+
+      when options[:search]
+        candidates_name = filters[:search][:candidates_name]
+        return search(application_choices, candidates_name)
+
+      when options[:search_and_provider]
+        candidates_name = filters[:search][:candidates_name]
+        return provider(search(application_choices, candidates_name), filters)
+
+      when options[:search_and_status]
+        candidates_name = filters[:search][:candidates_name]
+        return search(status(application_choices, filters), candidates_name)
+
+      when options[:search_status_and_provider]
+        candidates_name = filters[:search][:candidates_name]
+        return provider(search(application_choices, candidates_name), filters)
+      else
+        return application_choices
+      end
+    end
+  end
 end
-
-

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -8,14 +8,8 @@ class FilterApplicationChoicesForProviders
   class << self
   private
 
-    def prepare_search_array(search_terms)
-      search_terms.downcase.split.map { |name| "%#{name}%"}
-    end
-
     def search(application_choices, candidates_name)
-      search_array = prepare_search_array(candidates_name)
-      application_choices.where('first_name ILIKE ANY (array[?])', search_array)
-        .or(application_choices.where('last_name ILIKE ANY (array[?])', search_array))
+      application_choices.where("CONCAT(first_name, ' ', last_name) ILIKE ?", "%#{candidates_name}%")
     end
 
     def status(application_choices, filters)

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -16,7 +16,7 @@ class FilterApplicationChoicesForProviders
 
     def options
       # mirrors a three variable boolean truth table
-      # minus all false as this is caught by guard clause
+      # minus all false as this is caught by default
       {
         provider: [false, false, true],
         status: [false, true, false],
@@ -55,6 +55,8 @@ class FilterApplicationChoicesForProviders
     end
 
     def create_filter_query(application_choices, applied_filters, filters)
+      candidates_name = filters[:search][:candidates_name] if search_exists?(filters)
+
       case applied_filters
       when options[:provider]
         return provider(application_choices, filters)
@@ -66,19 +68,15 @@ class FilterApplicationChoicesForProviders
         return provider(status(application_choices, filters), filters)
 
       when options[:search]
-        candidates_name = filters[:search][:candidates_name]
         return search(application_choices, candidates_name)
 
       when options[:search_and_provider]
-        candidates_name = filters[:search][:candidates_name]
         return provider(search(application_choices, candidates_name), filters)
 
       when options[:search_and_status]
-        candidates_name = filters[:search][:candidates_name]
         return search(status(application_choices, filters), candidates_name)
 
       when options[:search_status_and_provider]
-        candidates_name = filters[:search][:candidates_name]
         return provider(search(application_choices, candidates_name), filters)
       else
         return application_choices

--- a/app/views/provider_interface/application_choices/_application_choices_table.html.erb
+++ b/app/views/provider_interface/application_choices/_application_choices_table.html.erb
@@ -1,0 +1,48 @@
+<table class='govuk-table'>
+   <thead class='govuk-table__head'>
+     <tr class='govuk-table__row'>
+        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
+                                                                         column_name: 'Name',
+                                                                         current_sort_by: @page_state.sort_by,
+                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                         params_for_current_state: @page_state.to_h) %>
+
+        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
+                                                                         column_name: 'Course',
+                                                                         current_sort_by: @page_state.sort_by,
+                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter',
+                                                                         params_for_current_state: @page_state.to_h) %>
+
+
+        <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
+
+        <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
+                                                                         column_name: 'Last updated',
+                                                                         current_sort_by: @page_state.sort_by,
+                                                                         css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
+                                                                         params_for_current_state: @page_state.to_h) %>
+      </tr>
+   </thead>
+
+   <tbody class='govuk-table__body'>
+    <% @application_choices.each do |application_choice| %>
+      <tr class='govuk-table__row'>
+        <th class='govuk-table__cell'>
+          <span class="govuk-caption-m govuk-!-font-size-16"><%= application_choice.application_form.support_reference %></span>
+          <%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %>
+        </th>
+       <td class='govuk-table__cell'>
+         <% if current_provider_user.providers.size > 1 %>
+           <span class='govuk-caption-m govuk-!-font-size-16'>
+             <%= application_choice.offered_course.provider.name %>
+           </span>
+         <% end %>
+
+         <%= application_choice.offered_course.name_and_code %>
+       </td>
+       <td class='govuk-table__cell'><%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %></td>
+       <td class='govuk-table__cell govuk-table__header--numeric'><%= application_choice.updated_at.to_s(:govuk_date_short_month) %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -19,6 +19,10 @@
         <div class='moj-scrollable-pane__wrapper'>
         <% if @application_choices.any? %>
           <%= render 'application_choices_table' %>
+        <% elsif @page_state.filter_selections.any? %>
+          <p class='govuk-body'>No applications for the selected filters.</p>
+        <% else %>
+          <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
         <% end %>
         </div>
       </div>
@@ -27,19 +31,12 @@
 
   <%= render(PaginatorComponent.new(scope: @application_choices)) %>
 
-  <% if @page_state.filter_selections.any? %>
-    <p class='govuk-body'>No applications for the selected filters.</p>
-  <% else %>
-    <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
-  <% end %>
 
 <% else %>
 
   <% if @application_choices.any? %>
     <%= render 'application_choices_table' %>
     <%= render(PaginatorComponent.new(scope: @application_choices)) %>
-  <% elsif @page_state.filter_selections.any? %>
-    <p class='govuk-body'>No applications for the selected filters.</p>
   <% else %>
     <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
   <% end %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -4,83 +4,45 @@
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <% if FeatureFlag.active?('provider_application_filters') %>
+  <div class='moj-filter-layout'>
+    <% if @page_state.filter_visible.eql?('true') %>
+      <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
+                                                        available_filters: @page_state.available_filters,
+                                                        applied_filters: @page_state.filter_selections,
+                                                        params_for_current_state: @page_state.to_h) %>
+    <% end %>
 
-<div class='moj-filter-layout'>
-  <% if @page_state.filter_visible.eql?('true') %>
-    <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
-                                                      available_filters: @page_state.available_filters,
-                                                      applied_filters: @page_state.filter_selections,
-                                                      params_for_current_state: @page_state.to_h) %>
-  <% end %>
-
-  <div class='moj-filter-layout__content'>
-    <%= render ProviderInterface::ToggleFilterComponent.new(filter_visible: @page_state.filter_visible,
-                                                            params_for_current_state: @page_state.to_h) %>
-    <div class='moj-scrollable-pane'>
-      <div class='moj-scrollable-pane__wrapper'>
-
-      <% end %>
-
-      <% if @application_choices.any? %>
-        <table class='govuk-table'>
-          <thead class='govuk-table__head'>
-            <tr class='govuk-table__row'>
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
-                                                                               column_name: 'Name',
-                                                                               current_sort_by: @page_state.sort_by,
-                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               params_for_current_state: @page_state.to_h) %>
-
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
-                                                                               column_name: 'Course',
-                                                                               current_sort_by: @page_state.sort_by,
-                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter',
-                                                                               params_for_current_state: @page_state.to_h) %>
-
-
-              <th scope='col' class='govuk-table__header govuk-!-width-one-quarter'>Status</th>
-
-              <%= render ProviderInterface::SortableColumnHeadingComponent.new(sort_order: @page_state.sort_order,
-                                                                               column_name: 'Last updated',
-                                                                               current_sort_by: @page_state.sort_by,
-                                                                               css_class: 'govuk-table__header govuk-!-width-one-quarter govuk-table__header--numeric',
-                                                                               params_for_current_state: @page_state.to_h) %>
-            </tr>
-          </thead>
-
-    <tbody class='govuk-table__body'>
-      <% @application_choices.each do |application_choice| %>
-        <tr class='govuk-table__row'>
-          <th class='govuk-table__cell'>
-            <span class="govuk-caption-m govuk-!-font-size-16"><%= application_choice.application_form.support_reference %></span>
-            <%= govuk_link_to application_choice.application_form.full_name, provider_interface_application_choice_path(application_choice) %>
-          </th>
-         <td class='govuk-table__cell'>
-           <% if current_provider_user.providers.size > 1 %>
-             <span class='govuk-caption-m govuk-!-font-size-16'>
-               <%= application_choice.offered_course.provider.name %>
-             </span>
-           <% end %>
-
-           <%= application_choice.offered_course.name_and_code %>
-         </td>
-         <td class='govuk-table__cell'><%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %></td>
-         <td class='govuk-table__cell govuk-table__header--numeric'><%= application_choice.updated_at.to_s(:govuk_date_short_month) %></td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
-
-<% if FeatureFlag.active?('provider_application_filters') %>
+    <div class='moj-filter-layout__content'>
+      <%= render ProviderInterface::ToggleFilterComponent.new(filter_visible: @page_state.filter_visible,
+                                                              params_for_current_state: @page_state.to_h) %>
+      <div class='moj-scrollable-pane'>
+        <div class='moj-scrollable-pane__wrapper'>
+        <% if @application_choices.any? %>
+          <%= render 'application_choices_table' %>
+        <% end %>
         </div>
       </div>
     </div>
   </div>
+
+  <%= render(PaginatorComponent.new(scope: @application_choices)) %>
+
+  <% if @page_state.filter_selections.any? %>
+    <p class='govuk-body'>No applications for the selected filters.</p>
+  <% else %>
+    <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
+  <% end %>
+
+<% else %>
+
+  <% if @application_choices.any? %>
+    <%= render 'application_choices_table' %>
+    <%= render(PaginatorComponent.new(scope: @application_choices)) %>
+  <% elsif @page_state.filter_selections.any? %>
+    <p class='govuk-body'>No applications for the selected filters.</p>
+  <% else %>
+    <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
+  <% end %>
+
 <% end %>
 
-<%= render(PaginatorComponent.new(scope: @application_choices)) %>
-<% elsif @page_state.filter_selections.any? %>
-     <p class='govuk-body'>No applications for the selected filters.</p>
-<% else %>
-  <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
-<% end %>

--- a/spec/components/provider_interface/current_filters_component_spec.rb
+++ b/spec/components/provider_interface/current_filters_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
     [
       {
         heading: 'status',
-        checkbox_config: [
+        input_config: [
           {
             name: 'pending-conditions',
             text: 'Accepted',
@@ -80,7 +80,7 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
       },
       {
         heading: 'provider',
-        checkbox_config: [
+        input_config: [
           {
             name: 'somerset-scitt-consortium',
             text: 'Somerset SCITT consortium',

--- a/spec/components/provider_interface/current_filters_component_spec.rb
+++ b/spec/components/provider_interface/current_filters_component_spec.rb
@@ -37,41 +37,49 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
         heading: 'status',
         input_config: [
           {
+            type: 'checkbox',
             name: 'pending-conditions',
             text: 'Accepted',
             value: 'pending_conditions',
           },
           {
+            type: 'checkbox',
             name: 'recruited',
             text: 'Conditions met',
             value: 'recruited',
           },
           {
+            type: 'checkbox',
             name: 'declined',
             text: 'Declined',
             value: 'declined',
           },
           {
+            type: 'checkbox',
             name: 'awaiting-provider-decision',
             text: 'New',
             value: 'awaiting_provider_decision',
           },
           {
+            type: 'checkbox',
             name: 'offer',
             text: 'Offered',
             value: 'offer',
           },
           {
+            type: 'checkbox',
             name: 'rejected',
             text: 'Rejected',
             value: 'rejected',
           },
           {
+            type: 'checkbox',
             name: 'withdrawn',
             text: 'Application withdrawn',
             value: 'withdrawn',
           },
           {
+            type: 'checkbox',
             name: 'offer-withdrawn',
             text: 'Withdrawn by us',
             value: 'offer_withdrawn',
@@ -82,11 +90,13 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
         heading: 'provider',
         input_config: [
           {
+            type: 'checkbox',
             name: 'somerset-scitt-consortium',
             text: 'Somerset SCITT consortium',
             value: '1',
           },
           {
+            type: 'checkbox',
             name: 'the-beach-teaching-school',
             text: 'The Beach Teaching School',
             value: '2',

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     [
       {
         heading: 'status',
-        checkbox_config: [
+        input_config: [
           {
             text: 'Accepted',
             name: 'pending_conditions',
@@ -72,7 +72,7 @@ RSpec.describe ProviderInterface::FilterComponent do
       },
       {
         heading: 'provider',
-        checkbox_config: [
+        input_config: [
           {
             text: 'Somerset SCITT consortium',
             name: '1',
@@ -91,7 +91,7 @@ RSpec.describe ProviderInterface::FilterComponent do
     [
       {
         heading: 'status',
-        checkbox_config: [
+        input_config: [
           {
             text: 'Accepted',
             name: 'pending_conditions',
@@ -104,7 +104,7 @@ RSpec.describe ProviderInterface::FilterComponent do
       },
       {
         heading: 'provider',
-        checkbox_config: [
+        input_config: [
           {
             text: 'Somerset SCITT consortium',
             name: '1',

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -37,34 +37,42 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'status',
         input_config: [
           {
+            type: 'checkbox',
             text: 'Accepted',
             name: 'pending_conditions',
           },
           {
+            type: 'checkbox',
             text: 'Conditions met',
             name: 'recruited',
           },
           {
+            type: 'checkbox',
             text: 'Declined',
             name: 'declined',
           },
           {
+            type: 'checkbox',
             text: 'New',
             name: 'awaiting_provider_decision',
           },
           {
+            type: 'checkbox',
             text: 'Offered',
             name: 'offer',
           },
           {
+            type: 'checkbox',
             text: 'Rejected',
             name: 'rejected',
           },
           {
+            type: 'checkbox',
             text: 'Application withdrawn',
             name: 'withdrawn',
           },
           {
+            type: 'checkbox',
             text: 'Withdrawn by us',
             name: 'offer_withdrawn',
           },
@@ -74,10 +82,12 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'provider',
         input_config: [
           {
+            type: 'checkbox',
             text: 'Somerset SCITT consortium',
             name: '1',
           },
           {
+            type: 'checkbox',
             text: 'The Beach Teaching School',
             name: '2',
           },
@@ -93,10 +103,12 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'status',
         input_config: [
           {
+            type: 'checkbox',
             text: 'Accepted',
             name: 'pending_conditions',
           },
           {
+            type: 'checkbox',
             text: 'Withdrawn by us',
             name: 'offer_withdrawn',
           },
@@ -106,6 +118,7 @@ RSpec.describe ProviderInterface::FilterComponent do
         heading: 'provider',
         input_config: [
           {
+            type: 'checkbox',
             text: 'Somerset SCITT consortium',
             name: '1',
           },

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -1,0 +1,210 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderApplicationsPageState do
+  let(:correct_available_filters) {
+        [{
+        :heading => "candidate's name",
+        :input_config => [{
+          :type => "search",
+          :text => "",
+          :name => "candidates_name"
+        }]
+      },
+      {
+        :heading => "status",
+        :input_config => [{
+           type: "checkbox",
+             text: "Accepted",
+             name: "pending_conditions"
+          },
+          {
+             type: "checkbox",
+             text: "Conditions met",
+             name: "recruited"
+          },
+          {
+             type: "checkbox",
+             text: "Declined",
+             name: "declined"
+          },
+          {
+             type: "checkbox",
+             text: "New",
+             name: "awaiting_provider_decision"
+          },
+          {
+             type: "checkbox",
+             text: "Offered",
+             name: "offer"
+          },
+          {
+             type: "checkbox",
+             text: "Rejected",
+             name: "rejected"
+          },
+          {
+             type: "checkbox",
+             text: "Application withdrawn",
+             name: "withdrawn"
+          },
+          {
+             type: "checkbox",
+             text: "Withdrawn by us",
+             name: "offer_withdrawn"
+          }
+        ]
+      },
+      {
+         heading: "provider",
+        input_config: [{
+           type: "checkbox",
+           text: "Gorse SCITT",
+           name: "1"
+        },
+        {
+           type: "checkbox",
+           text: "University of Chichester",
+           name: "4"
+        }
+        ]
+      }
+    ]
+  }
+
+  describe '#sort_order' do
+    it 'calculates correct sort order when params sort order is asc' do
+      params = ActionController::Parameters.new(sort_order: 'asc' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.sort_order).to eq('asc')
+    end
+
+    it 'calculates correct sort order when params sort order is desc' do
+      params = ActionController::Parameters.new(sort_order: 'desc' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.sort_order).to eq('desc')
+    end
+
+    it 'defaults to sort desc if not asc' do
+      params = ActionController::Parameters.new(sort_order: 'these are not the droids you\re looking for' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.sort_order).to eq('desc')
+    end
+  end
+
+  describe '#sort_by' do
+    it 'defaults to last-updated if not present' do
+      params = ActionController::Parameters.new
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.sort_by).to eq('last-updated')
+    end
+
+    it 'returns value if present' do
+      params = ActionController::Parameters.new(sort_by: 'name' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.sort_by).to eq('name')
+    end
+  end
+
+  describe '#filter_visible' do
+    it 'defaults to true if not present' do
+      params = ActionController::Parameters.new
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.filter_visible).to eq('true')
+    end
+
+    it 'returns value if present' do
+      params = ActionController::Parameters.new(filter_visible: 'false' )
+
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.filter_visible).to eq('false')
+    end
+  end
+
+  describe '#applications_ordering_query' do
+    it 'returns nil if "course", "updated", or "name" not presend as sort_by values' do
+      params = ActionController::Parameters.new(sort_by: 'something completely different' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.applications_ordering_query).to eq(nil)
+    end
+
+    it 'returns a sort order hash when user is sorting by course' do
+      params = ActionController::Parameters.new(sort_by: 'course', sort_order: 'desc' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.applications_ordering_query.keys.first).to eq('courses.name')
+      expect(state.applications_ordering_query['courses.name']).to eq('desc')
+    end
+
+    it 'returns a sort order hash when user is sorting by last-updated' do
+      params = ActionController::Parameters.new(sort_by: 'last-updated', sort_order: 'asc' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.applications_ordering_query.keys.first).to eq('application_choices.updated_at')
+      expect(state.applications_ordering_query['application_choices.updated_at']).to eq('asc')
+    end
+
+    it 'returns a sort order hash when user is sorting by name' do
+      params = ActionController::Parameters.new(sort_by: 'name', sort_order: 'asc' )
+      state = described_class.new(params: params, application_choices: {})
+
+      expect(state.applications_ordering_query.keys.first).to eq('last_name')
+      expect(state.applications_ordering_query.keys.last).to eq('first_name')
+      expect(state.applications_ordering_query['last_name']).to eq('asc')
+      expect(state.applications_ordering_query['first_name']).to eq('asc')
+    end
+  end
+
+  describe '#available_filters' do
+    it 'calculate the correct available_filters' do
+      active_record_relation_stub = double(provider:  double(Provider, id: "1", name:'Gorse SCITT'))
+      active_record_relation_stub_two = double(provider: double(Provider, id: "1", name:'Gorse SCITT'))
+
+      params = ActionController::Parameters.new
+      state = described_class.new(params: params, application_choices: [active_record_relation_stub,
+                                                                        active_record_relation_stub_two])
+
+      expect(state.available_filters).to eq(correct_available_filters)
+    end
+  end
+
+  describe '#filter_selections' do
+    it 'returns correct hash if values are present' do
+      filter_selections = {filter_selections: {"search"=>{"candidates_name"=>"Ellamae Kunze"},
+                                              "status"=>{"recruited"=>"on", "declined"=>"on"},
+                                              "provider"=>{"1"=>"on"}}}
+
+
+      params = ActionController::Parameters.new(filter_selections)
+      state = described_class.new(params: params, application_choices: {})
+      expect(state.filter_selections).to eq(filter_selections[:filter_selections])
+    end
+
+    it 'will return an empty hash if there are no filters selected' do
+      filter_selections = {filter_selections: {"search"=>{"candidates_name"=>""}}}
+
+
+      params = ActionController::Parameters.new(filter_selections)
+      state = described_class.new(params: params, application_choices: {})
+      expect(state.filter_selections).to eq({})
+    end
+
+    it 'will remove candidates_name field if empty (i.e. "")' do
+      filter_selections = {filter_selections: {"search"=>{"candidates_name"=>""},
+                                              "status"=>{"recruited"=>"on", "declined"=>"on"},
+                                              "provider"=>{"1"=>"on"}}}
+
+
+      params = ActionController::Parameters.new(filter_selections)
+      state = described_class.new(params: params, application_choices: {})
+      expect(state.filter_selections).to eq(filter_selections[:filter_selections].except('search'))
+    end
+  end
+end

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -2,92 +2,89 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderApplicationsPageState do
   let(:correct_available_filters) {
-        [{
-        :heading => "candidate's name",
-        :input_config => [{
-          :type => "search",
-          :text => "",
-          :name => "candidates_name"
-        }]
-      },
-      {
-        :heading => "status",
-        :input_config => [{
-           type: "checkbox",
-             text: "Accepted",
-             name: "pending_conditions"
-          },
-          {
-             type: "checkbox",
-             text: "Conditions met",
-             name: "recruited"
-          },
-          {
-             type: "checkbox",
-             text: "Declined",
-             name: "declined"
-          },
-          {
-             type: "checkbox",
-             text: "New",
-             name: "awaiting_provider_decision"
-          },
-          {
-             type: "checkbox",
-             text: "Offered",
-             name: "offer"
-          },
-          {
-             type: "checkbox",
-             text: "Rejected",
-             name: "rejected"
-          },
-          {
-             type: "checkbox",
-             text: "Application withdrawn",
-             name: "withdrawn"
-          },
-          {
-             type: "checkbox",
-             text: "Withdrawn by us",
-             name: "offer_withdrawn"
-          }
-        ]
-      },
-      {
-         heading: "provider",
-        input_config: [{
-           type: "checkbox",
-           text: "Gorse SCITT",
-           name: "1"
-        },
-        {
-           type: "checkbox",
-           text: "University of Chichester",
-           name: "4"
-        }
-        ]
-      }
-    ]
+    [{
+    heading: "candidate's name",
+    input_config: [{
+      type: 'search',
+      text: '',
+      name: 'candidates_name',
+    }],
+  },
+     {
+       heading: 'status',
+       input_config: [{
+          type: 'checkbox',
+            text: 'Accepted',
+            name: 'pending_conditions',
+         },
+                      {
+                         type: 'checkbox',
+                         text: 'Conditions met',
+                         name: 'recruited',
+                      },
+                      {
+                         type: 'checkbox',
+                         text: 'Declined',
+                         name: 'declined',
+                      },
+                      {
+                         type: 'checkbox',
+                         text: 'New',
+                         name: 'awaiting_provider_decision',
+                      },
+                      {
+                         type: 'checkbox',
+                         text: 'Offered',
+                         name: 'offer',
+                      },
+                      {
+                         type: 'checkbox',
+                         text: 'Rejected',
+                         name: 'rejected',
+                      },
+                      {
+                         type: 'checkbox',
+                         text: 'Application withdrawn',
+                         name: 'withdrawn',
+                      },
+                      {
+                         type: 'checkbox',
+                         text: 'Withdrawn by us',
+                         name: 'offer_withdrawn',
+                      }],
+     },
+     {
+        heading: 'provider',
+       input_config: [{
+          type: 'checkbox',
+          text: 'Gorse SCITT',
+          name: '1',
+       },
+                      {
+                         type: 'checkbox',
+                         text: 'University of Chichester',
+                         name: '4',
+                      }],
+     }]
   }
 
   describe '#sort_order' do
     it 'calculates correct sort order when params sort order is asc' do
-      params = ActionController::Parameters.new(sort_order: 'asc' )
+      params = ActionController::Parameters.new(sort_order: 'asc')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.sort_order).to eq('asc')
     end
 
     it 'calculates correct sort order when params sort order is desc' do
-      params = ActionController::Parameters.new(sort_order: 'desc' )
+      params = ActionController::Parameters.new(sort_order: 'desc')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.sort_order).to eq('desc')
     end
 
     it 'defaults to sort desc if not asc' do
-      params = ActionController::Parameters.new(sort_order: 'these are not the droids you\re looking for' )
+      params = ActionController::Parameters.new(sort_order: 'these are not the droids you\re looking for')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.sort_order).to eq('desc')
@@ -103,7 +100,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'returns value if present' do
-      params = ActionController::Parameters.new(sort_by: 'name' )
+      params = ActionController::Parameters.new(sort_by: 'name')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.sort_by).to eq('name')
@@ -119,7 +116,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'returns value if present' do
-      params = ActionController::Parameters.new(filter_visible: 'false' )
+      params = ActionController::Parameters.new(filter_visible: 'false')
 
       state = described_class.new(params: params, application_choices: {})
 
@@ -129,14 +126,14 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
   describe '#applications_ordering_query' do
     it 'returns nil if "course", "updated", or "name" not presend as sort_by values' do
-      params = ActionController::Parameters.new(sort_by: 'something completely different' )
+      params = ActionController::Parameters.new(sort_by: 'something completely different')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.applications_ordering_query).to eq(nil)
     end
 
     it 'returns a sort order hash when user is sorting by course' do
-      params = ActionController::Parameters.new(sort_by: 'course', sort_order: 'desc' )
+      params = ActionController::Parameters.new(sort_by: 'course', sort_order: 'desc')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.applications_ordering_query.keys.first).to eq('courses.name')
@@ -144,7 +141,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'returns a sort order hash when user is sorting by last-updated' do
-      params = ActionController::Parameters.new(sort_by: 'last-updated', sort_order: 'asc' )
+      params = ActionController::Parameters.new(sort_by: 'last-updated', sort_order: 'asc')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.applications_ordering_query.keys.first).to eq('application_choices.updated_at')
@@ -152,7 +149,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'returns a sort order hash when user is sorting by name' do
-      params = ActionController::Parameters.new(sort_by: 'name', sort_order: 'asc' )
+      params = ActionController::Parameters.new(sort_by: 'name', sort_order: 'asc')
       state = described_class.new(params: params, application_choices: {})
 
       expect(state.applications_ordering_query.keys.first).to eq('last_name')
@@ -164,12 +161,14 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
   describe '#available_filters' do
     it 'calculate the correct available_filters' do
-      active_record_relation_stub = double(provider:  double(Provider, id: "1", name:'Gorse SCITT'))
-      active_record_relation_stub_two = double(provider: double(Provider, id: "1", name:'Gorse SCITT'))
+      provider = instance_double(Provider, id: '1', name: 'Gorse SCITT')
+      provider_two = instance_double(Provider, id: '4', name: 'University of Chichester')
+
+      active_record_relation_stub = instance_double(ApplicationChoice, provider: provider)
+      active_record_relation_stub_two = instance_double(ApplicationChoice, provider: provider_two)
 
       params = ActionController::Parameters.new
-      state = described_class.new(params: params, application_choices: [active_record_relation_stub,
-                                                                        active_record_relation_stub_two])
+      state = described_class.new(params: params, application_choices: [active_record_relation_stub, active_record_relation_stub_two])
 
       expect(state.available_filters).to eq(correct_available_filters)
     end
@@ -177,9 +176,9 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
   describe '#filter_selections' do
     it 'returns correct hash if values are present' do
-      filter_selections = {filter_selections: {"search"=>{"candidates_name"=>"Ellamae Kunze"},
-                                              "status"=>{"recruited"=>"on", "declined"=>"on"},
-                                              "provider"=>{"1"=>"on"}}}
+      filter_selections = { filter_selections: { 'search' => { 'candidates_name' => 'Ellamae Kunze' },
+                                              'status' => { 'recruited' => 'on', 'declined' => 'on' },
+                                              'provider' => { '1' => 'on' } } }
 
 
       params = ActionController::Parameters.new(filter_selections)
@@ -188,7 +187,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'will return an empty hash if there are no filters selected' do
-      filter_selections = {filter_selections: {"search"=>{"candidates_name"=>""}}}
+      filter_selections = { filter_selections: { 'search' => { 'candidates_name' => '' } } }
 
 
       params = ActionController::Parameters.new(filter_selections)
@@ -197,9 +196,9 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'will remove candidates_name field if empty (i.e. "")' do
-      filter_selections = {filter_selections: {"search"=>{"candidates_name"=>""},
-                                              "status"=>{"recruited"=>"on", "declined"=>"on"},
-                                              "provider"=>{"1"=>"on"}}}
+      filter_selections = { filter_selections: { 'search' => { 'candidates_name' => '' },
+                                              'status' => { 'recruited' => 'on', 'declined' => 'on' },
+                                              'provider' => { '1' => 'on' } } }
 
 
       params = ActionController::Parameters.new(filter_selections)

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -1,0 +1,228 @@
+require 'rails_helper'
+
+RSpec.feature 'Providers should be able to filter applications' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'can filter applications by status and provider' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_provider_application_filters_are_active
+    and_i_am_permitted_to_see_applications_from_multiple_providers
+    and_my_organisation_has_courses_with_applications
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_page
+
+    then_i_expect_to_see_the_hide_filter_button
+    then_i_expect_to_see_the_filter_dialogue
+
+    when_i_search_for_candidate_name
+    then_only_applications_of_that_name_should_be_visible
+
+    when_i_search_for_candidate_name_with_odd_casing
+    then_only_applications_of_that_name_should_be_visible
+
+    when_i_filter_for_rejected_and_offered_applications
+    then_i_search_for_candidate_name
+    then_only_rejected_and_offered_applications_of_that_name_should_be_visible
+
+
+    when_i_clear_the_filters
+    then_i_expect_all_applications_to_be_visible
+
+    when_i_search_for_a_candidate_that_does_not_exist
+    then_i_should_see_the_no_filter_results_error_message
+
+    when_i_clear_the_filters
+    then_i_expect_all_applications_to_be_visible
+
+    when_i_filter_by_provider
+    then_i_search_for_candidate_name
+    then_only_applications_of_that_name_and_status_should_be_visible
+    then_the_relevant_tag_headings_shpuld_be_visible
+    and_the_relevant_tags_should_be_visible
+
+    and_provider_application_filters_are_deactivated
+
+    when_i_visit_the_provider_page
+    then_i_do_not_expect_to_see_the_filter_dialogue
+  end
+
+  def when_i_visit_the_provider_page
+    visit provider_interface_path
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def then_i_expect_to_see_the_hide_filter_button
+    expect(page).to have_content('Hide filter')
+  end
+
+  def then_i_expect_to_see_the_filter_dialogue
+    expect(page).to have_button('Apply filters')
+  end
+
+  def when_i_clear_the_filters
+    click_link('Clear')
+  end
+
+  def then_i_expect_all_applications_to_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).to have_css('.govuk-table__body', text: 'Offer')
+    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
+    expect(page).to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def and_provider_application_filters_are_active
+    FeatureFlag.activate('provider_application_filters')
+  end
+
+  def and_provider_application_filters_are_deactivated
+    FeatureFlag.deactivate('provider_application_filters')
+  end
+
+  def then_i_do_not_expect_to_see_the_filter_dialogue
+    expect(page).not_to have_button('Apply filters')
+  end
+
+  def and_i_am_permitted_to_see_applications_from_multiple_providers
+    provider_user_exists_in_apply_database_with_multiple_providers
+  end
+
+  def and_my_organisation_has_courses_with_applications
+    current_provider = create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training')
+    second_provider = create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University')
+    third_provider = create(:provider, :with_signed_agreement, code: 'GHI', name: 'University of Arrakis')
+
+    course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
+    course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
+    course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+
+    course_option_four = course_option_for_provider(provider: second_provider, course: create(:course, name: 'Science', provider: second_provider))
+    course_option_five = course_option_for_provider(provider: second_provider, course: create(:course, name: 'History', provider: second_provider))
+
+    course_option_six = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Maths', provider: third_provider))
+    course_option_seven = course_option_for_provider(provider: third_provider, course: create(:course, name: 'Engineering', provider: third_provider))
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
+           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           create(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'rejected', application_form:
+           create(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
+           create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_four, status: 'offer', application_form:
+           create(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_five, status: 'rejected', application_form:
+           create(:application_form, first_name: 'Paul', last_name: 'Atreides'), updated_at: 5.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_six, status: 'withdrawn', application_form:
+           create(:application_form, first_name: 'Duncan', last_name: 'Idaho'), updated_at: 6.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_seven, status: 'declined', application_form:
+           create(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
+  end
+
+  def then_i_should_see_the_no_filter_results_error_message
+    expect(page).to have_content('No applications for the selected filters.')
+  end
+
+  def when_i_filter_by_provider
+    find(:css, '#provider-hoth-teacher-training').set(true)
+    find(:css, '#provider-caladan-university').set(true)
+    click_button('Apply filters')
+  end
+
+  def then_i_expect_to_see_the_hide_filter_button
+    expect(page).to have_content('Hide filter')
+  end
+
+  def then_i_expect_to_see_the_filter_dialogue
+    expect(page).to have_button('Apply filters')
+  end
+
+  def when_i_filter_by_provider
+    find(:css, '#provider-hoth-teacher-training').set(true)
+    find(:css, '#provider-caladan-university').set(true)
+    click_button('Apply filters')
+  end
+
+
+
+#--------------------
+  def then_only_rejected_applications_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Offer')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def then_only_rejected_and_offered_applications_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).to have_css('.govuk-table__body', text: 'Offer')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def when_i_filter_for_rejected_applications
+    find(:css, '#status-rejected').set(true)
+    click_button('Apply filters')
+  end
+
+  def and_the_rejected_tickbox_should_still_be_checked
+    rejected_checkbox = find(:css, '#status-rejected')
+    expect(rejected_checkbox.checked?).to be(true)
+  end
+
+  def then_i_only_see_applications_for_a_given_provider
+    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
+    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
+  end
+
+  def then_i_expect_the_relevant_provider_tags_to_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.moj-filter-tags', text: 'Caladan University')
+  end
+
+  def when_i_click_to_remove_a_tag
+    click_link('Hoth Teacher Training')
+  end
+
+  def then_i_expect_that_tag_not_to_be_visible
+    expect(page).not_to have_css('.moj-filter-tags', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.moj-filter-tags', text: 'Caladan University')
+  end
+
+  def and_the_remaining_filters_to_still_apply
+    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
+  end
+
+  def and_a_rejected_tag_should_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: 'Rejected')
+  end
+#--------------------%%%
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+end

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -24,6 +24,10 @@ RSpec.feature 'Providers should be able to filter applications' do
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible
 
+    when_i_search_for_part_of_a_candidate_name
+    then_only_applications_of_that_name_should_be_visible
+    and_the_part_of_the_name_should_appear_in_search_field
+
     when_i_search_for_candidate_name_with_odd_casing
     then_only_applications_of_that_name_should_be_visible
 
@@ -54,6 +58,16 @@ RSpec.feature 'Providers should be able to filter applications' do
     when_i_visit_the_provider_page
     then_i_do_not_expect_to_see_the_filter_dialogue
   end
+
+  def when_i_search_for_part_of_a_candidate_name
+    find(:css, '#candidates_name').set('ame')
+    click_button('Apply filters')
+  end
+
+  def and_the_part_of_the_name_should_appear_in_search_field
+    expect(page).to have_field('filter_selections[search][candidates_name]', with: 'ame')
+  end
+
 
   def and_the_name_should_appear_in_search_field
     expect(page).to have_field('filter_selections[search][candidates_name]', with: 'Jim James')

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -17,13 +17,14 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_expect_to_see_the_filter_dialogue
     then_i_expect_to_see_the_search_input
 
-    #
-    # when_i_search_for_candidate_name
-    # then_only_applications_of_that_name_should_be_visible
-    #
-    # when_i_search_for_candidate_name_with_odd_casing
-    # then_only_applications_of_that_name_should_be_visible
-    #
+    when_i_search_for_candidate_name
+
+    then_only_applications_of_that_name_should_be_visible
+
+    when_i_clear_the_filters
+    when_i_search_for_candidate_name_with_odd_casing
+    then_only_applications_of_that_name_should_be_visible
+
     # when_i_filter_for_rejected_and_offered_applications
     # then_i_search_for_candidate_name
     # then_only_rejected_and_offered_applications_of_that_name_should_be_visible
@@ -48,6 +49,27 @@ RSpec.feature 'Providers should be able to filter applications' do
     #
     # when_i_visit_the_provider_page
     # then_i_do_not_expect_to_see_the_filter_dialogue
+  end
+
+  def when_i_search_for_candidate_name
+    find(:css, '#candidates_name').set('Jim James')
+    click_button('Apply filters')
+  end
+
+  def when_i_search_for_candidate_name_with_odd_casing
+    find(:css, '#candidates_name').set('jiM JAmeS')
+    click_button('Apply filters')
+  end
+
+  def then_only_applications_of_that_name_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Jim James')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Adam Jones')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Tom Jones')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Bill Bones')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Greg Taft')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Paul Atreides')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Duncan Idaho')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Luke Smith')
   end
 
   def then_i_expect_to_see_the_search_input

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -43,13 +43,14 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     then_i_search_for_candidate_name
     then_only_applications_of_that_name_and_provider_should_be_visible
-    # then_the_relevant_tag_headings_shpuld_be_visible
-    # and_the_relevant_tags_should_be_visible
-    #
-    # and_provider_application_filters_are_deactivated
-    #
-    # when_i_visit_the_provider_page
-    # then_i_do_not_expect_to_see_the_filter_dialogue
+    then_the_relevant_tag_headings_should_be_visible
+
+    and_the_relevant_tags_should_be_visible
+
+    and_provider_application_filters_are_deactivated
+
+    when_i_visit_the_provider_page
+    then_i_do_not_expect_to_see_the_filter_dialogue
   end
 
   def then_only_withdrawn_and_offered_applications_should_be_visible
@@ -57,6 +58,17 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_css('.govuk-table__body', text: 'Offered')
     expect(page).not_to have_css('.govuk-table__body', text: 'Rejected')
     expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def and_the_relevant_tags_should_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: 'Jim James')
+    then_i_expect_the_relevant_provider_tags_to_be_visible
+  end
+
+  def then_the_relevant_tag_headings_should_be_visible
+    expect(page).to have_css('.moj-filter__selected', text: 'Search')
+    expect(page).to have_css('.moj-filter__selected', text: 'Provider')
+
   end
 
   def then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -258,60 +258,8 @@ RSpec.feature 'Providers should be able to filter applications' do
     click_button('Apply filters')
   end
 
-  def then_i_expect_to_see_the_hide_filter_button
-    expect(page).to have_content('Hide filter')
-  end
-
-  def then_i_expect_to_see_the_filter_dialogue
-    expect(page).to have_button('Apply filters')
-  end
-
-  def when_i_filter_by_provider
-    find(:css, '#provider-hoth-teacher-training').set(true)
-    find(:css, '#provider-caladan-university').set(true)
-    click_button('Apply filters')
-  end
-
-
-
-#--------------------
-
-  def when_i_filter_for_rejected_applications
-    find(:css, '#status-rejected').set(true)
-    click_button('Apply filters')
-  end
-
-  def and_the_rejected_tickbox_should_still_be_checked
-    rejected_checkbox = find(:css, '#status-rejected')
-    expect(rejected_checkbox.checked?).to be(true)
-  end
-
-  def then_i_only_see_applications_for_a_given_provider
-    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
-    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
-    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
-  end
-
   def then_i_expect_the_relevant_provider_tags_to_be_visible
     expect(page).to have_css('.moj-filter-tags', text: 'Hoth Teacher Training')
     expect(page).to have_css('.moj-filter-tags', text: 'Caladan University')
   end
-
-  def when_i_click_to_remove_a_tag
-    click_link('Hoth Teacher Training')
-  end
-
-  def then_i_expect_that_tag_not_to_be_visible
-    expect(page).not_to have_css('.moj-filter-tags', text: 'Hoth Teacher Training')
-    expect(page).to have_css('.moj-filter-tags', text: 'Caladan University')
-  end
-
-  def and_the_remaining_filters_to_still_apply
-    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
-  end
-
-  def and_a_rejected_tag_should_be_visible
-    expect(page).to have_css('.moj-filter-tags', text: 'Rejected')
-  end
-#--------------------%%%
 end

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_the_relevant_tag_headings_should_be_visible
-    expect(page).to have_css('.moj-filter__selected', text: 'Search')
+    expect(page).to have_css('.moj-filter__selected', text: 'Candidate\'s name')
     expect(page).to have_css('.moj-filter__selected', text: 'Provider')
 
   end

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -78,7 +78,6 @@ RSpec.feature 'Providers should be able to filter applications' do
   def then_the_relevant_tag_headings_should_be_visible
     expect(page).to have_css('.moj-filter__selected', text: 'Candidate\'s name')
     expect(page).to have_css('.moj-filter__selected', text: 'Provider')
-
   end
 
   def then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -18,11 +18,11 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_expect_to_see_the_search_input
 
     when_i_search_for_candidate_name
-
     then_only_applications_of_that_name_should_be_visible
 
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible
+
     when_i_search_for_candidate_name_with_odd_casing
     then_only_applications_of_that_name_should_be_visible
 
@@ -36,13 +36,13 @@ RSpec.feature 'Providers should be able to filter applications' do
     when_i_search_for_a_candidate_that_does_not_exist
     then_i_should_see_the_no_filter_results_error_message
 
-    #
-    # when_i_clear_the_filters
-    # then_i_expect_all_applications_to_be_visible
-    #
-    # when_i_filter_by_provider
-    # then_i_search_for_candidate_name
-    # then_only_applications_of_that_name_and_status_should_be_visible
+    when_i_clear_the_filters
+
+    when_i_filter_by_provider
+    then_i_only_see_applications_for_a_given_provider
+
+    then_i_search_for_candidate_name
+    then_only_applications_of_that_name_and_provider_should_be_visible
     # then_the_relevant_tag_headings_shpuld_be_visible
     # and_the_relevant_tags_should_be_visible
     #
@@ -68,6 +68,19 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_css('.govuk-table__body', text: 'Offered')
     expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
     expect(page).to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def then_i_only_see_applications_for_a_given_provider
+    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
+    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
+  end
+
+  def then_only_applications_of_that_name_and_provider_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Caladan University')
+    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
+    then_only_applications_of_that_name_should_be_visible
   end
 
   def when_i_search_for_candidate_name

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -68,7 +68,6 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_field('filter_selections[search][candidates_name]', with: 'ame')
   end
 
-
   def and_the_name_should_appear_in_search_field
     expect(page).to have_field('filter_selections[search][candidates_name]', with: 'Jim James')
   end

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -15,37 +15,43 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     then_i_expect_to_see_the_hide_filter_button
     then_i_expect_to_see_the_filter_dialogue
+    then_i_expect_to_see_the_search_input
 
-    when_i_search_for_candidate_name
-    then_only_applications_of_that_name_should_be_visible
+    #
+    # when_i_search_for_candidate_name
+    # then_only_applications_of_that_name_should_be_visible
+    #
+    # when_i_search_for_candidate_name_with_odd_casing
+    # then_only_applications_of_that_name_should_be_visible
+    #
+    # when_i_filter_for_rejected_and_offered_applications
+    # then_i_search_for_candidate_name
+    # then_only_rejected_and_offered_applications_of_that_name_should_be_visible
+    #
+    #
+    # when_i_clear_the_filters
+    # then_i_expect_all_applications_to_be_visible
+    #
+    # when_i_search_for_a_candidate_that_does_not_exist
+    # then_i_should_see_the_no_filter_results_error_message
+    #
+    # when_i_clear_the_filters
+    # then_i_expect_all_applications_to_be_visible
+    #
+    # when_i_filter_by_provider
+    # then_i_search_for_candidate_name
+    # then_only_applications_of_that_name_and_status_should_be_visible
+    # then_the_relevant_tag_headings_shpuld_be_visible
+    # and_the_relevant_tags_should_be_visible
+    #
+    # and_provider_application_filters_are_deactivated
+    #
+    # when_i_visit_the_provider_page
+    # then_i_do_not_expect_to_see_the_filter_dialogue
+  end
 
-    when_i_search_for_candidate_name_with_odd_casing
-    then_only_applications_of_that_name_should_be_visible
-
-    when_i_filter_for_rejected_and_offered_applications
-    then_i_search_for_candidate_name
-    then_only_rejected_and_offered_applications_of_that_name_should_be_visible
-
-
-    when_i_clear_the_filters
-    then_i_expect_all_applications_to_be_visible
-
-    when_i_search_for_a_candidate_that_does_not_exist
-    then_i_should_see_the_no_filter_results_error_message
-
-    when_i_clear_the_filters
-    then_i_expect_all_applications_to_be_visible
-
-    when_i_filter_by_provider
-    then_i_search_for_candidate_name
-    then_only_applications_of_that_name_and_status_should_be_visible
-    then_the_relevant_tag_headings_shpuld_be_visible
-    and_the_relevant_tags_should_be_visible
-
-    and_provider_application_filters_are_deactivated
-
-    when_i_visit_the_provider_page
-    then_i_do_not_expect_to_see_the_filter_dialogue
+  def then_i_expect_to_see_the_search_input
+    expect(page).to have_content('Candidate\'s name')
   end
 
   def when_i_visit_the_provider_page

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -31,13 +31,11 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_only_withdrawn_and_offered_applications_should_be_visible
     then_i_search_for_candidate_name
     then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible
-    #
-    #
-    # when_i_clear_the_filters
-    # then_i_expect_all_applications_to_be_visible
-    #
-    # when_i_search_for_a_candidate_that_does_not_exist
-    # then_i_should_see_the_no_filter_results_error_message
+
+    when_i_clear_the_filters
+    when_i_search_for_a_candidate_that_does_not_exist
+    then_i_should_see_the_no_filter_results_error_message
+
     #
     # when_i_clear_the_filters
     # then_i_expect_all_applications_to_be_visible
@@ -74,6 +72,11 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def when_i_search_for_candidate_name
     find(:css, '#candidates_name').set('Jim James')
+    click_button('Apply filters')
+  end
+
+  def when_i_search_for_a_candidate_that_does_not_exist
+    find(:css, '#candidates_name').set('Simon Says')
     click_button('Apply filters')
   end
 

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -40,6 +40,7 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_filter_by_provider
     then_i_only_see_applications_for_a_given_provider
+    and_candidates_name_tags_should_not_be_visible
 
     then_i_search_for_candidate_name
     then_only_applications_of_that_name_and_provider_should_be_visible
@@ -51,6 +52,10 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_visit_the_provider_page
     then_i_do_not_expect_to_see_the_filter_dialogue
+  end
+
+  def and_candidates_name_tags_should_not_be_visible
+    expect(page).not_to have_css('.moj-filter__selected', text: 'Candidate\'s name')
   end
 
   def then_only_withdrawn_and_offered_applications_should_be_visible

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_search_for_candidate_name
     then_only_applications_of_that_name_should_be_visible
+    and_the_name_should_appear_in_search_field
 
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible
@@ -52,6 +53,10 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_visit_the_provider_page
     then_i_do_not_expect_to_see_the_filter_dialogue
+  end
+
+  def and_the_name_should_appear_in_search_field
+    expect(page).to have_field('filter_selections[search][candidates_name]', with: 'Jim James')
   end
 
   def and_candidates_name_tags_should_not_be_visible

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -22,12 +22,15 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_only_applications_of_that_name_should_be_visible
 
     when_i_clear_the_filters
+    then_i_expect_all_applications_to_be_visible
     when_i_search_for_candidate_name_with_odd_casing
     then_only_applications_of_that_name_should_be_visible
 
-    # when_i_filter_for_rejected_and_offered_applications
-    # then_i_search_for_candidate_name
-    # then_only_rejected_and_offered_applications_of_that_name_should_be_visible
+    when_i_clear_the_filters
+    then_i_filter_for_withdrawn_and_offered_applications
+    then_only_withdrawn_and_offered_applications_should_be_visible
+    then_i_search_for_candidate_name
+    then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible
     #
     #
     # when_i_clear_the_filters
@@ -51,14 +54,57 @@ RSpec.feature 'Providers should be able to filter applications' do
     # then_i_do_not_expect_to_see_the_filter_dialogue
   end
 
+  def then_only_withdrawn_and_offered_applications_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
+    expect(page).to have_css('.govuk-table__body', text: 'Offered')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+  end
+
+  def then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible
+    then_only_applications_of_that_name_and_status_should_be_visible
+  end
+
+  def then_i_expect_all_applications_to_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).to have_css('.govuk-table__body', text: 'Offered')
+    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
+    expect(page).to have_css('.govuk-table__body', text: 'Declined')
+  end
+
   def when_i_search_for_candidate_name
     find(:css, '#candidates_name').set('Jim James')
+    click_button('Apply filters')
+  end
+
+  def then_i_search_for_candidate_name
+    when_i_search_for_candidate_name
+  end
+
+  def then_i_filter_for_withdrawn_and_offered_applications
+    find(:css, '#status-application-withdrawn').set(true)
+    find(:css, '#status-offered').set(true)
     click_button('Apply filters')
   end
 
   def when_i_search_for_candidate_name_with_odd_casing
     find(:css, '#candidates_name').set('jiM JAmeS')
     click_button('Apply filters')
+  end
+
+  def then_only_applications_of_that_name_and_status_should_be_visible
+    expect(page).to have_css('.govuk-table__body', text: 'Jim James')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Adam Jones')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Tom Jones')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Bill Bones')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Greg Taft')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Paul Atreides')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Duncan Idaho')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Luke Smith')
+
+    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Rejected')
+    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
   end
 
   def then_only_applications_of_that_name_should_be_visible
@@ -94,13 +140,6 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def when_i_clear_the_filters
     click_link('Clear')
-  end
-
-  def then_i_expect_all_applications_to_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).to have_css('.govuk-table__body', text: 'Declined')
   end
 
   def and_provider_application_filters_are_active
@@ -186,19 +225,6 @@ RSpec.feature 'Providers should be able to filter applications' do
 
 
 #--------------------
-  def then_only_rejected_applications_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
-  end
-
-  def then_only_rejected_and_offered_applications_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
-  end
 
   def when_i_filter_for_rejected_applications
     find(:css, '#status-rejected').set(true)
@@ -238,19 +264,4 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_css('.moj-filter-tags', text: 'Rejected')
   end
 #--------------------%%%
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 end


### PR DESCRIPTION
## Context

Allows providers to filter/search applications be name - these also work in conjunction with other filters (i.e. Status and provider).

## Changes proposed in this pull request

**Before**
<img width="984" alt="Screenshot 2020-03-18 at 14 50 37" src="https://user-images.githubusercontent.com/13377553/76973431-d831ba00-6927-11ea-8cf3-890f9b49d4fb.png">

**After**
<img width="1023" alt="Screenshot 2020-03-18 at 14 49 56" src="https://user-images.githubusercontent.com/13377553/76973378-c0f2cc80-6927-11ea-802e-923d4102f977.png">


## Guidance to review
I am not happy with the way that I get the "candidate's name" heading in `current_filter_component.html.erb` its hard coded currently - Ideally I would like this to be part of the config for searching in `provider_applications_page_state.rb`

What are you're thoughts - this is behind a feature flag so my preference would be to merge and then refactor

## Link to Trello card

https://trello.com/c/CCOnShN1/1752-%F0%9F%8F%88-tech-spike-search-functionality-in-provider-interface

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
