### PR TITLE
Fix email logging

### DIFF
--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -1,5 +1,7 @@
 module Integrations
   class NotifyController < IntegrationsController
+    before_action :log_params
+
     include ActionController::HttpAuthentication::Token::ControllerMethods
 
     rescue_from ActionController::ParameterMissing, with: :render_unprocessable_entity
@@ -50,6 +52,12 @@ module Integrations
         message: 'Please provide a valid authentication token',
         status: :unauthorized,
       )
+    end
+
+    def log_params
+      relevant_parameters = params.permit(:reference, :status).to_h
+      RequestLocals.store[:identity] = relevant_parameters
+      Raven.user_context(relevant_parameters)
     end
   end
 end

--- a/app/controllers/support_interface/email_log_controller.rb
+++ b/app/controllers/support_interface/email_log_controller.rb
@@ -2,6 +2,10 @@ module SupportInterface
   class EmailLogController < SupportInterfaceController
     def index
       @emails = Email.order(id: :desc).includes(:application_form).limit(1000)
+
+      %w[to subject mailer mail_template notify_reference application_form_id delivery_status].each do |column|
+        @emails = @emails.where(column => params[column]) if params[column]
+      end
     end
   end
 end

--- a/app/controllers/support_interface/email_log_controller.rb
+++ b/app/controllers/support_interface/email_log_controller.rb
@@ -4,7 +4,9 @@ module SupportInterface
       @emails = Email.order(id: :desc).includes(:application_form).limit(1000)
 
       %w[to subject mailer mail_template notify_reference application_form_id delivery_status].each do |column|
-        @emails = @emails.where(column => params[column]) if params[column]
+        next unless params[column]
+
+        @emails = @emails.where(column => params[column])
       end
     end
   end

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -3,8 +3,8 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-third">Time</th>
-      <th class="govuk-table__header govuk-table__header govuk-!-width-two-thirds">Email</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Email</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -18,7 +18,7 @@
           { key: 'Type', value: email.humanised_email_type },
           { key: 'To', value: email.to },
           { key: 'Subject', value: email.subject },
-          { key: 'Application', value: (email.application_form ? govuk_link_to(email.application_form.full_name, support_interface_application_form_path(email.application_form)) : nil) },
+          { key: 'Application', value: (email.application_form ? govuk_link_to("#{email.application_form.full_name} (#{email.application_form.support_reference})", support_interface_application_form_path(email.application_form)) : nil) },
           { key: 'Status', value: tag.span(email.delivery_status.humanize, class: "govuk-tag #{email.delivered? ? nil : 'govuk-tag--red'}") },
         ]) %>
 

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -16,6 +16,7 @@
       <td class="govuk-table__cell">
         <%= render SummaryListComponent.new(rows: [
           { key: 'Type', value: email.humanised_email_type },
+          { key: 'Reference', value: email.notify_reference },
           { key: 'To', value: email.to },
           { key: 'Subject', value: email.subject },
           { key: 'Application', value: (email.application_form ? govuk_link_to("#{email.application_form.full_name} (#{email.application_form.support_reference})", support_interface_application_form_path(email.application_form)) : nil) },

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -1,3 +1,5 @@
+<% content_for :title, 'Email log' %>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -1,9 +1,8 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Type</th>
-      <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">What</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-third">Time</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-two-thirds">Email</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -13,10 +12,8 @@
         <%= email.created_at.to_s(:govuk_date_and_time) %>
       </td>
       <td class="govuk-table__cell">
-        <%= email.humanised_email_type %>
-      </td>
-      <td class="govuk-table__cell">
         <%= render SummaryListComponent.new(rows: [
+          { key: 'Type', value: email.humanised_email_type },
           { key: 'To', value: email.to },
           { key: 'Subject', value: email.subject },
           { key: 'Application', value: (email.application_form ? govuk_link_to(email.application_form.full_name, support_interface_application_form_path(email.application_form)) : nil) },

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -17,7 +17,7 @@
           { key: 'To', value: email.to },
           { key: 'Subject', value: email.subject },
           { key: 'Application', value: (email.application_form ? govuk_link_to(email.application_form.full_name, support_interface_application_form_path(email.application_form)) : nil) },
-          { key: 'Status', value: email.delivery_status.humanize },
+          { key: 'Status', value: tag.span(email.delivery_status.humanize, class: "govuk-tag #{email.delivered? ? nil : 'govuk-tag--red'}") },
         ]) %>
 
         <details class="govuk-details" data-module="govuk-details">

--- a/lib/email_log_interceptor.rb
+++ b/lib/email_log_interceptor.rb
@@ -1,7 +1,11 @@
 class EmailLogInterceptor
   def self.delivering_email(mail)
     notify_reference = mail.header['reference']&.value
-    notify_reference ||= generate_reference
+
+    unless notify_reference
+      notify_reference = generate_reference
+      mail.header['reference'] = notify_reference
+    end
 
     Email.create!(
       to: mail.to.first,

--- a/spec/system/support_interface/email_log_spec.rb
+++ b/spec/system/support_interface/email_log_spec.rb
@@ -22,16 +22,24 @@ RSpec.feature 'Email log' do
   end
 
   def when_an_email_with_custom_reference_is_sent
+    @candidate = create(:candidate, email_address: 'harry@example.com')
+
     AuthenticationMailer.sign_up_email(
-      candidate: create(:candidate, email_address: 'harry@example.com'),
+      candidate: @candidate,
       token: '123',
     ).deliver_now
+
+    open_email('harry@example.com')
+    expect(current_email.header('reference')).to eql("test-sign_up_email-#{@candidate.id}")
   end
 
   def and_an_email_with_an_application_id_is_sent
     CandidateMailer.application_submitted(
-      create(:application_form, first_name: 'Harry', last_name: 'Potter'),
+      create(:application_form, first_name: 'Harry', last_name: 'Potter', candidate: @candidate),
     ).deliver_now
+
+    open_email('harry@example.com')
+    expect(current_email.header('reference')).not_to be_nil
   end
 
   def and_i_visit_the_email_log

--- a/spec/system/support_interface/email_log_spec.rb
+++ b/spec/system/support_interface/email_log_spec.rb
@@ -71,7 +71,10 @@ RSpec.feature 'Email log' do
   end
 
   def then_the_delivery_status_is_displayed_on_the_page
-    visit support_interface_email_log_path
+    visit support_interface_email_log_path(delivery_status: 'permanent_failure')
     expect(page).to have_content 'Permanent failure'
+
+    visit support_interface_email_log_path(delivery_status: 'delivered')
+    expect(page).not_to have_content 'Permanent failure'
   end
 end


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1433 we started logging emails in the database. In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1614 we started tracking the delivery status. It turns out the tracking doesn't work yet. 

## Changes proposed in this pull request

This fixes an issue where we aren't sending a `reference` to Notify. This means that we can't match Notify's callbacks to the emails in our database, and most emails are marked with delivery status "Unknown". Commit https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1646/commits/e820da02145702c8622877c490dcaeb593474d55.

In order to debug this, I've added:

- Start logging the status/reference in Logit so we can see which callbacks arrive
- Update the UI for the email log to better accomodate all the information - mostly things that I needed for debugging
- Add a undocumented MVP search, which allows us to search for specific emails by fiddling with the query string. Once @willmcb's work on filtering in the provider UI is complete, we'll replace the MVP with nice filters. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/AFbxsqs4

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
