### PR TITLE
Redact equality and diversity data in audit component

### DIFF
--- a/app/components/support_interface/audit_trail_change_component.rb
+++ b/app/components/support_interface/audit_trail_change_component.rb
@@ -13,7 +13,9 @@ module SupportInterface
 
     def format_audit_values
       if values.is_a? Array
-        "#{values[0] || 'nil'} → #{values[1] || 'nil'}"
+        before = values[0] ? redact_equality_and_diversity_data(values[0]) : 'nil'
+        after = values[1] ? redact_equality_and_diversity_data(values[1]) : 'nil'
+        "#{before} → #{after}"
       else
         values.to_s
       end
@@ -21,6 +23,15 @@ module SupportInterface
 
     def style
       last_change ? 'border: none' : ''
+    end
+
+    def redact_equality_and_diversity_data(value)
+      %w[sex disabilities ethnic_group ethnic_background].each do |field|
+        next unless value[field]
+
+        value[field] = '[REDACTED]'
+      end
+      value
     end
 
     attr_reader :values, :attribute, :last_change

--- a/spec/components/support_interface/audit_trail_change_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_change_component_spec.rb
@@ -22,4 +22,9 @@ RSpec.describe SupportInterface::AuditTrailChangeComponent do
   it 'renders an create with a single value' do
     expect(render_result(values: 'only_one').text).to match(/title\s*only_one/m)
   end
+
+  it 'redacts sensitive information' do
+    expect(render_result(values: [{ 'sex' => 'male' }, { 'sex' => 'male', 'disabilities' => [] }]).text)
+      .to include('{"sex"=>"[REDACTED]"} → {"sex"=>"[REDACTED]", "disabilities"=>"[REDACTED]"}')
+  end
 end


### PR DESCRIPTION
## Context

Previously: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1643

We discovered that we were exposing this data to support users via the audit log.

## Changes proposed in this pull request

Scrub it out in the component.

## Guidance to review

### After

![Screenshot 2020-03-16 at 13 22 43](https://user-images.githubusercontent.com/1650875/76762479-4429ec00-6789-11ea-9b1d-01f42fa808cc.png)

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)