### PR TITLE
Fix bug: dates can be many decades into the future

### DIFF
--- a/app/models/candidate_interface/degree_form.rb
+++ b/app/models/candidate_interface/degree_form.rb
@@ -18,7 +18,7 @@ module CandidateInterface
     validates :grade, length: { maximum: 255 }, on: :grade
     validates :other_grade, :predicted_grade, length: { maximum: 255 }, on: :grade
 
-    validate :award_year_is_date, if: :award_year, on: :award_year
+    validate :award_year_is_valid_date, if: :award_year, on: :award_year
 
     class << self
       def build_all_from_application(application_form)
@@ -124,9 +124,22 @@ module CandidateInterface
       grade == 'predicted'
     end
 
-    def award_year_is_date
-      valid_award_year = valid_year?(award_year)
-      errors.add(:award_year, :invalid) unless valid_award_year
+    def award_year_is_valid_date
+      if valid_year?(award_year)
+        award_year_is_before_the_end_of_next_year
+      else
+        award_year_is_invalid
+      end
+    end
+
+    def award_year_is_invalid
+      errors.add(:award_year, :invalid)
+    end
+
+    def award_year_is_before_the_end_of_next_year
+      upper_year_limit = Time.zone.now.year.to_i + 2
+
+      errors.add(:award_year, :greater_than_limit, date: upper_year_limit) if award_year.to_i >= upper_year_limit
     end
 
     def determine_grade

--- a/app/models/candidate_interface/gcse_qualification_details_form.rb
+++ b/app/models/candidate_interface/gcse_qualification_details_form.rb
@@ -7,8 +7,7 @@ module CandidateInterface
     validates :grade, presence: true, on: :grade
     validates :award_year, presence: true, on: :award_year
     validates :grade, length: { maximum: 6 }, on: :grade
-    validate :award_year_is_date, if: :award_year, on: :award_year
-
+    validate :award_year_is_a_valid_date, if: :award_year, on: :award_year
     validate :validate_grade_format, unless: :new_record?, on: :grade
 
     def self.build_from_qualification(qualification)
@@ -39,9 +38,21 @@ module CandidateInterface
 
   private
 
-    def award_year_is_date
-      valid_award_year = valid_year?(award_year)
-      errors.add(:award_year, :invalid) unless valid_award_year
+    def award_year_is_not_in_the_future
+      date_limit = Time.zone.now.year.to_i + 1
+      errors.add(:award_year, :in_future, date: date_limit) if award_year.to_i >= date_limit
+    end
+
+    def award_year_is_invalid
+      errors.add(:award_year, :invalid)
+    end
+
+    def award_year_is_a_valid_date
+      if valid_year?(award_year)
+        award_year_is_not_in_the_future
+      else
+        award_year_is_invalid
+      end
     end
 
     def validate_grade_format

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -75,10 +75,12 @@ module CandidateInterface
   private
 
     def award_year_is_date_and_before_current_year
+      year_limit = Date.today.year.to_i + 1
+
       if !valid_year?(award_year)
         errors.add(:award_year, :invalid)
-      elsif Date.new(award_year.to_i, 1, 1).year > Date.today.year
-        errors.add(:award_year, :in_the_future)
+      elsif award_year.to_i >= year_limit
+        errors.add(:award_year, :in_the_future, date: year_limit)
       end
     end
   end

--- a/app/models/candidate_interface/personal_details_form.rb
+++ b/app/models/candidate_interface/personal_details_form.rb
@@ -18,6 +18,7 @@ module CandidateInterface
 
     validate :date_of_birth_valid
     validate :date_of_birth_not_in_future
+    validate :date_of_birth_is_within_lower_age_limit
 
     validates :first_nationality, :second_nationality,
               inclusion: { in: NATIONALITY_DEMONYMS, allow_blank: true }
@@ -81,6 +82,13 @@ module CandidateInterface
 
     def date_of_birth_not_in_future
       errors.add(:date_of_birth, :future) if date_of_birth.is_a?(Date) && date_of_birth > Date.today
+    end
+
+    def date_of_birth_is_within_lower_age_limit
+      return unless date_of_birth.is_a?(Date) && date_of_birth < Date.today
+
+      age_limit = Date.today - 16.years
+      errors.add(:date_of_birth, :below_lower_age_limit, date: age_limit.to_s(:govuk_date)) if date_of_birth > age_limit
     end
 
     def english_main_language?

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -449,6 +449,7 @@ en:
             award_year:
               blank: Enter your graduation year
               invalid: Enter a real graduation year
+              greater_than_limit: 'Enter a year before %{date}'
         candidate_interface/other_qualification_form:
           attributes:
             qualification_type:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -368,6 +368,7 @@ en:
             date_of_birth:
               invalid: Enter a date of birth in the correct format
               future: Enter a date of birth that is in the past, for example 31 3 1980
+              below_lower_age_limit: Enter a date of birth before %{date} – you must be over 16 years old to Apply for teacher training
         candidate_interface/becoming_a_teacher_form:
           attributes:
             becoming_a_teacher:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -467,7 +467,7 @@ en:
             award_year:
               blank: Enter the year the qualification was awarded
               invalid: Enter a real year
-              in_the_future: Enter a year that is not in the future
+              in_the_future: 'Enter a year before %{date}'
         candidate_interface/work_experience_form:
           attributes:
             role:
@@ -513,6 +513,7 @@ en:
             award_year:
               blank: Enter the year you gained your qualification
               invalid: Enter a real year
+              in_future: Enter a year before %{date}
         candidate_interface/gcse_qualification_type_form:
           attributes:
             qualification_type:

--- a/spec/models/candidate_interface/degree_form_spec.rb
+++ b/spec/models/candidate_interface/degree_form_spec.rb
@@ -63,11 +63,23 @@ RSpec.describe CandidateInterface::DegreeForm, type: :model do
         degree = CandidateInterface::DegreeForm.new(award_year: '2009')
         error_message = t('activemodel.errors.models.candidate_interface/degree_form.attributes.award_year.invalid')
 
-        degree.validate
+        degree.validate(:award_year)
 
         expect(degree.errors.full_messages_for(:award_year)).not_to eq(
           ["Award year #{error_message}"],
         )
+      end
+
+      it 'is invalid if the award year is more than one year into the future' do
+        Timecop.freeze(Time.zone.local(2008, 1, 1)) do
+          degree = CandidateInterface::DegreeForm.new(award_year: '2010')
+
+          degree.validate(:award_year)
+
+          expect(degree.errors.full_messages_for(:award_year)).to eq(
+            ['Award year Enter a year before 2010'],
+          )
+        end
       end
     end
   end

--- a/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
+++ b/spec/models/candidate_interface/gcse_qualification_details_form_spec.rb
@@ -126,6 +126,16 @@ RSpec.describe CandidateInterface::GcseQualificationDetailsForm, type: :model do
         expect(form.save_year).to eq(false)
       end
 
+      it 'returns validation error if award_year is in the future' do
+        Timecop.freeze(Time.zone.local(2008, 1, 1)) do
+          details_form = CandidateInterface::GcseQualificationDetailsForm.new(award_year: '2009')
+
+          details_form.save_year
+
+          expect(details_form.errors[:award_year]).to include('Enter a year before 2009')
+        end
+      end
+
       it 'updates qualification details if valid' do
         application_form = create(:application_form)
         qualification = ApplicationQualification.create(level: 'gcse', application_form: application_form)

--- a/spec/models/candidate_interface/other_qualification_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_form_spec.rb
@@ -39,15 +39,14 @@ RSpec.describe CandidateInterface::OtherQualificationForm, type: :model do
         end
       end
 
-      it 'is invalid if the award year is before the current year' do
+      it 'is invalid if the award year is in the future' do
         Timecop.freeze(Time.zone.local(2019, 10, 1, 12, 0, 0)) do
           qualification = CandidateInterface::OtherQualificationForm.new(award_year: '2029')
-          error_message = t('award_year.in_the_future', scope: error_message_scope)
 
           qualification.validate
 
           expect(qualification.errors.full_messages_for(:award_year)).to eq(
-            ["Award year #{error_message}"],
+            ['Award year Enter a year before 2020'],
           )
         end
       end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
Some dates do not have validations therefore we allow unrealistic dates to be submitted when entering DOB or qualification award years. 

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR:
- Add lower age limit to DOB on the personal details form, so we don't accept candidates who are younger than 16
- Update degree award year validation so graduation year must be before the end of next year
- Add validation to GCSE award year so they cannot be in the future
- Update validation on other qualification to follow the same pattern that degree and GCSE form has

### After:
![image](https://user-images.githubusercontent.com/22743709/76763492-2198d280-678b-11ea-9592-5fa3253aa36d.png)

![image](https://user-images.githubusercontent.com/22743709/76763531-383f2980-678b-11ea-8dc1-d4b47b5553fa.png)

![image](https://user-images.githubusercontent.com/22743709/76763563-468d4580-678b-11ea-9d24-62da5b234a73.png)

![image](https://user-images.githubusercontent.com/22743709/76763440-062dc780-678b-11ea-9646-d8c120befefb.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
👀 

## Link to Trello card
https://trello.com/c/wBZz1svf/897-dates-can-be-many-decades-into-the-future-or-past

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
