### PR TITLE
Link to filtered email view from application form

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -26,7 +26,7 @@ module SupportInterface
     def last_updated_row
       {
         key: 'Last updated',
-        value: "#{updated_at.to_s(:govuk_date_and_time)} (#{govuk_link_to('History', support_interface_application_form_audit_path(application_form))})".html_safe,
+        value: "#{updated_at.to_s(:govuk_date_and_time)} (#{govuk_link_to('History', support_interface_application_form_audit_path(application_form))}, #{govuk_link_to('Emails about application', support_interface_email_log_path(application_form_id: application_form.id))})".html_safe,
       }
     end
 

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -22,4 +22,8 @@
 
 <%= govuk_button_link_to 'Add comment', support_interface_application_form_new_comment_path %>
 
+<p class="govuk-body">
+  <%= govuk_link_to 'View all emails about this application', support_interface_email_log_path(application_form_id: @application_form.id) %>
+</p>
+
 <%= render SupportInterface::AuditTrailComponent.new(application_form: @application_form) %>


### PR DESCRIPTION
## Context

This adds a link to the email log, filtered by the application. This means we can easily find all emails that have been sent regarding a certain application.

## Changes proposed in this pull request

Use the MVP search functionality in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1646 to filter emails by application.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Y8PgKdM7

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
