### PR TITLE
Freeze time so that tests pass correctly.

### DIFF
--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.feature 'Receives rejection email' do
   include CandidateHelper
 
+  around do |example|
+    date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 3, 13)
+    Timecop.freeze(date_that_avoids_clocks_changing_by_ten_days) do
+      example.run
+    end
+  end
+
   scenario 'Receives rejection email' do
     given_the_pilot_is_open
 
@@ -88,8 +95,7 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.body).to include(@offer.provider.name)
     expect(current_email.body).to include(@offer.course.name_and_code)
 
-    # TODO: temporarily disabled because the date is off by 1 day
-    # expect(current_email.body).to include("Make a decision about your offer by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.body).to include("Make a decision about your offer by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 
   def and_it_includes_details_of_my_offers
@@ -97,8 +103,6 @@ RSpec.feature 'Receives rejection email' do
     expect(current_email.body).to include(@offer.course.name_and_code)
     expect(current_email.body).to include(@offer2.provider.name)
     expect(current_email.body).to include(@offer2.course.name_and_code)
-
-    # TODO: temporarily disabled because the date is off by 1 day
-    # expect(current_email.body).to include("Make a decision about your offers by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
+    expect(current_email.body).to include("Make a decision about your offers by #{@offer.decline_by_default_at.to_s(:govuk_date)}")
   end
 end


### PR DESCRIPTION
These tests passed on Friday 13th of March but not today (16th)

Why?

Reason being that we set `decline_by_default` in the spec to be
ten business days in the future. Then check this in the email and expect
it to be the the same day.

This fails if you are less than ten business days away from the clocks
going forward, because when we set the declined by default date using
`TimeLimitCalculator` it sets the date to be at the `.end_of_day`, and
this is pushed over to the next day when the clocks go forward.

This year clocks go forward on 29th of March.

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
