### PR TITLE
Clean up usage of single hashed token for a reference

### DIFF
--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -106,12 +106,6 @@ RSpec.describe ApplicationReference, type: :model do
       allow(devise_token_generator).to receive(:generate).and_return(%w[new_unhashed_token new_hashed_token])
     end
 
-    it 'updates the hashed sign in token using Devise' do
-      reference.refresh_feedback_token!
-
-      expect(reference.hashed_sign_in_token).to eq('new_hashed_token')
-    end
-
     it 'creates a new reference token' do
       reference.refresh_feedback_token!
 
@@ -123,9 +117,7 @@ RSpec.describe ApplicationReference, type: :model do
     before do
       devise_token_generator = instance_double(Devise::TokenGenerator)
       allow(Devise).to receive(:token_generator).and_return(devise_token_generator)
-      allow(devise_token_generator).to receive(:digest)
-        .with(ApplicationReference, :hashed_sign_in_token, 'unhashed_token')
-        .and_return('hashed_token')
+      allow(devise_token_generator).to receive(:digest).and_return('hashed_token')
     end
 
     context 'when the unhashed token does not match an unhashed sign in token on a reference' do
@@ -136,31 +128,9 @@ RSpec.describe ApplicationReference, type: :model do
       end
     end
 
-    context 'when the unhashed token matches an unhashed sign in token on a reference' do
-      it 'returns the reference' do
-        create(:reference, name: 'Chandler Bing', hashed_sign_in_token: 'hashed_token')
-        create(:reference, name: 'Monica Geller-Bing', hashed_sign_in_token: 'another_hashed_token')
-
-        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
-
-        expect(reference.name).to eq('Chandler Bing')
-      end
-    end
-
     context 'when the unhashed token can be found in the reference token table' do
       it 'returns the reference' do
         chandler = create(:reference, name: 'Chandler Bing')
-        create(:reference_token, application_reference: chandler, hashed_token: 'hashed_token')
-
-        reference = ApplicationReference.find_by_unhashed_token('unhashed_token')
-
-        expect(reference.name).to eq('Chandler Bing')
-      end
-    end
-
-    context 'when the unhashed token can be found in the reference token table and on a reference' do
-      it 'returns the reference' do
-        chandler = create(:reference, name: 'Chandler Bing', hashed_sign_in_token: 'hashed_token')
         create(:reference_token, application_reference: chandler, hashed_token: 'hashed_token')
 
         reference = ApplicationReference.find_by_unhashed_token('unhashed_token')


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1638, we added in the ability to allow a reference to use the token in the initial and chaser reference request email. Before, it was only possible to use the most recent one.

## Changes proposed in this pull request

This PR removes usage of `ApplicationReference#hashed_sign_in_token` the single field that stored the most recent token. This means that it is no longer updated when `#refresh_feedback_token!` is called and searched for in `.find_by_unhashed_token`.

It also adds a migration to remove the `hashed_sign_in_token` field from the `reference` table.

## Guidance to review

- Would I be correct to say that we should only merge this in when we have successfully deployed https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1638? 🤔 

## Link to Trello card

https://trello.com/c/Io6avau8/1119-dev-improve-user-journey-when-referees-click-on-their-first-email-after-a-chaser-has-been-sent

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
