### PR TITLE
Improve handling of offering a different course for new and existing offers

### DIFF
--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -48,7 +48,7 @@ module ProviderInterface
           actor: current_provider_user,
           application_choice: @application_choice,
           course_option_id: @change_offer_form.course_option_id,
-        ).save!
+        ).save
         redirect_to provider_interface_application_choice_path(@application_choice.id)
       else
         raise 'cannot update offer'

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -23,21 +23,13 @@ module VendorApi
         course_option = nil
       end
 
-      decision = if application_choice.offer?
-                   ChangeOffer.new(
-                     actor: api_user,
-                     application_choice: application_choice,
-                     course_option_id: course_option&.id,
-                     offer_conditions: params.dig(:data, :conditions),
-                   )
-                 else
-                   MakeAnOffer.new(
-                     actor: api_user,
-                     application_choice: application_choice,
-                     course_option_id: course_option&.id,
-                     offer_conditions: params.dig(:data, :conditions),
-                   )
-                 end
+      service = application_choice.offer? ? ChangeOffer : MakeAnOffer
+      decision = service.new(
+        actor: api_user,
+        application_choice: application_choice,
+        course_option_id: course_option&.id,
+        offer_conditions: params.dig(:data, :conditions),
+      )
 
       respond_to_decision(decision)
     end

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -7,12 +7,43 @@ module VendorApi
         vendor_api_token_id: @current_vendor_api_token.id,
       )
 
-      decision = MakeAnOffer.new(
-        actor: api_user,
-        application_choice: application_choice,
-        offer_conditions: params.dig(:data, :conditions),
-        course_data: params.dig(:data, :course),
-      )
+      course_data = params.dig(:data, :course)
+
+      if course_data.present?
+        course_option = GetCourseOptionFromCodes.new(
+          provider_code: course_data[:provider_code],
+          course_code: course_data[:course_code],
+          recruitment_cycle_year: course_data[:recruitment_cycle_year],
+          study_mode: course_data[:study_mode],
+          site_code: course_data[:site_code],
+        ).call
+
+        change_offer_form = ProviderInterface::ChangeOfferForm.new step: :update,
+                                                                   application_choice: application_choice,
+                                                                   provider_id: (course_option.course.provider.id if course_option),
+                                                                   course_id: (course_option.course.id if course_option),
+                                                                   course_option_id: (course_option.id if course_option)
+
+        (render_cannot_find_course_option and return) unless change_offer_form.valid?
+      else
+        course_option = nil
+      end
+
+      decision = if application_choice.offer?
+                   ChangeOffer.new(
+                     actor: api_user,
+                     application_choice: application_choice,
+                     course_option_id: course_option&.id,
+                     offer_conditions: params.dig(:data, :conditions),
+                   )
+                 else
+                   MakeAnOffer.new(
+                     actor: api_user,
+                     application_choice: application_choice,
+                     course_option_id: course_option&.id,
+                     offer_conditions: params.dig(:data, :conditions),
+                   )
+                 end
 
       respond_to_decision(decision)
     end
@@ -61,15 +92,25 @@ module VendorApi
   private
 
     def application_choice
-      @application_choice ||= GetApplicationChoicesForProviders.call(providers: current_provider)
-        .find(params[:application_id])
+      @application_choice ||= GetApplicationChoicesForProviders.call(providers: current_provider).find(params[:application_id])
     end
 
     def respond_to_decision(decision)
-      if decision.save
-        render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
-      else
-        render_validation_errors(decision.errors)
+      begin
+        if decision.save
+          render json: { data: SingleApplicationPresenter.new(application_choice).as_json }
+        else
+          render_validation_errors(decision.errors)
+        end
+      rescue ProviderAuthorisation::NotAuthorisedError => e
+        render status: :unprocessable_entity, json: {
+          errors: [
+            {
+              error: 'NotAuthorisedError',
+              message: "#{e.message} failed",
+            },
+          ],
+        }
       end
     end
 
@@ -77,6 +118,17 @@ module VendorApi
     def render_validation_errors(errors)
       error_responses = errors.full_messages.map { |message| { error: 'ValidationError', message: message } }
       render status: :unprocessable_entity, json: { errors: error_responses }
+    end
+
+    def render_cannot_find_course_option
+      render status: :unprocessable_entity, json: {
+        errors: [
+          {
+            error: 'CourseOptionError',
+            message: 'Cannot find an appropriate course option for these codes',
+          },
+        ],
+      }
     end
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -1,16 +1,28 @@
 class ChangeOffer
   include ActiveModel::Validations
 
-  def initialize(actor:, application_choice:, course_option_id:)
+  attr_reader :application_choice, :course_option_id
+
+  validates_each :course_option_id do |record, attr, value|
+    record.errors.add(attr, :no_change) if value == record.application_choice.offered_option.id
+  end
+
+  def initialize(actor:, application_choice:, course_option_id:, offer_conditions: nil)
     @application_choice = application_choice
     @course_option_id = course_option_id
+    @offer_conditions = offer_conditions
     @auth = ProviderAuthorisation.new(actor: actor)
   end
 
-  def save!
+  def save
     @auth.assert_can_change_offer! application_choice: @application_choice, course_option_id: @course_option_id
-    if @course_option_id != @application_choice.offered_option.id
-      @application_choice.update!(offered_course_option_id: @course_option_id, offered_at: Time.zone.now)
+    if valid?
+      attributes = {
+        offered_course_option_id: @course_option_id,
+        offered_at: Time.zone.now,
+      }
+      attributes[:offer] = { 'conditions' => @offer_conditions } if @offer_conditions
+      @application_choice.update! attributes
 
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       CandidateMailer.changed_offer(@application_choice).deliver_later

--- a/app/services/get_course_option_from_codes.rb
+++ b/app/services/get_course_option_from_codes.rb
@@ -1,0 +1,65 @@
+class GetCourseOptionFromCodes
+  include ActiveModel::Validations
+  attr_accessor :provider_code, :course_code, :recruitment_cycle_year, :study_mode, :site_code
+  attr_accessor :provider, :course, :site, :course_option
+
+  validates_each :provider_code do |record, attr, value|
+    record.provider ||= Provider.find_by(code: value)
+    record.errors.add(attr, "provider #{value} does not exist") unless record.provider
+  end
+
+  validates_each :course_code do |record, attr, value|
+    if record.provider
+      record.course ||= record.provider.courses.find_by(
+        code: value,
+        recruitment_cycle_year: record.recruitment_cycle_year,
+      )
+      unless record.course
+        record.errors.add(
+          attr,
+          "course #{value} does not exist for provider #{record.provider.code} and year #{record.recruitment_cycle_year}",
+        )
+      end
+    end
+  end
+
+  validates_each :site_code do |record, attr, value|
+    if record.provider
+      record.site ||= record.provider.sites.find_by(code: value)
+      record.errors.add(attr, "site #{value} does not exist for provider #{record.provider.code}") unless record.site
+    end
+  end
+
+  validates_each :course_option do |record, attr, _value|
+    if record.course && record.site
+      record.course_option ||= record.course.course_options.find_by(
+        study_mode: record.study_mode,
+        site: record.site,
+      )
+      unless record.course_option
+        record.errors.add(
+          attr,
+          "cannot find #{record.study_mode} option for course #{record.course.code} and site #{record.site.code}",
+        )
+      end
+    end
+  end
+
+  def initialize(
+    provider_code:,
+    course_code:,
+    study_mode:,
+    site_code:,
+    recruitment_cycle_year:
+  )
+    @provider_code = provider_code
+    @course_code = course_code
+    @study_mode = study_mode
+    @site_code = site_code
+    @recruitment_cycle_year = recruitment_cycle_year
+  end
+
+  def call
+    course_option if valid?
+  end
+end

--- a/app/services/get_course_option_from_codes.rb
+++ b/app/services/get_course_option_from_codes.rb
@@ -3,6 +3,10 @@ class GetCourseOptionFromCodes
   attr_accessor :provider_code, :course_code, :recruitment_cycle_year, :study_mode, :site_code
   attr_accessor :provider, :course, :site, :course_option
 
+  # Using validates_each because validation for each attribute depends on the values of other attributes
+  # The act of validation also performs the relevant lookups and memoizes the results, which are then used
+  # in subsequent validations.
+
   validates_each :provider_code do |record, attr, value|
     record.provider ||= Provider.find_by(code: value)
     record.errors.add(attr, "provider #{value} does not exist") unless record.provider

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -9,7 +9,6 @@ class MakeAnOffer
   MAX_CONDITION_LENGTH = 255
   STANDARD_CONDITIONS = ['Fitness to Teach check', 'Disclosure and Barring Service (DBS) check'].freeze
 
-  # validate :validate_course_data
   validate :validate_conditions_max_length
   validate :validate_further_conditions
 
@@ -76,48 +75,6 @@ private
       further_conditions2,
       further_conditions3,
     ]
-  end
-
-  def validate_course_data
-    return if @course_data.nil?
-
-    provider_code = @course_data[:provider_code]
-    course_code = @course_data[:course_code]
-    recruitment_cycle_year = @course_data[:recruitment_cycle_year]
-    study_mode = @course_data[:study_mode]
-    site_code = @course_data[:site_code]
-
-    provider = Provider.find_by(code: provider_code)
-    if provider.nil?
-      errors.add(:offered_course, "provider #{provider_code} does not exist")
-      return
-    end
-
-    course = provider.courses.find_by(
-      code: course_code,
-      recruitment_cycle_year: recruitment_cycle_year,
-      study_mode: study_mode,
-    )
-    if course.nil?
-      errors.add(:offered_course, "#{course_code} from recruitment cycle year #{recruitment_cycle_year} with study mode #{study_mode} does not exist or does not belong to provider #{provider_code}")
-      return
-    end
-
-    site = provider.sites.find_by(code: site_code)
-    if site.nil?
-      errors.add(:offered_course, "site #{site_code} does not exist or does not belong to provider #{provider_code}")
-      return
-    end
-
-    @course_option = CourseOption.find_by(course: course, site: site, study_mode: study_mode)
-    if @course_option.nil?
-      errors.add(:offered_course, 'does not exist')
-      return
-    end
-
-    current_provider = @application_choice.course_option.course.provider
-    providers_dont_match = current_provider != provider
-    errors.add(:offered_course, "does not belong to provider #{current_provider.code}, it belongs to #{provider.code}") if providers_dont_match
   end
 
   def validate_further_conditions

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -5,19 +5,23 @@ class ProviderAuthorisation
     @actor = actor
   end
 
-  def can_make_offer?(application_choice:)
-    @actor.is_a?(SupportUser) || @actor.providers.include?(application_choice.course.provider)
+  def can_make_offer?(application_choice:, course_option_id: nil)
+    supplied_course_option = CourseOption.find(course_option_id) if course_option_id
+    if @actor.is_a?(SupportUser)
+      true
+    elsif supplied_course_option && course_option_id != application_choice.course_option.id
+      application_choice_belongs_to_user_providers?(application_choice: application_choice) && \
+        course_option_belongs_to_user_providers?(course_option: supplied_course_option)
+    else
+      application_choice_belongs_to_user_providers?(application_choice: application_choice)
+    end
   end
 
   def can_change_offer?(application_choice:, course_option_id:)
-    course_option = CourseOption.find course_option_id
-    if @actor.is_a?(SupportUser)
-      true
-    else
-      authorised_user = @actor.providers.include?(application_choice.course.provider)
-      valid_option = @actor.providers.include?(course_option.course.provider)
-      authorised_user && valid_option
-    end
+    new_course_option = CourseOption.find course_option_id
+    @actor.is_a?(SupportUser) || \
+      application_choice_belongs_to_user_providers?(application_choice: application_choice) && \
+        course_option_belongs_to_user_providers?(course_option: new_course_option)
   end
 
   # automatically generates assert_can...! methods e.g. #assert_can_make_offer! for #can_make_offer?
@@ -30,4 +34,14 @@ class ProviderAuthorisation
   end
 
   class NotAuthorisedError < StandardError; end
+
+private
+
+  def application_choice_belongs_to_user_providers?(application_choice:)
+    @actor.providers.include?(application_choice.course.provider)
+  end
+
+  def course_option_belongs_to_user_providers?(course_option:)
+    @actor.providers.include?(course_option.course.provider)
+  end
 end

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -6,10 +6,10 @@ class ProviderAuthorisation
   end
 
   def can_make_offer?(application_choice:, course_option_id: nil)
+    return true if @actor.is_a?(SupportUser)
+
     supplied_course_option = CourseOption.find(course_option_id) if course_option_id
-    if @actor.is_a?(SupportUser)
-      true
-    elsif supplied_course_option && course_option_id != application_choice.course_option.id
+    if supplied_course_option && course_option_id != application_choice.course_option.id
       application_choice_belongs_to_user_providers?(application_choice: application_choice) && \
         course_option_belongs_to_user_providers?(course_option: supplied_course_option)
     else

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,6 +148,10 @@ en:
           attributes:
             conditions_met:
               blank: Please specify if the candidate has met the conditions of the offer
+        change_offer:
+          attributes:
+            course_option_id:
+              no_change: You are changing the offer to the same course option
         withdraw_offer:
           attributes:
             offer_withdrawal_reason:

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -126,62 +126,15 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
   end
 
   describe 'offering for application with a decision' do
-    it 'allows amending of conditions for existing offers' do
+    it 'allows amending of course_option and conditions for existing offers' do
       application_choice = create_application_choice_for_currently_authenticated_provider(
         status: 'awaiting_provider_decision',
       )
-      request_body = {
-        "data": {
-          "conditions": [
-            'Completion of subject knowledge enhancement',
-            'Completion of professional skills test',
-          ],
-        },
-      }
-
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
-
-      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
 
       request_body = {
         "data": {
           "conditions": [
-            'Completion of subject knowledge enhancement',
-            'Completion of professional skills test',
             'DBS Check',
-          ],
-        },
-      }
-
-      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
-
-      course_option = application_choice.course_option
-      expect(parsed_response['data']['attributes']['offer']).to eq(
-        'conditions' => [
-          'Completion of subject knowledge enhancement',
-          'Completion of professional skills test',
-          'DBS Check',
-        ],
-        'course' => {
-          'recruitment_cycle_year' => course_option.course.recruitment_cycle_year,
-          'provider_code' => course_option.course.provider.code,
-          'course_code' => course_option.course.code,
-          'site_code' => course_option.site.code,
-          'study_mode' => course_option.study_mode,
-        },
-      )
-    end
-
-    it 'allows amending of course_option for existing offers' do
-      application_choice = create_application_choice_for_currently_authenticated_provider(
-        status: 'awaiting_provider_decision',
-      )
-
-      request_body = {
-        "data": {
-          "conditions": [
-            'Completion of subject knowledge enhancement',
-            'Completion of professional skills test',
           ],
         },
       }
@@ -200,6 +153,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       request_body = {
         "data": {
           "conditions": [
+            'DBS Check',
             'Completion of subject knowledge enhancement',
             'Completion of professional skills test',
           ],
@@ -217,6 +171,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [
+          'DBS Check',
           'Completion of subject knowledge enhancement',
           'Completion of professional skills test',
         ],

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'provider_code' => course_option.course.provider.code,
           'course_code' => course_option.course.code,
           'site_code' => course_option.site.code,
-          'study_mode' => course_option.course.study_mode,
+          'study_mode' => course_option.study_mode,
         },
       )
     end
@@ -58,7 +58,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
             'provider_code' => other_course_option.course.provider.code,
             'course_code' => other_course_option.course.code,
             'site_code' => other_course_option.site.code,
-            'study_mode' => other_course_option.course.study_mode,
+            'study_mode' => other_course_option.study_mode,
           },
         },
       }
@@ -71,7 +71,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'provider_code' => other_course_option.course.provider.code,
           'course_code' => other_course_option.course.code,
           'site_code' => other_course_option.site.code,
-          'study_mode' => other_course_option.course.study_mode,
+          'study_mode' => other_course_option.study_mode,
         },
       )
     end
@@ -91,14 +91,14 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
             'provider_code' => other_course_option.course.provider.code,
             'course_code' => other_course_option.course.code,
             'site_code' => other_course_option.site.code,
-            'study_mode' => other_course_option.course.study_mode,
+            'study_mode' => other_course_option.study_mode,
           },
         },
       }
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'Offered course does not belong to provider'
+      expect(error_response['message']).to match 'can_make_offer? failed'
     end
 
     it 'returns an error when specifying a course that does not exist' do
@@ -121,12 +121,12 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'Offered course provider ABC does not exist'
+      expect(error_response['message']).to match 'Cannot find an appropriate course option for these codes'
     end
   end
 
   describe 'offering for application with a decision' do
-    it 'allows amending of existing offers' do
+    it 'allows amending of conditions for existing offers' do
       application_choice = create_application_choice_for_currently_authenticated_provider(
         status: 'awaiting_provider_decision',
       )
@@ -167,7 +167,65 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'provider_code' => course_option.course.provider.code,
           'course_code' => course_option.course.code,
           'site_code' => course_option.site.code,
-          'study_mode' => course_option.course.study_mode,
+          'study_mode' => course_option.study_mode,
+        },
+      )
+    end
+
+    it 'allows amending of course_option for existing offers' do
+      application_choice = create_application_choice_for_currently_authenticated_provider(
+        status: 'awaiting_provider_decision',
+      )
+
+      request_body = {
+        "data": {
+          "conditions": [
+            'Completion of subject knowledge enhancement',
+            'Completion of professional skills test',
+          ],
+        },
+      }
+
+      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
+
+      expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
+
+      original_course_option = application_choice.course_option
+      new_course_option = create(
+        :course_option,
+        course: original_course_option.course,
+        study_mode: original_course_option.study_mode,
+      )
+
+      request_body = {
+        "data": {
+          "conditions": [
+            'Completion of subject knowledge enhancement',
+            'Completion of professional skills test',
+          ],
+          "course": {
+            recruitment_cycle_year: original_course_option.course.recruitment_cycle_year,
+            provider_code: original_course_option.course.provider.code,
+            course_code: original_course_option.course.code,
+            study_mode: new_course_option.study_mode,
+            site_code: new_course_option.site.code,
+          },
+        },
+      }
+
+      post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
+
+      expect(parsed_response['data']['attributes']['offer']).to eq(
+        'conditions' => [
+          'Completion of subject knowledge enhancement',
+          'Completion of professional skills test',
+        ],
+        'course' => {
+          'recruitment_cycle_year' => original_course_option.course.recruitment_cycle_year,
+          'provider_code' => original_course_option.course.provider.code,
+          'course_code' => original_course_option.course.code,
+          'study_mode' => new_course_option.study_mode,
+          'site_code' => new_course_option.site.code,
         },
       )
     end
@@ -206,7 +264,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'provider_code' => course_option.course.provider.code,
           'course_code' => course_option.course.code,
           'site_code' => course_option.site.code,
-          'study_mode' => course_option.course.study_mode,
+          'study_mode' => course_option.study_mode,
         },
       )
     end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -14,28 +14,50 @@ RSpec.describe ChangeOffer do
   end
 
   it 'changes offered_course_option_id for the application choice if it is already set' do
-    expect { service.save! }.to change(application_choice, :offered_course_option_id)
+    expect { service.save }.to change(application_choice, :offered_course_option_id)
   end
 
   it 'sets offered_course_option_id for the application choice if it is not already set' do
     application_choice.update(offered_course_option_id: nil)
 
-    expect { service.save! }.to change(application_choice, :offered_course_option_id)
+    expect { service.save }.to change(application_choice, :offered_course_option_id)
+  end
+
+  it 'replaces conditions if offer_conditions is supplied' do
+    application_choice.update(offer: { 'conditions' => ['DBS check'] })
+
+    with_conditions = ChangeOffer.new(
+      actor: provider_user,
+      application_choice: application_choice,
+      course_option_id: new_course_option.id,
+      offer_conditions: ['First condition', 'Second condition'],
+    )
+
+    expect { with_conditions.save }.to change(application_choice, :offer)
+    expect(application_choice.offer['conditions']).to eq(['First condition', 'Second condition'])
   end
 
   it 'sets the offered_at date for the application_choice' do
     Timecop.freeze do
-      expect { service.save! }.to change(application_choice, :offered_at).to(Time.zone.now)
+      expect { service.save }.to change(application_choice, :offered_at).to(Time.zone.now)
     end
   end
 
   it 'resets declined_by_default_at for the application choice' do
-    expect { service.save! && application_choice.reload }.to change(application_choice, :decline_by_default_at)
+    expect { service.save && application_choice.reload }.to change(application_choice, :decline_by_default_at)
   end
 
   it 'does not change declined_by_default_at if the offered course option has not changed' do
-    noop = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option_id: original_course_option.id)
-    expect { noop.save! }.not_to change(application_choice, :decline_by_default_at)
+    current_course_option = application_choice.offered_option
+    noop = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option_id: current_course_option.id)
+    expect { noop.save }.not_to change(application_choice, :decline_by_default_at)
+  end
+
+  it 'adds :course_option_id validation error if the offered course option has not changed' do
+    current_course_option = application_choice.offered_option
+    noop = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option_id: current_course_option.id)
+    expect(noop).not_to be_valid
+    expect(noop.errors[:course_option_id]).not_to be_empty
   end
 
   it 'sends an email to the candidate to notify them about the change' do

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe ChangeOffer do
     mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
     allow(CandidateMailer).to receive(:changed_offer).and_return(mail)
 
-    service.save!
+    service.save
 
     expect(CandidateMailer).to have_received(:changed_offer).with(application_choice)
     expect(mail).to have_received(:deliver_later)

--- a/spec/services/get_course_option_from_codes_spec.rb
+++ b/spec/services/get_course_option_from_codes_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe GetCourseOptionFromCodes do
+  include CourseOptionHelpers
+
+  let(:course_option) { create(:course_option) }
+
+  let(:service) {
+    GetCourseOptionFromCodes.new(
+      provider_code: course_option.course.provider.code,
+      course_code: course_option.course.code,
+      study_mode: course_option.course.study_mode,
+      site_code: course_option.site.code,
+      recruitment_cycle_year: course_option.course.recruitment_cycle_year,
+    )
+  }
+
+  describe 'validation' do
+    required_attributes = %w[provider_code course_code study_mode site_code recruitment_cycle_year]
+    required_attributes.each do |attr|
+      it "complains about missing #{attr}" do
+        service.send("#{attr}=".to_sym, 'random')
+        expect(service).not_to be_valid
+      end
+    end
+  end
+
+  describe '#call' do
+    it 'returns the course_option if it can find it' do
+      expect(service.call).to eq(course_option)
+    end
+
+    it 'returns nil if it cannot find the course option' do
+      service.recruitment_cycle_year = 2017
+      expect(service.call).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
### Context

A [recent PR](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1551) introduced a `ChangeOffer` service and a UI for modifying courses for existing offers within the provider console. The ability to modify courses through the vendor API pre-dates this work. Although not well advertised/documented, it has been possible to perform multiple POST calls to `/applications/{application_id}/offer`, modifying the offer attributes such as conditions and course options after the initial offer was first made.

The aim of this work is to align the functionality of the provider interface and the vendor API, so that course modifications within an offer are handled by the same service, i.e. `ChangeOffer`, which will also perform email/Slack notifications.

### Changes proposed in this pull request

Introducing `ChangeOffer` to `app/controllers/vendor_api/decisions_controller.rb` should have been a relatively easy task, however the vendor API operates on different assumptions than the provider interface. While the provider interface expects a `CourseOption` id, which is a very specific identifier for a particular {provider, year, course, site/location, study_mode} combination, the vendor API expects a `Course` json structure, consisting of the following keys:

-  `provider_code` (e.g. '2FR')
-  `course_code (e.g. '3CVK')`
-  `study_mode` (e.g. 'full_time')
-  `site_code` (e.g. 'K')
-  `recruitment_cycle_year` (e.g. 2020)

This PR moves this code matching/translation logic from `MakeAnOffer`to another service `GetCourseOptionFromCodes`, which is responsible for identifying the appropriate `CourseOption` id from such parameters. In the process, it fixes a `study_mode`-related future bug which would impact the service once the first part-time courses were opened on Apply.

This allows refactoring of `MakeAnOffer` to accept a `CourseOption` id, while preserving the current API contract around identifying courses via codes. As a result, the public interfaces of`MakeAnOffer`and `ChangeOffer`converge, both accepting optional `course_option_id` and `offer_conditions` keyword params in their constructors and modifying state through `#save`.

This, in turn, enables `app/controllers/vendor_api/decisions_controller.rb` to use these services interchangeably and paves the way for [1770 - Allow providers to offer a different course when they first make their offer](https://trello.com/c/J3gqkQK6).

### Guidance to review

Find an application in `offer` state within the provider interface (e.g. by visiting http://localhost:3000/provider/applications?commit=Apply+filters&sort_by=last-updated&sort_order=desc&filter_selections%5Bstatus%5D%5Bawaiting-provider-decision%5D=awaiting_provider_decision&filter_selections%5Bstatus%5D%5Boffer%5D=offer on your dev enviroment) and note its `id` (e.g. by clicking on the application and noting the `id` present in the url). Use the same process to identify the `id` of a 'New'/`awaiting_provider_decision` application.
![image](https://user-images.githubusercontent.com/107591/76842883-dfc36700-6832-11ea-9eda-4036600aaf71.png)

Furthermore, you'll need codes for other courses run by this provider (e.g. 'Gorse SCITT'), in order to make/modify offers via the API. An easy way of obtaining these is through the 'change offer' screens within the provider interface. Codes are presented alongside the names of courses and sites in the relevant views. For example:

![image](https://user-images.githubusercontent.com/107591/76842931-eeaa1980-6832-11ea-8aad-4322730224e2.png)

Finally, make sure you know/have a Vendor API key associated with the same provider as the one offering the courses associated with the applications you will use for testing.

![image](https://user-images.githubusercontent.com/107591/76842965-fb2e7200-6832-11ea-8ccf-139c030c92bd.png)

You can then make API calls creating new offers or modifying existing offers using the application choice ids you identified before. The following example uses `curl`:

First, construct an appropriate `json` document to submit as part of the `POST`. For example:

```json
// offer.json
{
  "data": {
    "conditions": [ "First Condition", "Second Condition" ],
    "course": {
      "recruitment_cycle_year": 2020,
      "provider_code": "1N1",
      "course_code": "238T",
      "site_code": "5",
      "study_mode": "full_time"
    }
  },
  "meta": {
    "attribution": {
      "full_name": "Jane Jones",
      "email": "jane.jones@example.com",
      "user_id": "12345"
    },
    "timestamp": "2020-03-01T15:33:49.216Z"
  }
}
```

Then `POST` this document to the appropriate url:

```bash
curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ko3_sXXi9VqNhgLxXzX1Xq' --data @offer.json http://localhost:3000/api/v1/applications/67/offer
```

You can then inspect the API responses and what happens to these applications.

Otherwise, inspect this PR and run specs: `spec/services/change_offer_spec.rb`, `spec/services/make_an_offer_spec.rb`, `spec/services/get_course_option_from_codes_spec.rb` and `spec/requests/vendor_api/post_make_an_offer_spec.rb`.

### Link to Trello card

[1754 - Update Vendor API to use the new ChangeOffer service if it's modifying an offer](https://trello.com/c/u86uvnXW)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
