### PR TITLE
Revert "Fix email logging"

### DIFF
--- a/app/controllers/integrations/notify_controller.rb
+++ b/app/controllers/integrations/notify_controller.rb
@@ -1,7 +1,5 @@
 module Integrations
   class NotifyController < IntegrationsController
-    before_action :log_params
-
     include ActionController::HttpAuthentication::Token::ControllerMethods
 
     rescue_from ActionController::ParameterMissing, with: :render_unprocessable_entity
@@ -52,12 +50,6 @@ module Integrations
         message: 'Please provide a valid authentication token',
         status: :unauthorized,
       )
-    end
-
-    def log_params
-      relevant_parameters = params.permit(:reference, :status).to_h
-      RequestLocals.store[:identity] = relevant_parameters
-      Raven.user_context(relevant_parameters)
     end
   end
 end

--- a/app/controllers/support_interface/email_log_controller.rb
+++ b/app/controllers/support_interface/email_log_controller.rb
@@ -2,12 +2,6 @@ module SupportInterface
   class EmailLogController < SupportInterfaceController
     def index
       @emails = Email.order(id: :desc).includes(:application_form).limit(1000)
-
-      %w[to subject mailer mail_template notify_reference application_form_id delivery_status].each do |column|
-        next unless params[column]
-
-        @emails = @emails.where(column => params[column])
-      end
     end
   end
 end

--- a/app/views/support_interface/email_log/index.html.erb
+++ b/app/views/support_interface/email_log/index.html.erb
@@ -1,10 +1,9 @@
-<% content_for :title, 'Email log' %>
-
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
-      <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Email</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Type</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-half">What</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
@@ -14,13 +13,14 @@
         <%= email.created_at.to_s(:govuk_date_and_time) %>
       </td>
       <td class="govuk-table__cell">
+        <%= email.humanised_email_type %>
+      </td>
+      <td class="govuk-table__cell">
         <%= render SummaryListComponent.new(rows: [
-          { key: 'Type', value: email.humanised_email_type },
-          { key: 'Reference', value: email.notify_reference },
           { key: 'To', value: email.to },
           { key: 'Subject', value: email.subject },
-          { key: 'Application', value: (email.application_form ? govuk_link_to("#{email.application_form.full_name} (#{email.application_form.support_reference})", support_interface_application_form_path(email.application_form)) : nil) },
-          { key: 'Status', value: tag.span(email.delivery_status.humanize, class: "govuk-tag #{email.delivered? ? nil : 'govuk-tag--red'}") },
+          { key: 'Application', value: (email.application_form ? govuk_link_to(email.application_form.full_name, support_interface_application_form_path(email.application_form)) : nil) },
+          { key: 'Status', value: email.delivery_status.humanize },
         ]) %>
 
         <details class="govuk-details" data-module="govuk-details">

--- a/lib/email_log_interceptor.rb
+++ b/lib/email_log_interceptor.rb
@@ -1,11 +1,7 @@
 class EmailLogInterceptor
   def self.delivering_email(mail)
     notify_reference = mail.header['reference']&.value
-
-    unless notify_reference
-      notify_reference = generate_reference
-      mail.header['reference'] = notify_reference
-    end
+    notify_reference ||= generate_reference
 
     Email.create!(
       to: mail.to.first,

--- a/spec/system/support_interface/email_log_spec.rb
+++ b/spec/system/support_interface/email_log_spec.rb
@@ -22,24 +22,16 @@ RSpec.feature 'Email log' do
   end
 
   def when_an_email_with_custom_reference_is_sent
-    @candidate = create(:candidate, email_address: 'harry@example.com')
-
     AuthenticationMailer.sign_up_email(
-      candidate: @candidate,
+      candidate: create(:candidate, email_address: 'harry@example.com'),
       token: '123',
     ).deliver_now
-
-    open_email('harry@example.com')
-    expect(current_email.header('reference')).to eql("test-sign_up_email-#{@candidate.id}")
   end
 
   def and_an_email_with_an_application_id_is_sent
     CandidateMailer.application_submitted(
-      create(:application_form, first_name: 'Harry', last_name: 'Potter', candidate: @candidate),
+      create(:application_form, first_name: 'Harry', last_name: 'Potter'),
     ).deliver_now
-
-    open_email('harry@example.com')
-    expect(current_email.header('reference')).not_to be_nil
   end
 
   def and_i_visit_the_email_log
@@ -79,10 +71,7 @@ RSpec.feature 'Email log' do
   end
 
   def then_the_delivery_status_is_displayed_on_the_page
-    visit support_interface_email_log_path(delivery_status: 'permanent_failure')
+    visit support_interface_email_log_path
     expect(page).to have_content 'Permanent failure'
-
-    visit support_interface_email_log_path(delivery_status: 'delivered')
-    expect(page).not_to have_content 'Permanent failure'
   end
 end


### PR DESCRIPTION
Today we tried to deploy and we were unable to receive emails on staging, once I reverted these changes and deployed to Heroku it worked again. I'm not sure what the issue is, but I'll revert this for now so we can continue the deployment. https://app.slack.com/client/T50RK42V7/CAHBLU6ET/thread/CAHBLU6ET-1584442452.055600

Reverts DFE-Digital/apply-for-postgraduate-teacher-training#1646