### PR TITLE
Store an ISO3166 country code for addresses

### DIFF
--- a/app/models/candidate_interface/contact_details_form.rb
+++ b/app/models/candidate_interface/contact_details_form.rb
@@ -40,7 +40,7 @@ module CandidateInterface
         address_line3: address_line3,
         address_line4: address_line4,
         postcode: postcode.upcase,
-        country: 'UK',
+        country: 'GB',
       )
     end
   end

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Vendor receives the application' do
           address_line3: 'London',
           address_line4: '',
           postcode: 'SW1P 3BT',
-          country: 'UK',
+          country: 'GB',
           email: @current_candidate.email_address,
         },
         course: {


### PR DESCRIPTION
## Context

A vendor queried why we were returning "UK" when the API docs say that we'll return an ISO3166 country code.

The "UK" is hardcoded as we don't support international applications yet.

I discussed with the design team whether we expect to collect free text or structured data via this field in future (according to GOV.UK precedent), and the conclusion was that we thought we could and should collect structured data for it.

https://ukgovernmentdfe.slack.com/archives/CN9Q1VB2M/p1584350626329400

So this PR changes the hardcoded "UK" to "GB".

## Changes proposed in this pull request

Change the hardcoding and update the associated spec.

After it's merged we'll need to run 

```
ApplicationForm.update_all(country: 'GB')
```

on all environments.

## Guidance to review

Look at the Slack thread.

## Link to Trello card

https://trello.com/c/FKMkRrtg/1753-tribal-bug-report-on-nationalities

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
