### PR TITLE
Don’t put sidekiq into test mode when generating test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,5 +1,4 @@
 require 'active_support/testing/time_helpers'
-require 'sidekiq/testing'
 
 module TestApplications
   class NotEnoughCoursesError < RuntimeError; end

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -4,22 +4,20 @@ class GenerateTestApplications
   def perform
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
-    Sidekiq::Testing.inline! do
-      TestApplications.create_application states: [:unsubmitted]
-      TestApplications.create_application states: [:awaiting_references]
-      TestApplications.create_application states: [:application_complete]
-      TestApplications.create_application states: [:awaiting_provider_decision] * 3
-      TestApplications.create_application states: [:offer] * 2
-      TestApplications.create_application states: %i[offer rejected]
-      TestApplications.create_application states: [:rejected] * 2
-      TestApplications.create_application states: [:offer_withdrawn]
-      TestApplications.create_application states: [:declined]
-      TestApplications.create_application states: [:accepted]
-      TestApplications.create_application states: [:accepted_no_conditions]
-      TestApplications.create_application states: [:recruited]
-      TestApplications.create_application states: [:conditions_not_met]
-      TestApplications.create_application states: [:enrolled]
-      TestApplications.create_application states: [:withdrawn]
-    end
+    TestApplications.create_application states: [:unsubmitted]
+    TestApplications.create_application states: [:awaiting_references]
+    TestApplications.create_application states: [:application_complete]
+    TestApplications.create_application states: [:awaiting_provider_decision] * 3
+    TestApplications.create_application states: [:offer] * 2
+    TestApplications.create_application states: %i[offer rejected]
+    TestApplications.create_application states: [:rejected] * 2
+    TestApplications.create_application states: [:offer_withdrawn]
+    TestApplications.create_application states: [:declined]
+    TestApplications.create_application states: [:accepted]
+    TestApplications.create_application states: [:accepted_no_conditions]
+    TestApplications.create_application states: [:recruited]
+    TestApplications.create_application states: [:conditions_not_met]
+    TestApplications.create_application states: [:enrolled]
+    TestApplications.create_application states: [:withdrawn]
   end
 end

--- a/lib/tasks/generate_test_data.rake
+++ b/lib/tasks/generate_test_data.rake
@@ -1,5 +1,3 @@
-require 'sidekiq/testing'
-
 desc 'Delete and create test data, including courses and options'
 task generate_test_data: :environment do
   GenerateTestData.new(100).generate


### PR DESCRIPTION
Once this is required it hangs around for the life of the process. This means Sidekiq is effectively disabled.

## Context

Sidekiq was broken on QA.

## Changes proposed in this pull request

Don't turn on `sidekiq/testing` in `test_applications.rb` (or elsewhere outside the test suite).

## Guidance to review

Did we miss any?

## Link to Trello card

Thread of deploy where this defect was detected https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1584442452055600