### PR TITLE
Do not report Find 404s to Sentry

### DIFF
--- a/app/models/find_api/course.rb
+++ b/app/models/find_api/course.rb
@@ -20,10 +20,10 @@ module FindAPI
         .where(provider_code: provider_code)
         .find(course_code)
         .first
+    rescue JsonApiClient::Errors::NotFound
+      nil
     rescue JsonApiClient::Errors::ServerError, JsonApiClient::Errors::ConnectionError => e
       Raven.capture_exception(e)
-      nil
-    rescue JsonApiClient::Errors::NotFound
       nil
     end
   end

--- a/spec/models/find_api/course_spec.rb
+++ b/spec/models/find_api/course_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe FindAPI::Course do
       it 'returns nil' do
         expect(fetch_course).to be_nil
       end
+
+      it 'does not report the error to Sentry' do
+        allow(Raven).to receive(:capture_exception)
+
+        fetch_course
+
+        expect(Raven).not_to have_received(:capture_exception)
+      end
     end
 
     context 'when Find returns a 503 error' do


### PR DESCRIPTION
The original intention of this code was to discard plain 404s, and for
other errors, notify sentry, then discard them.

Because Errors::NotFound is a subclass of Errors::ServerError, the first
rescue was picking up NotFounds and reporting them to Sentry.

Reversing the order of the rescues fixes this.

props @stevehook and @malcolmbaig who actually wrote the fix for the bug on the Trello card 🙂 .

## Context

Too many of these, which we don't care about: https://sentry.io/organizations/dfe-bat/issues/1524365521/?project=1765973&referrer=slack

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/3JcfMh7T/1723-suppress-find-api-not-found-errors-in-sentry

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
