### PR TITLE
Send email to referee in background worker

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -61,8 +61,6 @@ module RefereeInterface
     end
 
     def submit_feedback
-      @application = reference.application_form
-
       @reference_form = ReferenceFeedbackForm.new(
         reference: reference,
         feedback: params[:referee_interface_reference_feedback_form][:feedback],
@@ -72,8 +70,6 @@ module RefereeInterface
         if FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
           redirect_to referee_interface_reference_review_path(token: @token_param)
         else
-          SendReferenceConfirmationEmail.call(application_form: @application, reference: reference)
-
           redirect_to referee_interface_confirmation_path(token: @token_param)
         end
       else
@@ -86,9 +82,6 @@ module RefereeInterface
     end
 
     def submit_reference
-      @application = reference.application_form
-
-      SendReferenceConfirmationEmail.call(application_form: @application, reference: reference)
       ReceiveReference.new(reference: reference, feedback: reference.feedback).save!
 
       redirect_to referee_interface_confirmation_path(token: @token_param)

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -11,7 +11,7 @@ class ReceiveReference
     ActiveRecord::Base.transaction do
       @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
       CandidateMailer.reference_received(@reference).deliver_later
-      RefereeMailer.reference_confirmation_email(application_form, reference).deliver
+      RefereeMailer.reference_confirmation_email(application_form, reference).deliver_later
       progress_application_if_enough_references_have_been_submitted
     end
   end

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -11,7 +11,7 @@ class ReceiveReference
     ActiveRecord::Base.transaction do
       @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
       CandidateMailer.reference_received(@reference).deliver_later
-      SendReferenceConfirmationEmail.call(application_form: @reference.application, reference: reference)
+      RefereeMailer.reference_confirmation_email(application_form, reference).deliver
       progress_application_if_enough_references_have_been_submitted
     end
   end

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -11,6 +11,7 @@ class ReceiveReference
     ActiveRecord::Base.transaction do
       @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
       CandidateMailer.reference_received(@reference).deliver_later
+      SendReferenceConfirmationEmail.call(application_form: @reference.application, reference: reference)
       progress_application_if_enough_references_have_been_submitted
     end
   end

--- a/app/services/send_reference_confirmation_email.rb
+++ b/app/services/send_reference_confirmation_email.rb
@@ -1,8 +1,0 @@
-class SendReferenceConfirmationEmail
-  def self.call(application_form:, reference:)
-    RefereeMailer.reference_confirmation_email(application_form, reference).deliver
-
-    audit_comment = "Reference confirmation email has been sent to the candidate’s reference: #{reference.name} using #{reference.email_address}."
-    application_form.update!(audit_comment: audit_comment)
-  end
-end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     then_i_see_am_told_i_submittted_my_refernce
     then_i_see_the_confirmation_page
     and_i_receive_an_email_confirmation
-    and_an_audit_comment_is_added
     and_the_candidate_receives_a_notification
     when_i_choose_to_be_contactable
     and_i_click_the_finish_button
@@ -93,12 +92,6 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     open_email('terri@example.com')
 
     expect(current_email.subject).to have_content(t('reference_confirmation_email.subject', candidate_name: @application.full_name))
-  end
-
-  def and_an_audit_comment_is_added
-    expect(@application.audits.last.comment).to eq(
-      'Reference confirmation email has been sent to the candidate’s reference: Terri Tudor using terri@example.com.',
-    )
   end
 
   def and_the_candidate_receives_a_notification

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -58,7 +58,6 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     then_i_see_am_told_i_submittted_my_refernce
     then_i_see_the_confirmation_page
     and_i_receive_an_email_confirmation
-    and_an_audit_comment_is_added
     and_the_candidate_receives_a_notification
 
     when_i_choose_to_be_contactable
@@ -206,12 +205,6 @@ RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true 
     open_email('terri@example.com')
 
     expect(current_email.subject).to have_content(t('reference_confirmation_email.subject', candidate_name: @application.full_name))
-  end
-
-  def and_an_audit_comment_is_added
-    expect(@application.audits.last.comment).to eq(
-      'Reference confirmation email has been sent to the candidate’s reference: Terri Tudor using terri@example.com.',
-    )
   end
 
   def and_the_candidate_receives_a_notification


### PR DESCRIPTION
## Context

When sending emails, we should use `deliver_later` to use the background workers. This means that we don't show errors to users if GOV.UK Notify is down.

## Changes proposed in this pull request

- Fix the issue
- Do a bit of driveby refactoring and cleanup to make the change easy

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

Related to https://sentry.io/organizations/dfe-bat/issues/1568618872

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
