### PR TITLE
Redirect to review courses page when no to adding another course

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -172,7 +172,7 @@ module CandidateInterface
       if @add_another_course.add_another_course?
         redirect_to candidate_interface_course_choices_choose_path
       else
-        redirect_to candidate_interface_application_form_path
+        redirect_to candidate_interface_course_choices_index_path
       end
     end
 

--- a/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe 'Add additional courses flow' do
     and_i_should_be_told_i_can_add_2_more_courses
     and_i_should_be_prompted_to_add_an_additional_course
 
+    when_i_choose_no
+    then_i_should_be_on_the_course_choice_review_page
+
+    given_i_am_on_the_additional_courses_page
     when_i_choose_yes
     then_i_should_see_the_have_you_chosen_a_course_page
 
@@ -99,6 +103,15 @@ RSpec.describe 'Add additional courses flow' do
 
   def and_i_should_be_prompted_to_add_an_additional_course
     expect(page).to have_content('Do you want to add another course?')
+  end
+
+  def when_i_choose_no
+    choose 'No, not at the moment'
+    click_on 'Continue'
+  end
+
+  def given_i_am_on_the_additional_courses_page
+    visit candidate_interface_course_choices_add_another_course_path
   end
 
   def when_i_choose_yes


### PR DESCRIPTION
## Context

In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1558, we build the add another course flow. There was just a smol issue when product reviewed. We redirected to the 'Your application' page if the candidate chose 'No, not at the moment' when asked if they want to add another course. This is incorrect.

![image](https://user-images.githubusercontent.com/42817036/76872275-21b8d100-6864-11ea-87e5-0949442f7e44.png)

## Changes proposed in this pull request

This PR updates the redirect to be to the review course choices page.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/lgMDVrWk/1090-build-add-another-course-flow-read-comment

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
