### PR TITLE
Fix bug when users double submit the find course selection form

### DIFF
--- a/app/controllers/candidate_interface/find_course_selections_controller.rb
+++ b/app/controllers/candidate_interface/find_course_selections_controller.rb
@@ -44,11 +44,11 @@ module CandidateInterface
         course_option_id: course_option_id,
       )
 
-      if pick_site.save
-        redirect_to candidate_interface_course_choices_index_path
-      else
-        render :options_for_site
+      unless pick_site.save
+        flash[:warning] = pick_site.errors.full_messages.first
       end
+
+      redirect_to candidate_interface_course_choices_index_path
     end
 
     def course_selection_params

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -30,7 +30,7 @@ module CandidateInterface
           flash[:warning] = "You have already selected #{course.name_and_code}."
           redirect_to candidate_interface_course_choices_review_path
         elsif service.candidate_already_has_3_courses
-          flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
+          flash[:warning] = I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course.name_and_code)
           redirect_to candidate_interface_course_choices_review_path
         elsif !service.candidate_does_not_have_a_course_from_find
           redirect_to candidate_interface_course_confirm_selection_path(course_id: course.id)
@@ -55,7 +55,7 @@ module CandidateInterface
           flash[:warning] = "You have already selected #{course.name_and_code}."
           redirect_to candidate_interface_course_choices_review_path
         elsif service.candidate_already_has_3_courses
-          flash[:warning] = "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course.name_and_code}."
+          flash[:warning] = I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course.name_and_code)
           redirect_to candidate_interface_course_choices_review_path
         elsif service.candidate_has_new_course_added
           redirect_to candidate_interface_course_choices_review_path

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     def candidate_can_only_apply_to_3_courses
       return if application_form.application_choices.count <= 2
 
-      errors[:base] << I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course.name_and_code)
+      errors[:base] << I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course_option.course.name_and_code)
     end
   end
 end

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -41,7 +41,7 @@ module CandidateInterface
     def candidate_can_only_apply_to_3_courses
       return if application_form.application_choices.count <= 2
 
-      errors[:base] << 'You can only apply for up to 3 courses'
+      errors[:base] << I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course.name_and_code)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,14 +4,14 @@ en:
     manage: Manage teacher training applications
     support: Support for Apply
   page_titles:
-    application: ''
+    application: ""
     application_form: Your application
     edit_application_form: Edit your application
     application_dashboard: Application dashboard
     application_edit: Editing your application
     eligibility: Check we’re ready for you to use this service
-    error_prefix: 'Error: '
-    success_prefix: 'Success: '
+    error_prefix: "Error: "
+    success_prefix: "Success: "
     not_eligible_yet: We’re sorry, but we’re not ready for you yet
     submitted_application: Your submitted application
     sign_up: Create an account
@@ -88,7 +88,7 @@ en:
     providers: Training providers available through Apply for teacher training
     view_and_respond_to_offer: Details of offer
     api_docs:
-      home:  Apply for teacher training
+      home: Apply for teacher training
       usage: Usage scenarios
       reference: API reference
       help: Get help
@@ -211,6 +211,7 @@ en:
   errors:
     messages:
       too_many_words: Must be %{count} words or fewer
+      too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course_name_and_code}.
   date:
     formats:
       long: "%e %B %Y"

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_without_selection_page.spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_without_selection_page.spec.rb
@@ -154,7 +154,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_should_be_informed_i_already_have_3_courses
-    expect(page).to have_content "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course_with_multiple_sites.name_and_code}"
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course_with_multiple_sites.name_and_code)
   end
 
   def when_i_sign_out

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_should_be_informed_i_already_have_3_courses
-    expect(page).to have_content "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course_with_multiple_sites.name_and_code}"
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course_with_multiple_sites.name_and_code)
   end
 
   def when_i_sign_out

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_should_be_informed_i_already_have_3_courses
-    expect(page).to have_content "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course.name_and_code}"
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course_with_multiple_sites.name_and_code)
   end
 
   def when_i_sign_out

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_without_selection_page_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_without_selection_page_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_should_be_informed_i_already_have_3_courses
-    expect(page).to have_content "You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{@course.name_and_code}"
+    expect(page).to have_content I18n.t('errors.messages.too_many_course_choices', course_name_and_code: @course_with_multiple_sites.name_and_code)
   end
 
   def when_i_sign_out


### PR DESCRIPTION
## Context

If a user comes in from find, adds a course to their application that brings them up to 3 courses, and then goes back with their browser and resubmits the form, they'll get a 500 because `:options_for_site` is not defined in this controller.

Instead, we should display an error message and direct them to the index page for course choices.

## Changes proposed in this pull request

Remove the `else` clause and always redirect to the index page, with an error message if appropriate.

## Guidance to review

I couldn't find a way to test this using system specs, because our `rack_test` driver does not allow `page.go_back`. `visit` will reset the session and log you out.

I have tested this manually as such:

- Log in and apply to 2 courses
- Find a course with only 1 site on Find
- Apply from Find for that course, you'll have 3 courses now
- Press back in your browser
- Resubmit the same form
- You should get a 500 (without the changes in this branch)

If you want to give it a go, the system spec to update is `spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb`.

## Link to Trello card

https://trello.com/c/Mpybdjth/1196-fix-live-bug-when-user-double-submits-the-form-when-they-arrive-from-find-on-a-course-with-only-one-site

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)