### PR TITLE
Allow providers to select a different course, location or provider as they make an offer

### DIFF
--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -8,10 +8,6 @@ module ProviderInterface
       @header = header
     end
 
-    def render?
-      application_choice.offer.present? || raise(NoOfferError)
-    end
-
     def rows
       [
         {
@@ -32,7 +28,5 @@ module ProviderInterface
         },
       ]
     end
-
-    class NoOfferError < StandardError; end
   end
 end

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -9,12 +9,10 @@ module ProviderInterface
 
     def submit_response
       @pick_response_form = PickResponseForm.new(decision: params.dig(:provider_interface_pick_response_form, :decision))
-      render action: :respond if !@pick_response_form.valid?
-
-      if @pick_response_form.decision == 'offer'
-        redirect_to action: :new_offer
-      elsif @pick_response_form.decision == 'reject'
-        redirect_to action: :new_reject
+      if @pick_response_form.valid?
+        redirect_to submit_response_redirect_attrs
+      else
+        render action: :respond
       end
     end
 
@@ -22,6 +20,7 @@ module ProviderInterface
       @application_offer = MakeAnOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
+        course_option_id: params[:course_option_id],
       )
     end
 
@@ -29,6 +28,7 @@ module ProviderInterface
       @application_offer = MakeAnOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
+        course_option_id: params[:course_option_id],
         standard_conditions: make_an_offer_params[:standard_conditions],
         further_conditions: make_an_offer_params.permit(
           :further_conditions0,
@@ -46,6 +46,7 @@ module ProviderInterface
       @application_offer = MakeAnOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
+        course_option_id: params[:course_option_id],
         offer_conditions: offer_conditions_array,
       )
 
@@ -130,6 +131,12 @@ module ProviderInterface
 
     def make_an_offer_params
       params.require(:make_an_offer)
+    end
+
+    def submit_response_redirect_attrs
+      attrs = { action: @pick_response_form.decision }
+      attrs[:controller] = 'offer_changes' if @pick_response_form.decision_is_change?
+      attrs
     end
   end
 end

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -31,7 +31,7 @@ module ProviderInterface
       @change_offer_form.step = :confirm
 
       if @change_offer_form.valid?
-        return redirect_to_amend_new_offer if @change_offer_form.new_offer?
+        return redirect_to_confirm_new_offer if @change_offer_form.new_offer?
 
         @future_application_choice = @application_choice.dup
         @future_application_choice.offered_course_option_id = @change_offer_form.course_option_id
@@ -78,7 +78,7 @@ module ProviderInterface
       render_course_options
     end
 
-    def redirect_to_amend_new_offer
+    def redirect_to_confirm_new_offer
       redirect_to(
         provider_interface_application_choice_new_offer_path(
           course_option_id: @change_offer_form.course_option_id,

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -29,15 +29,14 @@ module ProviderInterface
 
     def confirm_update
       @change_offer_form.step = :confirm
+
       if @change_offer_form.valid?
+        return redirect_to_amend_new_offer if @change_offer_form.new_offer?
+
         @future_application_choice = @application_choice.dup
         @future_application_choice.offered_course_option_id = @change_offer_form.course_option_id
-      elsif @change_offer_form.errors[:provider_id].present?
-        render_providers
-      elsif @change_offer_form.errors[:course_id].present?
-        render_courses
       else
-        render_course_options
+        render_step_for_invalid_form
       end
     end
 
@@ -70,6 +69,21 @@ module ProviderInterface
     def render_course_options
       set_alternative_course_options
       render :edit_course_option
+    end
+
+    def render_step_for_invalid_form
+      return render_providers if @change_offer_form.errors[:provider_id].present?
+      return render_courses if @change_offer_form.errors[:course_id].present?
+
+      render_course_options
+    end
+
+    def redirect_to_amend_new_offer
+      redirect_to(
+        provider_interface_application_choice_new_offer_path(
+          course_option_id: @change_offer_form.course_option_id,
+        ),
+      )
     end
 
     def requires_provider_change_response_feature_flag

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -45,5 +45,9 @@ module ProviderInterface
     def self.course_option_matches_course?(record)
       record.course_option_id && CourseOption.find(record.course_option_id).course.id == record.course_id
     end
+
+    def new_offer?
+      application_choice.offer.blank?
+    end
   end
 end

--- a/app/models/provider_interface/pick_response_form.rb
+++ b/app/models/provider_interface/pick_response_form.rb
@@ -2,7 +2,14 @@ module ProviderInterface
   class PickResponseForm
     include ActiveModel::Model
 
+    VALID_CHANGE_DECISIONS = %w[edit_course edit_course_option edit_provider].freeze
+    VALID_DECISIONS = (%w[new_offer new_reject] + VALID_CHANGE_DECISIONS).freeze
+
     attr_accessor :decision
-    validates :decision, presence: true
+    validates :decision, inclusion: { in: VALID_DECISIONS }
+
+    def decision_is_change?
+      VALID_CHANGE_DECISIONS.include?(decision)
+    end
   end
 end

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -26,6 +26,8 @@ class MakeAnOffer
     @offer_conditions = offer_conditions
     @standard_conditions = standard_conditions
     further_conditions.each { |key, value| self.send("#{key}=", value) }
+
+    @application_choice.offered_course_option = offered_course_option
   end
 
   def save
@@ -58,15 +60,15 @@ class MakeAnOffer
     ].flatten.reject(&:blank?)
   end
 
-private
-
-  attr_reader :application_choice
-
   def offered_course_option
-    return nil unless @course_option_id && @course_option_id != application_choice.course_option.id
+    return unless @course_option_id.present? && @course_option_id != application_choice.course_option.id
 
     CourseOption.find @course_option_id
   end
+
+private
+
+  attr_reader :application_choice
 
   def further_conditions
     [

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -47,9 +47,9 @@
 
     <%= render SummaryListComponent.new(rows: [
       { key: 'Provider', value: @application_choice.provider.name_and_code },
-      { key: 'Course', value: @application_choice.course.name_and_code },
+      { key: 'Course', value: @application_choice.offered_course.name_and_code },
       { key: 'Cycle', value: @application_choice.course.recruitment_cycle_year },
-      { key: 'Preferred location', value: @application_choice.site.name_and_code },
+      { key: 'Preferred location', value: @application_choice.offered_site.name_and_code },
       { key: 'Study mode', value: @application_choice.course_option.study_mode.humanize },
     ]) %>
 

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -3,11 +3,6 @@
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
 
-<h1 class="govuk-heading-xl">
-	<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-  Check and confirm offer
-</h1>
-
 <% conditions = capture do %>
   <% if @application_offer.offer_conditions.empty? %>
     Unconditional offer
@@ -20,33 +15,35 @@
   <% end %>
 <% end %>
 
-<%= render SummaryListComponent.new(rows: [
-  { key: 'Course', value: @application_choice.offered_course.name_and_code },
-  { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-  { key: 'Preferred location', value: @application_choice.offered_site.name },
-  { key: 'Conditions', value: conditions },
-]) %>
-
 <%= form_with model: @application_offer, url: provider_interface_application_choice_create_offer_path(@application_choice.id), method: :post do |f| %>
+  <h1 class="govuk-heading-xl">
+    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    Check and confirm offer
+  </h1>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
 
-      <p class="govuk-body govuk-!-font-weight-bold">
-        Make a note of the conditions you have set.
+      <%= render SummaryListComponent.new(rows: [
+        { key: 'Course', value: @application_choice.offered_course.name_and_code },
+        { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
+        { key: 'Preferred location', value: @application_choice.offered_site.name },
+        { key: 'Conditions', value: conditions },
+      ]) %>
+
+      <p class="govuk-body">
+        By making this offer, you guarantee this candidate a place on their chosen course, if they meet the conditions you have set out.
       </p>
       <p class="govuk-body">
-        When you confirm this offer, you’ll guarantee this candidate a place on their chosen course, providing they meet the conditions given.
-      </p>
-      <p class="govuk-body">
-        You can only change the conditions of this offer with the candidate’s permission.
+        Once the candidate has accepted, you can only change the conditions of this offer with their permission.
       </p>
 
       <% if @application_offer.offered_course_option.present? %>
         <%= hidden_field_tag :course_option_id, @application_offer.offered_course_option.id %>
       <% end %>
       <%= hidden_field_tag :offer_conditions, @application_offer.offer_conditions.to_json %>
-      <%= f.govuk_submit 'Confirm offer' %>
+      <%= f.govuk_submit 'Make offer' %>
 
       <p class="govuk-body">
         <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -19,9 +19,9 @@
 
 <%= render SummaryListComponent.new(rows: [
   { key: 'Full name', value: @application_choice.application_form.full_name },
-  { key: 'Course', value: @application_choice.course.name_and_code },
+  { key: 'Course', value: @application_choice.offered_course.name_and_code },
   { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-  { key: 'Preferred location', value: @application_choice.site.name },
+  { key: 'Preferred location', value: @application_choice.offered_site.name },
   { key: 'Conditions', value: conditions },
 ]) %>
 
@@ -40,6 +40,9 @@
         You can only change the conditions of this offer with the candidate’s permission.
       </p>
 
+      <% if @application_offer.offered_course_option.present? %>
+        <%= hidden_field_tag :course_option_id, @application_offer.offered_course_option.id %>
+      <% end %>
       <%= hidden_field_tag :offer_conditions, @application_offer.offer_conditions.to_json %>
       <%= f.govuk_submit 'Confirm offer' %>
 

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -3,7 +3,10 @@
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
 
-<h1 class="govuk-heading-xl">Confirm offer</h1>
+<h1 class="govuk-heading-xl">
+	<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+  Check and confirm offer
+</h1>
 
 <% conditions = capture do %>
   <% if @application_offer.offer_conditions.empty? %>
@@ -18,7 +21,6 @@
 <% end %>
 
 <%= render SummaryListComponent.new(rows: [
-  { key: 'Full name', value: @application_choice.application_form.full_name },
   { key: 'Course', value: @application_choice.offered_course.name_and_code },
   { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
   { key: 'Preferred location', value: @application_choice.offered_site.name },

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -5,6 +5,7 @@
 
 <%= form_with model: @application_offer, url: provider_interface_application_choice_confirm_offer_path(@application_choice.id), method: :post do |f| %>
   <%= f.govuk_error_summary %>
+  <%= hidden_field_tag :course_option_id, params[:course_option_id] %>
 
   <h1 class="govuk-heading-xl">
     Conditions of offer
@@ -12,9 +13,9 @@
 
   <%= render SummaryListComponent.new(rows: [
     { key: 'Full name', value: @application_choice.application_form.full_name },
-    { key: 'Course', value: @application_choice.course.name_and_code },
+    { key: 'Course', value: @application_choice.offered_course.name_and_code },
     { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-    { key: 'Preferred location', value: @application_choice.site.name },
+    { key: 'Preferred location', value: @application_choice.offered_site.name },
   ]) %>
 
   <div class="govuk-grid-row">

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -7,16 +7,10 @@
   <%= f.govuk_error_summary %>
   <%= hidden_field_tag :course_option_id, params[:course_option_id] %>
 
-  <h1 class="govuk-heading-xl">
-    Conditions of offer
-  </h1>
-
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Full name', value: @application_choice.application_form.full_name },
-    { key: 'Course', value: @application_choice.offered_course.name_and_code },
-    { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-    { key: 'Preferred location', value: @application_choice.offered_site.name },
-  ]) %>
+	<h1 class="govuk-heading-xl">
+		<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+		Conditions of offer
+	</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -10,10 +10,13 @@
       <%- reject_text = 'Reject application' %>
 
       <%= f.govuk_radio_buttons_fieldset :decision do %>
-				<h1 class="govuk-heading-xl">
-					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-					Respond to application
-				</h1>
+
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+            Respond to application
+          </h1>
+        </legend>
 
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
         <% if FeatureFlag.active?('provider_change_response') -%>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -21,9 +21,11 @@
       <%- reject_text = 'Reject application' %>
       <%= f.govuk_radio_buttons_fieldset :decision, legend: { size: 'm', text: 'Choose response' } do %>
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
-        <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>
-        <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" }, link_errors: true %>
-        <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" }, link_errors: true %>
+        <% if FeatureFlag.active?('provider_change_response') -%>
+          <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>
+          <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" }, link_errors: true %>
+          <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" }, link_errors: true %>
+        <% end -%>
         <%= f.govuk_radio_button :decision, 'new_reject', label: { text: reject_text } %>
       <% end %>
 

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -20,8 +20,11 @@
       <%- offer_text = 'Make an offer' %>
       <%- reject_text = 'Reject application' %>
       <%= f.govuk_radio_buttons_fieldset :decision, legend: { size: 'm', text: 'Choose response' } do %>
-        <%= f.govuk_radio_button :decision, 'offer', label: { text: offer_text }, link_errors: true %>
-        <%= f.govuk_radio_button :decision, 'reject', label: { text: reject_text } %>
+        <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" }, link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" }, link_errors: true %>
+        <%= f.govuk_radio_button :decision, 'new_reject', label: { text: reject_text } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -6,20 +6,15 @@
     <%= form_with model: @pick_response_form, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl">
-        Respond to application
-      </h1>
-
-      <%= render SummaryListComponent.new(rows: [
-        { key: 'Full name', value: @application_choice.application_form.full_name },
-        { key: 'Course', value: @application_choice.course.name_and_code },
-        { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-        { key: 'Preferred location', value: @application_choice.site.name },
-      ]) %>
-
       <%- offer_text = 'Make an offer' %>
       <%- reject_text = 'Reject application' %>
-      <%= f.govuk_radio_buttons_fieldset :decision, legend: { size: 'm', text: 'Choose response' } do %>
+
+      <%= f.govuk_radio_buttons_fieldset :decision do %>
+				<h1 class="govuk-heading-xl">
+					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+					Respond to application
+				</h1>
+
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
         <% if FeatureFlag.active?('provider_change_response') -%>
           <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -24,7 +24,9 @@
         <% if FeatureFlag.active?('provider_change_response') -%>
           <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>
           <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" }, link_errors: true %>
-          <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" }, link_errors: true %>
+          <% if current_provider_user.providers.size > 1 %>
+            <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" }, link_errors: true %>
+          <% end %>
         <% end -%>
         <%= f.govuk_radio_button :decision, 'new_reject', label: { text: reject_text } %>
       <% end %>

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -1,3 +1,5 @@
+<% content_for :before_content, govuk_back_link_to(request.referer) %>
+
 <h1 class="govuk-heading-xl">
 	<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
 	Check and confirm changes to offer

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -1,5 +1,7 @@
-<h1 class="govuk-heading-xl">Check and confirm changes to offer</h2>
-
+<h1 class="govuk-heading-xl">
+	<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+	Check and confirm changes to offer
+</h1>
 <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
 <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @future_application_choice, header: 'Your new offer') %>
 

--- a/app/views/provider_interface/offer_changes/edit_course.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course.html.erb
@@ -1,3 +1,5 @@
+<% content_for :before_content, govuk_back_link_to(request.referer) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
@@ -7,10 +9,12 @@
       <%= f.hidden_field :provider_id %>
       <%= f.govuk_radio_buttons_fieldset :course_id do %>
 
-				<h1 class="govuk-heading-xl">
-					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-					<%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' course') %>
-				</h1>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+					  <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+					  <%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' course') %>
+				  </h1>
+        </legend>
 
         <% @alternative_courses.each do |course| %>
           <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint_text: nil %>

--- a/app/views/provider_interface/offer_changes/edit_course.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-xl">Choose new course</h2>
-<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
@@ -7,7 +5,13 @@
           method: :get do |f| %>
 
       <%= f.hidden_field :provider_id %>
-      <%= f.govuk_radio_buttons_fieldset :course_id, legend: { size: 'm', text: 'Select course', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :course_id do %>
+
+				<h1 class="govuk-heading-xl">
+					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+					<%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' course') %>
+				</h1>
+
         <% @alternative_courses.each do |course| %>
           <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint_text: nil %>
         <% end %>

--- a/app/views/provider_interface/offer_changes/edit_course_option.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course_option.html.erb
@@ -1,3 +1,5 @@
+<% content_for :before_content, govuk_back_link_to(request.referer) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
@@ -7,10 +9,12 @@
       <%= f.hidden_field :provider_id %>
       <%= f.hidden_field :course_id %>
       <%= f.govuk_radio_buttons_fieldset :course_option_id do %>
-				<h1 class="govuk-heading-xl">
-					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-					<%= (@application_choice.offer? ? 'Change' : 'Select').concat(' location') %>
-				</h1>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+            <%= (@application_choice.offer? ? 'Change' : 'Select').concat(' location') %>
+          </h1>
+        </legend>
 
         <% @alternative_course_options.each do |course_option| %>
           <%= f.govuk_radio_button :course_option_id, course_option.id, label: { text: course_option.site.name }, hint_text: course_option.site.full_address %>

--- a/app/views/provider_interface/offer_changes/edit_course_option.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course_option.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-xl">Choose new location</h2>
-<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
@@ -8,7 +6,12 @@
 
       <%= f.hidden_field :provider_id %>
       <%= f.hidden_field :course_id %>
-      <%= f.govuk_radio_buttons_fieldset :course_option_id, legend: { size: 'm', text: 'Select location', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :course_option_id do %>
+				<h1 class="govuk-heading-xl">
+					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+					<%= (@application_choice.offer? ? 'Change' : 'Select').concat(' location') %>
+				</h1>
+
         <% @alternative_course_options.each do |course_option| %>
           <%= f.govuk_radio_button :course_option_id, course_option.id, label: { text: course_option.site.name }, hint_text: course_option.site.full_address %>
         <% end %>

--- a/app/views/provider_interface/offer_changes/edit_provider.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_provider.html.erb
@@ -1,5 +1,3 @@
-<h1 class="govuk-heading-xl">Change training provider</h2>
-<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -7,7 +5,12 @@
           url: provider_interface_application_choice_change_offer_edit_course_path(@application_choice.id),
           method: :get do |f| %>
 
-      <%= f.govuk_radio_buttons_fieldset :provider_id, legend: { size: 'm', text: 'Select alternative provider', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :provider_id do %>
+				<h1 class="govuk-heading-xl">
+					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+					<%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' provider') %>
+				</h1>
+
         <% @alternative_providers.each do |provider| %>
           <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code } %>
         <% end %>

--- a/app/views/provider_interface/offer_changes/edit_provider.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_provider.html.erb
@@ -1,3 +1,5 @@
+<% content_for :before_content, govuk_back_link_to(request.referer) %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
@@ -6,10 +8,13 @@
           method: :get do |f| %>
 
       <%= f.govuk_radio_buttons_fieldset :provider_id do %>
-				<h1 class="govuk-heading-xl">
-					<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-					<%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' provider') %>
-				</h1>
+
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading">
+            <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+            <%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' provider') %>
+          </h1>
+        </legend>
 
         <% @alternative_providers.each do |provider| %>
           <%= f.govuk_radio_button :provider_id, provider.id, label: { text: provider.name_and_code } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,7 +135,7 @@ en:
         provider_interface/pick_response_form:
           attributes:
             decision:
-              blank: Select if you want to make an offer or reject the application
+              inclusion: Select if you want to make an offer or reject the application
         provider_interface/change_offer_form:
           attributes:
             provider_id:

--- a/spec/models/provider_interface/pick_response_form_spec.rb
+++ b/spec/models/provider_interface/pick_response_form_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::PickResponseForm do
   describe 'validations' do
-    it { is_expected.to validate_presence_of(:decision).with_message('Select if you want to make an offer or reject the application') }
+    it do
+      expect(described_class.new).to validate_inclusion_of(:decision)
+        .in_array(described_class::VALID_DECISIONS)
+        .with_message('Select if you want to make an offer or reject the application')
+    end
   end
 end

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature 'Provider makes an offer' do
   end
 
   def when_i_confirm_the_offer
-    click_on 'Confirm offer'
+    click_on 'Make offer'
   end
 
   def then_i_am_back_to_the_application_page

--- a/spec/system/provider_interface/provider_makes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_an_offer_spec.rb
@@ -51,8 +51,6 @@ RSpec.feature 'Provider makes an offer' do
 
   def then_i_see_some_application_info
     expect(page).to have_content \
-      @application_awaiting_provider_decision.course.name_and_code
-    expect(page).to have_content \
       @application_awaiting_provider_decision.application_form.first_name
     expect(page).to have_content \
       @application_awaiting_provider_decision.application_form.last_name
@@ -77,7 +75,7 @@ RSpec.feature 'Provider makes an offer' do
         @application_awaiting_provider_decision.id,
       ),
     )
-    expect(page).to have_content 'Confirm offer'
+    expect(page).to have_content 'Check and confirm offer'
   end
 
   def and_i_see_the_correct_offer_conditions

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -9,15 +9,17 @@ RSpec.feature 'Provider makes changes before making an offer' do
     when_change_response_feature_is_activated
     and_i_am_permitted_to_see_applications_for_two_providers
     and_an_application_choice_exists_for_one_of_my_providers
-    and_another_two_course_options_exist_for_this_provider
+    and_another_two_course_options_exist_for_another_provider
     and_i_sign_in_to_the_provider_interface
     and_i_view_an_application
 
     and_i_click_on_respond_to_application
     then_i_see_options_to_make_an_offer
 
-    when_i_choose_make_offer_but_change_course
-    then_i_see_all_courses_for_this_provider
+    when_i_choose_make_offer_but_change_provider
+    then_i_see_all_providers
+    and_i_can_change_training_provider
+    and_i_see_all_courses_for_this_provider
     and_i_can_change_the_course
     and_i_see_all_available_locations_for_this_course
     and_i_can_change_the_location
@@ -39,16 +41,19 @@ RSpec.feature 'Provider makes changes before making an offer' do
     provider_user_exists_in_apply_database
     @provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
     @provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
   end
 
   def and_an_application_choice_exists_for_one_of_my_providers
-    @course_option_one = course_option_for_provider_code(provider_code: @provider.code)
+    @course_option_one = course_option_for_provider(provider: @provider)
     @application = create(:application_choice, :awaiting_provider_decision, course_option: @course_option_one)
   end
 
-  def and_another_two_course_options_exist_for_this_provider
-    @course_option_two = course_option_for_provider_code(provider_code: @provider.code)
-    @course_option_three = create(:course_option, course: @course_option_two.course, site: create(:site, provider: @provider))
+  def and_another_two_course_options_exist_for_another_provider
+    @course_option_two = course_option_for_provider(provider: @another_provider)
+    @course_option_three = create(:course_option,
+                                  course: @course_option_two.course,
+                                  site: create(:site, provider: @another_provider))
   end
 
   def and_i_view_an_application
@@ -70,13 +75,22 @@ RSpec.feature 'Provider makes changes before making an offer' do
     expect(page).to have_content 'Reject application'
   end
 
-  def when_i_choose_make_offer_but_change_course
-    choose 'Make an offer but change course'
+  def when_i_choose_make_offer_but_change_provider
+    choose 'Make an offer but change training provider'
     click_on 'Continue'
   end
 
-  def then_i_see_all_courses_for_this_provider
-    @provider.courses.each do |course|
+  def then_i_see_all_providers
+    expect(page).to have_content @another_provider.name_and_code
+  end
+
+  def and_i_can_change_training_provider
+    choose @another_provider.name_and_code
+    click_on 'Continue'
+  end
+
+  def and_i_see_all_courses_for_this_provider
+    @another_provider.courses.each do |course|
       expect(page).to have_content course.name_and_code
     end
   end

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -145,7 +145,7 @@ RSpec.feature 'Provider makes changes before making an offer' do
     expect(page).to have_content(@course_option_three.course.name_and_code)
     expect(page).to have_content(@course_option_three.site.name)
 
-    click_on 'Confirm offer'
+    click_on 'Make offer'
   end
 
   def then_a_new_offer_has_new_course_and_location_details

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -1,0 +1,125 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider makes changes before making an offer' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'Provider makes changes to course and location' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    when_change_response_feature_is_activated
+    and_i_am_permitted_to_see_applications_for_two_providers
+    and_an_application_choice_exists_for_one_of_my_providers
+    and_another_two_course_options_exist_for_this_provider
+    and_i_sign_in_to_the_provider_interface
+    and_i_view_an_application
+
+    and_i_click_on_respond_to_application
+    then_i_see_options_to_make_an_offer
+
+    when_i_choose_make_offer_but_change_course
+    then_i_see_all_courses_for_this_provider
+    and_i_can_change_the_course
+    and_i_see_all_available_locations_for_this_course
+    and_i_can_change_the_location
+
+    and_i_can_add_conditions_to_the_offer
+    and_i_can_see_the_offer_confirmation_details
+    then_a_new_offer_has_new_course_and_location_details
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def when_change_response_feature_is_activated
+    FeatureFlag.activate('provider_change_response')
+  end
+
+  def and_i_am_permitted_to_see_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = Provider.find_by(code: 'ABC')
+  end
+
+  def and_an_application_choice_exists_for_one_of_my_providers
+    @course_option_one = course_option_for_provider_code(provider_code: @provider.code)
+    @application = create(:application_choice, :awaiting_provider_decision, course_option: @course_option_one)
+  end
+
+  def and_another_two_course_options_exist_for_this_provider
+    @course_option_two = course_option_for_provider_code(provider_code: @provider.code)
+    @course_option_three = create(:course_option, course: @course_option_two.course, site: create(:site, provider: @provider))
+  end
+
+  def and_i_view_an_application
+    visit provider_interface_application_choice_path(
+      @application.id,
+    )
+  end
+
+  def and_i_click_on_respond_to_application
+    visit provider_interface_application_choice_path(@application.id)
+    click_on 'Respond to application'
+  end
+
+  def then_i_see_options_to_make_an_offer
+    expect(page).to have_content 'Make an offer'
+    expect(page).to have_content 'Make an offer but change course'
+    expect(page).to have_content 'Make an offer but change location'
+    expect(page).to have_content 'Make an offer but change training provider'
+    expect(page).to have_content 'Reject application'
+  end
+
+  def when_i_choose_make_offer_but_change_course
+    choose 'Make an offer but change course'
+    click_on 'Continue'
+  end
+
+  def then_i_see_all_courses_for_this_provider
+    @provider.courses.each do |course|
+      expect(page).to have_content course.name_and_code
+    end
+  end
+
+  def and_i_can_change_the_course
+    choose @course_option_two.course.name_and_code
+    click_on 'Continue'
+  end
+
+  def and_i_see_all_available_locations_for_this_course
+    @course_option_two.course.course_options.each do |course_option|
+      expect(page).to have_content course_option.site.name
+    end
+  end
+
+  def and_i_can_change_the_location
+    choose @course_option_three.site.name
+    click_on 'Continue'
+  end
+
+  def and_i_can_add_conditions_to_the_offer
+    expect(page).to have_content 'Conditions of offer'
+    expect(page).to have_content(@course_option_three.course.name_and_code)
+    expect(page).to have_content(@course_option_three.site.name)
+
+    fill_in 'First condition', with: 'Condition the first'
+    fill_in 'Second condition', with: 'Condition the second'
+
+    click_on 'Continue'
+  end
+
+  def and_i_can_see_the_offer_confirmation_details
+    expect(page).to have_content 'Confirm offer'
+
+    expect(page).to have_content(@course_option_three.course.name_and_code)
+    expect(page).to have_content(@course_option_three.site.name)
+
+    click_on 'Confirm offer'
+  end
+
+  def then_a_new_offer_has_new_course_and_location_details
+    expect(page).to have_content @course_option_three.course.name_and_code
+    expect(page).to have_content @course_option_three.site.name_and_address
+    expect(@application.reload.offered_option).to eq(@course_option_three)
+  end
+end

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -132,8 +132,6 @@ RSpec.feature 'Provider makes changes before making an offer' do
 
   def and_i_can_add_conditions_to_the_offer
     expect(page).to have_content 'Conditions of offer'
-    expect(page).to have_content(@course_option_three.course.name_and_code)
-    expect(page).to have_content(@course_option_three.site.name)
 
     fill_in 'First condition', with: 'Condition the first'
     fill_in 'Second condition', with: 'Condition the second'
@@ -142,7 +140,7 @@ RSpec.feature 'Provider makes changes before making an offer' do
   end
 
   def and_i_can_see_the_offer_confirmation_details
-    expect(page).to have_content 'Confirm offer'
+    expect(page).to have_content 'Check and confirm offer'
 
     expect(page).to have_content(@course_option_three.course.name_and_code)
     expect(page).to have_content(@course_option_three.site.name)

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -61,9 +61,9 @@ RSpec.feature 'See applications' do
 
   def then_i_should_see_the_applications_from_my_organisation
     expect(page).to have_content @my_provider_choice1.application_form.support_reference
-    expect(page).to have_content @my_provider_choice1.application_form.first_name
+    expect(page).to have_content @my_provider_choice1.application_form.full_name
     expect(page).to have_content @my_provider_choice2.application_form.support_reference
-    expect(page).to have_content @my_provider_choice2.application_form.first_name
+    expect(page).to have_content @my_provider_choice2.application_form.full_name
   end
 
   def and_i_should_not_see_a_covid19_information_banner
@@ -71,12 +71,12 @@ RSpec.feature 'See applications' do
   end
 
   def when_i_click_on_an_application
-    click_on @my_provider_choice1.application_form.first_name
+    click_on @my_provider_choice1.application_form.full_name
   end
 
   def then_i_should_be_on_the_application_view_page
     expect(page).to have_content @my_provider_choice1.application_form.support_reference
-    expect(page).to have_content @my_provider_choice1.application_form.first_name
+    expect(page).to have_content @my_provider_choice1.application_form.full_name
   end
 
   def when_covid19_feature_flag_is_active


### PR DESCRIPTION
## Context

Providers can change an offer after it has been made, it also makes sense to allow them to make amendments to candidate choices and offer these.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds the options _Make an offer but change course/location/training provider_ to the offer response screen:

![image](https://user-images.githubusercontent.com/93511/77094340-3d5add80-6a04-11ea-9ff3-d521a87c1782.png)

- Diverts the flow of making a new offer to allow the provider to change course, location or training provider:

![image](https://user-images.githubusercontent.com/93511/77094495-7abf6b00-6a04-11ea-970b-c44b0cd362ea.png)

- Returns the provider to the new offer conditions flow once amends have been made:

![image](https://user-images.githubusercontent.com/93511/77094640-b0645400-6a04-11ea-894d-b9ad4c362b8a.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I've left a `FIXME` in this draft PR for now as I'm keen to get feedback on how to best achieve setting the as-yet-to-be-amended application choice. The issue being we need to present either the correct offered or chosen course and location in several places.
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

@mnacos has provided a lot of context about this work and his PR here: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1657 would ideally be merged before this PR is wrapped up.

The failing tests are around the vendor API expectations, this PR will need to be rebased with changes from https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1657 and some integration work to complete.

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/J3gqkQK6/1770-%F0%9F%8F%88-allow-providers-to-offer-a-different-course-when-they-first-make-their-offer

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
