### PR TITLE
Send all emails in the background

### DIFF
--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -32,7 +32,7 @@ module CandidateInterface
       references_to_confirm = not_requested_references.includes(:application_form).to_a
 
       references_to_confirm.each do |reference|
-        RefereeMailer.reference_request_email(current_candidate.current_application, reference).deliver_now
+        RefereeMailer.reference_request_email(current_candidate.current_application, reference).deliver_later
         reference.update!(feedback_status: 'feedback_requested')
       end
 

--- a/app/controllers/support_interface/survey_emails_controller.rb
+++ b/app/controllers/support_interface/survey_emails_controller.rb
@@ -5,7 +5,7 @@ module SupportInterface
     def show; end
 
     def deliver
-      CandidateMailer.survey_email(@application_form).deliver
+      CandidateMailer.survey_email(@application_form).deliver_later
 
       candidate_email = @application_form.candidate.email_address
       audit_comment = I18n.t('survey_emails.send.audit_comment', candidate_email: candidate_email)

--- a/app/services/accept_offer.rb
+++ b/app/services/accept_offer.rb
@@ -18,7 +18,7 @@ class AcceptOffer
     end
 
     @application_choice.provider.provider_users.each do |provider_user|
-      ProviderMailer.offer_accepted(provider_user, @application_choice).deliver
+      ProviderMailer.offer_accepted(provider_user, @application_choice).deliver_later
     end
 
     StateChangeNotifier.call(:offer_accepted, application_choice: @application_choice)

--- a/app/services/conditions_not_met.rb
+++ b/app/services/conditions_not_met.rb
@@ -8,7 +8,7 @@ class ConditionsNotMet
   def save
     ApplicationStateChange.new(@application_choice).conditions_not_met!
     @application_choice.update!(conditions_not_met_at: Time.zone.now)
-    CandidateMailer.conditions_not_met(@application_choice).deliver
+    CandidateMailer.conditions_not_met(@application_choice).deliver_later
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/confirm_offer_conditions.rb
+++ b/app/services/confirm_offer_conditions.rb
@@ -8,7 +8,7 @@ class ConfirmOfferConditions
   def save
     ApplicationStateChange.new(@application_choice).confirm_conditions_met!
     @application_choice.update!(recruited_at: Time.zone.now)
-    CandidateMailer.conditions_met(@application_choice).deliver
+    CandidateMailer.conditions_met(@application_choice).deliver_later
   rescue Workflow::NoTransitionAllowed
     errors.add(
       :base,

--- a/app/services/decline_offer.rb
+++ b/app/services/decline_offer.rb
@@ -9,7 +9,7 @@ class DeclineOffer
     StateChangeNotifier.call(:offer_declined, application_choice: @application_choice)
 
     @application_choice.provider.provider_users.each do |provider_user|
-      ProviderMailer.declined(provider_user, @application_choice).deliver
+      ProviderMailer.declined(provider_user, @application_choice).deliver_later
     end
   end
 end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -12,11 +12,11 @@ class DeclineOfferByDefault
         ApplicationStateChange.new(application_choice).decline_by_default!
 
         application_choice.provider.provider_users.each do |provider_user|
-          ProviderMailer.declined_by_default(provider_user, application_choice).deliver
+          ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
         end
       end
 
-      CandidateMailer.declined_by_default(application_form).deliver
+      CandidateMailer.declined_by_default(application_form).deliver_later
     end
   end
 end

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -6,7 +6,7 @@ class SendApplicationsToProvider
         SendApplicationToProvider.new(application_choice: choice).call
       end
 
-      CandidateMailer.application_sent_to_provider(application_form).deliver_now
+      CandidateMailer.application_sent_to_provider(application_form).deliver_later
     end
   end
 end

--- a/app/services/send_chase_email_to_candidate.rb
+++ b/app/services/send_chase_email_to_candidate.rb
@@ -1,6 +1,6 @@
 class SendChaseEmailToCandidate
   def self.call(application_form:)
-    CandidateMailer.chase_candidate_decision(application_form).deliver
+    CandidateMailer.chase_candidate_decision(application_form).deliver_later
     ChaserSent.create!(chased: application_form, chaser_type: :candidate_decision_request)
 
     audit_comment =

--- a/app/services/send_chase_email_to_provider.rb
+++ b/app/services/send_chase_email_to_provider.rb
@@ -1,7 +1,7 @@
 class SendChaseEmailToProvider
   def self.call(application_choice:)
     application_choice.provider.provider_users.each do |provider_user|
-      ProviderMailer.chase_provider_decision(provider_user, application_choice).deliver
+      ProviderMailer.chase_provider_decision(provider_user, application_choice).deliver_later
       audit_chase_email(provider_user, application_choice)
     end
     ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)

--- a/app/services/send_chase_email_to_referee_and_candidate.rb
+++ b/app/services/send_chase_email_to_referee_and_candidate.rb
@@ -1,9 +1,9 @@
 class SendChaseEmailToRefereeAndCandidate
   def self.call(application_form:, reference:)
-    RefereeMailer.reference_request_chaser_email(application_form, reference).deliver
+    RefereeMailer.reference_request_chaser_email(application_form, reference).deliver_later
     ChaserSent.create!(chased: reference, chaser_type: :reference_request)
 
-    CandidateMailer.chase_reference(reference).deliver
+    CandidateMailer.chase_reference(reference).deliver_later
 
     audit_comment = I18n.t(
       'application_form.referees.audit_comment',

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -9,7 +9,7 @@ class SendNewApplicationEmailToProvider
     return false unless application_choice.awaiting_provider_decision?
 
     application_choice.provider.provider_users.each do |provider_user|
-      ProviderMailer.application_submitted(provider_user, application_choice).deliver_now
+      ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
 
       course_name = application_choice.course.name
       course_code = application_choice.course.code

--- a/app/services/send_new_referee_request_email.rb
+++ b/app/services/send_new_referee_request_email.rb
@@ -1,6 +1,6 @@
 class SendNewRefereeRequestEmail
   def self.call(application_form:, reference:, reason: :not_responded)
-    CandidateMailer.new_referee_request(reference, reason: reason).deliver
+    CandidateMailer.new_referee_request(reference, reason: reason).deliver_later
 
     ChaserSent.create!(chaser_type: :reference_replacement, chased: reference)
 

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -9,7 +9,7 @@ class SendRejectByDefaultEmailToProvider
     return false unless application_choice.rejected?
 
     application_choice.provider.provider_users.each do |provider_user|
-      ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_now
+      ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_later
 
       course_name_and_code = application_choice.course.name_and_code
       audit_comment =

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -20,7 +20,7 @@ private
 
   def send_email_notification_to_provider_users(application_choice)
     application_choice.provider.provider_users.each do |provider_user|
-      ProviderMailer.application_withrawn(provider_user, application_choice).deliver
+      ProviderMailer.application_withrawn(provider_user, application_choice).deliver_later
     end
   end
 end

--- a/spec/requests/integrations/post_notify_callback_spec.rb
+++ b/spec/requests/integrations/post_notify_callback_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Notify Callback - POST /integrations/notify/callback', type: :request do
+RSpec.describe 'Notify Callback - POST /integrations/notify/callback', type: :request, sidekiq: true do
   let(:application_form) { create(:application_form) }
   let(:reference) do
     create(:reference, feedback_status: 'feedback_requested', application_form: application_form)

--- a/spec/services/invite_provider_user_spec.rb
+++ b/spec/services/invite_provider_user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe InviteProviderUser do
+RSpec.describe InviteProviderUser, sidekiq: true do
   include DsiAPIHelper
 
   let(:provider) { create(:provider) }

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe MakeAnOffer do
+RSpec.describe MakeAnOffer, sidekiq: true do
   let(:user) { SupportUser.new }
 
   describe '#save' do

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,7 +1,20 @@
+ActiveJob::Base.queue_adapter = :test
+
 RSpec.configure do |config|
+  include ActiveJob::TestHelper
+
+  # Turn Sidekiq on automatically in system tests. Use `sidekiq: false` in
+  # tests to avoid Sidekiq running.
+  config.define_derived_metadata(file_path: Regexp.new('/spec/system/')) do |metadata|
+    metadata[:sidekiq] = true unless metadata[:sidekiq] == false
+  end
+
+  # Use `sidekiq: true` to run jobs immediately
   config.around sidekiq: true do |example|
-    Sidekiq::Testing.inline! do
-      example.run
+    perform_enqueued_jobs do
+      Sidekiq::Testing.inline! do
+        example.run
+      end
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_accepts_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate accepts an offer', sidekiq: true do
+RSpec.feature 'Candidate accepts an offer' do
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and accepts' do

--- a/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate clicks on an expired link', sidekiq: true do
+RSpec.feature 'Candidate clicks on an expired link' do
   scenario 'Candidate clicks on a link with an id and expired token link in an email' do
     given_the_pilot_is_open
     and_the_improved_expired_token_flow_feature_flag_is_on

--- a/spec/system/candidate_interface/candidate_declines_offer_spec.rb
+++ b/spec/system/candidate_interface/candidate_declines_offer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate declines an offer', sidekiq: true do
+RSpec.feature 'Candidate declines an offer' do
   include CourseOptionHelpers
 
   scenario 'Candidate views an offer and declines' do

--- a/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_application_after_submission_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'A candidate edits their application' do
     end
   end
 
-  scenario 'candidate selects to edit their application', sidekiq: true do
+  scenario 'candidate selects to edit their application' do
     given_the_edit_application_feature_flag_is_on
     and_i_am_signed_in_as_a_candidate
 

--- a/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choice_after_submission_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'A candidate edits their course choice after submission' do
     end
   end
 
-  scenario 'candidate deletes their course choice and add a new one', sidekiq: true do
+  scenario 'candidate deletes their course choice and add a new one' do
     given_the_edit_application_feature_flag_is_on
     and_i_am_signed_in_as_a_candidate
     and_i_have_a_completed_application

--- a/spec/system/candidate_interface/candidate_existing_user_with_course_params_without_selection_page.spec.rb
+++ b/spec/system/candidate_interface/candidate_existing_user_with_course_params_without_selection_page.spec.rb
@@ -84,11 +84,9 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_submit_my_email_address
-    perform_enqueued_jobs do
-      fill_in t('authentication.sign_up.email_address.label'), with: @email
-      check t('authentication.sign_up.accept_terms_checkbox')
-      click_on t('authentication.sign_up.button_continue')
-    end
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    check t('authentication.sign_up.accept_terms_checkbox')
+    click_on t('authentication.sign_up.button_continue')
   end
 
   def and_click_on_the_magic_link

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_spec_with_selection_page.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_spec_with_selection_page.rb
@@ -84,12 +84,10 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   end
 
   def when_i_submit_my_email_address
-    perform_enqueued_jobs do
-      @email = "#{SecureRandom.hex}@example.com"
-      fill_in t('authentication.sign_up.email_address.label'), with: @email
-      check t('authentication.sign_up.accept_terms_checkbox')
-      click_on t('authentication.sign_up.button_continue')
-    end
+    @email = "#{SecureRandom.hex}@example.com"
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    check t('authentication.sign_up.accept_terms_checkbox')
+    click_on t('authentication.sign_up.button_continue')
   end
 
   def and_click_on_the_magic_link

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'A candidate withdraws her application' do
   include CandidateHelper
 
-  scenario 'successful withdrawal', sidekiq: true do
+  scenario 'successful withdrawal' do
     given_i_am_signed_in_as_a_candidate
     and_i_have_an_application_choice_awaiting_provider_decision
 

--- a/spec/system/candidate_interface/course_selection/candidate_existing_submitted_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_submitted_user_with_course_params_spec.rb
@@ -39,11 +39,9 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_submit_my_email_address
-    perform_enqueued_jobs do
-      fill_in t('authentication.sign_up.email_address.label'), with: @email
-      check t('authentication.sign_up.accept_terms_checkbox')
-      click_on t('authentication.sign_up.button_continue')
-    end
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    check t('authentication.sign_up.accept_terms_checkbox')
+    click_on t('authentication.sign_up.button_continue')
   end
 
   def and_click_on_the_magic_link

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -98,11 +98,9 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_submit_my_email_address
-    perform_enqueued_jobs do
-      fill_in t('authentication.sign_up.email_address.label'), with: @email
-      check t('authentication.sign_up.accept_terms_checkbox')
-      click_on t('authentication.sign_up.button_continue')
-    end
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    check t('authentication.sign_up.accept_terms_checkbox')
+    click_on t('authentication.sign_up.button_continue')
   end
 
   def and_click_on_the_magic_link

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -71,12 +71,10 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   end
 
   def when_i_submit_my_email_address
-    perform_enqueued_jobs do
-      @email = "#{SecureRandom.hex}@example.com"
-      fill_in t('authentication.sign_up.email_address.label'), with: @email
-      check t('authentication.sign_up.accept_terms_checkbox')
-      click_on t('authentication.sign_up.button_continue')
-    end
+    @email = "#{SecureRandom.hex}@example.com"
+    fill_in t('authentication.sign_up.email_address.label'), with: @email
+    check t('authentication.sign_up.accept_terms_checkbox')
+    click_on t('authentication.sign_up.button_continue')
   end
 
   def and_click_on_the_magic_link

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate submits the application', sidekiq: true do
+RSpec.feature 'Candidate submits the application' do
   include CandidateHelper
 
   scenario 'Candidate with a completed application' do

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Decline by default' do
   include CourseOptionHelpers
   include CandidateHelper
 
-  scenario 'An application is declined by default', sidekiq: true do
+  scenario 'An application is declined by default' do
     given_the_pilot_is_open
 
     when_i_have_an_offer_waiting_for_my_decision

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'An application is waiting for decision for 20 working days' do
   include CourseOptionHelpers
   include CandidateHelper
 
-  scenario 'the provider receives a chaser email', sidekiq: true do
+  scenario 'the provider receives a chaser email' do
     FeatureFlag.activate('training_with_a_disability')
 
     given_a_candidate_has_submitted_an_application_form

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true do
+RSpec.feature 'Referee can submit reference', with_audited: true do
   include CandidateHelper
 
   scenario 'Referee submits a reference for a candidate' do

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Referee can submit reference', sidekiq: true, with_audited: true do
+RSpec.feature 'Referee can submit reference', with_audited: true do
   include CandidateHelper
 
   scenario 'Referee submits a reference for a candidate with relationship, safeguarding and review page' do

--- a/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
+++ b/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Referee can use sign in link in the initial and chaser email', sidekiq: true do
+RSpec.feature 'Referee can use sign in link in the initial and chaser email' do
   scenario 'Referee clicks sign in links on the initial and chaser reference request emails' do
     given_the_confirm_relationship_and_safeguarding_feature_flag_is_active
     and_i_am_a_referee_of_an_submitted_application

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Referee does not respond in time', sidekiq: true do
+RSpec.feature 'Referee does not respond in time' do
   include CandidateHelper
 
   scenario 'Emails are sent if a referee does not respond in time' do

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Refusing to give a reference', sidekiq: true do
+RSpec.feature 'Refusing to give a reference' do
   include CandidateHelper
 
   scenario 'Referee refuses to give a reference' do

--- a/spec/system/support_interface/tasks_spec.rb
+++ b/spec/system/support_interface/tasks_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Tasks' do
+RSpec.feature 'Tasks', sidekiq: false do
   include DfESignInHelpers
 
   scenario 'Support user performs a task' do


### PR DESCRIPTION
## Context

GOV.UK Notify had a bit of temperature this morning and returned a 500. This caused a user to see an error.

https://sentry.io/organizations/dfe-bat/issues/1568618872/?referrer=slack

(Slack convo https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1584451545393100)

This isn't necessary because we can use Sidekiq to send the email using Rails' magic `deliver_later` method. We did this for one type of email in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1663

## Changes proposed in this pull request

- Send all emails in the background
- Make sure the tests work when doing this

## Guidance to review



## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/1568618872

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
