### PR TITLE
Revert "Merge pull request #1609 from DFE-Digital/1744-make-test-appl…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :test do
   gem 'capybara-email'
   gem 'climate_control'
   gem 'launchy'
+  gem 'timecop'
   gem 'guard-rspec'
   gem 'webmock'
   gem 'simplecov', require: false
@@ -93,7 +94,6 @@ group :test do
   gem 'clockwork-test'
   gem 'deepsort'
   gem 'rspec-benchmark'
-  gem 'timecop'
 end
 
 group :development, :test do

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -10,20 +10,6 @@ RSpec.describe TestApplications do
     expect(choices.count).to eq(2)
   end
 
-  it 'creates a realistic timeline' do
-    courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
-
-    application_choice = TestApplications.create_application(states: %i[enrolled], courses_to_apply_to: courses_we_want).first
-
-    application_form = application_choice.application_form
-    candidate = application_form.candidate
-    expect(application_choice.created_at - candidate.created_at).to be >= 1.day
-    expect(application_form.submitted_at - application_choice.created_at).to be >= 1.day
-    expect(application_choice.offered_at - application_form.submitted_at).to be >= 1.day
-    expect(application_choice.accepted_at - application_choice.offered_at).to be >= 1.day
-    expect(application_choice.enrolled_at - application_choice.accepted_at).to be >= 1.day
-  end
-
   it 'throws an exception if there aren’t enough courses to apply to' do
     expect {
       TestApplications.create_application(states: %i[offer])


### PR DESCRIPTION
…ication-generation-spread-events-out-over-time"

This reverts commit c0c1c8a911fa0c45a367fe30713e0889dfde04e4, reversing
changes made to 8995412556ef6b0b8c8a578d8421d865f1797668.

## Context

The time travel code appears not to have been thread-safe, causing sidekiq jobs which were concurrently enqueued to read the travelled-to time instead of the current time.

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1584528599413100

This sounds like a nice benefit, but in fact it's a liability:

- Notify requests fail because the clock is wrong
- if another sidekiq job happened to run at the same time, its clock would be wrong too. This could have serious consequences.
