### PR TITLE
Allow candidates to review and edit the type of their reference

### DIFF
--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -14,10 +14,10 @@ module CandidateInterface
       [
         name_row(referee),
         email_row(referee),
+        (reference_type_row(referee) if FeatureFlag.active?('referee_type')),
         relationship_row(referee),
         feedback_status_row(referee),
-      ]
-        .compact
+      ].compact
     end
 
     def minimum_references
@@ -56,6 +56,15 @@ module CandidateInterface
         value: referee.relationship,
         action: "relationship for #{referee.name}",
         change_path: candidate_interface_edit_referee_path(referee.id),
+      }
+    end
+
+    def reference_type_row(referee)
+      {
+        key: 'Reference type',
+        value: referee.referee_type.capitalize.dasherize || '',
+        action: "reference type for #{referee.name}",
+        change_path: candidate_interface_referees_type_path(referee.id),
       }
     end
 

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -12,15 +12,31 @@ module CandidateInterface
     end
 
     def type
-      @reference_type_form = Reference::RefereeTypeForm.new
+      if params[:id]
+        set_referee_id
+
+        @reference_type_form = Reference::RefereeTypeForm.build_from_reference(@referee)
+      else
+        @reference_type_form = Reference::RefereeTypeForm.new
+      end
     end
 
     def update_type
       @reference_type_form = Reference::RefereeTypeForm.new(referee_type: referee_type_param)
 
-      return render :type unless @reference_type_form.valid?
+      if params[:id]
+        set_referee_id
 
-      redirect_to candidate_interface_new_referee_path(type: referee_type_param)
+        return redirect_to action: 'type', id: @id unless @reference_type_form.valid?
+
+        @reference_type_form.save(@referee)
+
+        redirect_to candidate_interface_review_referees_path
+      else
+        return render :type unless @reference_type_form.valid?
+
+        redirect_to candidate_interface_new_referee_path(type: referee_type_param)
+      end
     end
 
     def new
@@ -72,6 +88,12 @@ module CandidateInterface
                                     .application_references
                                     .includes(:application_form)
                                     .find(params[:id])
+    end
+
+    def set_referee_id
+      set_referee
+
+      @id = @referee.id
     end
 
     def set_referees

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -3,7 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_not_amendable
     before_action :redirect_to_review_referees_if_amendable, except: %i[index review]
     before_action :set_referee, only: %i[edit update confirm_destroy destroy]
-    before_action :set_referees, only: %i[type update_type index review]
+    before_action :set_referees, only: %i[type update_type new create index review]
 
     def index
       unless @referees.empty?

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -26,6 +26,13 @@ class ApplicationReference < ApplicationRecord
     email_bounced: 'email_bounced',
   }
 
+  enum referee_type: {
+    academic: 'academic',
+    professional: 'professional',
+    school_based: 'school-based',
+    character: 'character',
+  }
+
   def ordinal
     self.application_form.application_references.find_index(self).to_i + 1
   end

--- a/app/views/candidate_interface/referees/new.html.erb
+++ b/app/views/candidate_interface/referees/new.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl">
-          <%= t('page_titles.nth_referee')[@referee.ordinal] %>
+          <%= t('page_titles.nth_referee')[(@referees.count + 1)] %>
         </span>
         <% if @referee.referee_type %>
           Details of <%= @referee.referee_type.downcase.dasherize %> referee

--- a/app/views/candidate_interface/referees/new.html.erb
+++ b/app/views/candidate_interface/referees/new.html.erb
@@ -11,7 +11,7 @@
           <%= t('page_titles.nth_referee')[@referee.ordinal] %>
         </span>
         <% if @referee.referee_type %>
-          Details of <%= @referee.referee_type.downcase %> referee
+          Details of <%= t("referee_type.#{@referee.referee_type}").downcase %> referee
         <% else %>
           <%= t('page_titles.add_referee') %>
         <% end %>

--- a/app/views/candidate_interface/referees/new.html.erb
+++ b/app/views/candidate_interface/referees/new.html.erb
@@ -11,7 +11,7 @@
           <%= t('page_titles.nth_referee')[@referee.ordinal] %>
         </span>
         <% if @referee.referee_type %>
-          Details of <%= t("referee_type.#{@referee.referee_type}").downcase %> referee
+          Details of <%= @referee.referee_type.downcase.dasherize %> referee
         <% else %>
           <%= t('page_titles.add_referee') %>
         <% end %>

--- a/app/views/candidate_interface/referees/type.html.erb
+++ b/app/views/candidate_interface/referees/type.html.erb
@@ -3,7 +3,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @reference_type_form, url: candidate_interface_update_referees_type_path, method: :post do |f| %>
+    <%= form_with model: @reference_type_form, url: candidate_interface_update_referees_type_path(id: @id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
         <% title = @referees.any? ? 'Second referee' : 'First referee' %>
@@ -14,11 +14,11 @@
       <p class="govuk-body">If you’re struggling to find a suitable referee, contact your provider to discuss this.</p>
 
       <%= f.govuk_radio_buttons_fieldset :referee_type, legend: { text: 'What kind of reference is this?' } do %>
-          <%= f.govuk_radio_button :referee_type, 'Academic', link_errors: true, label: { text: 'Academic', size: 's' }, hint_text: 'For example, your university tutor or supervisor. Choose an academic referee if you graduated in the last 5 years or you have a predicted grade for your degree.' %>
-          <%= f.govuk_radio_button :referee_type, 'Professional', label: { text: 'Professional', size: 's' }, hint_text: 'For example, your current line manager or a previous employer. If you’re self-employed, you could use a client or supplier.' %>
-          <%= f.govuk_radio_button :referee_type, 'School-based', label: { text: 'School-based', size: 's' }, hint_text: 'For example, a teacher at a school where you’ve volunteered or gained experience.' %>
+          <%= f.govuk_radio_button :referee_type, 'academic', link_errors: true, label: { text: 'Academic', size: 's' }, hint_text: 'For example, your university tutor or supervisor. Choose an academic referee if you graduated in the last 5 years or you have a predicted grade for your degree.' %>
+          <%= f.govuk_radio_button :referee_type, 'professional', label: { text: 'Professional', size: 's' }, hint_text: 'For example, your current line manager or a previous employer. If you’re self-employed, you could use a client or supplier.' %>
+          <%= f.govuk_radio_button :referee_type, 'school-based', label: { text: 'School-based', size: 's' }, hint_text: 'For example, a teacher at a school where you’ve volunteered or gained experience.' %>
           <%= f.govuk_radio_divider %>
-          <%= f.govuk_radio_button :referee_type, 'Character', label: { text: 'Character', size: 's' }, hint_text: 'Choose a responsible person who can confirm you’re suitable for teaching – for example, a sports coach. Training providers will only accept character references if there’s also an academic or professional reference.' %>
+          <%= f.govuk_radio_button :referee_type, 'character', label: { text: 'Character', size: 's' }, hint_text: 'Choose a responsible person who can confirm you’re suitable for teaching – for example, a sports coach. Training providers will only accept character references if there’s also an academic or professional reference.' %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/referees/type.html.erb
+++ b/app/views/candidate_interface/referees/type.html.erb
@@ -6,8 +6,11 @@
     <%= form_with model: @reference_type_form, url: candidate_interface_update_referees_type_path(id: @id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
-        <% title = @referees.any? ? 'Second referee' : 'First referee' %>
-        <%= title %>
+        <% if @referee %>
+            <%= t('page_titles.nth_referee')[@referee.ordinal] %>
+        <% else %>
+            <%= t('page_titles.nth_referee')[(@referees.count + 1)] %>
+        <% end %>
       </h1>
 
       <p class="govuk-body">Referees should not be family members, partners or friends.</p>

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -94,6 +94,42 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       expect(change_email).to eq("Change email address for #{first_referee.name}")
       expect(change_relationship).to eq("Change relationship for #{first_referee.name}")
     end
+
+    context 'When referee type feature flag is off' do
+      before do
+        FeatureFlag.deactivate('referee_type')
+      end
+
+      it "renders component without a referee's type" do
+        first_referee = application_form.application_references.first
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__key').text).not_to include('Reference type')
+        expect(result.css('.govuk-summary-list__value').to_html).not_to include(first_referee.referee_type.capitalize.dasherize)
+      end
+    end
+
+    context 'When referee type feature flag is on' do
+      before do
+        FeatureFlag.activate('referee_type')
+      end
+
+      it "renders component with correct values for a referee's type" do
+        first_referee = application_form.application_references.first
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Reference type')
+        expect(result.css('.govuk-summary-list__value').to_html).to include(first_referee.referee_type.capitalize.dasherize)
+      end
+
+      it 'renders correct text for "Change" links in reference type attribute row' do
+        first_referee = application_form.application_references.first
+        result = render_inline(described_class.new(application_form: application_form))
+        change_reference_type = result.css('.govuk-summary-list__actions')[2].text.strip
+
+        expect(change_reference_type).to eq("Change reference type for #{first_referee.name}")
+      end
+    end
   end
 
   context 'when referees are not editable' do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -357,6 +357,7 @@ FactoryBot.define do
     email_address { "#{SecureRandom.hex(5)}@example.com" }
     name { "#{Faker::Name.first_name} #{Faker::Name.last_name}" }
     relationship { Faker::Lorem.paragraph(sentence_count: 3) }
+    referee_type { %i[academic professional school_based character].sample }
     questionnaire { nil }
 
     trait :unsubmitted do

--- a/spec/models/candidate_interface/reference/referee_type_form_spec.rb
+++ b/spec/models/candidate_interface/reference/referee_type_form_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe CandidateInterface::Reference::RefereeTypeForm, type: :model do
   describe '.build_from_reference' do
     it 'creates an object based on the reference' do
-      application_reference = build_stubbed(:reference, referee_type: 'School-based')
+      application_reference = build_stubbed(:reference, referee_type: :school_based)
       form = CandidateInterface::Reference::RefereeTypeForm.build_from_reference(application_reference)
 
-      expect(form.referee_type).to eq('School-based')
+      expect(form.referee_type).to eq('school_based')
     end
   end
 
@@ -23,18 +23,18 @@ RSpec.describe CandidateInterface::Reference::RefereeTypeForm, type: :model do
 
     context 'when referee_type has a value' do
       it 'updates the reference' do
-        form = CandidateInterface::Reference::RefereeTypeForm.new(referee_type: 'Professional')
+        form = CandidateInterface::Reference::RefereeTypeForm.new(referee_type: 'professional')
         form.save(application_reference)
 
-        expect(application_reference.referee_type).to eq('Professional')
+        expect(application_reference.referee_type).to eq('professional')
       end
 
       it 'updates the existing referee_type of the reference' do
-        application_reference = create(:reference, referee_type: 'School-based')
-        form = CandidateInterface::Reference::RefereeTypeForm.new(referee_type: 'Professional')
+        application_reference = create(:reference, referee_type: 'school-based')
+        form = CandidateInterface::Reference::RefereeTypeForm.new(referee_type: 'professional')
         form.save(application_reference)
 
-        expect(application_reference.referee_type).to eq('Professional')
+        expect(application_reference.referee_type).to eq('professional')
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -48,6 +48,11 @@ RSpec.feature 'Candidate adding referees' do
     and_i_submit_the_form
     then_i_see_updated_reference
 
+    when_i_click_on_change_second_reference_type
+    and_i_choose_school_based_as_reference_type
+    and_i_click_continue
+    then_i_see_the_updated_reference_type
+
     when_i_click_continue
     then_i_see_referees_is_complete
   end
@@ -143,14 +148,6 @@ RSpec.feature 'Candidate adding referees' do
     expect(page).to have_content('What kind of reference is this?')
   end
 
-  def when_i_choose_school_based_as_reference_type
-    choose 'School-based'
-  end
-
-  def then_i_am_asked_for_the_details_of_my_school_based_referee
-    expect(page).to have_content('Details of school-based referee')
-  end
-
   def when_i_fill_in_all_required_fields
     full_name_with_trailing_space = 'Bill Lumbergh '
     fill_in('Full name', with: full_name_with_trailing_space)
@@ -161,11 +158,13 @@ RSpec.feature 'Candidate adding referees' do
   def then_i_see_both_referees
     expect(page).to have_content('AJP Taylor')
     expect(page).to have_content('ajptaylor@example.com')
+    expect(page).to have_content('Academic')
     expect(page).to have_content('Thats my tutor, that is')
 
     full_name_without_trailing_space = "Bill Lumbergh\n"
     expect(page).to have_content(full_name_without_trailing_space)
     expect(page).to have_content('lumbergh@example.com')
+    expect(page).to have_content('Academic')
     expect(page).to have_content('manager for several years')
   end
 
@@ -179,5 +178,21 @@ RSpec.feature 'Candidate adding referees' do
 
   def then_i_see_updated_reference
     expect(page).to have_content('Taught me everything I know')
+  end
+
+  def when_i_click_on_change_second_reference_type
+    click_link 'Change reference type for Bill Lumbergh'
+  end
+
+  def and_i_choose_school_based_as_reference_type
+    choose 'School-based'
+  end
+
+  def then_i_see_the_updated_reference_type
+    full_name_without_trailing_space = "Bill Lumbergh\n"
+    expect(page).to have_content(full_name_without_trailing_space)
+    expect(page).to have_content('lumbergh@example.com')
+    expect(page).to have_content('School-based')
+    expect(page).to have_content('manager for several years')
   end
 end


### PR DESCRIPTION
## Context
We want to allow candidates to select the type of referee, so that the correct guidance can be shown to the referee on the style of reference that is required, improving the quality of reference.

- The previous PR allows candidates to choose the reference type  #1669
- This PR is to allow candidates to review and change the reference type

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
Changes in this PR:
- Define possible referee types enum in ApplicationReference model
- Update RefereesReviewComponent to show Reference type row
- Complete the candidate journey to review and edit the type of their reference

### After
![image](https://user-images.githubusercontent.com/22743709/76982872-690e9280-6934-11ea-8d08-450fbccafefc.png)


## Guidance to review


## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/wwoQFSeB/1146-dev-iterate-candidate-select-type-of-referee

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
