### PR TITLE
Add UCAS downtime banner wherever we link off to the site

### DIFF
--- a/app/components/candidate_interface/ucas_downtime_component.html.erb
+++ b/app/components/candidate_interface/ucas_downtime_component.html.erb
@@ -1,0 +1,6 @@
+<div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
+  <div class="app-banner__message">
+    <h2 class="govuk-heading-m">UCAS planned maintenance</h2>
+    <p class="govuk-body">UCAS services won’t be available from 6pm on Friday 20 March until Sunday 22 March.</p>
+  </div>
+</div>

--- a/app/components/candidate_interface/ucas_downtime_component.rb
+++ b/app/components/candidate_interface/ucas_downtime_component.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class UcasDowntimeComponent < ActionView::Component::Base
+    def initialize; end
+
+    def render?
+      FeatureFlag.active?('banner_for_ucas_downtime')
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -2,6 +2,7 @@ class FeatureFlag
   FEATURES = %w[
     add_additional_courses_page
     banner_about_problems_with_dfe_sign_in
+    banner_for_ucas_downtime
     choose_study_mode
     display_additional_course_details
     check_full_courses

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
       <%= t('apply_from_find.heading') %>

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
        You can apply for this course using a new GOV.UK service

--- a/app/views/candidate_interface/apply_from_find/not_found.html.erb
+++ b/app/views/candidate_interface/apply_from_find/not_found.html.erb
@@ -2,6 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+
     <h1 class="govuk-heading-xl">
       <%= service_name %>
     </h1>

--- a/app/views/candidate_interface/course_choices/ucas.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.not_eligible_yet') %>
     </h1>

--- a/app/views/candidate_interface/decisions/decline.html.erb
+++ b/app/views/candidate_interface/decisions/decline.html.erb
@@ -1,6 +1,12 @@
 <% content_for :title, 'Are you sure you want to decline this offer?' %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_offer_path(@application_choice), 'Back to application dashboard') %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+  </div>
+</div>
+
 <h1 class="govuk-heading-xl govuk-heading-xl">
   Are you sure you want to decline this offer?
 </h1>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -2,6 +2,12 @@
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back to application dashboard') %>
 
 <%= form_with model: @respond_to_offer, url: candidate_interface_respond_to_offer_path(@application_choice) do |f| %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+    </div>
+  </div>
+
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl govuk-heading-xl">

--- a/app/views/candidate_interface/shared/pilot_holding_page.html.erb
+++ b/app/views/candidate_interface/shared/pilot_holding_page.html.erb
@@ -2,6 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+
     <h1 class="govuk-heading-xl">
       <%= service_name %>
     </h1>

--- a/app/views/candidate_interface/start_page/not_eligible.html.erb
+++ b/app/views/candidate_interface/start_page/not_eligible.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.not_eligible_yet') %>
     </h1>

--- a/spec/components/candidate_interface/ucas_downtime_component_spec.rb
+++ b/spec/components/candidate_interface/ucas_downtime_component_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::UcasDowntimeComponent do
+  context 'when the banner for UCAS downtime feature flag is on' do
+    it 'renders the banner' do
+      FeatureFlag.activate('banner_for_ucas_downtime')
+
+      result = render_inline(CandidateInterface::UcasDowntimeComponent.new)
+
+      expect(result.text).to include('UCAS services won’t be available from 6pm on Friday 20 March until Sunday 22 March.')
+    end
+  end
+
+  context 'when the banner for UCAS downtime feature flag is off' do
+    it 'does not render the banner' do
+      FeatureFlag.deactivate('banner_for_ucas_downtime')
+
+      result = render_inline(CandidateInterface::UcasDowntimeComponent.new)
+
+      expect(result.text).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
## Context

UCAS is planning downtime on 20 - 22nd March so we should inform our users that this is happening as there are a number of places we link off to the site.

## Changes proposed in this pull request

This PR adds a banner to inform candidates of the downtime which is hidden under a feature flag called `banner_for_ucas_downtime` wherever we link off to UCAS i.e. wherever we call `UCAS.apply_url`.

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/76984787-37e39180-6937-11ea-88e0-4b64a63fd31d.png)

## Guidance to review

- Copy and pasta okay for this? 🍝 ~~Could be a component but seems overkill.~~ Much noicer.
- Didn't add a system spec for this. Should I?

## Link to Trello card

https://trello.com/c/vyOK6UCd/1154-update-content-ucas-down-time

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
