### PR TITLE
Change assertion in email_log_spec to use HostingEnvironment.environment_name

### DIFF
--- a/spec/system/support_interface/email_log_spec.rb
+++ b/spec/system/support_interface/email_log_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Email log' do
     ).deliver_now
 
     open_email('harry@example.com')
-    expect(current_email.header('reference')).to eql("test-sign_up_email-#{@candidate.id}")
+    expect(current_email.header('reference')).to eql("#{HostingEnvironment.environment_name}-sign_up_email-#{@candidate.id}")
   end
 
   def and_an_email_with_an_application_id_is_sent


### PR DESCRIPTION
## Context
There is a hardcoded env name introduced in #1646 that caused this test to fail when running `rake` locally.

## Changes proposed in this pull request
Change assertion in email_log_spec to use HostingEnvironment.environment_name instead of the hardcoded string