### PR TITLE
Make test application generation spread events out over time - second attempt

### DIFF
--- a/app/controllers/vendor_api/test_data_controller.rb
+++ b/app/controllers/vendor_api/test_data_controller.rb
@@ -14,7 +14,7 @@ module VendorApi
     end
 
     def generate
-      application_choices = TestApplications.generate_for_provider(
+      application_choices = TestApplications.new.generate_for_provider(
         provider: current_provider,
         courses_per_application: courses_per_application_param,
         count: count_param,

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -60,7 +60,7 @@ module TestApplications
       return if states.include? :unsubmitted
 
       without_slack_message_sending do
-        SubmitApplication.new(application_form).call
+        SubmitApplication.new(application_form, skip_emails: true).call
         return if states.include? :awaiting_references
 
         application_form.application_references.each do |reference|

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -65,6 +65,7 @@ class TestApplications
       return if states.include? :unsubmitted
 
       without_slack_message_sending do
+        fast_forward(1..2)
         SubmitApplication.new(@application_form, skip_emails: true).call
         @application_form.update_columns(submitted_at: @time)
         @application_form.application_choices.each do |application_choice|

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -2,6 +2,8 @@ class TestApplications
   class NotEnoughCoursesError < RuntimeError; end
   class ZeroCoursesPerApplicationError < RuntimeError; end
 
+  attr_reader :time
+
   def generate_for_provider(provider:, courses_per_application:, count:)
     1.upto(count).flat_map do
       create_application(
@@ -20,7 +22,7 @@ class TestApplications
     candidate = FactoryBot.create(
       :candidate,
       email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
-      created_at: @time,
+      created_at: time,
     )
 
     courses_to_apply_to ||= Course.joins(:course_options)
@@ -47,7 +49,7 @@ class TestApplications
         candidate: candidate,
         first_name: first_name,
         last_name: last_name,
-        created_at: @time,
+        created_at: time,
       )
 
       fast_forward(1..2)
@@ -58,7 +60,7 @@ class TestApplications
           course_option: course.course_options.first,
           application_form: @application_form,
           personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
-          created_at: @time,
+          created_at: time,
         )
       end
 
@@ -67,9 +69,9 @@ class TestApplications
       without_slack_message_sending do
         fast_forward(1..2)
         SubmitApplication.new(@application_form, skip_emails: true).call
-        @application_form.update_columns(submitted_at: @time)
+        @application_form.update_columns(submitted_at: time)
         @application_form.application_choices.each do |application_choice|
-          application_choice.update_columns(edit_by: @time + 7.days)
+          application_choice.update_columns(edit_by: time + 7.days)
         end
         return if states.include? :awaiting_references
 
@@ -104,76 +106,76 @@ class TestApplications
     case state
     when :offer
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
     when :rejected
       fast_forward(1..3)
       RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
-      choice.update_columns(rejected_at: @time)
+      choice.update_columns(rejected_at: time)
     when :offer_withdrawn
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
       fast_forward(1..3)
       WithdrawOffer.new(application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
-      choice.update_columns(withdrawn_at: @time)
+      choice.update_columns(withdrawn_at: time)
     when :declined
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
       fast_forward(1..3)
       DeclineOffer.new(application_choice: choice).save!
-      choice.update_columns(declined_at: @time)
+      choice.update_columns(declined_at: time)
     when :accepted
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: @time)
+      choice.update_columns(accepted_at: time)
     when :accepted_no_conditions
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: []).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: @time)
+      choice.update_columns(accepted_at: time)
     when :conditions_not_met
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check', 'Complete course']).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: @time)
+      choice.update_columns(accepted_at: time)
       fast_forward(1..3)
       ConditionsNotMet.new(application_choice: choice).save
-      choice.update_columns(conditions_not_met_at: @time)
+      choice.update_columns(conditions_not_met_at: time)
     when :recruited
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: @time)
+      choice.update_columns(accepted_at: time)
       fast_forward(1..3)
       ConfirmOfferConditions.new(application_choice: choice).save
-      choice.update_columns(recruited_at: @time)
+      choice.update_columns(recruited_at: time)
     when :enrolled
       fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: @time)
+      choice.update_columns(offered_at: time)
       fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: @time)
+      choice.update_columns(accepted_at: time)
       fast_forward(1..3)
       ConfirmOfferConditions.new(application_choice: choice).save
-      choice.update_columns(recruited_at: @time)
+      choice.update_columns(recruited_at: time)
       fast_forward(1..3)
       ConfirmEnrolment.new(application_choice: choice).save
-      choice.update_columns(enrolled_at: @time)
+      choice.update_columns(enrolled_at: time)
     when :withdrawn
       fast_forward(1..3)
       WithdrawApplication.new(application_choice: choice).save!
-      choice.update_columns(withdrawn_at: @time)
+      choice.update_columns(withdrawn_at: time)
     end
   end
 
@@ -192,14 +194,14 @@ class TestApplications
   end
 
   def fast_forward(range)
-    @time = @time + rand(range).days
+    @time = time + rand(range).days
     update_new_audits
   end
 
   def update_new_audits
     @last_audit_id ||= 0
     @application_form.own_and_associated_audits.where('id > ?', @last_audit_id).each do |audit|
-      audit.update_columns(created_at: @time)
+      audit.update_columns(created_at: time)
       @last_audit_id = audit.id
     end
   end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -1,8 +1,8 @@
-module TestApplications
+class TestApplications
   class NotEnoughCoursesError < RuntimeError; end
   class ZeroCoursesPerApplicationError < RuntimeError; end
 
-  def self.generate_for_provider(provider:, courses_per_application:, count:)
+  def generate_for_provider(provider:, courses_per_application:, count:)
     1.upto(count).flat_map do
       create_application(
         states: [:awaiting_provider_decision] * courses_per_application,
@@ -11,7 +11,8 @@ module TestApplications
     end
   end
 
-  def self.create_application(states:, courses_to_apply_to: nil)
+  def create_application(states:, courses_to_apply_to: nil)
+    travel_to rand(30..60).days.ago
     raise ZeroCoursesPerApplicationError.new('You can\'t have zero courses per application') unless states.any?
 
     first_name = Faker::Name.first_name
@@ -19,6 +20,7 @@ module TestApplications
     candidate = FactoryBot.create(
       :candidate,
       email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
+      created_at: @time,
     )
 
     courses_to_apply_to ||= Course.joins(:course_options)
@@ -34,7 +36,7 @@ module TestApplications
     end
 
     Audited.audit_class.as_user(candidate) do
-      application_form = FactoryBot.create(
+      @application_form = FactoryBot.create(
         :completed_application_form,
         application_choices_count: 0,
         full_work_history: true,
@@ -45,25 +47,29 @@ module TestApplications
         candidate: candidate,
         first_name: first_name,
         last_name: last_name,
+        created_at: @time,
       )
 
+      fast_forward(1..2)
       application_choices = courses_to_apply_to.map do |course|
         FactoryBot.create(
           :application_choice,
           status: 'unsubmitted',
           course_option: course.course_options.first,
-          application_form: application_form,
+          application_form: @application_form,
           personal_statement: Faker::Lorem.paragraph(sentence_count: 5),
+          created_at: @time,
         )
       end
 
       return if states.include? :unsubmitted
 
       without_slack_message_sending do
-        SubmitApplication.new(application_form, skip_emails: true).call
+        SubmitApplication.new(@application_form, skip_emails: true).call
+        @application_form.update_columns(submitted_at: @time)
         return if states.include? :awaiting_references
 
-        application_form.application_references.each do |reference|
+        @application_form.application_references.each do |reference|
           reference.relationship_correction = [nil, Faker::Lorem.sentence].sample
           reference.safeguarding_concerns = [nil, Faker::Lorem.sentence].sample
 
@@ -85,54 +91,112 @@ module TestApplications
     end
   end
 
-  def self.put_application_choice_in_state(choice, state)
-    # This is only supposed to happen after 7 days, but SendApplicationToProvider
-    # doesn't check the `edit_by` date of the ApplicationChoice
+  def put_application_choice_in_state(choice, state)
+    travel_to(choice.edit_by) if choice.edit_by > Time.zone.now
     SendApplicationToProvider.new(application_choice: choice).call
     choice.update(edit_by: Time.zone.now)
     return if state == :awaiting_provider_decision
 
-    if state == :offer
+    case state
+    when :offer
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-    elsif state == :rejected
+      choice.update_columns(offered_at: @time)
+    when :rejected
+      fast_forward(1..3)
       RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
-    elsif state == :offer_withdrawn
+      choice.update_columns(rejected_at: @time)
+    when :offer_withdrawn
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
+      choice.update_columns(offered_at: @time)
+      fast_forward(1..3)
       WithdrawOffer.new(application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
-    elsif state == :declined
+      choice.update_columns(withdrawn_at: @time)
+    when :declined
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
+      choice.update_columns(offered_at: @time)
+      fast_forward(1..3)
       DeclineOffer.new(application_choice: choice).save!
-    elsif state == :accepted
+      choice.update_columns(declined_at: @time)
+    when :accepted
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
+      choice.update_columns(offered_at: @time)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-    elsif state == :accepted_no_conditions
+      choice.update_columns(accepted_at: @time)
+    when :accepted_no_conditions
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: []).save
+      choice.update_columns(offered_at: @time)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
-    elsif state == :conditions_not_met
+      choice.update_columns(accepted_at: @time)
+    when :conditions_not_met
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check', 'Complete course']).save
+      choice.update_columns(offered_at: @time)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
+      choice.update_columns(accepted_at: @time)
+      fast_forward(1..3)
       ConditionsNotMet.new(application_choice: choice).save
-    elsif state == :recruited
+      choice.update_columns(conditions_not_met_at: @time)
+    when :recruited
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
+      choice.update_columns(offered_at: @time)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
+      choice.update_columns(accepted_at: @time)
+      fast_forward(1..3)
       ConfirmOfferConditions.new(application_choice: choice).save
-    elsif state == :enrolled
+      choice.update_columns(recruited_at: @time)
+    when :enrolled
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
+      choice.update_columns(offered_at: @time)
+      fast_forward(1..3)
       AcceptOffer.new(application_choice: choice).save!
+      choice.update_columns(accepted_at: @time)
+      fast_forward(1..3)
       ConfirmOfferConditions.new(application_choice: choice).save
+      choice.update_columns(recruited_at: @time)
+      fast_forward(1..3)
       ConfirmEnrolment.new(application_choice: choice).save
-    elsif state == :withdrawn
+      choice.update_columns(enrolled_at: @time)
+    when :withdrawn
+      fast_forward(1..3)
       WithdrawApplication.new(application_choice: choice).save!
+      choice.update_columns(withdrawn_at: @time)
     end
   end
 
-  def self.actor
+  def actor
     SupportUser.first_or_initialize
   end
 
-  def self.without_slack_message_sending
+  def without_slack_message_sending
     RequestStore.store[:disable_slack_messages] = true
     yield
     RequestStore.store[:disable_slack_messages] = false
+  end
+
+  def travel_to(time)
+    @time = time
+  end
+
+  def fast_forward(range)
+    @time = @time + rand(range).days
+    update_new_audits
+  end
+
+  def update_new_audits
+    @last_audit_id ||= 0
+    @application_form.own_and_associated_audits.where('id > ?', @last_audit_id).each do |audit|
+      audit.update_columns(created_at: @time)
+      @last_audit_id = audit.id
+    end
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -67,6 +67,9 @@ class TestApplications
       without_slack_message_sending do
         SubmitApplication.new(@application_form, skip_emails: true).call
         @application_form.update_columns(submitted_at: @time)
+        @application_form.application_choices.each do |application_choice|
+          application_choice.update_columns(edit_by: @time + 7.days)
+        end
         return if states.include? :awaiting_references
 
         @application_form.application_references.each do |reference|

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -1,11 +1,12 @@
 class SubmitApplication
-  attr_reader :application_form, :application_choices
+  attr_reader :application_form, :application_choices, :skip_emails
 
   REFEREE_BOT_EMAIL_ADDRESSES = ['refbot1@example.com', 'refbot2@example.com'].freeze
 
-  def initialize(application_form)
+  def initialize(application_form, skip_emails: false)
     @application_form = application_form
     @application_choices = application_form.application_choices
+    @skip_emails = skip_emails
   end
 
   def call
@@ -24,7 +25,7 @@ private
 
   def send_reference_request_email_to_referees(application_form)
     application_form.application_references.includes(:application_form).each do |reference|
-      RefereeMailer.reference_request_email(application_form, reference).deliver_later
+      RefereeMailer.reference_request_email(application_form, reference).deliver_later unless skip_emails
 
       reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
     end

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -4,20 +4,20 @@ class GenerateTestApplications
   def perform
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
-    TestApplications.create_application states: [:unsubmitted]
-    TestApplications.create_application states: [:awaiting_references]
-    TestApplications.create_application states: [:application_complete]
-    TestApplications.create_application states: [:awaiting_provider_decision] * 3
-    TestApplications.create_application states: [:offer] * 2
-    TestApplications.create_application states: %i[offer rejected]
-    TestApplications.create_application states: [:rejected] * 2
-    TestApplications.create_application states: [:offer_withdrawn]
-    TestApplications.create_application states: [:declined]
-    TestApplications.create_application states: [:accepted]
-    TestApplications.create_application states: [:accepted_no_conditions]
-    TestApplications.create_application states: [:recruited]
-    TestApplications.create_application states: [:conditions_not_met]
-    TestApplications.create_application states: [:enrolled]
-    TestApplications.create_application states: [:withdrawn]
+    TestApplications.new.create_application states: [:unsubmitted]
+    TestApplications.new.create_application states: [:awaiting_references]
+    TestApplications.new.create_application states: [:application_complete]
+    TestApplications.new.create_application states: [:awaiting_provider_decision] * 3
+    TestApplications.new.create_application states: [:offer] * 2
+    TestApplications.new.create_application states: %i[offer rejected]
+    TestApplications.new.create_application states: [:rejected] * 2
+    TestApplications.new.create_application states: [:offer_withdrawn]
+    TestApplications.new.create_application states: [:declined]
+    TestApplications.new.create_application states: [:accepted]
+    TestApplications.new.create_application states: [:accepted_no_conditions]
+    TestApplications.new.create_application states: [:recruited]
+    TestApplications.new.create_application states: [:conditions_not_met]
+    TestApplications.new.create_application states: [:enrolled]
+    TestApplications.new.create_application states: [:withdrawn]
   end
 end

--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -4,20 +4,21 @@ class GenerateTestApplications
   def perform
     raise 'You can\'t generate test data in production' if HostingEnvironment.production?
 
-    TestApplications.new.create_application states: [:unsubmitted]
-    TestApplications.new.create_application states: [:awaiting_references]
-    TestApplications.new.create_application states: [:application_complete]
-    TestApplications.new.create_application states: [:awaiting_provider_decision] * 3
-    TestApplications.new.create_application states: [:offer] * 2
-    TestApplications.new.create_application states: %i[offer rejected]
-    TestApplications.new.create_application states: [:rejected] * 2
-    TestApplications.new.create_application states: [:offer_withdrawn]
-    TestApplications.new.create_application states: [:declined]
-    TestApplications.new.create_application states: [:accepted]
-    TestApplications.new.create_application states: [:accepted_no_conditions]
-    TestApplications.new.create_application states: [:recruited]
-    TestApplications.new.create_application states: [:conditions_not_met]
-    TestApplications.new.create_application states: [:enrolled]
-    TestApplications.new.create_application states: [:withdrawn]
+    test_applications = TestApplications.new
+    test_applications.create_application states: [:unsubmitted]
+    test_applications.create_application states: [:awaiting_references]
+    test_applications.create_application states: [:application_complete]
+    test_applications.create_application states: [:awaiting_provider_decision] * 3
+    test_applications.create_application states: [:offer] * 2
+    test_applications.create_application states: %i[offer rejected]
+    test_applications.create_application states: [:rejected] * 2
+    test_applications.create_application states: [:offer_withdrawn]
+    test_applications.create_application states: [:declined]
+    test_applications.create_application states: [:accepted]
+    test_applications.create_application states: [:accepted_no_conditions]
+    test_applications.create_application states: [:recruited]
+    test_applications.create_application states: [:conditions_not_met]
+    test_applications.create_application states: [:enrolled]
+    test_applications.create_application states: [:withdrawn]
   end
 end

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -5,20 +5,34 @@ RSpec.describe TestApplications do
     create(:course_option, course: create(:course, :open_on_apply))
     create(:course_option, course: create(:course, :open_on_apply))
 
-    choices = TestApplications.create_application(states: %i[offer rejected])
+    choices = TestApplications.new.create_application(states: %i[offer rejected])
 
     expect(choices.count).to eq(2)
   end
 
+  it 'creates a realistic timeline' do
+    courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+    application_choice = TestApplications.new.create_application(states: %i[enrolled], courses_to_apply_to: courses_we_want).first
+
+    application_form = application_choice.application_form
+    candidate = application_form.candidate
+    expect(application_choice.created_at - candidate.created_at).to be >= 1.day
+    expect(application_form.submitted_at - application_choice.created_at).to be >= 1.day
+    expect(application_choice.offered_at - application_form.submitted_at).to be >= 1.day
+    expect(application_choice.accepted_at - application_choice.offered_at).to be >= 1.day
+    expect(application_choice.enrolled_at - application_choice.accepted_at).to be >= 1.day
+  end
+
   it 'throws an exception if there aren’t enough courses to apply to' do
     expect {
-      TestApplications.create_application(states: %i[offer])
+      TestApplications.new.create_application(states: %i[offer])
     }.to raise_error(/Not enough distinct courses/)
   end
 
   it 'throws an exception if zero courses are specified per application' do
     expect {
-      TestApplications.create_application(states: [])
+      TestApplications.new.create_application(states: [])
     }.to raise_error(/You can't have zero courses per application/)
   end
 
@@ -26,7 +40,7 @@ RSpec.describe TestApplications do
     it 'creates applications only for the supplied courses' do
       course_we_want = create(:course_option, course: create(:course, :open_on_apply)).course
 
-      choices = TestApplications.create_application(states: %i[offer], courses_to_apply_to: [course_we_want])
+      choices = TestApplications.new.create_application(states: %i[offer], courses_to_apply_to: [course_we_want])
 
       expect(choices.first.course).to eq(course_we_want)
     end
@@ -34,7 +48,7 @@ RSpec.describe TestApplications do
     it 'creates the right number of applications' do
       courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
-      choices = TestApplications.create_application(states: %i[offer], courses_to_apply_to: courses_we_want)
+      choices = TestApplications.new.create_application(states: %i[offer], courses_to_apply_to: courses_we_want)
 
       expect(choices.count).to eq(1)
     end
@@ -44,7 +58,7 @@ RSpec.describe TestApplications do
     it 'creates applications with work experience as well as explained and unexplained breaks' do
       create(:course_option, course: create(:course, :open_on_apply))
 
-      choices = TestApplications.create_application(states: %i[awaiting_provider_decision])
+      choices = TestApplications.new.create_application(states: %i[awaiting_provider_decision])
 
       expect(choices.count).to eq(1)
       expect(choices.first.application_form.application_work_experiences.count).to eq(2)


### PR DESCRIPTION
## Context

At the moment an application is created, submitted, receives references, is offered/accepted/enrolled etc all at the same moment. The data is useless for testing the timeline, sorting by date, etc.

The first attempt to do this used Rails testing time travel helpers https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1609. This ran into trouble when run on `qa` and we suspect may have interfered with the clock in other jobs (running concurrently in different threads). This PR uses a somewhat less 'clever' way to achieve the same effect.

## Changes proposed in this pull request

- [x] Go back to a semi-random start point then fast forward time by a few days at a time between lifecycle steps.
- [x] Keep track of 'application time' in the `TestApplications` as we fast forward and use this time to update key attributes of the `ApplicationForm` and `ApplicationChoice` as well as audit trail entries.

## Guidance to review

- Is there are more elegant way of doing this?
- Note that I've kept the structure of the `travel_to` and `fast_forward` methods from the first attempt, just changed the implementation.

## Link to Trello card

https://trello.com/c/Vn06dsBl/1744-make-test-application-generation-spread-events-out-over-time
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)