### PR TITLE
Update guidance and hint text on declaring safeguarding issues page

### DIFF
--- a/app/views/candidate_interface/safeguarding/edit.html.erb
+++ b/app/views/candidate_interface/safeguarding/edit.html.erb
@@ -32,10 +32,10 @@
         about whether this will affect your application.
       </p>
 
-      <p class="govuk-body">A criminal conviction won’t necessarily stop you becoming a teacher.</p>
+      <p class="govuk-body">It won’t necessarily stop you becoming a teacher.</p>
 
       <%= f.govuk_radio_buttons_fieldset :share_safeguarding_issues, legend: { size: 'm', text: 'Do you want to share any safeguarding issues?' } do %>
-        <%= f.govuk_radio_button :share_safeguarding_issues, 'Yes', label: { text: 'Yes, I want to share something' }, hint_text: 'Talk to your provider directly or tell us about it here. This won’t stop you from submitting your application.' do %>
+        <%= f.govuk_radio_button :share_safeguarding_issues, 'Yes', label: { text: 'Yes, I want to share something' }, hint_text: 'After you have submitted your application, your provider may be in touch to discuss the information you shared. If you prefer, you can contact your provider directly.' do %>
           <%= f.govuk_text_area :safeguarding_issues, rows: 8, label: { text: 'Give any relevant information', size: 's' }, max_words: 400 %>
         <% end %>
 


### PR DESCRIPTION
## Context

We want to avoid candidates being taken by surprise if they get a call from a provider asking about their criminal convictions. 

## Changes proposed in this pull request

This PR updates the guidance and hint text on the declaring any safeguarding issues page.

### Before

![screencapture-localhost-3000-candidate-application-safeguarding-2020-03-19-09_14_22](https://user-images.githubusercontent.com/42817036/77050752-20051f80-69c2-11ea-8e3f-fffa38f055e8.png)

### After

![screencapture-localhost-3000-candidate-application-safeguarding-2020-03-19-09_13_02](https://user-images.githubusercontent.com/42817036/77050662-006df700-69c2-11ea-83db-8d6ffc46b285.png)

## Guidance to review

See prototype (https://apply-beta-prototype.herokuapp.com/application/6IZO5/suitability).

## Link to Trello card

https://trello.com/c/Cc3DjaCr/1202-dev-content-change-to-safeguarding-section-following-decisions-about-how-providers-access-this-data

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
