### PR TITLE
Audit redaction fix

### DIFF
--- a/app/components/support_interface/audit_trail_change_component.rb
+++ b/app/components/support_interface/audit_trail_change_component.rb
@@ -26,6 +26,8 @@ module SupportInterface
     end
 
     def redact_equality_and_diversity_data(value)
+      return value unless value.is_a? Hash
+
       %w[sex disabilities ethnic_group ethnic_background].each do |field|
         next unless value[field]
 

--- a/app/components/support_interface/audit_trail_change_component.rb
+++ b/app/components/support_interface/audit_trail_change_component.rb
@@ -13,11 +13,10 @@ module SupportInterface
 
     def format_audit_values
       if values.is_a? Array
-        before = values[0] ? redact_equality_and_diversity_data(values[0]) : 'nil'
-        after = values[1] ? redact_equality_and_diversity_data(values[1]) : 'nil'
+        before, after = values.map { |v| redact_equality_and_diversity_data(v) || 'nil' }
         "#{before} → #{after}"
       else
-        values.to_s
+        redact_equality_and_diversity_data(values) || 'nil'
       end
     end
 
@@ -33,6 +32,7 @@ module SupportInterface
 
         value[field] = '[REDACTED]'
       end
+
       value
     end
 

--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -33,19 +33,11 @@ module SupportInterface
     end
 
     def changes
-      audit.audited_changes.merge(comment_change).select { |_, values| audit_value_present?(values) }
+      audit.audited_changes.merge(comment_change).reject { |_, values| values.blank? }
     end
 
     def comment_change
       { 'comment' => audit.comment }
-    end
-
-    def audit_value_present?(value)
-      if value.is_a? Array
-        value.any?(&:present?)
-      else
-        value.present?
-      end
     end
 
     attr_reader :audit

--- a/spec/components/support_interface/audit_trail_change_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_change_component_spec.rb
@@ -45,8 +45,9 @@ RSpec.describe SupportInterface::AuditTrailChangeComponent do
         .to include('{"sex"=>"[REDACTED]"} → {"sex"=>"[REDACTED]", "disabilities"=>"[REDACTED]"}')
     end
 
-    # this doesn’t happen at the moment but it would be suprising
-    # not to support it
-    it 'redacts top level keys as well as nested hashes'
+    it 'redacts top level keys as well as nested hashes' do
+      expect(render_result(attribute: 'sex', values: [nil, 'male']).text)
+        .to include('[REDACTED]')
+    end
   end
 end

--- a/spec/components/support_interface/audit_trail_change_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_change_component_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe SupportInterface::AuditTrailChangeComponent do
     expect(render_result(values: 'only_one').text).to match(/title\s*only_one/m)
   end
 
+  it 'renders an update with hash values' do
+    expect(render_result(values: [{ 'fox' => 'in socks' }, { 'cat' => 'in hat' }]).text).to include('{"fox"=>"in socks"} → {"cat"=>"in hat"}')
+  end
+
+  it 'renders an update with an integer value' do
+    expect(render_result(values: [nil, 40]).text).to include('40')
+  end
+
+  it 'renders a create with a hash value' do
+    expect(render_result(values: { 'fox' => 'in socks' }).text).to include('{"fox"=>"in socks"}')
+  end
+
   it 'redacts sensitive information' do
     expect(render_result(values: [{ 'sex' => 'male' }, { 'sex' => 'male', 'disabilities' => [] }]).text)
       .to include('{"sex"=>"[REDACTED]"} → {"sex"=>"[REDACTED]", "disabilities"=>"[REDACTED]"}')

--- a/spec/components/support_interface/audit_trail_change_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_change_component_spec.rb
@@ -35,8 +35,18 @@ RSpec.describe SupportInterface::AuditTrailChangeComponent do
     expect(render_result(values: { 'fox' => 'in socks' }).text).to include('{"fox"=>"in socks"}')
   end
 
-  it 'redacts sensitive information' do
-    expect(render_result(values: [{ 'sex' => 'male' }, { 'sex' => 'male', 'disabilities' => [] }]).text)
-      .to include('{"sex"=>"[REDACTED]"} → {"sex"=>"[REDACTED]", "disabilities"=>"[REDACTED]"}')
+  describe 'redaction' do
+    it 'redacts sensitive information on creates' do
+      expect(render_result(values: { 'sex' => 'male' }).text).to include('{"sex"=>"[REDACTED]"}')
+    end
+
+    it 'redacts sensitive information on updates' do
+      expect(render_result(values: [{ 'sex' => 'male' }, { 'sex' => 'male', 'disabilities' => [] }]).text)
+        .to include('{"sex"=>"[REDACTED]"} → {"sex"=>"[REDACTED]", "disabilities"=>"[REDACTED]"}')
+    end
+
+    # this doesn’t happen at the moment but it would be suprising
+    # not to support it
+    it 'redacts top level keys as well as nested hashes'
   end
 end


### PR DESCRIPTION
## Context

We got a production error associated with unexpected data passing through the component which renders audits. The error happened when we tried to redact data from an integer instead of a hash.

https://sentry.io/organizations/dfe-bat/issues/1571505476/?project=1765973&referrer=slack

## Changes proposed in this pull request

The fix:
- Guard against trying to treat non-hash things as hashes

Also:
- Redact "create" actions as well as "update" actions
- Be cautious and redact top-level keys as well as nested keys

## Guidance to review

See tests.

## Link to Trello card

https://trello.com/c/BjmrVkde/1800-address-production-error-related-to-scrubbing-audit-data

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
