### PR TITLE
Add validation for uniqueness of support users

### DIFF
--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -2,7 +2,7 @@ class SupportUser < ActiveRecord::Base
   include Discard::Model
 
   validates :dfe_sign_in_uid, presence: true
-  validates :email_address, presence: true
+  validates :email_address, presence: true, uniqueness: true
 
   before_save :downcase_email_address
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -197,6 +197,7 @@ en:
           attributes:
             email_address:
               blank: Email address can’t be blank
+              taken: A support user with this email address already exists
             dfe_sign_in_uid:
               blank: DfE Sign-in UID can’t be blank
         application_choice:

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -15,6 +15,9 @@ RSpec.feature 'Managing support users' do
 
     then_i_should_see_the_list_of_support_users
     and_i_should_see_the_user_i_created
+
+    when_i_submit_the_same_email_address_again
+    then_i_see_an_error
   end
 
   def given_i_am_a_support_user
@@ -52,5 +55,15 @@ RSpec.feature 'Managing support users' do
 
   def and_i_should_see_the_user_i_created
     expect(page).to have_content('harrison@example.com')
+  end
+
+  def when_i_submit_the_same_email_address_again
+    and_i_click_the_add_user_link
+    and_i_enter_the_users_email_and_dsi_uid
+    and_i_click_add_user
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content 'A support user with this email address already exists'
   end
 end


### PR DESCRIPTION
## Context

Currently we raise a database error and show the user a 500:

https://sentry.io/organizations/dfe-bat/issues/1381063687

## Changes proposed in this pull request

Add validation.

![image](https://user-images.githubusercontent.com/233676/77073127-aa5f7a80-69e6-11ea-96b8-8a89a5b572e7.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/PC2iipOi

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
