### PR TITLE
Update content on referee form feedback page

### DIFF
--- a/app/components/referee_interface/feedback_hints_component.html.erb
+++ b/app/components/referee_interface/feedback_hints_component.html.erb
@@ -1,0 +1,29 @@
+<p class="govuk-body">When giving your reference try to cover the following, but don’t worry if there are areas you can’t comment on:</p>
+<ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+  <% if @academic %>
+    <li>
+      <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
+      <p class="govuk-body">Does the candidate think critically and have good numeracy and literacy skills?</p>
+    </li>
+  <% end %>
+  <li>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
+    <p class="govuk-body">Is the candidate emotionally resilient? Do they work well with others?</p>
+  </li>
+  <li>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Subject knowledge</h2>
+    <p class="govuk-body">Is the candidate passionate and informed about their teaching subject?</p>
+  </li>
+  <li>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
+    <p class="govuk-body">Can the candidate meet deadlines and manage their time?</p>
+  </li>
+  <li>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Suitability to work with children</h2>
+    <p class="govuk-body">Does the candidate care about the wellbeing of children?</p>
+  </li>
+  <li>
+    <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
+    <p class="govuk-body">What abilities would the candidate bring to teaching - for example, communication, creativity, project management?</p>
+  </li>
+</ul>

--- a/app/components/referee_interface/feedback_hints_component.rb
+++ b/app/components/referee_interface/feedback_hints_component.rb
@@ -1,0 +1,7 @@
+module RefereeInterface
+  class FeedbackHintsComponent < ActionView::Component::Base
+    def initialize(reference:)
+      @academic = reference.referee_type.nil? || reference.referee_type == 'academic'
+    end
+  end
+end

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix("Give a teacher training reference for #{@application.full_name}", @reference_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix("Your reference for #{@application.full_name}", @reference_form.errors.any?) %>
 <% if FeatureFlag.active?('referee_confirm_relationship_and_safeguarding') %>
   <% content_for :before_content, govuk_back_link_to(referee_interface_safeguarding_path(token: @token_param)) %>
 <% end %>
@@ -7,39 +7,9 @@
   <%= f.govuk_error_summary %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Give a teacher training reference for <%= @application.full_name %></h1>
+      <h1 class="govuk-heading-xl">Your reference for <%= @application.full_name %></h1>
 
-      <p class="govuk-body"><%= @application.full_name %> applied to the following courses:</p>
-
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-        <% @application.application_choices.each do |application_choice| %>
-          <li><%= application_choice.course.name %> - <%= application_choice.site.name %></li>
-        <% end %>
-      </ul>
-
-      <p class="govuk-body">Try to cover the following, but don’t worry if there are areas you can’t comment on:</p>
-      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-        <li>
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Teaching potential</h2>
-          <p class="govuk-body">For example, does the candidate care about the wellbeing of children? Are they emotionally resilient and do they work well with others?</p>
-        </li>
-        <li>
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Subject knowledge</h2>
-          <p class="govuk-body">Is the candidate passionate and informed about their teaching subject?</p>
-        </li>
-        <li>
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Academic abilities</h2>
-          <p class="govuk-body">For example, does the candidate think critically and have good numeracy and literacy skills?</p>
-        </li>
-        <li>
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Reliability and professionalism</h2>
-          <p class="govuk-body">What abilities would the candidate bring to teaching, for example, communication, creativity, project management?</p>
-        </li>
-        <li>
-          <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Transferable skills</h2>
-          <p class="govuk-body">For example, can the candidate meet deadlines and manage their time?</p>
-        </li>
-      </ul>
+      <%= render(RefereeInterface::FeedbackHintsComponent.new(reference: @reference_form.reference)) %>
 
       <%= f.govuk_text_area :feedback, label: { text: 'Your reference', size: 'm' }, max_words: 300, rows: 15 %>
 

--- a/app/views/referee_interface/reference/refuse_feedback.html.erb
+++ b/app/views/referee_interface/reference/refuse_feedback.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, "Give a teacher training reference for #{@application.full_name}" %>
+<% content_for :title, "Your reference for #{@application.full_name}" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/components/referee_interface/feedback_hints_component_spec.rb
+++ b/spec/components/referee_interface/feedback_hints_component_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::FeedbackHintsComponent do
+  context 'when it is an academic reference' do
+    let(:reference) { build_stubbed(:reference, referee_type: :academic) }
+
+    it 'displays the academic abilities guidance' do
+      result = render_inline(described_class.new(reference: reference))
+
+      expect(result.text).to include('Academic abilities')
+    end
+  end
+
+  context 'when it is non-academic reference' do
+    let(:reference) { build_stubbed(:reference, referee_type: :school_based) }
+
+    it 'does not display that the academic abilities guidance' do
+      result = render_inline(described_class.new(reference: reference))
+
+      expect(result.text).not_to include('Academic abilities')
+    end
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
     when_i_click_on_the_link_within_the_email
     then_i_see_the_reference_comment_page
-    and_i_see_the_list_of_the_courses_the_candidate_applied_to
 
     when_i_fill_in_the_reference_field
     and_i_click_the_submit_reference_button
@@ -69,7 +68,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_see_the_reference_comment_page
-    expect(page).to have_content("Give a teacher training reference for #{@application.full_name}")
+    expect(page).to have_content("Your reference for #{@application.full_name}")
   end
 
   def when_i_fill_in_the_reference_field
@@ -111,13 +110,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def when_i_retry_to_edit_the_feedback
     visit @reference_feedback_url
-  end
-
-  def and_i_see_the_list_of_the_courses_the_candidate_applied_to
-    @application.application_choices.each do |application_choice|
-      expect(page).to have_content(application_choice.course.name)
-      expect(page).to have_content(application_choice.site.name)
-    end
   end
 
   def then_i_see_the_confirmation_page

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -38,7 +38,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     when_i_choose_the_candidate_is_suitable_for_working_with_children
     and_i_click_on_continue
     then_i_see_the_reference_comment_page
-    and_i_see_the_list_of_the_courses_the_candidate_applied_to
 
     when_i_fill_in_the_reference_field
     and_i_click_on_continue
@@ -152,7 +151,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_see_the_reference_comment_page
-    expect(page).to have_content("Give a teacher training reference for #{@application.full_name}")
+    expect(page).to have_content("Your reference for #{@application.full_name}")
   end
 
   def when_i_fill_in_the_reference_field
@@ -224,13 +223,6 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def when_i_retry_to_edit_the_feedback
     visit @reference_feedback_url
-  end
-
-  def and_i_see_the_list_of_the_courses_the_candidate_applied_to
-    @application.application_choices.each do |application_choice|
-      expect(page).to have_content(application_choice.course.name)
-      expect(page).to have_content(application_choice.site.name)
-    end
   end
 
   def then_i_see_the_confirmation_page

--- a/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
+++ b/spec/system/referee_interface/referee_refuses_to_give_a_reference_spec.rb
@@ -42,7 +42,7 @@ RSpec.feature 'Refusing to give a reference' do
   end
 
   def then_i_see_the_reference_comment_page
-    expect(page).to have_content("Give a teacher training reference for #{@application.full_name}")
+    expect(page).to have_content("Your reference for #{@application.full_name}")
   end
 
   def and_a_slack_notification_is_sent


### PR DESCRIPTION
## Context
We want to show more specific content/guidance for academic/non-academic references to improve the quality of the references. See Design: 
- https://bat-design-history.netlify.com/apply-for-teacher-training/give-a-reference-second-iteration#reference
- https://bat-design-history.netlify.com/apply-for-teacher-training/give-a-reference-second-iteration#reference-for-an-academic-referee

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR updates the content on the reference feedback page

### Before
<img width="768" alt="before" src="https://user-images.githubusercontent.com/22743709/77087248-cf5de880-69fa-11ea-8c47-0611651fa192.png">

### After 
<img width="738" alt="non-academic" src="https://user-images.githubusercontent.com/22743709/77087260-d4229c80-69fa-11ea-992a-03da331ac430.png">
<img width="848" alt="after-academic" src="https://user-images.githubusercontent.com/22743709/77087286-da187d80-69fa-11ea-8c6f-2ecf3152a71c.png">


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
There is a tiny bit of logic to show/hide a paragraph based on academic or non-academic reference:
```ruby
  <% if @reference_form.reference.referee_type.nil? || @reference_form.reference.referee_type == 'academic' %>
```
I tested locally, but there is no system test for this, do you think we need to add to the system tests?
Its currently showing the academic reference content for referees that has no `referee type` because I don't think we can backfill referee types in the DB. Does this make sense?

I did not add feature flag around this because of its a minor content change, but I am open for suggestions! 


## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/l267SMp9/1160-dev-content-change-for-academic-referees

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
