### PR TITLE
Automatically send an email to a candidate to notify them of a changed offer

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -152,6 +152,17 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def changed_offer(application_choice)
+    @application_choice = application_choice
+    @previous_offer = @application_choice.course_option
+    @new_offer = @application_choice.offered_course_option
+
+    email_for_candidate(
+      @application_choice.application_form,
+      subject: I18n.t!('candidate_mailer.changed_offer.subject', provider_name: @previous_offer.course.provider.name),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/previews/candidate_mailer_preview.rb
+++ b/app/mailers/previews/candidate_mailer_preview.rb
@@ -17,6 +17,12 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.application_sent_to_provider(application_form)
   end
 
+  def changed_offer
+    application_choice = FactoryBot.build(:submitted_application_choice, :with_modified_offer)
+
+    CandidateMailer.changed_offer(application_choice)
+  end
+
   def chase_reference
     CandidateMailer.chase_reference(reference)
   end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -13,7 +13,7 @@ class ChangeOffer
       @application_choice.update!(offered_course_option_id: @course_option_id, offered_at: Time.zone.now)
 
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
-      # TODO: SendChangeOfferEmailToCandidate.new(application_choice: @application_choice).call
+      CandidateMailer.changed_offer(@application_choice).deliver_later
       # TODO: StateChangeNotifier.call(:change_offer, application_choice: application_choice)
     end
   end

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -1,0 +1,21 @@
+Dear <%= @application_form.first_name %>,
+
+<%= @previous_offer.course.provider.name %> has changed the details of your offer.
+
+# Previous offer
+
+<%= @previous_offer.course.name_and_code %> at <%= @previous_offer.site.name %>
+
+# New offer
+
+<%= @new_offer.course.name_and_code %> at <%= @new_offer.site.name %> with <%= @new_offer.course.provider.name %>
+
+Contact <%= @previous_offer.course.provider.name %> directly if you have any questions about this.
+
+You can sign in to Apply for teacher training to check the status of your application(s):
+
+<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
+
+# Give feedback or report a problem
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -120,6 +120,7 @@ en:
         are no academic conditions.
       emails:
         - candidate_mailer-chase_candidate_decision
+        - candidate_mailer-changed_offer
 
     recruited:
       name: Recruited

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -38,3 +38,5 @@ en:
       subject: "You have met your conditions for %{course_name}: next steps"
     conditions_not_met:
       subject: "You have not met your conditions for %{course_name}: next steps"
+    changed_offer:
+      subject: "%{provider_name} changed the details of your offer"

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -180,4 +180,37 @@ RSpec.describe CandidateMailer, type: :mailer do
       )
     end
   end
+
+  describe '.changed_offer' do
+    before do
+      application_form = build_stubbed(:application_form, first_name: 'Tingker Bell')
+      provider = build_stubbed(:provider, name: 'Neverland University')
+      course_option = build_stubbed(
+        :course_option,
+        course: build_stubbed(:course, name: 'Flying', code: 'F1Y', provider: provider),
+        site: build_stubbed(:site, name: 'Peter School', provider: provider),
+      )
+      offered_course_option = build_stubbed(
+        :course_option,
+        course: build_stubbed(:course, name: 'Fighting', code: 'F1G', provider: provider),
+        site: build_stubbed(:site, name: 'Pan School', provider: provider),
+      )
+
+      @application_choice = build_stubbed(
+        :submitted_application_choice,
+        course_option: course_option,
+        offered_course_option: offered_course_option,
+        application_form: application_form,
+      )
+    end
+
+    it_behaves_like(
+      'a mail with subject and content',
+      :changed_offer,
+      'Neverland University changed the details of your offer',
+      'heading' => 'Dear Tingker Bell',
+      'previous offer' => 'Flying (F1Y) at Peter School',
+      'new offer' => 'Fighting (F1G) at Pan School with Neverland University',
+    )
+  end
 end

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -37,4 +37,14 @@ RSpec.describe ChangeOffer do
     noop = ChangeOffer.new(actor: provider_user, application_choice: application_choice, course_option_id: original_course_option.id)
     expect { noop.save! }.not_to change(application_choice, :decline_by_default_at)
   end
+
+  it 'sends an email to the candidate to notify them about the change' do
+    mail = instance_double(ActionMailer::MessageDelivery, deliver_later: true)
+    allow(CandidateMailer).to receive(:changed_offer).and_return(mail)
+
+    service.save!
+
+    expect(CandidateMailer).to have_received(:changed_offer).with(application_choice)
+    expect(mail).to have_received(:deliver_later)
+  end
 end

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -25,6 +25,9 @@ RSpec.feature 'Provider changes an offer' do
 
     when_i_inspect_and_confirm_these_changes
     then_the_offer_has_new_course_and_location_details
+
+    given_i_am_the_candidate_of_the_changed_offer
+    then_i_receive_an_email_about_the_changed_offer
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -113,5 +116,17 @@ RSpec.feature 'Provider changes an offer' do
     expect(page).to have_content @course_option_three.course.name_and_code
     expect(page).to have_content @course_option_three.site.name_and_address
     expect(@application_offered.reload.offered_option).to eq(@course_option_three)
+  end
+
+  def given_i_am_the_candidate_of_the_changed_offer
+    @candidate = @application_offered.application_form.candidate
+  end
+
+  def then_i_receive_an_email_about_the_changed_offer
+    open_email(@candidate.email_address)
+
+    expect(current_email.subject).to include(
+      t('candidate_mailer.changed_offer.subject', provider_name: @course_option_three.course.provider.name),
+    )
   end
 end


### PR DESCRIPTION
## Context

We want to notify a candidate when a provider has modified their offer to them. This was done in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1551 and some improvement work in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1657.

## Changes proposed in this pull request

This PR adds a new email to the `CandidateMailer` called `changed_offer` which is then used in the `ChangeOffer` service.

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/77088873-fcab9600-69fc-11ea-8e9c-a3058c8e2db5.png)

## Guidance to review

- Having a look #1657, there isn't any conflict apart from calling `#save` instead of `#save!` in the spec which can be easily updated. Would you agree?
- There was a commented suggestion to use a service to send the email. Feels like calling the mailer directly is okay because we no longer have to create an audit comment because we now have an email log and there is no other logic required for this. Is this right?

## Link to Trello card

https://trello.com/c/LS1Nqt32/1052-build-email-to-candidate-provider-changed-offer-to-different-course

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
