### PR TITLE
Fix test applications audit trail attribution (for provider actions)

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -105,79 +105,91 @@ class TestApplications
 
     case state
     when :offer
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: time)
+      make_offer(choice)
     when :rejected
-      fast_forward(1..3)
-      RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
-      choice.update_columns(rejected_at: time)
+      reject_application(choice)
     when :offer_withdrawn
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: time)
-      fast_forward(1..3)
-      WithdrawOffer.new(application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
-      choice.update_columns(withdrawn_at: time)
+      make_offer(choice)
+      withdraw_offer(choice)
     when :declined
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: time)
-      fast_forward(1..3)
-      DeclineOffer.new(application_choice: choice).save!
-      choice.update_columns(declined_at: time)
+      make_offer(choice)
+      decline_offer(choice)
     when :accepted
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
-      choice.update_columns(offered_at: time)
-      fast_forward(1..3)
-      AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: time)
+      make_offer(choice)
+      accept_offer(choice)
     when :accepted_no_conditions
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: []).save
-      choice.update_columns(offered_at: time)
-      fast_forward(1..3)
-      AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: time)
+      make_offer(choice, conditions: [])
+      accept_offer(choice)
     when :conditions_not_met
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check', 'Complete course']).save
-      choice.update_columns(offered_at: time)
-      fast_forward(1..3)
-      AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: time)
-      fast_forward(1..3)
-      ConditionsNotMet.new(application_choice: choice).save
-      choice.update_columns(conditions_not_met_at: time)
+      make_offer(choice)
+      accept_offer(choice)
+      conditions_not_met(choice)
     when :recruited
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS', 'Fitness to teach check']).save
-      choice.update_columns(offered_at: time)
-      fast_forward(1..3)
-      AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: time)
-      fast_forward(1..3)
-      ConfirmOfferConditions.new(application_choice: choice).save
-      choice.update_columns(recruited_at: time)
+      make_offer(choice)
+      accept_offer(choice)
+      confirm_offer_conditions(choice)
     when :enrolled
-      fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
-      choice.update_columns(offered_at: time)
-      fast_forward(1..3)
-      AcceptOffer.new(application_choice: choice).save!
-      choice.update_columns(accepted_at: time)
-      fast_forward(1..3)
-      ConfirmOfferConditions.new(application_choice: choice).save
-      choice.update_columns(recruited_at: time)
-      fast_forward(1..3)
-      ConfirmEnrolment.new(application_choice: choice).save
-      choice.update_columns(enrolled_at: time)
+      make_offer(choice)
+      accept_offer(choice)
+      confirm_offer_conditions(choice)
+      confirm_enrollment(choice)
     when :withdrawn
-      fast_forward(1..3)
-      WithdrawApplication.new(application_choice: choice).save!
-      choice.update_columns(withdrawn_at: time)
+      withdraw_application(choice)
     end
+  end
+
+  def accept_offer(choice)
+    fast_forward(1..3)
+    AcceptOffer.new(application_choice: choice).save!
+    choice.update_columns(accepted_at: time)
+  end
+
+  def make_offer(choice, conditions: ['Complete DBS'])
+    fast_forward(1..3)
+    MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: conditions).save
+    choice.update_columns(offered_at: time)
+  end
+
+  def reject_application(choice)
+    fast_forward(1..3)
+    RejectApplication.new(application_choice: choice, rejection_reason: 'Some').save
+    choice.update_columns(rejected_at: time)
+  end
+
+  def withdraw_offer(choice)
+    fast_forward(1..3)
+    WithdrawOffer.new(application_choice: choice, offer_withdrawal_reason: 'Offer withdrawal reason is...').save
+    choice.update_columns(withdrawn_at: time)
+  end
+
+  def conditions_not_met(choice)
+    fast_forward(1..3)
+    ConditionsNotMet.new(application_choice: choice).save
+    choice.update_columns(conditions_not_met_at: time)
+  end
+
+  def confirm_offer_conditions(choice)
+    fast_forward(1..3)
+    ConfirmOfferConditions.new(application_choice: choice).save
+    choice.update_columns(recruited_at: time)
+  end
+
+  def withdraw_application(choice)
+    fast_forward(1..3)
+    WithdrawApplication.new(application_choice: choice).save!
+    choice.update_columns(withdrawn_at: time)
+  end
+
+  def decline_offer(choice)
+    fast_forward(1..3)
+    DeclineOffer.new(application_choice: choice).save!
+    choice.update_columns(declined_at: time)
+  end
+
+  def confirm_enrollment(choice)
+    fast_forward(1..3)
+    ConfirmEnrolment.new(application_choice: choice).save
+    choice.update_columns(enrolled_at: time)
   end
 
   def actor


### PR DESCRIPTION
## Context

When we generate test applications audit trail items associated with the various lifecycle actions are attributed to candidates. To look more realistic we need to attribute actions like 'submits application' to candidates and other such as 'reject' or 'offer' to a provider user.

## Changes proposed in this pull request

- [x] Refactor `TestApplications` to remove some duplication by extracting methods for each lifecycle action.
- [x] Wrap all of the provider actions with a new `as_provider_user` method that sets a provider user as the user associated with each audit entry triggered by the action.

Example:

![image](https://user-images.githubusercontent.com/450843/77120976-013e7180-6a32-11ea-9db6-a4fc004a6623.png)

## Guidance to review

- Does the refactoring make sense? Could it be simpler?
- Are tests sufficient?

## Link to Trello card

https://trello.com/c/ZvgOpW5Z/1697-%F0%9F%8F%88-implement-the-new-timeline-design-for-applications-on-the-provider-ui-application-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
