### PR TITLE
Fix NoMethodError when calling capitalize on referee type that is nil

### DIFF
--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -62,7 +62,7 @@ module CandidateInterface
     def reference_type_row(referee)
       {
         key: 'Reference type',
-        value: referee.referee_type.capitalize.dasherize || '',
+        value: referee.referee_type ? referee.referee_type.capitalize.dasherize : '',
         action: "reference type for #{referee.name}",
         change_path: candidate_interface_referees_type_path(referee.id),
       }

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -122,6 +122,15 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
         expect(result.css('.govuk-summary-list__value').to_html).to include(first_referee.referee_type.capitalize.dasherize)
       end
 
+      it 'can tolerate when referee type is nil' do
+        first_referee = application_form.application_references.first
+        first_referee.update!(referee_type: nil)
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-summary-list__key').text).to include('Reference type')
+        expect(result.css('.govuk-summary-list__value').to_html).to include('')
+      end
+
       it 'renders correct text for "Change" links in reference type attribute row' do
         first_referee = application_form.application_references.first
         result = render_inline(described_class.new(application_form: application_form))


### PR DESCRIPTION
## Context
The `RefereesReviewComponent` calls `capitalize` method on `referee_tye` to show it in a correct format, but this blows up when `referee_tye` is nil.
![image](https://user-images.githubusercontent.com/22743709/77149739-2a8aec00-6a8a-11ea-919b-1e5fb453f97e.png)

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds a check for value before calling `capitalize` method in the review component 

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
👀 
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
