### PR TITLE
Create RecalculateDates worker

### DIFF
--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -2,19 +2,21 @@ class RecalculateDates
   include Sidekiq::Worker
 
   def perform(*)
-    ApplicationChoice
-      .where(status: :awaiting_provider_decision)
-      .includes(:application_form)
-      .find_each do |application_choice|
-        update_reject_by_default(application_choice)
-      end
+    Audited.audit_class.as_user('RecalculateDates worker') do
+      ApplicationChoice
+        .where(status: :awaiting_provider_decision)
+        .includes(:application_form)
+        .find_each do |application_choice|
+          update_reject_by_default(application_choice)
+        end
 
-    ApplicationChoice
-      .where(status: :offer)
-      .includes(:application_form)
-      .find_each do |application_choice|
-        update_decline_by_default(application_choice)
-      end
+      ApplicationChoice
+        .where(status: :offer)
+        .includes(:application_form)
+        .find_each do |application_choice|
+          update_decline_by_default(application_choice)
+        end
+    end
   end
 
 private

--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -1,0 +1,20 @@
+class RecalculateDates
+  include Sidekiq::Worker
+
+  def perform(*)
+    application_choices = ApplicationChoice.where(status: :awaiting_provider_decision).includes(:application_form)
+    application_choices.find_each do |application_choice|
+      time_limit = TimeLimitCalculator.new(
+        rule: :reject_by_default,
+        effective_date: application_choice.application_form.submitted_at,
+      ).call
+
+      days = time_limit[:days]
+      time = time_limit[:time_in_future]
+
+      application_choice.reject_by_default_days = days
+      application_choice.reject_by_default_at = time
+      application_choice.save!
+    end
+  end
+end

--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -30,9 +30,11 @@ private
     days = time_limit[:days]
     time = time_limit[:time_in_future]
 
-    application_choice.reject_by_default_days = days
-    application_choice.reject_by_default_at = time
-    application_choice.save!
+    if times_are_different(time, application_choice.reject_by_default_at)
+      application_choice.reject_by_default_days = days
+      application_choice.reject_by_default_at = time
+      application_choice.save!
+    end
   end
 
   def update_decline_by_default(application_choice)
@@ -44,8 +46,14 @@ private
     days = time_limit[:days]
     time = time_limit[:time_in_future]
 
-    application_choice.decline_by_default_days = days
-    application_choice.decline_by_default_at = time
-    application_choice.save!
+    if times_are_different(time, application_choice.decline_by_default_at)
+      application_choice.decline_by_default_days = days
+      application_choice.decline_by_default_at = time
+      application_choice.save!
+    end
+  end
+
+  def times_are_different(time1, time2)
+    time1.to_s != time2.to_s
   end
 end

--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -2,19 +2,48 @@ class RecalculateDates
   include Sidekiq::Worker
 
   def perform(*)
-    application_choices = ApplicationChoice.where(status: :awaiting_provider_decision).includes(:application_form)
-    application_choices.find_each do |application_choice|
-      time_limit = TimeLimitCalculator.new(
-        rule: :reject_by_default,
-        effective_date: application_choice.application_form.submitted_at,
-      ).call
+    ApplicationChoice
+      .where(status: :awaiting_provider_decision)
+      .includes(:application_form)
+      .find_each do |application_choice|
+        update_reject_by_default(application_choice)
+      end
 
-      days = time_limit[:days]
-      time = time_limit[:time_in_future]
+    ApplicationChoice
+      .where(status: :offer)
+      .includes(:application_form)
+      .find_each do |application_choice|
+        update_decline_by_default(application_choice)
+      end
+  end
 
-      application_choice.reject_by_default_days = days
-      application_choice.reject_by_default_at = time
-      application_choice.save!
-    end
+private
+
+  def update_reject_by_default(application_choice)
+    time_limit = TimeLimitCalculator.new(
+      rule: :reject_by_default,
+      effective_date: application_choice.application_form.submitted_at,
+    ).call
+
+    days = time_limit[:days]
+    time = time_limit[:time_in_future]
+
+    application_choice.reject_by_default_days = days
+    application_choice.reject_by_default_at = time
+    application_choice.save!
+  end
+
+  def update_decline_by_default(application_choice)
+    time_limit = TimeLimitCalculator.new(
+      rule: :decline_by_default,
+      effective_date: application_choice.offered_at,
+    ).call
+
+    days = time_limit[:days]
+    time = time_limit[:time_in_future]
+
+    application_choice.decline_by_default_days = days
+    application_choice.decline_by_default_at = time
+    application_choice.save!
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -265,7 +265,7 @@ FactoryBot.define do
 
     factory :submitted_application_choice do
       status { 'awaiting_provider_decision' }
-      reject_by_default_at { Time.zone.now + 40.days }
+      reject_by_default_at { 40.business_days.from_now }
       reject_by_default_days { 40 }
       association :application_form, factory: %i[completed_application_form with_completed_references]
     end

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -1,12 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe RecalculateDates do
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 3, 20)) do
+      example.run
+    end
+  end
+
   after do
     unmock_holidays
   end
 
   it 'recalculates reject_by_default_at for a submitted application choice' do
-    application_form = create(:completed_application_form, :with_completed_references, submitted_at: Time.zone.local(2020, 3, 20))
+    application_form = create(:completed_application_form, :with_completed_references, submitted_at: Time.zone.now)
     application_choice = create(:submitted_application_choice, application_form: application_form)
 
     mock_holidays
@@ -16,6 +22,24 @@ RSpec.describe RecalculateDates do
     new_reject_by_default = Time.zone.local(2020, 5, 21).end_of_day
 
     expect(application_choice.reload.reject_by_default_at).to be_within(1.second).of new_reject_by_default
+  end
+
+  it 'recalculates decline_by_default_at for a submitted application choice with an offer' do
+    application_form = create(:completed_application_form, :with_completed_references, submitted_at: Time.zone.now)
+    application_choice = create(
+      :submitted_application_choice, :with_offer,
+      application_form: application_form,
+      decline_by_default_at: 10.business_days.from_now,
+      offered_at: Time.zone.now
+    )
+
+    mock_holidays
+
+    RecalculateDates.new.perform
+
+    new_decline_by_default = Time.zone.local(2020, 4, 6).end_of_day
+
+    expect(application_choice.reload.decline_by_default_at).to be_within(1.second).of new_decline_by_default
   end
 
   def mock_holidays

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe RecalculateDates do
+  after do
+    unmock_holidays
+  end
+
+  it 'recalculates reject_by_default_at for a submitted application choice' do
+    application_form = create(:completed_application_form, :with_completed_references, submitted_at: Time.zone.local(2020, 3, 20))
+    application_choice = create(:submitted_application_choice, application_form: application_form)
+
+    mock_holidays
+
+    RecalculateDates.new.perform
+
+    new_reject_by_default = Time.zone.local(2020, 5, 21).end_of_day
+
+    expect(application_choice.reload.reject_by_default_at).to be_within(1.second).of new_reject_by_default
+  end
+
+  def mock_holidays
+    BusinessTime::Config.holidays << Date.new(2020, 3, 23)
+  end
+
+  def unmock_holidays
+    BusinessTime::Config.holidays - [Date.new(2020, 3, 23)]
+  end
+end


### PR DESCRIPTION
## Context

We need a way to pause/defer RBD and DBDs until providers can start processing applications again. Our approach for this is to add to `BusinessTime::Config.holidays` and then recalculate these dates using a worker.

## Changes proposed in this pull request

- Implement a `RecalculateDates` worker

## Guidance to review

Tested locally, example application:

![Screenshot 2020-03-20 at 15 33 56](https://user-images.githubusercontent.com/1650875/77179384-55903280-6ac0-11ea-8a41-558d169620d2.png)

Added this to `config/initializers/business_time.rb` and restarted the application:

```ruby
BusinessTime::Config.holidays << Date.new(2020, 3, 23)
BusinessTime::Config.holidays << Date.new(2020, 3, 24)
BusinessTime::Config.holidays << Date.new(2020, 3, 25)
BusinessTime::Config.holidays << Date.new(2020, 3, 26)
BusinessTime::Config.holidays << Date.new(2020, 3, 27)
```

Then ran this in the Rails console:

```ruby
> RecalculateDates.new.perform
```

And the result:

![Screenshot 2020-03-20 at 15 34 08](https://user-images.githubusercontent.com/1650875/77179496-79537880-6ac0-11ea-8bcd-b2186d8c60f2.png)

This is exactly right; it got pushed 8 days further because the 25th of May was already a bank holiday.

## Link to Trello card

https://trello.com/c/iV0jnliU/1207-ucas-rbd-dbd-date-suspension-until-20th-april

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
