### PR TITLE
Allow time limits to use calendar days instead of business days

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -1,27 +1,27 @@
 class TimeLimitConfig
-  Rule = Struct.new(:from_date, :to_date, :limit)
+  Rule = Struct.new(:from_date, :to_date, :limit, :use_business_days)
 
   RULES = {
     reject_by_default: [
-      Rule.new(nil, nil, 40),
+      Rule.new(nil, nil, 40, true),
     ],
     decline_by_default: [
-      Rule.new(nil, nil, 10),
+      Rule.new(nil, nil, 10, true),
     ],
     edit_by: [
-      Rule.new(nil, nil, 5),
+      Rule.new(nil, nil, 7, false),
     ],
     chase_provider_before_rbd: [
-      Rule.new(nil, nil, 20),
+      Rule.new(nil, nil, 20, true),
     ],
     chase_referee_by: [
-      Rule.new(nil, nil, 5),
+      Rule.new(nil, nil, 5, true),
     ],
     replace_referee_by: [
-      Rule.new(nil, nil, 10),
+      Rule.new(nil, nil, 10, true),
     ],
     chase_candidate_before_dbd: [
-      Rule.new(nil, nil, 5),
+      Rule.new(nil, nil, 5, true),
     ],
   }.freeze
 

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -2,24 +2,29 @@ require 'rails_helper'
 
 RSpec.describe TimeLimitConfig do
   describe '#limits_for' do
-    it ':reject_by_default returns a default limit of 40 days' do
+    it ':reject_by_default returns a default limit of 40 business days' do
       expect(TimeLimitConfig.limits_for(:reject_by_default).first.limit).to eq(40)
+      expect(TimeLimitConfig.limits_for(:reject_by_default).first.use_business_days).to eq(true)
     end
 
-    it ':decline_by_default returns a default limit of 10 days' do
+    it ':decline_by_default returns a default limit of 10 business days' do
       expect(TimeLimitConfig.limits_for(:decline_by_default).first.limit).to eq(10)
+      expect(TimeLimitConfig.limits_for(:decline_by_default).first.use_business_days).to eq(true)
     end
 
-    it ':edit_by returns a default limit of 5 days' do
-      expect(TimeLimitConfig.limits_for(:edit_by).first.limit).to eq(5)
+    it ':edit_by returns a default limit of 7 days' do
+      expect(TimeLimitConfig.limits_for(:edit_by).first.limit).to eq(7)
+      expect(TimeLimitConfig.limits_for(:edit_by).first.use_business_days).to eq(false)
     end
 
-    it ':chase_provider_before_rbd returns a default limit of 20 days' do
+    it ':chase_provider_before_rbd returns a default limit of 20 business days' do
       expect(TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit).to eq(20)
+      expect(TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.use_business_days).to eq(true)
     end
 
-    it ':chase_candidate_before_dbd returns a default limit of 5 days' do
+    it ':chase_candidate_before_dbd returns a default limit of 5 business days' do
       expect(TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit).to eq(5)
+      expect(TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.use_business_days).to eq(true)
     end
   end
 end


### PR DESCRIPTION
## Context

We need `edit_by` to be set using calendar days instead of business days in order to allow RBD and DBD to be flexible if holidays change.

## Changes proposed in this pull request

Add `use_business_days` to TimeLimitConfig rule struct, use it in TimeLimitCalculator.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/iV0jnliU/1207-ucas-rbd-dbd-date-suspension-until-20th-april

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)