### PR TITLE
Add 23 March to 20 April to holidays

### DIFF
--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -2,5 +2,9 @@ Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).m
   BusinessTime::Config.holidays << holiday[:date]
 end
 
+(Date.new(2020, 3, 23)..Date.new(2020, 4, 20)).each do |date|
+  BusinessTime::Config.holidays << date
+end
+
 BusinessTime::Config.beginning_of_workday = '0:00 am'
 BusinessTime::Config.end_of_workday = '11:59 pm'

--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -1,10 +1,16 @@
 require 'rails_helper'
 
+# Hello!
+# Is this spec broken due to daylight savings?
+# If yes, please increment this counter:
+#
+#   number_of_times_this_spec_has_broken_because_of_dst = 2
+
 RSpec.feature 'Receives rejection email' do
   include CandidateHelper
 
   around do |example|
-    date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 3, 13)
+    date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 1, 13)
     Timecop.freeze(date_that_avoids_clocks_changing_by_ten_days) do
       example.run
     end

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RecalculateDates do
 
     RecalculateDates.new.perform
 
-    new_reject_by_default = Time.zone.local(2020, 5, 21).end_of_day
+    new_reject_by_default = Time.zone.local(2020, 6, 17).end_of_day
 
     expect(application_choice.reload.reject_by_default_at).to be_within(1.second).of new_reject_by_default
   end
@@ -37,7 +37,7 @@ RSpec.describe RecalculateDates do
 
     RecalculateDates.new.perform
 
-    new_decline_by_default = Time.zone.local(2020, 4, 6).end_of_day
+    new_decline_by_default = Time.zone.local(2020, 5, 4).end_of_day
 
     expect(application_choice.reload.decline_by_default_at).to be_within(1.second).of new_decline_by_default
   end


### PR DESCRIPTION
## Context

We're planning on suspending RBD and DBD for this period.


## Changes proposed in this pull request

Add 23 March to 20 April to holidays.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/iV0jnliU/1207-ucas-rbd-dbd-date-suspension-until-20th-april

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)