### PR TITLE
Fix for bugs in qa exposed by RecalculateDates

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -98,13 +98,14 @@ class TestApplications
   end
 
   def put_application_choice_in_state(choice, state)
-    travel_to(choice.edit_by) if choice.edit_by > Time.zone.now
+    travel_to(choice.edit_by) if choice.edit_by > time
     SendApplicationToProvider.new(application_choice: choice).call
-    choice.update(edit_by: Time.zone.now)
+    choice.update(edit_by: time)
     return if state == :awaiting_provider_decision
 
     case state
     when :offer
+      fast_forward(1..3)
       MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: ['Complete DBS']).save
       choice.update_columns(offered_at: time)
     when :rejected

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -15,8 +15,8 @@ class DeclineOfferByDefault
           ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
         end
       end
-
-      CandidateMailer.declined_by_default(application_form).deliver_later
     end
+
+    CandidateMailer.declined_by_default(application_form).deliver_later
   end
 end

--- a/app/services/decline_offer_by_default.rb
+++ b/app/services/decline_offer_by_default.rb
@@ -6,14 +6,19 @@ class DeclineOfferByDefault
   end
 
   def call
+    application_choices = []
+
     ActiveRecord::Base.transaction do
       application_form.application_choices.offer.each do |application_choice|
         application_choice.update!(declined_by_default: true, declined_at: Time.zone.now)
         ApplicationStateChange.new(application_choice).decline_by_default!
+        application_choices << application_choice
+      end
+    end
 
-        application_choice.provider.provider_users.each do |provider_user|
-          ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
-        end
+    application_choices.each do |application_choice|
+      application_choice.provider.provider_users.each do |provider_user|
+        ProviderMailer.declined_by_default(provider_user, application_choice).deliver_later
       end
     end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe TestApplications do
     expect(choices.count).to eq(2)
   end
 
-  it 'creates a realistic timeline' do
+  it 'creates a realistic timeline for an enrolled application' do
     courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
 
     application_choice = TestApplications.new.create_application(states: %i[enrolled], courses_to_apply_to: courses_we_want).first
@@ -22,6 +22,18 @@ RSpec.describe TestApplications do
     expect(application_choice.offered_at - application_form.submitted_at).to be >= 1.day
     expect(application_choice.accepted_at - application_choice.offered_at).to be >= 1.day
     expect(application_choice.enrolled_at - application_choice.accepted_at).to be >= 1.day
+  end
+
+  it 'creates a realistic timeline for an offered application' do
+    courses_we_want = create_list(:course_option, 2, course: create(:course, :open_on_apply)).map(&:course)
+
+    application_choice = TestApplications.new.create_application(states: %i[offer], courses_to_apply_to: courses_we_want).first
+
+    application_form = application_choice.application_form
+    candidate = application_form.candidate
+    expect(application_choice.created_at - candidate.created_at).to be >= 1.day
+    expect(application_form.submitted_at - application_choice.created_at).to be >= 1.day
+    expect(application_choice.offered_at - application_form.submitted_at).to be >= 1.day
   end
 
   it 'throws an exception if there aren’t enough courses to apply to' do


### PR DESCRIPTION
## Context

We need a way to pause/defer RBD and DBDs until providers can start processing applications again. Some of the work done to achieve this, in particular https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1692, has exposed a couple of problems that led to some errors on `qa`.

See https://sentry.io/organizations/dfe-bat/issues/1573923287/?project=1765973&referrer=slack

I _think_ that the reason for this error is a race condition in `DeclineOfferByDefault` and the `CandidateMailer`. The mailer assumes that there is a declined by default application choice attached to the application form that it is given. However it could (at least in theory) run before the transaction in `DeclineOfferByDefault` gets committed. The mailer call was changed to be async just a few days ago so this didn't matter until very recently.

It also highlighted an issue in `TestApplications` the `offered_at` status is being set to the `submitted_at` date due to some time errors in the logic around `edit_by` in this class.

## Changes proposed in this pull request

- [x] Change references to `Time.zone.local` to `time` in `TestApplications` - we should be using the fake time that `TestApplications` manages to spread events across a realistic date range.
- [x] Move the invocation of `CandidateMailer` in `DeclineByDefault` outside the transaction so that it can't run the Sidekiq job until after the transaction has been committed. 

## Guidance to review

- Does the theory and solution to the race condition sound plausible?
- It looks like there are other dates set in `TestApplications` that don't set to reflect the fake timeline. e.g. `DeclineByDefault` sets `decline_by_default_at` based on the current time - it knows nothing of the fake time

## Link to Trello card

https://trello.com/c/iV0jnliU/1207-ucas-rbd-dbd-date-suspension-until-20th-april

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
