### PR TITLE
Update hint text on reference page

### DIFF
--- a/app/views/candidate_interface/referees/_form.html.erb
+++ b/app/views/candidate_interface/referees/_form.html.erb
@@ -19,6 +19,7 @@
   </div>
 <% end %>
 <%= f.govuk_text_field :email_address, type: 'email', label: { text: t('application_form.referees.email_address.label'), size: 'm' }, hint_text: t('application_form.referees.email_address.hint_text').first %>
-<%= f.govuk_text_area :relationship, label: { text: t('application_form.referees.relationship.label'), size: 'm' }, hint_text: t('application_form.referees.relationship.hint_text'), max_words: 50 %>
+<% referee_type = @referee.referee_type ? @referee.referee_type : 'academic' %>
+<%= f.govuk_text_area :relationship, label: { text: t('application_form.referees.relationship.label'), size: 'm' }, hint_text: t("application_form.referees.relationship.hint_text.#{referee_type}"), max_words: 50 %>
 
 <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>

--- a/app/views/candidate_interface/referees/edit.html.erb
+++ b/app/views/candidate_interface/referees/edit.html.erb
@@ -10,7 +10,11 @@
         <span class="govuk-caption-xl">
           <%= t('page_titles.nth_referee')[@referee.ordinal] %>
         </span>
-        <%= t('page_titles.add_referee') %>
+        <% if @referee.referee_type %>
+          Details of <%= @referee.referee_type.downcase.dasherize %> referee
+        <% else %>
+          <%= t('page_titles.add_referee') %>
+        <% end %>
       </h1>
 
       <%= render 'form', f: f %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -299,7 +299,11 @@ en:
         label: Full name
       relationship:
         label: What is your relationship to this referee and how long have you known them?
-        hint_text: For example, ’She’s the deputy head at the school where I currently volunteer’
+        hint_text:
+          academic: For example, ‘He was my course supervisor at university. I’ve known him for a year’.
+          professional: For example, ‘He was my line manager in my last job. I’ve known him for 2 years’.
+          school_based: For example, ‘She’s the deputy head at the school where I currently volunteer. I’ve known her for 3 years’.
+          character: For example, ‘She’s the head coach for my athletics club. I’ve known her for 5 years’.
       review:
         button: Continue
       sure_delete_entry: Yes I’m sure - delete this referee

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'Candidate adding referees' do
     when_i_choose_academic_as_reference_type
     and_i_click_continue
     then_i_am_asked_for_the_details_of_my_academic_referee
+    and_i_can_see_the_corresponding_hint_text_for_academic_reference
 
     when_i_fill_in_name_and_email_address
     and_i_submit_the_form
@@ -35,9 +36,10 @@ RSpec.feature 'Candidate adding referees' do
     and_i_click_on_add_second_referee
     then_i_am_asked_to_specify_the_type_of_my_second_referee
 
-    when_i_choose_academic_as_reference_type
+    when_i_choose_school_based_as_reference_type
     and_i_click_continue
-    then_i_am_asked_for_the_details_of_my_academic_referee
+    then_i_am_asked_for_the_details_of_my_school_based_referee
+    and_i_can_see_the_corresponding_hint_text_for_school_based_reference
 
     when_i_fill_in_all_required_fields
     and_i_submit_the_form
@@ -114,6 +116,10 @@ RSpec.feature 'Candidate adding referees' do
     expect(page).to have_content('Details of academic referee')
   end
 
+  def and_i_can_see_the_corresponding_hint_text_for_school_based_reference
+    expect(page).to have_content('For example, ‘She’s the deputy head at the school where I currently volunteer. I’ve known her for 3 years’.')
+  end
+
   def when_i_fill_in_name_and_email_address
     fill_in('Full name', with: 'AJP Taylor')
     fill_in('Email address', with: 'ajptaylor@example.com')
@@ -146,6 +152,18 @@ RSpec.feature 'Candidate adding referees' do
   def then_i_am_asked_to_specify_the_type_of_my_second_referee
     expect(page).to have_content('Second referee')
     expect(page).to have_content('What kind of reference is this?')
+  end
+
+  def when_i_choose_school_based_as_reference_type
+    choose 'School-based'
+  end
+
+  def then_i_am_asked_for_the_details_of_my_school_based_referee
+    expect(page).to have_content('Details of school-based referee')
+  end
+
+  def and_i_can_see_the_corresponding_hint_text_for_academic_reference
+    expect(page).to have_content('For example, ‘He was my course supervisor at university. I’ve known him for a year’.')
   end
 
   def when_i_fill_in_all_required_fields

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -46,6 +46,9 @@ RSpec.feature 'Candidate adding referees' do
     then_i_see_both_referees
 
     when_i_click_on_change_first_relationship
+    then_i_am_asked_for_the_details_of_my_academic_referee
+    and_i_can_see_the_corresponding_hint_text_for_academic_reference
+
     when_i_enter_an_updated_relationship
     and_i_submit_the_form
     then_i_see_updated_reference


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The Candidate select type of referee card needed a tiny bit more work to show the corresponding hint texts for a reference type 

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds
- Hint text on reference page that is corresponding to the reference type
- Fix the page title on `candidate_interface/referees/edit` page

#### After
![image](https://user-images.githubusercontent.com/22743709/77303237-8489ec80-6cea-11ea-8b51-482fc432f79c.png)
![image](https://user-images.githubusercontent.com/22743709/77303277-94093580-6cea-11ea-896b-7927363cfb35.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
👀 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/wwoQFSeB/1146-dev-iterate-candidate-select-type-of-referee

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
