### PR TITLE
Add Slack notification to ChangeOffer

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -22,6 +22,9 @@ class StateChangeNotifier
     when :make_an_offer
       text = "#{provider_name} has just made an offer to #{applicant}'s application"
       url = helpers.support_interface_application_form_url(application_form_id)
+    when :change_an_offer
+      text = "#{provider_name} has just changed an offer for #{applicant}'s application"
+      url = helpers.support_interface_application_form_url(application_form_id)
     when :reject_application
       text = "#{provider_name} has just rejected #{applicant}'s application"
       url = helpers.support_interface_application_form_url(application_form_id)

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -14,7 +14,7 @@ class ChangeOffer
 
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       CandidateMailer.changed_offer(@application_choice).deliver_later
-      # TODO: StateChangeNotifier.call(:change_offer, application_choice: application_choice)
+      StateChangeNotifier.call(:change_an_offer, application_choice: @application_choice)
     end
   end
 end

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -70,6 +70,20 @@ RSpec.describe StateChangeNotifier do
       end
     end
 
+    describe ':change_an_offer' do
+      before { StateChangeNotifier.call(:change_an_offer, application_choice: application_choice) }
+
+      it 'mentions applicant\s first name and provider name' do
+        arg1 = "#{provider_name} has just changed an offer for #{applicant}'s application"
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
+      end
+
+      it 'links the notification to the relevant support_interface application_form' do
+        arg2 = helpers.support_interface_application_form_url(application_form_id)
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
+      end
+    end
+
     describe ':reject_application' do
       before { StateChangeNotifier.call(:reject_application, application_choice: application_choice) }
 

--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -47,4 +47,10 @@ RSpec.describe ChangeOffer do
     expect(CandidateMailer).to have_received(:changed_offer).with(application_choice)
     expect(mail).to have_received(:deliver_later)
   end
+
+  it 'calls `StateChangeNotifier` to send a Slack notification' do
+    allow(StateChangeNotifier).to receive(:call).and_return(nil)
+    service.save!
+    expect(StateChangeNotifier).to have_received(:call).with(:change_an_offer, application_choice: application_choice)
+  end
 end


### PR DESCRIPTION
## Context

We recently added a feature to allow providers to change an offer. We've wondered how often this happens in practice and this will help us get a sense of that. Once a course offer has been changed, we get a slack notification.

## Changes proposed in this pull request

- [x] Add a new `changed_an_offer` notification event and trigger it from the `ChangeOffer` service.

## Guidance to review

- Is there anywhere else that we can change an offer? (Assumption is that everything goes through `ChangeOffer`.

## Link to Trello card

https://trello.com/c/Coi66eP7/1771-send-a-slack-notification-when-an-offer-is-changed
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
