### PR TITLE
Add feature flag for COVID-19 related changes

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,6 +4,7 @@ class FeatureFlag
     banner_about_problems_with_dfe_sign_in
     banner_for_ucas_downtime
     choose_study_mode
+    covid_19
     display_additional_course_details
     check_full_courses
     confirm_conditions


### PR DESCRIPTION
## Context

We need to provide specific guidance to candidates related to COVID-19 and want to be able to turn this content on and off easily.

## Changes proposed in this pull request

This PR adds a `covid_19` feature flag so that we can encapsulate all guidance around it with a single feature flag.

![image](https://user-images.githubusercontent.com/42817036/77306948-514a5c00-6cf0-11ea-8a85-3be1c393e409.png)

## Guidance to review

Could this be named better? Am I missing anything?

## Link to Trello card

https://trello.com/c/lBLa3fwp

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
