### PR TITLE
Add COVID-19 information to the confirmation page

### DIFF
--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -20,6 +20,15 @@
     <p class="govuk-body">We can’t send your application to your training provider(s) without your references.</p>
     <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
 
+    <% if FeatureFlag.active?('covid_19') %>
+
+      <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
+      <p class="govuk-body">We have extended the length of time training providers have to access your application. You may also have longer to respond to training providers once all your offers are in.</p>
+      <p class="govuk-body">You can check your deadlines on your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
+      
+    <% end %>
+
+
     <h2 class="govuk-heading-m">Interview</h2>
     <p class="govuk-body">If your training provider decides to offer you an interview, they will get in touch directly via email to organise a date and give you all the information you need.</p>
 

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Candidate submits the application' do
   scenario 'Candidate with a completed application' do
     given_i_am_signed_in
     and_the_training_with_a_disability_feature_flag_is_on
+    and_the_covid_19_feature_flag_is_on
 
     when_i_have_completed_my_application
     and_i_review_my_application
@@ -36,6 +37,7 @@ RSpec.feature 'Candidate submits the application' do
     then_i_can_see_my_application_has_been_successfully_submitted
 
     and_i_can_see_my_support_ref
+    and_that_covid_19_may_affect_my_application
     and_i_receive_an_email_with_my_support_ref
     and_my_referees_receive_a_request_for_a_reference_by_email
     and_a_slack_notification_is_sent
@@ -57,6 +59,10 @@ RSpec.feature 'Candidate submits the application' do
 
   def and_the_suitability_to_work_with_children_feature_flag_is_on
     FeatureFlag.activate('suitability_to_work_with_children')
+  end
+
+  def and_the_covid_19_feature_flag_is_on
+    FeatureFlag.activate('covid_19')
   end
 
   def when_i_have_completed_my_application
@@ -187,6 +193,10 @@ RSpec.feature 'Candidate submits the application' do
     expect(support_ref).not_to be_empty
   end
 
+  def and_that_covid_19_may_affect_my_application
+    expect(page).to have_content 'Coronavirus (COVID-19)'
+  end
+
   def and_i_receive_an_email_with_my_support_ref
     open_email(current_candidate.email_address)
     expect(current_email).to have_content 'Application submitted'
@@ -206,7 +216,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_click_on_track_your_application
-    click_link t('page_titles.application_dashboard')
+    click_link t('page_titles.application_dashboard'), match: :first
   end
 
   def then_i_can_see_my_application_dashboard


### PR DESCRIPTION
## Context

We need to update the confirmation page with new guidance relating to COVID 19 (and the changes to RBD and DBD dates) so candidates are aware of the impacts to timeframes. 

## Changes proposed in this pull request

Before
![image](https://user-images.githubusercontent.com/42515961/77309689-00893200-6cf5-11ea-9703-6d448614dce8.png)

After
![image](https://user-images.githubusercontent.com/42515961/77309039-d97e3080-6cf3-11ea-9379-c55816b2fa03.png)

## Guidance to review

Nothing really 

## Link to Trello card

https://trello.com/c/38iYI0bC/1214-dev-covid-19-changes-to-application-confirmation-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
