### PR TITLE
Adds covid banner to provider microsite

### DIFF
--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -25,6 +25,16 @@
   </div>
 </div>
 
+<% if FeatureFlag.active?('covid_19') %>
+  <div class="govuk-width-container">
+    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="success-message" data-module="govuk-error-summary" tabindex="-1" role="alert">
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m" id="success-message">Coronavirus (COVID-19): <%= link_to 'find out how this service is changing','#', class: 'govuk-link' %> to help you right now</h2>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-width-container">
   <section class="app-product-section">
     <div class="govuk-grid-row">


### PR DESCRIPTION
## Context

Adds Covid-19 banner to provider microsite.

**NOTE:** **once the guidance page is ready then the URL to it will need to be updated in the link inside the banner on line 52 in:** `app/views/provider_interface/start_page/show.html.erb
`

## Changes proposed in this pull request
**Before:**
<img width="783" alt="Screenshot 2020-03-23 at 11 31 10" src="https://user-images.githubusercontent.com/13377553/77312386-cec69a00-6cf9-11ea-95c1-3b5f37dda89d.png">

**After:**
<img width="815" alt="Screenshot 2020-03-23 at 11 30 03" src="https://user-images.githubusercontent.com/13377553/77312314-ac348100-6cf9-11ea-89f4-228e8cbfe65b.png">
## Guidance to review

Check that the feature flag works `covid_19` is its name.

## Link to Trello card

https://trello.com/c/7jHHrWSo/1805-dev-covid-19-changes-to-provider-microsite

## Things to check

- [*] This code doesn't rely on migrations in the same Pull Request
- [*] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [*] API release notes have been updated if necessary
- [*] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
