### PR TITLE
Adds covid banner to provider microsite

### DIFF
--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -25,6 +25,16 @@
   </div>
 </div>
 
+<% if FeatureFlag.active?('covid_19') %>
+  <div class="govuk-width-container">
+    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="success-message" data-module="govuk-error-summary" tabindex="-1" role="alert">
+      <div class="app-banner__message">
+        <h2 class="govuk-heading-m" id="success-message">Coronavirus (COVID-19): <%= link_to 'find out how this service is changing','#', class: 'govuk-link' %> to help you right now</h2>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-width-container">
   <section class="app-product-section">
     <div class="govuk-grid-row">

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -29,7 +29,7 @@
   <div class="govuk-width-container">
     <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="covid-message" >
       <div class="app-banner__message">
-        <h2 class="govuk-heading-m" id="covid-message">Coronavirus (COVID-19): <%= link_to 'find out how this service is changing','#', class: 'govuk-link' %> to help you right now</h2>
+        <h2 class="govuk-heading-m" id="covid-message">Coronavirus (COVID-19): <%= link_to 'find out how this service is changing', provider_interface_covid_19_guidance_path, class: 'govuk-link' %> to help you right now</h2>
       </div>
     </div>
   </div>

--- a/app/views/provider_interface/start_page/show.html.erb
+++ b/app/views/provider_interface/start_page/show.html.erb
@@ -27,9 +27,9 @@
 
 <% if FeatureFlag.active?('covid_19') %>
   <div class="govuk-width-container">
-    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="success-message" data-module="govuk-error-summary" tabindex="-1" role="alert">
+    <div class="app-banner govuk-!-margin-top-4 govuk-!-margin-bottom-0" aria-labelledby="covid-message" >
       <div class="app-banner__message">
-        <h2 class="govuk-heading-m" id="success-message">Coronavirus (COVID-19): <%= link_to 'find out how this service is changing','#', class: 'govuk-link' %> to help you right now</h2>
+        <h2 class="govuk-heading-m" id="covid-message">Coronavirus (COVID-19): <%= link_to 'find out how this service is changing','#', class: 'govuk-link' %> to help you right now</h2>
       </div>
     </div>
   </div>

--- a/spec/system/provider_interface/first_login_spec.rb
+++ b/spec/system/provider_interface/first_login_spec.rb
@@ -13,8 +13,13 @@ RSpec.feature 'See applications' do
     when_the_covid_19_feature_is_active
     and_i_visit_the_provider_page
     then_i_expect_to_see_the_covid_19_message
+
+    when_i_click_the_covid_19_message_link_to_covid_19_guidance
+    then_i_expect_to_see_the_covid_19_guidance_page
+
     then_the_covid_19_feature_is_deactivated
 
+    when_i_visit_the_provider_page
     given_a_support_user_has_pre_approved_my_email_address
     and_i_am_a_new_provider_user_authenticated_with_dfe_sign_in
 
@@ -22,6 +27,14 @@ RSpec.feature 'See applications' do
 
     then_i_should_be_on_the_applications_page
     and_my_dfe_sign_in_uid_has_been_stored
+  end
+
+  def when_i_click_the_covid_19_message_link_to_covid_19_guidance
+    click_link('find out how this service is changing')
+  end
+
+  def then_i_expect_to_see_the_covid_19_guidance_page
+    expect(page).to have_content('Coronavirus (COVID-19): new deadlines for processing applications')
   end
 
   def then_i_expect_to_see_the_covid_19_message

--- a/spec/system/provider_interface/first_login_spec.rb
+++ b/spec/system/provider_interface/first_login_spec.rb
@@ -10,6 +10,11 @@ RSpec.feature 'See applications' do
   end
 
   scenario 'Provider user can access interface immediately if pre-approved' do
+    when_the_covid_19_feature_is_active
+    and_i_visit_the_provider_page
+    then_i_expect_to_see_the_covid_19_message
+    then_the_covid_19_feature_is_deactivated
+
     given_a_support_user_has_pre_approved_my_email_address
     and_i_am_a_new_provider_user_authenticated_with_dfe_sign_in
 
@@ -17,6 +22,18 @@ RSpec.feature 'See applications' do
 
     then_i_should_be_on_the_applications_page
     and_my_dfe_sign_in_uid_has_been_stored
+  end
+
+  def then_i_expect_to_see_the_covid_19_message
+    expect(page).to have_content('Coronavirus (COVID-19): find out how this service is changing to help you right now')
+  end
+
+  def when_the_covid_19_feature_is_active
+    FeatureFlag.activate('covid_19')
+  end
+
+  def then_the_covid_19_feature_is_deactivated
+    FeatureFlag.deactivate('covid_19')
   end
 
   def given_a_support_user_has_pre_approved_my_email_address
@@ -35,6 +52,10 @@ RSpec.feature 'See applications' do
 
   def when_i_visit_the_provider_page
     visit provider_interface_path
+  end
+
+  def and_i_visit_the_provider_page
+    when_i_visit_the_provider_page
   end
 
   def then_i_should_be_on_the_applications_page


### PR DESCRIPTION
## Context

Adds Covid-19 banner to provider microsite.

**NOTE:** **once the guidance page is ready then the URL to it will need to be updated in the link inside the banner on line 52 in:** `app/views/provider_interface/start_page/show.html.erb
`

## Changes proposed in this pull request
**Before:**
<img width="783" alt="Screenshot 2020-03-23 at 11 31 10" src="https://user-images.githubusercontent.com/13377553/77312386-cec69a00-6cf9-11ea-95c1-3b5f37dda89d.png">

**After:**
<img width="815" alt="Screenshot 2020-03-23 at 11 30 03" src="https://user-images.githubusercontent.com/13377553/77312314-ac348100-6cf9-11ea-89f4-228e8cbfe65b.png">
## Guidance to review

Check that the feature flag works `covid_19` is its name.

## Link to Trello card

https://trello.com/c/7jHHrWSo/1805-dev-covid-19-changes-to-provider-microsite

## Things to check

- [*] This code doesn't rely on migrations in the same Pull Request
- [*] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [*] API release notes have been updated if necessary
- [*] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
