### PR TITLE
Covid 19 changes to service email notifications(candidate interface)

### DIFF
--- a/app/views/candidate_mailer/application_rejected_offers_made.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_made.erb
@@ -9,12 +9,21 @@ You’ve received the following offers:
   - <%= "#{offered_application_choice.course_option.course.name_and_code} at #{offered_application_choice.course_option.course.provider.name}"%>
 <% end %>
 
+<% if FeatureFlag.active?('covid_19') %>
+If you don’t reply by <%= @decline_by_default_at %> your application will be withdrawn. 
+<% else %>
 If you don’t reply within <%= @dbd_days %> working days, your applications will be withdrawn.
+<% end %>
 
 <% else %>
 
+<% if FeatureFlag.active?('covid_19') %>
+You’ve received an offer for a place on <%= @offers.first.course_option.course.name_and_code %> at <%= @offers.first.course_option.course.provider.name%>.
+If you don’t reply by <%= @decline_by_default_at %> your application will be withdrawn. 
+<% else %>
 You now have <%= @dbd_days %> working days to make a decision about your offer for a place on <%= @offers.first.course_option.course.name_and_code %> at <%= @offers.first.course_option.course.provider.name%>.
-
+<% end %>
+  
 <% end %>
 
 Sign in to your account to respond:

--- a/app/views/candidate_mailer/application_sent_to_provider.text.erb
+++ b/app/views/candidate_mailer/application_sent_to_provider.text.erb
@@ -4,9 +4,15 @@ Dear <%= @application_form.first_name %>,
 
 Your application is now with your teacher training <%= 'provider'.pluralize(@application_form.application_choices.count) %>.
 
+<% if FeatureFlag.active?('covid_19') %>
+They’ll be in touch with you if they want to arrange an interview.
+
+Due to the impact of coronavirus, this may take some time. 
+<% else %>
 We’ve asked them to make a final decision within <%= @application_form.application_choices.first.reject_by_default_days %> working days.
 
 They’ll be in touch with you sooner if they want to arrange an interview.
+<% end %>
 
 Sign in to Apply for teacher training to review your application:
 

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -52,7 +52,11 @@ Your application won’t be sent to your provider until your references are in.
 
 If your training provider decides to progress your application, they’ll contact you directly to organise an interview date.
 
+<% if FeatureFlag.active?('covid_19') %>
+Due to the impact of coronavirus, it might take some time for providers to get back to you. 
+<% else %>
 They should make a decision on whether to make an offer within <%= TimeLimitConfig.limits_for(:reject_by_default).first.limit %> working days of receiving your application.
+<% end %>
 
 # Need help?
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -142,6 +142,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     context 'Application rejected and one offer has been made' do
       before do
+        FeatureFlag.activate('covid_19')
         provider = build_stubbed(:provider, name: 'Vertapple University')
         course_option = build_stubbed(:course_option, course: build_stubbed(:course, name: 'Law', code: 'UFHG', provider: provider))
         @application_choice_with_offer = @application_form.application_choices.build(
@@ -160,12 +161,15 @@ RSpec.describe CandidateMailer, type: :mailer do
         'course name and code' => 'Forensic Science (E0FO)',
         'other course with an offer ' => 'Law (UFHG)',
         'other provider they got an offer from' => 'Vertapple University',
-        'their DBD date' => 'Make a decision about your offer by 25 February 2020'
+        'their DBD date' => 'Make a decision about your offer by 25 February 2020',
+        'prompt to reply with one offer' => 'You’ve received an offer for a place on',
+        'updated covid-19 prompt' => 'If you don’t reply by 25 February 2020 your application will be withdrawn.'
       )
     end
 
     context 'Application rejected and multiple offers has been made' do
       before do
+        FeatureFlag.activate('covid_19')
         setup_application_form_with_two_offers(@application_form)
       end
 
@@ -176,7 +180,9 @@ RSpec.describe CandidateMailer, type: :mailer do
         'course name and code' => 'MS Painting (P00)',
         'first course with offer' => 'Code Refactoring (Z00)',
         'first course provider with offer' => 'Wen University',
-        'their DBD date' => 'Make a decision about your offers by 25 February 2020'
+        'their DBD date' => 'Make a decision about your offers by 25 February 2020',
+        'prompt to reply with multiple offers' => 'You’ve received the following offers:',
+        'updated covid-19 prompt' => 'If you don’t reply by 25 February 2020 your application will be withdrawn.'
       )
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe CandidateMailer, type: :mailer do
                       I18n.t!('candidate_mailer.application_submitted.subject'),
                       'link to sign in and id' => 'http://localhost:3000/candidate/sign-in')
     end
+
+    context 'when the covid-19 feature flag is on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it_behaves_like('a mail with subject and content', :application_submitted,
+                      I18n.t!('candidate_mailer.application_submitted.subject'),
+                      'RBD time limit' => 'Due to the impact of coronavirus, it might take some time for providers to get back to you.')
+    end
   end
 
   describe 'Send survey email' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe CandidateMailer, type: :mailer do
         'sign in url' => 'http://localhost:3000/candidate/sign-in'
       )
     end
+
+    context 'when the covid-19 feature flag is on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it_behaves_like(
+        'a mail with subject and content', :application_sent_to_provider,
+        'Your application is being considered',
+        'time frame provider has to respond' => "They’ll be in touch with you if they want to arrange an interview.\r\n\r\nDue to the impact of coronavirus, this may take some time."
+      )
+    end
   end
 
   describe 'Candidate decision chaser email' do


### PR DESCRIPTION
## Context
We need to update service notifications (emails) in light of the changes we're making as a result of changing RBD/DBD dates (in response to COVID-19). This PR includes changes for the candidate mails

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR updates the following mails with new prompt message and rdb/dbd dates:
- `Application_submitted`
- `Application sent to provider`
- `application_rejected_offers_made`

#### After: 
![image](https://user-images.githubusercontent.com/22743709/77314849-5e6e4780-6cfe-11ea-8593-a4a1ee7abb76.png)

![image](https://user-images.githubusercontent.com/22743709/77315036-bc9b2a80-6cfe-11ea-91ce-12b1d6050c08.png)

![image](https://user-images.githubusercontent.com/22743709/77315124-e2c0ca80-6cfe-11ea-8d31-381f0febf6ff.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/lUggdcuq/1215-dev-covid-19-changes-to-service-email-notifications

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
