### PR TITLE
Update provider emails content (COVID-19)

### DIFF
--- a/app/views/provider_mailer/application_rejected_by_default.text.erb
+++ b/app/views/provider_mailer/application_rejected_by_default.text.erb
@@ -4,7 +4,15 @@ Dear <%= @provider_user_name || 'colleague' %>
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
+<% if FeatureFlag.active?('covid_19') %>
+
+This application has been rejected automatically because you did not respond in time.
+
+<% else %>
+
 This application has been rejected automatically because you did not respond within <%= @application.rbd_days %> working days.
+
+<% end %>
 
 # Give feedback or report a problem
 

--- a/app/views/provider_mailer/application_submitted.text.erb
+++ b/app/views/provider_mailer/application_submitted.text.erb
@@ -10,7 +10,15 @@ Log in to Manage teacher training applications to respond:
 
 <%= provider_interface_application_choice_url(application_choice_id: @application.application_choice_id) %>
 
+<% if FeatureFlag.active?('covid_19') %>
+
+We’ll reject the application automatically if you have not responded by <%= @application.rbd_date.to_s(:govuk_date).strip %>.
+
+<% else %>
+
 We’ll reject the application on your behalf after <%= @application.rbd_days %> working days.
+
+<% end %>
 
 # Give feedback or report a problem
 

--- a/app/views/provider_mailer/chase_provider_decision.text.erb
+++ b/app/views/provider_mailer/chase_provider_decision.text.erb
@@ -1,10 +1,26 @@
 Dear <%= @provider_user_name || 'colleague' %>
 
+<% if FeatureFlag.active?('covid_19') %>
+
+# Respond by <%= @application.rbd_date.to_s(:govuk_date).strip %>
+
+<% else %>
+
 # Only <%= TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit %> working days left to respond
+
+<% end %>
 
 <%= @application.candidate_name %> submitted an application for <%= @application.course_name_and_code %> on <%= @application.submitted_at %>.
 
+<% if FeatureFlag.active?('covid_19') %>
+
+Log in to Manage teacher training applications to respond:
+
+<% else %>
+
 Log in to Manage teacher training applications to respond within <%= TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit %> working days:
+
+<% end %>
 
 <%= provider_interface_application_choice_url(@application.application_choice) %>
 

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -47,38 +47,83 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send application submitted email' do
-    it_behaves_like('a provider mail with subject and content', :application_submitted,
-                    I18n.t!('provider_application_submitted.email.subject',
-                            course_name_and_code: 'Computer Science (6IND)'),
-                    'provider name' => 'Dear Johny English',
-                    'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)',
-                    'reject by default days' => 'after 123 working days',
-                    'link to the application' => 'http://localhost:3000/provider/applications/')
+    context 'with the covid_19 feature flag off' do
+      it_behaves_like('a provider mail with subject and content', :application_submitted,
+                      I18n.t!('provider_application_submitted.email.subject',
+                              course_name_and_code: 'Computer Science (6IND)'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'reject by default days' => 'after 123 working days',
+                      'link to the application' => 'http://localhost:3000/provider/applications/')
+    end
+
+    context 'with the covid_19 feature flag on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it_behaves_like('a provider mail with subject and content', :application_submitted,
+                      I18n.t!('provider_application_submitted.email.subject',
+                              course_name_and_code: 'Computer Science (6IND)'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'reject by default at' => (Time.zone.now + 40.days).to_s(:govuk_date).strip,
+                      'link to the application' => 'http://localhost:3000/provider/applications/')
+    end
   end
 
   describe 'Send application rejected by default email' do
-    it_behaves_like('a provider mail with subject and content', :application_rejected_by_default,
-                    I18n.t!('provider_application_rejected_by_default.email.subject',
-                            candidate_name: 'Harry Potter'),
-                    'provider name' => 'Dear Johny English',
-                    'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)',
-                    'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
-                    'reject by default days' => 'within 123 working days')
+    context 'with the covid_19 feature flag off' do
+      it_behaves_like('a provider mail with subject and content', :application_rejected_by_default,
+                      I18n.t!('provider_application_rejected_by_default.email.subject',
+                              candidate_name: 'Harry Potter'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'reject by default days' => 'within 123 working days',
+                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip)
+    end
+
+    context 'with the covid_19 feature flag on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it_behaves_like('a provider mail with subject and content', :application_rejected_by_default,
+                      I18n.t!('provider_application_rejected_by_default.email.subject',
+                              candidate_name: 'Harry Potter'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip)
+    end
   end
 
   describe 'Send provider decision chaser email' do
-    it_behaves_like('a provider mail with subject and content', :chase_provider_decision,
-                    I18n.t!('provider_application_waiting_for_decision.email.subject',
-                            candidate_name: 'Harry Potter'),
-                    'provider name' => 'Dear Johny English',
-                    'candidate name' => 'Harry Potter',
-                    'course name and code' => 'Computer Science (6IND)',
-                    'time to respond' => "Only #{TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit} working days left to respond",
-                    'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
-                    'reject by default at' => (Time.zone.now + 40.days).to_s(:govuk_date).strip,
-                    'link to the application' => 'http://localhost:3000/provider/applications/')
+    context 'with the covid_19 feature flag off' do
+      it_behaves_like('a provider mail with subject and content', :chase_provider_decision,
+                      I18n.t!('provider_application_waiting_for_decision.email.subject',
+                              candidate_name: 'Harry Potter'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'time to respond' => "Only #{TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit} working days left to respond",
+                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
+                      'reject by default at' => (Time.zone.now + 40.days).to_s(:govuk_date).strip,
+                      'link to the application' => 'http://localhost:3000/provider/applications/')
+    end
+
+    context 'with the covid_19 feature flag on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it_behaves_like('a provider mail with subject and content', :chase_provider_decision,
+                      I18n.t!('provider_application_waiting_for_decision.email.subject',
+                              candidate_name: 'Harry Potter'),
+                      'provider name' => 'Dear Johny English',
+                      'candidate name' => 'Harry Potter',
+                      'course name and code' => 'Computer Science (6IND)',
+                      'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
+                      'reject by default at' => (Time.zone.now + 40.days).to_s(:govuk_date).strip,
+                      'link to the application' => 'http://localhost:3000/provider/applications/')
+    end
   end
 
   describe '.offer_accepted' do


### PR DESCRIPTION
## Context

We need to update service notifications (emails) in light of the changes we're making as a result of changing RBD/DBD dates (in response to COVID-19). 

## Changes proposed in this pull request

**Application rejected by default**

Before

![image](https://user-images.githubusercontent.com/42515961/77315254-1ef42b00-6cff-11ea-943c-8e8475845b22.png)

After

![image](https://user-images.githubusercontent.com/42515961/77315229-13086900-6cff-11ea-9b05-3ea2ecf672e8.png)

**Application submitted**

Before

![image](https://user-images.githubusercontent.com/42515961/77315162-f2d8aa00-6cfe-11ea-956c-9f0e2cc9fc30.png)

After

![image](https://user-images.githubusercontent.com/42515961/77315199-02f08980-6cff-11ea-9bce-17fb6cc46090.png)

**Chase provider decision**

Before

![image](https://user-images.githubusercontent.com/42515961/77315130-e5232480-6cfe-11ea-978d-0e8eed105d35.png)

After

![image](https://user-images.githubusercontent.com/42515961/77315109-dccae980-6cfe-11ea-95a1-b10a6527156a.png)

## Guidance to review

Here's the content https://docs.google.com/document/d/1yjUxi5r9QIxSUamx5jekLRFEE08CPuRLcG017mdw7Og/edit#heading=h.5lh9uriclgum

It says DBD, but I'm pretty sure it should. be using RDB.

## Link to Trello card

https://trello.com/c/lUggdcuq/1215-dev-covid-19-changes-to-service-email-notifications

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
