### PR TITLE
Add COVID-19 banner to provider index page

### DIFF
--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -2,9 +2,13 @@
 <% content_for :page_width, 'wide' %>
 
 <% if FeatureFlag.active?('covid_19') %>
-  <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
-    <div class="app-banner__message">
-      <h2 class="govuk-heading-m" id="success-message">Check our guidance to see how <%= link_to 'coronavirus (COVID-19) will affect your deadlines for responding to applications', '#', class: 'govuk-link' %></h2>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+        <div class="app-banner__message">
+          <h2 class="govuk-heading-m" id="success-message">Check our guidance to see how <%= link_to 'coronavirus (COVID-19) will affect your deadlines for responding to applications', '#', class: 'govuk-link' %></h2>
+        </div>
+      </div>
     </div>
   </div>
 <% end %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -6,7 +6,12 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
         <div class="app-banner__message">
-          <h2 class="govuk-heading-m" id="success-message">Check our guidance to see how <%= link_to 'coronavirus (COVID-19) will affect your deadlines for responding to applications', provider_interface_covid_19_guidance_path, class: 'govuk-link' %></h2>
+          <h2 class="govuk-heading-m" id="success-message">
+            <%= link_to 'Coronavirus (COVID-19): check our guidance to see new deadlines for processing applications',
+              provider_interface_covid_19_guidance_path,
+              class: 'govuk-link'
+            %>
+          </h2>
         </div>
       </div>
     </div>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,6 +1,14 @@
 <% content_for :title, 'Applications' %>
 <% content_for :page_width, 'wide' %>
 
+<% if FeatureFlag.active?('covid_19') %>
+  <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+    <div class="app-banner__message">
+      <h2 class="govuk-heading-m" id="success-message">Check our guidance to see how <%= link_to 'coronavirus (COVID-19) will affect your deadlines for responding to applications', '#', class: 'govuk-link' %></h2>
+    </div>
+  </div>
+<% end %>
+
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <% if FeatureFlag.active?('provider_application_filters') %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
         <div class="app-banner__message">
-          <h2 class="govuk-heading-m" id="success-message">Check our guidance to see how <%= link_to 'coronavirus (COVID-19) will affect your deadlines for responding to applications', '#', class: 'govuk-link' %></h2>
+          <h2 class="govuk-heading-m" id="success-message">Check our guidance to see how <%= link_to 'coronavirus (COVID-19) will affect your deadlines for responding to applications', provider_interface_covid_19_guidance_path, class: 'govuk-link' %></h2>
         </div>
       </div>
     </div>

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -14,9 +14,14 @@ RSpec.feature 'See applications' do
     when_my_apply_account_has_been_created
     and_i_sign_in_to_the_provider_interface
     then_i_should_see_the_applications_from_my_organisation
+    and_i_should_not_see_a_covid19_information_banner
 
     when_i_click_on_an_application
     then_i_should_be_on_the_application_view_page
+
+    when_covid19_feature_flag_is_active
+    and_i_visit_the_provider_page
+    then_i_should_see_a_covid19_information_banner
   end
 
   def when_my_apply_account_has_been_created
@@ -61,6 +66,10 @@ RSpec.feature 'See applications' do
     expect(page).to have_content @my_provider_choice2.application_form.first_name
   end
 
+  def and_i_should_not_see_a_covid19_information_banner
+    expect(page).not_to have_content 'coronavirus'
+  end
+
   def when_i_click_on_an_application
     click_on @my_provider_choice1.application_form.first_name
   end
@@ -68,5 +77,13 @@ RSpec.feature 'See applications' do
   def then_i_should_be_on_the_application_view_page
     expect(page).to have_content @my_provider_choice1.application_form.support_reference
     expect(page).to have_content @my_provider_choice1.application_form.first_name
+  end
+
+  def when_covid19_feature_flag_is_active
+    FeatureFlag.activate('covid_19')
+  end
+
+  def then_i_should_see_a_covid19_information_banner
+    expect(page).to have_content 'Check our guidance to see how coronavirus (COVID-19)'
   end
 end

--- a/spec/system/provider_interface/see_applications_spec.rb
+++ b/spec/system/provider_interface/see_applications_spec.rb
@@ -84,6 +84,6 @@ RSpec.feature 'See applications' do
   end
 
   def then_i_should_see_a_covid19_information_banner
-    expect(page).to have_content 'Check our guidance to see how coronavirus (COVID-19)'
+    expect(page).to have_content 'Coronavirus (COVID-19): check our guidance to see new deadlines for processing applications'
   end
 end


### PR DESCRIPTION
## Context

We need to display a banner that links providers to COVID 19 guidance so they can understand the changes we're making and the impact on the service.

## Changes proposed in this pull request

- [x] Add a banner to the index template visible only with the `covid_19` feature flag and adjust system spec.
- [x] Add link to guidance page after https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1714 is merged

![image](https://user-images.githubusercontent.com/450843/77423791-e2403680-6dc7-11ea-8085-87a3629f88c3.png)


## Guidance to review

- Is the styling correct?
- Is the wording correct?
- Is the spec reasonable?
- we need to add the actual link once the content page is available.

## Link to Trello card

https://trello.com/c/uqICCjDZ/1806-dev-covid-19-provider-banner

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
