### PR TITLE
Add a banner on application dashboard for COVID-19 guidance

### DIFF
--- a/app/components/candidate_interface/covid19_dashboard_banner_component.html.erb
+++ b/app/components/candidate_interface/covid19_dashboard_banner_component.html.erb
@@ -1,0 +1,9 @@
+<div class="app-banner govuk-!-margin-bottom-7">
+  <div class="app-banner__message">
+    <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
+    <p class="govuk-body">
+      Training providers may take longer to respond to your application.
+      You may also have longer to respond to any offers. Deadlines will show on this page.
+    </p>
+  </div>
+</div>

--- a/app/components/candidate_interface/covid19_dashboard_banner_component.rb
+++ b/app/components/candidate_interface/covid19_dashboard_banner_component.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  class Covid19DashboardBannerComponent < ActionView::Component::Base
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def render?
+      FeatureFlag.active?('covid_19') && @application_form.any_enrolled? == false
+    end
+  end
+end

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -1,6 +1,11 @@
 <% content_for :title, t('page_titles.application_dashboard') %>
 
-<%= render CandidateInterface::NewReferencesNeededComponent.new(application_form: @application_form) %>
+<% new_references_needed_component = CandidateInterface::NewReferencesNeededComponent.new(application_form: @application_form) %>
+<% if new_references_needed_component.render? %>
+  <%= render new_references_needed_component %>
+<% else %>
+  <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>
+<% end %>
 
 <h1 class="govuk-heading-xl govuk-heading-xl govuk-!-margin-bottom-2">
   <%= t('page_titles.application_dashboard') %>

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -3,7 +3,7 @@
 <% new_references_needed_component = CandidateInterface::NewReferencesNeededComponent.new(application_form: @application_form) %>
 <% if new_references_needed_component.render? %>
   <%= render new_references_needed_component %>
-<% else %>
+<% elsif flash.empty? %>
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>
 <% end %>
 

--- a/spec/components/candidate_interface/covid19_dashboard_banner_component_spec.rb
+++ b/spec/components/candidate_interface/covid19_dashboard_banner_component_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::Covid19DashboardBannerComponent do
+  context 'when the COVID-19 feature flag is on' do
+    before { FeatureFlag.activate('covid_19') }
+
+    context 'and the application form is not enrolled' do
+      it 'renders the banner' do
+        application_form = build_stubbed(:application_form)
+        allow(application_form).to receive(:any_enrolled?).and_return(false)
+
+        result = render_inline(CandidateInterface::Covid19DashboardBannerComponent.new(application_form: application_form))
+
+        expect(result.text).to include('Coronavirus (COVID-19)')
+      end
+    end
+
+    context 'and the application form is enrolled' do
+      it 'does not render the banner' do
+        application_form = build_stubbed(:application_form)
+        allow(application_form).to receive(:any_enrolled?).and_return(true)
+
+        result = render_inline(CandidateInterface::Covid19DashboardBannerComponent.new(application_form: application_form))
+
+        expect(result.text).to eq('')
+      end
+    end
+  end
+
+  context 'when the COVID-19 feature flag is off' do
+    it 'does not render the banner' do
+      FeatureFlag.deactivate('covid_19')
+      application_form = build_stubbed(:application_form)
+
+      result = render_inline(CandidateInterface::Covid19DashboardBannerComponent.new(application_form: application_form))
+
+      expect(result.text).to eq('')
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Candidate needs to provide a new referee' do
   scenario "Candidate provides a new referee because one didn't respond" do
     FeatureFlag.activate('pilot_open')
     FeatureFlag.activate('show_new_referee_needed')
+    FeatureFlag.activate('covid_19')
 
     given_i_am_signed_in_as_a_candidate
     and_i_have_submitted_my_application
@@ -16,6 +17,7 @@ RSpec.describe 'Candidate needs to provide a new referee' do
 
     when_i_choose_to_continue_without_adding_a_new_referee
     then_i_see_that_i_need_a_new_reference_on_the_dashboard
+    and_i_do_not_see_the_covid_19_guidance
 
     when_i_sign_in_again
     then_i_see_the_interstitial_page_to_add_new_referee
@@ -64,6 +66,10 @@ RSpec.describe 'Candidate needs to provide a new referee' do
 
   def then_i_see_that_i_need_a_new_reference_on_the_dashboard
     expect(page).to have_content 'You need to give details of a new referee'
+  end
+
+  def and_i_do_not_see_the_covid_19_guidance
+    expect(page).not_to have_content 'Coronavirus (COVID-19)'
   end
 
   def then_i_see_the_interstitial_page_to_add_new_referee

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'A candidate withdraws her application' do
 
   scenario 'successful withdrawal' do
     given_i_am_signed_in_as_a_candidate
+    and_the_covid_19_feature_flag_is_on
     and_i_have_an_application_choice_awaiting_provider_decision
 
     when_i_visit_the_application_dashboard
@@ -13,6 +14,7 @@ RSpec.feature 'A candidate withdraws her application' do
 
     when_i_click_to_confirm_withdrawal
     then_my_application_should_be_withdrawn
+    and_i_do_not_see_the_covid_19_guidance
     and_a_slack_notification_is_sent
     and_the_provider_has_received_an_email
 
@@ -22,6 +24,10 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def given_i_am_signed_in_as_a_candidate
     create_and_sign_in_candidate
+  end
+
+  def and_the_covid_19_feature_flag_is_on
+    FeatureFlag.activate('covid_19')
   end
 
   def and_i_have_an_application_choice_awaiting_provider_decision
@@ -49,6 +55,10 @@ RSpec.feature 'A candidate withdraws her application' do
 
   def then_my_application_should_be_withdrawn
     expect(page).to have_content('Your application has been withdrawn')
+  end
+
+  def and_i_do_not_see_the_covid_19_guidance
+    expect(page).not_to have_content('Coronavirus (COVID-19)')
   end
 
   def and_a_slack_notification_is_sent

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -44,6 +44,7 @@ RSpec.feature 'Candidate submits the application' do
 
     when_i_click_on_track_your_application
     then_i_can_see_my_application_dashboard
+    and_i_see_the_covid_19_guidance
 
     when_i_click_view_application
     then_i_can_see_my_submitted_application
@@ -55,6 +56,10 @@ RSpec.feature 'Candidate submits the application' do
 
   def and_the_training_with_a_disability_feature_flag_is_on
     FeatureFlag.activate('training_with_a_disability')
+  end
+
+  def and_the_covid_19_feature_flag_is_on
+    FeatureFlag.activate('covid_19')
   end
 
   def and_the_suitability_to_work_with_children_feature_flag_is_on
@@ -226,6 +231,10 @@ RSpec.feature 'Candidate submits the application' do
     expect(page).to have_content 'Gorse SCITT'
     expect(page).to have_content current_candidate.current_application.application_references.first.name
     expect(page).to have_content 'Submitted'
+  end
+
+  def and_i_see_the_covid_19_guidance
+    expect(page).to have_content 'Coronavirus (COVID-19)'
   end
 
   def when_i_click_view_application


### PR DESCRIPTION
## Context

We want to notify candidates about the potential effects of COVID-19 on their application post-submission.

## Changes proposed in this pull request

This PR adds a `Covid19DashboardBannerComponent` component. This will only show when the `covid_19` feature flag is on and the application form has not been enrolled onto a course.

Further, we'll only display the COVID-19 banner when the new referees needed banner is not shown so that two banners aren't shown at the same time.

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/77328891-1a3a7180-6d15-11ea-9583-5130e25ba098.png)

## Guidance to review

- Does when we show the component make sense? Not enrolled and when new referees aren't needed.
- Testing only showing when new referees aren't need: I initially wanted to create a component something like `DashboardBannerComponent` but struggled with stubbing the components so changed to using system specs to test this. Is this okay?

## Link to Trello card

https://trello.com/c/VEtyaWji

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
