### PR TITLE
Refactor hard coded edit within 5 working days to use TimeLimitCalculator

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
     end
 
     def edit
+      @editable_days_count = TimeLimitCalculator.new(rule: :edit_by, effective_date: @current_application.submitted_at).call[:days]
       if FeatureFlag.active?('edit_application')
         render :edit
       else
@@ -54,6 +55,7 @@ module CandidateInterface
 
     def submit_success
       @support_reference = current_application.support_reference
+      @editable_days_count = TimeLimitCalculator.new(rule: :edit_by, effective_date: @current_application.submitted_at).call[:days]
     end
 
     def review_submitted

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -7,9 +7,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have 5 working days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">You have <%= @editable_days_count %> working days after submission to edit most sections of your application.</p>
     <h2 class="govuk-heading-m">Course choice</h2>
-    <p class="govuk-body">You can change your choice of training provider, course or location within the 5 working day editing period.</p>
+    <p class="govuk-body">You can change your choice of training provider, course or location within the <%= @editable_days_count %> working day editing period.</p>
     <p class="govuk-body">You can also delete a course choice.</p>
     <h2 class="govuk-heading-m">References</h2>
     <p class="govuk-body">You can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>

--- a/app/views/candidate_interface/application_form/edit_by_support.html.erb
+++ b/app/views/candidate_interface/application_form/edit_by_support.html.erb
@@ -7,11 +7,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have 5 working days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">You have <%= @editable_days_count %> working days after submission to edit most sections of your application.</p>
     <p class="govuk-body">To edit, you’ll need to email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>, explaining which changes you’d like to make.</p>
     <p class="govuk-body">We can only edit your application once.</p>
     <h2 class="govuk-heading-m">Course choice</h2>
-    <p class="govuk-body">We can change your choice of training provider, course or location within the 5 working day editing period.</p>
+    <p class="govuk-body">We can change your choice of training provider, course or location within the <%= @editable_days_count %> working day editing period.</p>
     <p class="govuk-body">We can also delete a course choice.</p>
     <p class="govuk-body">After this, you can email us asking to withdraw your application completely.</p>
     <h2 class="govuk-heading-m">References</h2>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -25,15 +25,14 @@
       <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
       <p class="govuk-body">We have extended the length of time training providers have to access your application. You may also have longer to respond to training providers once all your offers are in.</p>
       <p class="govuk-body">You can check your deadlines on your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
-      
-    <% end %>
 
+    <% end %>
 
     <h2 class="govuk-heading-m">Interview</h2>
     <p class="govuk-body">If your training provider decides to offer you an interview, they will get in touch directly via email to organise a date and give you all the information you need.</p>
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
-    <p class="govuk-body">You have 5 working days to make changes to a submitted application. We won’t send your application to your training provider(s) until the 5 working days are up.</p>
+    <p class="govuk-body">You have <%= @editable_days_count %> working days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>
     <p class="govuk-body">To edit your application, return to your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
   </div>
 </div>


### PR DESCRIPTION
## Context

We shouldn't be coding in the editable day count. Instead, we should be using the TimeLimitCalculator service.

## Changes proposed in this pull request

- Refactor to use the TimeLimitCalculator  service

## Guidance to review

None really

## Link to Trello card

https://trello.com/c/ugGjHmC0/1232-fix-places-in-app-that-have-hard-coded-5-working-days

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
