### PR TITLE
Add COVID-19 candidate banner to ‘Your application’ page

### DIFF
--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -1,5 +1,14 @@
 <% content_for :title, @application_form.amendable? ? t('page_titles.edit_application_form') : t('page_titles.application_form') %>
 
+<% if FeatureFlag.active?('covid_19') %>
+  <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
+    <div class="app-banner__message">
+      <h2 class="govuk-heading-m" id="success-message">There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)</h2>
+    </div>
+  </div>
+<% end %>
+
+
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-2">
   <%= @application_form.amendable? ? t('page_titles.edit_application_form') : t('page_titles.application_form') %>
 </h1>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, @application_form.amendable? ? t('page_titles.edit_application_form') : t('page_titles.application_form') %>
 
-<% if FeatureFlag.active?('covid_19') %>
+<% if FeatureFlag.active?('covid_19') && flash.empty? %>
   <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
     <div class="app-banner__message">
       <h2 class="govuk-heading-m" id="success-message">There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)</h2>

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_the_pilot_is_open
     and_the_improved_expired_token_flow_feature_flag_is_on
+    and_the_covid_19_feature_flag_is_active
 
     given_i_am_a_candidate_without_an_account
 
@@ -20,6 +21,8 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     then_i_receive_an_email_inviting_me_to_sign_in
     and_i_click_on_the_link_in_my_email
     then_i_am_taken_to_the_sign_up_page
+    and_i_should_see_an_account_created_flash_message
+    and_i_should_not_see_the_covid19_banner
   end
 
 
@@ -29,6 +32,10 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def and_the_improved_expired_token_flow_feature_flag_is_on
     FeatureFlag.activate('improved_expired_token_flow')
+  end
+
+  def and_the_covid_19_feature_flag_is_active
+    FeatureFlag.activate('covid_19')
   end
 
   def given_i_am_a_candidate_without_an_account
@@ -86,5 +93,13 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def then_i_am_taken_to_the_sign_up_page
     expect(page).to have_current_path(candidate_interface_application_form_path)
+  end
+
+  def and_i_should_see_an_account_created_flash_message
+    expect(page).to have_content(t('apply_from_find.account_created_message'))
+  end
+
+  def and_i_should_not_see_the_covid19_banner
+    expect(page).not_to have_content 'There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)'
   end
 end

--- a/spec/system/candidate_interface/candidate_viewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_application_spec.rb
@@ -7,6 +7,11 @@ RSpec.feature 'Viewing their new application' do
     given_i_am_signed_in
     when_i_visit_the_site
     then_i_should_see_that_i_have_made_no_choices
+    and_i_should_not_see_the_covid19_banner
+
+    given_covid19_feature_flag_is_active
+    when_i_visit_the_site
+    then_i_should_see_the_covid19_banner
 
     #while I have not submitted an application
     when_i_visit_the_review_page
@@ -45,5 +50,17 @@ RSpec.feature 'Viewing their new application' do
 
   def then_i_am_on_the_application_form_page
     then_i_should_see_that_i_have_made_no_choices
+  end
+
+  def and_i_should_not_see_the_covid19_banner
+    expect(page).not_to have_content 'There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)'
+  end
+
+  def given_covid19_feature_flag_is_active
+    FeatureFlag.activate('covid_19')
+  end
+
+  def then_i_should_see_the_covid19_banner
+    expect(page).to have_content 'There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)'
   end
 end


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
We need to update candidate UI with the COVID 19 banner with the guidance for candidates

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR adds the banner to the ‘Your application’ page

#### After
![image](https://user-images.githubusercontent.com/22743709/77324570-d9d7f500-6d0e-11ea-823e-a0703974d68a.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
The acceptance criteria say:
- only shows if no other banner is not activated
Not sure if I need to add any more logic to prevent this?

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/lBLa3fwp/1217-dev-covid-19-candidate-banner

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
