### PR TITLE
Add COVID-19 provider guidance page

### DIFF
--- a/app/controllers/provider_interface/content_controller.rb
+++ b/app/controllers/provider_interface/content_controller.rb
@@ -22,5 +22,9 @@ module ProviderInterface
     def terms_provider
       render_content_page :terms_provider
     end
+
+    def covid_19_guidance
+      render_content_page :covid_19_guidance
+    end
   end
 end

--- a/app/views/content/covid_19_guidance.md
+++ b/app/views/content/covid_19_guidance.md
@@ -43,7 +43,7 @@ We’ll let candidates know if they have longer to respond to an offer and tell 
 Please update the statuses of your training programmes to tell potential applicants if you’re not recruiting at the moment.
 
 
-Providers in England can do this using [Find postgraduate teacher training courses](https://www2.find-postgraduate-teacher-training.service.gov.uk/).
+Providers in England can do this using [Find postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/).
 
 
 Providers in Wales can do this using [UCAS Search](https://digital.ucas.com/search).  

--- a/app/views/content/covid_19_guidance.md
+++ b/app/views/content/covid_19_guidance.md
@@ -43,10 +43,8 @@ We’ll let candidates know if they have longer to respond to an offer and tell 
 Please update the statuses of your training programmes to tell potential applicants if you’re not recruiting at the moment.
 
 
-Providers in England can do this using [Find postgraduate teacher training courses](https://www.find-postgraduate-teacher-training.service.gov.uk/).
+Providers in England can do this using [Publish teacher training courses](https://www.publish-teacher-training-courses.service.gov.uk/).  
 
-
-Providers in Wales can do this using [UCAS Search](https://digital.ucas.com/search).  
 
 ## Get help 
 

--- a/app/views/content/covid_19_guidance.md
+++ b/app/views/content/covid_19_guidance.md
@@ -2,43 +2,43 @@
 
 ## Giving you more time before applications are rejected by default (RBD)
 
-#### Applications that have been submitted already
+### Applications that have been submitted already
 
 You have until 23:59 on 20 April to make decisions on applications which would normally be automatically rejected on or before 20 April.
 
 For applications which have a RBD date after 20 April, you’ll also have more time to make a decision. We’ll add an extra 4 weeks to the response deadlines.
 
-#### Applications that are submitted between now and 20 April
+### Applications that are submitted between now and 20 April
 
 If applications come in between now and 20 April, you have until 23:59 on 15 June to respond. No applications in this category will be automatically rejected until then.
 
-#### How to keep track of your new RBD dates
+### How to keep track of your new RBD dates
 
 You can see your new RBD dates in [Manage teacher training applications](/provider/applications).
 
-#### Keeping candidates up to date
+### Keeping candidates up to date
 
 We’ll let candidates know that it might take you longer to respond to their application, and tell them your new RBD date. 
 
 ## Giving candidates more time to make decisions on offers
 
-#### Hearing back from candidates might take longer
+### Hearing back from candidates might take longer
 
 We’re pausing all automatic decline by default (DBD) dates until 20 April. This means that there may be a delay hearing back from any candidates who would normally have to respond to an offer on or before 20 April. We’re giving everyone in this category until 23:59 on 20 April to respond. 
 
 There may also be a delay hearing back from candidates who have a DBD date after 20 April. For example, if you made the offer before 20 April, a candidate will have a bit more time than the usual 10 days to respond because we’re pausing the system until 20 April. 
 
-#### How to keep track of candidates’ new DBD dates
+### How to keep track of candidates’ new DBD dates
 
 You can find candidates’ new DBD dates in [Manage teacher training applications](/provider/applications).
 
-#### Keeping candidates up to date
+### Keeping candidates up to date
 
 We’ll let candidates know if they have longer to respond to an offer and tell them their new DBD date.  
 
 ## What we ask of you during this time
 
-#### Keep your vacancy statuses up to date
+### Keep your vacancy statuses up to date
 
 Please update the statuses of your training programmes to tell potential applicants if you’re not recruiting at the moment.
 
@@ -50,5 +50,5 @@ Providers in Wales can do this using [UCAS Search](https://digital.ucas.com/sear
 
 ## Get help 
 
-If you have any questions, you can contact your relationship manager or email us at [becomingateacher@education.gov.uk](mailto:becomingateacher@education.gov.uk)
+If you have any questions, you can contact your relationship manager or email us at <becomingateacher@education.gov.uk>
 

--- a/app/views/content/covid_19_guidance.md
+++ b/app/views/content/covid_19_guidance.md
@@ -1,4 +1,4 @@
-* To give you more time to make decisions, we won’t reject or decline any offers automatically until 20 April 2020. Below we outline what this means for you and your candidates. We’ll keep you updated if anything else changes. 
+To give you more time to make decisions, we won’t reject or decline any offers automatically until 20 April 2020. Below we outline what this means for you and your candidates. We’ll keep you updated if anything else changes. 
 
 ## Giving you more time before applications are rejected by default (RBD)
 

--- a/app/views/content/covid_19_guidance.md
+++ b/app/views/content/covid_19_guidance.md
@@ -1,0 +1,54 @@
+* To give you more time to make decisions, we won’t reject or decline any offers automatically until 20 April 2020. Below we outline what this means for you and your candidates. We’ll keep you updated if anything else changes. 
+
+## Giving you more time before applications are rejected by default (RBD)
+
+#### Applications that have been submitted already
+
+You have until 23:59 on 20 April to make decisions on applications which would normally be automatically rejected on or before 20 April.
+
+For applications which have a RBD date after 20 April, you’ll also have more time to make a decision. We’ll add an extra 4 weeks to the response deadlines.
+
+#### Applications that are submitted between now and 20 April
+
+If applications come in between now and 20 April, you have until 23:59 on 15 June to respond. No applications in this category will be automatically rejected until then.
+
+#### How to keep track of your new RBD dates
+
+You can see your new RBD dates in [Manage teacher training applications](/provider/applications).
+
+#### Keeping candidates up to date
+
+We’ll let candidates know that it might take you longer to respond to their application, and tell them your new RBD date. 
+
+## Giving candidates more time to make decisions on offers
+
+#### Hearing back from candidates might take longer
+
+We’re pausing all automatic decline by default (DBD) dates until 20 April. This means that there may be a delay hearing back from any candidates who would normally have to respond to an offer on or before 20 April. We’re giving everyone in this category until 23:59 on 20 April to respond. 
+
+There may also be a delay hearing back from candidates who have a DBD date after 20 April. For example, if you made the offer before 20 April, a candidate will have a bit more time than the usual 10 days to respond because we’re pausing the system until 20 April. 
+
+#### How to keep track of candidates’ new DBD dates
+
+You can find candidates’ new DBD dates in [Manage teacher training applications](/provider/applications).
+
+#### Keeping candidates up to date
+
+We’ll let candidates know if they have longer to respond to an offer and tell them their new DBD date.  
+
+## What we ask of you during this time
+
+#### Keep your vacancy statuses up to date
+
+Please update the statuses of your training programmes to tell potential applicants if you’re not recruiting at the moment.
+
+
+Providers in England can do this using [Find postgraduate teacher training courses](https://www2.find-postgraduate-teacher-training.service.gov.uk/).
+
+
+Providers in Wales can do this using [UCAS Search](https://digital.ucas.com/search).  
+
+## Get help 
+
+If you have any questions, you can contact your relationship manager or email us at [becomingateacher@education.gov.uk](mailto:becomingateacher@education.gov.uk)
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,7 +98,7 @@ en:
     provider:
       respond: Respond to application
       confirm: Confirm offer
-    covid_19_guidance: "Coronavirus: How our service is changing to help you right now"
+    covid_19_guidance: "Coronavirus (COVID-19): new deadlines for processing applications"
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,6 +98,7 @@ en:
     provider:
       respond: Respond to application
       confirm: Confirm offer
+    covid_19_guidance: "Coronavirus: How our service is changing to help you right now"
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,6 +340,7 @@ Rails.application.routes.draw do
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/cookies', to: 'content#cookies_provider', as: :cookies
     get '/terms-of-use', to: 'content#terms_provider', as: :terms
+    get '/covid-19-guidance', to: 'content#covid_19_guidance', as: :covid_19_guidance
 
     get '/data-sharing-agreements/new', to: 'provider_agreements#new_data_sharing_agreement', as: :new_data_sharing_agreement
     post '/data-sharing-agreements', to: 'provider_agreements#create_data_sharing_agreement', as: :create_data_sharing_agreement


### PR DESCRIPTION
## Context

We would like to provide COVID-19 specific guidance for providers during exceptional circumstances.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds the relevant guidance content at the path `/provider/covid-19-guidance`

![image](https://user-images.githubusercontent.com/93511/77329489-f297d900-6d15-11ea-9d09-5660a0e33223.png)

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/XgMfvcn1/1807-dev-covid-19-guidance-page

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
