### PR TITLE
Update ChangeOffer service spec to call #save

### DIFF
--- a/spec/services/change_offer_spec.rb
+++ b/spec/services/change_offer_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ChangeOffer do
 
   it 'calls `StateChangeNotifier` to send a Slack notification' do
     allow(StateChangeNotifier).to receive(:call).and_return(nil)
-    service.save!
+    service.save
     expect(StateChangeNotifier).to have_received(:call).with(:change_an_offer, application_choice: application_choice)
   end
 end


### PR DESCRIPTION
## Context

Master broke because a test failed: 

![image](https://user-images.githubusercontent.com/42817036/77331037-152af180-6d18-11ea-8168-5f8054616ee4.png)

Two PRs related to a provider changing an offer were merged at the same time: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1701 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1657. The method name of the `ChangeOffer` service was changed to `#save` instead of `#save!`.

## Changes proposed in this pull request

This PR ensures that `ChangeOffer#save` is called instead of `ChangeOffer#save!` in the unit test.

## Guidance to review

👀 

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
