### PR TITLE
Use calendar days for edit_by calculation

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
     end
 
     def edit
-      @editable_days_count = TimeLimitCalculator.new(rule: :edit_by, effective_date: @current_application.submitted_at).call[:days]
+      @editable_days_count = TimeLimitConfig.edit_by
       if FeatureFlag.active?('edit_application')
         render :edit
       else
@@ -55,7 +55,7 @@ module CandidateInterface
 
     def submit_success
       @support_reference = current_application.support_reference
-      @editable_days_count = TimeLimitCalculator.new(rule: :edit_by, effective_date: @current_application.submitted_at).call[:days]
+      @editable_days_count = TimeLimitConfig.edit_by
     end
 
     def review_submitted

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -1,15 +1,16 @@
 class TimeLimitConfig
   Rule = Struct.new(:from_date, :to_date, :limit)
 
+  def self.edit_by
+    7
+  end
+
   RULES = {
     reject_by_default: [
       Rule.new(nil, nil, 40),
     ],
     decline_by_default: [
       Rule.new(nil, nil, 10),
-    ],
-    edit_by: [
-      Rule.new(nil, nil, 5),
     ],
     chase_provider_before_rbd: [
       Rule.new(nil, nil, 20),

--- a/app/services/sandbox_time_limit_calculator.rb
+++ b/app/services/sandbox_time_limit_calculator.rb
@@ -1,7 +1,0 @@
-class SandboxTimeLimitCalculator
-  def initialize(*); end
-
-  def call
-    { days: 0, time_in_future: Time.zone.now }
-  end
-end

--- a/app/services/submit_application_choice.rb
+++ b/app/services/submit_application_choice.rb
@@ -4,18 +4,17 @@ class SubmitApplicationChoice
   end
 
   def call
-    edit_by_time = time_limit_calculator.call[:time_in_future]
     @application_choice.edit_by = edit_by_time
     ApplicationStateChange.new(@application_choice).submit!
   end
 
 private
 
-  def time_limit_calculator
-    klass = HostingEnvironment.sandbox_mode? ? SandboxTimeLimitCalculator : TimeLimitCalculator
-    klass.new(
-      rule: :edit_by,
-      effective_date: @application_choice.application_form.submitted_at,
-    )
+  def edit_by_time
+    if HostingEnvironment.sandbox_mode?
+      Time.zone.now
+    else
+      TimeLimitConfig.edit_by.days.after(@application_choice.application_form.submitted_at).end_of_day
+    end
   end
 end

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have <%= @editable_days_count %> working days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">You have <%= @editable_days_count %> days after submission to edit most sections of your application.</p>
     <h2 class="govuk-heading-m">Course choice</h2>
     <p class="govuk-body">You can change your choice of training provider, course or location within the <%= @editable_days_count %> working day editing period.</p>
     <p class="govuk-body">You can also delete a course choice.</p>

--- a/app/views/candidate_interface/application_form/edit_by_support.html.erb
+++ b/app/views/candidate_interface/application_form/edit_by_support.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have <%= @editable_days_count %> working days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">You have <%= @editable_days_count %> days after submission to edit most sections of your application.</p>
     <p class="govuk-body">To edit, you’ll need to email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>, explaining which changes you’d like to make.</p>
     <p class="govuk-body">We can only edit your application once.</p>
     <h2 class="govuk-heading-m">Course choice</h2>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -32,7 +32,7 @@
     <p class="govuk-body">If your training provider decides to offer you an interview, they will get in touch directly via email to organise a date and give you all the information you need.</p>
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
-    <p class="govuk-body">You have <%= @editable_days_count %> working days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>
+    <p class="govuk-body">You have <%= @editable_days_count %> days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>
     <p class="govuk-body">To edit your application, return to your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
   </div>
 </div>

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -17,7 +17,7 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 # Making changes to your application
 
 <% if FeatureFlag.active?('edit_application') %>
-  You have <%= TimeLimitConfig.edit_by %> working days to edit your application or change your choice of provider, course or training location.
+  You have <%= TimeLimitConfig.edit_by %> days to edit your application or change your choice of provider, course or training location.
 
   To make changes, [sign back in to your account](<%= candidate_sign_in_url(@candidate) %>).
 
@@ -25,7 +25,7 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 
   We’ll pass any changes on to the training <%= 'provider'.pluralize(@application_form.application_choices.count) %>.
 <% else %>
-  Get in touch with us as soon as possible if you need to make any amends, as we only have <%= TimeLimitConfig.edit_by %> working days to make changes.
+  Get in touch with us as soon as possible if you need to make any amends, as we only have <%= TimeLimitConfig.edit_by %> days to make changes.
 
   Once we’ve processed your request, you can’t make any more changes.
 

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -17,7 +17,7 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 # Making changes to your application
 
 <% if FeatureFlag.active?('edit_application') %>
-  You have <%= TimeLimitConfig.limits_for(:edit_by).first.limit %> working days to edit your application or change your choice of provider, course or training location.
+  You have <%= TimeLimitConfig.edit_by %> working days to edit your application or change your choice of provider, course or training location.
 
   To make changes, [sign back in to your account](<%= candidate_sign_in_url(@candidate) %>).
 
@@ -25,10 +25,10 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 
   We’ll pass any changes on to the training <%= 'provider'.pluralize(@application_form.application_choices.count) %>.
 <% else %>
-  Get in touch with us as soon as possible if you need to make any amends, as we only have <%= TimeLimitConfig.limits_for(:edit_by).first.limit %> working days to make changes.
+  Get in touch with us as soon as possible if you need to make any amends, as we only have <%= TimeLimitConfig.edit_by %> working days to make changes.
 
   Once we’ve processed your request, you can’t make any more changes.
-  
+
   However, you can ask us to update your name or contact details at any point up until enrolment.
 
   Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) if you need to make changes.
@@ -53,7 +53,7 @@ Your application won’t be sent to your provider until your references are in.
 If your training provider decides to progress your application, they’ll contact you directly to organise an interview date.
 
 <% if FeatureFlag.active?('covid_19') %>
-Due to the impact of coronavirus, it might take some time for providers to get back to you. 
+Due to the impact of coronavirus, it might take some time for providers to get back to you.
 <% else %>
 They should make a decision on whether to make an offer within <%= TimeLimitConfig.limits_for(:reject_by_default).first.limit %> working days of receiving your application.
 <% end %>

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe TimeLimitConfig do
       expect(TimeLimitConfig.limits_for(:decline_by_default).first.limit).to eq(10)
     end
 
-    it ':edit_by returns a default limit of 5 days' do
-      expect(TimeLimitConfig.limits_for(:edit_by).first.limit).to eq(5)
+    it ':edit_by returns a limit of 7 days' do
+      expect(TimeLimitConfig.edit_by).to eq(7)
     end
 
     it ':chase_provider_before_rbd returns a default limit of 20 days' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like('a mail with subject and content', :application_submitted,
                       I18n.t!('candidate_mailer.application_submitted.subject'),
-                      'edit by time limit' => "You have #{TimeLimitConfig.edit_by} working days to edit")
+                      'edit by time limit' => "You have #{TimeLimitConfig.edit_by} days to edit")
     end
 
     context 'when the improved_expired_token_flow feature flag is on' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like('a mail with subject and content', :application_submitted,
                       I18n.t!('candidate_mailer.application_submitted.subject'),
-                      'edit by time limit' => "You have #{TimeLimitConfig.limits_for(:edit_by).first.limit} working days to edit")
+                      'edit by time limit' => "You have #{TimeLimitConfig.edit_by} working days to edit")
     end
 
     context 'when the improved_expired_token_flow feature flag is on' do

--- a/spec/services/submit_application_choice_spec.rb
+++ b/spec/services/submit_application_choice_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe SubmitApplicationChoice do
     end
 
     it 'updates the application choice to edit_by date' do
-      days_to_edit = TimeLimitCalculator.new(rule: :edit_by, effective_date: application_form.submitted_at).call[:days]
-      expected_edit_by_day = days_to_edit.business_days.after(application_form.submitted_at).end_of_day
+      expected_edit_by_day = 7.days.after(application_form.submitted_at).end_of_day
 
       SubmitApplicationChoice.new(application_choice).call
       expect(application_choice.edit_by).to eq(expected_edit_by_day)


### PR DESCRIPTION
## Context

We're changing this from business days, and adding another method to TimeLimitConfig is simpler than refactoring it.

Simpler version of https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1693.

## Changes proposed in this pull request

Add `edit_by` to TimeLimitConfig and use it. Remove SandboxTimeLimitCalculator.

## Guidance to review

`chase_referee_by` and `replace_referee_by` in a future PR.

## Link to Trello card

https://trello.com/c/iV0jnliU/1207-ucas-rbd-dbd-date-suspension-until-20th-april

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)