### PR TITLE
Fix how we reculculate the DBD and RBD dates

### DIFF
--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -24,10 +24,12 @@ class SetDeclineByDefault
     dbd_days = dbd_time_limit[:days]
     dbd_time = dbd_time_limit[:time_in_future]
 
-    application_choices.where(status: 'offer').update_all(
-      decline_by_default_at: dbd_time,
-      decline_by_default_days: dbd_days,
-    )
+    application_choices.where(status: 'offer').each do |application_choice|
+      application_choice.update!(
+        decline_by_default_at: dbd_time,
+        decline_by_default_days: dbd_days,
+      )
+    end
   end
 
 private

--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -4,7 +4,11 @@ class SetDeclineByDefault
   end
 
   def call
-    return false if pending_decisions? || no_offers?
+    # Only set Decline by Default (DBD) date if all applications have been acted upon.
+    return if pending_decisions?
+
+    # If there aren't any offers we don't need to set a DBD date
+    return if no_offers?
 
     # We only start counting the days for decline by default when all the candidate's
     # applications have either an offer, been rejected by provider, withdrawn by

--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -6,7 +6,10 @@ class SetDeclineByDefault
   def call
     return false if pending_decisions? || no_offers?
 
-    most_recent_decision_date = [
+    # We only start counting the days for decline by default when all the candidate's
+    # applications have either an offer, been rejected by provider, withdrawn by
+    # the candidate, or have the offer withdrawn.
+    final_decision_date = [
       application_choices.maximum(:offered_at),
       application_choices.maximum(:rejected_at),
       application_choices.maximum(:withdrawn_at),
@@ -15,7 +18,7 @@ class SetDeclineByDefault
 
     dbd_time_limit = TimeLimitCalculator.new(
       rule: :decline_by_default,
-      effective_date: most_recent_decision_date,
+      effective_date: final_decision_date,
     ).call
 
     dbd_days = dbd_time_limit[:days]

--- a/app/services/set_decline_by_default.rb
+++ b/app/services/set_decline_by_default.rb
@@ -29,6 +29,9 @@ class SetDeclineByDefault
     dbd_time = dbd_time_limit[:time_in_future]
 
     application_choices.where(status: 'offer').each do |application_choice|
+      next if application_choice.decline_by_default_at.to_s == dbd_time.in_time_zone.to_s &&
+        application_choice.decline_by_default_days == dbd_days
+
       application_choice.update!(
         decline_by_default_at: dbd_time,
         decline_by_default_days: dbd_days,

--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -14,6 +14,9 @@ class SetRejectByDefault
     days = time_limit[:days]
     time = time_limit[:time_in_future]
 
+    return if application_choice.reject_by_default_at.to_s == time.in_time_zone.to_s &&
+      application_choice.reject_by_default_days == days
+
     application_choice.update!(
       reject_by_default_at: time,
       reject_by_default_days: days,

--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -8,7 +8,7 @@ class SetRejectByDefault
   def call
     time_limit = TimeLimitCalculator.new(
       rule: :reject_by_default,
-      effective_date: Time.zone.now,
+      effective_date: application_choice.sent_to_provider_at,
     ).call
 
     days = time_limit[:days]

--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -1,0 +1,21 @@
+class SetRejectByDefault
+  attr_reader :application_choice
+
+  def initialize(application_choice)
+    @application_choice = application_choice
+  end
+
+  def call
+    time_limit = TimeLimitCalculator.new(
+      rule: :reject_by_default,
+      effective_date: Time.zone.now,
+    ).call
+
+    days = time_limit[:days]
+    time = time_limit[:time_in_future]
+
+    application_choice.reject_by_default_days = days
+    application_choice.reject_by_default_at = time
+    application_choice.save!
+  end
+end

--- a/app/services/set_reject_by_default.rb
+++ b/app/services/set_reject_by_default.rb
@@ -14,8 +14,9 @@ class SetRejectByDefault
     days = time_limit[:days]
     time = time_limit[:time_in_future]
 
-    application_choice.reject_by_default_days = days
-    application_choice.reject_by_default_at = time
-    application_choice.save!
+    application_choice.update!(
+      reject_by_default_at: time,
+      reject_by_default_days: days,
+    )
   end
 end

--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -7,7 +7,7 @@ class RecalculateDates
         .where(status: :awaiting_provider_decision)
         .includes(:application_form)
         .find_each do |application_choice|
-          update_reject_by_default(application_choice)
+          SetRejectByDefault.new(application_choice).call
         end
 
       application_forms_with_offers = ApplicationForm.where(
@@ -18,27 +18,5 @@ class RecalculateDates
         SetDeclineByDefault.new(application_form: application_form).call
       end
     end
-  end
-
-private
-
-  def update_reject_by_default(application_choice)
-    time_limit = TimeLimitCalculator.new(
-      rule: :reject_by_default,
-      effective_date: application_choice.application_form.submitted_at,
-    ).call
-
-    days = time_limit[:days]
-    time = time_limit[:time_in_future]
-
-    if times_are_different(time, application_choice.reject_by_default_at)
-      application_choice.reject_by_default_days = days
-      application_choice.reject_by_default_at = time
-      application_choice.save!
-    end
-  end
-
-  def times_are_different(time1, time2)
-    time1.to_s != time2.to_s
   end
 end

--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -11,7 +11,7 @@ class RecalculateDates
         end
 
       application_forms_with_offers = ApplicationForm.where(
-        id: ApplicationChoice.where(status: :offer).select(:application_form_id)
+        id: ApplicationChoice.where(status: :offer).select(:application_form_id),
       )
 
       application_forms_with_offers.find_each do |application_form|

--- a/spec/services/set_decline_by_default_spec.rb
+++ b/spec/services/set_decline_by_default_spec.rb
@@ -206,5 +206,12 @@ RSpec.describe SetDeclineByDefault do
         expect(choice.reload.decline_by_default_days).to be_nil
       end
     end
+
+    it 'does not update dates when nothing changes', with_audited: true do
+      choices[0].update(status: :offer, offered_at: 2.business_days.before(now))
+
+      expect { call_service }.to change { Audited::Audit.count }.by(1)
+      expect { call_service }.to change { Audited::Audit.count }.by(0)
+    end
   end
 end

--- a/spec/services/set_reject_by_default_spec.rb
+++ b/spec/services/set_reject_by_default_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe SetRejectByDefault do
+  describe '#call' do
+    it 'does not update dates when nothing changes', with_audited: true do
+      application_choice = create(:application_choice, sent_to_provider_at: Time.zone.now)
+
+      expect { call_service(application_choice) }.to change { Audited::Audit.count }.by(1)
+      expect { call_service(application_choice) }.to change { Audited::Audit.count }.by(0)
+    end
+  end
+
+  def call_service(application_choice)
+    SetRejectByDefault.new(application_choice).call
+  end
+end

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RecalculateDates do
     application_form = create(
       :completed_application_form,
       :with_completed_references,
-      submitted_at: Time.zone.now
+      submitted_at: Time.zone.now,
     )
 
     application_choice = create(

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -25,21 +25,22 @@ RSpec.describe RecalculateDates do
   end
 
   it 'recalculates decline_by_default_at for a submitted application choice with an offer' do
-    application_form = create(:completed_application_form, :with_completed_references, submitted_at: Time.zone.now)
+    application_form = create(
+      :completed_application_form,
+      :with_completed_references,
+      submitted_at: Time.zone.now
+    )
+
     application_choice = create(
       :submitted_application_choice, :with_offer,
       application_form: application_form,
-      decline_by_default_at: 10.business_days.from_now,
+      decline_by_default_at: nil,
       offered_at: Time.zone.now
     )
 
-    mock_holidays
-
     RecalculateDates.new.perform
 
-    new_decline_by_default = Time.zone.local(2020, 4, 6).end_of_day
-
-    expect(application_choice.reload.decline_by_default_at).to be_within(1.second).of new_decline_by_default
+    expect(application_choice.reload.decline_by_default_at).not_to be_nil
   end
 
   def mock_holidays

--- a/spec/workers/recalculate_dates_spec.rb
+++ b/spec/workers/recalculate_dates_spec.rb
@@ -1,27 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe RecalculateDates do
-  around do |example|
-    Timecop.freeze(Time.zone.local(2020, 3, 20)) do
-      example.run
-    end
-  end
-
-  after do
-    unmock_holidays
-  end
-
   it 'recalculates reject_by_default_at for a submitted application choice' do
-    application_form = create(:completed_application_form, :with_completed_references, submitted_at: Time.zone.now)
-    application_choice = create(:submitted_application_choice, application_form: application_form)
-
-    mock_holidays
+    application_choice = create(:submitted_application_choice, sent_to_provider_at: Time.zone.now)
 
     RecalculateDates.new.perform
 
-    new_reject_by_default = Time.zone.local(2020, 5, 21).end_of_day
-
-    expect(application_choice.reload.reject_by_default_at).to be_within(1.second).of new_reject_by_default
+    expect(application_choice.reload.reject_by_default_at).not_to be_nil
   end
 
   it 'recalculates decline_by_default_at for a submitted application choice with an offer' do
@@ -41,13 +26,5 @@ RSpec.describe RecalculateDates do
     RecalculateDates.new.perform
 
     expect(application_choice.reload.decline_by_default_at).not_to be_nil
-  end
-
-  def mock_holidays
-    BusinessTime::Config.holidays << Date.new(2020, 3, 23)
-  end
-
-  def unmock_holidays
-    BusinessTime::Config.holidays - [Date.new(2020, 3, 23)]
   end
 end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1692. We need a worker to recalculate all of the DBD/RDB days when holidays change.

## Changes proposed in this pull request

First, refactor and change the RBD/DBD code to make it possible repeatedly run `SetRejectByDefault` and `SetDeclineByDefault` without generating extra audit entries.

Then, use the services in the recalculation worker.

## Guidance to review

Per commit!

## Link to Trello card

https://trello.com/c/iV0jnliU

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
