### PR TITLE
Keep track of the time we sent an application to providers (2/2)

### DIFF
--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -10,6 +10,7 @@ class SendApplicationToProvider
     return false unless application_choice.application_complete?
 
     ActiveRecord::Base.transaction do
+      application_choice.update!(sent_to_provider_at: Time.zone.now)
       set_reject_by_default
       ApplicationStateChange.new(application_choice).send_to_provider!
       StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice)

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -43,6 +43,7 @@
       { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) },
     ] %>
     <% rows << { key: 'Reason for rejection', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>
+    <% rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at %>
     <% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at %>
     <% rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at %>
 

--- a/db/migrate/20200323161500_backfill_sent_to_provider_at.rb
+++ b/db/migrate/20200323161500_backfill_sent_to_provider_at.rb
@@ -1,0 +1,21 @@
+class BackfillSentToProviderAt < ActiveRecord::Migration[6.0]
+  def up
+    ApplicationChoice.all.each do |application_choice|
+      state_change = application_choice.audits.find do |audit|
+        audit.audited_changes['status'] == %w[application_complete awaiting_provider_decision]
+      end
+
+      next unless state_change
+
+      application_choice.update!(
+        sent_to_provider_at: state_change.created_at,
+        audit_comment: 'Backfill of `sent_to_provider_at`',
+      )
+      puts "Application form #{application_choice.application_form.id} was sent to the provider at #{state_change.created_at}"
+    end
+  end
+
+  def down
+    # Nothing to do
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_23_154535) do
+ActiveRecord::Schema.define(version: 2020_03_23_161500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe SendApplicationToProvider do
     expect(application_choice.reload.status).to eq 'awaiting_provider_decision'
   end
 
+  it 'sets the `sent_to_provider` date' do
+    SendApplicationToProvider.new(application_choice: application_choice).call
+
+    expect(application_choice.reload.sent_to_provider_at).not_to be_nil
+  end
+
   it 'does nothing if the status is not `application_complete`' do
     SendApplicationToProvider.new(application_choice: application_choice(status: 'awaiting_references')).call
 


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1719 to keep track of when we send an application to a provider.

## Changes proposed in this pull request

- Set the attribute when sending to the provider
- Add the attribute to the support UI
- Backfill existing records

## Guidance to review

Is the backfill correct?

## Link to Trello card

https://trello.com/c/iV0jnliU

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
