### PR TITLE
Don't error when somebody writes too long a reference

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -130,6 +130,7 @@ module RefereeInterface
 
       RequestLocals.store[:identity] = { reference_id: reference.id }
       Raven.user_context(reference_id: reference.id)
+      Raven.extra_context(application_support_url: support_interface_application_form_url(reference.application_form))
     end
 
     def reference

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -56,7 +56,6 @@ module RefereeInterface
     end
 
     def feedback
-      @application = reference.application_form
       @reference_form = ReferenceFeedbackForm.new(reference: reference, feedback: reference.feedback)
     end
 

--- a/app/models/referee_interface/reference_feedback_form.rb
+++ b/app/models/referee_interface/reference_feedback_form.rb
@@ -1,9 +1,9 @@
 module RefereeInterface
   class ReferenceFeedbackForm
     include ActiveModel::Validations
-
     attr_reader :reference, :feedback
     validates :feedback, presence: true, word_count: { maximum: 300 }
+    delegate :application_form, to: :reference
 
     def initialize(reference:, feedback: nil)
       @reference = reference

--- a/app/views/referee_interface/reference/feedback.html.erb
+++ b/app/views/referee_interface/reference/feedback.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix("Your reference for #{@application.full_name}", @reference_form.errors.any?) %>
+<% content_for :title, title_with_error_prefix("Your reference for #{@reference_form.application_form.full_name}", @reference_form.errors.any?) %>
 <% if FeatureFlag.active?('referee_confirm_relationship_and_safeguarding') %>
   <% content_for :before_content, govuk_back_link_to(referee_interface_safeguarding_path(token: @token_param)) %>
 <% end %>
@@ -7,7 +7,7 @@
   <%= f.govuk_error_summary %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Your reference for <%= @application.full_name %></h1>
+      <h1 class="govuk-heading-xl">Your reference for <%= @reference_form.application_form.full_name %></h1>
 
       <%= render(RefereeInterface::FeedbackHintsComponent.new(reference: @reference_form.reference)) %>
 

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_spec.rb
@@ -15,6 +15,10 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
     when_i_click_on_the_link_within_the_email
     then_i_see_the_reference_comment_page
 
+    when_i_fill_in_too_many_words_in_the_reference_field
+    and_i_click_the_submit_reference_button
+    then_i_see_an_error
+
     when_i_fill_in_the_reference_field
     and_i_click_the_submit_reference_button
     then_i_see_am_told_i_submittted_my_refernce
@@ -73,6 +77,14 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
 
   def when_i_fill_in_the_reference_field
     fill_in 'Your reference', with: 'This is a reference for the candidate.'
+  end
+
+  def when_i_fill_in_too_many_words_in_the_reference_field
+    fill_in 'Your reference', with: ('This is a reference for the candidate.' * 100)
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content 'Your reference must be 300 words or fewer'
   end
 
   def and_i_click_the_submit_reference_button


### PR DESCRIPTION
##  Context

We currently crash when a user enters more than 300 words in the reference field, because we try to `render :feedback`, but we aren't setting the `@application` instance variable.

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1584992242041500

## Changes proposed in this pull request

This fixes the issue by making sure we only deal with a single ivar.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1584992242041500

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
