### PR TITLE
Covid 19 changes to service email notifications(candidate interface) 2

### DIFF
--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -1,6 +1,11 @@
 Dear <%= @application_form.first_name %>
 
+<% if FeatureFlag.active?('covid_19') %>
+# Respond by <%= @dbd_date %>
+<% else %>
+If you don’t reply within <%= @dbd_days %> working days, your applications will be withdrawn.
 # Respond within <%= TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit %> working days
+<% end %>
 
 <% if @application_choices.count > 1 %>
 

--- a/app/views/candidate_mailer/declined_by_default.text.erb
+++ b/app/views/candidate_mailer/declined_by_default.text.erb
@@ -2,7 +2,11 @@ Dear <%= @application_form.first_name %>,
 
 # <%= 'Application'.pluralize(@declined_course_names.size) %> withdrawn automatically
 
+<% if FeatureFlag.active?('covid_19') %>
+We withdrew your application for <%= @declined_course_names.to_sentence %> because you didn’t respond in time.
+<% else %>
 We withdrew your application for <%= @declined_course_names.to_sentence %> because you didn’t respond to the <%= 'offer'.pluralize(@declined_course_names.size) %> within <%= @declined_courses.first.decline_by_default_days %> working days.
+<% end %>
 
 # Give feedback or report a problem
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -14,7 +14,11 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
+<% if FeatureFlag.active?('covid_19') %>
+If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn. 
+<% else %>
 You have 10 working days to make a decision. If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
+<% end %>
 
 # Offers you’ve received
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -14,7 +14,11 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
+<% if FeatureFlag.active?('covid_19') %>
+If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn. 
+<% else %>
 You have 10 working days to make a decision. If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
+<% end %>
 
 Sign in to your account to respond:
 

--- a/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
+++ b/spec/mailers/candidate_mailer_offers_and_rejections_spec.rb
@@ -32,6 +32,16 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe 'send new offer email to candidate' do
+    context 'when the covid-19 feature flag is on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it_behaves_like(
+        'a mail with subject and content', :new_offer_single_offer,
+        'Offer received for Applied Science (Psychology) (3TT5) at Brighthurst Technical College',
+        'Days to make an offer' => 'If you don’t reply by 25 February 2020'
+      )
+    end
+
     describe '#new_offer_single_offer' do
       it_behaves_like(
         'a mail with subject and content', :new_offer_single_offer,
@@ -39,7 +49,8 @@ RSpec.describe CandidateMailer, type: :mailer do
         'heading' => 'Dear Bob',
         'decline by default date' => 'Make a decision by 25 February 2020',
         'first_condition' => 'DBS check',
-        'second_condition' => 'Pass exams'
+        'second_condition' => 'Pass exams',
+        'Days to make an offer' => 'You have 10 working days to make a decision. If you don’t reply by 25 February 2020'
       )
     end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -150,6 +150,22 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '.decline_by_default' do
+    context 'when the covid-19 feature flag is on' do
+      before do
+        FeatureFlag.activate('covid_19')
+        @application_form = build_stubbed(
+          :application_form,
+          application_choices: [build_stubbed(:application_choice, status: 'declined', declined_by_default: true, decline_by_default_days: 10)],
+          )
+      end
+
+      it_behaves_like(
+        'a mail with subject and content', :declined_by_default,
+        'Application withdrawn automatically',
+        'Reason' => 'because you didn’t respond in time.'
+      )
+    end
+
     context 'when a candidate has 1 offer that was declined' do
       before do
         @application_form = build_stubbed(

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -111,6 +111,16 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe 'Candidate decision chaser email' do
+    context 'when the covid-19 feature flag is on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it_behaves_like(
+        'a mail with subject and content', :chase_candidate_decision,
+        I18n.t!('chase_candidate_decision_email.subject_singular'),
+        'Date to resbond by' => "Respond by #{10.business_days.from_now.to_s(:govuk_date).strip}"
+    )
+    end
+
     context 'when a candidate has one appication choice with offer' do
       it_behaves_like(
         'a mail with subject and content', :chase_candidate_decision,


### PR DESCRIPTION
## Context
We need to update service notifications (emails) in light of the changes we're making as a result of changing RBD/DBD dates (in response to COVID-19). The previous PR #1707 updated:
- `Application_submitted`
- `Application sent to provider`
- `application_rejected_offers_made`

This PR includes changes for the rest of the candidate mails.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
This PR updates the following mails with new prompt message and rdb/dbd dates:
- `candidate_mailer#chase_candidate_decision `
- `candidate_mailer#declined_by_default`
- `candidate_mailer#new_offer`

#### Before:
![image](https://user-images.githubusercontent.com/22743709/77407161-a009fb80-6dad-11ea-9ef3-1a647734982b.png)

![image](https://user-images.githubusercontent.com/22743709/77407204-b0ba7180-6dad-11ea-9e4c-762a361026b0.png)

![image](https://user-images.githubusercontent.com/22743709/77407693-77cecc80-6dae-11ea-8afa-b7b564aaab1d.png)

![image](https://user-images.githubusercontent.com/22743709/77407732-89b06f80-6dae-11ea-9e5f-786cf2669b2e.png)

![image](https://user-images.githubusercontent.com/22743709/77407773-9765f500-6dae-11ea-9566-b28e087c296c.png)

![image](https://user-images.githubusercontent.com/22743709/77407811-a351b700-6dae-11ea-9021-7bcf1bbc773a.png)

#### After: 

![image](https://user-images.githubusercontent.com/22743709/77407868-bf555880-6dae-11ea-8ba6-997503d0a8fa.png)

![image](https://user-images.githubusercontent.com/22743709/77407901-cf6d3800-6dae-11ea-83e2-af8038cb91b0.png)

![image](https://user-images.githubusercontent.com/22743709/77407924-dbf19080-6dae-11ea-8532-682ae7941c76.png)

![image](https://user-images.githubusercontent.com/22743709/77407945-e449cb80-6dae-11ea-92ef-6173388a1d11.png)

![image](https://user-images.githubusercontent.com/22743709/77407976-ef046080-6dae-11ea-9561-31f05da17825.png)

![image](https://user-images.githubusercontent.com/22743709/77408022-fe83a980-6dae-11ea-9be8-3f0bf6ea17b4.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/lUggdcuq/1215-dev-covid-19-changes-to-service-email-notifications

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)