### PR TITLE
Update referee time limits

### DIFF
--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -5,6 +5,14 @@ class TimeLimitConfig
     7
   end
 
+  def self.chase_referee_by
+    7
+  end
+
+  def self.replace_referee_by
+    14
+  end
+
   RULES = {
     reject_by_default: [
       Rule.new(nil, nil, 40),
@@ -14,12 +22,6 @@ class TimeLimitConfig
     ],
     chase_provider_before_rbd: [
       Rule.new(nil, nil, 20),
-    ],
-    chase_referee_by: [
-      Rule.new(nil, nil, 5),
-    ],
-    replace_referee_by: [
-      Rule.new(nil, nil, 10),
     ],
     chase_candidate_before_dbd: [
       Rule.new(nil, nil, 5),

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -64,13 +64,13 @@ class ApplicationReference < ApplicationRecord
   def chase_referee_at
     return unless requested_at
 
-    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: requested_at).call[:time_in_future]
+    TimeLimitConfig.chase_referee_by.days.after(requested_at)
   end
 
   def replace_referee_at
     return unless requested_at
 
-    TimeLimitCalculator.new(rule: :replace_referee_by, effective_date: requested_at).call[:time_in_future]
+    TimeLimitConfig.replace_referee_by.days.after(requested_at)
   end
 
   def feedback_overdue?

--- a/app/services/get_referees_to_chase.rb
+++ b/app/services/get_referees_to_chase.rb
@@ -7,6 +7,6 @@ class GetRefereesToChase
   end
 
   def self.chase_referee_time_limit
-    TimeLimitCalculator.new(rule: :chase_referee_by, effective_date: Time.zone.now).call[:time_in_past]
+    TimeLimitConfig.chase_referee_by.days.before(Time.zone.now)
   end
 end

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -44,7 +44,7 @@ Sign in to your account and click ‘withdraw’ next to the course(s) you want 
 
 # References
 
-We’ve contacted your referees. If we don’t get a reference from them within <%= TimeLimitConfig.limits_for(:replace_referee_by).first.limit %> days we’ll ask you for a replacement.
+We’ve contacted your referees. If we don’t get a reference from them within <%= TimeLimitConfig.replace_referee_by %> days we’ll ask you for a replacement.
 
 Your application won’t be sent to your provider until your references are in.
 

--- a/spec/services/get_referees_to_chase_spec.rb
+++ b/spec/services/get_referees_to_chase_spec.rb
@@ -2,27 +2,27 @@ require 'rails_helper'
 
 RSpec.describe GetRefereesToChase do
   describe '.call' do
-    it 'returns referees that were sent their reference email more than 5 days ago and have not already been chased' do
-      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.business_days.ago)
+    it 'returns referees that were sent their reference email more than 7 days ago and have not already been chased' do
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 8.days.ago)
 
       expect(described_class.call).to include reference
     end
 
     it 'only returns application choices which are awaiting references' do
-      create(:reference, :complete, requested_at: 6.business_days.ago)
+      create(:reference, :complete, requested_at: 8.days.ago)
 
       expect(described_class.call).to be_empty
     end
 
-    it 'does not return referees which were sent their reference email less than 5 days ago' do
-      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.business_days.ago)
+    it 'does not return referees which were sent their reference email less than 7 days ago' do
+      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.days.ago)
 
       expect(described_class.call).to be_empty
     end
 
 
     it 'does not return referess who have already been sent a chase email' do
-      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 6.business_days.ago)
+      reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 8.days.ago)
 
       SendChaseEmailToRefereeAndCandidate.call(application_form: reference.application_form, reference: reference)
 


### PR DESCRIPTION
## Context

We're changing this from business days, and adding another method to TimeLimitConfig is simpler than refactoring it.

## Changes proposed in this pull request

Use calendar days instead of business days.

## Guidance to review

Does this make sense?

Prior art: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1716

## Link to Trello card

https://trello.com/c/iV0jnliU/1207-ucas-rbd-dbd-date-suspension-until-20th-april

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)