### PR TITLE
Add COVID-19 holidays to business_time config

### DIFF
--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -2,5 +2,9 @@ Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).m
   BusinessTime::Config.holidays << holiday[:date]
 end
 
+(Date.new(2020, 3, 23)..Date.new(2020, 4, 20)).each do |date|
+  BusinessTime::Config.holidays << date
+end
+
 BusinessTime::Config.beginning_of_workday = '0:00 am'
 BusinessTime::Config.end_of_workday = '11:59 pm'

--- a/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
+++ b/spec/system/candidate_interface/candidate_receives_rejection_email_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Receives rejection email' do
   include CandidateHelper
 
   around do |example|
-    date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 3, 13)
+    date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 1, 13)
     Timecop.freeze(date_that_avoids_clocks_changing_by_ten_days) do
       example.run
     end


### PR DESCRIPTION
## Context

We're bumping our RBD and DBD dates until the 20th of April because of the ongoing coronavirus pandemic.

## Changes proposed in this pull request

Add the dates to the `business_time.rb` initializer and update one failing spec.

## Guidance to review

:ship:

## Link to Trello card

https://trello.com/c/iV0jnliU/1207-ucas-rbd-dbd-date-suspension-until-20th-april

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)