### PR TITLE
Make the choice between Apply and UCAS clearer

### DIFF
--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -7,27 +7,52 @@ module CandidateInterface
     rescue_from ActionController::ParameterMissing, with: :render_not_found
 
     def show
-      service = ApplyFromFindPage.new(provider_code: params[:providerCode],
-                                      course_code: params[:courseCode],
-                                      can_apply_on_apply: false,
-                                      course_on_find: false,
-                                      course: nil)
-      service.determine_whether_course_is_on_find_or_apply
-      @course = service.course
+      set_service_and_course(params[:providerCode], params[:courseCode])
 
-      if service.can_apply_on_apply?
+      if @service.can_apply_on_apply?
+        @apply_on_ucas_or_apply = CandidateInterface::ApplyOnUcasOrApplyForm.new(
+          provider_code: params[:providerCode], course_code: params[:courseCode],
+        )
+
         render :apply_on_ucas_or_apply
-      elsif service.course_on_find?
+      elsif @service.course_on_find?
         render :apply_on_ucas_only
       else
         render_not_found
       end
     end
 
+    def ucas_or_apply
+      @apply_on_ucas_or_apply = CandidateInterface::ApplyOnUcasOrApplyForm.new(apply_on_ucas_or_apply_params)
+
+      set_service_and_course(@apply_on_ucas_or_apply.provider_code, @apply_on_ucas_or_apply.course_code)
+
+      if @apply_on_ucas_or_apply.valid?
+        if @apply_on_ucas_or_apply.apply?
+          redirect_to candidate_interface_eligibility_path(providerCode: @apply_on_ucas_or_apply.provider_code, courseCode: @apply_on_ucas_or_apply.course_code)
+        else
+          redirect_to UCAS.apply_url
+        end
+      else
+        render :apply_on_ucas_or_apply
+      end
+    end
+
   private
+
+    def set_service_and_course(provider_code, course_code)
+      @service = ApplyFromFindPage.new(provider_code: provider_code, course_code: course_code)
+      @service.determine_whether_course_is_on_find_or_apply
+      @course = @service.course
+    end
 
     def render_not_found
       render :not_found, status: :not_found
+    end
+
+    def apply_on_ucas_or_apply_params
+      params.require(:candidate_interface_apply_on_ucas_or_apply_form)
+        .permit(:service, :provider_code, :course_code)
     end
   end
 end

--- a/app/models/candidate_interface/apply_on_ucas_or_apply_form.rb
+++ b/app/models/candidate_interface/apply_on_ucas_or_apply_form.rb
@@ -1,0 +1,13 @@
+module CandidateInterface
+  class ApplyOnUcasOrApplyForm
+    include ActiveModel::Model
+
+    attr_accessor :service, :provider_code, :course_code
+
+    validates :service, presence: true
+
+    def apply?
+      service == 'apply'
+    end
+  end
+end

--- a/app/services/candidate_interface/apply_from_find_page.rb
+++ b/app/services/candidate_interface/apply_from_find_page.rb
@@ -2,12 +2,12 @@ module CandidateInterface
   class ApplyFromFindPage
     attr_accessor :course
 
-    def initialize(provider_code:, course_code:, can_apply_on_apply:, course_on_find:, course:)
+    def initialize(provider_code:, course_code:)
       @provider_code = provider_code
       @course_code = course_code
-      @can_apply_on_apply = can_apply_on_apply
-      @course_on_find = course_on_find
-      @course = course
+      @can_apply_on_apply = false
+      @course_on_find = false
+      @course = nil
     end
 
     def determine_whether_course_is_on_find_or_apply

--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_or_apply.html.erb
@@ -1,51 +1,53 @@
-<% content_for :title, 'You can apply for this course using a new GOV.UK service' %>
+<% content_for :title, 'Apply for this course' %>
 <% content_for :service_link, candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render CandidateInterface::UcasDowntimeComponent.new  %>
+    <%= render CandidateInterface::UcasDowntimeComponent.new %>
 
-    <h1 class="govuk-heading-xl">
-      <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
-       You can apply for this course using a new GOV.UK service
-    </h1>
+    <%= form_with model: @apply_on_ucas_or_apply, url: candidate_interface_apply_from_find_path, method: :post do |f| %>
+      <%= f.govuk_error_summary %>
 
-    <p class="govuk-body">
-      <%= service_name %> is a streamlined new GOV.UK service which is
-      designed to make application easier. It comes with personalised support
-      for candidates.
-    </p>
-    <p class="govuk-body">
-      <a class="govuk-link" href="https://getintoteaching.education.gov.uk/the-way-you-apply-for-teacher-training-is-changing">
-        Learn more about changes to teacher training applications
-      </a>
-    </p>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
+          Apply for this course
+      </h1>
 
-    <h2 class="govuk-heading-l">Is this new service right for you?</h2>
-    <p class="govuk-body">
-      <%= service_name %> is still in development. The service will eventually
-      replace UCAS as the way candidates apply for teacher training. However,
-      for now, it is limited to just a few courses.
-    </p>
-    <p class="govuk-body">
-      You can <%= govuk_link_to 'preview a list of training providers and courses', candidate_interface_providers_path %> currently available on <%= service_name %>.
-    </p>
-    <p class="govuk-body">
-      For most courses, you’ll still need to apply through UCAS.
-    </p>
-    <p class="govuk-body">
-      Additionally, the service isn’t ready yet for international candidates or
-      candidates who’ve studied outside the UK.
-    </p>
+      <p class="govuk-body">
+        The course you’ve chosen is available through a new GOV.UK service called <%= service_name %>.
+      </p>
 
-    <p class="govuk-body">
-      <%= govuk_button_link_to t('apply_from_find.apply_button'), candidate_interface_eligibility_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), class: 'govuk-!-margin-top-4 govuk-!-margin-bottom-3' %>
-    </p>
+      <p class="govuk-body">
+        This will eventually replace UCAS as the way candidates apply for all teacher training.
+        However, for now, the service is limited to certain providers.
+      </p>
 
-    <p class="govuk-body">or</p>
+      <p class="govuk-body">
+        <%= govuk_link_to 'See a list of available training providers and courses', candidate_interface_providers_path %>.
+      </p>
 
-    <p class="govuk-body">
-      <%= govuk_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %>
-    </p>
+      <div class="govuk-!-margin-top-6">
+        <%= f.hidden_field :provider_code, value: @course.provider.code %>
+        <%= f.hidden_field :course_code, value: @course.code %>
+
+        <%= f.govuk_radio_buttons_fieldset :service, legend: { size: 'm', text: 'Do you want to apply using a new GOV.UK service?' } do %>
+          <%= f.govuk_radio_button :service, :apply, label: { text: 'Yes, I want to apply using the new service', size: 's' }, link_errors: true, hint_text:
+            "<p class=\"govuk-body govuk-!-margin-top-2\">Choose this option if:</p>
+            <ul class=\"govuk-list govuk-list--bullet\">
+              <li>all your chosen providers are available on the new service</li>
+              <li>you want to try a streamlined service with personalised support</li>
+            </ul>".html_safe %>
+
+          <%= f.govuk_radio_button :service, :ucas, label: { text: 'No, I want to apply with UCAS', size: 's' }, hint_text:
+            "<p class=\"govuk-body govuk-!-margin-top-2\">Choose this option if:</p>
+            <ul class=\"govuk-list govuk-list--bullet\">
+              <li>some of your chosen providers are not available on #{service_name} and you don’t want to use 2 different services.</li>
+              <li>you’ve already started applying with UCAS</li>
+            </ul>".html_safe %>
+          <% end %>
+
+          <%= f.govuk_submit 'Continue' %>
+        <% end %>
+      </div>
   </div>
 </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -613,7 +613,10 @@ en:
               too_many_words: Your reason must be %{count} words or fewer
         referee_interface/reference_feedback_form:
           attributes:
-            feedback: 
+            feedback:
               blank: Enter your reference
               too_many_words: Your reference must be %{count} words or fewer
-              
+        candidate_interface/apply_on_ucas_or_apply_form:
+          attributes:
+            service:
+              blank: Choose if you want to use the new GOV.UK service

--- a/config/locales/apply_from_find.yml
+++ b/config/locales/apply_from_find.yml
@@ -2,7 +2,6 @@ en:
   apply_from_find:
     heading: Apply for this course
     ucas_apply_button: Apply through UCAS
-    apply_button: Apply through the new service
     find_button: Find postgraduate teacher training
     heading_not_found: We couldn’t find the course you’re looking for
     account_created_message: 'Your Apply for teacher training account has been created'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     get '/authenticate', to: 'sign_in#authenticate', as: :authenticate
 
     get '/apply', to: 'apply_from_find#show', as: :apply_from_find
+    post '/apply', to: 'apply_from_find#ucas_or_apply'
 
     get '/interstitial', to: 'sign_in#interstitial', as: :interstitial
 

--- a/spec/models/candidate_interface/apply_on_ucas_or_apply_form_spec.rb
+++ b/spec/models/candidate_interface/apply_on_ucas_or_apply_form_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::ApplyOnUcasOrApplyForm, type: :model do
+  it { is_expected.to validate_presence_of(:service) }
+
+  describe '#apply?' do
+    context 'when service is apply' do
+      it 'returns true' do
+        form = CandidateInterface::ApplyOnUcasOrApplyForm.new(service: 'apply')
+
+        expect(form.apply?).to eq(true)
+      end
+    end
+
+    context 'when service is ucas' do
+      it 'returns false' do
+        form = CandidateInterface::ApplyOnUcasOrApplyForm.new(service: 'ucas')
+
+        expect(form.apply?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/services/candidate_interface/apply_from_find_page_spec.rb
+++ b/spec/services/candidate_interface/apply_from_find_page_spec.rb
@@ -9,10 +9,7 @@ RSpec.describe CandidateInterface::ApplyFromFindPage do
         FeatureFlag.activate('pilot_open')
         course = create(:course, open_on_apply: true, exposed_in_find: true)
         service = described_class.new(provider_code: course.provider.code,
-                                      course_code: course.code,
-                                      can_apply_on_apply: false,
-                                      course_on_find: false,
-                                      course: nil)
+                                      course_code: course.code)
         service.determine_whether_course_is_on_find_or_apply
 
         expect(service.can_apply_on_apply?).to be_truthy
@@ -26,10 +23,7 @@ RSpec.describe CandidateInterface::ApplyFromFindPage do
         FeatureFlag.activate('pilot_open')
         stub_find_api_course_200('A999', 'B999', 'potions')
         service = described_class.new(provider_code: 'A999',
-                                      course_code: 'B999',
-                                      can_apply_on_apply: false,
-                                      course_on_find: false,
-                                      course: nil)
+                                      course_code: 'B999')
         service.determine_whether_course_is_on_find_or_apply
 
         expect(service.course_on_find?).to be_truthy

--- a/spec/system/candidate_interface/candidate_new_user_with_course_params_and_cancel_spec.rb
+++ b/spec/system/candidate_interface/candidate_new_user_with_course_params_and_cancel_spec.rb
@@ -44,7 +44,9 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
   end
 
   def and_i_choose_to_use_apply
-    click_on t('apply_from_find.apply_button')
+    choose 'Yes, I want to apply using the new service'
+
+    click_button 'Continue'
   end
 
   def and_i_answer_eligibility_questions

--- a/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
     when_i_visit_the_available_courses_page
     then_i_should_see_the_available_providers_and_courses
 
+    given_i_am_on_the_apply_through_apply_page
+    when_i_do_not_make_a_choice_between_ucas_and_apply
+    then_i_see_an_error
+
+    when_i_choose_to_apply_through_apply
+    then_i_see_the_eligibility_page
+
     given_the_pilot_is_not_open
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
     then_i_should_be_able_to_apply_through_ucas_only
@@ -57,8 +64,8 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def when_i_arrive_from_find_to_a_course_that_is_open_on_apply
-    course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
-    visit candidate_interface_apply_from_find_path providerCode: course.provider.code, courseCode: course.code
+    @course_on_apply = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Potions')
+    visit candidate_interface_apply_from_find_path providerCode: @course_on_apply.provider.code, courseCode: @course_on_apply.code
   end
 
   def then_i_should_see_the_landing_page
@@ -80,7 +87,7 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   end
 
   def then_i_should_be_able_to_apply_through_apply
-    expect(page).to have_content 'You can apply for this course using a new GOV.UK service'
+    expect(page).to have_content 'Apply for this course'
   end
 
   def when_i_visit_the_available_courses_page
@@ -90,5 +97,27 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
   def then_i_should_see_the_available_providers_and_courses
     expect(page).not_to have_content 'Biology'
     expect(page).to have_content 'Potions'
+  end
+
+  def given_i_am_on_the_apply_through_apply_page
+    visit candidate_interface_apply_from_find_path providerCode: @course_on_apply.provider.code, courseCode: @course_on_apply.code
+  end
+
+  def when_i_do_not_make_a_choice_between_ucas_and_apply
+    click_button 'Continue'
+  end
+
+  def then_i_see_an_error
+    expect(page).to have_content('Choose if you want to use the new GOV.UK service')
+  end
+
+  def when_i_choose_to_apply_through_apply
+    choose 'Yes, I want to apply using the new service'
+
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_eligibility_page
+    expect(page).to have_content('Check we’re ready for you to use this service')
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -55,7 +55,9 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
   end
 
   def and_i_click_apply_on_apply
-    click_on t('apply_from_find.apply_button')
+    choose 'Yes, I want to apply using the new service'
+
+    click_button 'Continue'
   end
 
   def when_i_fill_in_the_eligiblity_form_with_yes

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -55,7 +55,9 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
   end
 
   def and_i_click_apply_on_apply
-    click_on t('apply_from_find.apply_button')
+    choose 'Yes, I want to apply using the new service'
+
+    click_button 'Continue'
   end
 
   def then_i_should_see_the_study_mode_page

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -93,7 +93,9 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_click_apply_on_apply
-    click_on t('apply_from_find.apply_button')
+    choose 'Yes, I want to apply using the new service'
+
+    click_button 'Continue'
   end
 
   def then_i_should_see_the_course_selection_page

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_without_selection_page_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_without_selection_page_spec.rb
@@ -82,7 +82,9 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_click_apply_on_apply
-    click_on t('apply_from_find.apply_button')
+    choose 'Yes, I want to apply using the new service'
+
+    click_button 'Continue'
   end
 
   def and_i_submit_my_email_address


### PR DESCRIPTION
## Context

We want to make it easier for the candidate to choose between Apply and UCAS.

## Changes proposed in this pull request

This PR updates the content on the Apply or UCAS page and adds radio buttons to choose between Apply and UCAS.

### Before

![image](https://user-images.githubusercontent.com/42817036/77457856-2eee3680-6df5-11ea-8561-24becd247516.png)

### After

![image](https://user-images.githubusercontent.com/42817036/77457816-2138b100-6df5-11ea-8fa1-b005dda59f89.png)

## Guidance to review

- ~~Needs refactoring, currently there's duplication in the `ApplyFromFindController`.~~
- There's some spooky injection of HTML for the hint text for the radio buttons. Not sure how else to do this with `GOVUKDesignSystemFormBuilder::FormBuilder`.
- The redirect to UCAS isn't tested. I was hoping to do just check the content of the page for UCAS stuff but that doesn't work because it's not part of the site.
- Review commit by commit.

Any ideas about the above?

## Link to Trello card

https://trello.com/c/Ig9Gco50

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
