### PR TITLE
Calculate work gaps based on submission date

### DIFF
--- a/app/services/check_breaks_in_work_history.rb
+++ b/app/services/check_breaks_in_work_history.rb
@@ -7,25 +7,21 @@ class CheckBreaksInWorkHistory
       jobs.each do |job|
         return true if month_or_more_break_between_dates?(latest_end_date, job.start_date)
 
-        return false if less_than_month_to_current_date?(job.end_date)
+        return false unless month_or_more_break_between_dates?(job.end_date, submitted_at(application_form))
 
         latest_end_date = [latest_end_date, job.end_date].compact.max
       end
-      month_or_more_break_between_end_date_and_current_date?(latest_end_date)
+      month_or_more_break_between_dates?(latest_end_date, submitted_at(application_form))
     end
 
   private
-
-    def month_or_more_break_between_end_date_and_current_date?(end_date)
-      month_or_more_break_between_dates?(end_date, Time.zone.now)
-    end
 
     def month_or_more_break_between_dates?(end_date, next_date)
       end_date.present? && end_date.next_month <= next_date
     end
 
-    def less_than_month_to_current_date?(end_date)
-      end_date.nil? || end_date.next_month > Time.zone.now
+    def submitted_at(application_form)
+      application_form.submitted_at || Time.zone.now
     end
   end
 end

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -18,6 +18,7 @@ class WorkHistoryWithBreaks
   end
 
   def initialize(application_form)
+    @application_form = application_form
     @work_history = application_form.application_work_experiences.sort_by(&:start_date)
     @existing_breaks = application_form.application_work_history_breaks.sort_by(&:start_date)
     @current_job = nil
@@ -31,8 +32,8 @@ class WorkHistoryWithBreaks
 
     if @work_history.any?
       timeline_in_months = month_range(
-        start_date: Time.zone.now - 5.years,
-        end_date: Time.zone.now - 1.month,
+        start_date: submitted_at - 5.years,
+        end_date: submitted_at - 1.month,
       )
       break_months_in_timeline = remove_months(timeline: timeline_in_months, entries: @work_history)
       remaining_months = remove_months(timeline: break_months_in_timeline, entries: @existing_breaks)
@@ -45,6 +46,11 @@ class WorkHistoryWithBreaks
 
 private
 
+  def submitted_at
+    # Time.zone.now
+    @application_form.submitted_at || Time.zone.now
+  end
+
   def month_range(start_date:, end_date:)
     (start_date.to_date..end_date.to_date).map(&:beginning_of_month).uniq
   end
@@ -53,7 +59,7 @@ private
     remaining_months_in_timeline = timeline
 
     entries.each do |entry|
-      entry_end_date = entry.end_date.nil? ? Time.zone.now : entry.end_date
+      entry_end_date = entry.end_date.nil? ? submitted_at : entry.end_date
       months_in_entry_period = month_range(start_date: entry.start_date, end_date: entry_end_date)
 
       remaining_months_in_timeline -= months_in_entry_period

--- a/app/services/work_history_with_breaks.rb
+++ b/app/services/work_history_with_breaks.rb
@@ -47,7 +47,6 @@ class WorkHistoryWithBreaks
 private
 
   def submitted_at
-    # Time.zone.now
     @application_form.submitted_at || Time.zone.now
   end
 

--- a/spec/components/provider_interface/work_history_component_spec.rb
+++ b/spec/components/provider_interface/work_history_component_spec.rb
@@ -1,9 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::WorkHistoryComponent do
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 4, 1)) do
+      example.run
+    end
+  end
+
   context 'with an empty history' do
     it 'renders nothing' do
-      application_form = instance_double(ApplicationForm)
+      application_form = instance_double(ApplicationForm, submitted_at: Time.zone.local(2020, 2, 1))
       allow(application_form).to receive(:application_work_experiences).and_return([])
       allow(application_form).to receive(:application_work_history_breaks).and_return([])
 
@@ -14,7 +20,7 @@ RSpec.describe ProviderInterface::WorkHistoryComponent do
 
   context 'with work experiences' do
     it 'renders work experience details' do
-      application_form = instance_double(ApplicationForm)
+      application_form = instance_double(ApplicationForm, submitted_at: Time.zone.local(2020, 2, 1))
       experiences = [
         build(
           :application_work_experience,
@@ -55,7 +61,7 @@ RSpec.describe ProviderInterface::WorkHistoryComponent do
 
   context 'with work experiences working with children' do
     it 'renders work experience details and worked with children flag' do
-      application_form = instance_double(ApplicationForm)
+      application_form = instance_double(ApplicationForm, submitted_at: Time.zone.local(2020, 2, 1))
       experiences = [
         build(
           :application_work_experience,
@@ -81,7 +87,7 @@ RSpec.describe ProviderInterface::WorkHistoryComponent do
 
   context 'with work experiences and unexplained work break' do
     it 'renders work experience details and unexplained break' do
-      application_form = instance_double(ApplicationForm)
+      application_form = instance_double(ApplicationForm, submitted_at: Time.zone.local(2020, 2, 1))
       experiences = [
         build(
           :application_work_experience,
@@ -118,7 +124,7 @@ RSpec.describe ProviderInterface::WorkHistoryComponent do
 
   context 'with work experiences and explained work break' do
     it 'renders work experience details and explained break' do
-      application_form = instance_double(ApplicationForm)
+      application_form = instance_double(ApplicationForm, submitted_at: Time.zone.local(2020, 2, 1))
       breaks = [
         build(
           :application_work_history_break,

--- a/spec/services/check_breaks_in_work_history_spec.rb
+++ b/spec/services/check_breaks_in_work_history_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe CheckBreaksInWorkHistory do
         current_date = october2019
 
         Timecop.freeze(current_date) do
-          application_form = create(:application_form) do |form|
+          application_form = create(:application_form, submitted_at: october2019) do |form|
             form.application_work_experiences.create(
               start_date: august2019,
               end_date: september2019,
@@ -82,7 +82,7 @@ RSpec.describe CheckBreaksInWorkHistory do
         current_date = october2019
 
         Timecop.freeze(current_date) do
-          application_form = create(:application_form) do |form|
+          application_form = create(:application_form, submitted_at: october2019) do |form|
             form.application_work_experiences.create(
               start_date: january2019,
               end_date: march2019,

--- a/spec/services/work_history_with_breaks_spec.rb
+++ b/spec/services/work_history_with_breaks_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe WorkHistoryWithBreaks do
     let(:december2019) { Time.zone.local(2019, 12, 1) }
     let(:january2020) { Time.zone.local(2020, 1, 1) }
     let(:february2020) { Time.zone.local(2020, 2, 1) }
-    let(:current_date) { february2020 }
+    let(:april2020) { Time.zone.local(2020, 4, 1) }
+    let(:current_date) { april2020 }
+    let(:submitted_at) { february2020 }
 
     around do |example|
       Timecop.freeze(current_date) do
@@ -28,7 +30,11 @@ RSpec.describe WorkHistoryWithBreaks do
     context 'when there are no jobs' do
       it 'returns an empty array' do
         work_history = []
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -41,7 +47,11 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns the job' do
         job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: nil)
         work_history = [job1]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -55,7 +65,29 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns the job' do
         job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: current_date)
         work_history = [job1]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
+
+        get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
+        work_history_with_breaks = get_work_history_with_breaks.timeline
+
+        expect(work_history_with_breaks.count).to eq(1)
+        expect(work_history_with_breaks[0]).to eq(job1)
+      end
+    end
+
+    context 'when there is one job that ends at submission_date' do
+      it 'returns the job' do
+        job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2020)
+        work_history = [job1]
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -69,7 +101,11 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns the job then a break placeholder with a length of one month' do
         job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: december2019)
         work_history = [job1]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -87,7 +123,11 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns the job then a break placeholder with a length of three months' do
         job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: october2019)
         work_history = [job1]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -105,7 +145,11 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: december2019)
         job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
         work_history = [job2, job1, job3]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -123,7 +167,11 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: october2019, end_date: november2019)
         job3 = build_stubbed(:application_work_experience, start_date: january2020, end_date: current_date)
         work_history = [job1, job2, job3]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -142,7 +190,11 @@ RSpec.describe WorkHistoryWithBreaks do
         job1 = build_stubbed(:application_work_experience, start_date: january2014, end_date: march2014)
         job2 = build_stubbed(:application_work_experience, start_date: october2014, end_date: current_date)
         work_history = [job1, job2]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -159,7 +211,11 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
         work_history = [job1, job2, job3]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -177,7 +233,11 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: nil)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: december2019)
         work_history = [job1, job2, job3]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -197,7 +257,11 @@ RSpec.describe WorkHistoryWithBreaks do
         job2 = build_stubbed(:application_work_experience, start_date: april2019, end_date: september2019)
         job3 = build_stubbed(:application_work_experience, start_date: november2019, end_date: nil)
         work_history = [job1, job2, job3]
-        application_form = build_stubbed(:application_form, application_work_experiences: work_history)
+        application_form = build_stubbed(
+          :application_form,
+          application_work_experiences: work_history,
+          submitted_at: submitted_at,
+        )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
         work_history_with_breaks = get_work_history_with_breaks.timeline
@@ -220,6 +284,7 @@ RSpec.describe WorkHistoryWithBreaks do
           :application_form,
           application_work_experiences: work_history,
           application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
         )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
@@ -244,6 +309,7 @@ RSpec.describe WorkHistoryWithBreaks do
           :application_form,
           application_work_experiences: work_history,
           application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
         )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
@@ -260,13 +326,14 @@ RSpec.describe WorkHistoryWithBreaks do
     context 'when there are no jobs and multiple existing breaks' do
       it 'returns all existing breaks and sorted by start date' do
         work_history = []
-        break1 = build_stubbed(:application_work_history_break, start_date: november2019, end_date: current_date)
+        break1 = build_stubbed(:application_work_history_break, start_date: november2019, end_date: submitted_at)
         break2 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
         breaks = [break2, break1]
         application_form = build_stubbed(
           :application_form,
           application_work_experiences: work_history,
           application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
         )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
@@ -279,7 +346,7 @@ RSpec.describe WorkHistoryWithBreaks do
         expect(work_history_with_breaks[0].length).to eq(1)
         expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
         expect(work_history_with_breaks[1].start_date).to eq(november2019)
-        expect(work_history_with_breaks[1].end_date).to eq(current_date)
+        expect(work_history_with_breaks[1].end_date).to eq(submitted_at)
         expect(work_history_with_breaks[1].length).to eq(2)
       end
     end
@@ -288,12 +355,13 @@ RSpec.describe WorkHistoryWithBreaks do
       it 'returns the job and existing break, it does not include a break placeholder' do
         job1 = build_stubbed(:application_work_experience, start_date: february2015, end_date: february2016)
         work_history = [job1]
-        break1 = build_stubbed(:application_work_history_break, start_date: february2015, end_date: current_date)
+        break1 = build_stubbed(:application_work_history_break, start_date: february2015, end_date: submitted_at)
         breaks = [break1]
         application_form = build_stubbed(
           :application_form,
           application_work_experiences: work_history,
           application_work_history_breaks: breaks,
+          submitted_at: submitted_at,
         )
 
         get_work_history_with_breaks = WorkHistoryWithBreaks.new(application_form)
@@ -303,7 +371,7 @@ RSpec.describe WorkHistoryWithBreaks do
         expect(work_history_with_breaks[0]).to eq(job1)
         expect(work_history_with_breaks[1]).to be_instance_of(ApplicationWorkHistoryBreak)
         expect(work_history_with_breaks[1].start_date).to eq(february2015)
-        expect(work_history_with_breaks[1].end_date).to eq(current_date)
+        expect(work_history_with_breaks[1].end_date).to eq(submitted_at)
         expect(work_history_with_breaks[1].length).to eq(59)
       end
     end


### PR DESCRIPTION
## Context

We calculate whether a candidate has a gap at the end of their work history based on when their last job/volunteering ended (as we do now) and the date they submitted their application (rather than today's date).

When we work out whether a candidate has a work gap at the end of the work history we use something like this: `(Time.zone.now - last_job_end_date) > 1.month`. Because today's date is a moving target the outcome of this calculation is fairly likely to change from false to true while the provider is going through their process. Instead we should use `(date_application_submitted - last_job_end_date) > 1.month`
 
## Changes proposed in this pull request

- [x] Use `ApplicationForm.submitted_at` as the 'baseline' for work break calculations.
- [x] Update specs including one new initially failing spec

## Guidance to review

- Is there anywhere else in the code for work gaps that uses current date in the same way that I've missed?

## Link to Trello card

https://trello.com/c/9KbrH4yC/1721-calculate-work-gaps-based-on-submission-date

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
