### PR TITLE
Populate `ApplicationChoice#sent_to_provider_at` in test data

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -100,7 +100,7 @@ class TestApplications
   def put_application_choice_in_state(choice, state)
     travel_to(choice.edit_by) if choice.edit_by > time
     SendApplicationToProvider.new(application_choice: choice).call
-    choice.update(edit_by: time)
+    choice.update(edit_by: time, sent_to_provider_at: time)
     return if state == :awaiting_provider_decision
 
     case state

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe TestApplications do
     candidate = application_form.candidate
     expect(application_choice.created_at - candidate.created_at).to be >= 1.day
     expect(application_form.submitted_at - application_choice.created_at).to be >= 1.day
-    expect(application_choice.offered_at - application_form.submitted_at).to be >= 1.day
+    expect(application_choice.sent_to_provider_at - application_form.submitted_at).to be >= 1.day
+    expect(application_choice.offered_at - application_choice.sent_to_provider_at).to be >= 1.day
     expect(application_choice.accepted_at - application_choice.offered_at).to be >= 1.day
     expect(application_choice.enrolled_at - application_choice.accepted_at).to be >= 1.day
   end
@@ -33,7 +34,8 @@ RSpec.describe TestApplications do
     candidate = application_form.candidate
     expect(application_choice.created_at - candidate.created_at).to be >= 1.day
     expect(application_form.submitted_at - application_choice.created_at).to be >= 1.day
-    expect(application_choice.offered_at - application_form.submitted_at).to be >= 1.day
+    expect(application_choice.sent_to_provider_at - application_form.submitted_at).to be >= 1.day
+    expect(application_choice.offered_at - application_choice.sent_to_provider_at).to be >= 1.day
   end
 
   it 'attributes actions to candidates', with_audited: true do


### PR DESCRIPTION
## Context

This attribute was recently introduced by #1720. 

## Changes proposed in this pull request

Set `ApplicationChoice#sent_to_provider_at` to the 'fake' time in the test application generator for all applications that have progressed to that point or beyond.

## Guidance to review

- Check that `RecalculateDates` works with this change

## Link to Trello card

https://trello.com/c/peehB7G5/1816-populate-applicationchoicesenttoproviderat-in-test-data

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
