### PR TITLE
Ensure all provider users have a first name and last name

### DIFF
--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -6,7 +6,7 @@ module SupportInterface
     attr_accessor :first_name, :last_name, :provider_ids, :provider_user
     attr_reader :email_address
 
-    validates :email_address, presence: true, email: true
+    validates :email_address, :first_name, :last_name, presence: true, email: true
     validates :provider_ids, presence: true
     validate :email_is_unique
 

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -6,7 +6,8 @@ module SupportInterface
     attr_accessor :first_name, :last_name, :provider_ids, :provider_user
     attr_reader :email_address
 
-    validates :email_address, :first_name, :last_name, presence: true, email: true
+    validates :email_address, :first_name, :last_name, presence: true
+    validates :email_address, email: true
     validates :provider_ids, presence: true
     validate :email_is_unique
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,6 +126,10 @@ en:
           attributes:
             email_address:
               blank: Email address can’t be blank
+            first_name:
+              blank: First name can’t be blank
+            last_name:
+              blank: Last name can’t be blank
             dfe_sign_in_uid:
               blank: DfE Sign-in UID can’t be blank
             provider_ids:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,8 +130,6 @@ en:
               blank: First name can’t be blank
             last_name:
               blank: Last name can’t be blank
-            dfe_sign_in_uid:
-              blank: DfE Sign-in UID can’t be blank
             provider_ids:
               blank: Please specify a provider
         support_interface/new_offer_form:

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature 'Managing provider users' do
     and_i_click_add_user
     then_i_see_an_error
 
-    and_i_enter_the_users_email
+    and_i_enter_the_users_email_and_name
     and_i_select_a_provider
     and_i_click_add_user
 
@@ -72,8 +72,10 @@ RSpec.feature 'Managing provider users' do
     expect(page).to have_content 'This email address is already in use'
   end
 
-  def and_i_enter_the_users_email
+  def and_i_enter_the_users_email_and_name
     fill_in 'support_interface_provider_user_form[email_address]', with: 'harrison@example.com'
+    fill_in 'support_interface_provider_user_form[first_name]', with: 'Harrison'
+    fill_in 'support_interface_provider_user_form[last_name]', with: 'Bergeron'
   end
 
   def and_i_click_add_user


### PR DESCRIPTION
## Context

We have relied on DfE Sign-in to validate ProviderUsers having first and last names, but the validation doesn't work (it accepts " ", for example).

This matters because we address provider users by their first and last names in emails, and we email all users affiliated with a given provider when the application changes.

I'll also check the production database to make sure we have nobody in this state. (Done and updated on the Trello card)

## Changes proposed in this pull request

Add validation to the form, plus translation strings for the error messages.

## Link to Trello card

https://trello.com/c/vf5xjN1L/1662-ensure-all-provider-users-have-a-first-name-and-last-name

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
