### PR TITLE
Rely on email log for email history

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -110,7 +110,7 @@ module RefereeInterface
 
       send_slack_notification
 
-      SendNewRefereeRequestEmail.call(application_form: @reference.application_form, reference: @reference, reason: :refused)
+      SendNewRefereeRequestEmail.call(reference: @reference, reason: :refused)
 
       redirect_to referee_interface_confirmation_path(token: @token_param)
     end

--- a/app/controllers/support_interface/survey_emails_controller.rb
+++ b/app/controllers/support_interface/survey_emails_controller.rb
@@ -7,11 +7,6 @@ module SupportInterface
     def deliver
       CandidateMailer.survey_email(@application_form).deliver_later
 
-      candidate_email = @application_form.candidate.email_address
-      audit_comment = I18n.t('survey_emails.send.audit_comment', candidate_email: candidate_email)
-      application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
-      application_comment.save(@application_form)
-
       flash[:success] = t('survey_emails.send.success')
 
       redirect_to support_interface_application_form_path(@application_form)

--- a/app/services/process_notify_callback.rb
+++ b/app/services/process_notify_callback.rb
@@ -46,7 +46,6 @@ private
       reference.update!(feedback_status: 'email_bounced')
 
       SendNewRefereeRequestEmail.call(
-        application_form: reference.application_form,
         reference: reference,
         reason: :email_bounced,
       )

--- a/app/services/send_chase_email_to_candidate.rb
+++ b/app/services/send_chase_email_to_candidate.rb
@@ -2,10 +2,5 @@ class SendChaseEmailToCandidate
   def self.call(application_form:)
     CandidateMailer.chase_candidate_decision(application_form).deliver_later
     ChaserSent.create!(chased: application_form, chaser_type: :candidate_decision_request)
-
-    audit_comment =
-      'Chase email has been sent to candidate because ' +
-      'the application form is close to its DBD date.'
-    application_form.update!(audit_comment: audit_comment)
   end
 end

--- a/app/services/send_chase_email_to_provider.rb
+++ b/app/services/send_chase_email_to_provider.rb
@@ -2,16 +2,8 @@ class SendChaseEmailToProvider
   def self.call(application_choice:)
     application_choice.provider.provider_users.each do |provider_user|
       ProviderMailer.chase_provider_decision(provider_user, application_choice).deliver_later
-      audit_chase_email(provider_user, application_choice)
     end
-    ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)
-  end
 
-  def self.audit_chase_email(provider_user, application_choice)
-    course_name_and_code = application_choice.course.name_and_code
-    audit_comment =
-      "Chase emails have been sent to the provider #{provider_user.email_address} because " +
-      "the application for #{course_name_and_code} is close to its RBD date."
-    application_choice.application_form.update!(audit_comment: audit_comment)
+    ChaserSent.create!(chased: application_choice, chaser_type: :provider_decision_request)
   end
 end

--- a/app/services/send_chase_email_to_referee_and_candidate.rb
+++ b/app/services/send_chase_email_to_referee_and_candidate.rb
@@ -1,17 +1,7 @@
 class SendChaseEmailToRefereeAndCandidate
   def self.call(application_form:, reference:)
     RefereeMailer.reference_request_chaser_email(application_form, reference).deliver_later
-    ChaserSent.create!(chased: reference, chaser_type: :reference_request)
-
     CandidateMailer.chase_reference(reference).deliver_later
-
-    audit_comment = I18n.t(
-      'application_form.referees.audit_comment',
-      referee_email: reference.email_address,
-      candidate_email: application_form.candidate.email_address,
-    )
-
-    application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
-    application_comment.save(application_form)
+    ChaserSent.create!(chased: reference, chaser_type: :reference_request)
   end
 end

--- a/app/services/send_new_application_email_to_provider.rb
+++ b/app/services/send_new_application_email_to_provider.rb
@@ -10,12 +10,6 @@ class SendNewApplicationEmailToProvider
 
     application_choice.provider.provider_users.each do |provider_user|
       ProviderMailer.application_submitted(provider_user, application_choice).deliver_later
-
-      course_name = application_choice.course.name
-      course_code = application_choice.course.code
-      audit_comment = I18n.t('submit_application_success.audit_comment', course_name: course_name, course_code: course_code, provider_user_email: provider_user.email_address)
-      application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
-      application_comment.save(application_choice.application_form)
     end
   end
 end

--- a/app/services/send_new_offer_email_to_candidate.rb
+++ b/app/services/send_new_offer_email_to_candidate.rb
@@ -10,17 +10,9 @@ class SendNewOfferEmailToCandidate
       "new_offer_#{mail_type(application_choice)}".to_sym,
       application_choice,
     ).deliver_later
-    add_comment_to_audit_trail
   end
 
 private
-
-  def add_comment_to_audit_trail
-    audit_comment =
-      "New offer email sent to candidate #{application_choice.application_form.candidate.email_address} for " +
-      "#{application_choice.course_option.course.name_and_code} at #{application_choice.course_option.course.provider.name}."
-    application_choice.application_form.update!(audit_comment: audit_comment)
-  end
 
   def mail_type(application_choice)
     candidate_application_choices = application_choice.application_form.application_choices

--- a/app/services/send_new_referee_request_email.rb
+++ b/app/services/send_new_referee_request_email.rb
@@ -1,12 +1,6 @@
 class SendNewRefereeRequestEmail
-  def self.call(application_form:, reference:, reason: :not_responded)
+  def self.call(reference:, reason: :not_responded)
     CandidateMailer.new_referee_request(reference, reason: reason).deliver_later
-
     ChaserSent.create!(chaser_type: :reference_replacement, chased: reference)
-
-    candidate_email = application_form.candidate.email_address
-    audit_comment = I18n.t("new_referee_request.#{reason}.audit_comment", candidate_email: candidate_email)
-    application_comment = SupportInterface::ApplicationCommentForm.new(comment: audit_comment)
-    application_comment.save(application_form)
   end
 end

--- a/app/services/send_reject_by_default_email_to_provider.rb
+++ b/app/services/send_reject_by_default_email_to_provider.rb
@@ -10,12 +10,6 @@ class SendRejectByDefaultEmailToProvider
 
     application_choice.provider.provider_users.each do |provider_user|
       ProviderMailer.application_rejected_by_default(provider_user, application_choice).deliver_later
-
-      course_name_and_code = application_choice.course.name_and_code
-      audit_comment =
-        'Rejected by default email have been sent to the provider user' +
-        " #{provider_user.email_address} for application #{course_name_and_code}."
-      application_choice.application_form.update!(audit_comment: audit_comment)
     end
   end
 end

--- a/app/workers/ask_candidates_for_new_referees_worker.rb
+++ b/app/workers/ask_candidates_for_new_referees_worker.rb
@@ -4,7 +4,6 @@ class AskCandidatesForNewRefereesWorker
   def perform
     GetRefereesThatNeedReplacing.call.each do |reference|
       SendNewRefereeRequestEmail.call(
-        application_form: reference.application_form,
         reference: reference,
         reason: :not_responded,
       )

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -317,7 +317,6 @@ en:
         - Sixth referee
       chase: Chase this referee and notify the candidate
       confirm_chase: Are you sure you want to send emails to chase the referee?
-      audit_comment: "Chase emails have been sent to the referee (%{referee_email}) and candidate (%{candidate_email})."
       info:
         before_submission: We’ll contact your referees after you submit your application. We’ll let you know if they don’t supply a reference.
         after_submission: We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.

--- a/config/locales/new_referee_request.yml
+++ b/config/locales/new_referee_request.yml
@@ -6,14 +6,11 @@ en:
     success: New referee request sent to candidate
     not_responded:
       option: Explain the referee has not responded
-      audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining non-response.
       confirm_text: We’ll send an email to explain that their referee (%{referee_name}) has not responded.
     refused:
       option: Explain the referee won’t give a reference
-      audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining refusal to provide a reference.
       confirm_text: We’ll send an email to explain that their referee (%{referee_name}) won’t give a reference.
     email_bounced:
       option: Explain the referee’s email has bounced
-      audit_comment: New referee request email has been sent to candidate (%{candidate_email}) explaining email bounce.
       confirm_text: We’ll send an email to explain their referee’s email has bounced.
     auto_approve_feedback: Automatically approved.

--- a/config/locales/submit_application_success.yml
+++ b/config/locales/submit_application_success.yml
@@ -2,4 +2,3 @@ en:
   submit_application_success:
     title: Application submitted
     heading: Application successfully submitted
-    audit_comment: "New application email have been sent to the provider user (%{provider_user_email}) for application (%{course_name}) (%{course_code})."

--- a/config/locales/survey_emails.yml
+++ b/config/locales/survey_emails.yml
@@ -12,4 +12,3 @@ en:
       confirm: Are you sure you want to send a survey email to %{candidate_name}?
       button: Yes - send the email
       success: Survey request sent to candidate
-      audit_comment: Survey email has been sent to candidate (%{candidate_email}).

--- a/spec/services/get_referees_that_need_replacing_spec.rb
+++ b/spec/services/get_referees_that_need_replacing_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GetRefereesThatNeedReplacing do
     it 'does not return referees who have already been sent a chase email' do
       reference = create(:reference, feedback_status: 'feedback_requested', requested_at: 11.business_days.ago)
 
-      SendNewRefereeRequestEmail.call(application_form: reference.application_form, reference: reference, reason: :not_responded)
+      SendNewRefereeRequestEmail.call(reference: reference, reason: :not_responded)
 
       expect(described_class.call).to be_empty
     end

--- a/spec/services/send_chase_email_to_candidate_spec.rb
+++ b/spec/services/send_chase_email_to_candidate_spec.rb
@@ -15,12 +15,5 @@ RSpec.describe SendChaseEmailToCandidate do
     it 'sends a chaser email to the provider' do
       expect(application_form.chasers_sent.candidate_decision_request.count).to eq(1)
     end
-
-    it 'audits the chase emails', with_audited: true do
-      expected_comment =
-        'Chase email has been sent to candidate because ' +
-        'the application form is close to its DBD date.'
-      expect(application_form.audits.last.comment).to eq(expected_comment)
-    end
   end
 end

--- a/spec/services/send_chase_email_to_provider_spec.rb
+++ b/spec/services/send_chase_email_to_provider_spec.rb
@@ -18,12 +18,5 @@ RSpec.describe SendChaseEmailToProvider do
     it 'sends a chaser email to the provider' do
       expect(application_choice.chasers_sent.provider_decision_request.count).to eq(1)
     end
-
-    it 'audits the chase emails', with_audited: true do
-      expected_comment =
-        "Chase emails have been sent to the provider #{provider_user.email_address}" +
-        " because the application for #{application_choice.course.name_and_code} is close to its RBD date."
-      expect(application_choice.application_form.audits.last.comment).to eq(expected_comment)
-    end
   end
 end

--- a/spec/services/send_new_offer_email_to_candidate_spec.rb
+++ b/spec/services/send_new_offer_email_to_candidate_spec.rb
@@ -27,14 +27,6 @@ RSpec.describe SendNewOfferEmailToCandidate do
         described_class.new(application_choice: @application_choice).call
         expect(CandidateMailer).to have_received(:new_offer_single_offer).with(@application_choice)
       end
-
-      it 'audits the new offer email', with_audited: true do
-        expected_comment =
-          "New offer email sent to candidate #{@application_choice.application_form.candidate.email_address} for " +
-          "#{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.course.provider.name}."
-        described_class.new(application_choice: @application_choice).call
-        expect(@application_choice.application_form.audits.last.comment).to eq(expected_comment)
-      end
     end
 
     context 'when there are multiple offers' do
@@ -54,14 +46,6 @@ RSpec.describe SendNewOfferEmailToCandidate do
         described_class.new(application_choice: @application_choice).call
         expect(CandidateMailer).to have_received(:new_offer_multiple_offers).with(@application_choice)
       end
-
-      it 'audits the new offer email', with_audited: true do
-        expected_comment =
-          "New offer email sent to candidate #{@application_choice.application_form.candidate.email_address} for " +
-          "#{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.course.provider.name}."
-        described_class.new(application_choice: @application_choice).call
-        expect(@application_choice.application_form.audits.last.comment).to eq(expected_comment)
-      end
     end
 
     context 'when there are decisions pending' do
@@ -80,14 +64,6 @@ RSpec.describe SendNewOfferEmailToCandidate do
       it 'sends new offer email for pending decision case' do
         described_class.new(application_choice: @application_choice).call
         expect(CandidateMailer).to have_received(:new_offer_decisions_pending).with(@application_choice)
-      end
-
-      it 'audits the new offer email', with_audited: true do
-        expected_comment =
-          "New offer email sent to candidate #{@application_choice.application_form.candidate.email_address} for " +
-          "#{@application_choice.course_option.course.name_and_code} at #{@application_choice.course_option.course.provider.name}."
-        described_class.new(application_choice: @application_choice).call
-        expect(@application_choice.application_form.audits.last.comment).to eq(expected_comment)
       end
     end
   end

--- a/spec/system/provider_interface/provider_receives_email_when_a_new_application_has_been_submitted_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_a_new_application_has_been_submitted_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature 'A new application has been submitted' do
     when_the_application_is_delivered_to_my_provider
 
     then_i_should_receive_an_email_with_a_link_to_the_application
-    and_an_audit_comment_has_submitted
   end
 
   def given_i_am_a_provider_user_with_a_provider
@@ -43,14 +42,5 @@ RSpec.feature 'A new application has been submitted' do
     expect(current_email.subject).to include("Application received for #{@application_choice.course.name_and_code}")
 
     expect(current_email.body).to include("http://localhost:3000/provider/applications/#{@application_choice.id}")
-  end
-
-  def and_an_audit_comment_has_submitted
-    expected_audit_comment =
-      'New application email have been sent to the provider user' +
-      " (#{@provider_user.email_address}) for application (#{@application_choice.course.name})" +
-      " (#{@application_choice.course.code})."
-
-    expect(@application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
   end
 end

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_has_been_rejected_by_default_spec.rb
@@ -10,7 +10,6 @@ RSpec.feature 'An application has been rejected by default' do
     when_the_application_is_rejected_by_default
 
     then_i_should_receive_an_email
-    and_an_audit_comment_has_submitted
   end
 
   def given_i_am_a_provider_user_with_a_provider
@@ -42,13 +41,5 @@ RSpec.feature 'An application has been rejected by default' do
 
     expect(current_email.subject).to include(t('provider_application_rejected_by_default.email.subject',
                                                candidate_name: @application_choice.application_form.full_name))
-  end
-
-  def and_an_audit_comment_has_submitted
-    expected_audit_comment =
-      'Rejected by default email have been sent to the provider user' +
-      " #{@provider_user.email_address} for application #{@application_choice.course.name_and_code}."
-
-    expect(@application_choice.application_form.audits.last.comment).to eq(expected_audit_comment)
   end
 end

--- a/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
+++ b/spec/system/support_interface/send_survey_email_to_candidate_spec.rb
@@ -17,9 +17,6 @@ RSpec.feature 'Send survey email to candidate', with_audited: true do
     when_i_click_to_confirm_sending_the_survey_email
     then_i_see_the_survey_email_is_successfully_sent
     and_i_am_sent_back_to_the_application_form_with_a_flash
-
-    when_i_click_on_the_history_for_the_application
-    then_i_see_a_comment_stating_a_survey_emails_has_been_sent
   end
 
   def given_i_am_a_support_user
@@ -62,18 +59,5 @@ RSpec.feature 'Send survey email to candidate', with_audited: true do
 
   def and_i_am_sent_back_to_the_application_form_with_a_flash
     expect(page).to have_content(t('survey_emails.send.success'))
-  end
-
-  def when_i_click_on_the_history_for_the_application
-    click_link 'History'
-  end
-
-  def then_i_see_a_comment_stating_a_survey_emails_has_been_sent
-    candidate_email = @application.candidate.email_address
-
-    within('tbody tr:eq(1)') do
-      expect(page).to have_content 'Comment on Application Form'
-      expect(page).to have_content t('survey_emails.send.audit_comment', candidate_email: candidate_email)
-    end
   end
 end


### PR DESCRIPTION
## Context

We have an email log now with all of the emails that we send. This means we don't have to keep track of them in the audit log anymore.

## Changes proposed in this pull request

Remove all the relevant code. I'm not removing the actual audit entries, as they might be useful.

## Guidance to review

Did I miss anything?

## Link to Trello card

https://trello.com/c/banAlSI0

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
