### PR TITLE
Use the referee as the user in audit log

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -19,6 +19,8 @@ module SupportInterface
     def audit_entry_user_label
       if audit.user_type == 'Candidate'
         "#{audit.user.email_address} (Candidate)"
+      elsif audit.user_type == 'ApplicationReference'
+        "#{audit.user.name} - #{audit.user.email_address} (Referee)"
       elsif audit.user_type == 'VendorApiUser'
         "#{audit.user.email_address} (Vendor API)"
       elsif audit.user_type == 'SupportUser'

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -9,6 +9,10 @@ module RefereeInterface
 
     layout 'application'
 
+    def audit_user
+      reference
+    end
+
     def relationship
       redirect_to referee_interface_reference_feedback_path(token: @token_param) unless FeatureFlag.active?('referee_confirm_relationship_and_safeguarding')
 

--- a/spec/components/support_interface/audit_trail_item_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_item_component_spec.rb
@@ -85,6 +85,12 @@ RSpec.describe SupportInterface::AuditTrailItemComponent do
     expect(render_result.text).to include('jim@example.com (Provider user)')
   end
 
+  it 'renders an update on application form audit record with a referee' do
+    audit.user = build(:reference, name: 'Harry', email_address: 'harry@hogwarts.edu')
+    audit.action = 'update'
+    expect(render_result.text).to include('Harry - harry@hogwarts.edu (Referee)')
+  end
+
   it 'renders an update application form audit record with the username (rather than a persistent model)' do
     audit.user = nil
     audit.username = 'SYSTEM'


### PR DESCRIPTION
## Context

When a referee adds a reference we currently say that it was done by "Unknown user". 

## Changes proposed in this pull request

We can fix that by using the reference as the audit user and displaying that in the log.

![image](https://user-images.githubusercontent.com/233676/77544810-73cfa700-6ea1-11ea-8b28-9f28b6bac7c4.png)


## Guidance to review

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
