### PR TITLE
Correct service type variable for Logit

### DIFF
--- a/azure/containers.json
+++ b/azure/containers.json
@@ -105,7 +105,10 @@
     "variables": {
         "containerImageName": "[concat(parameters('dockerHubUsername'), '/', parameters('containerImageReference'))]",
         "appServiceRuntimeStack": "[concat('DOCKER|', parameters('dockerHubUsername'), '/', parameters('containerImageReference'))]",
-        "rubyAuthHosts": "[if(greater(length(parameters('customHostName')), 0), concat(parameters('authorisedHosts'), ',', parameters('customHostName')), parameters('authorisedHosts'))]"
+        "rubyAuthHosts": "[if(greater(length(parameters('customHostName')), 0), concat(parameters('authorisedHosts'), ',', parameters('customHostName')), parameters('authorisedHosts'))]",
+        "environmentVariablesWeb": "[concat(parameters('appEnvironmentVariables'), array(json('{\"name\": \"SERVICE_TYPE\", \"value\": \"web\"}')))]",
+        "environmentVariablesClk": "[concat(parameters('appEnvironmentVariables'), array(json('{\"name\": \"SERVICE_TYPE\", \"value\": \"clock\"}')))]",
+        "environmentVariablesWkr": "[concat(parameters('appEnvironmentVariables'), array(json('{\"name\": \"SERVICE_TYPE\", \"value\": \"worker\"}')))]"
     },
     "resources": [
         {
@@ -141,7 +144,7 @@
                         "value": "[variables('appServiceRuntimeStack')]"
                     },
                     "appServiceAppSettings": {
-                        "value": "[json(replace(string(parameters('appEnvironmentVariables')), 'secureValue', 'value'))]"
+                        "value": "[json(replace(string(variables('environmentVariablesWeb')), 'secureValue', 'value'))]"
                     }
                 }
             }
@@ -179,7 +182,7 @@
                         "value": ["/bin/sh",  "-c", "bundle exec sidekiq -c 5 -C config/sidekiq.yml"]
                     },
                     "environmentVariables": {
-                        "value": "[parameters('appEnvironmentVariables')]"
+                        "value": "[variables('environmentVariablesWkr')]"
                     }
                 }
             }
@@ -217,7 +220,7 @@
                         "value": ["/bin/sh", "-c", "bundle exec clockwork config/clock.rb"]
                     },
                     "environmentVariables": {
-                        "value": "[parameters('appEnvironmentVariables')]"
+                        "value": "[variables('environmentVariablesClk')]"
                     }
                 }
             }

--- a/azure/template.json
+++ b/azure/template.json
@@ -707,10 +707,6 @@
                                 "value": "[parameters('stateChangeSlackUrl')]"
                             },
                             {
-                                "name": "SERVICE_TYPE",
-                                "value": "web"
-                            },
-                            {
                                 "name": "DFE_SIGN_IN_CLIENT_ID",
                                 "value": "[parameters('dfeSignInClientId')]"
                             },


### PR DESCRIPTION
## Context

The logs from the App Service and container instances are indistinguishable in Logit because they all report the `SERVICE_TYPE` as `web`.

## Changes proposed in this pull request

Updated the ARM templates `SERVICE_TYPE` environment variable to `web`, `clock` and `worker` on the respective resources.

## Guidance to review

Check Logit to verify that the various resources are reporting correctly. This change can also be verified by checking the environment variables in the Azure Portal.

## Link to Trello card

https://trello.com/c/0APNMvZ0/1647-fix-servicetype-var-for-clock-and-worker-processes

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
