### PR TITLE
Change how study modes are determined in SyncProviderFromFind

### DIFF
--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -244,4 +244,79 @@ RSpec.describe SyncProviderFromFind do
       end
     end
   end
+
+  describe 'CourseStudyModes#derive' do
+    context 'when the course has no course options' do
+      let(:course) { create(:course) }
+
+      it 'returns both study modes if the course supports both study modes' do
+        course.full_time_or_part_time!
+
+        study_modes = SyncProviderFromFind::CourseStudyModes.new(course).derive
+        expect(study_modes).to match_array %w(full_time part_time)
+      end
+
+      it 'returns one study mode if the course only supports one' do
+        course.full_time!
+
+        study_modes = SyncProviderFromFind::CourseStudyModes.new(course).derive
+        expect(study_modes).to match_array %w(full_time)
+      end
+    end
+
+    context 'when the course has existing course options with uniform study modes' do
+      let(:course) do
+        create(:course, :part_time) do |course|
+          course.course_options = [
+            create(:course_option, :part_time, course: course),
+            create(:course_option, :part_time, course: course),
+            create(:course_option, :part_time, course: course),
+          ]
+        end
+      end
+
+      it 'returns the existing study mode' do
+        study_modes = SyncProviderFromFind::CourseStudyModes.new(course).derive
+        expect(study_modes).to match_array %w(part_time)
+      end
+
+      it 'returns both study modes if the course changes to support both study modes' do
+        course.full_time_or_part_time!
+
+        study_modes = SyncProviderFromFind::CourseStudyModes.new(course).derive
+        expect(study_modes).to match_array %w(full_time part_time)
+      end
+
+      it 'returns both study modes if the course changes from one to the other' do
+        course.full_time!
+
+        study_modes = SyncProviderFromFind::CourseStudyModes.new(course).derive
+        expect(study_modes).to match_array %w(full_time part_time)
+      end
+    end
+
+    context 'when the course has existing course options with a mix of study modes' do
+      let(:course) do
+        create(:course, :with_both_study_modes) do |course|
+          course.course_options = [
+            create(:course_option, :part_time, course: course),
+            create(:course_option, :part_time, course: course),
+            create(:course_option, :full_time, course: course),
+          ]
+        end
+      end
+
+      it 'returns both study modes' do
+        study_modes = SyncProviderFromFind::CourseStudyModes.new(course).derive
+        expect(study_modes).to match_array %w(full_time part_time)
+      end
+
+      it 'returns both study modes even if the course changes to a specific one' do
+        course.full_time!
+
+        study_modes = SyncProviderFromFind::CourseStudyModes.new(course).derive
+        expect(study_modes).to match_array %w(full_time part_time)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Context

When we upsert course options during the sync, part of the process
involves iterating over available study modes.

Determining available study modes is currently subject to the following
issue:

- We pull a Course (C) with full_time_or_part_time study_mode.
- We create CourseOptions (O1 and O2) with full_time and part_time
  study_modes respectively.
- The study_mode of C changes to full_time because there are no longer
  any part time places.
- On next sync, we use the study_mode of C to find the associated
  CourseOptions. We find O2 because it's part time, but don't find O1.
  Therefore we don't update O1's vacancy status, which is bad because it
  remains available for applications when it's actually full.

(Shout out to @duncanjbrown for an issue description that articulates the problem more clearly than my earlier attempts.)


## Changes proposed in this pull request


Fix this by introducing an object that helps determine the appropriate
study modes list. It returns either one or both study modes depending on
the current and historical study mode of the **course.**


## Guidance to review

Changes are probably best understood by reading the specs.

![Screenshot 2020-03-25 at 13 51 01](https://user-images.githubusercontent.com/519250/77550624-42f37000-6ea9-11ea-81ed-d98cecd61058.png)

## Link to Trello card

Related to https://trello.com/c/zUcpQrGi 

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
