### PR TITLE
Fix Sentry error message for invalid course options

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -123,17 +123,16 @@ private
     course_options = course.course_options.joins(:site)
     canonical_site_codes = find_course.sites.map(&:code)
     invalid_course_options = course_options.where.not(sites: { code: canonical_site_codes })
-
     return if invalid_course_options.blank?
 
     chosen_course_option_ids = ApplicationChoice.where(course_option: invalid_course_options).pluck(:course_option_id)
 
     not_part_of_an_application = invalid_course_options.where.not(id: chosen_course_option_ids)
     not_part_of_an_application.delete_all
-
     part_of_an_application = invalid_course_options.where(id: chosen_course_option_ids)
-    part_of_an_application.update_all(invalidated_by_find: true)
+    return if part_of_an_application.size.zero?
 
+    part_of_an_application.update_all(invalidated_by_find: true)
     Raven.capture_message(
       "#{part_of_an_application.count} invalid course options chosen by candidates.",
     )


### PR DESCRIPTION


## Context

Ensure that we don't send a message to Sentry if there aren't any
invalid course options chosen as part of an application.

https://sentry.io/organizations/dfe-bat/issues/1581016838/?project=1765973&referrer=slack

## Changes proposed in this pull request

Return early if there aren't any course options that are part of an application.

## Guidance to review

n/a

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
