### PR TITLE
Improve guidance around GCSE qualifications

### DIFF
--- a/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
+++ b/app/components/candidate_interface/gcse_grade_guidance_component.html.erb
@@ -1,0 +1,38 @@
+<p class="govuk-body">
+  <%= t('gcse_edit_grade.guidance.main') %>
+</p>
+
+<% if science? %>
+  <p class="govuk-body">
+    <% if scottish_national_5? %>
+      <%= t('gcse_edit_grade.guidance.triple_scottish_national_science') %>
+    <% elsif gcse? || gce_o_level? %>
+      <%= t('gcse_edit_grade.guidance.triple_gcse_science') %>
+    <% end %>
+  </p>
+<% end %>
+
+<% if english? && (gcse? || gce_o_level?) %>
+  <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        <% type = gcse? ? 'a GCSE' : 'an O level' %>
+        <%= t('gcse_edit_grade.guidance.english_literature_only.summary', type: type) %>
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <%= t('gcse_edit_grade.guidance.english_literature_only.details') %>
+    </div>
+  </details>
+
+  <details class="govuk-details govuk-!-margin-bottom-6" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        <%= t('gcse_edit_grade.guidance.multiple_english_qualifications.summary') %>
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <%= t('gcse_edit_grade.guidance.multiple_english_qualifications.details') %>
+    </div>
+  </details>
+<% end %>

--- a/app/components/candidate_interface/gcse_grade_guidance_component.rb
+++ b/app/components/candidate_interface/gcse_grade_guidance_component.rb
@@ -1,0 +1,30 @@
+module CandidateInterface
+  class GcseGradeGuidanceComponent < ActionView::Component::Base
+    def initialize(subject, qualification_type)
+      @subject = subject
+      @qualification_type = qualification_type
+    end
+
+  private
+
+    def english?
+      @subject == 'english'
+    end
+
+    def science?
+      @subject == 'science'
+    end
+
+    def gcse?
+      @qualification_type == 'gcse'
+    end
+
+    def gce_o_level?
+      @qualification_type == 'gce_o_level'
+    end
+
+    def scottish_national_5?
+      @qualification_type == 'scottish_national_5'
+    end
+  end
+end

--- a/app/helpers/gcse_qualification_helper.rb
+++ b/app/helpers/gcse_qualification_helper.rb
@@ -5,12 +5,6 @@ module GcseQualificationHelper
     t('application_form.gcse.qualification_types').map { |id, label| option.new(id, label) }
   end
 
-  def guidance_for_gcse_edit_grade(subject, qualification_type)
-    if I18n.exists?("gcse_edit_grade.guidance.#{subject}.#{qualification_type}")
-      tag.p(t("gcse_edit_grade.guidance.#{subject}.#{qualification_type}"), class: 'govuk-body')
-    end
-  end
-
   def heading_for_gcse_edit_type(subject)
     t("gcse_edit_type.page_titles.#{subject}")
   end

--- a/app/views/candidate_interface/gcse/grade/edit.html.erb
+++ b/app/views/candidate_interface/gcse/grade/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl"><%= t('gcse_edit_grade.page_title', subject: @subject) %></h1>
 
-      <%= guidance_for_gcse_edit_grade(@subject, @qualification_type) %>
+      <%= render CandidateInterface::GcseGradeGuidanceComponent.new(@subject, @qualification_type) %>
 
       <%= f.govuk_text_field :grade, label: { text: t('application_form.gcse.grade.label'), size: 'm' }, hint_text: hint_for_gcse_edit_grade(@subject, @qualification_type), width: 10 %>
 

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -7,6 +7,18 @@ en:
   gcse_edit_grade:
     page_title: What grade is your %{subject} qualification?
     guidance:
+      main: >
+        Providers expect you to have a grade C or 4 (or the equivalent) in order
+        to train. If you don’t have this, contact your provider to discuss your
+        options. You might be able to retake an exam or do an equivalence test.
+      triple_gcse_science: If you have a combined or triple GCSE in science, enter your total grade.
+      triple_scottish_national_science: If you studied three science subjects separately or took a general science qualification, enter your total grade.
+      english_literature_only:
+        summary: If you have %{type} in English Literature only
+        details: Enter your grade here – but be aware that providers may want further evidence of your abilities in English.
+      multiple_english_qualifications:
+        summary: If you have more than one English qualification
+        details: Enter any English Literature qualifications under ‘Academic and other relevant qualifications’.
       english:
         gcse: Enter your grade for English Language GCSE. If you have a GCSE in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.
         gce_o_level: Enter your grade for English Language O level. If you have an O level in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.

--- a/config/locales/gcse_details.yml
+++ b/config/locales/gcse_details.yml
@@ -19,13 +19,6 @@ en:
       multiple_english_qualifications:
         summary: If you have more than one English qualification
         details: Enter any English Literature qualifications under ‘Academic and other relevant qualifications’.
-      english:
-        gcse: Enter your grade for English Language GCSE. If you have a GCSE in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.
-        gce_o_level: Enter your grade for English Language O level. If you have an O level in English Literature only, enter this grade – but be aware that providers may want further evidence of your abilities in English.
-      science:
-        gcse: If you have a single, double (also known as combined) or triple GCSE in science, enter your total grade.
-        gce_o_level: If you have a single, double or triple O Level in science, enter your total grade.
-        scottish_national_5: If you studied three science subjects separately or took a general science qualification, enter your total grade.
     hint:
       science:
         gcse: For example, ‘A*A*A*’, ‘AA’, ‘B’, ‘999’, ‘88’, ‘7’

--- a/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_grade_guidance_component_spec.rb
@@ -1,0 +1,167 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::GcseGradeGuidanceComponent do
+  context 'when the subject is maths' do
+    it 'displays the guidance around the expectation of providers' do
+      subject = 'maths'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+
+      expect(result.text).to include(t('gcse_edit_grade.guidance.main'))
+    end
+
+    it 'does not display the guidance around triple science' do
+      subject = 'maths'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_science'))
+    end
+
+    it 'does not display the guidance around english literature and multiple english qualifications' do
+      subject = 'maths'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+    end
+  end
+
+  context 'when the subject is science' do
+    it 'displays the guidance around the expectation of providers' do
+      subject = 'science'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+
+      expect(result.text).to include(t('gcse_edit_grade.guidance.main'))
+    end
+
+    it 'does not display the guidance around english literature and multiple english qualifications' do
+      subject = 'science'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+    end
+
+    context 'and a GCSE' do
+      it 'displays the guidance around triple GCSE science' do
+        subject = 'science'
+        qualification_type = 'gcse'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
+      end
+    end
+
+    context 'and a GCE O Level' do
+      it 'displays the guidance around triple GCSE science' do
+        subject = 'science'
+        qualification_type = 'gce_o_level'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
+      end
+    end
+
+    context 'and a Scottish National 5' do
+      it 'displays the guidance around three science subjects' do
+        subject = 'science'
+        qualification_type = 'scottish_national_5'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+      end
+    end
+
+    context 'and an other UK qualification' do
+      it 'does not display the guidance around triple science or three science subjects' do
+        subject = 'science'
+        qualification_type = 'other_uk'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_scottish_national_science'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_gcse_science'))
+      end
+    end
+  end
+
+  context 'when the subject is english' do
+    it 'displays the guidance around the expectation of providers' do
+      subject = 'english'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+
+      expect(result.text).to include(t('gcse_edit_grade.guidance.main'))
+    end
+
+    it 'does not display the guidance around triple science' do
+      subject = 'english'
+
+      result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, nil))
+
+      expect(result.text).not_to include(t('gcse_edit_grade.guidance.triple_science'))
+    end
+
+    context 'and a GCSE' do
+      it 'displays the guidance around only having english literature and more than one english qualification' do
+        subject = 'english'
+        qualification_type = 'gcse'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).to include(t('gcse_edit_grade.guidance.english_literature_only.summary', type: 'a GCSE'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.summary'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+      end
+    end
+
+    context 'and a GCE O Level' do
+      it 'displays the guidance around only having english literature and more than one english qualification' do
+        subject = 'english'
+        qualification_type = 'gce_o_level'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).to include(t('gcse_edit_grade.guidance.english_literature_only.summary', type: 'an O level'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.summary'))
+        expect(result.text).to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+      end
+    end
+
+    context 'and a Scottish National 5' do
+      it 'does not display the guidance around english literature and multiple english qualifications' do
+        subject = 'english'
+        qualification_type = 'scottish_national_5'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+      end
+    end
+
+    context 'and an other UK qualification' do
+      it 'does not display the guidance around triple science or three science subjects' do
+        subject = 'english'
+        qualification_type = 'other_uk'
+
+        result = render_inline(CandidateInterface::GcseGradeGuidanceComponent.new(subject, qualification_type))
+
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.english_literature_only.details'))
+        expect(result.text).not_to include(t('gcse_edit_grade.guidance.multiple_english_qualifications.details'))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

We have had multiple instances of candidates applying to courses they don't meet the entry requirements for. 

## Changes proposed in this pull request

This PR adds better guidance around each GCSE subject. The content for all three subjects are slightly different and sometimes depend on the qualification type. A `GcseGradeGuidanceComponent` component was created to deal with this.

Previously, we used for this `GcseQualificationHelper#guidance_for_gcse_edit_grade` but because of the tad complexity around this, a component was opted for instead and the helper removed as a result.

### Some screenshots

![image](https://user-images.githubusercontent.com/42817036/77557267-7afeb100-6eb1-11ea-9a12-57f97f193597.png)

![image](https://user-images.githubusercontent.com/42817036/77557409-a386ab00-6eb1-11ea-9e94-ab9bf0595b45.png)

![image](https://user-images.githubusercontent.com/42817036/77557476-b5684e00-6eb1-11ea-8c63-6e5af2c4f535.png)

## Guidance to review

Would recommend reviewing commit by commit, looking at the tests in particular and then checking alongside the prototype that I've considered all the permutations.

## Link to Trello card

https://trello.com/c/GIpFCnEw

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
