### PR TITLE
Prevent editing of ProviderUser email addresses until they log in for the first time

### DIFF
--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -23,7 +23,11 @@
         Edit provider user
       </h1>
 
-      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
+      <% if @form.provider_user.dfe_sign_in_uid.present? %>
+        <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
+      <% else %>
+        <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' }, disabled: true, hint_text: 'The email address is not editable until the user has signed in for the first time. This is to ensure it continues to match the email on their DfE Sign-in invitation' %>
+      <% end %>
       <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
 

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -25,9 +25,16 @@ RSpec.feature 'Managing provider users' do
     and_i_should_see_the_user_i_created
     and_the_user_should_be_sent_a_welcome_email
 
-    when_i_click_on_that_user
-    and_i_add_them_to_another_organisation
+    when_the_user_has_not_signed_in_yet
+    and_i_click_on_that_user
+    then_their_email_should_not_be_editable
+
+    when_i_add_them_to_another_organisation
     then_i_see_that_they_have_been_added_to_that_organisation
+
+    when_they_have_signed_in_at_least_once
+    and_i_reload_the_page
+    then_their_email_should_be_editable
   end
 
   def given_dfe_signin_is_configured
@@ -93,11 +100,11 @@ RSpec.feature 'Managing provider users' do
     expect(current_email.subject).to have_content t('provider_account_created.email.subject')
   end
 
-  def when_i_click_on_that_user
+  def and_i_click_on_that_user
     click_link 'harrison@example.com'
   end
 
-  def and_i_add_them_to_another_organisation
+  def when_i_add_them_to_another_organisation
     check 'Another provider (DEF)'
     click_button 'Update user'
   end
@@ -105,5 +112,25 @@ RSpec.feature 'Managing provider users' do
   def then_i_see_that_they_have_been_added_to_that_organisation
     expect(page).to have_checked_field('Example provider (ABC)')
     expect(page).to have_checked_field('Another provider (DEF)')
+  end
+
+  def when_the_user_has_not_signed_in_yet; end
+
+  def then_their_email_should_not_be_editable
+    expect(page).to have_field 'Email address', disabled: true
+    expect(page).to have_content 'The email address is not editable'
+  end
+
+  def when_they_have_signed_in_at_least_once
+    user = ProviderUser.find_by(email_address: 'harrison@example.com')
+    user.update!(dfe_sign_in_uid: 'ABC123')
+  end
+
+  def and_i_reload_the_page
+    page.refresh
+  end
+
+  def then_their_email_should_be_editable
+    expect(page).to have_field 'Email address', disabled: false
   end
 end


### PR DESCRIPTION
## Context

When a Provider user first arrives from DSI, we look their DSI email up against the list of emails in the database.

If the email in the database changes, they'll be unable to log in.

To prevent this happening in production, prevent it via the UI.

## Changes proposed in this pull request

If the user hasn't logged in yet, disable the email field and add a note

### Before

![Screenshot 2020-03-25 at 16 18 03](https://user-images.githubusercontent.com/642279/77559893-a6cf6600-6eb4-11ea-9004-ee7a44084b4c.png)

### After

![Screenshot 2020-03-25 at 16 16 47](https://user-images.githubusercontent.com/642279/77559904-a9ca5680-6eb4-11ea-8c00-7ae273a400f7.png)

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/azumou1V/1779-prevent-editing-of-provideruser-email-address-if-theyve-never-logged-in-via-dsi

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
