### PR TITLE
Split up the provider page

### DIFF
--- a/app/components/sub_navigation_component.html.erb
+++ b/app/components/sub_navigation_component.html.erb
@@ -2,7 +2,7 @@
   <ul class="moj-sub-navigation__list">
     <% items.each do |item| %>
       <li class="moj-sub-navigation__item">
-        <% if item[:current] %>
+        <% if item[:current] || current_page?(item.fetch(:url)) %>
           <%= govuk_link_to item.fetch(:name), item.fetch(:url), class: 'moj-sub-navigation__link', 'aria-current': 'page' %>
         <% else %>
           <%= govuk_link_to item.fetch(:name), item.fetch(:url), class: 'moj-sub-navigation__link' %>

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -9,9 +9,21 @@ module SupportInterface
     end
 
     def show
-      @provider = Provider.includes(:courses, :sites).find(params[:provider_id])
+      @provider = Provider.find(params[:provider_id])
       @provider_agreement = ProviderAgreement.data_sharing_agreements.for_provider(@provider).last
+    end
+
+    def courses
+      @provider = Provider.includes(:courses).find(params[:provider_id])
+    end
+
+    def vacancies
+      @provider = Provider.find(params[:provider_id])
       @course_options = @provider.course_options.includes(:course, :site)
+    end
+
+    def sites
+      @provider = Provider.includes(:courses, :sites).find(params[:provider_id])
     end
 
     def open_all_courses
@@ -30,7 +42,7 @@ module SupportInterface
       yield @provider
 
       flash[:success] = success_message
-      redirect_to support_interface_provider_path(@provider)
+      redirect_to support_interface_provider_courses_path(@provider)
     end
   end
 end

--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "#{@provider.name_and_code} - #{title}" %>
+
+<% content_for :before_content, govuk_back_link_to(support_interface_providers_path, 'Back to providers') %>
+
+<%= render SubNavigationComponent.new(items: [
+  { name: 'Details', url: support_interface_provider_path },
+  { name: 'Courses', url: support_interface_provider_courses_path },
+  { name: 'Vacancies', url: support_interface_provider_vacancies_path },
+  { name: 'Sites', url: support_interface_provider_sites_path },
+]) %>
+
+<h2 class='govuk-heading-l'><%= title %></h2>

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -1,0 +1,23 @@
+<%= render 'provider_navigation', title: 'Courses' %>
+
+<%= render(SupportInterface::ProviderSyncCoursesToggleComponent.new(provider: @provider)) %>
+
+<% if @provider.courses.any? %>
+  <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>
+    <h3 class="govuk-heading-m">
+      Open all courses
+    </h3>
+
+    <p class="govuk-body">This will toggle every course on this provider to be available through Apply.</p>
+
+    <%= f.govuk_submit "Open #{pluralize(@provider.courses.size, 'course')}" %>
+  <% end %>
+<% end %>
+
+<h2 class='govuk-heading-l'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.open_on_apply.size %> on DfE Apply)</h2>
+<%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accrediting_provider))) %>
+
+<% if @provider.accredited_courses.any? %>
+  <h2 class='govuk-heading-l'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
+  <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses)) %>
+<% end %>

--- a/app/views/support_interface/providers/show.html.erb
+++ b/app/views/support_interface/providers/show.html.erb
@@ -1,63 +1,20 @@
-<% content_for :title, @provider.name_and_code %>
-<% content_for :before_content, govuk_back_link_to(support_interface_providers_path, 'Back to providers') %>
+<%= render 'provider_navigation', title: 'Details' %>
 
-<%= render(SupportInterface::ProviderSyncCoursesToggleComponent.new(provider: @provider)) %>
-
-<% if @provider.courses.any? %>
-  <%= form_with model: @provider, url: support_interface_provider_path(@provider), method: :post do |f| %>
-    <h3 class="govuk-heading-m">
-      Data Sharing Agreement
-    </h3>
-
-    <p class="govuk-body">
-      <% if @provider_agreement %>
-        Accepted by <strong>
-        <%= @provider_agreement.provider_user.email_address %>
-        </strong>
-        on
-        <%= @provider_agreement.accepted_at.to_s(:govuk_date) %>.
-      <% else %>
-        No data sharing agreement has been accepted yet.
-      <% end %>
-    </p>
-
-    <h3 class="govuk-heading-m">
-      Open all courses
-    </h3>
-
-    <p class="govuk-body">This will toggle every course on this provider to be available through Apply.</p>
-
-    <%= f.govuk_submit "Open #{pluralize(@provider.courses.size, 'course')}" %>
+<% dsa = capture do %>
+  <% if @provider_agreement %>
+    Accepted by <strong>
+    <%= @provider_agreement.provider_user.email_address %>
+    </strong>
+    on
+    <%= @provider_agreement.accepted_at.to_s(:govuk_date) %>.
+  <% else %>
+    No data sharing agreement has been accepted yet.
   <% end %>
 <% end %>
 
-<h2 class='govuk-heading-l'>Offers <%= pluralize(@provider.courses.size, 'course') %> (<%= @provider.courses.open_on_apply.size %> on DfE Apply)</h2>
-<%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.courses.includes(:accrediting_provider))) %>
-
-<% if @provider.accredited_courses.any? %>
-  <h2 class='govuk-heading-l'>Accredits <%= pluralize(@provider.accredited_courses.size, 'course') %> (<%= @provider.accredited_courses.open_on_apply.size %> on DfE Apply)</h2>
-  <%= render(SupportInterface::ProviderCoursesTableComponent.new(provider: @provider, courses: @provider.accredited_courses)) %>
-<% end %>
-
-<h2 class='govuk-heading-l'>Course choices & vacancies</h2>
-<%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>
-
-<h2 class='govuk-heading-l'>Sites (<%= @provider.sites.size %>)</h2>
-
-<table class='govuk-table'>
-  <thead class='govuk-table__head'>
-    <tr class='govuk-table__row'>
-      <th scope='col' class='govuk-table__header'>Name</th>
-      <th scope='col' class='govuk-table__header'>Address</th>
-    </tr>
-  </thead>
-
-  <tbody class='govuk-table__body'>
-    <% @provider.sites.each do |site| %>
-      <tr class='govuk-table__row'>
-        <td class='govuk-table__cell'><%= site.name_and_code %></td>
-        <td class='govuk-table__cell'><%= site.full_address %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= render(SummaryCardComponent.new(rows: {
+  'Name' => @provider.name,
+  'Code' => @provider.code,
+  'Last updated' => @provider.updated_at.to_s(:govuk_date_and_time),
+  'Data sharing agreement' => dsa,
+})) %>

--- a/app/views/support_interface/providers/sites.html.erb
+++ b/app/views/support_interface/providers/sites.html.erb
@@ -1,0 +1,19 @@
+<%= render 'provider_navigation', title: 'Sites' %>
+
+<table class='govuk-table'>
+  <thead class='govuk-table__head'>
+    <tr class='govuk-table__row'>
+      <th scope='col' class='govuk-table__header'>Name</th>
+      <th scope='col' class='govuk-table__header'>Address</th>
+    </tr>
+  </thead>
+
+  <tbody class='govuk-table__body'>
+    <% @provider.sites.each do |site| %>
+      <tr class='govuk-table__row'>
+        <td class='govuk-table__cell'><%= site.name_and_code %></td>
+        <td class='govuk-table__cell'><%= site.full_address %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/providers/vacancies.html.erb
+++ b/app/views/support_interface/providers/vacancies.html.erb
@@ -1,0 +1,3 @@
+<%= render 'provider_navigation', title: 'Vacancies' %>
+
+<%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course_options)) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -417,7 +417,12 @@ Rails.application.routes.draw do
 
     get '/providers' => 'providers#index', as: :providers
     get '/providers/other' => 'providers#other_providers', as: :other_providers
+
     get '/providers/:provider_id' => 'providers#show', as: :provider
+    get '/providers/:provider_id/courses' => 'providers#courses', as: :provider_courses
+    get '/providers/:provider_id/vacancies' => 'providers#vacancies', as: :provider_vacancies
+    get '/providers/:provider_id/sites' => 'providers#sites', as: :provider_sites
+
     post '/providers/:provider_id' => 'providers#open_all_courses'
     post '/providers/:provider_id/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing
 

--- a/spec/system/support_interface/provider_sync_courses_spec.rb
+++ b/spec/system/support_interface/provider_sync_courses_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature 'See provider course syncing' do
 
   def when_i_click_on_a_provider
     click_link 'ABC College'
+    click_link 'Courses'
   end
 
   def then_i_see_that_course_syncing_is_off

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -15,7 +15,11 @@ RSpec.feature 'See providers' do
     and_i_should_see_the_updated_list_of_providers
 
     when_i_click_on_a_provider
-    then_i_see_the_providers_courses_and_sites
+    and_i_click_on_sites
+    then_i_see_the_provider_sites
+
+    and_i_click_on_courses
+    then_i_see_the_provider_courses
 
     when_i_click_on_a_course
     then_i_see_the_course_information
@@ -25,10 +29,12 @@ RSpec.feature 'See providers' do
 
     when_i_visit_the_providers_page
     when_i_click_on_a_provider
+    and_i_click_on_courses
     then_i_see_the_updated_providers_courses_and_sites
 
     when_i_visit_the_providers_page
     when_i_click_on_a_different_provider
+    and_i_click_on_courses
     and_i_choose_to_open_all_courses
     then_all_courses_should_be_open_on_apply
   end
@@ -119,9 +125,20 @@ RSpec.feature 'See providers' do
     click_link 'Royal Academy of Dance'
   end
 
-  def then_i_see_the_providers_courses_and_sites
-    expect(page).to have_content 'ABC-1'
+  def and_i_click_on_sites
+    click_link 'Sites'
+  end
+
+  def and_i_click_on_courses
+    click_link 'Courses'
+  end
+
+  def then_i_see_the_provider_courses
     expect(page).to have_content '1 course (0 on DfE Apply)'
+  end
+
+  def then_i_see_the_provider_sites
+    expect(page).to have_content 'Main site'
   end
 
   def when_i_click_on_a_course


### PR DESCRIPTION
## Context

The provider page has too much information on it, as you can see from this 19,472 pixel tall screenshot:

<details>
<summary>Show it</summary>

![image](https://user-images.githubusercontent.com/233676/77560361-47be2100-6eb5-11ea-837f-7e7fb35dca9c.png)

</details>

We'd like to add users and applications to this page too, so we need to reorganise a bit.

## Changes proposed in this pull request

 This splits it up into 4 separate pages, for info, courses, vacancies, and sites. In the future we'll add tabs for users and applications as well.


### After

![image](https://user-images.githubusercontent.com/233676/77560685-b1d6c600-6eb5-11ea-80ad-63370c74fa3b.png)

![image](https://user-images.githubusercontent.com/233676/77560719-ba2f0100-6eb5-11ea-9a9b-8de4b50f4843.png)

![image](https://user-images.githubusercontent.com/233676/77560732-bef3b500-6eb5-11ea-961f-1639985cc9ef.png)

![image](https://user-images.githubusercontent.com/233676/77560752-c31fd280-6eb5-11ea-80be-1392fbf36cea.png)

## Guidance to review

Does this make things better?

## Link to Trello card

https://trello.com/c/suHzTO20/1518-support-for-apply-improve-provider-users-index-view

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
