### PR TITLE
Small design tweaks

### DIFF
--- a/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
+++ b/app/components/candidate_interface/equality_and_diversity_review_component.html.erb
@@ -1,1 +1,5 @@
-<%= render(SummaryCardComponent.new(rows: equality_and_diversity_rows, border: false, editable: @editable)) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render(SummaryCardComponent.new(rows: equality_and_diversity_rows, border: false, editable: @editable)) %>
+  </div>
+</div>

--- a/app/components/safeguarding_review_component.rb
+++ b/app/components/safeguarding_review_component.rb
@@ -17,7 +17,7 @@ private
 
   def sharing_safeguarding_issues_row
     {
-      key: 'Do you want to share any information which could have an impact on your application?',
+      key: 'Do you want to share any safeguarding issues?',
       value: @safeguarding.share_safeguarding_issues,
       action: 'if you want to share any safeguarding issues',
       change_path: candidate_interface_edit_safeguarding_path,

--- a/app/frontend/styles/_summary-card.scss
+++ b/app/frontend/styles/_summary-card.scss
@@ -1,6 +1,13 @@
 .app-summary-card {
   border: 1px solid $govuk-border-colour;
-  &.no-border { border: none; }
+
+  &.no-border {
+    border: none;
+
+    .app-summary-card__body {
+      padding: 0;
+    }
+  }
 
   .app-summary-card__header {
     align-items: center;

--- a/app/views/candidate_interface/course_choices/go_to_find.html.erb
+++ b/app/views/candidate_interface/course_choices/go_to_find.html.erb
@@ -7,11 +7,15 @@
       <%= t('page_titles.find_a_course') %>
     </h1>
 
-    <p class="govuk-body-l">Search for courses near you on Find postgraduate teacher training.</p>
+    <p class="govuk-body-l">Search for courses near you on Find postgraduate teacher&nbsp;training.</p>
 
-    <%= govuk_button_link_to 'Start now', 'https://find-postgraduate-teacher-training.education.gov.uk', class: 'govuk-button--start' %>
-
-    <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_complete_path %></p>
-
+    <%= link_to 'https://find-postgraduate-teacher-training.education.gov.uk', role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-2 govuk-button--start', target: '_blank', rel: 'noopener', 'data-module': 'govuk-button', 'aria-describedby': 'find-new-window' do %>
+      <%= t('application_form.begin_button') %>
+      <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+        <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+      </svg>
+    <% end %>
+    <p class="govuk-body-s govuk-!-margin-bottom-8" id="find-new-window" aria-hidden="true">Opens in a new window</p>
+    <p class="govuk-body"><%= govuk_link_to 'Return to your application', candidate_interface_application_form_path %></p>
   </div>
 </div>

--- a/spec/components/safeguarding_review_component_spec.rb
+++ b/spec/components/safeguarding_review_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SafeguardingReviewComponent do
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
 
-      expect(result.text).to include('Do you want to share any information which could have an impact on your application?')
+      expect(result.text).to include('Do you want to share any safeguarding issues?')
       expect(result.text).to include('Yes')
       expect(result.text).to include('Relevant information')
       expect(result.text).to include('Not entered')
@@ -20,7 +20,7 @@ RSpec.describe SafeguardingReviewComponent do
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
 
-      expect(result.text).to include('Do you want to share any information which could have an impact on your application?')
+      expect(result.text).to include('Do you want to share any safeguarding issues?')
       expect(result.text).to include('No')
       expect(result.text).not_to include('Relevant information')
     end
@@ -32,7 +32,7 @@ RSpec.describe SafeguardingReviewComponent do
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
 
-      expect(result.text).to include('Do you want to share any information which could have an impact on your application?')
+      expect(result.text).to include('Do you want to share any safeguarding issues?')
       expect(result.text).to include('Yes')
       expect(result.text).to include('Relevant information')
       expect(result.text).to include('I have a criminal conviction.')


### PR DESCRIPTION
Small design issues found when reviewing the service for Apply 2:

- Add chevron to start now button that goes to Find, open link in new window as designed
- Make safeguarding review match the question we ask (we iterated the question but not the review bit)
- Fix alignment of equality check your answers section (remove padding from component when there is no border)

