### PR TITLE
Update terms of use for candidates

### DIFF
--- a/app/views/content/terms_candidate.md
+++ b/app/views/content/terms_candidate.md
@@ -4,21 +4,19 @@ Using Apply for teacher training means you agree to these terms of use.
 
 ## How to apply for teacher training courses
 
-### Stage 1: submitting your initial application(s)
+### Stage 1: submitting your initial application
 
-You can apply for up to 3 courses across Apply for teacher training and UCAS.
+You can apply for up to 3 courses across Apply for teacher training and [UCAS Teacher Training](https://www.ucas.com/teaching-in-the-uk).
 
 **You can only accept 1 offer**, even if you use both services.
 
+You can not apply for the same course on both services.
+
 ### Stage 2: trying again if your application wasn’t successful
 
-You can apply for more courses at this stage if:
+You can apply for another course at this stage if you don’t get an offer or if you choose not to accept your offer(s).
 
-* you’re rejected by your choices
-* you decline the offers you receive
-* you withdraw your application from your choices
-
-[Get Into Teaching](https://getintoteaching.education.gov.uk/get-help-and-support) can guide you through the process of applying for more courses. Contact them on Freephone 0800 389 2500, or [chat to an adviser using the online chat service](https://getintoteaching.education.gov.uk/lp/live-chat).
+[Get Into Teaching](https://getintoteaching.education.gov.uk/get-help-and-support) can guide you through the process of applying for more courses. Contact them for free on 0800 389 2500, or [chat to an adviser using the online chat service](https://getintoteaching.education.gov.uk/lp/live-chat).
 
 ### Making changes to your application
 
@@ -30,28 +28,18 @@ Once we’ve processed your request, we won’t be able to make any more changes
 
 However, you can ask us to amend your name or contact details at any point up until enrolment.
 
-Contact us at <becomingateacher@digital.education.gov.uk> if you need to make changes and we’ll let your training provider(s) know.
+Contact us at <becomingateacher@digital.education.gov.uk> if you need to make changes.
 
 ### Withdrawing your application
 
 You can withdraw your application to your course(s) at any point, even after you’ve accepted an offer.
 
-[Sign in to your account](/candidate/sign-in) and click ‘withdraw’ next to the course(s) you want to withdraw and we’ll let your training provider(s) know.
-
-### Declaring that what you’ve said is true
-
-Before you submit your application, we’ll ask you to confirm that the information you’ve given is true, complete and accurate.
+[Sign in to your account](/candidate/sign-in) and click ‘withdraw’ next to the course(s) you want to withdraw.
 
 ## How we check your suitability for working with children
 
-All candidates must agree to have an enhanced DBS check. This will show up any spent or unspent criminal convictions.
+All candidates must have an enhanced DBS check. This will show up any spent or unspent criminal convictions.
 
 Not all convictions will stop you from teaching. [Talk to your provider about their policy on criminal convictions](https://www.gov.uk/exoffenders-and-employment).
 
 Your name will also be checked against a DBS list of people who have been barred from working with children.
-
-## How you can contact us
-
-You can contact the team at <becomingateacher@digital.education.gov.uk>.
-
-We typically respond within one working day for urgent queries. It can take up to 5 working days for less urgent queries. We don’t provide support over the weekend or on public holidays.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
     data_sharing_agreement: Data sharing agreement
     accessibility: Accessibility statement
     privacy_policy: How we look after your personal data
-    terms_candidate: Terms of use for candidates
+    terms_candidate: Terms of use
     terms_provider: Terms of use for teacher training providers
     cookies_candidate: Cookies
     cookies_provider: Cookies


### PR DESCRIPTION
## Context

We received provider feedback about ensuring that candidates can't apply to the same course on both services, and about them accepting more than one offer across the different systems. As a result we want to update the terms of use.

## Changes proposed in this pull request

This PR updates the terms of use as per the Google Doc linked in the card.

### Screenshot

![image](https://user-images.githubusercontent.com/42817036/77563454-36771380-6eb9-11ea-9472-9f0b2b4d4ea4.png)

## Guidance to review

Have I made all the changes required?

## Link to Trello card

https://trello.com/c/VpB858gb

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
