### PR TITLE
Update COVID-19 guidance on application confirmation page

### DIFF
--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -23,7 +23,7 @@
     <% if FeatureFlag.active?('covid_19') %>
       <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
       <p class="govuk-body">We’ve made some changes to response deadlines to give providers more time to make decisions. This may affect your response deadlines too.</p>
-      <p class="govuk-body"><%= govuk_link_to "We’ll keep deadlines up to date on your #{t('page_titles.application_dashboard')}.", candidate_interface_application_complete_path %></p>
+      <p class="govuk-body"><%= govuk_link_to 'We’ll keep deadlines up to date on your application dashboard.', candidate_interface_application_complete_path %></p>
     <% end %>
 
     <h2 class="govuk-heading-m">Interview</h2>
@@ -31,6 +31,6 @@
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
     <p class="govuk-body">You have <%= @editable_days_count %> days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>
-    <p class="govuk-body"><%= govuk_link_to "To edit your application, return to your #{t('page_titles.application_dashboard')}.", candidate_interface_application_complete_path %></p>
+    <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
   </div>
 </div>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -31,6 +31,6 @@
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
     <p class="govuk-body">You have <%= @editable_days_count %> days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>
-    <p class="govuk-body">To edit your application, return to your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
+    <p class="govuk-body"><%= govuk_link_to "To edit your application, return to your #{t('page_titles.application_dashboard')}.", candidate_interface_application_complete_path %></p>
   </div>
 </div>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -13,12 +13,14 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">What happens next</h2>
-    <p class="govuk-body">The <%= service_name %> service will send you an email to confirm the successful submission of your application.</p>
+    <p class="govuk-body">You’ll get an email to confirm that your application has been submitted.</p>
 
     <h2 class="govuk-heading-m">References</h2>
-    <p class="govuk-body">We will also contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training provider(s).</p>
+    <p class="govuk-body">We’ll contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training provider(s).</p>
     <p class="govuk-body">We can’t send your application to your training provider(s) without your references.</p>
-    <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
+    <% unless FeatureFlag.active?('covid_19') %>
+      <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
+    <% end %>
 
     <% if FeatureFlag.active?('covid_19') %>
       <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
@@ -27,7 +29,7 @@
     <% end %>
 
     <h2 class="govuk-heading-m">Interview</h2>
-    <p class="govuk-body">If your training provider decides to offer you an interview, they will get in touch directly via email to organise a date and give you all the information you need.</p>
+    <p class="govuk-body">Your training provider will be in touch with you if they want to arrange an interview.</p>
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
     <p class="govuk-body">You have <%= @editable_days_count %> days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -21,11 +21,9 @@
     <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
 
     <% if FeatureFlag.active?('covid_19') %>
-
       <h2 class="govuk-heading-m">Coronavirus (COVID-19)</h2>
-      <p class="govuk-body">We have extended the length of time training providers have to access your application. You may also have longer to respond to training providers once all your offers are in.</p>
-      <p class="govuk-body">You can check your deadlines on your <%= govuk_link_to t('page_titles.application_dashboard'), candidate_interface_application_complete_path %>.</p>
-
+      <p class="govuk-body">We’ve made some changes to response deadlines to give providers more time to make decisions. This may affect your response deadlines too.</p>
+      <p class="govuk-body"><%= govuk_link_to "We’ll keep deadlines up to date on your #{t('page_titles.application_dashboard')}.", candidate_interface_application_complete_path %></p>
     <% end %>
 
     <h2 class="govuk-heading-m">Interview</h2>

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -221,7 +221,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_click_on_track_your_application
-    click_link t('page_titles.application_dashboard'), match: :first
+    click_link 'To edit your application, return to your application dashboard.', match: :first
   end
 
   def then_i_can_see_my_application_dashboard


### PR DESCRIPTION
## Context

We want to tweak the guidance around COVID-19 on the application confirmation page (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1703). Because:

- we ideally shouldn't say 'when all your offers are in' because they might not get any offers
- telling candidates that they and providers have 'longer than the usual amount of time' isn't that great because candidates may not be familiar with what the 'usual' is
- we should link to the application dashboard from the entire sentence for accessibility reasons

## Changes proposed in this pull request

This PR updates the guidance given about COVID-19 on the application confirmation page.

### Screenshots (Updated 26/03 11:16)

![image](https://user-images.githubusercontent.com/42817036/77640986-2f044880-6f53-11ea-9aec-4cfd499cfbb6.png)

## Guidance to review

Have the content been updated as expected?

## Link to Trello card

https://trello.com/c/mwUONZp8

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
