### PR TITLE
Add users & applications tabs to provider page

### DIFF
--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -22,6 +22,14 @@ module SupportInterface
       @course_options = @provider.course_options.includes(:course, :site)
     end
 
+    def users
+      @provider = Provider.includes(:provider_users).find(params[:provider_id])
+    end
+
+    def applications
+      @provider = Provider.find(params[:provider_id])
+    end
+
     def sites
       @provider = Provider.includes(:courses, :sites).find(params[:provider_id])
     end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -30,4 +30,8 @@ class Provider < ApplicationRecord
   def accredited_courses
     Course.where(accrediting_provider: self)
   end
+
+  def application_forms
+    ApplicationForm.where(id: application_choices.select(:application_form_id))
+  end
 end

--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -4,6 +4,8 @@
 
 <%= render SubNavigationComponent.new(items: [
   { name: 'Details', url: support_interface_provider_path },
+  { name: 'Applications', url: support_interface_provider_applications_path },
+  { name: 'Users', url: support_interface_provider_user_list_path },
   { name: 'Courses', url: support_interface_provider_courses_path },
   { name: 'Vacancies', url: support_interface_provider_vacancies_path },
   { name: 'Sites', url: support_interface_provider_sites_path },

--- a/app/views/support_interface/providers/applications.html.erb
+++ b/app/views/support_interface/providers/applications.html.erb
@@ -1,0 +1,3 @@
+<%= render 'provider_navigation', title: 'Applications' %>
+
+<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @provider.application_forms) %>

--- a/app/views/support_interface/providers/users.html.erb
+++ b/app/views/support_interface/providers/users.html.erb
@@ -1,0 +1,5 @@
+<%= render 'provider_navigation', title: 'Users' %>
+
+<%= link_to 'Add provider user', new_support_interface_provider_user_path, class: 'govuk-button' %>
+
+<%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider.provider_users)) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -422,6 +422,8 @@ Rails.application.routes.draw do
     get '/providers/:provider_id/courses' => 'providers#courses', as: :provider_courses
     get '/providers/:provider_id/vacancies' => 'providers#vacancies', as: :provider_vacancies
     get '/providers/:provider_id/sites' => 'providers#sites', as: :provider_sites
+    get '/providers/:provider_id/users' => 'providers#users', as: :provider_user_list
+    get '/providers/:provider_id/applications' => 'providers#applications', as: :provider_applications
 
     post '/providers/:provider_id' => 'providers#open_all_courses'
     post '/providers/:provider_id/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing

--- a/spec/system/support_interface/providers_spec.rb
+++ b/spec/system/support_interface/providers_spec.rb
@@ -18,6 +18,12 @@ RSpec.feature 'See providers' do
     and_i_click_on_sites
     then_i_see_the_provider_sites
 
+    when_i_click_on_users
+    then_i_see_the_provider_users
+
+    when_i_click_on_applications
+    then_i_see_the_provider_applications
+
     and_i_click_on_courses
     then_i_see_the_provider_courses
 
@@ -48,7 +54,12 @@ RSpec.feature 'See providers' do
   end
 
   def and_providers_are_configured_to_be_synced
-    create :provider, code: 'ABC', name: 'Royal Academy of Dance', sync_courses: true
+    provider = create :provider, code: 'ABC', name: 'Royal Academy of Dance', sync_courses: true
+    create(:provider_user, email_address: 'harry@example.com', providers: [provider])
+
+    course_option = create(:course_option, course: create(:course, provider: provider))
+    create(:application_choice, application_form: create(:application_form, support_reference: 'XYZ123'), course_option: course_option)
+
     create :provider, code: 'DEF', name: 'Gorse SCITT', sync_courses: true
     create :provider, code: 'GHI', name: 'Somerset SCITT Consortium', sync_courses: true
   end
@@ -133,8 +144,26 @@ RSpec.feature 'See providers' do
     click_link 'Courses'
   end
 
+  def when_i_click_on_users
+    within 'main' do
+      click_link 'Users'
+    end
+  end
+
+  def then_i_see_the_provider_users
+    expect(page).to have_content 'harry@example.com'
+  end
+
+  def when_i_click_on_applications
+    click_link 'Applications'
+  end
+
+  def then_i_see_the_provider_applications
+    expect(page).to have_content 'XYZ123'
+  end
+
   def then_i_see_the_provider_courses
-    expect(page).to have_content '1 course (0 on DfE Apply)'
+    expect(page).to have_content '2 courses (0 on DfE Apply)'
   end
 
   def then_i_see_the_provider_sites
@@ -162,7 +191,7 @@ RSpec.feature 'See providers' do
   def then_i_see_the_updated_providers_courses_and_sites
     expect(page).to have_content 'ABC-1'
     expect(page).to have_content 'Vacancies'
-    expect(page).to have_content '1 course (1 on DfE Apply)'
+    expect(page).to have_content '2 courses (1 on DfE Apply)'
     expect(page).to have_content 'Accredited body'
     expect(page).to have_content 'University of Chester'
   end


### PR DESCRIPTION
## Context

It's currently not possible to filter the applications by provider. Also not possible to see which users a provider has. Builds on https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1749.

## Changes proposed in this pull request

This was very painless because we could reuse components!

![image](https://user-images.githubusercontent.com/233676/77588857-91713080-6ee2-11ea-8e5d-d3eed474453c.png)

---

![image](https://user-images.githubusercontent.com/233676/77588875-99c96b80-6ee2-11ea-9250-d08223dcd142.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/suHzTO20/1518-support-for-apply-improve-provider-users-index-view

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
