### PR TITLE
Fix layout of timeline on provider application show page

### DIFF
--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -26,17 +26,9 @@
         download: @application_choice.application_form.support_reference
       ) %>
     </p>
-  </div>
-</div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-  <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
-  </div>
-</div>
+    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Application</h2>
 
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -28,7 +28,15 @@
     </p>
 
     <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
+  </div>
 
+  <div class="govuk-grid-column-one-third">
+    <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Application</h2>
 
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>
@@ -104,9 +112,5 @@
         <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference) %>
       <% end %>
     <% end %>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
   </div>
 </div>


### PR DESCRIPTION
## Context

Timeline was pushed down below status panel due to a merge issue.

## Changes proposed in this pull request

- Put timeline and status panel in a single grid row containing two columns

## Guidance to review

Probably best to just test it locally with different sized timelines and different window sizes.

Before:

![image](https://user-images.githubusercontent.com/450843/77633225-10985000-6f47-11ea-9a70-b3f99d6ea1d5.png)

After: 

![image](https://user-images.githubusercontent.com/450843/77633257-1c841200-6f47-11ea-9780-08b9687badeb.png)




## Link to Trello card

https://trello.com/c/nhgjhHUA/1818-provider-interface-application-timeline-is-out-of-position
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
