### PR TITLE
Content tweak on covid-19 banner

### DIFF
--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -3,7 +3,7 @@
 <% if FeatureFlag.active?('covid_19') && flash.empty? %>
   <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
     <div class="app-banner__message">
-      <h2 class="govuk-heading-m" id="success-message">There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)</h2>
+      <h2 class="govuk-heading-m" id="success-message">There might be a delay in processing your application due to the impact of coronavirus (COVID-19)</h2>
     </div>
   </div>
 <% end %>

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -100,6 +100,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
   end
 
   def and_i_should_not_see_the_covid19_banner
-    expect(page).not_to have_content 'There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)'
+    expect(page).not_to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
   end
 end

--- a/spec/system/candidate_interface/candidate_viewing_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_application_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Viewing their new application' do
   end
 
   def and_i_should_not_see_the_covid19_banner
-    expect(page).not_to have_content 'There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)'
+    expect(page).not_to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
   end
 
   def given_covid19_feature_flag_is_active
@@ -61,6 +61,6 @@ RSpec.feature 'Viewing their new application' do
   end
 
   def then_i_should_see_the_covid19_banner
-    expect(page).to have_content 'There might be a delay in processing your teacher training application due to the impact of coronavirus (COVID-19)'
+    expect(page).to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
   end
 end


### PR DESCRIPTION
## Context
We added a COVID 19 banner with the guidance for candidates in #1713, this needed some content tweak.

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
### Before
![image](https://user-images.githubusercontent.com/22743709/77324570-d9d7f500-6d0e-11ea-823e-a0703974d68a.png)

###After:
![image](https://user-images.githubusercontent.com/22743709/77633556-8997a780-6f47-11ea-8a1d-1b9a89d0a9e7.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
👓 

## Link to Trello card
<!-- http://trello.com/123-example-card -->
https://trello.com/c/lBLa3fwp/1217-dev-covid-19-candidate-banner

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
