### PR TITLE
Sync: refactor creation of Course Options

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -73,6 +73,7 @@ private
 
       find_site_status = site_statuses.find { |ss| ss.site.id == find_site.id }
 
+
       study_modes = \
         if course.both_study_modes_available?
           %i[full_time part_time]
@@ -81,7 +82,7 @@ private
         end
 
       study_modes.each do |mode|
-        course_option = CourseOption.find_or_create_by(
+        course_option = CourseOption.find_or_initialize_by(
           site: site,
           course_id: course.id,
           study_mode: mode,
@@ -91,7 +92,8 @@ private
           find_site_status.vac_status,
           course_option.study_mode,
         ).derive
-        course_option.update(vacancy_status: vacancy_status)
+
+        course_option.update!(vacancy_status: vacancy_status)
       end
     end
 


### PR DESCRIPTION
## Context

We have a validation to ensure the presence of `vacancy_status`. This means that `CourseOption.find_or_create_by` actually always fails.

Unfortunately, this doesn't raise an error in Rails but just results in a CourseOption that isn't persisted.

Luckily, we fix our own bug in the last line of the iteration, where we `update` the object and it's persisted after all (however, if something else is wrong then we silently fail because it'll return true/false).

## Changes proposed in this pull request

Make it more explicit, fail if something is wrong.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Uf5EVruU

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
