### PR TITLE
Keep track of changes to a provider and associated models

### DIFF
--- a/app/components/support_interface/audit_trail_component.rb
+++ b/app/components/support_interface/audit_trail_component.rb
@@ -2,16 +2,16 @@ module SupportInterface
   class AuditTrailComponent < ActionView::Component::Base
     include ViewHelper
 
-    validates :application_form, presence: true
+    validates :audited_thing, presence: true
 
-    def initialize(application_form:)
-      @application_form = application_form
+    def initialize(audited_thing:)
+      @audited_thing = audited_thing
     end
 
     def audits
-      application_form.own_and_associated_audits.includes(:user).order('id desc')
+      audited_thing.own_and_associated_audits.includes(:user).order('id desc')
     end
 
-    attr_reader :application_form
+    attr_reader :audited_thing
   end
 end

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -34,6 +34,10 @@ module SupportInterface
       @provider = Provider.includes(:courses, :sites).find(params[:provider_id])
     end
 
+    def history
+      @provider = Provider.find(params[:provider_id])
+    end
+
     def open_all_courses
       update_provider('Successfully updated all courses') { |provider| OpenProviderCourses.new(provider: provider).call }
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -4,6 +4,8 @@ class Course < ApplicationRecord
   has_many :application_choices, through: :course_options
   belongs_to :accrediting_provider, class_name: 'Provider', optional: true
 
+  audited associated_with: :provider
+
   validates :level, presence: true
   validates :code, uniqueness: { scope: :provider_id }
 

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -3,6 +3,9 @@ class CourseOption < ApplicationRecord
   belongs_to :site
   has_many :application_choices
 
+  audited associated_with: :provider
+  delegate :provider, to: :course
+
   validates :vacancy_status, presence: true
   validate :validate_providers
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -23,6 +23,8 @@ class Provider < ApplicationRecord
     yorkshire_and_the_humber: 'yorkshire_and_the_humber',
   }
 
+  audited
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/models/provider_agreement.rb
+++ b/app/models/provider_agreement.rb
@@ -3,6 +3,8 @@ class ProviderAgreement < ActiveRecord::Base
   belongs_to :provider_user
   attr_accessor :accept_agreement
 
+  audited associated_with: :provider
+
   validates :accept_agreement, :agreement_type, :provider, :provider_user, presence: true
   validate :provider_is_associated_with_the_user
   before_create :set_accepted_at

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,8 @@
 class Site < ApplicationRecord
   belongs_to :provider
 
+  audited associated_with: :provider
+
   validates :code, presence: true
   validates :name, presence: true
 

--- a/app/models/vendor_api_token.rb
+++ b/app/models/vendor_api_token.rb
@@ -1,6 +1,8 @@
 class VendorApiToken < ApplicationRecord
   belongs_to :provider
 
+  audited associated_with: :provider
+
   def self.create_with_random_token!(provider:)
     unhashed_token, hashed_token = Devise.token_generator.generate(VendorApiToken, :hashed_token)
     create!(hashed_token: hashed_token, provider: provider)

--- a/app/views/support_interface/application_forms/audit.html.erb
+++ b/app/views/support_interface/application_forms/audit.html.erb
@@ -26,4 +26,4 @@
   <%= govuk_link_to 'View all emails about this application', support_interface_email_log_path(application_form_id: @application_form.id) %>
 </p>
 
-<%= render SupportInterface::AuditTrailComponent.new(application_form: @application_form) %>
+<%= render SupportInterface::AuditTrailComponent.new(audited_thing: @application_form) %>

--- a/app/views/support_interface/providers/_provider_navigation.html.erb
+++ b/app/views/support_interface/providers/_provider_navigation.html.erb
@@ -9,6 +9,7 @@
   { name: 'Courses', url: support_interface_provider_courses_path },
   { name: 'Vacancies', url: support_interface_provider_vacancies_path },
   { name: 'Sites', url: support_interface_provider_sites_path },
+  { name: 'History', url: support_interface_provider_history_path },
 ]) %>
 
 <h2 class='govuk-heading-l'><%= title %></h2>

--- a/app/views/support_interface/providers/history.html.erb
+++ b/app/views/support_interface/providers/history.html.erb
@@ -1,0 +1,3 @@
+<%= render 'provider_navigation', title: 'History' %>
+
+<%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -424,6 +424,7 @@ Rails.application.routes.draw do
     get '/providers/:provider_id/sites' => 'providers#sites', as: :provider_sites
     get '/providers/:provider_id/users' => 'providers#users', as: :provider_user_list
     get '/providers/:provider_id/applications' => 'providers#applications', as: :provider_applications
+    get '/providers/:provider_id/history' => 'providers#history', as: :provider_history
 
     post '/providers/:provider_id' => 'providers#open_all_courses'
     post '/providers/:provider_id/enable_course_syncing' => 'providers#enable_course_syncing', as: :enable_provider_course_syncing

--- a/spec/components/support_interface/audit_trail_component_spec.rb
+++ b/spec/components/support_interface/audit_trail_component_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe SupportInterface::AuditTrailComponent, with_audited: true do
     end
   end
 
-  subject(:component) { described_class.new(application_form: application_form) }
+  subject(:component) { described_class.new(audited_thing: application_form) }
 
   def render_result
-    render_inline(described_class.new(application_form: application_form))
+    render_inline(described_class.new(audited_thing: application_form))
   end
 
   it 'renders a create application form audit record' do

--- a/spec/system/provider_interface/provider_history_spec.rb
+++ b/spec/system/provider_interface/provider_history_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider history', with_audited: true do
+  include DfESignInHelpers
+
+  scenario 'Provider user makes and reviews changes' do
+    given_i_am_a_support_user
+
+    when_a_course_is_created_and_updated
+    and_a_related_record_is_created
+    and_i_visit_the_provider_history
+    then_i_see_the_changes
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def when_a_course_is_created_and_updated
+    @provider = create(:provider)
+    @provider.update!(sync_courses: true)
+  end
+
+  def and_a_related_record_is_created
+    create(:site, provider: @provider)
+  end
+
+  def and_i_visit_the_provider_history
+    visit support_interface_provider_history_path(@provider)
+  end
+
+  def then_i_see_the_changes
+    expect(page).to have_content 'Create Provider'
+    expect(page).to have_content 'Update Provider'
+    expect(page).to have_content 'Create Site'
+  end
+end


### PR DESCRIPTION
## Context

The syncing of providers and courses has grown in complexity. In order to keep track of what the background sync process is changing, it'll be useful to have a an audit log.

## Changes proposed in this pull request

This adds auditing to all provider-related models and exposes it in support. Reuses the audit trail component #synergy.

![image](https://user-images.githubusercontent.com/233676/77645512-ba350c80-6f5a-11ea-856c-1d67d02156b4.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/Uf5EVruU

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
