### PR TITLE
Fix GCSE qualifications design

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.html.erb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.html.erb
@@ -3,7 +3,7 @@
     <% title = if @application_qualification.missing_qualification?
                  t('application_form.gcse.qualification_types.missing')
                else
-                 t('application_form.gcse.qualification_types.gcse')
+                 t("application_form.gcse.qualification_types.#{application_qualification.qualification_type.downcase}")
                end %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: @heading_level)) %>
   <% end %>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -12,6 +12,7 @@
 
       <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { size: 'm', text: t('application_form.gcse.qualification_type.label'), tag: 'span' } do %>
         <% select_gcse_qualification_type_options.each_with_index do |option, i| %>
+          <%= f.govuk_radio_divider if i == select_gcse_qualification_type_options.count - 1 %>
           <% if option.id == :other_uk %>
 
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>


### PR DESCRIPTION
## Context
#### The bugs
- The heading of the summary card for the qualifications should reflect the qualification type, not say ‘GCSE’. So if a user selects ‘GCE O Level’, that’s what should appear as the card title.

- On the qualification type page, there should be an ‘or’ divider before the last option.
## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
### Before
![image](https://user-images.githubusercontent.com/22743709/77650898-eacd7400-6f63-11ea-92dc-62eb20c29f32.png)

![image](https://user-images.githubusercontent.com/22743709/77650925-f3be4580-6f63-11ea-9751-32673e933629.png)


### After

![image](https://user-images.githubusercontent.com/22743709/77650793-d6897700-6f63-11ea-8247-715377a6a147.png)

![image](https://user-images.githubusercontent.com/22743709/77650839-dee1b200-6f63-11ea-9749-9cef22d3387b.png)


## Guidance to review
👀 
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/gYaHY1qn/1251-fix-gcse-qualifications-design
## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
