### PR TITLE
Implement the new design for applications in the provider applications index page

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -1,20 +1,20 @@
 <div class="app-application-card">
 
   <div class="app-application-card__primary">
-    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">
+    <h3 id="applicant-name-<%= index %>" class="govuk-heading-m govuk-!-margin-bottom-3">
       <%= link_to candidate_name, provider_interface_application_choice_path(application_choice), class: 'govuk-link' %>
     </h3>
-    <p class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
-    <p class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
-    <p class="govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider %></p>
+    <p id="course-provider-name-<%= index %>" class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
+    <p id="course-name-and-code-<%= index %>" class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
+    <p id="accredited-body-<%= index %>" class="govuk-body govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider.name if accrediting_provider %></p>
   </div>
 
   <div class="app-application-card__secondary">
-    <div class="app-application-card__status">
+    <div id="status-<%= index %>" class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
     </div>
     <div>
-      <p class="govuk-!-margin-bottom-0 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
+      <p id="updated-at-<%= index %>" class="govuk-!-margin-bottom-0 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
     </div>
   </div>
 </div>

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -13,8 +13,6 @@
     <div id="status-<%= index %>" class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
     </div>
-    <div>
-      <p id="updated-at-<%= index %>" class="govuk-!-margin-bottom-0 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
-    </div>
+    <p id="updated-at-<%= index %>" class="govuk-!-margin-bottom-1 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
   </div>
 </div>

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -1,0 +1,20 @@
+<div class="app-application-card">
+
+  <div class="app-application-card__primary">
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">
+      <%= link_to candidate_name, provider_interface_application_choice_path(application_choice), class: 'govuk-link' %>
+    </h3>
+    <p class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
+    <p class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
+    <p class="govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider %></p>
+  </div>
+
+  <div class="app-application-card__secondary">
+    <div class="app-application-card__status">
+      <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
+    </div>
+    <div>
+      <p class="govuk-!-margin-bottom-0 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
+    </div>
+  </div>
+</div>

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -6,7 +6,9 @@
     </h3>
     <p id="course-provider-name-<%= index %>" class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
     <p id="course-name-and-code-<%= index %>" class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
-    <p id="accredited-body-<%= index %>" class="govuk-body govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider.name if accrediting_provider %></p>
+    <% if accrediting_provider %>
+      <p id="accredited-body-<%= index %>" class="govuk-body govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider.name %> </p>
+    <% end %>
   </div>
 
   <div class="app-application-card__secondary">

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -7,7 +7,9 @@
     <p class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
     <p class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
     <% if accrediting_provider %>
-      <p class="govuk-body govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider.name %> </p>
+      <p class="govuk-body govuk-caption-m govuk-!-font-size-16 app-application-card__accredited-body">
+      Accredited body: <%= accrediting_provider.name %>
+      </p>
     <% end %>
   </div>
 

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -1,22 +1,35 @@
-<div data-qa="application-card-<%= index %>"class="app-application-card">
+<div class="app-application-card">
 
-  <div class="app-application-card__primary">
-    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">
-      <%= link_to candidate_name, provider_interface_application_choice_path(application_choice), class: 'govuk-link' %>
-    </h3>
-    <p class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
-    <p class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
-    <% if accrediting_provider %>
-      <p class="govuk-body govuk-caption-m govuk-!-font-size-16 app-application-card__accredited-body">
-      Accredited body: <%= accrediting_provider.name %>
-      </p>
-    <% end %>
-  </div>
-
-  <div class="app-application-card__secondary">
+  <h3 class="govuk-heading-m">
+    <%= link_to candidate_name, provider_interface_application_choice_path(application_choice), class: 'govuk-link' %>
     <div class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
+    <div>
+  </h3>
+
+  <dl>
+    <div class="app-application-card__provider" >
+      <dt class="govuk-visually-hidden">Provider:</dt>
+      <dd class="govuk-body"><%= course_provider_name %></dd>
     </div>
-    <p class="govuk-!-margin-bottom-1 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
-  </div>
+
+    <dt class="govuk-visually-hidden">Course:</dt>
+    <dd class="govuk-body"><%= course_name_and_code %></dd>
+
+    <div class="app-application-card__footer">
+      <div class="app-application-card__secondary">
+        <dt class="govuk-body">Accredited body:</dt>
+        <dd class="govuk-body">
+          <%= accrediting_provider.nil? ? course_provider_name : accrediting_provider.name %>
+        </dd>
+      </div>
+
+      <div class="app-application-card__secondary">
+        <div class="app-application-card__date">
+          <dt class="govuk-visually-hidden">Date:</dt>
+          <dd class="govuk-body">Updated on <%= updated_at %></dd>
+        </div>
+      </div>
+    </div>
+  </dl>
 </div>

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -1,7 +1,7 @@
 <div class="app-application-card">
 
   <h3 class="govuk-heading-m">
-    <%= link_to candidate_name, provider_interface_application_choice_path(application_choice), class: 'govuk-link' %>
+    <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice) %>
     <div class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
     <div>

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -1,20 +1,20 @@
-<div class="app-application-card">
+<div data-qa="application-card-<%= index %>"class="app-application-card">
 
   <div class="app-application-card__primary">
-    <h3 id="applicant-name-<%= index %>" class="govuk-heading-m govuk-!-margin-bottom-3">
+    <h3 class="govuk-heading-m govuk-!-margin-bottom-3">
       <%= link_to candidate_name, provider_interface_application_choice_path(application_choice), class: 'govuk-link' %>
     </h3>
-    <p id="course-provider-name-<%= index %>" class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
-    <p id="course-name-and-code-<%= index %>" class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
+    <p class="govuk-body govuk-!-font-size-16"><%= course_provider_name %></p>
+    <p class="govuk-body govuk-!-margin-bottom-0"><%= course_name_and_code %></p>
     <% if accrediting_provider %>
-      <p id="accredited-body-<%= index %>" class="govuk-body govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider.name %> </p>
+      <p class="govuk-body govuk-caption-m govuk-!-font-size-16">Accredited body: <%= accrediting_provider.name %> </p>
     <% end %>
   </div>
 
   <div class="app-application-card__secondary">
-    <div id="status-<%= index %>" class="app-application-card__status">
+    <div class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
     </div>
-    <p id="updated-at-<%= index %>" class="govuk-!-margin-bottom-1 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
+    <p class="govuk-!-margin-bottom-1 govuk-caption-m govuk-!-font-size-16">Updated on <%= updated_at %></p>
   </div>
 </div>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -1,0 +1,16 @@
+module ProviderInterface
+  class ApplicationCardComponent < ActionView::Component::Base
+
+    attr_accessor :accrediting_provider, :application_choice, :application_choice_path,
+                  :candidate_name, :course_name_and_code, :course_provider_name, :updated_at
+
+    def initialize(application_choice:)
+      @accrediting_provider = application_choice.accrediting_provider
+      @application_choice = application_choice
+      @candidate_name = application_choice.application_form.full_name
+      @course_name_and_code = application_choice.offered_course.name_and_code
+      @course_provider_name = application_choice.offered_course.provider.name
+      @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
+    end
+  end
+end

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -2,14 +2,15 @@ module ProviderInterface
   class ApplicationCardComponent < ActionView::Component::Base
 
     attr_accessor :accrediting_provider, :application_choice, :application_choice_path,
-                  :candidate_name, :course_name_and_code, :course_provider_name, :updated_at
+                  :candidate_name, :course_name_and_code, :course_provider_name, :index, :updated_at
 
-    def initialize(application_choice:)
+    def initialize(application_choice:, index:)
       @accrediting_provider = application_choice.accrediting_provider
       @application_choice = application_choice
       @candidate_name = application_choice.application_form.full_name
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
+      @index = index
       @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
     end
   end

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -1,6 +1,5 @@
 module ProviderInterface
   class ApplicationCardComponent < ActionView::Component::Base
-
     attr_accessor :accrediting_provider, :application_choice, :application_choice_path,
                   :candidate_name, :course_name_and_code, :course_provider_name, :index, :updated_at
 

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ApplicationCardComponent < ActionView::Component::Base
+    include ViewHelper
+
     attr_accessor :accrediting_provider, :application_choice, :application_choice_path,
                   :candidate_name, :course_name_and_code, :course_provider_name, :updated_at
 

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -1,15 +1,14 @@
 module ProviderInterface
   class ApplicationCardComponent < ActionView::Component::Base
     attr_accessor :accrediting_provider, :application_choice, :application_choice_path,
-                  :candidate_name, :course_name_and_code, :course_provider_name, :index, :updated_at
+                  :candidate_name, :course_name_and_code, :course_provider_name, :updated_at
 
-    def initialize(application_choice:, index:)
+    def initialize(application_choice:)
       @accrediting_provider = application_choice.accrediting_provider
       @application_choice = application_choice
       @candidate_name = application_choice.application_form.full_name
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
-      @index = index
       @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
     end
   end

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -1,4 +1,4 @@
-  <div class="moj-filter-layout__filter">
+  <div class="moj-filter-layout__filter app-filter">
     <div class="moj-filter" tabindex="-1">
       <div class="moj-filter__header">
         <div class="moj-filter__header-title">

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -1,0 +1,70 @@
+.app-application-card {
+  border-bottom: 1px solid govuk-colour('mid-grey');
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  // position: relative;
+  @include govuk-media-query($from: tablet) {
+    // overflow: hidden;
+    display: flex;
+    align-items: stretch;
+  }
+}
+
+.app-application-card:first-of-type {
+  border-top: 1px solid govuk-colour('mid-grey');
+  padding-top: 15px;
+}
+
+.app-application-card__primary {
+  @include govuk-media-query($from: tablet) {
+    width: 60%;
+  }
+
+  p {
+    margin-bottom: 0;
+  }
+}
+
+.app-application-card__secondary {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 40%;
+    text-align: right;
+  }
+}
+
+.app-application-card__status {
+  margin-bottom: govuk-spacing(2);
+  margin-top: govuk-spacing(3);
+  @include govuk-media-query($from: tablet) {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+.app-application-card__note {
+  margin-bottom: govuk-spacing(1);
+  @include govuk-font(16);
+}
+
+.app-application-card__note {
+  padding-left: 15px;
+  display: inline-block;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  color: govuk-colour('black');
+  position: relative;
+}
+
+.app-application-card__note:before {
+  border-radius: 25px;
+  height: 10px;
+  width: 10px;
+  background: govuk-colour('black');
+  content: " ";
+  position: absolute;
+  left: 0;
+  top: 6px;
+}

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -1,72 +1,53 @@
-.app-application-card {
-  border-bottom: 1px solid govuk-colour('mid-grey');
-  margin-bottom: govuk-spacing(3);
-  padding-bottom: govuk-spacing(3);
-  @include govuk-media-query($from: tablet) {
-    display: flex;
-    align-items: stretch;
-  }
-}
-
 .app-application-card:first-of-type {
   border-top: 1px solid govuk-colour('mid-grey');
   padding-top: govuk-spacing(3);
 }
 
-.app-application-card__primary {
-  @include govuk-media-query($from: tablet) {
-    width: 60%;
+.app-application-card {
+  border-bottom: 1px solid govuk-colour('mid-grey');
+  margin-bottom: govuk-spacing(3);
+
+  &__footer {
+    @include govuk-media-query($from: tablet) {
+      display: flex;
+    }
+
+    display: inline;
   }
 
-  p {
-    margin-bottom: 0;
+  &__secondary {
+    width: 100%;
+
+    dd, dt {
+      font-size: govuk-font(16);
+      color: govuk-colour('mid-grey');
+      display: inline;
+    }
+
+  }
+
+  &__provider {
+    dd {
+      font-size: govuk-font(16);
+    }
+  }
+
+  &__date {
+    dd {
+      display: flex;
+      @include govuk-media-query($from: tablet) {
+        float: right;
+      }
+    }
+  }
+
+  &__status {
+    float: right;
+  }
+
+  dd {
+    margin: 0;
   }
 }
 
-.app-application-card__secondary {
-  @include govuk-media-query($from: tablet) {
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-    width: 40%;
-    text-align: right;
-  }
-}
 
-.app-application-card__accredited-body {
-  color: govuk-colour('dark-grey');
-}
-
-.app-application-card__status {
-  margin-bottom: govuk-spacing(2);
-  margin-top: govuk-spacing(3);
-  @include govuk-media-query($from: tablet) {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-}
-
-.app-application-card__note {
-  margin-bottom: govuk-spacing(1);
-  @include govuk-font(16);
-}
-
-.app-application-card__note {
-  padding-left: govuk-spacing(3);
-  display: inline-block;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  color: govuk-colour('black');
-  position: relative;
-}
-
-.app-application-card__note:before {
-  border-radius: govuk-spacing(5);
-  height: govuk-spacing(2);
-  width: govuk-spacing(2);
-  background: govuk-colour('black');
-  content: " ";
-  position: absolute;
-  left: 0;
-  top: 6px;
-}

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -2,9 +2,7 @@
   border-bottom: 1px solid govuk-colour('mid-grey');
   margin-bottom: 15px;
   padding-bottom: 15px;
-  // position: relative;
   @include govuk-media-query($from: tablet) {
-    // overflow: hidden;
     display: flex;
     align-items: stretch;
   }

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -33,6 +33,10 @@
   }
 }
 
+.app-application-card__accredited-body {
+  color: govuk-colour('dark-grey');
+}
+
 .app-application-card__status {
   margin-bottom: govuk-spacing(2);
   margin-top: govuk-spacing(3);

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -20,7 +20,7 @@
 
     dd, dt {
       font-size: govuk-font(16);
-      color: govuk-colour('mid-grey');
+      color: govuk-colour('dark-grey');
       display: inline;
     }
 

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -37,6 +37,7 @@
       display: flex;
       @include govuk-media-query($from: tablet) {
         float: right;
+        display: inline
       }
     }
   }

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -1,7 +1,7 @@
 .app-application-card {
   border-bottom: 1px solid govuk-colour('mid-grey');
-  margin-bottom: 15px;
-  padding-bottom: 15px;
+  margin-bottom: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
   @include govuk-media-query($from: tablet) {
     display: flex;
     align-items: stretch;
@@ -10,7 +10,7 @@
 
 .app-application-card:first-of-type {
   border-top: 1px solid govuk-colour('mid-grey');
-  padding-top: 15px;
+  padding-top: govuk-spacing(3);
 }
 
 .app-application-card__primary {
@@ -52,7 +52,7 @@
 }
 
 .app-application-card__note {
-  padding-left: 15px;
+  padding-left: govuk-spacing(3);
   display: inline-block;
   padding-top: 1px;
   padding-bottom: 1px;
@@ -61,9 +61,9 @@
 }
 
 .app-application-card__note:before {
-  border-radius: 25px;
-  height: 10px;
-  width: 10px;
+  border-radius: govuk-spacing(5);
+  height: govuk-spacing(2);
+  width: govuk-spacing(2);
   background: govuk-colour('black');
   content: " ";
   position: absolute;

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -31,7 +31,7 @@
 }
 
 .app-filter {
-  @include govuk-media-query($until: filter_hide) {
+  @include govuk-media-query($until: large) {
     display: none;
   }
 }

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -31,7 +31,7 @@
 }
 
 .app-filter {
-  @include govuk-media-query($until: desktop) {
+  @include govuk-media-query($until: filter_hide) {
     display: none;
   }
 }

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -31,7 +31,8 @@
 }
 
 .app-filter {
-  @include govuk-media-query($until: large) {
-    display: none;
+  display: none;
+  @include govuk-media-query($from: large) {
+    display: block;
   }
 }

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -29,3 +29,9 @@
 .moj-filter__options {
   box-shadow: none;
 }
+
+.app-filter {
+  @include govuk-media-query($until: desktop) {
+    display: none;
+  }
+}

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -3,3 +3,7 @@
     max-width: 1220px;
   }
 }
+
+.moj-action-bar {
+  overflow: hidden;
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -49,6 +49,7 @@ $govuk-breakpoints: (
 @import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
 @import "_filter";
 @import "_provider";
+@import "_application-card";
 
 // Support
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -13,7 +13,7 @@ $govuk-image-url-function: frontend-image-url;
 $govuk-breakpoints: (
   mobile:  320px,
   tablet:  641px,
-  filter_hide: 945px,
+  large: 945px,
   desktop: 769px,
   wide:    1300px
 );

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -13,6 +13,7 @@ $govuk-image-url-function: frontend-image-url;
 $govuk-breakpoints: (
   mobile:  320px,
   tablet:  641px,
+  filter_hide: 945px,
   desktop: 769px,
   wide:    1300px
 );

--- a/app/services/get_application_choices_for_providers.rb
+++ b/app/services/get_application_choices_for_providers.rb
@@ -20,6 +20,6 @@ class GetApplicationChoicesForProviders
       .where('courses.provider_id' => providers)
       .or(ApplicationChoice.includes(*includes)
         .where('courses.accrediting_provider_id' => providers))
-      .where('status IN (?)', ApplicationStateChange.states_visible_to_provider)
+      .where('status IN (?)', ApplicationStateChange.states_visible_to_provider).includes([:accrediting_provider])
   end
 end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -3,7 +3,7 @@
 
 <% if FeatureFlag.active?('covid_19') %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-full">
       <div class="app-banner" aria-labelledby="success-message" data-module="govuk-error-summary" role="alert">
         <div class="app-banner__message">
           <h2 class="govuk-heading-m" id="success-message">
@@ -33,12 +33,10 @@
       <div class='moj-scrollable-pane'>
         <div class='moj-scrollable-pane__wrapper'>
         <% if @application_choices.any? %>
-          <div>
-            <div class="app-application-cards">
-              <% @application_choices.each_with_index do |choice, index| %>
-                <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, index: index) %>
-              <% end %>
-            </div>
+          <div class="app-application-cards">
+            <% @application_choices.each_with_index do |choice, index| %>
+              <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, index: index) %>
+            <% end %>
           </div>
         <% elsif @page_state.filter_selections.any? %>
           <p class='govuk-body'>No applications for the selected filters.</p>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -35,7 +35,7 @@
         <% if @application_choices.any? %>
           <div class="app-application-cards">
             <% @application_choices.each_with_index do |choice, index| %>
-              <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, index: index) %>
+              <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
             <% end %>
           </div>
         <% elsif @page_state.filter_selections.any? %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -35,7 +35,13 @@
       <div class='moj-scrollable-pane'>
         <div class='moj-scrollable-pane__wrapper'>
         <% if @application_choices.any? %>
-          <%= render 'application_choices_table' %>
+          <div>
+            <div class="app-application-cards">
+              <% @application_choices.each do |choice| %>
+                <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
+              <% end %>
+            </div>
+          </div>
         <% elsif @page_state.filter_selections.any? %>
           <p class='govuk-body'>No applications for the selected filters.</p>
         <% else %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -30,15 +30,13 @@
     <% end %>
 
     <div class='moj-filter-layout__content'>
-      <%= render ProviderInterface::ToggleFilterComponent.new(filter_visible: @page_state.filter_visible,
-                                                              params_for_current_state: @page_state.to_h) %>
       <div class='moj-scrollable-pane'>
         <div class='moj-scrollable-pane__wrapper'>
         <% if @application_choices.any? %>
           <div>
             <div class="app-application-cards">
-              <% @application_choices.each do |choice| %>
-                <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
+              <% @application_choices.each_with_index do |choice, index| %>
+                <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice, index: index) %>
               <% end %>
             </div>
           </div>

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -10,12 +10,19 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
            name: 'Hoth Teacher Training')
   end
 
+  let(:accrediting_provider) do
+    create(:provider,
+           :with_signed_agreement,
+           code: 'XYZ',
+           name: 'Yavin University')
+  end
+
   let(:course_option) do
     course_option_for_provider(provider: current_provider,
                                course: create(:course,
                                               name: 'Alchemy',
                                               provider: current_provider,
-                                              accrediting_provider: current_provider))
+                                              accrediting_provider: accrediting_provider))
   end
 
   let(:application_choice) do
@@ -28,37 +35,58 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
                                                          updated_at: Date.parse('25-03-2020'))
   end
 
-  let(:result) { render_inline described_class.new(application_choice: application_choice, index: 1) }
+  let(:result) { render_inline described_class.new(application_choice: application_choice) }
 
-  let(:card) { result.css('[data-qa=application-card-1]') }
-
-  let(:card_primary) { card.css('> div.app-application-card__primary') }
-
-  let(:card_secondary) { card.css('> div.app-application-card__secondary') }
+  let(:card) { result.css('.app-application-card').to_html }
 
   describe 'rendering' do
     it 'renders the name of the candidate' do
-      expect(card_primary.css('> h3').text).to include('Jim James')
+      expect(card).to include('Jim James')
     end
 
     it 'renders the name of education provider' do
-      expect(card_primary.css('> p:nth-of-type(1)').text).to include('Hoth Teacher Training')
+      expect(card).to include('Hoth Teacher Training')
     end
 
     it 'renders the name of the course' do
-      expect(card_primary.css('> p:nth-of-type(2)').text).to include('Alchemy')
+      expect(card).to include('Alchemy')
     end
 
     it 'renders the name of the accredited provider' do
-      expect(card_primary.css('> p:nth-of-type(3)').text).to include('Hoth Teacher Training')
+      expect(card).to include('Yavin University')
     end
 
     it 'renders the status of the application' do
-      expect(card_secondary.css('> div').text).to include('Application withdrawn')
+      expect(card).to include('Application withdrawn')
     end
 
     it 'renders the last updated date' do
-      expect(card_secondary.css('> p').text).to include('25 Mar 2020')
+      expect(card).to include('25 Mar 2020')
+    end
+
+    context 'when there is no accrediting provider' do
+      let(:course_option_without_accrediting_provider) do
+        course_option_for_provider(provider: current_provider,
+                                   course: create(:course,
+                                                  name: 'Baking',
+                                                  provider: current_provider))
+      end
+
+      let(:application_choice_without_accrediting_provider) do
+        create(:application_choice,
+               :awaiting_provider_decision,
+               course_option: course_option_without_accrediting_provider,
+               status: 'withdrawn', application_form: create(:application_form,
+                                                             first_name: 'Jim',
+                                                             last_name: 'James'),
+                                                             updated_at: Date.parse('25-03-2020'))
+      end
+
+      let(:result) { render_inline described_class.new(application_choice: application_choice_without_accrediting_provider) }
+
+      it 'renders the course provider name instead' do
+        expect(result.css('.app-application-card__secondary').text).to include('Hoth Teacher Training')
+      end
     end
   end
 end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ApplicationCardComponent do
+  include CourseOptionHelpers
+
+  describe 'rendering' do
+    it 'renders what it should' do
+      current_provider = create(:provider,
+                                :with_signed_agreement,
+                                code: 'ABC',
+                                name: 'Hoth Teacher Training')
+
+      course_option = course_option_for_provider(provider: current_provider,
+                                                     course: create(:course,
+                                                                    name: 'Alchemy',
+                                                                    provider: current_provider,
+                                                                    accrediting_provider: current_provider))
+
+      application_choice = create(:application_choice,
+                                  :awaiting_provider_decision,
+                                  course_option: course_option,
+                                  status: 'withdrawn', application_form: create(:application_form,
+                                                                                first_name: 'Jim',
+                                                                                last_name: 'James'),
+                                                                                updated_at: Date.parse('25-03-2020'))
+
+      result = render_inline described_class.new(application_choice: application_choice, index: 1)
+
+      expect(result.css('#applicant-name-1').text).to include('Jim James')
+      expect(result.css('#course-provider-name-1').text).to include('Hoth Teacher Training')
+      expect(result.css('#course-name-and-code-1').text).to include('Alchemy')
+      expect(result.css('#accredited-body-1').text).to include('Hoth Teacher Training')
+      expect(result.css('#status-1').text).to include('Application withdrawn')
+      expect(result.css('#updated-at-1').text).to include('25 Mar 2020')
+    end
+  end
+end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -3,38 +3,61 @@ require 'rails_helper'
 RSpec.describe ProviderInterface::ApplicationCardComponent do
   include CourseOptionHelpers
 
+  let(:current_provider) do
+    create(:provider,
+           :with_signed_agreement,
+           code: 'ABC',
+           name: 'Hoth Teacher Training')
+  end
+
+  let(:course_option) do
+    course_option_for_provider(provider: current_provider,
+                               course: create(:course,
+                                              name: 'Alchemy',
+                                              provider: current_provider,
+                                              accrediting_provider: current_provider))
+  end
+
+  let(:application_choice) do
+    create(:application_choice,
+           :awaiting_provider_decision,
+           course_option: course_option,
+           status: 'withdrawn', application_form: create(:application_form,
+                                                         first_name: 'Jim',
+                                                         last_name: 'James'),
+                                                         updated_at: Date.parse('25-03-2020'))
+  end
+
+  let(:result) { render_inline described_class.new(application_choice: application_choice, index: 1) }
+
+  let(:card) { result.css('[data-qa=application-card-1]') }
+
+  let(:card_primary) { card.css('> div.app-application-card__primary') }
+
+  let(:card_secondary) { card.css('> div.app-application-card__secondary') }
+
   describe 'rendering' do
-    it 'renders what it should' do
-      current_provider = create(:provider,
-                                :with_signed_agreement,
-                                code: 'ABC',
-                                name: 'Hoth Teacher Training')
-
-      course_option = course_option_for_provider(provider: current_provider,
-                                                     course: create(:course,
-                                                                    name: 'Alchemy',
-                                                                    provider: current_provider,
-                                                                    accrediting_provider: current_provider))
-
-      application_choice = create(:application_choice,
-                                  :awaiting_provider_decision,
-                                  course_option: course_option,
-                                  status: 'withdrawn', application_form: create(:application_form,
-                                                                                first_name: 'Jim',
-                                                                                last_name: 'James'),
-                                                                                updated_at: Date.parse('25-03-2020'))
-
-      result = render_inline described_class.new(application_choice: application_choice, index: 1)
-
-      card = result.css('[data-qa=application-card-1]')
-      card_primary = card.css('> div.app-application-card__primary')
-      card_secondary = card.css('> div.app-application-card__secondary')
-
+    it 'renders the name of the candidate' do
       expect(card_primary.css('> h3').text).to include('Jim James')
+    end
+
+    it 'renders the name of education provider' do
       expect(card_primary.css('> p:nth-of-type(1)').text).to include('Hoth Teacher Training')
+    end
+
+    it 'renders the name of the course' do
       expect(card_primary.css('> p:nth-of-type(2)').text).to include('Alchemy')
+    end
+
+    it 'renders the name of the accredited provider' do
       expect(card_primary.css('> p:nth-of-type(3)').text).to include('Hoth Teacher Training')
+    end
+
+    it 'renders the status of the application' do
       expect(card_secondary.css('> div').text).to include('Application withdrawn')
+    end
+
+    it 'renders the last updated date' do
       expect(card_secondary.css('> p').text).to include('25 Mar 2020')
     end
   end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -26,12 +26,16 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
       result = render_inline described_class.new(application_choice: application_choice, index: 1)
 
-      expect(result.css('#applicant-name-1').text).to include('Jim James')
-      expect(result.css('#course-provider-name-1').text).to include('Hoth Teacher Training')
-      expect(result.css('#course-name-and-code-1').text).to include('Alchemy')
-      expect(result.css('#accredited-body-1').text).to include('Hoth Teacher Training')
-      expect(result.css('#status-1').text).to include('Application withdrawn')
-      expect(result.css('#updated-at-1').text).to include('25 Mar 2020')
+      card = result.css('[data-qa=application-card-1]')
+      card_primary = card.css('> div.app-application-card__primary')
+      card_secondary = card.css('> div.app-application-card__secondary')
+
+      expect(card_primary.css('> h3').text).to include('Jim James')
+      expect(card_primary.css('> p:nth-of-type(1)').text).to include('Hoth Teacher Training')
+      expect(card_primary.css('> p:nth-of-type(2)').text).to include('Alchemy')
+      expect(card_primary.css('> p:nth-of-type(3)').text).to include('Hoth Teacher Training')
+      expect(card_secondary.css('> div').text).to include('Application withdrawn')
+      expect(card_secondary.css('> p').text).to include('25 Mar 2020')
     end
   end
 end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -13,13 +13,6 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_visit_the_provider_page
 
-    then_i_expect_to_see_the_hide_filter_button
-    then_i_expect_to_see_the_filter_dialogue
-
-    when_i_hide_the_filter_dialogue
-    then_i_do_not_expect_to_see_the_filter_dialogue
-
-    when_i_show_the_filter_dialogue
     then_i_expect_to_see_the_filter_dialogue
 
     when_i_filter_for_rejected_applications
@@ -29,24 +22,11 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_filter_for_applications_that_i_do_not_have
     then_i_should_see_the_no_filter_results_error_message
-    then_i_expect_to_see_the_hide_filter_button
     then_i_expect_to_see_the_filter_dialogue
 
     when_i_filter_for_rejected_and_offered_applications
-    when_i_hide_the_filter_dialogue
-    then_only_rejected_and_offered_applications_should_be_visible
-    when_i_show_the_filter_dialogue
     then_only_rejected_and_offered_applications_should_be_visible
 
-    when_i_sort_by_name
-    then_only_rejected_and_offered_applications_should_be_visible
-
-    when_i_hide_the_filter_dialogue
-    when_i_sort_by_course
-    then_only_rejected_and_offered_applications_should_be_visible
-    then_i_do_not_expect_to_see_the_filter_dialogue
-
-    when_i_show_the_filter_dialogue
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible
 
@@ -61,7 +41,6 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_provider_application_filters_are_deactivated
 
     when_i_visit_the_provider_page
-    then_i_do_not_expect_to_see_the_filter_dialogue
   end
 
   def when_i_visit_the_provider_page
@@ -116,24 +95,8 @@ RSpec.feature 'Providers should be able to filter applications' do
            create(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
   end
 
-  def then_i_expect_to_see_the_hide_filter_button
-    expect(page).to have_content('Hide filter')
-  end
-
   def then_i_expect_to_see_the_filter_dialogue
     expect(page).to have_button('Apply filters')
-  end
-
-  def when_i_hide_the_filter_dialogue
-    click_link('Hide filter')
-  end
-
-  def then_i_do_not_expect_to_see_the_filter_dialogue
-    expect(page).not_to have_button('Apply filters')
-  end
-
-  def when_i_show_the_filter_dialogue
-    click_link('Show filter')
   end
 
   def when_i_filter_for_rejected_applications
@@ -142,10 +105,10 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_only_rejected_applications_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+    expect(page).to have_css('.app-application-cards', text: 'Rejected')
+    expect(page).not_to have_css('.app-application-cards', text: 'Offer')
+    expect(page).not_to have_css('.app-application-cards', text: 'Application withdrawn')
+    expect(page).not_to have_css('.app-application-cards', text: 'Declined')
   end
 
   def and_the_rejected_tickbox_should_still_be_checked
@@ -171,18 +134,10 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_only_rejected_and_offered_applications_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
-  end
-
-  def when_i_sort_by_name
-    click_link('Name')
-  end
-
-  def when_i_sort_by_course
-    click_link('Course')
+    expect(page).to have_css('.app-application-cards', text: 'Rejected')
+    expect(page).to have_css('.app-application-cards', text: 'Offer')
+    expect(page).not_to have_css('.app-application-cards', text: 'Application withdrawn')
+    expect(page).not_to have_css('.app-application-cards', text: 'Declined')
   end
 
   def when_i_clear_the_filters
@@ -190,10 +145,10 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_expect_all_applications_to_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).to have_css('.govuk-table__body', text: 'Offer')
-    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).to have_css('.govuk-table__body', text: 'Declined')
+    expect(page).to have_css('.app-application-cards', text: 'Rejected')
+    expect(page).to have_css('.app-application-cards', text: 'Offer')
+    expect(page).to have_css('.app-application-cards', text: 'Application withdrawn')
+    expect(page).to have_css('.app-application-cards', text: 'Declined')
   end
 
   def when_i_filter_by_provider
@@ -203,9 +158,9 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_only_see_applications_for_a_given_provider
-    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
-    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
-    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
+    expect(page).to have_css('.app-application-cards', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.app-application-cards', text: 'Caladan University')
+    expect(page).not_to have_css('.app-application-cards', text: 'University of Arrakis')
   end
 
   def and_provider_application_filters_are_active
@@ -231,7 +186,7 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def and_the_remaining_filters_to_still_apply
-    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
+    expect(page).to have_css('.app-application-cards', text: 'Caladan University')
   end
 
   def and_a_rejected_tag_should_be_visible

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -13,7 +13,6 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_visit_the_provider_page
 
-    then_i_expect_to_see_the_hide_filter_button
     then_i_expect_to_see_the_filter_dialogue
     then_i_expect_to_see_the_search_input
 
@@ -50,7 +49,6 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_search_for_candidate_name
     then_only_applications_of_that_name_and_provider_should_be_visible
     then_the_relevant_tag_headings_should_be_visible
-
     and_the_relevant_tags_should_be_visible
 
     and_provider_application_filters_are_deactivated
@@ -77,10 +75,10 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_only_withdrawn_and_offered_applications_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).to have_css('.govuk-table__body', text: 'Offered')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+    expect(page).to have_css('.app-application-cards', text: 'Application withdrawn')
+    expect(page).to have_css('.app-application-cards', text: 'Offered')
+    expect(page).not_to have_css('.app-application-cards', text: 'Rejected')
+    expect(page).not_to have_css('.app-application-cards', text: 'Declined')
   end
 
   def and_the_relevant_tags_should_be_visible
@@ -98,22 +96,22 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_expect_all_applications_to_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).to have_css('.govuk-table__body', text: 'Offered')
-    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).to have_css('.govuk-table__body', text: 'Declined')
+    expect(page).to have_css('.app-application-cards', text: 'Rejected')
+    expect(page).to have_css('.app-application-cards', text: 'Offered')
+    expect(page).to have_css('.app-application-cards', text: 'Application withdrawn')
+    expect(page).to have_css('.app-application-cards', text: 'Declined')
   end
 
   def then_i_only_see_applications_for_a_given_provider
-    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
-    expect(page).to have_css('.govuk-table__body', text: 'Caladan University')
-    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
+    expect(page).to have_css('.app-application-cards', text: 'Hoth Teacher Training')
+    expect(page).to have_css('.app-application-cards', text: 'Caladan University')
+    expect(page).not_to have_css('.app-application-cards', text: 'University of Arrakis')
   end
 
   def then_only_applications_of_that_name_and_provider_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Hoth Teacher Training')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Caladan University')
-    expect(page).not_to have_css('.govuk-table__body', text: 'University of Arrakis')
+    expect(page).to have_css('.app-application-cards', text: 'Hoth Teacher Training')
+    expect(page).not_to have_css('.app-application-cards', text: 'Caladan University')
+    expect(page).not_to have_css('.app-application-cards', text: 'University of Arrakis')
     then_only_applications_of_that_name_should_be_visible
   end
 
@@ -143,29 +141,29 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_only_applications_of_that_name_and_status_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Jim James')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Adam Jones')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Tom Jones')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Bill Bones')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Greg Taft')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Paul Atreides')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Duncan Idaho')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Luke Smith')
+    expect(page).to have_css('.app-application-cards', text: 'Jim James')
+    expect(page).not_to have_css('.app-application-cards', text: 'Adam Jones')
+    expect(page).not_to have_css('.app-application-cards', text: 'Tom Jones')
+    expect(page).not_to have_css('.app-application-cards', text: 'Bill Bones')
+    expect(page).not_to have_css('.app-application-cards', text: 'Greg Taft')
+    expect(page).not_to have_css('.app-application-cards', text: 'Paul Atreides')
+    expect(page).not_to have_css('.app-application-cards', text: 'Duncan Idaho')
+    expect(page).not_to have_css('.app-application-cards', text: 'Luke Smith')
 
-    expect(page).to have_css('.govuk-table__body', text: 'Application withdrawn')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Rejected')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Declined')
+    expect(page).to have_css('.app-application-cards', text: 'Application withdrawn')
+    expect(page).not_to have_css('.app-application-cards', text: 'Rejected')
+    expect(page).not_to have_css('.app-application-cards', text: 'Declined')
   end
 
   def then_only_applications_of_that_name_should_be_visible
-    expect(page).to have_css('.govuk-table__body', text: 'Jim James')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Adam Jones')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Tom Jones')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Bill Bones')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Greg Taft')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Paul Atreides')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Duncan Idaho')
-    expect(page).not_to have_css('.govuk-table__body', text: 'Luke Smith')
+    expect(page).to have_css('.app-application-cards', text: 'Jim James')
+    expect(page).not_to have_css('.app-application-cards', text: 'Adam Jones')
+    expect(page).not_to have_css('.app-application-cards', text: 'Tom Jones')
+    expect(page).not_to have_css('.app-application-cards', text: 'Bill Bones')
+    expect(page).not_to have_css('.app-application-cards', text: 'Greg Taft')
+    expect(page).not_to have_css('.app-application-cards', text: 'Paul Atreides')
+    expect(page).not_to have_css('.app-application-cards', text: 'Duncan Idaho')
+    expect(page).not_to have_css('.app-application-cards', text: 'Luke Smith')
   end
 
   def then_i_expect_to_see_the_search_input
@@ -178,10 +176,6 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   def given_i_am_a_provider_user_with_dfe_sign_in
     provider_exists_in_dfe_sign_in
-  end
-
-  def then_i_expect_to_see_the_hide_filter_button
-    expect(page).to have_content('Hide filter')
   end
 
   def then_i_expect_to_see_the_filter_dialogue

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -75,10 +75,11 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_only_withdrawn_and_offered_applications_should_be_visible
-    expect(page).to have_css('.app-application-cards', text: 'Application withdrawn')
-    expect(page).to have_css('.app-application-cards', text: 'Offered')
-    expect(page).not_to have_css('.app-application-cards', text: 'Rejected')
-    expect(page).not_to have_css('.app-application-cards', text: 'Declined')
+    cards = find(:css, '.app-application-cards')
+    expect(cards).to have_text('Application withdrawn')
+    expect(cards).to have_text('Offered')
+    expect(cards).not_to have_text('Rejected')
+    expect(cards).not_to have_text('Declined')
   end
 
   def and_the_relevant_tags_should_be_visible
@@ -87,8 +88,9 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_the_relevant_tag_headings_should_be_visible
-    expect(page).to have_css('.moj-filter__selected', text: 'Candidate\'s name')
-    expect(page).to have_css('.moj-filter__selected', text: 'Provider')
+    selected_filters = find(:css, '.moj-filter__selected')
+    expect(selected_filters).to have_text('Candidate\'s name')
+    expect(selected_filters).to have_text('Provider')
   end
 
   def then_only_withdrawn_and_offered_applications_of_that_name_should_be_visible
@@ -96,22 +98,25 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_expect_all_applications_to_be_visible
-    expect(page).to have_css('.app-application-cards', text: 'Rejected')
-    expect(page).to have_css('.app-application-cards', text: 'Offered')
-    expect(page).to have_css('.app-application-cards', text: 'Application withdrawn')
-    expect(page).to have_css('.app-application-cards', text: 'Declined')
+    cards = find(:css, '.app-application-cards')
+    expect(cards).to have_text('Rejected')
+    expect(cards).to have_text('Offered')
+    expect(cards).to have_text('Application withdrawn')
+    expect(cards).to have_text('Declined')
   end
 
   def then_i_only_see_applications_for_a_given_provider
-    expect(page).to have_css('.app-application-cards', text: 'Hoth Teacher Training')
-    expect(page).to have_css('.app-application-cards', text: 'Caladan University')
-    expect(page).not_to have_css('.app-application-cards', text: 'University of Arrakis')
+    cards = find(:css, '.app-application-cards')
+    expect(cards).to have_text('Hoth Teacher Training')
+    expect(cards).to have_text('Caladan University')
+    expect(cards).not_to have_text('University of Arrakis')
   end
 
   def then_only_applications_of_that_name_and_provider_should_be_visible
-    expect(page).to have_css('.app-application-cards', text: 'Hoth Teacher Training')
-    expect(page).not_to have_css('.app-application-cards', text: 'Caladan University')
-    expect(page).not_to have_css('.app-application-cards', text: 'University of Arrakis')
+    cards = find(:css, '.app-application-cards')
+    expect(cards).to have_text('Hoth Teacher Training')
+    expect(cards).not_to have_text('Caladan University')
+    expect(cards).not_to have_text('University of Arrakis')
     then_only_applications_of_that_name_should_be_visible
   end
 
@@ -141,29 +146,31 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_only_applications_of_that_name_and_status_should_be_visible
-    expect(page).to have_css('.app-application-cards', text: 'Jim James')
-    expect(page).not_to have_css('.app-application-cards', text: 'Adam Jones')
-    expect(page).not_to have_css('.app-application-cards', text: 'Tom Jones')
-    expect(page).not_to have_css('.app-application-cards', text: 'Bill Bones')
-    expect(page).not_to have_css('.app-application-cards', text: 'Greg Taft')
-    expect(page).not_to have_css('.app-application-cards', text: 'Paul Atreides')
-    expect(page).not_to have_css('.app-application-cards', text: 'Duncan Idaho')
-    expect(page).not_to have_css('.app-application-cards', text: 'Luke Smith')
+    cards = find(:css, '.app-application-cards')
+    expect(cards).to have_text('Jim James')
+    expect(cards).not_to have_text('Adam Jones')
+    expect(cards).not_to have_text('Tom Jones')
+    expect(cards).not_to have_text('Bill Bones')
+    expect(cards).not_to have_text('Greg Taft')
+    expect(cards).not_to have_text('Paul Atreides')
+    expect(cards).not_to have_text('Duncan Idaho')
+    expect(cards).not_to have_text('Luke Smith')
 
-    expect(page).to have_css('.app-application-cards', text: 'Application withdrawn')
-    expect(page).not_to have_css('.app-application-cards', text: 'Rejected')
-    expect(page).not_to have_css('.app-application-cards', text: 'Declined')
+    expect(cards).to have_text('Application withdrawn')
+    expect(cards).not_to have_text('Rejected')
+    expect(cards).not_to have_text('Declined')
   end
 
   def then_only_applications_of_that_name_should_be_visible
-    expect(page).to have_css('.app-application-cards', text: 'Jim James')
-    expect(page).not_to have_css('.app-application-cards', text: 'Adam Jones')
-    expect(page).not_to have_css('.app-application-cards', text: 'Tom Jones')
-    expect(page).not_to have_css('.app-application-cards', text: 'Bill Bones')
-    expect(page).not_to have_css('.app-application-cards', text: 'Greg Taft')
-    expect(page).not_to have_css('.app-application-cards', text: 'Paul Atreides')
-    expect(page).not_to have_css('.app-application-cards', text: 'Duncan Idaho')
-    expect(page).not_to have_css('.app-application-cards', text: 'Luke Smith')
+    cards = find(:css, '.app-application-cards')
+    expect(cards).to have_text('Jim James')
+    expect(cards).not_to have_text('Adam Jones')
+    expect(cards).not_to have_text('Tom Jones')
+    expect(cards).not_to have_text('Bill Bones')
+    expect(cards).not_to have_text('Greg Taft')
+    expect(cards).not_to have_text('Paul Atreides')
+    expect(cards).not_to have_text('Duncan Idaho')
+    expect(cards).not_to have_text('Luke Smith')
   end
 
   def then_i_expect_to_see_the_search_input
@@ -253,7 +260,8 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def then_i_expect_the_relevant_provider_tags_to_be_visible
-    expect(page).to have_css('.moj-filter-tags', text: 'Hoth Teacher Training')
-    expect(page).to have_css('.moj-filter-tags', text: 'Caladan University')
+    tags = find(:css, '.moj-filter-tags:nth-of-type(2)')
+    expect(tags).to have_text('Hoth Teacher Training')
+    expect(tags).to have_text('Caladan University')
   end
 end

--- a/spec/system/provider_interface/provider_applications_search_spec.rb
+++ b/spec/system/provider_interface/provider_applications_search_spec.rb
@@ -78,8 +78,6 @@ RSpec.feature 'Providers should be able to filter applications' do
     cards = find(:css, '.app-application-cards')
     expect(cards).to have_text('Application withdrawn')
     expect(cards).to have_text('Offered')
-    expect(cards).not_to have_text('Rejected')
-    expect(cards).not_to have_text('Declined')
   end
 
   def and_the_relevant_tags_should_be_visible
@@ -109,14 +107,11 @@ RSpec.feature 'Providers should be able to filter applications' do
     cards = find(:css, '.app-application-cards')
     expect(cards).to have_text('Hoth Teacher Training')
     expect(cards).to have_text('Caladan University')
-    expect(cards).not_to have_text('University of Arrakis')
   end
 
   def then_only_applications_of_that_name_and_provider_should_be_visible
     cards = find(:css, '.app-application-cards')
     expect(cards).to have_text('Hoth Teacher Training')
-    expect(cards).not_to have_text('Caladan University')
-    expect(cards).not_to have_text('University of Arrakis')
     then_only_applications_of_that_name_should_be_visible
   end
 
@@ -148,29 +143,12 @@ RSpec.feature 'Providers should be able to filter applications' do
   def then_only_applications_of_that_name_and_status_should_be_visible
     cards = find(:css, '.app-application-cards')
     expect(cards).to have_text('Jim James')
-    expect(cards).not_to have_text('Adam Jones')
-    expect(cards).not_to have_text('Tom Jones')
-    expect(cards).not_to have_text('Bill Bones')
-    expect(cards).not_to have_text('Greg Taft')
-    expect(cards).not_to have_text('Paul Atreides')
-    expect(cards).not_to have_text('Duncan Idaho')
-    expect(cards).not_to have_text('Luke Smith')
-
     expect(cards).to have_text('Application withdrawn')
-    expect(cards).not_to have_text('Rejected')
-    expect(cards).not_to have_text('Declined')
   end
 
   def then_only_applications_of_that_name_should_be_visible
     cards = find(:css, '.app-application-cards')
     expect(cards).to have_text('Jim James')
-    expect(cards).not_to have_text('Adam Jones')
-    expect(cards).not_to have_text('Tom Jones')
-    expect(cards).not_to have_text('Bill Bones')
-    expect(cards).not_to have_text('Greg Taft')
-    expect(cards).not_to have_text('Paul Atreides')
-    expect(cards).not_to have_text('Duncan Idaho')
-    expect(cards).not_to have_text('Luke Smith')
   end
 
   def then_i_expect_to_see_the_search_input


### PR DESCRIPTION
## Context

New "application card" design for Provider application choices index page. Will remove the need for page resizing - will remove this in another PR.

## Changes proposed in this pull request

**Before:**
<img width="1177" alt="Screenshot 2020-03-26 at 14 39 57" src="https://user-images.githubusercontent.com/13377553/77659212-acd64d00-6f6f-11ea-9227-d61e74be662b.png">

**After:**
<img width="1151" alt="Screenshot 2020-03-26 at 14 40 50" src="https://user-images.githubusercontent.com/13377553/77659301-cd9ea280-6f6f-11ea-8110-72319b9ac813.png">


## Guidance to review

- I have also amended the Covid-19 banner to be full width after speaking to @adamsilver about it (is two thirds on master currently)
- will do another PR to remove page resizing currently the page is 1220px which is larger than the rest of the app.
- Please note that notes are in the design but not implement in the app yet. When notes are added to the app this card will have to be further amended. 

## Link to Trello card

https://trello.com/c/csW7QE92/1810-implement-the-new-design-for-applications-in-the-provider-applications-index-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
