### PR TITLE
Add pending retries queue to healthcheck endpoint

### DIFF
--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -9,10 +9,24 @@ class SimulatedFailureCheck < OkComputer::Check
   end
 end
 
+class SidekiqRetriesCheck < OkComputer::Check
+  def check
+    retries_queue_length = Sidekiq::RetrySet.new.size
+    queue_length_text = " (#{retries_queue_length})"
+    if retries_queue_length > 10
+      mark_failure
+      mark_message "Sidekiq pending retries depth is high #{queue_length_text}. Suggests high error rate"
+    else
+      mark_message 'Sidekiq pending retries depth at reasonable level' + queue_length_text
+    end
+  end
+end
+
 OkComputer.mount_at = 'integrations/monitoring'
 
 OkComputer::Registry.register 'postgres', OkComputer::ActiveRecordCheck.new
 OkComputer::Registry.register 'redis', OkComputer::RedisCheck.new(url: ENV['REDIS_URL'])
-OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100)
-OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100)
+OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'default', threshold: 100) # threshold in seconds
+OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
+OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new


### PR DESCRIPTION
## Context

It is possible to have a large number of failures and pending retries on the system without the healthcheck endpoint complaining. This is because jobs are processed immediately, and the errors raised place these jobs in sidekiq's `retries` queue, so both `default` and `mailers` queues remain free of latency while the retries queue grows.

More of a precaution against sustained third party outages than anything else.

## Changes proposed in this pull request

Add a check for the depth of the `retries` queue.

## Guidance to review

Inspect changes to the okcomputer config.

## Link to Trello card

[Add 'retries queue'-length check to healthcheck endpoint](https://trello.com/c/zGHKksui)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
