### PR TITLE
Refactor and use COVID-19 feature flag when calculating edit by date

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
     end
 
     def edit
-      @editable_days_count = TimeLimitConfig.edit_by
+      @editable_days = TimeLimitConfig.edit_by
       if FeatureFlag.active?('edit_application')
         render :edit
       else
@@ -55,7 +55,7 @@ module CandidateInterface
 
     def submit_success
       @support_reference = current_application.support_reference
-      @editable_days_count = TimeLimitConfig.edit_by
+      @editable_days = TimeLimitConfig.edit_by
     end
 
     def review_submitted

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -1,8 +1,28 @@
 class TimeLimitConfig
+  class Days
+    attr_reader :count, :type
+
+    def initialize(count:, type:)
+      raise ArgumentError, 'Argument is not an integer' unless count.is_a?(Integer)
+      raise ArgumentError, 'Argument is not :calendar or :working' unless (type == :calendar) || (type == :working)
+
+      @count = count
+      @type = type
+    end
+
+    def to_s
+      "#{@count} #{@type} #{'day'.pluralize(@count)}"
+    end
+  end
+
   Rule = Struct.new(:from_date, :to_date, :limit)
 
   def self.edit_by
-    7
+    if FeatureFlag.active?('covid_19')
+      Days.new(count: 7, type: :calendar)
+    else
+      Days.new(count: 5, type: :working)
+    end
   end
 
   def self.chase_referee_by

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -10,6 +10,10 @@ class TimeLimitConfig
       @type = type
     end
 
+    def to_days
+      type == :calendar ? count.days : count.business_days
+    end
+
     def to_s
       "#{@count} #{@type} #{'day'.pluralize(@count)}"
     end

--- a/app/services/submit_application_choice.rb
+++ b/app/services/submit_application_choice.rb
@@ -14,7 +14,10 @@ private
     if HostingEnvironment.sandbox_mode?
       Time.zone.now
     else
-      TimeLimitConfig.edit_by.days.after(@application_choice.application_form.submitted_at).end_of_day
+      days = TimeLimitConfig.edit_by
+      date = days.type == :calendar ? days.count.days : days.count.business_days
+
+      date.after(@application_choice.application_form.submitted_at).end_of_day
     end
   end
 end

--- a/app/services/submit_application_choice.rb
+++ b/app/services/submit_application_choice.rb
@@ -14,10 +14,7 @@ private
     if HostingEnvironment.sandbox_mode?
       Time.zone.now
     else
-      days = TimeLimitConfig.edit_by
-      date = days.type == :calendar ? days.count.days : days.count.business_days
-
-      date.after(@application_choice.application_form.submitted_at).end_of_day
+      TimeLimitConfig.edit_by.to_days.after(@application_choice.application_form.submitted_at).end_of_day
     end
   end
 end

--- a/app/views/candidate_interface/application_form/edit.html.erb
+++ b/app/views/candidate_interface/application_form/edit.html.erb
@@ -7,9 +7,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have <%= @editable_days_count %> days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">You have <%= @editable_days %> after submission to edit most sections of your application.</p>
     <h2 class="govuk-heading-m">Course choice</h2>
-    <p class="govuk-body">You can change your choice of training provider, course or location within the <%= @editable_days_count %> working day editing period.</p>
+    <p class="govuk-body">You can change your choice of training provider, course or location within the <%= @editable_days %> editing period.</p>
     <p class="govuk-body">You can also delete a course choice.</p>
     <h2 class="govuk-heading-m">References</h2>
     <p class="govuk-body">You can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>

--- a/app/views/candidate_interface/application_form/edit_by_support.html.erb
+++ b/app/views/candidate_interface/application_form/edit_by_support.html.erb
@@ -7,11 +7,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have <%= @editable_days_count %> days after submission to edit most sections of your application.</p>
+    <p class="govuk-body">You have <%= @editable_days %> after submission to edit most sections of your application.</p>
     <p class="govuk-body">To edit, you’ll need to email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>, explaining which changes you’d like to make.</p>
     <p class="govuk-body">We can only edit your application once.</p>
     <h2 class="govuk-heading-m">Course choice</h2>
-    <p class="govuk-body">We can change your choice of training provider, course or location within the <%= @editable_days_count %> working day editing period.</p>
+    <p class="govuk-body">We can change your choice of training provider, course or location within the <%= @editable_days %> editing period.</p>
     <p class="govuk-body">We can also delete a course choice.</p>
     <p class="govuk-body">After this, you can email us asking to withdraw your application completely.</p>
     <h2 class="govuk-heading-m">References</h2>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -32,7 +32,7 @@
     <p class="govuk-body">Your training provider will be in touch with you if they want to arrange an interview.</p>
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
-    <p class="govuk-body">You have <%= @editable_days_count %> days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>
+    <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your provider(s) when this editing period is over.</p>
     <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
   </div>
 </div>

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -17,7 +17,7 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 # Making changes to your application
 
 <% if FeatureFlag.active?('edit_application') %>
-  You have <%= TimeLimitConfig.edit_by %> days to edit your application or change your choice of provider, course or training location.
+  You have <%= TimeLimitConfig.edit_by %> to edit your application or change your choice of provider, course or training location.
 
   To make changes, [sign back in to your account](<%= candidate_sign_in_url(@candidate) %>).
 
@@ -25,7 +25,7 @@ You can track the progress of your <%= 'application'.pluralize(@application_form
 
   We’ll pass any changes on to the training <%= 'provider'.pluralize(@application_form.application_choices.count) %>.
 <% else %>
-  Get in touch with us as soon as possible if you need to make any amends, as we only have <%= TimeLimitConfig.edit_by %> days to make changes.
+  Get in touch with us as soon as possible if you need to make any amends, as we only have <%= TimeLimitConfig.edit_by %> to make changes.
 
   Once we’ve processed your request, you can’t make any more changes.
 

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -10,16 +10,46 @@ RSpec.describe TimeLimitConfig do
       expect(TimeLimitConfig.limits_for(:decline_by_default).first.limit).to eq(10)
     end
 
-    it ':edit_by returns a limit of 7 days' do
-      expect(TimeLimitConfig.edit_by).to eq(7)
-    end
-
     it ':chase_provider_before_rbd returns a default limit of 20 days' do
       expect(TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit).to eq(20)
     end
 
     it ':chase_candidate_before_dbd returns a default limit of 5 days' do
       expect(TimeLimitConfig.limits_for(:chase_candidate_before_dbd).first.limit).to eq(5)
+    end
+  end
+
+  describe '.edit_by' do
+    context 'when the COVID-19 feature flag is on' do
+      before { FeatureFlag.activate('covid_19') }
+
+      it 'returns 7 days' do
+        expect(TimeLimitConfig.edit_by.count).to eq(7)
+      end
+
+      it 'returns type as calendar' do
+        expect(TimeLimitConfig.edit_by.type).to eq(:calendar)
+      end
+
+      it 'displays "7 calendar days"' do
+        expect(TimeLimitConfig.edit_by.to_s).to eq('7 calendar days')
+      end
+    end
+
+    context 'when the COVID-19 feature flag is off' do
+      before { FeatureFlag.deactivate('covid_19') }
+
+      it 'returns 5 days' do
+        expect(TimeLimitConfig.edit_by.count).to eq(5)
+      end
+
+      it 'returns type as working' do
+        expect(TimeLimitConfig.edit_by.type).to eq(:working)
+      end
+
+      it 'displays "5 calendar days"' do
+        expect(TimeLimitConfig.edit_by.to_s).to eq('5 working days')
+      end
     end
   end
 end

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -34,6 +34,10 @@ RSpec.describe TimeLimitConfig do
       it 'displays "7 calendar days"' do
         expect(TimeLimitConfig.edit_by.to_s).to eq('7 calendar days')
       end
+
+      it 'returns days as ActiveSupport:Duration object' do
+        expect(TimeLimitConfig.edit_by.to_days).to be_a_kind_of(ActiveSupport::Duration)
+      end
     end
 
     context 'when the COVID-19 feature flag is off' do
@@ -49,6 +53,10 @@ RSpec.describe TimeLimitConfig do
 
       it 'displays "5 calendar days"' do
         expect(TimeLimitConfig.edit_by.to_s).to eq('5 working days')
+      end
+
+      it 'returns days as BusinessTime::BusinessDays object' do
+        expect(TimeLimitConfig.edit_by.to_days).to be_a_kind_of(BusinessTime::BusinessDays)
       end
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
       it_behaves_like('a mail with subject and content', :application_submitted,
                       I18n.t!('candidate_mailer.application_submitted.subject'),
-                      'edit by time limit' => "You have #{TimeLimitConfig.edit_by} days to edit")
+                      'edit by time limit' => "You have #{TimeLimitConfig.edit_by} to edit")
     end
 
     context 'when the improved_expired_token_flow feature flag is on' do

--- a/spec/services/submit_application_choice_spec.rb
+++ b/spec/services/submit_application_choice_spec.rb
@@ -2,29 +2,47 @@ require 'rails_helper'
 
 RSpec.describe SubmitApplicationChoice do
   describe 'Submit an application choice', sandbox: false do
+    let(:current_date) { Time.zone.local(2020, 3, 1) }
     let(:application_form) { create(:application_form, submitted_at: Time.zone.now) }
     let(:application_choice) { create(:application_choice, application_form: application_form, status: 'unsubmitted') }
 
-    it 'updates the application choice to Submitted' do
-      SubmitApplicationChoice.new(application_choice).call
-      expect(application_choice).to be_awaiting_references
+    around do |example|
+      Timecop.freeze(current_date) do
+        example.run
+      end
     end
 
-    it 'updates the application choice to edit_by date' do
-      expected_edit_by_day = 7.days.after(application_form.submitted_at).end_of_day
-
+    it 'updates the application choice to Submitted' do
       SubmitApplicationChoice.new(application_choice).call
-      expect(application_choice.edit_by).to eq(expected_edit_by_day)
+
+      expect(application_choice).to be_awaiting_references
     end
 
     context 'when running in a provider sandbox', sandbox: true do
       it 'sets the edit_by timestamp to now' do
-        now = Time.zone.local(2019, 11, 11, 15, 0, 0)
-        Timecop.freeze(now) do
-          SubmitApplicationChoice.new(application_choice).call
+        SubmitApplicationChoice.new(application_choice).call
 
-          expect(application_choice.edit_by).to eq now
-        end
+        expect(application_choice.edit_by).to eq(current_date)
+      end
+    end
+
+    context 'when edit by days are in calendar days' do
+      it 'updates the application choice to edit_by date' do
+        allow(TimeLimitConfig).to receive(:edit_by).and_return(TimeLimitConfig::Days.new(count: 7, type: :calendar))
+
+        SubmitApplicationChoice.new(application_choice).call
+
+        expect(application_choice.edit_by.to_s).to eq(Time.zone.local(2020, 3, 8, 23, 59, 59).to_s)
+      end
+    end
+
+    context 'when edit by days are in working days' do
+      it 'updates the application choice to edit_by date' do
+        allow(TimeLimitConfig).to receive(:edit_by).and_return(TimeLimitConfig::Days.new(count: 7, type: :working))
+
+        SubmitApplicationChoice.new(application_choice).call
+
+        expect(application_choice.edit_by.to_s).to eq(Time.zone.local(2020, 3, 11, 23, 59, 59).to_s)
       end
     end
   end


### PR DESCRIPTION
## Context

A conversation came up about the time a candidate has to edit their application after submission during COVID-19 and not. This was because there was a question about whether the guidance around this on the "Application successfully submitted" page was correct. See Slack thread: https://ukgovernmentdfe.slack.com/archives/CN9Q1VB2M/p1585225722060500.

From this, we want:

- Normal: You have 5 working days to edit your application. We'll only send your application to your provider(s) when this editing period is over.
- COVID: You have 7 calendar days to edit your application. We'll only send your application to your provider(s) when this editing period is over.

Changing to calendar days for the `edit_by` date in `TimeLimitConfig` was done recently in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1716.

## Changes proposed in this pull request

This PR does some refactoring in `TimeLimitConfig`:

- When the `covid_19` feature flag is on, we will return 7 calendar days, else return 5 working days.
- Returns a `Days` object with a helpful `to_s` method. This means we won't have to have `if... else..` statements for displaying `7 working days` or `7 calendar days` or update all the places when we do switch over.

And updates `SubmitApplicationChoice` service to take into consideration whether `edit_by` is in calendar or working days.

## Guidance to review

- Does any of this make sense?
- What do you think of the refactoring?
- Is a can of worm going to be opened?

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
