### PR TITLE
Layout changes to the provider ui single application view

### DIFF
--- a/app/components/personal_details_component.rb
+++ b/app/components/personal_details_component.rb
@@ -8,6 +8,7 @@ class PersonalDetailsComponent < ActionView::Component::Base
            :phone_number,
            :candidate,
            :support_reference,
+           :submitted_at,
            to: :application_form
 
   delegate :email_address, to: :candidate
@@ -18,6 +19,7 @@ class PersonalDetailsComponent < ActionView::Component::Base
 
   def rows
     [
+      application_submitted_row,
       support_reference_row,
       name_row,
       date_of_birth_row,
@@ -29,6 +31,15 @@ class PersonalDetailsComponent < ActionView::Component::Base
   end
 
 private
+
+  def application_submitted_row
+    return unless submitted_at
+
+    {
+      key: 'Application submitted',
+      value: submitted_at.to_s(:govuk_date),
+    }
+  end
 
   def name_row
     {

--- a/app/components/provider_interface/conditions_component.html.erb
+++ b/app/components/provider_interface/conditions_component.html.erb
@@ -7,7 +7,7 @@
         <td class="govuk-table__cell govuk-table__cell--numeric">
           <% if conditions.present? %>
             <% if conditions_met? %>
-              <strong class="govuk-tag app-tag">Met</strong>
+              <strong class="govuk-tag govuk-tag--green app-tag">Met</strong>
             <% elsif known_conditions_state? %>
               <strong class="govuk-tag govuk-tag--red app-tag">Not met</strong>
             <% else %>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,5 +1,5 @@
 <div data-qa="app-status-box">
-  <div class="app-card app-card--white govuk-!-margin-bottom-9">
+  <div class="app-card app-card--white">
     <%= render status_box_component_to_render.new(application_choice: @application_choice) %>
   </div>
 </div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,5 +1,6 @@
-<div data-qa="app-status-box">
-  <div class="app-card app-card--white">
-    <%= render status_box_component_to_render.new(application_choice: @application_choice) %>
+<% status_box_component = status_box_component_to_render.new(application_choice: @application_choice) -%>
+<% if status_box_component.render? -%>
+  <div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
+    <%= render status_box_component %>
   </div>
-</div>
+<% end -%>

--- a/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
+++ b/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
@@ -9,21 +9,7 @@ module ProviderInterface
       end
 
       def render?
-        application_choice.awaiting_provider_decision? || \
-          raise(ProviderInterface::StatusBoxComponent::ComponentMismatchError)
-      end
-
-      def rows
-        [
-          {
-            key: 'Application submitted',
-            value: application_choice.application_form.submitted_at.to_s(:govuk_date),
-          },
-          {
-            key: 'Respond to applicant by',
-            value: application_choice.reject_by_default_at.to_s(:govuk_date),
-          },
-        ]
+        false
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
+++ b/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Application submitted',
             value: application_choice.application_form.submitted_at.to_s(:govuk_date),
           },

--- a/app/components/provider_interface/status_box_components/conditions_not_met_component.html.erb
+++ b/app/components/provider_interface/status_box_components/conditions_not_met_component.html.erb
@@ -1,4 +1,3 @@
-<h2 class="govuk-heading-l">Candidate did not meet conditions</h2>
-
+<h2 class="govuk-heading-l">Offer</h2>
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
+++ b/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Provider',
             value: application_choice.offered_course.provider.name,
           },

--- a/app/components/provider_interface/status_box_components/declined_component.html.erb
+++ b/app/components/provider_interface/status_box_components/declined_component.html.erb
@@ -1,3 +1,3 @@
-<h2 class="govuk-heading-l">Candidate declined offer</h2>
+<h2 class="govuk-heading-l">Offer</h2>
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/status_box_components/declined_component.rb
+++ b/app/components/provider_interface/status_box_components/declined_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Offer declined',
             value: application_choice.declined_at.to_s(:govuk_date),
           },

--- a/app/components/provider_interface/status_box_components/enrolled_component.html.erb
+++ b/app/components/provider_interface/status_box_components/enrolled_component.html.erb
@@ -1,3 +1,3 @@
-<h2 class="govuk-heading-l">Candidate enrolled</h2>
+<h2 class="govuk-heading-l">Offer</h2>
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/status_box_components/enrolled_component.rb
+++ b/app/components/provider_interface/status_box_components/enrolled_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Enrolled',
             value: application_choice.enrolled_at.to_s(:govuk_date),
           },

--- a/app/components/provider_interface/status_box_components/offer_component.html.erb
+++ b/app/components/provider_interface/status_box_components/offer_component.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Offer made to candidate</h2>
+<h2 class="govuk-heading-l">Offer</h2>
 
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Offer made',
             value: application_choice.offered_at.to_s(:govuk_date),
           },

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Candidate accepted offer</h2>
+<h2 class="govuk-heading-l">Offer</h2>
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.rb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Offer accepted',
             value: application_choice.accepted_at.to_s(:govuk_date),
           },

--- a/app/components/provider_interface/status_box_components/recruited_component.html.erb
+++ b/app/components/provider_interface/status_box_components/recruited_component.html.erb
@@ -1,3 +1,3 @@
-<h2 class="govuk-heading-l">Candidate met conditions</h2>
+<h2 class="govuk-heading-l">Offer</h2>
 <%= render SummaryListComponent.new(rows: rows) %>
 <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>

--- a/app/components/provider_interface/status_box_components/recruited_component.rb
+++ b/app/components/provider_interface/status_box_components/recruited_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Conditions met',
             value: application_choice.recruited_at.to_s(:govuk_date),
           },

--- a/app/components/provider_interface/status_box_components/rejected_component.html.erb
+++ b/app/components/provider_interface/status_box_components/rejected_component.html.erb
@@ -1,5 +1,5 @@
 <% if offer_withdrawn_at %>
-  <h2 class="govuk-heading-l">Offer to candidate withdrawn</h2>
+  <h2 class="govuk-heading-l">Offer</h2>
   <%= render SummaryListComponent.new(rows: offer_withdrawn_rows) %>
   <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
 <% else %>

--- a/app/components/provider_interface/status_box_components/rejected_component.rb
+++ b/app/components/provider_interface/status_box_components/rejected_component.rb
@@ -20,10 +20,6 @@ module ProviderInterface
       def offer_withdrawn_rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Offer withdrawn',
             value: offer_withdrawn_at,
           },

--- a/app/components/provider_interface/status_box_components/withdrawn_component.rb
+++ b/app/components/provider_interface/status_box_components/withdrawn_component.rb
@@ -16,10 +16,6 @@ module ProviderInterface
       def rows
         [
           {
-            key: 'Status',
-            value: render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)),
-          },
-          {
             key: 'Application withdrawn',
             value: application_choice.withdrawn_at.to_s(:govuk_date),
           },

--- a/app/components/provider_interface/status_box_components/withdrawn_component.rb
+++ b/app/components/provider_interface/status_box_components/withdrawn_component.rb
@@ -9,17 +9,7 @@ module ProviderInterface
       end
 
       def render?
-        (application_choice.withdrawn? && !application_choice.offer_withdrawn_at) || \
-          raise(ProviderInterface::StatusBoxComponent::ComponentMismatchError)
-      end
-
-      def rows
-        [
-          {
-            key: 'Application withdrawn',
-            value: application_choice.withdrawn_at.to_s(:govuk_date),
-          },
-        ]
+        false
       end
     end
   end

--- a/app/frontend/styles/_card.scss
+++ b/app/frontend/styles/_card.scss
@@ -27,7 +27,6 @@
 
 .app-card--white {
   background-color: govuk-colour("white");
-  border: 5px solid #BFC1C3;
 }
 
 .app-card__count {

--- a/app/frontend/styles/_tag.scss
+++ b/app/frontend/styles/_tag.scss
@@ -1,3 +1,4 @@
-.app-tag {
+.govuk-heading-xl .app-tag {
+  vertical-align: middle;
   white-space: nowrap;
 }

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -73,6 +73,10 @@ module ViewHelper
     end
   end
 
+  def days_to_respond_to(application_choice)
+    (application_choice.reject_by_default_at.to_date - Date.current).to_i
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -13,6 +13,16 @@
   </div>
 <% end %>
 
+<% if @application_choice.status == 'awaiting_provider_decision' -%>
+<div class="app-banner">
+  <div class="app-banner__message">
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+      You have <%= (@application_choice.reject_by_default_at.to_date - Date.current).to_i %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
+    </h2>
+  </div>
+</div>
+<% end -%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -23,29 +23,22 @@
   </div>
 <% end -%>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-      <%= @application_choice.application_form.full_name %>
-      <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
-    </h1>
-    <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
-      <%= govuk_link_to(
-        'Download application (PDF)',
-        provider_interface_application_choice_path(@application_choice.id, format: :pdf),
-        download: @application_choice.application_form.support_reference
-      ) %>
-    </p>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
-  </div>
-</div>
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
+  <%= @application_choice.application_form.full_name %>
+  <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
+</h1>
+<p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
+  <%= govuk_link_to(
+    'Download application (PDF)',
+    provider_interface_application_choice_path(@application_choice.id, format: :pdf),
+    download: @application_choice.application_form.support_reference
+  ) %>
+</p>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+
     <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Application</h2>
-
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>
 
     <% unless HostingEnvironment.production? %>
@@ -120,4 +113,8 @@
       <% end %>
     <% end %>
   </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
+  </div>
+
 </div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -17,8 +17,10 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
       <%= @application_choice.application_form.full_name %>
+      <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
     </h1>
   </div>
+
   <div class="govuk-grid-column-one-third">
     <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
       <%= govuk_link_to(
@@ -27,6 +29,11 @@
         download: @application_choice.application_form.support_reference
       ) %>
     </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
     <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
   </div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -14,13 +14,13 @@
 <% end %>
 
 <% if @application_choice.status == 'awaiting_provider_decision' -%>
-<div class="app-banner">
-  <div class="app-banner__message">
-    <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-      You have <%= days_to_respond_to(@application_choice) %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
-    </h2>
+  <div class="app-banner">
+    <div class="app-banner__message">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+        You have <%= days_to_respond_to(@application_choice) %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
+      </h2>
+    </div>
   </div>
-</div>
 <% end -%>
 
 <div class="govuk-grid-row">
@@ -29,9 +29,6 @@
       <%= @application_choice.application_form.full_name %>
       <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
     </h1>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
     <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
       <%= govuk_link_to(
         'Download application (PDF)',
@@ -40,14 +37,6 @@
       ) %>
     </p>
   </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-
-    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
-  </div>
-
   <div class="govuk-grid-column-one-third">
     <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
   </div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -17,7 +17,7 @@
 <div class="app-banner">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-      You have <%= (@application_choice.reject_by_default_at.to_date - Date.current).to_i %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
+      You have <%= days_to_respond_to(@application_choice) %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
     </h2>
   </div>
 </div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -38,7 +38,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Application</h2>
+    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
+
+    <h2 class="govuk-heading-l" id="course-info">Application</h2>
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>
 
     <% unless HostingEnvironment.production? %>
@@ -116,5 +118,4 @@
   <div class="govuk-grid-column-one-third">
     <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
   </div>
-
 </div>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -16,9 +16,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-      <span class="govuk-caption-xl"><%= @application_choice.application_form.support_reference %></span>
       <%= @application_choice.application_form.full_name %>
     </h1>
+  </div>
+  <div class="govuk-grid-column-one-third">
     <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
       <%= govuk_link_to(
         'Download application (PDF)',

--- a/spec/components/provider_interface/status_box_component_spec.rb
+++ b/spec/components/provider_interface/status_box_component_spec.rb
@@ -11,4 +11,11 @@ RSpec.describe ProviderInterface::StatusBoxComponent do
         'uninitialized constant ProviderInterface::StatusBoxComponents::DummyComponent',
       )
   end
+
+  it 'does not render for certain application choice statuses' do
+    application_choice = instance_double(ApplicationChoice)
+    allow(application_choice).to receive(:status).and_return('withdrawn')
+
+    expect(render_inline(described_class, application_choice: application_choice).to_html).to eq ''
+  end
 end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -134,4 +134,11 @@ RSpec.describe ViewHelper, type: :helper do
       end
     end
   end
+
+  describe '#days_to_respond_to' do
+    it 'returns the number of days before application is rejected' do
+      choice = build(:application_choice, reject_by_default_at: Date.current + 1.week)
+      expect(helper.days_to_respond_to(choice)).to eq(7)
+    end
+  end
 end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_i_should_see_the_candidates_references
     and_i_should_see_the_disability_disclosure
     and_i_should_see_the_application_timeline
+    and_i_should_see_a_link_to_respond_to_the_application
+    and_i_should_see_a_link_to_download_as_pdf
   end
 
   def and_i_should_see_the_safeguarding_declaration_section
@@ -209,8 +211,13 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     expect(page).to have_content 'I am hard of hearing'
   end
 
-  def and_i_should_see_a_link_to_print_this_page
-    expect(page).to have_link 'Print this page'
+  def and_i_should_see_a_link_to_respond_to_the_application
+    expect(page).to have_content(/You have \d+ days to send a response/)
+    expect(page).to have_link 'Respond to application'
+  end
+
+  def and_i_should_see_a_link_to_download_as_pdf
+    expect(page).to have_link 'Download application (PDF)'
   end
 
   def and_i_should_see_the_application_timeline


### PR DESCRIPTION
## Context

Design changes in the [prototype app](https://manage-applications-beta.herokuapp.com/application/AS1623) should be applied to the application details page.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Move application status tag up in line with candidate name.
- Remove status box border.
- Move download as PDF link under candidate name.
- Move 'Respond to application' into a banner above candidate name.

#### After

![image](https://user-images.githubusercontent.com/93511/78001480-a5c38c00-732d-11ea-84ef-f9a8d8ddc039.png)


<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/zFHoIVCU/1783-layout-changes-to-the-provider-ui-single-application-view

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
