### PR TITLE
Allow candidates to change the location of their course choice 

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -68,9 +68,20 @@ module CandidateInterface
     end
 
     def location_row(course_choice)
+      change_path = if FeatureFlag.active?('edit_course_choices') && has_multiple_sites?(course_choice)
+                      candidate_interface_course_choices_site_path(
+                        course_choice.provider.id,
+                        course_choice.course.id,
+                        course_choice.course.study_mode,
+                        course_choice_id: course_choice.id,
+                      )
+                    end
+
       {
         key: 'Location',
         value: "#{course_choice.offered_site.name}\n#{course_choice.offered_site.full_address}",
+        action: "location for #{course_choice.course.name_and_code}",
+        change_path: change_path,
       }
     end
 
@@ -141,6 +152,10 @@ module CandidateInterface
         key: 'Reason for offer withdrawal',
         value: course_choice.offer_withdrawal_reason,
       }
+    end
+
+    def has_multiple_sites?(course_choice)
+      CourseOption.where(course_id: course_choice.course.id).many?
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -132,18 +132,35 @@ module CandidateInterface
     end
 
     def options_for_site
-      @pick_site = PickSiteForm.new(
-        provider_id: params.fetch(:provider_id),
-        course_id: params.fetch(:course_id),
-        study_mode: params.fetch(:study_mode),
-      )
+      if params[:course_choice_id]
+        @course_choice_id = params[:course_choice_id]
+        current_application_choice = current_application.application_choices.find(@course_choice_id)
+
+        @pick_site = PickSiteForm.new(
+          application_form: current_application,
+          provider_id: current_application_choice.provider.id,
+          course_id: current_application_choice.course.id,
+          study_mode: current_application_choice.offered_option.study_mode,
+          course_option_id: current_application_choice.course_option_id.to_s,
+        )
+      else
+        @pick_site = PickSiteForm.new(
+          provider_id: params.fetch(:provider_id),
+          course_id: params.fetch(:course_id),
+          study_mode: params.fetch(:study_mode),
+        )
+      end
     end
 
     def pick_site
       course_id = params.fetch(:course_id)
       course_option_id = params.dig(:candidate_interface_pick_site_form, :course_option_id)
 
-      pick_site_for_course(course_id, course_option_id)
+      if params[:course_choice_id]
+        pick_new_site_for_course(course_id, course_option_id)
+      else
+        pick_site_for_course(course_id, course_option_id)
+      end
     end
 
     def review
@@ -238,6 +255,24 @@ module CandidateInterface
           redirect_to candidate_interface_course_choices_index_path
         end
 
+      else
+        render :options_for_site
+      end
+    end
+
+    def pick_new_site_for_course(course_id, course_option_id)
+      @course_choice_id = params[:course_choice_id]
+      application_choice = current_application.application_choices.find(params[:course_choice_id])
+
+      @pick_site = PickSiteForm.new(
+        application_form: current_application,
+        provider_id: params.fetch(:provider_id),
+        course_id: course_id,
+        course_option_id: course_option_id,
+      )
+
+      if @pick_site.update(application_choice)
+        redirect_to candidate_interface_course_choices_index_path
       else
         render :options_for_site
       end

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -4,7 +4,7 @@ module CandidateInterface
 
     attr_accessor :application_form, :provider_id, :course_id, :study_mode, :course_option_id
     validates :course_option_id, presence: true
-    validate :candidate_can_only_apply_to_3_courses
+    validate :candidate_can_only_apply_to_3_courses, on: :save
 
     def available_sites
       relation = CourseOption.includes(:site).where(course_id: course.id)
@@ -17,11 +17,17 @@ module CandidateInterface
     end
 
     def save
-      return unless valid?
+      return unless valid?(:save)
 
       application_form.application_choices.create!(
         course_option: course_option,
       )
+    end
+
+    def update(application_choice)
+      return unless valid?
+
+      application_choice.update!(course_option: course_option)
     end
 
   private

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -27,6 +27,7 @@ class FeatureFlag
     referee_type
     replacement_referee_with_referee_type
     timeline
+    edit_course_choices
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/course_choices/options_for_site.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_site.html.erb
@@ -6,7 +6,7 @@
     <%= form_with(
           model: @pick_site,
           url: candidate_interface_course_choices_site_path(
-            params[:provider_id], params[:course_id], params[:study_mode]
+            params[:provider_id], params[:course_id], params[:study_mode], course_choice_id: @course_choice_id
           ),
           builder: GOVUKDesignSystemFormBuilder::FormBuilder,
         ) do |f| %>

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -69,8 +69,11 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'when there are multiple site options for course' do
-      before { create(:course_option, course: application_form.application_choices.first.course) }
+    context 'when there are multiple site options for course and edit course choices feature is active' do
+      before do
+        create(:course_option, course: application_form.application_choices.first.course)
+        FeatureFlag.activate('edit_course_choices')
+      end
 
       it 'renders the correct text for "Change" location links' do
         course_choice = application_form.application_choices.first
@@ -91,10 +94,13 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.courses.delete'))
     end
 
-    context 'when there are multiple site options for course' do
+    context 'when there are multiple site options for course and edit course choices feature is active' do
       let(:application_form) { create_application_form_with_course_choices(statuses: %w[application_complete]) }
 
-      before { create(:course_option, course: application_form.application_choices.first.course) }
+      before do
+        create(:course_option, course: application_form.application_choices.first.course)
+        FeatureFlag.activate('edit_course_choices')
+      end
 
       it 'renders without a "Change" location links' do
         result = render_inline(described_class.new(application_form: application_form, editable: false))

--- a/spec/models/candidate_interface/pick_site_form_spec.rb
+++ b/spec/models/candidate_interface/pick_site_form_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
         course_option_id: create(:course_option).id,
       )
 
-      expect(pick_site_form).to be_valid
+      expect(pick_site_form).to be_valid(:save)
 
       pick_site_form.save
 
@@ -21,7 +21,23 @@ RSpec.describe CandidateInterface::PickSiteForm, type: :model do
         course_option_id: create(:course_option).id,
       )
 
-      expect(pick_site_form).not_to be_valid
+      expect(pick_site_form).not_to be_valid(:save)
+    end
+  end
+
+  describe '#update' do
+    it 'updates the course_option for an existing course choice' do
+      application_choice = create(:application_choice)
+      new_course_option = create(:course_option)
+
+      expect(application_choice.course_option.id).not_to eq(new_course_option.id)
+
+      CandidateInterface::PickSiteForm.new(
+        application_form: application_choice.application_form,
+        course_option_id: new_course_option.id,
+      ).update(application_choice)
+
+      expect(application_choice.course_option.id).to eq(new_course_option.id)
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate edits course choices' do
+  include CandidateHelper
+  include CourseOptionHelpers
+
+  scenario 'Candidate is signed in' do
+    given_that_the_edit_course_choices_feature_flag_is_active
+    and_i_am_signed_in
+    and_there_is_a_course_with_one_course_option
+    and_there_is_a_course_with_multiple_course_options
+
+    when_i_visit_my_application_page
+    and_i_click_on_course_choices
+    and_i_click_on_add_course
+
+    when_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_the_single_site_course_as_my_first_course_choice
+    then_i_should_be_on_the_course_choice_review_page
+    and_i_should_not_see_a_change_location_link
+
+    when_i_click_to_add_another_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_the_multi_site_course_as_my_second_course_choice
+    and_i_choose_the_first_site
+    then_i_should_be_on_the_course_choice_review_page
+    and_i_should_see_the_first_site
+    and_i_should_see_a_change_location_link
+
+    when_i_click_to_change_the_location_of_the_second_course_choice
+    and_i_choose_the_second_site
+    then_i_should_be_on_the_course_choice_review_page
+  end
+
+  def given_that_the_edit_course_choices_feature_flag_is_active
+    FeatureFlag.activate('edit_course_choices')
+  end
+
+  def and_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_there_is_a_course_with_one_course_option
+    @provider = create(:provider)
+    create_list(:course, 2, provider: @provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
+    course_option_for_provider(provider: @provider, course: @provider.courses.first)
+  end
+
+  def and_there_is_a_course_with_multiple_course_options
+    course_option_for_provider(provider: @provider, course: @provider.courses.second)
+    course_option_for_provider(provider: @provider, course: @provider.courses.second)
+  end
+
+  def when_i_visit_my_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_click_on_course_choices
+    click_link 'Course choices'
+  end
+
+  def and_i_click_on_add_course
+    click_link 'Continue'
+  end
+
+  def when_i_choose_that_i_know_where_i_want_to_apply
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+  end
+
+  def and_i_choose_a_provider
+    select @provider.name_and_code
+    click_button 'Continue'
+  end
+
+  def and_i_choose_the_single_site_course_as_my_first_course_choice
+    choose @provider.courses.first.name_and_code
+    click_button 'Continue'
+  end
+
+  def then_i_should_be_on_the_course_choice_review_page
+    expect(page).to have_current_path(candidate_interface_course_choices_review_path)
+  end
+
+  def and_i_should_not_see_a_change_location_link
+    expect(page).not_to have_content("Change location for #{@provider.courses.first.name}")
+  end
+
+  def when_i_click_to_add_another_course
+    click_link 'Add another course'
+  end
+
+  def and_i_choose_that_i_know_where_i_want_to_apply
+    when_i_choose_that_i_know_where_i_want_to_apply
+  end
+
+  def and_i_choose_the_multi_site_course_as_my_second_course_choice
+    choose @provider.courses.second.name_and_code
+    click_button 'Continue'
+  end
+
+  def and_i_choose_the_first_site
+    choose @provider.courses.second.course_options.first.site.name
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_the_first_site
+    expect(page).to have_content(@provider.courses.second.course_options.first.site.name)
+  end
+
+  def and_i_should_see_a_change_location_link
+    expect(page).to have_content("Change location for #{@provider.courses.second.name}")
+  end
+
+  def when_i_click_to_change_the_location_of_the_second_course_choice
+    click_link "Change location for #{@provider.courses.second.name}"
+  end
+
+  def and_i_choose_the_second_site
+    choose @provider.courses.second.course_options.second.site.name
+    click_button 'Continue'
+  end
+
+  def and_i_choose_the_updated_site_name
+    expect(page).to have_content(@provider.courses.second.course_options.second.site.name)
+  end
+end


### PR DESCRIPTION
## Context
We want to allow candidates to be able to change the course, full time or part-time, or location for a course. If they want to change their location, they currently need to delete the choice and add a new one, instead of editing the location directly. 

This PR is the first(and potentially simplest slice) to add change location link to the course choices review component.

## Changes proposed in this pull request
This PR adds:
- Feature flag for `edit_course_choices` feature
- Add `#update` method to the `PickSiteForm` to allow updating an existing choice
- Updates the `CourseChoicesReviewComponent` to show the change link when there are multiple site options

### Before
![image](https://user-images.githubusercontent.com/22743709/77743010-528cc900-700f-11ea-9d86-112a049df658.png)

### After
![image](https://user-images.githubusercontent.com/22743709/77742995-4acd2480-700f-11ea-9afb-a6278eb6acc2.png)


## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Does this approach make sense? 

## Link to Trello card
https://trello.com/c/awBTB88j/1171-change-links-are-missing-from-the-course-choices-summary-cards

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
