### PR TITLE
Require users to be signed in for the interstitial route

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -1,0 +1,59 @@
+module CandidateInterface
+  class AfterSignInController < CandidateInterfaceController
+    def interstitial
+      course = current_candidate.course_from_find
+
+      if FeatureFlag.active?('you_selected_a_course_page')
+        service = InterstitialRouteSelector.new(candidate: current_candidate)
+        service.execute
+
+        if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
+          if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
+            redirect_to candidate_interface_additional_referee_path
+          elsif current_candidate.current_application.blank_application? && FeatureFlag.active?('before_you_start')
+            redirect_to candidate_interface_before_you_start_path
+          else
+            redirect_to candidate_interface_application_form_path
+          end
+        elsif service.candidate_has_already_selected_the_course
+          flash[:warning] = "You have already selected #{course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_already_has_3_courses
+          flash[:warning] = I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course.name_and_code)
+          redirect_to candidate_interface_course_choices_review_path
+        elsif !service.candidate_does_not_have_a_course_from_find
+          redirect_to candidate_interface_course_confirm_selection_path(course_id: course.id)
+        elsif service.candidate_should_choose_site
+          redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
+        elsif service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
+          redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
+        end
+      else
+        service = AddCourseFromFind.new(candidate: current_candidate)
+        service.execute
+
+        if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
+          if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
+            redirect_to candidate_interface_additional_referee_path
+          elsif current_candidate.current_application.blank_application? && FeatureFlag.active?('before_you_start')
+            redirect_to candidate_interface_before_you_start_path
+          else
+            redirect_to candidate_interface_application_form_path
+          end
+        elsif service.candidate_has_already_selected_the_course
+          flash[:warning] = "You have already selected #{course.name_and_code}."
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_already_has_3_courses
+          flash[:warning] = I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course.name_and_code)
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_has_new_course_added
+          redirect_to candidate_interface_course_choices_review_path
+        elsif service.candidate_should_choose_site
+          redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
+        elsif service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
+          redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,7 @@ Rails.application.routes.draw do
     get '/apply', to: 'apply_from_find#show', as: :apply_from_find
     post '/apply', to: 'apply_from_find#ucas_or_apply'
 
-    get '/interstitial', to: 'sign_in#interstitial', as: :interstitial
+    get '/interstitial', to: 'after_sign_in#interstitial', as: :interstitial
 
     scope '/application' do
       get '/' => 'application_form#show', as: :application_form


### PR DESCRIPTION
## Context

An error occurred on production that is caused by a non-signed-in candidate visiting the /candidate/interstitial URL. I'm assuming that they pressed the back button or something similar.

## Changes proposed in this pull request

This solves the issue by pulling out the interstitial method into a separate controller, which doesn't skip `authenticate_candidate!` and will require candidates to be signed in. Bonus that it cleans up the original controller, which is pretty large already.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/1534179482

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
