### PR TITLE
Allow support to add a course to an application

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,3 +118,6 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false

--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -5,13 +5,34 @@ module SupportInterface
     end
 
     def show
-      @application_form = ApplicationForm
-        .find(params[:application_form_id])
+      @application_form = application_form
     end
 
     def audit
-      @application_form = ApplicationForm
-        .find(params[:application_form_id])
+      @application_form = application_form
+    end
+
+    def select_course_to_add
+      @form = SupportInterface::AddCourseToApplicationForm.new(application_form: application_form)
+    end
+
+    def add_course
+      course_option_id = params.require(:support_interface_add_course_to_application_form).fetch(:course_option_id)
+
+      @form = SupportInterface::AddCourseToApplicationForm.new(
+        application_form: application_form,
+        course_option_id: course_option_id,
+      )
+
+      if @form.save
+        redirect_to support_interface_application_form_path(application_form)
+      else
+        render :select_course_to_add
+      end
+    end
+
+    def application_form
+      @_application_form ||= ApplicationForm.find(params[:application_form_id])
     end
   end
 end

--- a/app/models/support_interface/add_course_to_application_form.rb
+++ b/app/models/support_interface/add_course_to_application_form.rb
@@ -1,0 +1,44 @@
+module SupportInterface
+  class AddCourseToApplicationForm
+    include ActiveModel::Model
+    attr_accessor :course_option_id, :application_form
+
+    validate :application_form_in_correct_state
+    validate :course_option_exists
+
+    def save
+      return unless valid?
+
+      application_choice = ApplicationChoice.create!(
+        application_form: application_form,
+        course_option: course_option,
+        status: 'unsubmitted',
+      )
+
+      SubmitApplicationChoice.new(application_choice).call
+    end
+
+  private
+
+    def course_option
+      @course_option ||= CourseOption.find(course_option_id)
+    rescue ActiveRecord::RecordNotFound
+      nil
+    end
+
+    def course_option_exists
+      return if course_option
+
+      errors[:base] << "There's no course option with ID #{course_option_id}"
+    end
+
+    # For simplicity we only support adding applications to forms that are in
+    # "Awaiting references" state, because we need to add the choices in the
+    # same state as other applications.
+    def application_form_in_correct_state
+      return if application_form.application_choices.any?(&:awaiting_references?)
+
+      errors[:base] << 'You can only add a course to an application that has at least 1 other application choice in the "awaiting references" state.'
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/select_course_to_add.html.erb
+++ b/app/views/support_interface/application_forms/select_course_to_add.html.erb
@@ -1,0 +1,25 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: support_interface_add_course_to_application_path(@form.application_form), builder: GOVUKDesignSystemFormBuilder::FormBuilder do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class='govuk-heading-xl'>
+        Add course to <%= @form.application_form.full_name %>'s application
+      </h1>
+
+      <p class="govuk-body">
+        Warning: there is no way to undo this action.
+      </p>
+
+      <p class="govuk-body">
+        Adding a new course will not email the candidate.
+      </p>
+
+      <%= f.govuk_text_field :course_option_id,
+        label: { text: 'Course Option ID' },
+        hint_text: "You can find this in the Vacancies tab on the provider page" %>
+
+      <%= f.govuk_submit 'Add course to application' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -35,7 +35,7 @@
 
 <% if @application_form.application_choices.any? %>
   <h2 class="govuk-heading-l govuk-!-margin-top-8">Course choices</h2>
-  <% @application_form.application_choices.includes(:course, :provider, :site).each do |application_choice| %>
+  <% @application_form.application_choices.includes(:course, :provider, :site, :offered_course_option).each do |application_choice| %>
     <% rows = [
       { key: 'Course', value: application_choice.offered_course.name_and_code },
       { key: 'Provider', value: application_choice.offered_course.provider.name_and_code },
@@ -51,6 +51,10 @@
       <%= render SummaryCardHeaderComponent.new(title: application_choice.offered_course.name_and_code) %>
     <% end %>
   <% end %>
+<% end %>
+
+<% if @application_form.application_choices.any?(&:awaiting_references?) %>
+  <%= govuk_button_link_to 'Add course', support_interface_add_course_to_application_path(@application_form) %>
 <% end %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">References</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -401,6 +401,8 @@ Rails.application.routes.draw do
 
     get '/applications' => 'application_forms#index'
     get '/applications/:application_form_id' => 'application_forms#show', as: :application_form
+    get '/applications/:application_form_id/add-course' => 'application_forms#select_course_to_add', as: :add_course_to_application
+    post '/applications/:application_form_id/add-course' => 'application_forms#add_course'
     get '/applications/:application_form_id/audit' => 'application_forms#audit', as: :application_form_audit
     get '/applications/:application_form_id/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
     post '/applications/:application_form_id/comments' => 'application_forms/comments#create', as: :application_form_comments

--- a/spec/models/support_interface/add_course_to_application_form_spec.rb
+++ b/spec/models/support_interface/add_course_to_application_form_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::AddCourseToApplicationForm, type: :model do
+  describe '#valid?' do
+    it 'is not valid if the course option does not exist' do
+      application_form = build_stubbed(:application_form)
+      form = SupportInterface::AddCourseToApplicationForm.new(application_form: application_form, course_option_id: 7125871235812)
+
+      form.validate
+
+      expect(form.errors.full_messages).to include "There's no course option with ID 7125871235812"
+    end
+  end
+end

--- a/spec/system/support_interface/adding_a_course_spec.rb
+++ b/spec/system/support_interface/adding_a_course_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.feature 'Adding a course' do
+  include DfESignInHelpers
+
+  scenario 'A support user adds a course to a application' do
+    given_i_am_a_support_user
+    and_there_is_a_candidate_who_wants_a_course_added
+    when_i_visit_the_application_form
+    and_click_on_the_button_to_add_a_course
+    and_i_fill_in_the_course_option_id_for_the_desired_course
+    then_the_new_course_is_added_to_the_application
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_is_a_candidate_who_wants_a_course_added
+    @application_form = create(:completed_application_form)
+
+    create(:application_choice, status: 'awaiting_references', application_form: @application_form)
+
+    @new_course_option = create(:course_option, course: create(:course, name: 'A new course'))
+  end
+
+  def when_i_visit_the_application_form
+    visit support_interface_application_form_path(@application_form)
+  end
+
+  def and_click_on_the_button_to_add_a_course
+    click_on 'Add course'
+  end
+
+  def and_i_fill_in_the_course_option_id_for_the_desired_course
+    fill_in 'Course Option ID', with: @new_course_option.id
+    click_on 'Add course to application'
+  end
+
+  def then_the_new_course_is_added_to_the_application
+    expect(page).to have_content 'A new course'
+  end
+end


### PR DESCRIPTION
## Context

We regularly have candidates who request a course to be added to their application after they've submitted it. We currently have to do this in the console.

## Changes proposed in this pull request

Allow support users to add a course to an application manually.

# 👉 [Watch the video!](https://www.loom.com/share/6f7865da143641e5841d07e117ea366a)

## Guidance to review

Will this work? Any more validations that we need?

## Link to Trello card

https://trello.com/c/eqOOQ4BW/1253-dev-add-course-to-user-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
