### PR TITLE
Fix business_days-dependent failing referee replacement spec

### DIFF
--- a/spec/services/get_referees_that_need_replacing_spec.rb
+++ b/spec/services/get_referees_that_need_replacing_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GetRefereesThatNeedReplacing do
     end
 
     it 'does not return referees which were sent their reference email less than 5 days ago' do
-      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.business_days.ago)
+      create(:reference, feedback_status: 'feedback_requested', requested_at: 4.days.ago)
 
       expect(described_class.call).to be_empty
     end


### PR DESCRIPTION
## Context

With the recent holiday adjustments, `4.business_days.ago` resolves to 16th March, therefore 'GetRefereesThatNeedReplacing does not return referees which were sent their reference email less than 5 days ago' is failing.

## Changes proposed in this pull request

Use `4.days.ago` rather than `business_days`.

## Guidance to review

Self-explanatory.

## Link to Trello card

No card

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
