### PR TITLE
Prompt user to add additional qualifications

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -18,8 +18,9 @@ module CandidateInterface
       @qualification = OtherQualificationForm.new(other_qualification_params)
 
       if @qualification.valid?
+        @qualification.save(current_application)
+
         if @qualification.choice == 'same_type'
-          @qualification.save(current_application)
           qualification = ApplicationQualification.find(params[:id])
 
           @qualification_type = OtherQualificationTypeForm.new(
@@ -30,18 +31,9 @@ module CandidateInterface
 
           redirect_to candidate_interface_new_other_qualification_details_path(id: current_application.application_qualifications.last.id)
         elsif @qualification.choice == 'different_type'
-          @qualification.save(current_application)
-
           redirect_to candidate_interface_new_other_qualification_type_path
         elsif @qualification.choice == 'no'
-          @qualification.save(current_application)
-
           redirect_to candidate_interface_review_other_qualifications_path
-        else
-          qualifications = OtherQualificationForm.build_all_from_application(current_application)
-          @type = qualifications.last.qualification_type
-
-          render :new
         end
       else
         qualifications = OtherQualificationForm.build_all_from_application(current_application)
@@ -55,8 +47,8 @@ module CandidateInterface
 
     def other_qualification_params
       params.require(:candidate_interface_other_qualification_form).permit(
-        :id, :qualification_type, :subject, :institution_name, :grade, :award_year, :choice
-      ).merge!(id: params[:id]).transform_values(&:strip)
+        :id, :subject, :institution_name, :grade, :award_year, :choice
+      ).merge!(id: params[:id], qualification_type: get_qualification_type).transform_values(&:strip)
     end
 
     def last_two_qualifications_are_of_same_type(qualifications)
@@ -71,6 +63,10 @@ module CandidateInterface
 
     def pre_fill_award_year(qualifications)
       qualifications[-2].award_year
+    end
+
+    def get_qualification_type
+      ApplicationQualification.find(params[:id]).qualification_type
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -1,0 +1,56 @@
+module CandidateInterface
+  class OtherQualifications::DetailsController < CandidateInterfaceController
+    def new
+      qualifications = OtherQualificationForm.build_all_from_application(current_application)
+      last_qualification = qualifications[-2]
+      @type = qualifications.last.qualification_type
+
+      @qualification = if @type == last_qualification&.qualification_type
+                         OtherQualificationForm.new(
+                           institution_name: last_qualification.institution_name,
+                           award_year: last_qualification.award_year,
+                         )
+                       else
+                         OtherQualificationForm.new
+                       end
+    end
+
+    def create
+      @qualification = OtherQualificationForm.new(other_qualification_params)
+
+      if @qualification.valid? && @qualification.choice == 'same_type'
+        @qualification.save(current_application)
+        qualification = ApplicationQualification.find_by!(id: params[:id])
+
+        @qualification_type = OtherQualificationTypeForm.new(
+          qualification_type: qualification.qualification_type,
+        )
+
+        @qualification_type.save(current_application)
+
+        redirect_to candidate_interface_new_other_qualification_details_path(id: current_application.application_qualifications.last.id)
+      elsif @qualification.valid? && @qualification.choice == 'different_type'
+        @qualification.save(current_application)
+
+        redirect_to candidate_interface_new_other_qualification_type_path
+      elsif @qualification.valid? && @qualification.choice == 'no'
+        @qualification.save(current_application)
+
+        redirect_to candidate_interface_review_other_qualifications_path
+      else
+        qualifications = OtherQualificationForm.build_all_from_application(current_application)
+        @type = qualifications.last.qualification_type
+
+        render :new
+      end
+    end
+
+  private
+
+    def other_qualification_params
+      params.require(:candidate_interface_other_qualification_form).permit(
+        :id, :qualification_type, :subject, :institution_name, :grade, :award_year, :choice
+      ).merge!(id: params[:id]).transform_values(&:strip)
+    end
+  end
+end

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -4,7 +4,6 @@ module CandidateInterface
       qualifications = OtherQualificationForm.build_all_from_application(current_application)
       last_qualification = qualifications[-2]
       @type = qualifications.last.qualification_type
-      @id = qualifications.last.id
 
       @qualification = if @type == last_qualification&.qualification_type
                          OtherQualificationForm.new(
@@ -21,7 +20,7 @@ module CandidateInterface
 
       if @qualification.valid? && @qualification.choice == 'same_type'
         @qualification.save(current_application)
-        qualification = ApplicationQualification.find_by!(id: params[:id])
+        qualification = ApplicationQualification.find(params[:id])
 
         @qualification_type = OtherQualificationTypeForm.new(
           qualification_type: qualification.qualification_type,
@@ -41,7 +40,6 @@ module CandidateInterface
       else
         qualifications = OtherQualificationForm.build_all_from_application(current_application)
         @type = qualifications.last.qualification_type
-        @id = qualifications.last.id
 
         render :new
       end
@@ -52,7 +50,7 @@ module CandidateInterface
     def other_qualification_params
       params.require(:candidate_interface_other_qualification_form).permit(
         :id, :qualification_type, :subject, :institution_name, :grade, :award_year, :choice
-      ).transform_values(&:strip)
+      ).merge!(id: params[:id]).transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
       qualifications = OtherQualificationForm.build_all_from_application(current_application)
       last_qualification = qualifications[-2]
       @type = qualifications.last.qualification_type
+      @id = qualifications.last.id
 
       @qualification = if @type == last_qualification&.qualification_type
                          OtherQualificationForm.new(
@@ -40,6 +41,7 @@ module CandidateInterface
       else
         qualifications = OtherQualificationForm.build_all_from_application(current_application)
         @type = qualifications.last.qualification_type
+        @id = qualifications.last.id
 
         render :new
       end
@@ -50,7 +52,7 @@ module CandidateInterface
     def other_qualification_params
       params.require(:candidate_interface_other_qualification_form).permit(
         :id, :qualification_type, :subject, :institution_name, :grade, :award_year, :choice
-      ).merge!(id: params[:id]).transform_values(&:strip)
+      ).transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -4,6 +4,11 @@ module CandidateInterface
 
     def show
       @application_form = current_application
+      @application_form.application_qualifications.other.each do |qualification|
+        if qualification.institution_name.nil? || qualification.grade.nil? || qualification.award_year.nil?
+          qualification.destroy
+        end
+      end
     end
 
     def complete

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -4,19 +4,20 @@ module CandidateInterface
 
     def show
       @application_form = current_application
-      @application_form.application_qualifications.other.each do |qualification|
-        if qualification.institution_name.nil? || qualification.grade.nil? || qualification.award_year.nil?
-          qualification.destroy
-        end
-      end
     end
 
     def complete
       @application_form = current_candidate.current_application
 
-      @application_form.update!(application_form_params)
+      if section_marked_as_complete? && there_are_incomplete_qualifications?
+        flash[:warning] = 'You can’t complete this section with incomplete qualifications'
 
-      redirect_to candidate_interface_application_form_path
+        render :show
+      else
+        @application_form.update!(application_form_params)
+
+        redirect_to candidate_interface_application_form_path
+      end
     end
 
   private
@@ -24,6 +25,18 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:other_qualifications_completed)
         .transform_values(&:strip)
+    end
+
+    def there_are_incomplete_qualifications?
+      attributes_that_should_be_completed = @application_form.application_qualifications.other.map do |qualification|
+        [qualification.qualification_type, qualification.subject, qualification.grade, qualification.institution_name]
+      end
+
+      attributes_that_should_be_completed.flatten.length != attributes_that_should_be_completed.flatten.compact.length
+    end
+
+    def section_marked_as_complete?
+      application_form_params[:other_qualifications_completed] == 'true'
     end
   end
 end

--- a/app/controllers/candidate_interface/other_qualifications/review_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/review_controller.rb
@@ -10,7 +10,7 @@ module CandidateInterface
       @application_form = current_candidate.current_application
 
       if section_marked_as_complete? && there_are_incomplete_qualifications?
-        flash[:warning] = 'You can’t complete this section with incomplete qualifications'
+        flash[:warning] = 'You must fill in all your qualifications to complete this section'
 
         render :show
       else

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -1,0 +1,24 @@
+module CandidateInterface
+  class OtherQualifications::TypeController < CandidateInterfaceController
+    def new
+      @qualification_type = OtherQualificationTypeForm.new
+    end
+
+    def create
+      @qualification_type = OtherQualificationTypeForm.new(other_qualification_type_params)
+      if @qualification_type.save(current_application)
+        redirect_to candidate_interface_new_other_qualification_details_path(id: current_application.application_qualifications.last.id)
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def other_qualification_type_params
+      params.require(:candidate_interface_other_qualification_type_form).permit(
+        :qualification_type,
+      )
+    end
+  end
+end

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -4,7 +4,7 @@ module CandidateInterface
     include ValidationUtils
 
     attr_accessor :id, :qualification_type, :subject, :institution_name, :grade,
-                  :award_year
+                  :award_year, :choice
 
     validates :qualification_type, :subject, :institution_name, :grade, :award_year, presence: true
 
@@ -40,16 +40,27 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      application_form.application_qualifications.create!(
-        level: ApplicationQualification.levels[:other],
-        qualification_type: qualification_type,
-        subject: subject,
-        institution_name: institution_name,
-        grade: grade,
-        predicted_grade: false,
-        award_year: award_year,
-      )
-
+      if FeatureFlag.active?('prompt_for_additional_qualifications')
+        qualification = ApplicationQualification.find_by!(id: id)
+        qualification.update!(
+          qualification_type: qualification_type,
+          subject: subject,
+          institution_name: institution_name,
+          grade: grade,
+          predicted_grade: false,
+          award_year: award_year,
+        )
+      else
+        application_form.application_qualifications.create!(
+          level: ApplicationQualification.levels[:other],
+          qualification_type: qualification_type,
+          subject: subject,
+          institution_name: institution_name,
+          grade: grade,
+          predicted_grade: false,
+          award_year: award_year,
+          )
+      end
       true
     end
 

--- a/app/models/candidate_interface/other_qualification_form.rb
+++ b/app/models/candidate_interface/other_qualification_form.rb
@@ -41,7 +41,7 @@ module CandidateInterface
       return false unless valid?
 
       if FeatureFlag.active?('prompt_for_additional_qualifications')
-        qualification = ApplicationQualification.find_by!(id: id)
+        qualification = ApplicationQualification.find(id)
         qualification.update!(
           qualification_type: qualification_type,
           subject: subject,

--- a/app/models/candidate_interface/other_qualification_type_form.rb
+++ b/app/models/candidate_interface/other_qualification_type_form.rb
@@ -6,6 +6,8 @@ module CandidateInterface
 
     validates :qualification_type, presence: true
 
+    validates :qualification_type, inclusion: { in: ['A level', 'AS level', 'GCSE', 'Other'], allow_blank: false }
+
     def save(application_form)
       return false unless valid?
 

--- a/app/models/candidate_interface/other_qualification_type_form.rb
+++ b/app/models/candidate_interface/other_qualification_type_form.rb
@@ -1,0 +1,19 @@
+module CandidateInterface
+  class OtherQualificationTypeForm
+    include ActiveModel::Model
+
+    attr_accessor :qualification_type
+
+    validates :qualification_type, presence: true
+
+    def save(application_form)
+      return false unless valid?
+
+      application_form.application_qualifications.create!(
+        level: ApplicationQualification.levels[:other],
+        qualification_type: qualification_type,
+      )
+      true
+    end
+  end
+end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -85,6 +85,8 @@ module CandidateInterface
     def other_qualification_path
       if other_qualifications_completed? || other_qualifications_added?
         Rails.application.routes.url_helpers.candidate_interface_review_other_qualifications_path
+      elsif FeatureFlag.active?('prompt_for_additional_qualifications')
+        Rails.application.routes.url_helpers.candidate_interface_new_other_qualification_type_path
       else
         Rails.application.routes.url_helpers.candidate_interface_new_other_qualification_path
       end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -14,6 +14,7 @@ class FeatureFlag
     force_ok_computer_to_fail
     improved_expired_token_flow
     pilot_open
+    prompt_for_additional_qualifications
     provider_application_filters
     provider_change_response
     provider_view_safeguarding

--- a/app/views/candidate_interface/other_qualifications/base/_form.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/_form.html.erb
@@ -1,14 +1,5 @@
-<p class="govuk-body">
-  Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
-</p>
-<p class="govuk-body">
-  Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.
-</p>
-
 <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: t('application_form.other_qualification.qualification_type.hint_text') %>
 <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
 <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
 <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
 <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
-
-<%= f.govuk_submit t('application_form.other_qualification.base.button') %>

--- a/app/views/candidate_interface/other_qualifications/base/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/edit.html.erb
@@ -10,15 +10,9 @@
         <%= t('page_titles.edit_other_qualification') %>
       </h1>
 
-      <p class="govuk-body">
-        Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
-      </p>
-      <p class="govuk-body">
-        Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.
-      </p>
+      <%= render 'candidate_interface/other_qualifications/shared/instructions' %>
 
       <%= f.hidden_field :id, value: @qualification.id %>
-      <%= f.hidden_field :qualification_type, value: @qualification.qualification_type %>
 
       <%= render 'form', f: f %>
 

--- a/app/views/candidate_interface/other_qualifications/base/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/edit.html.erb
@@ -10,8 +10,19 @@
         <%= t('page_titles.edit_other_qualification') %>
       </h1>
 
+      <p class="govuk-body">
+        Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
+      </p>
+      <p class="govuk-body">
+        Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.
+      </p>
+
       <%= f.hidden_field :id, value: @qualification.id %>
+      <%= f.hidden_field :qualification_type, value: @qualification.qualification_type %>
+
       <%= render 'form', f: f %>
+
+      <%= f.govuk_submit t('application_form.other_qualification.base.button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/other_qualifications/base/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/new.html.erb
@@ -10,7 +10,15 @@
         <%= t('page_titles.add_other_qualification') %>
       </h1>
 
+      <p class="govuk-body">
+        Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
+      </p>
+      <p class="govuk-body">
+        Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.
+      </p>
+
       <%= render 'form', f: f %>
+      <%= f.govuk_submit t('application_form.other_qualification.base.button') %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/other_qualifications/base/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/new.html.erb
@@ -10,12 +10,7 @@
         <%= t('page_titles.add_other_qualification') %>
       </h1>
 
-      <p class="govuk-body">
-        Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
-      </p>
-      <p class="govuk-body">
-        Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.
-      </p>
+      <%= render 'candidate_interface/other_qualifications/shared/instructions' %>
 
       <%= render 'form', f: f %>
       <%= f.govuk_submit t('application_form.other_qualification.base.button') %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -24,8 +24,6 @@
         <%= f.hidden_field :qualification_type, value: @type %>
       <% end %>
 
-      <%= f.hidden_field :id, value: @id %>
-
       <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
       <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
       <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -30,11 +30,11 @@
       <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
 
       <%= f.govuk_radio_buttons_fieldset :add_another_qualification, legend: { text: 'Do you want to add another qualification?', tag: 'span' } do %>
-      <% if @type != 'Other' %>
-        <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another #{@type}" } %>
-      <% else %>
+        <% if @type != 'Other' %>
+          <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another #{@type}" } %>
+        <% else %>
           <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another qualification" } %>
-      <% end %>
+        <% end %>
         <%= f.govuk_radio_button :choice, 'different_type', label: { text: 'Yes, add a different qualification' } %>
         <%= f.govuk_radio_button :choice, 'no', label: { text: 'No, not right  now' } %>
       <% end %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -24,6 +24,8 @@
         <%= f.hidden_field :qualification_type, value: @type %>
       <% end %>
 
+      <%= f.hidden_field :id, value: @id %>
+
       <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
       <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
       <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
@@ -33,7 +35,7 @@
       <% if @type != 'Other' %>
         <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another #{@type}" } %>
       <% else %>
-          <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another qualificaiton" } %>
+          <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another qualification" } %>
       <% end %>
         <%= f.govuk_radio_button :choice, 'different_type', label: { text: 'Yes, add a different qualification' } %>
         <%= f.govuk_radio_button :choice, 'no', label: { text: 'No, not right  now' } %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -1,0 +1,45 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.qualification_details'), @qualification.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification, url: candidate_interface_create_other_qualification_details_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <% if @type != 'Other' %>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+          Add <%= @type %> qualification
+        </h1>
+      <% else %>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">Academic and other relevant qualifications</span>
+          Qualification Details
+        </h1>
+      <% end %>
+
+      <% if @type == 'Other' %>
+        <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: 'For example, BTEC, NVQ or non-UK other' %>
+      <% else %>
+        <%= f.hidden_field :qualification_type, value: @type %>
+      <% end %>
+
+      <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>
+      <%= f.govuk_text_field :grade, label: { text: t('application_form.other_qualification.grade.label'), size: 'm' }, width: 10 %>
+      <%= f.govuk_text_field :award_year, label: { text: t('application_form.other_qualification.award_year.label'), size: 'm' }, hint_text: t('application_form.other_qualification.award_year.hint_text'), width: 4 %>
+      <%= f.govuk_text_field :institution_name, label: { text: t('application_form.other_qualification.institution_name.label'), size: 'm' } %>
+
+      <%= f.govuk_radio_buttons_fieldset :add_another_qualification, legend: { text: 'Do you want to add another qualification?', tag: 'span' } do %>
+      <% if @type != 'Other' %>
+        <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another #{@type}" } %>
+      <% else %>
+          <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another qualificaiton" } %>
+      <% end %>
+        <%= f.govuk_radio_button :choice, 'different_type', label: { text: 'Yes, add a different qualification' } %>
+        <%= f.govuk_radio_button :choice, 'no', label: { text: 'No, not right  now' } %>
+      <% end %>
+
+      <%= f.govuk_submit t('application_form.other_qualification.base.button') %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -20,8 +20,6 @@
 
       <% if @type == 'Other' %>
         <%= f.govuk_text_field :qualification_type, label: { text: t('application_form.other_qualification.qualification_type.label'), size: 'm' }, hint_text: 'For example, BTEC, NVQ or non-UK other' %>
-      <% else %>
-        <%= f.hidden_field :qualification_type, value: @type %>
       <% end %>
 
       <%= f.govuk_text_field :subject, label: { text: t('application_form.other_qualification.subject.label'), size: 'm' } %>

--- a/app/views/candidate_interface/other_qualifications/review/show.html.erb
+++ b/app/views/candidate_interface/other_qualifications/review/show.html.erb
@@ -11,7 +11,11 @@
 
 <%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_new_other_qualification_path, class: 'govuk-button--secondary' %>
+<% if FeatureFlag.active?('prompt_for_additional_qualifications') %>
+  <%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_new_other_qualification_type_path, class: 'govuk-button--secondary' %>
+<% else %>
+  <%= govuk_button_link_to t('application_form.other_qualification.another.button'), candidate_interface_new_other_qualification_path, class: 'govuk-button--secondary' %>
+<% end %>
 
 <%= form_with model: @application_form, url: candidate_interface_complete_other_qualifications_path do |f| %>
   <div class='govuk-form-group'>

--- a/app/views/candidate_interface/other_qualifications/shared/_instructions.html.erb
+++ b/app/views/candidate_interface/other_qualifications/shared/_instructions.html.erb
@@ -1,0 +1,6 @@
+<p class="govuk-body">
+  Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
+</p>
+<p class="govuk-body">
+  Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.
+</p>

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, title_with_error_prefix(t('page_titles.add_other_qualification'), @qualification_type.errors.any?) %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @qualification_type, url: candidate_interface_create_other_qualification_type_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-xl">
+        <%= t('page_titles.add_other_qualification') %>
+      </h1>
+
+      <p class="govuk-body">
+        Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
+      </p>
+      <p class="govuk-body">Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.</p>
+
+      <%= f.govuk_radio_buttons_fieldset :choose_qualification_type, legend: { text: 'What type of qualification do you want to add?', tag: 'span' } do %>
+        <%= f.govuk_radio_button :qualification_type, 'GCSE', label: { text: 'GCSE' } %>
+        <%= f.govuk_radio_button :qualification_type, 'A level', label: { text: 'A level' } %>
+        <%= f.govuk_radio_button :qualification_type, 'AS Level', label: { text: 'AS level' } %>
+        <%= f.govuk_radio_button :qualification_type, 'Other', label: { text: 'Other' }  %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -18,7 +18,7 @@
       <%= f.govuk_radio_buttons_fieldset :choose_qualification_type, legend: { text: 'What type of qualification do you want to add?', tag: 'span' } do %>
         <%= f.govuk_radio_button :qualification_type, 'GCSE', label: { text: 'GCSE' } %>
         <%= f.govuk_radio_button :qualification_type, 'A level', label: { text: 'A level' } %>
-        <%= f.govuk_radio_button :qualification_type, 'AS Level', label: { text: 'AS level' } %>
+        <%= f.govuk_radio_button :qualification_type, 'AS level', label: { text: 'AS level' } %>
         <%= f.govuk_radio_button :qualification_type, 'Other', label: { text: 'Other' }  %>
       <% end %>
 

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -10,10 +10,7 @@
         <%= t('page_titles.add_other_qualification') %>
       </h1>
 
-      <p class="govuk-body">
-        Enter your qualifications as completely as you can, including all your GCSEs and A levels (or equivalents), and any other qualifications where you showed skills that might help you as a teacher.
-      </p>
-      <p class="govuk-body">Undergraduate and postgraduate degrees should be included in the ‘Degree’ section.</p>
+      <%= render 'candidate_interface/other_qualifications/shared/instructions' %>
 
       <%= f.govuk_radio_buttons_fieldset :choose_qualification_type, legend: { text: 'What type of qualification do you want to add?', tag: 'span' } do %>
         <%= f.govuk_radio_button :qualification_type, 'GCSE', label: { text: 'GCSE' } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,6 +62,7 @@ en:
     edit_degree: Edit degree
     other_qualification: Academic and other relevant qualifications
     add_other_qualification: Academic and other relevant qualifications
+    qualification_details: Qualification details
     edit_other_qualification: Edit qualification
     destroy_other_qualification: Are you sure you want to delete this qualification?
     becoming_a_teacher: Why do you want to be a teacher?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -232,8 +232,14 @@ Rails.application.routes.draw do
       end
 
       scope '/other-qualifications' do
-        get '/' => 'other_qualifications/base#new', as: :new_other_qualification
-        post '/' => 'other_qualifications/base#create', as: :create_other_qualification
+        get '/' => 'other_qualifications/type#new', as: :new_other_qualification_type
+        post '/' => 'other_qualifications/type#create', as: :create_other_qualification_type
+
+        get '/new/:id' => 'other_qualifications/details#new', as: :new_other_qualification_details
+        post '/new/:id' => 'other_qualifications/details#create', as: :create_other_qualification_details
+
+        get '/new' => 'other_qualifications/base#new', as: :new_other_qualification
+        post '/new' => 'other_qualifications/base#create', as: :create_other_qualification
 
         get '/review' => 'other_qualifications/review#show', as: :review_other_qualifications
         patch '/review' => 'other_qualifications/review#complete', as: :complete_other_qualifications

--- a/spec/models/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_type_form_spec.rb
@@ -32,12 +32,12 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
     it 'creates a new other qualification if valid' do
       application_form = create(:application_form)
 
-      form = CandidateInterface::OtherQualificationTypeForm.new(qualification_type: 'other')
+      form = CandidateInterface::OtherQualificationTypeForm.new(qualification_type: 'Other')
 
       form.save(application_form)
 
       expect(application_form.application_qualifications.last.level).to eq('other')
-      expect(application_form.application_qualifications.last.qualification_type).to eq('other')
+      expect(application_form.application_qualifications.last.qualification_type).to eq('Other')
     end
   end
 end

--- a/spec/models/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_type_form_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::OtherQualificationTypeForm do
+  describe '#validations' do
+    context 'with a qualification type present' do
+      it 'is valid' do
+        expect(described_class.new(qualification_type: 'A level')).to be_valid
+      end
+    end
+
+    context 'without a qualification type present' do
+      it 'is not valid' do
+        expect(described_class.new(qualification_type: nil)).not_to be_valid
+      end
+    end
+  end
+
+  describe '#save' do
+    it 'return false if not valid' do
+      application_form = double
+
+      form = CandidateInterface::GcseQualificationTypeForm.new({})
+      expect(form.save_base(application_form)).to eq(false)
+    end
+
+    it 'creates a new other qualification if valid' do
+      application_form = create(:application_form)
+
+      form = CandidateInterface::OtherQualificationTypeForm.new(qualification_type: 'other')
+
+      form.save(application_form)
+
+      expect(application_form.application_qualifications.last.level).to eq('other')
+      expect(application_form.application_qualifications.last.qualification_type).to eq('other')
+    end
+  end
+end

--- a/spec/models/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_type_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
   end
 
   describe '#save' do
-    it 'return false if not valid' do
+    it 'returns false if not valid' do
       application_form = double
 
       form = CandidateInterface::GcseQualificationTypeForm.new({})

--- a/spec/models/candidate_interface/other_qualification_type_form_spec.rb
+++ b/spec/models/candidate_interface/other_qualification_type_form_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe CandidateInterface::OtherQualificationTypeForm do
         expect(described_class.new(qualification_type: nil)).not_to be_valid
       end
     end
+
+    context 'with a type that is not in the available options' do
+      it 'is not valid' do
+        expect(described_class.new(qualification_type: 'Invalid qualification')).not_to be_valid
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
@@ -23,7 +23,7 @@ RSpec.feature 'Entering their other qualifications' do
     and_select_add_another_a_level
     and_click_save_and_continue
     then_i_see_the_other_qualifications_form
-    and_the_year_and_instituion_fields_are_pre_populated_with_my_previous_details
+    and_the_year_and_institution_fields_are_pre_populated_with_my_previous_details
 
     when_i_fill_out_the_remainder_of_the_form
     and_i_choose_a_different_type_of_qualification
@@ -32,7 +32,7 @@ RSpec.feature 'Entering their other qualifications' do
 
     when_i_choose_gcse
     and_i_click_continue
-    then_the_year_and_instituion_fields_are_not_pre_populated_with_my_previous_details
+    then_the_year_and_institution_fields_are_not_pre_populated_with_my_previous_details
 
     when_i_fill_in_my_gcse_details
     and_i_choose_not_to_add_additional_qualifications
@@ -129,7 +129,7 @@ RSpec.feature 'Entering their other qualifications' do
     click_button 'Save and continue'
   end
 
-  def and_the_year_and_instituion_fields_are_pre_populated_with_my_previous_details
+  def and_the_year_and_institution_fields_are_pre_populated_with_my_previous_details
     expect(page.find('#candidate-interface-other-qualification-form-institution-name-field').value).to eq('Yugi College')
     expect(page.find('#candidate-interface-other-qualification-form-award-year-field').value).to eq('2015')
   end
@@ -147,7 +147,7 @@ RSpec.feature 'Entering their other qualifications' do
     choose 'GCSE'
   end
 
-  def then_the_year_and_instituion_fields_are_not_pre_populated_with_my_previous_details
+  def then_the_year_and_institution_fields_are_not_pre_populated_with_my_previous_details
     expect(page.find('#candidate-interface-other-qualification-form-institution-name-field').value).to eq(nil)
     expect(page.find('#candidate-interface-other-qualification-form-award-year-field').value).to eq(nil)
   end

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
@@ -256,7 +256,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def then_i_should_be_told_i_cannot_submit_incomplete_qualifications
-    expect(page).to have_content('You can’t complete this section with incomplete qualifications')
+    expect(page).to have_content('You must fill in all your qualifications to complete this section')
   end
 
   def when_i_delete_my_incomplete_qualification

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
@@ -44,11 +44,11 @@ RSpec.feature 'Entering their other qualifications' do
     and_choose_as_level
     and_i_click_continue
     and_i_visit_the_other_qualification_review_page
-    then_i_should_not_see_an_incomplete_as_level_qualification
+    then_i_should_see_an_incomplete_as_level_qualification
 
     when_i_click_on_delete_my_first_qualification
     and_i_confirm_that_i_want_to_delete_my_additional_qualification
-    then_i_can_only_see_two_qualifacitions
+    then_i_can_only_see_three_qualifacitions
 
     when_i_click_to_change_my_first_qualification
     then_i_see_my_qualification_filled_in
@@ -63,6 +63,14 @@ RSpec.feature 'Entering their other qualifications' do
 
     when_i_click_on_other_qualifications
     then_i_can_check_my_answers
+
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_should_be_told_i_cannot_submit_incomplete_qualifications
+
+    when_i_delete_my_incomplete_qualification
+    and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    then_i_can_only_see_two_qualifications
 
     when_i_mark_this_section_as_completed
     and_i_click_on_continue
@@ -185,8 +193,9 @@ RSpec.feature 'Entering their other qualifications' do
     visit candidate_interface_review_other_qualifications_path
   end
 
-  def then_i_should_not_see_an_incomplete_as_level_qualification
-    expect(page).not_to have_content('Other')
+  def then_i_should_see_an_incomplete_as_level_qualification
+    expect(page).to have_content('AS level')
+    expect(all('.govuk-summary-list__value').last.text).to eq ''
   end
 
   def when_i_click_on_delete_my_first_qualification
@@ -199,10 +208,11 @@ RSpec.feature 'Entering their other qualifications' do
     click_button t('application_form.other_qualification.confirm_delete')
   end
 
-  def then_i_can_only_see_two_qualifacitions
+  def then_i_can_only_see_three_qualifacitions
     expect(page).not_to have_content 'A level Losing to Yugi'
     expect(page).to have_content('A level Oh')
     expect(page).to have_content('GCSE Maths')
+    expect(page).to have_content('AS level')
   end
 
   def when_i_click_to_change_my_first_qualification
@@ -243,6 +253,23 @@ RSpec.feature 'Entering their other qualifications' do
 
   def and_i_click_on_continue
     when_i_click_on_continue
+  end
+
+  def then_i_should_be_told_i_cannot_submit_incomplete_qualifications
+    expect(page).to have_content('You can’t complete this section with incomplete qualifications')
+  end
+
+  def when_i_delete_my_incomplete_qualification
+    within(all('.app-summary-card')[2]) do
+      click_link(t('application_form.other_qualification.delete'))
+    end
+  end
+
+  def then_i_can_only_see_two_qualifications
+    expect(page).not_to have_content 'A level Losing to Yugi'
+    expect(page).not_to have_content('AS level')
+    expect(page).to have_content('A level How to Win Against Kaiba')
+    expect(page).to have_content('GCSE Maths')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Entering their other qualifications' do
     and_i_visit_the_site
 
     when_i_click_on_other_qualifications
-    then_i_see_the_select_qualifcation_type_page
+    then_i_see_the_select_qualification_type_page
 
     when_i_select_add_a_level_qualification
     and_i_click_continue
@@ -28,7 +28,7 @@ RSpec.feature 'Entering their other qualifications' do
     when_i_fill_out_the_remainder_of_the_form
     and_i_choose_a_different_type_of_qualification
     and_click_save_and_continue
-    then_i_see_the_select_qualifcation_type_page
+    then_i_see_the_select_qualification_type_page
 
     when_i_choose_gcse
     and_i_click_continue
@@ -39,6 +39,12 @@ RSpec.feature 'Entering their other qualifications' do
     and_click_save_and_continue
     then_i_see_the_other_qualification_review_page
     and_i_should_see_my_qualifications
+
+    when_i_select_add_anoher_qualification
+    and_choose_as_level
+    and_i_click_continue
+    and_i_visit_the_other_qualification_review_page
+    then_i_should_not_see_an_incomplete_as_level_qualification
 
     when_i_click_on_delete_my_first_qualification
     and_i_confirm_that_i_want_to_delete_my_additional_qualification
@@ -80,7 +86,7 @@ RSpec.feature 'Entering their other qualifications' do
     click_link t('page_titles.other_qualification')
   end
 
-  def then_i_see_the_select_qualifcation_type_page
+  def then_i_see_the_select_qualification_type_page
     expect(page).to have_current_path(candidate_interface_new_other_qualification_type_path)
   end
 
@@ -165,6 +171,22 @@ RSpec.feature 'Entering their other qualifications' do
     expect(page).to have_content('A level Believing in the Heart of the Cards')
     expect(page).to have_content('A level Oh')
     expect(page).to have_content('GCSE Maths')
+  end
+
+  def when_i_select_add_anoher_qualification
+    click_link 'Add another qualification'
+  end
+
+  def and_choose_as_level
+    choose 'AS level'
+  end
+
+  def and_i_visit_the_other_qualification_review_page
+    visit candidate_interface_review_other_qualifications_path
+  end
+
+  def then_i_should_not_see_an_incomplete_as_level_qualification
+    expect(page).not_to have_content('Other')
   end
 
   def when_i_click_on_delete_my_first_qualification

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
@@ -1,0 +1,233 @@
+require 'rails_helper'
+
+RSpec.feature 'Entering their other qualifications' do
+  include CandidateHelper
+
+  scenario 'Candidate submits their other qualifications with the prompt_for_additional_qualifications on' do
+    given_i_am_signed_in
+    and_the_prompt_for_additional_qualifications_flag_is_on
+    and_i_visit_the_site
+
+    when_i_click_on_other_qualifications
+    then_i_see_the_select_qualifcation_type_page
+
+    when_i_select_add_a_level_qualification
+    and_i_click_continue
+    then_i_see_the_other_qualifications_form
+
+    when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
+    and_i_submit_the_other_qualification_form
+    then_i_see_validation_errors_for_my_qualification
+
+    when_i_fill_in_my_qualification
+    and_select_add_another_a_level
+    and_click_save_and_continue
+    then_i_see_the_other_qualifications_form
+    and_the_year_and_instituion_fields_are_pre_populated_with_my_previous_details
+
+    when_i_fill_out_the_remainder_of_the_form
+    and_i_choose_a_different_type_of_qualification
+    and_click_save_and_continue
+    then_i_see_the_select_qualifcation_type_page
+
+    when_i_choose_gcse
+    and_i_click_continue
+    then_the_year_and_instituion_fields_are_not_pre_populated_with_my_previous_details
+
+    when_i_fill_in_my_gcse_details
+    and_i_choose_not_to_add_additional_qualifications
+    and_click_save_and_continue
+    then_i_see_the_other_qualification_review_page
+    and_i_should_see_my_qualifications
+
+    when_i_click_on_delete_my_first_qualification
+    and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    then_i_can_only_see_two_qualifacitions
+
+    when_i_click_to_change_my_first_qualification
+    then_i_see_my_qualification_filled_in
+
+    when_i_change_my_qualification
+    and_click_save_and_continue
+    then_i_can_check_my_revised_qualification
+
+    when_i_click_on_continue
+    then_i_should_see_the_form
+    and_the_section_is_not_completed
+
+    when_i_click_on_other_qualifications
+    then_i_can_check_my_answers
+
+    when_i_mark_this_section_as_completed
+    and_i_click_on_continue
+    then_i_should_see_the_form
+    and_that_the_section_is_completed
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_the_prompt_for_additional_qualifications_flag_is_on
+    FeatureFlag.activate('prompt_for_additional_qualifications')
+  end
+
+  def and_i_visit_the_site
+    visit candidate_interface_application_form_path
+  end
+
+  def when_i_click_on_other_qualifications
+    click_link t('page_titles.other_qualification')
+  end
+
+  def then_i_see_the_select_qualifcation_type_page
+    expect(page).to have_current_path(candidate_interface_new_other_qualification_type_path)
+  end
+
+  def when_i_select_add_a_level_qualification
+    choose 'A level'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_other_qualifications_form
+    expect(page).to have_content('Add A level qualification')
+  end
+
+  def when_i_fill_in_some_of_my_qualification_but_omit_some_required_details
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
+  end
+
+  def and_i_submit_the_other_qualification_form
+    click_button t('application_form.other_qualification.base.button')
+  end
+
+  def then_i_see_validation_errors_for_my_qualification
+    expect(page).to have_content t('activemodel.errors.models.candidate_interface/other_qualification_form.attributes.institution_name.blank')
+  end
+
+  def when_i_fill_in_my_qualification
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Believing in the Heart of the Cards'
+    fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
+    fill_in t('application_form.other_qualification.grade.label'), with: 'A'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
+  end
+
+  def and_select_add_another_a_level
+    choose 'Yes, add another A level'
+  end
+
+  def and_click_save_and_continue
+    click_button 'Save and continue'
+  end
+
+  def and_the_year_and_instituion_fields_are_pre_populated_with_my_previous_details
+    expect(page.find('#candidate-interface-other-qualification-form-institution-name-field').value).to eq('Yugi College')
+    expect(page.find('#candidate-interface-other-qualification-form-award-year-field').value).to eq('2015')
+  end
+
+  def when_i_fill_out_the_remainder_of_the_form
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Oh'
+    fill_in t('application_form.other_qualification.grade.label'), with: 'B'
+  end
+
+  def and_i_choose_a_different_type_of_qualification
+    choose 'Yes, add a different qualification'
+  end
+
+  def when_i_choose_gcse
+    choose 'GCSE'
+  end
+
+  def then_the_year_and_instituion_fields_are_not_pre_populated_with_my_previous_details
+    expect(page.find('#candidate-interface-other-qualification-form-institution-name-field').value).to eq(nil)
+    expect(page.find('#candidate-interface-other-qualification-form-award-year-field').value).to eq(nil)
+  end
+
+  def when_i_fill_in_my_gcse_details
+    fill_in t('application_form.other_qualification.subject.label'), with: 'Maths'
+    fill_in t('application_form.other_qualification.institution_name.label'), with: 'School'
+    fill_in t('application_form.other_qualification.grade.label'), with: 'U'
+    fill_in t('application_form.other_qualification.award_year.label'), with: '2012'
+  end
+
+  def and_i_choose_not_to_add_additional_qualifications
+    choose 'No, not right now'
+  end
+
+  def then_i_see_the_other_qualification_review_page
+    expect(page).to have_current_path(candidate_interface_review_other_qualifications_path)
+  end
+
+  def and_i_should_see_my_qualifications
+    expect(page).to have_content('A level Believing in the Heart of the Cards')
+    expect(page).to have_content('A level Oh')
+    expect(page).to have_content('GCSE Maths')
+  end
+
+  def when_i_click_on_delete_my_first_qualification
+    within(all('.app-summary-card')[0]) do
+      click_link(t('application_form.other_qualification.delete'))
+    end
+  end
+
+  def and_i_confirm_that_i_want_to_delete_my_additional_qualification
+    click_button t('application_form.other_qualification.confirm_delete')
+  end
+
+  def then_i_can_only_see_two_qualifacitions
+    expect(page).not_to have_content 'A level Losing to Yugi'
+    expect(page).to have_content('A level Oh')
+    expect(page).to have_content('GCSE Maths')
+  end
+
+  def when_i_click_to_change_my_first_qualification
+    first('.govuk-summary-list__actions').click_link 'Change'
+  end
+
+  def then_i_see_my_qualification_filled_in
+    expect(page).to have_selector("input[value='A level']")
+    expect(page).to have_selector("input[value='Oh']")
+    expect(page).to have_selector("input[value='Yugi College']")
+    expect(page).to have_selector("input[value='B']")
+    expect(page).to have_selector("input[value='2015']")
+  end
+
+  def when_i_change_my_qualification
+    fill_in t('application_form.other_qualification.subject.label'), with: 'How to Win Against Kaiba'
+  end
+
+  def then_i_can_check_my_revised_qualification
+    expect(page).to have_content 'A level How to Win Against Kaiba'
+  end
+
+  def when_i_click_on_continue
+    click_button t('application_form.other_qualification.review.button')
+  end
+
+  def and_the_section_is_not_completed
+    expect(page).not_to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
+  end
+
+  def then_i_can_check_my_answers
+    then_i_can_check_my_revised_qualification
+  end
+
+  def when_i_mark_this_section_as_completed
+    check t('application_form.other_qualification.review.completed_checkbox')
+  end
+
+  def and_i_click_on_continue
+    when_i_click_on_continue
+  end
+
+  def then_i_should_see_the_form
+    expect(page).to have_content(t('page_titles.application_form'))
+  end
+
+  def and_that_the_section_is_completed
+    expect(page).to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
+  end
+end


### PR DESCRIPTION
## Context

Candidates need to be prompted to add additional qualifications. 

When a candidate adds a qualification they are asked if they would like to add another of the same type, different type or none. 

If they add another of the same type the institution and year awards fields are pre-filled.

## Changes proposed in this pull request

- Adds a new flow which has a choose qualification page
- On the add details page, a user can select whether they want to add another qualification of the same type, add another qualification or return to the other qualification review page
- If the candidate selects add another of the same type it prefills institution name and year awarded 

Before

![image](https://user-images.githubusercontent.com/42515961/77891882-9418b080-7269-11ea-973f-1fef2680dc02.png)

![image](https://user-images.githubusercontent.com/42515961/77891912-9f6bdc00-7269-11ea-94cb-0219dc6162f7.png)

After

![image](https://user-images.githubusercontent.com/42515961/77908117-ca165e80-7282-11ea-8e60-e380d54eb7f0.png)

![image](https://user-images.githubusercontent.com/42515961/77908140-d3073000-7282-11ea-8892-0c6474c16525.png)


## Guidance to review

I actually implemented the wrong version of this as the prototype had different feature flags on and was showing fields for qualification name and country. I probably didn't need to create the type/description controller, but they will be necessary going forward when it comes to implementing the above.

If a user misclicks on adding another type/ same type of qualification and then decides they don't want to, validations currently don't allow them to leave the page. We still need them though. Is there a good way around this?

I was thinking that maybe I could check to see if they have not populated any fields and skip them if that is the case? Not really sure what the right way to go is there.

 ## Link to Trello card

https://trello.com/c/kDK3DZnr/1228-dev-content-qualifications-prompt-candidates-to-input-all

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
