### PR TITLE
Add a unique index for dfe_sign_in_uid on ProviderUsers

### DIFF
--- a/db/migrate/20200330084106_add_index_to_provider_user_dfe_sign_in_uid.rb
+++ b/db/migrate/20200330084106_add_index_to_provider_user_dfe_sign_in_uid.rb
@@ -1,0 +1,6 @@
+class AddIndexToProviderUserDfESignInUid < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :provider_users, :dfe_sign_in_uid
+    add_index :provider_users, :dfe_sign_in_uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_27_110814) do
+ActiveRecord::Schema.define(version: 2020_03_30_084106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -247,7 +247,7 @@ ActiveRecord::Schema.define(version: 2020_03_27_110814) do
     t.datetime "last_signed_in_at"
     t.string "first_name"
     t.string "last_name"
-    t.index ["dfe_sign_in_uid"], name: "index_provider_users_on_dfe_sign_in_uid"
+    t.index ["dfe_sign_in_uid"], name: "index_provider_users_on_dfe_sign_in_uid", unique: true
     t.index ["email_address"], name: "index_provider_users_on_email_address", unique: true
   end
 


### PR DESCRIPTION
## Context

Rubocop now enforces a unique index on columns with a `unique: true` validation.

This was flagged by Rubocop after dependabot upgraded `govuk-rubocop`: #1776 

## Changes proposed in this pull request

Remove the old, non-unique index and add a new unique one.

## Guidance to review

I think this cop makes sense — any reason not to do this?

I'll raise a separate PR to introduce a uniqueness constraint for the same field on SupportUsers.

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
