### PR TITLE
Remove choose_study_type feature flag

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -14,24 +14,22 @@ module CandidateInterface
     end
 
     def course_choice_rows(course_choice)
-      if FeatureFlag.active?('display_additional_course_details')
-        rows = [
-          course_row(course_choice),
-          location_row(course_choice),
-          study_mode_row(course_choice),
-          type_row(course_choice.course),
-          course_length_row(course_choice.course),
-          start_date_row(course_choice.course),
-        ]
-      else
-        rows = [
-          course_row(course_choice),
-          location_row(course_choice),
-        ]
-        rows.insert(1, study_mode_row(course_choice)) if FeatureFlag.active?('choose_study_mode')
-      end
-
-
+      rows = if FeatureFlag.active?('display_additional_course_details')
+               [
+                 course_row(course_choice),
+                 location_row(course_choice),
+                 study_mode_row(course_choice),
+                 type_row(course_choice.course),
+                 course_length_row(course_choice.course),
+                 start_date_row(course_choice.course),
+               ]
+             else
+               [
+                 course_row(course_choice),
+                 location_row(course_choice),
+                 study_mode_row(course_choice),
+               ]
+             end
 
       rows.tap do |r|
         r << status_row(course_choice) if @show_status

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -25,7 +25,7 @@ module CandidateInterface
           redirect_to candidate_interface_course_confirm_selection_path(course_id: course.id)
         elsif service.candidate_should_choose_site
           redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
-        elsif service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
+        elsif service.candidate_should_choose_study_mode
           redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
         end
       else
@@ -50,7 +50,7 @@ module CandidateInterface
           redirect_to candidate_interface_course_choices_review_path
         elsif service.candidate_should_choose_site
           redirect_to candidate_interface_course_choices_site_path(course.provider.id, course.id, course.study_mode)
-        elsif service.candidate_should_choose_study_mode && FeatureFlag.active?('choose_study_mode')
+        elsif service.candidate_should_choose_study_mode
           redirect_to candidate_interface_course_choices_study_mode_path(course.provider.id, course.id)
         end
       end

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -78,7 +78,7 @@ module CandidateInterface
           @pick_course.provider_id,
           @pick_course.course_id,
         )
-      elsif @pick_course.both_study_modes_available? && FeatureFlag.active?('choose_study_mode')
+      elsif @pick_course.both_study_modes_available?
         redirect_to candidate_interface_course_choices_study_mode_path(
           @pick_course.provider_id,
           @pick_course.course_id,

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -8,11 +8,7 @@ module CandidateInterface
 
     def available_sites
       relation = CourseOption.includes(:site).where(course_id: course.id)
-
-      if FeatureFlag.active?('choose_study_mode')
-        relation = relation.where(study_mode: study_mode)
-      end
-
+      relation = relation.where(study_mode: study_mode)
       relation.sort_by { |course_option| course_option.site.name }
     end
 

--- a/app/services/candidate_interface/add_course_from_find.rb
+++ b/app/services/candidate_interface/add_course_from_find.rb
@@ -37,7 +37,7 @@ module CandidateInterface
       elsif candidate_has_already_selected_the_course?
         set_course_from_find_id_to_nil
         @candidate_has_already_selected_the_course = true
-      elsif course_has_both_study_modes? && FeatureFlag.active?('choose_study_mode')
+      elsif course_has_both_study_modes?
         set_course_from_find_id_to_nil
         @candidate_should_choose_study_mode = true
       elsif course_has_one_site?

--- a/app/services/candidate_interface/interstitial_route_selector.rb
+++ b/app/services/candidate_interface/interstitial_route_selector.rb
@@ -35,7 +35,7 @@ module CandidateInterface
         @candidate_already_has_3_courses = true
       elsif candidate_has_already_selected_the_course?
         @candidate_has_already_selected_the_course = true
-      elsif course_has_both_study_modes? && FeatureFlag.active?('choose_study_mode')
+      elsif course_has_both_study_modes?
         set_course_from_find_id_to_nil
         @candidate_should_choose_study_mode = true
       elsif course_has_one_site?

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -4,7 +4,6 @@ class FeatureFlag
     banner_about_problems_with_dfe_sign_in
     banner_for_ucas_downtime
     create_account_or_sign_in_page
-    choose_study_mode
     covid_19
     display_additional_course_details
     check_full_courses

--- a/spec/services/candidate_interface/add_course_from_find_spec.rb
+++ b/spec/services/candidate_interface/add_course_from_find_spec.rb
@@ -65,7 +65,6 @@ RSpec.describe CandidateInterface::AddCourseFromFind do
 
     context 'when the candidate has a course_from_find_id and the course has a choice of study modes' do
       it 'sets the course_from_find_id to nil and sets the appropriate boolean flag' do
-        FeatureFlag.activate('choose_study_mode')
         course = create(:course, study_mode: :full_time_or_part_time)
         candidate = create(:candidate, course_from_find_id: course.id)
 

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature 'Selecting a study mode' do
   include CandidateHelper
 
   scenario 'Candidate selects different study modes' do
-    given_choosing_a_study_mode_is_active
     given_i_am_signed_in
     and_there_are_course_options
 
@@ -19,10 +18,6 @@ RSpec.feature 'Selecting a study mode' do
     when_i_select_the_single_site_full_time_course
     and_i_visit_my_course_choices_page
     then_the_site_is_resolved_automatically_and_i_see_the_course_choice
-  end
-
-  def given_choosing_a_study_mode_is_active
-    FeatureFlag.activate('choose_study_mode')
   end
 
   def given_i_am_signed_in

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
 
   scenario 'Signed in user with Find course params selects a part time course' do
     given_the_pilot_is_open
-    given_choosing_a_study_mode_is_active
     and_i_am_an_existing_candidate_on_apply
     and_the_course_i_selected_has_a_choice_of_study_modes
     and_i_am_signed_in
@@ -21,10 +20,6 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def given_choosing_a_study_mode_is_active
-    FeatureFlag.activate('choose_study_mode')
   end
 
   def and_i_am_an_existing_candidate_on_apply


### PR DESCRIPTION
## Context

This has been live for quite a while so the feature flag can be removed

## Changes proposed in this pull request

- Remove the choose_study_mode FeatureFlag from the codebase


## Link to Trello card

https://trello.com/c/EAUiQy0O/1199-remove-the-youselectedacoursepage-feature-flag

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
