### PR TITLE
Remove display_additional_course_details feature flag

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -14,8 +14,7 @@ module CandidateInterface
     end
 
     def course_choice_rows(course_choice)
-      rows = if FeatureFlag.active?('display_additional_course_details')
-               [
+      rows =   [
                  course_row(course_choice),
                  location_row(course_choice),
                  study_mode_row(course_choice),
@@ -23,13 +22,6 @@ module CandidateInterface
                  course_length_row(course_choice.course),
                  start_date_row(course_choice.course),
                ]
-             else
-               [
-                 course_row(course_choice),
-                 location_row(course_choice),
-                 study_mode_row(course_choice),
-               ]
-             end
 
       rows.tap do |r|
         r << status_row(course_choice) if @show_status

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -5,7 +5,6 @@ class FeatureFlag
     banner_for_ucas_downtime
     create_account_or_sign_in_page
     covid_19
-    display_additional_course_details
     check_full_courses
     confirm_conditions
     edit_application

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -6,32 +6,16 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       create_application_form_with_course_choices(statuses: %w[application_complete])
     end
 
-    context 'without display_additional_course_details active' do
-      it 'renders component with correct values for a course' do
-        course_choice = application_form.application_choices.first
-        result = render_inline(described_class.new(application_form: application_form))
+    it 'renders component with correct values for a course' do
+      course_choice = application_form.application_choices.first
+      result = render_inline(described_class.new(application_form: application_form))
 
-        expect(result.css('.app-summary-card__title').text).to include(course_choice.provider.name)
-        expect(result.css('.govuk-summary-list__key').text).to include('Course')
-        expect(result.css('.govuk-summary-list__value').to_html).to include("#{course_choice.course.name} (#{course_choice.course.code})")
-        expect(result.css('.govuk-summary-list__value').to_html).not_to include('1 year')
-        expect(result.css('.govuk-summary-list__value').to_html).not_to include(course_choice.course.start_date.strftime('%B %Y'))
-      end
-    end
-
-    context 'with display_additional_course_details active' do
-      it 'renders additional values for the course' do
-        FeatureFlag.activate('display_additional_course_details')
-        course_choice = application_form.application_choices.first
-        result = render_inline(described_class.new(application_form: application_form))
-
-        expect(result.css('.app-summary-card__title').text).to include(course_choice.provider.name)
-        expect(result.css('.govuk-summary-list__key').text).to include('Course')
-        expect(result.css('.govuk-summary-list__value').to_html).to include("#{course_choice.course.name} (#{course_choice.course.code})")
-        expect(result.css('.govuk-summary-list__value').to_html).to include(course_choice.course.description)
-        expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
-        expect(result.css('.govuk-summary-list__value').to_html).to include(course_choice.course.start_date.strftime('%B %Y'))
-      end
+      expect(result.css('.app-summary-card__title').text).to include(course_choice.provider.name)
+      expect(result.css('.govuk-summary-list__key').text).to include('Course')
+      expect(result.css('.govuk-summary-list__value').to_html).to include("#{course_choice.course.name} (#{course_choice.course.code})")
+      expect(result.css('.govuk-summary-list__value').to_html).to include(course_choice.course.description)
+      expect(result.css('.govuk-summary-list__value').to_html).to include('1 year')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(course_choice.course.start_date.strftime('%B %Y'))
     end
 
     it 'renders component with correct values for a location' do


### PR DESCRIPTION
## Context

This is another one of my old feature flags that's been on prod for quite a while.

## Changes proposed in this pull request

-Remove the display_additional_course_details feature flag

## Link to Trello card

https://trello.com/c/EAUiQy0O/1199-remove-the-youselectedacoursepage-and-choosestudymode-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
