### PR TITLE
Design updates to the respond-to-an-application flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'puma', '~> 4.3'
 gem 'pg', '~> 1.2.3'
 
 gem 'webpacker'
-gem 'govuk_design_system_formbuilder', '1.1.9'
+gem 'govuk_design_system_formbuilder', '~> 1.1.6'
 
 # GovUK Notify
 gem 'mail-notify'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -534,7 +534,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
-  govuk_design_system_formbuilder (= 1.1.9)
+  govuk_design_system_formbuilder (~> 1.1.6)
   guard-rspec
   holidays
   http

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -1,6 +1,7 @@
 <% content_for :title, t('page_titles.application') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_reject_path(@application_choice.id)) %>
 
+<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
 <h1 class="govuk-heading-xl">Check and confirm rejection</h1>
 
 <%= render SummaryListComponent.new(rows: [

--- a/app/views/provider_interface/decisions/confirm_reject.html.erb
+++ b/app/views/provider_interface/decisions/confirm_reject.html.erb
@@ -1,33 +1,38 @@
 <% content_for :title, t('page_titles.application') %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_new_reject_path(@application_choice.id)) %>
 
-<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-<h1 class="govuk-heading-xl">Check and confirm rejection</h1>
 
-<%= render SummaryListComponent.new(rows: [
-  { key: 'Full name', value: @application_choice.application_form.full_name },
-  { key: 'Course', value: @application_choice.course.name_and_code },
-  { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-  { key: 'Preferred location', value: @application_choice.site.name },
-  { key: 'Reasons for rejection', value: @reject_application.rejection_reason },
-]) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
 
-<%= form_with model: @reject_application, url: provider_interface_application_choice_create_reject_path(@application_choice.id), method: :post do |f| %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <%= f.govuk_error_summary %>
-    </div>
-  </div>
+    <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+    <h1 class="govuk-heading-xl">Check and confirm rejection</h1>
+      <%= form_with model: @reject_application, url: provider_interface_application_choice_create_reject_path(@application_choice.id), method: :post do |f| %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= f.govuk_error_summary %>
+          </div>
+        </div>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+        <%= render SummaryListComponent.new(rows: [
+          { key: 'Reasons for rejection', value: @reject_application.rejection_reason },
+        ]) %>
 
       <%= f.hidden_field :rejection_reason %>
-      <%= f.govuk_submit 'Confirm rejection' %>
+
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          We’ll tell the candidate you rejected their application, and share your reasons.
+        </strong>
+      </div>
+
+      <%= f.govuk_submit 'Reject application' %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
       </p>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -1,36 +1,26 @@
 <% content_for :browser_title, @reject_application.errors.any? ? 'Error: Reject application' : 'Reject application' %>
 <% content_for :before_content, govuk_back_link_to(provider_interface_application_choice_respond_path(@application_choice.id)) %>
 
-<%= form_with model: @reject_application,
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @reject_application,
       url: provider_interface_application_choice_confirm_reject_path(@application_choice.id),
       method: :post do |f| %>
-  <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl">
-    Reject application
-  </h1>
+      <%= f.govuk_error_summary %>
 
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Full name', value: @application_choice.application_form.full_name },
-    { key: 'Course', value: @application_choice.course.name_and_code },
-    { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-    { key: 'Preferred location', value: @application_choice.site.name },
-  ]) %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <div class="govuk-form-group">
+        <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
         <%= f.govuk_text_area :rejection_reason,
-                              label: { text: 'Tell the candidate why their application was rejected', size: 'm' },
-                              hint_text: 'We’ll forward them your feedback',
-                              rows: 5 %>
+          label: { text: 'Tell the candidate why you’re rejecting their application', size: 'xl' },
+          rows: 5 %>
       </div>
 
       <%= f.govuk_submit 'Continue' %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
       </p>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -4,19 +4,19 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @pick_response_form, url: provider_interface_application_choice_submit_response_path(@application_choice.id), method: :post do |f| %>
-      <%= f.govuk_error_summary %>
-
       <%- offer_text = 'Make an offer' %>
       <%- reject_text = 'Reject application' %>
 
-      <%= f.govuk_radio_buttons_fieldset :decision do %>
+      <%= f.govuk_error_summary %>
 
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading">
-            <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-            Respond to application
-          </h1>
-        </legend>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+        <h1 class="govuk-fieldset__heading">
+          <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+          Respond to application
+        </h1>
+      </legend>
+
+      <%= f.govuk_radio_buttons_fieldset :decision do %>
 
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
         <% if FeatureFlag.active?('provider_change_response') -%>

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -16,9 +16,7 @@ RSpec.feature 'Provider rejects application' do
 
     when_i_respond_to_an_application
     and_i_choose_to_reject_it
-    then_i_see_some_application_info
-
-    when_i_add_a_rejection_reason
+    and_i_add_a_rejection_reason
     and_i_click_to_continue
     then_i_am_asked_to_confirm_the_rejection
 
@@ -46,17 +44,8 @@ RSpec.feature 'Provider rejects application' do
     click_on 'Continue'
   end
 
-  def then_i_see_some_application_info
-    expect(page).to have_content \
-      application_awaiting_provider_decision.course.name_and_code
-    expect(page).to have_content \
-      application_awaiting_provider_decision.application_form.first_name
-    expect(page).to have_content \
-      application_awaiting_provider_decision.application_form.last_name
-  end
-
-  def when_i_add_a_rejection_reason
-    fill_in('Tell the candidate why their application was rejected', with: 'A rejection reason')
+  def and_i_add_a_rejection_reason
+    fill_in('Tell the candidate why you’re rejecting their application', with: 'A rejection reason')
   end
 
   def and_i_click_to_continue
@@ -72,7 +61,7 @@ RSpec.feature 'Provider rejects application' do
   end
 
   def when_i_confirm_the_rejection
-    click_on 'Confirm rejection'
+    click_on 'Reject application'
   end
 
   def then_i_am_back_to_the_application_page


### PR DESCRIPTION
## Context

There are some inconsistencies in the design around the "respond to application" flow for providers.

## Changes proposed in this pull request

One by one, from the card:

- Move the candidate name above the title on Confirm Rejection form consistent with placing on other forms.

✅ Done

### Before

![Screenshot 2020-03-30 at 16 50 15](https://user-images.githubusercontent.com/642279/77933310-8df4f500-72a6-11ea-8d28-5f4585ab6618.png)

### After

![Screenshot 2020-03-30 at 16 50 05](https://user-images.githubusercontent.com/642279/77933312-8e8d8b80-72a6-11ea-88eb-209287e46d6a.png)

This introduces a bit of duplication but the UI benefit from consistency is worth it

- Vertical space between 'Continue' button and cancel link (all change/reject forms) should be reduced

💪 Fixed upstream in the formbuilder and will be picked up once the release makes it to rubygems
https://github.com/DFE-Digital/govuk_design_system_formbuilder/releases/tag/v1.1.7

- Respond to application error message should appear above radio group and below H1
https://ukgovernmentdfe.slack.com/files/UPWN7EC2V/F010VTG33NK/image.png

😑 Imperfectly done with a hack — see commit. Probably needs an upstream change in the form builder to be 📐.

### Before

![Screenshot 2020-03-30 at 16 55 37](https://user-images.githubusercontent.com/642279/77933978-59356d80-72a7-11ea-8e1f-16fc5699857f.png)

### After

![Screenshot 2020-03-30 at 16 54 35](https://user-images.githubusercontent.com/642279/77934000-5f2b4e80-72a7-11ea-9bf9-76933d9ddbd4.png)


- "Tell the candidate why their application was rejected" on Reject Application form should be a label.
https://ukgovernmentdfe.slack.com/files/UPWN7EC2V/F010J3KU0Q1/image.png

✅  It's already a label

- 'Change' link should be present against conditions in confirmation step: /provider/applications/<id>/offer/confirm

❌ Not done. This is tricky as we don't have an intermediate step where we store the conditions. They do exist in memory at this point but we'd have to fake a POST to get them back into the form for editing. When we come to create individual conditions we might solve this for free, so I think we should punt it for now?

## Link to Trello card

https://trello.com/c/2B8lduBk/1822-design-updates-to-respond-change-reject-application

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
