### PR TITLE
Make Slack poster channel aware

### DIFF
--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -19,15 +19,23 @@ private
   end
 
   def post_to_slack(text)
-    slack_message = HostingEnvironment.production? ? text : "[#{HostingEnvironment.environment_name.upcase}] #{text}"
+    if HostingEnvironment.production?
+      slack_message = text
+      slack_channel = '#twd_apply_support'
+    else
+      slack_message = "[#{HostingEnvironment.environment_name.upcase}] #{text}"
+      slack_channel = '#twd_apply_test'
+    end
 
     payload = {
-      username: 'ApplyBot',
-      icon_emoji: ':parrot:',
+      username: 'Apply for teacher training',
+      icon_emoji: ':shipitbeaver:',
+      channel: slack_channel,
       text: slack_message,
       mrkdwn: true,
     }
-    response = HTTP.post @webhook_url, body: payload.to_json
+
+    response = HTTP.post(@webhook_url, body: payload.to_json)
     Rails.logger.warn "Notification to slack failed: #{response.status}" if !response.status.success?
   rescue StandardError => e
     Rails.logger.warn "Notification to slack failed: #{e.message}"

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -55,9 +55,11 @@ RSpec.describe SlackNotificationWorker do
         ClimateControl.modify STATE_CHANGE_SLACK_URL: webhook_url do
           invoke_worker
         end
-        expect(HTTP).to have_received(:post).with \
+
+        expect(HTTP).to have_received(:post).with(
           'https://example.com/webhook',
-          body: '{"username":"ApplyBot","icon_emoji":":parrot:","text":"[TEST] \u003chttps://example.com/support|example text\u003e","mrkdwn":true}'
+          body: '{"username":"Apply for teacher training","icon_emoji":":shipitbeaver:","channel":"#twd_apply_test","text":"[TEST] \u003chttps://example.com/support|example text\u003e","mrkdwn":true}',
+        )
       end
     end
   end


### PR DESCRIPTION
## Context

We currently use a channel-specific webhook, but we now have a webhook configured that is allowed to post to all channels. This will make the app more flexible, for example we'll be able to post important messages to `#twd_apply` too.

## Changes proposed in this pull request

This specifies the channel, username and emoji for the Slack posts, so that it goes to the correct one.

## Guidance to review

It should all work on QA - we'll know if it doesn't.

I've tried the code in https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1585585959026100.


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
