### PR TITLE
Allow candidates to edit the study mode of their course choices

### DIFF
--- a/app/views/candidate_interface/course_choices/options_for_study_mode.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_study_mode.html.erb
@@ -8,6 +8,7 @@
           url: candidate_interface_course_choices_study_mode_path(
             provider_id: @pick_study_mode.provider_id,
             course_id: @pick_study_mode.course_id,
+            course_choice_id: @course_choice_id,
           ),
         ) do |f| %>
       <%= f.govuk_error_summary %>

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -1,8 +1,8 @@
 module CourseOptionHelpers
-  def course_option_for_provider(provider:, course: nil)
+  def course_option_for_provider(provider:, course: nil, study_mode: 'full_time')
     course ||= create(:course, :open_on_apply, provider: provider)
     site = create(:site, provider: provider)
-    create(:course_option, course: course, site: site)
+    create(:course_option, course: course, site: site, study_mode: study_mode)
   end
 
   def course_option_for_provider_code(provider_code:)

--- a/spec/support/test_helpers/course_option_helpers.rb
+++ b/spec/support/test_helpers/course_option_helpers.rb
@@ -1,7 +1,7 @@
 module CourseOptionHelpers
-  def course_option_for_provider(provider:, course: nil, study_mode: 'full_time')
+  def course_option_for_provider(provider:, course: nil, site: nil, study_mode: 'full_time')
     course ||= create(:course, :open_on_apply, provider: provider)
-    site = create(:site, provider: provider)
+    site ||= create(:site, provider: provider)
     create(:course_option, course: course, site: site, study_mode: study_mode)
   end
 

--- a/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe 'Candidate edits course choices' do
 
   scenario 'Candidate is signed in' do
     given_that_the_edit_course_choices_feature_flag_is_active
-    and_the_choose_study_mode_feature_flag_is_active
     and_i_am_signed_in
     and_there_is_a_course_with_one_course_option
     and_there_is_a_course_with_multiple_course_options
+    and_there_is_a_course_with_both_study_modes_but_one_site
 
     when_i_visit_my_application_page
     and_i_click_on_course_choices
@@ -33,17 +33,35 @@ RSpec.describe 'Candidate edits course choices' do
     and_i_should_see_a_change_location_link
     and_i_should_see_a_change_study_mode_link
 
+    when_i_click_to_add_another_course
+    and_i_choose_that_i_know_where_i_want_to_apply
+    and_i_choose_a_provider
+    and_i_choose_the_single_site_course_as_my_third_course_choice
+    and_i_choose_the_full_time_study_mode
+    then_i_should_be_on_the_course_choice_review_page
+    and_i_should_see_another_change_study_mode_link
+    and_i_should_not_see_another_change_location_link
+
     when_i_click_to_change_the_location_of_the_second_course_choice
     and_i_choose_the_second_site
     then_i_should_be_on_the_course_choice_review_page
+    and_i_should_see_the_updated_site
+
+    when_i_click_to_change_the_study_mode_of_the_second_course_choice
+    and_i_choose_part_time_study_mode
+    and_i_am_asked_to_select_site
+    and_i_choose_the_first_site_that_offers_part_time_study_mode
+    then_i_should_be_on_the_course_choice_review_page
+    and_i_should_see_the_updated_study_mode_for_the_second_choice
+
+    when_i_click_to_change_the_study_mode_of_the_third_course_choice
+    and_i_choose_part_time_study_mode
+    then_i_should_be_on_the_course_choice_review_page
+    and_i_should_see_the_updated_study_mode_for_the_third_choice
   end
 
   def given_that_the_edit_course_choices_feature_flag_is_active
     FeatureFlag.activate('edit_course_choices')
-  end
-
-  def and_the_choose_study_mode_feature_flag_is_active
-    FeatureFlag.activate('choose_study_mode')
   end
 
   def and_i_am_signed_in
@@ -61,11 +79,21 @@ RSpec.describe 'Candidate edits course choices' do
     create(:course, :with_both_study_modes, provider: @provider, exposed_in_find: true, open_on_apply: true)
 
     # Sites with full time study mode
-    course_option_for_provider(provider: @provider, course: @provider.courses.second)
-    course_option_for_provider(provider: @provider, course: @provider.courses.second)
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'full_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'full_time')
 
-    # Site with part time study mode
+    # Sites with part time study mode
     course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'part_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'part_time')
+  end
+
+  def and_there_is_a_course_with_both_study_modes_but_one_site
+    create(:course, :with_both_study_modes, provider: @provider, exposed_in_find: true, open_on_apply: true)
+
+    site = create(:site, provider: @provider)
+
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site: site, study_mode: 'full_time')
+    course_option_for_provider(provider: @provider, course: @provider.courses.third, site: site, study_mode: 'part_time')
   end
 
   def when_i_visit_my_application_page
@@ -142,6 +170,19 @@ RSpec.describe 'Candidate edits course choices' do
     expect(page).to have_content("Change study mode for #{@provider.courses.second.name}")
   end
 
+  def and_i_choose_the_single_site_course_as_my_third_course_choice
+    choose @provider.courses.third.name_and_code
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_another_change_study_mode_link
+    expect(page).to have_content("Change study mode for #{@provider.courses.third.name}")
+  end
+
+  def and_i_should_not_see_another_change_location_link
+    expect(page).not_to have_content("Change location for #{@provider.courses.third.name}")
+  end
+
   def when_i_click_to_change_the_location_of_the_second_course_choice
     click_link "Change location for #{@provider.courses.second.name}"
   end
@@ -151,7 +192,40 @@ RSpec.describe 'Candidate edits course choices' do
     click_button 'Continue'
   end
 
-  def and_i_choose_the_updated_site_name
+  def and_i_should_see_the_updated_site
     expect(page).to have_content(@provider.courses.second.course_options.second.site.name)
+  end
+
+  def when_i_click_to_change_the_study_mode_of_the_second_course_choice
+    click_link "Change study mode for #{@provider.courses.second.name_and_code}"
+  end
+
+  def and_i_choose_part_time_study_mode
+    choose 'Part time'
+    click_button 'Continue'
+  end
+
+  def and_i_am_asked_to_select_site
+    expect(page).to have_content('Which location are you applying to?')
+  end
+
+  def and_i_choose_the_first_site_that_offers_part_time_study_mode
+    choose @provider.courses.second.course_options.third.site.name
+    click_button 'Continue'
+  end
+
+  def and_i_should_see_the_updated_study_mode_for_the_second_choice
+    second_chouce = page.all('.govuk-summary-list').to_a.second.text
+    expect(second_chouce).to have_content("Full time or part time\nPart time")
+  end
+
+  def when_i_click_to_change_the_study_mode_of_the_third_course_choice
+    click_link "Change study mode for #{@provider.courses.third.name_and_code}"
+  end
+
+  def and_i_should_see_the_updated_study_mode_for_the_third_choice
+    third_choice = page.all('.govuk-summary-list').to_a.second.text
+
+    expect(third_choice).to have_content("Full time or part time\nPart time")
   end
 end


### PR DESCRIPTION
## Context
We want to allow candidates to be able to change the course, full time or part-time, or location for a course. If they want to change their location, they currently need to delete the choice and add a new one, instead of editing the location directly. 

This PR is the second slice to add change study mode link to the course choices review component.

## Changes proposed in this pull request
This PR adds:
- Update `CourseChoicesReviewComponent` to show `study modes` to only show that row if the user has needed to make a choice about it
- Updates the `CourseChoicesReviewComponent` to show the change link when both study modes available
- Updates the candidate journey to allow editing the study mode of an existing course choice

### Before
![image](https://user-images.githubusercontent.com/22743709/78002478-38185f80-732f-11ea-81ae-4937c94dd2a8.png)


### After
![image](https://user-images.githubusercontent.com/22743709/78001788-1ff41080-732e-11ea-9f46-01ac105e8a71.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
When candidate changes study mode, they also asked to re-confirm or select a new course location, unless the study mode only available at a single site, this is expected behaviour. Study mode and course location are coupled and the choice always gets updated/created on the choose location page. I couldn't come up with a simpler solution, but I'm open to suggestions! 

## Link to Trello card
https://trello.com/c/awBTB88j/1171-change-links-are-missing-from-the-course-choices-summary-cards

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
