### PR TITLE
Signed in users don't see apply on Apply or UCAS page

### DIFF
--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -9,7 +9,11 @@ module CandidateInterface
     def show
       set_service_and_course(params[:providerCode], params[:courseCode])
 
-      if @service.can_apply_on_apply?
+      if @service.can_apply_on_apply? && current_candidate.present?
+        current_candidate.update!(course_from_find_id: @course.id)
+
+        redirect_to candidate_interface_interstitial_path
+      elsif @service.can_apply_on_apply?
         @apply_on_ucas_or_apply = CandidateInterface::ApplyOnUcasOrApplyForm.new(
           provider_code: params[:providerCode], course_code: params[:courseCode],
         )

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -2,7 +2,6 @@ module CandidateInterface
   class StartPageController < CandidateInterfaceController
     before_action :show_pilot_holding_page_if_not_open
     skip_before_action :authenticate_candidate!
-    before_action :redirect_to_interstitial_path_if_signed_in
 
     def show; end
 
@@ -52,20 +51,6 @@ module CandidateInterface
 
     def create_account_or_sign_in_params
       params.require(:candidate_interface_create_account_or_sign_in_form).permit(:existing_account, :email)
-    end
-
-    def redirect_to_interstitial_path_if_signed_in
-      if current_candidate.present?
-        add_course_from_find_id_to_candidate if params[:providerCode].present?
-
-        redirect_to candidate_interface_interstitial_path
-      end
-    end
-
-    def add_course_from_find_id_to_candidate
-      provider = Provider.find_by(code: params[:providerCode])
-      @course = provider.courses.find_by(code: params[:courseCode]) if provider.present?
-      current_candidate.update!(course_from_find_id: @course.id) if @course.present?
     end
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_picks_study_mode_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
     and_i_am_signed_in
 
     when_i_arrive_at_the_apply_from_find_page_with_course_params
-    and_i_click_apply_on_apply
     then_i_should_see_the_course_selection_page
 
     when_i_say_yes
@@ -52,10 +51,15 @@ RSpec.describe 'An existing candidate arriving from Find with course params sele
     )
   end
 
-  def and_i_click_apply_on_apply
-    choose 'Yes, I want to apply using the new service'
+  def then_i_should_see_the_course_selection_page
+    expect(page).to have_content('You selected a course')
+    expect(page).to have_content(@course.provider.name)
+    expect(page).to have_content(@course.name_and_code)
+  end
 
-    click_button 'Continue'
+  def when_i_say_yes
+    choose 'Yes'
+    click_on 'Continue'
   end
 
   def then_i_should_see_the_course_selection_page

--- a/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_signed_in_user_with_course_params_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_am_signed_in
 
     when_i_arrive_at_the_apply_from_find_page_with_course_params_with_one_site
-    and_i_click_apply_on_apply
     then_i_should_see_the_course_selection_page
 
     when_i_say_yes
@@ -19,7 +18,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_should_see_the_site
 
     when_i_arrive_at_the_apply_from_find_page_with_the_same_course_params
-    and_i_click_apply_on_apply
     then_i_should_see_the_courses_review_page
     and_i_should_be_informed_i_have_already_selected_that_course
 
@@ -29,7 +27,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_have_less_than_3_application_options
 
     when_i_arrive_at_the_apply_from_find_page_with_course_params_with_multiple_sites
-    and_i_click_apply_on_apply
     then_i_should_see_the_multi_site_course_selection_page
 
     when_i_say_yes
@@ -42,7 +39,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     and_i_have_3_application_options
 
     when_i_arrive_at_the_apply_from_find_page_with_course_params_with_one_site
-    and_i_click_apply_on_apply
     then_i_should_see_the_courses_review_page
     and_i_should_be_informed_i_already_have_3_courses
   end
@@ -85,12 +81,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def when_i_arrive_at_the_apply_from_find_page_with_the_same_course_params
     visit candidate_interface_apply_from_find_path providerCode: @course.provider.code, courseCode: @course.code
-  end
-
-  def and_i_click_apply_on_apply
-    choose 'Yes, I want to apply using the new service'
-
-    click_button 'Continue'
   end
 
   def then_i_should_see_the_course_selection_page


### PR DESCRIPTION
## Context

Currently, candidates who are signed in are asked if they would like to apply on Apply or UCAS. They should not be asked and instead be sent to the interstitial action of the AfterSignin controller.

Here, they are asked to confirm the course, told they already have it as an option, or are told they already have 3 choices etc.

## Changes proposed in this pull request

- Move the logic that sends signed-in users to the AfterSigninController from the StartPageController to the ApplyFromFindController

## Guidance to review

Test the flow. You should not see the apply from UCAS or Apply page with a course on apply.

## Link to Trello card

https://trello.com/c/JtXJlcBI/1128-find-%E2%86%92-apply-dont-show-ucas-or-apply-choice-to-signed-in-candidates-redirect-to-you-selected-a-course-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
