### PR TITLE
Use .new rather than method call for Component rendering

### DIFF
--- a/app/views/api_docs/pages/lifecycle.html.erb
+++ b/app/views/api_docs/pages/lifecycle.html.erb
@@ -16,6 +16,6 @@
 </style>
 
 <% ApplicationStateChange.workflow_spec.states.each do |_, state| %>
-  <%= render StateExplanationComponent, machine: ApplicationStateChange, state: state %>
+  <%= render StateExplanationComponent.new(machine: ApplicationStateChange, state: state) %>
   <hr class='govuk-section-break govuk-section-break--xl govuk-section-break--visible'>
 <% end %>


### PR DESCRIPTION
Use `.new()` rather than method call for Component rendering 

It was raising warning when running tests.

## Link to Trello card
N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
