### PR TITLE
Fix failing test that expects sites for full-time course while selected a part-time course option

### DIFF
--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -155,18 +155,18 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def and_i_see_the_form_to_pick_a_location
-    expect(page).to have_content @site1.name
-    expect(page).to have_content @site1.address_line1
-    expect(page).to have_content @site1.address_line2
-    expect(page).to have_content @site1.address_line3
-    expect(page).to have_content @site1.address_line4
-    expect(page).to have_content @site1.postcode
     expect(page).to have_content @site2.name
     expect(page).to have_content @site2.address_line1
     expect(page).to have_content @site2.address_line2
     expect(page).to have_content @site2.address_line3
     expect(page).to have_content @site2.address_line4
     expect(page).to have_content @site2.postcode
+    expect(page).to have_content @site3.name
+    expect(page).to have_content @site3.address_line1
+    expect(page).to have_content @site3.address_line2
+    expect(page).to have_content @site3.address_line3
+    expect(page).to have_content @site3.address_line4
+    expect(page).to have_content @site3.postcode
   end
 
   def and_my_course_from_find_id_should_be_set_to_nil


### PR DESCRIPTION
## Context
<!-- Why are you making this change? What might surprise someone about it? -->
The tests fail on master caused by an incorrect assertion when testing `An existing candidate arriving from Find with a course and provider code (with course selection page)`
In the test candidate selects part-time study mode but the assertion expects to see the sites for full-time course option which causes the fail

I have not looked into carefully but I think we introduced this in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1781 or https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1785 may be an unresolved merge conflict? 🤔  @malcolmbaig @davidgisbey 

## Changes proposed in this pull request
<!-- If there are UI changes, please include Before and After screenshots. -->
Change the expectation to test for the part-time site options rather than the full-time

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->
Is this correct?

## Link to Trello card
<!-- http://trello.com/123-example-card -->

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
