### PR TITLE
Authenticate sign ins from 'create account or sign in' page

### DIFF
--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -7,6 +7,15 @@ module CandidateInterface
     layout 'application'
     alias :audit_user :current_candidate
 
+    def add_identity_to_log(candidate_id = current_candidate&.id)
+      RequestLocals.store[:identity] = { candidate_id: candidate_id }
+      Raven.user_context(candidate_id: candidate_id)
+
+      return unless current_candidate
+
+      Raven.extra_context(application_support_url: support_interface_application_form_url(current_application))
+    end
+
   private
 
     def redirect_to_dashboard_if_not_amendable
@@ -29,15 +38,6 @@ module CandidateInterface
       return if FeatureFlag.active?('pilot_open')
 
       render 'candidate_interface/shared/pilot_holding_page'
-    end
-
-    def add_identity_to_log(candidate_id = current_candidate&.id)
-      RequestLocals.store[:identity] = { candidate_id: candidate_id }
-      Raven.user_context(candidate_id: candidate_id)
-
-      return unless current_candidate
-
-      Raven.extra_context(application_support_url: support_interface_application_form_url(current_application))
     end
 
     def current_application

--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -7,32 +7,13 @@ module CandidateInterface
       if FeatureFlag.active?('improved_expired_token_flow') && params[:u]
         redirect_to candidate_interface_expired_sign_in_path(u: params[:u])
       else
-        @candidate = Candidate.new
+        candidate = Candidate.new
+        render 'candidate_interface/sign_in/new', locals: { candidate: candidate }
       end
     end
 
     def create
-      @candidate = Candidate.for_email candidate_params[:email_address]
-
-      course_from_find_params = Provider
-        .find_by(code: params[:providerCode])
-        &.courses
-        &.find_by(code: params[:courseCode])
-
-      if @candidate.persisted?
-        if course_from_find_params.present?
-          @candidate.update(course_from_find_id: course_from_find_params.id)
-        end
-
-        MagicLinkSignIn.call(candidate: @candidate)
-        add_identity_to_log @candidate.id
-        redirect_to candidate_interface_check_email_sign_in_path
-      elsif @candidate.valid?
-        AuthenticationMailer.sign_in_without_account_email(to: @candidate.email_address).deliver_now
-        redirect_to candidate_interface_check_email_sign_in_path
-      else
-        render :new
-      end
+      SignInCandidate.new(candidate_params[:email_address], self).call
     end
 
     def authenticate

--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -15,10 +15,7 @@ module CandidateInterface
       render :create_account_or_sign_in and return unless @create_account_or_sign_in_form.valid?
 
       if @create_account_or_sign_in_form.existing_account?
-        redirect_to candidate_interface_sign_in_path(
-          providerCode: params[:providerCode],
-          courseCode: params[:courseCode],
-        )
+        SignInCandidate.new(@create_account_or_sign_in_form.email, self).call
       else
         redirect_to candidate_interface_eligibility_path(
           providerCode: params[:providerCode],

--- a/app/models/candidate_interface/create_account_or_sign_in_form.rb
+++ b/app/models/candidate_interface/create_account_or_sign_in_form.rb
@@ -2,9 +2,10 @@ module CandidateInterface
   class CreateAccountOrSignInForm
     include ActiveModel::Model
 
-    attr_accessor :existing_account
+    attr_accessor :existing_account, :email
 
     validates :existing_account, presence: true
+    validates :email, presence: true, email_address: true, if: -> { existing_account? }
 
     def existing_account?
       ActiveModel::Type::Boolean.new.cast(existing_account)

--- a/app/services/candidate_interface/sign_in_candidate.rb
+++ b/app/services/candidate_interface/sign_in_candidate.rb
@@ -1,0 +1,47 @@
+module CandidateInterface
+  class SignInCandidate
+    attr_reader :controller, :email
+
+    def initialize(email, controller)
+      @controller = controller
+      @email = email
+    end
+
+    delegate(
+      :params,
+      :redirect_to,
+      :render,
+      :candidate_interface_check_email_sign_in_path,
+      to: :controller,
+    )
+
+    def call
+      candidate = Candidate.for_email email
+
+      if candidate.persisted?
+        update_course_from_find(candidate)
+        MagicLinkSignIn.call(candidate: candidate)
+        controller.add_identity_to_log(candidate.id)
+        redirect_to candidate_interface_check_email_sign_in_path
+      elsif candidate.valid?
+        AuthenticationMailer.sign_in_without_account_email(to: candidate.email_address).deliver_now
+        redirect_to candidate_interface_check_email_sign_in_path
+      else
+        render 'candidate_interface/sign_in/new', locals: { candidate: candidate }
+      end
+    end
+
+  private
+
+    def update_course_from_find(candidate)
+      course_from_find = Provider
+        .find_by(code: params[:providerCode])
+        &.courses
+        &.find_by(code: params[:courseCode])
+
+      if course_from_find
+        candidate.update!(course_from_find_id: course_from_find.id)
+      end
+    end
+  end
+end

--- a/app/views/candidate_interface/sign_in/new.html.erb
+++ b/app/views/candidate_interface/sign_in/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, title_with_error_prefix(t('page_titles.sign_in'), @candidate.errors.any?) %>
+<% content_for :title, title_with_error_prefix(t('page_titles.sign_in'), candidate.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_start_path) %>
 
 <div class="govuk-grid-row">
@@ -10,7 +10,7 @@
 
     <p class="govuk-body-l">Enter the email address you used to register with, and we will send you a link to sign in.</p>
 
-    <%= form_with model: @candidate, url: candidate_interface_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
+    <%= form_with model: candidate, url: candidate_interface_sign_in_path(providerCode: params[:providerCode], courseCode: params[:courseCode]), html: { novalidate: true } do |f| %>
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :email_address, label: { text: t('authentication.sign_up.email_address.label'), size: 'm' }, type: :email, width: 'two-thirds', autocomplete: 'email' %>

--- a/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
+++ b/app/views/candidate_interface/start_page/create_account_or_sign_in.html.erb
@@ -12,7 +12,9 @@
       method: :post,
     ) do |f| %>
       <%= f.govuk_radio_buttons_fieldset :existing_account, legend: { text: 'Do you already have an account?' } do %>
-        <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' } %>
+        <%= f.govuk_radio_button :existing_account, true, label: { text: 'Yes, sign in' } do %>
+          <%= f.govuk_email_field :email %>
+        <% end %>
         <%= f.govuk_radio_button :existing_account, false, label: { text: 'No, I need to create an account' } %>
       <% end %>
       <%= f.govuk_submit 'Continue' %>

--- a/spec/models/candidate_interface/create_account_or_sign_in_form_spec.rb
+++ b/spec/models/candidate_interface/create_account_or_sign_in_form_spec.rb
@@ -12,4 +12,31 @@ RSpec.describe CandidateInterface::CreateAccountOrSignInForm, type: :model do
       expect(form.existing_account?).to be true
     end
   end
+
+  describe '#email' do
+    context 'when existing_account is true' do
+      let(:form) { described_class.new(existing_account: 'true') }
+
+      it 'validates presence' do
+        expect(form).not_to be_valid
+        form.email = 'rick.roll@email.com'
+        expect(form).to be_valid
+      end
+
+      it 'validates email address format' do
+        form.email = 'rick.roll'
+        expect(form).not_to be_valid
+        form.email = 'rick.roll@email.com'
+        expect(form).to be_valid
+      end
+    end
+
+    context 'when existing_account is false' do
+      let(:form) { described_class.new(existing_account: 'false') }
+
+      it 'is valid without an email' do
+        expect(form).to be_valid
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -94,9 +94,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
     click_button 'Continue'
 
     choose 'Yes, sign in'
-    click_button 'Continue'
-
-    fill_in 'Enter your email address', with: @email
+    fill_in 'Email', with: @email
     click_button 'Continue'
   end
 


### PR DESCRIPTION
## Context

On the 'create account or sign in' page, if a candidate selects the latter they currently get sent to the dedicated sign in page.

In order to make this slightly simpler for the candidate, change it so that we ask for an email and begin the magic link authentication process immediately without the additional step.

## Changes proposed in this pull request

- Add an email field to the 'create account or sign in' page and its
  corresponding form.
- Extract existing sign in logic into a service object.
- Call this service from both the SignInController and
  StartPageController.

**Note:** I've opted to write the SignInCandidate service object such that one of its arguments is the controller context from which it's called. It's a little unconventional, but it seemed like the simplest way to ensure we have the same logic in two places. I considered simple duplication, but I think the sign in logic is complex enough that we'd want to define it in just one place.

## Updated Form
![Screenshot 2020-03-31 at 12 39 12](https://user-images.githubusercontent.com/519250/78022530-00b8ab80-734d-11ea-9f05-5c5f86888237.png)




## Updated Form With validation error
![Screenshot 2020-03-31 at 12 39 33](https://user-images.githubusercontent.com/519250/78022546-09a97d00-734d-11ea-8f76-a5cc4c6c0879.png)
## Existing sign in screen with validation behavior preserved
![Screenshot 2020-03-31 at 12 40 00](https://user-images.githubusercontent.com/519250/78022560-0f06c780-734d-11ea-88e9-e61267e14c5a.png)

## Guidance to review

* Easiest to test locally with a pre-existing user and both sidekiq and `tail -f log/mail.log` running for magic link emails.
* Worth checking sign in from the 'Create account or sign in' page and the dedicated sign in page (linked in header).
* Course selections from Find should also work across the new sign in mechanism.

## Link to Trello card

https://trello.com/c/HlCpxZ5D

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
