### PR TITLE
Post a daily update with service performance to Slack   

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,6 +82,7 @@ RSpec/DescribeClass:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - 'spec/support/slack_notifications.rb'
+    - 'spec/system/support_interface/daily_report_spec.rb'
     - 'spec/requests/vendor_api/api_authentication_spec.rb'
 
 # We don't want to subclass from ApplicationController. This enables separation

--- a/app/models/performance_statistics.rb
+++ b/app/models/performance_statistics.rb
@@ -59,4 +59,16 @@ class PerformanceStatistics
       .execute(CANDIDATE_QUERY)
       .to_a
   end
+
+  def total_submitted_count
+    total_candidate_count(except: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress})
+  end
+
+  def ended_without_success_count
+    total_candidate_count(only: %i{ended_without_success})
+  end
+
+  def accepted_offer_count
+    total_candidate_count(only: %i{pending_conditions recruited enrolled})
+  end
 end

--- a/app/views/integrations/performance_dashboard/dashboard.html.erb
+++ b/app/views/integrations/performance_dashboard/dashboard.html.erb
@@ -17,7 +17,7 @@
     <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count(only: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'in pre-submission') %>
   </div>
   <div class="govuk-grid-column-one-half">
-    <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count(except: %i{never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'submitted') %>
+    <%= render SupportInterface::TileComponent.new(count: @statistics.total_submitted_count, label: 'submitted') %>
   </div>
 </div>
 
@@ -41,10 +41,10 @@
         <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count(except: %i{ended_without_success pending_conditions recruited enrolled never_signed_in unsubmitted_not_started_form unsubmitted_in_progress}), label: 'still being processed', size: :reduced) %>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count(only: %i{ended_without_success}), label: 'ended w/o success', size: :reduced, colour: :red) %>
+        <%= render SupportInterface::TileComponent.new(count: @statistics.ended_without_success_count, label: 'ended w/o success', size: :reduced, colour: :red) %>
       </div>
       <div class="govuk-grid-column-one-third">
-        <%= render SupportInterface::TileComponent.new(count: @statistics.total_candidate_count(only: %i{pending_conditions recruited enrolled}), label: 'accepted an offer', size: :reduced, colour: :green) %>
+        <%= render SupportInterface::TileComponent.new(count: @statistics.accepted_offer_count, label: 'accepted an offer', size: :reduced, colour: :green) %>
       </div>
     </div>
   </div>

--- a/app/workers/daily_report.rb
+++ b/app/workers/daily_report.rb
@@ -1,0 +1,103 @@
+class DailyReport
+  include Sidekiq::Worker
+
+  def perform
+    HTTP.post(ENV.fetch('STATE_CHANGE_SLACK_URL'), body: payload.to_json)
+  end
+
+private
+
+  def payload
+    blocks = []
+
+    blocks << {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: headlines_message,
+      },
+    }
+
+    blocks << {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: ":#{%w[male female].sample}-student: *<https://www.apply-for-teacher-training.education.gov.uk/integrations/performance-dashboard|Candidate stats>*",
+      },
+    }
+
+    # Slack only allows 10 fields per section, so we have to split them up
+    # https://api.slack.com/reference/block-kit/blocks#section
+    candidate_stats_blocks.each_slice(10).map do |fields|
+      blocks << {
+        type: 'section',
+        fields: fields,
+      }
+    end
+
+    blocks << {
+      type: 'divider',
+    }
+
+    blocks << {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: ':school: *<https://www.apply-for-teacher-training.education.gov.uk/support/providers|Provider stats>*',
+      },
+      fields: [
+        {
+          type: 'mrkdwn',
+          text: '*Providers with courses on Apply*',
+        },
+        {
+          type: 'mrkdwn',
+          text: "#{Course.open_on_apply.uniq(&:provider_id).count} providers",
+        },
+        {
+          type: 'mrkdwn',
+          text: '*Courses available on Apply*',
+        },
+        {
+          type: 'mrkdwn',
+          text: "#{Course.open_on_apply.count} courses",
+        },
+      ],
+    }
+
+    {
+      username: 'Apply for teacher training',
+      icon_emoji: ':shipitbeaver:',
+      channel: HostingEnvironment.production? ? '#twd_apply' : '#twd_apply_test',
+      text: headlines_message,
+      blocks: blocks,
+    }
+  end
+
+  def headlines_message
+    [
+      ':wave: Good morning!',
+      "This is your daily stats update. Headlines: we've now got #{statistics.total_candidate_count} sign-ups,",
+      "#{statistics.total_submitted_count} candidates who submitted their application, and #{statistics.accepted_offer_count} candidates who received and accepted an offer :tada:",
+    ].join(' ')
+  end
+
+  def candidate_stats_blocks
+    statistics.candidate_status_counts.flat_map do |row|
+      [
+        {
+          type: 'mrkdwn',
+          text: "*#{I18n.t!("candidate_flow_application_states.#{row['status']}.name")}*",
+        },
+        {
+          type: 'mrkdwn',
+          text: "#{row['count']} #{'candidate'.pluralize(row['count'])}",
+        },
+      ]
+    end
+  end
+
+  def statistics
+    @statistics ||= PerformanceStatistics.new
+  end
+end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -16,4 +16,5 @@ class Clock
   every(1.hour, 'SendChaseEmailToProviders', at: '**:25') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'AskCandidatesForNewReferees', at: '**:30') { AskCandidatesForNewRefereesWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:35') { SendChaseEmailToCandidatesWorker.perform_async }
+  every(1.day, 'DailyReport', at: '08:00', if: lambda { |_| Time.zone.today.weekday? }) { DailyReport.perform_async }
 end

--- a/spec/system/support_interface/daily_report_spec.rb
+++ b/spec/system/support_interface/daily_report_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.feature 'Daily Report' do
+  scenario 'Every workday morning' do
+    create(:application_choice, status: 'unsubmitted', updated_at: Time.zone.now + 1.day)
+    create(:application_choice, status: 'awaiting_provider_decision')
+    create(:application_choice, status: 'recruited')
+    create(:application_choice, status: 'withdrawn')
+
+    DailyReport.perform_async
+
+    expect(WebMock).to have_requested(:post, 'https://example.com/slack-webhook').with { |req|
+      payload = JSON.parse(req.body)
+
+      expect(payload['channel']).to eql('#twd_apply_test')
+      expect(payload['text']).to eql(":wave: Good morning! This is your daily stats update. Headlines: we've now got 4 sign-ups, 3 candidates who submitted their application, and 1 candidates who received and accepted an offer :tada:")
+    }
+  end
+end


### PR DESCRIPTION
## Context

With everyone being out of the office, we're missing the [service performance dashboard](https://www.apply-for-teacher-training.education.gov.uk/integrations/performance-dashboard?screen=1).

## Changes proposed in this pull request

This posts the most important stats to `#twd_apply` each morning at 8am on weekdays.

It [looks like this](https://ukgovernmentdfe.slack.com/archives/CQA59PB98/p1585656048004600):

<img width="709" alt="Screenshot 2020-03-31 at 13 01 12" src="https://user-images.githubusercontent.com/233676/78024436-45921180-7350-11ea-9733-0c420036eb6e.png">

The version on production will have more stats, as it hides metrics with 0 candidates (this is the same as the performance dashboard).

## Guidance to review

Any more stats? Does the headlines sentence make sense?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
