### PR TITLE
Don't allow withdrawal for applications not sent to provider

### DIFF
--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -26,7 +26,6 @@ class ApplicationStateChange
 
     state :application_complete do
       event :send_to_provider, transitions_to: :awaiting_provider_decision
-      event :withdraw, transitions_to: :withdrawn
     end
 
     state :awaiting_provider_decision do

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -187,13 +187,6 @@ en:
         - candidate_mailer-application_sent_to_provider
         - provider_mailer-application_submitted
 
-    application_complete-withdraw:
-      name: Candidate withdraws
-      by: candidate
-      description: Candidates can withdraw at any time.
-      emails:
-        - provider_mailer-application_withrawn
-
     awaiting_provider_decision-make_offer:
       name: Provider makes offer
       by: provider

--- a/features/successful_application_statuses.feature
+++ b/features/successful_application_statuses.feature
@@ -10,7 +10,6 @@ Feature: successful application statuses
       | original status            | actor     | action                 | new status                 |
       | unsubmitted                | candidate | submit                 | awaiting references        |
       | awaiting references        | candidate | references complete    | application complete       |
-      | application complete       | candidate | withdraw               | withdrawn                  |
       | application complete       | candidate | send to provider       | awaiting provider decision |
       | awaiting provider decision | provider  | make offer             | offer                      |
       | awaiting provider decision | provider  | reject                 | rejected                   |


### PR DESCRIPTION
## Context

We currently allow applications to be withdrawn by candidates in the "application_complete" state (when references have been received but the application is still in the 5 day edit window).

We've realised that withdrawing an application that hasn't been sent to the provider causes a number of undesirable side effects:

- The application becomes visible to the provider because the `withdrawn` state is not hidden to providers
- We send out emails about the withdrawal to providers. This is confusing because the provider wouldn't have seen the application before the withdrawal.

## Changes proposed in this pull request

Remove the state transition. This cleverly gets picked up by the interface, and hides the withdrawal button. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/oR4IbJBy/1250-bug-allow-candidate-to-withdraw-during-cool-off-before-references-returned

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
