### PR TITLE
App service container start timeout pipeline variable

### DIFF
--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -68,6 +68,7 @@ stages:
       databaseStorageAutoGrow: 'disabled'
       databaseBackupRetentionDays: 7
       dockerhubUsername: '$(dockerHubUsername)'
+      containerStartTimeLimit: '$(appServiceContainerTimeoutSeconds)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
       basicAuthEnabled: '$(basicAuthEnabled)'
@@ -124,6 +125,7 @@ stages:
       databaseStorageAutoGrow: 'disabled'
       databaseBackupRetentionDays: 7
       dockerhubUsername: '$(dockerHubUsername)'
+      containerStartTimeLimit: '$(appServiceContainerTimeoutSeconds)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
       basicAuthEnabled: '$(basicAuthEnabled)'
@@ -183,6 +185,7 @@ stages:
       databaseStorageAutoGrow: 'enabled'
       databaseBackupRetentionDays: 35
       dockerhubUsername: '$(dockerHubUsername)'
+      containerStartTimeLimit: '$(appServiceContainerTimeoutSeconds)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
       basicAuthEnabled: '$(basicAuthEnabled)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,6 +239,7 @@ stages:
       databaseStorageAutoGrow: 'disabled'
       databaseBackupRetentionDays: 7
       dockerhubUsername: '$(dockerHubUsername)'
+      containerStartTimeLimit: '$(appServiceContainerTimeoutSeconds)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
       basicAuthEnabled: '$(basicAuthEnabled)'
@@ -295,6 +296,7 @@ stages:
       databaseStorageAutoGrow: 'disabled'
       databaseBackupRetentionDays: 7
       dockerhubUsername: '$(dockerHubUsername)'
+      containerStartTimeLimit: '$(appServiceContainerTimeoutSeconds)'
       railsSecretKeyBase: '$(railsSecretKeyBase)'
       railsEnv: 'production'
       basicAuthEnabled: '$(basicAuthEnabled)'


### PR DESCRIPTION
## Context

Due to exceptional demand on Azure resources we have seen app service staging slot startups timeout and therefore wish to increase this timeout.

## Changes proposed in this pull request

The slot timeout is currently 600s and is set to a default value in the `azure-pipelines-deploy-template.yml` file. This change introduces a new pipeline variable named `appServiceContainerTimeoutSeconds` that is set in the shared variable group to apply to all environments. This parameter can be overridden on a per environment basis if required.

## Guidance to review

Verify in DevOps environment that the app service container environment variable `WEBSITES_CONTAINER_START_TIME_LIMIT` is now set to 1200 instead of the default of 600 as seen in all the other environment presently.
https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/289869cc-7183-46bd-8131-f673c5eb94ba/resourceGroups/s106d02-apply/providers/Microsoft.Web/sites/s106d02-apply-as/configuration

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
