### PR TITLE
Fix missing translations

### DIFF
--- a/app/helpers/select_options_helper.rb
+++ b/app/helpers/select_options_helper.rb
@@ -7,13 +7,13 @@ module SelectOptionsHelper
 
   def select_course_options(courses)
     [
-      OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_course_form.attributes.code.blank')),
+      OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_course_form.attributes.course_id.blank')),
     ] + courses.map { |course| OpenStruct.new(id: course.id, name: course.name) }
   end
 
   def select_provider_options(providers)
     [
-      OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_provider_form.attributes.code.blank')),
+      OpenStruct.new(id: '', name: t('activemodel.errors.models.candidate_interface/pick_provider_form.attributes.provider_id.blank')),
     ] + providers.map { |provider| OpenStruct.new(id: provider.id, name: "#{provider.name} (#{provider.code})") }
   end
 end

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -329,11 +329,15 @@ en:
               blank: Select if you have chosen a course or not
         candidate_interface/pick_provider_form:
           attributes:
-            code:
-              blank: Select a course provider
+            provider_id:
+              blank: Select a training provider
+        candidate_interface/pick_study_mode_form:
+          attributes:
+            study_mode:
+              blank: Select full time or part time
         candidate_interface/pick_course_form:
           attributes:
-            code:
+            course_id:
               blank: Select a course
         candidate_interface/pick_site_form:
           attributes:

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -134,7 +134,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_should_see_an_error
-    expect(page).to have_content "can't be blank"
+    expect(page).to have_content 'Select a course'
   end
 
   def and_i_choose_a_course

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_study_mode_spec.rb
@@ -74,7 +74,7 @@ RSpec.feature 'Selecting a study mode' do
     click_button 'Continue'
 
     click_button 'Continue'
-    expect(page).to have_text "can't be blank"
+    expect(page).to have_text 'Select full time or part time'
     choose 'Part time'
     click_button 'Continue'
   end


### PR DESCRIPTION
These properties changed from a `code` to an `id`, but we didn't update the
translation keys.

Also add a missing translation for a blank study mode.

## Context

@laurahermionetennant92 pointed out that we had some default "can't be blank" errors: https://ukgovernmentdfe.slack.com/archives/CAHBLU6ET/p1585662865189500.

## Changes proposed in this pull request

I deleted everything under the default `errors:` key in my local version of `ActiveModel`, then ran the test suite. It duly blew up whenever we tried to fall back to a default key. I then added or corrected translations associated with the defaults.

Two of the three missing translations result from a recent change to use IDs instead of codes in the course selection flow (#1426).

## Guidance to review

I invented a message for a missing study mode, hopefully not controversial. 

## Link to Trello card

https://trello.com/c/MNp8WqPT/1747-error-messages

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
