### PR TITLE
Allow candidates to edit the course of their course choices

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -50,10 +50,18 @@ module CandidateInterface
 
     def course_row(course_choice)
       url = "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course_choice.provider.code}/#{course_choice.course.code}"
+      change_path = if FeatureFlag.active?('edit_course_choices') && has_multiple_courses?(course_choice)
+                      candidate_interface_course_choices_course_path(
+                        course_choice.provider.id,
+                        course_choice_id: course_choice.id,
+                      )
+                    end
 
       {
         key: 'Course',
         value: govuk_link_to("#{course_choice.offered_course.name} (#{course_choice.offered_course.code})", url, target: '_blank', rel: 'noopener'),
+        action: "course choice for #{course_choice.course.name_and_code}",
+        change_path: change_path,
       }
     end
 
@@ -158,6 +166,10 @@ module CandidateInterface
 
     def has_multiple_sites?(course_choice)
       CourseOption.where(course_id: course_choice.course.id, study_mode: course_choice.offered_option.study_mode).many?
+    end
+
+    def has_multiple_courses?(course_choice)
+      Course.where(provider: course_choice.provider).many?
     end
   end
 end

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -56,10 +56,21 @@ module CandidateInterface
     end
 
     def options_for_course
-      @pick_course = PickCourseForm.new(
-        provider_id: params.fetch(:provider_id),
-        application_form: current_application,
-      )
+      if params[:course_choice_id]
+        @course_choice_id = params[:course_choice_id]
+        current_application_choice = current_application.application_choices.find(@course_choice_id)
+
+        @pick_course = PickCourseForm.new(
+          provider_id: params.fetch(:provider_id),
+          application_form: current_application,
+          course_id: current_application_choice.course.id,
+        )
+      else
+        @pick_course = PickCourseForm.new(
+          provider_id: params.fetch(:provider_id),
+          application_form: current_application,
+        )
+      end
     end
 
     def pick_course
@@ -82,15 +93,21 @@ module CandidateInterface
         redirect_to candidate_interface_course_choices_study_mode_path(
           @pick_course.provider_id,
           @pick_course.course_id,
+          course_choice_id: params[:course_choice_id],
         )
       elsif @pick_course.single_site?
         course_option = CourseOption.where(course_id: @pick_course.course.id).first
-        pick_site_for_course(course_id, course_option.id)
+        if params[:course_choice_id]
+          pick_new_site_for_course(course_id, course_option.id)
+        else
+          pick_site_for_course(course_id, course_option.id)
+        end
       else
         redirect_to candidate_interface_course_choices_site_path(
           @pick_course.provider_id,
           @pick_course.course_id,
           @pick_course.study_mode,
+          course_choice_id: params[:course_choice_id],
         )
       end
     end
@@ -105,8 +122,8 @@ module CandidateInterface
         current_application_choice = current_application.application_choices.find(@course_choice_id)
 
         @pick_study_mode = PickStudyModeForm.new(
-          provider_id: current_application_choice.provider.id,
-          course_id: current_application_choice.course.id,
+          provider_id: params.fetch(:provider_id),
+          course_id: params.fetch(:course_id),
           study_mode: current_application_choice.offered_option.study_mode,
         )
       else
@@ -157,8 +174,8 @@ module CandidateInterface
 
         @pick_site = PickSiteForm.new(
           application_form: current_application,
-          provider_id: current_application_choice.provider.id,
-          course_id: current_application_choice.course.id,
+          provider_id: params.fetch(:provider_id),
+          course_id: params.fetch(:course_id),
           study_mode: params.fetch(:study_mode),
           course_option_id: current_application_choice.course_option_id.to_s,
         )

--- a/app/views/candidate_interface/course_choices/options_for_course.html.erb
+++ b/app/views/candidate_interface/course_choices/options_for_course.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
           model: @pick_course,
-          url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id]),
+          url: candidate_interface_course_choices_course_path(provider_id: params[:provider_id], course_choice_id: @course_choice_id),
           id: 'pick-course-form',
         ) do |f| %>
       <%= f.govuk_error_summary %>

--- a/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
@@ -17,8 +17,15 @@ RSpec.describe 'Candidate edits course choices' do
 
     when_i_choose_that_i_know_where_i_want_to_apply
     and_i_choose_a_provider
+    and_i_choose_the_third_course_as_my_first_course_choice
+    and_i_choose_the_full_time_study_mode
+    then_i_should_be_on_the_course_choice_review_page
+    and_i_should_see_a_change_course_link
+
+    when_i_click_to_change_the_course_for_the_first_course_choice
     and_i_choose_the_single_site_course_as_my_first_course_choice
     then_i_should_be_on_the_course_choice_review_page
+    and_i_should_see_the_updated_change_course_link
     and_i_should_not_see_a_change_location_link
     and_i_should_not_see_a_change_study_mode_link
 
@@ -118,6 +125,15 @@ RSpec.describe 'Candidate edits course choices' do
     click_button 'Continue'
   end
 
+  def and_i_choose_the_third_course_as_my_first_course_choice
+    choose @provider.courses.third.name_and_code
+    click_button 'Continue'
+  end
+
+  def when_i_click_to_change_the_course_for_the_first_course_choice
+    click_link "Change course choice for #{@provider.courses.third.name}"
+  end
+
   def and_i_choose_the_single_site_course_as_my_first_course_choice
     choose @provider.courses.first.name_and_code
     click_button 'Continue'
@@ -125,6 +141,14 @@ RSpec.describe 'Candidate edits course choices' do
 
   def then_i_should_be_on_the_course_choice_review_page
     expect(page).to have_current_path(candidate_interface_course_choices_review_path)
+  end
+
+  def and_i_should_see_a_change_course_link
+    expect(page).to have_content("Change course choice for #{@provider.courses.third.name}")
+  end
+
+  def and_i_should_see_the_updated_change_course_link
+    expect(page).to have_content("Change course choice for #{@provider.courses.first.name}")
   end
 
   def and_i_should_not_see_a_change_location_link


### PR DESCRIPTION
## Context
We want to allow candidates to be able to change the course, full time or part-time, or location for a course. If they want to change their location, they currently need to delete the choice and add a new one, instead of editing the location directly. 

This PR is the third slice to add `change course choice` link to the course choices review component

## Changes proposed in this pull request
This PR adds:
- Updates the `CourseChoicesReviewComponent` to show a `change course` link when multiple courses are available for the selected provider
- Updates the candidate journey to allow editing the course of an existing course choice

### Before
![image](https://user-images.githubusercontent.com/22743709/78050889-ccf17c00-7374-11ea-91bd-c2577ab534b9.png)

### After
![image](https://user-images.githubusercontent.com/22743709/78050734-961b6600-7374-11ea-8e47-584f2a01bf19.png)

## Guidance to review
<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/awBTB88j/1171-change-links-are-missing-from-the-course-choices-summary-cards

## Things to check
- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
