### PR TITLE
Add first page of the candidate satisfaction survey

### DIFF
--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -1,5 +1,28 @@
 module CandidateInterface
   class SatisfactionSurveyController < CandidateInterfaceController
-    def recommendation; end
+    def recommendation
+      @survey = SatisfactionSurveyForm.new
+    end
+
+    def submit_recommendation
+      @survey = SatisfactionSurveyForm.new(survey_params)
+
+      if @survey.save(current_application)
+        redirect_to candidate_interface_satisfaction_survey_complexity_path
+      else
+        @survey = SatisfactionSurveyForm.new
+
+        render :recommendation
+      end
+    end
+
+    def complexity; end
+
+  private
+
+    def survey_params
+      params.require(:candidate_interface_satisfaction_survey_form)
+        .permit(:question, :response)
+    end
   end
 end

--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -1,0 +1,5 @@
+module CandidateInterface
+  class SatisfactionSurveyController < CandidateInterfaceController
+    def recommendation; end
+  end
+end

--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -22,7 +22,7 @@ module CandidateInterface
 
     def survey_params
       params.require(:candidate_interface_satisfaction_survey_form)
-        .permit(:question, :response)
+        .permit(:question, :answer)
     end
   end
 end

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -2,24 +2,24 @@ module CandidateInterface
   class SatisfactionSurveyForm
     include ActiveModel::Model
 
-    attr_accessor :question, :response
+    attr_accessor :question, :answer
 
     validates :question, presence: true
 
     def save(application_form)
       return false unless valid?
 
-      remove_strongly_agree_and_strongly_disagree_text(@response)
-      application_form.update(satisfaction_survey: { @question => @response })
+      remove_strongly_agree_and_strongly_disagree_text(@answer)
+      application_form.update(satisfaction_survey: { @question => @answer })
     end
 
   private
 
-    def remove_strongly_agree_and_strongly_disagree_text(response)
-      if response == '1 - strongly agree'
-        @response = '1'
-      elsif response == '5 - strongly disagree'
-        @response = '5'
+    def remove_strongly_agree_and_strongly_disagree_text(answer)
+      if answer == '1 - strongly agree'
+        @answer = '1'
+      elsif answer == '5 - strongly disagree'
+        @answer = '5'
       end
     end
   end

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -1,0 +1,22 @@
+module CandidateInterface
+  class SatisfactionSurveyForm
+    include ActiveModel::Model
+
+    attr_accessor :question, :response
+
+    def save(application_form)
+      remove_strongly_agree_and_strongly_disagree_text(@response)
+      application_form.update(satisfaction_survey: { @question => @response })
+    end
+
+  private
+
+    def remove_strongly_agree_and_strongly_disagree_text(response)
+      if response == '1 - strongly agree'
+        @response = '1'
+      elsif response == '5 - strongly disagree'
+        @response = '5'
+      end
+    end
+  end
+end

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -9,18 +9,7 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      remove_strongly_agree_and_strongly_disagree_text(@answer)
       application_form.update(satisfaction_survey: { @question => @answer })
-    end
-
-  private
-
-    def remove_strongly_agree_and_strongly_disagree_text(answer)
-      if answer == '1 - strongly agree'
-        @answer = '1'
-      elsif answer == '5 - strongly disagree'
-        @answer = '5'
-      end
     end
   end
 end

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -4,7 +4,11 @@ module CandidateInterface
 
     attr_accessor :question, :response
 
+    validates :question, presence: true
+
     def save(application_form)
+      return false unless valid?
+
       remove_strongly_agree_and_strongly_disagree_text(@response)
       application_form.update(satisfaction_survey: { @question => @response })
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,6 +26,7 @@ class FeatureFlag
     replacement_referee_with_referee_type
     timeline
     edit_course_choices
+    satisfaction_survey
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -38,7 +38,7 @@
     <% if FeatureFlag.active?('satisfaction_survey') %>
       <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
       <p class="govuk-body">Your feedback will help us improve.</p>
-      <%= govuk_link_to 'Give feedback', candidate_interface_start_satisfaction_survey_path, class: 'govuk-button' %>
+      <%= govuk_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path, class: 'govuk-button' %>
     <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -34,5 +34,11 @@
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
     <p class="govuk-body">You have <%= @editable_days_count %> days to make changes to a submitted application. We won’t send your application to your training provider(s) until the <%= @editable_days_count %> working days are up.</p>
     <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
+
+    <% if FeatureFlag.active?('satisfaction_survey') %>
+      <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
+      <p class="govuk-body">Your feedback will help us improve.</p>
+      <%= govuk_link_to 'Give feedback', candidate_interface_start_satisfaction_survey_path, class: 'govuk-button' %>
+    <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
@@ -1,0 +1,1 @@
+I found this service unnecessarily complex

--- a/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
@@ -1,0 +1,24 @@
+<% content_for :title, t('page_titles.recommendation') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
+
+<%= form_with model: @application_form, url: candidate_interface_satisfaction_survey_submit_recommendation_path, method: :post do |f| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-xl">
+        <%= t('page_titles.recommendation') %>
+      </h2>
+
+      <%= f.govuk_radio_buttons_fieldset :ratings do %>
+        <%= f.govuk_radio_button :rating, '1', label: { text: '1 - strongly agree' }  %>
+        <%= f.govuk_radio_button :rating, '2', label: { text: '2' }  %>
+        <%= f.govuk_radio_button :rating, '3', label: { text: '3' }  %>
+        <%= f.govuk_radio_button :rating, '4', label: { text: '4' }  %>
+        <%= f.govuk_radio_button :rating, '5', label: { text: '5 - strongly disagree' }  %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, t('page_titles.recommendation') %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
-<%= form_with model: @application_form, url: candidate_interface_satisfaction_survey_submit_recommendation_path, method: :post do |f| %>
+<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_recommendation_path, method: :post do |f| %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -10,12 +10,14 @@
         <%= t('page_titles.recommendation') %>
       </h2>
 
+      <%= f.hidden_field :question, value: t('page_titles.recommendation') %>
+
       <%= f.govuk_radio_buttons_fieldset :ratings do %>
-        <%= f.govuk_radio_button :rating, '1', label: { text: '1 - strongly agree' }  %>
-        <%= f.govuk_radio_button :rating, '2', label: { text: '2' }  %>
-        <%= f.govuk_radio_button :rating, '3', label: { text: '3' }  %>
-        <%= f.govuk_radio_button :rating, '4', label: { text: '4' }  %>
-        <%= f.govuk_radio_button :rating, '5', label: { text: '5 - strongly disagree' }  %>
+        <%= f.govuk_radio_button :response, '1', label: { text: '1 - strongly agree' }  %>
+        <%= f.govuk_radio_button :response, '2', label: { text: '2' }  %>
+        <%= f.govuk_radio_button :response, '3', label: { text: '3' }  %>
+        <%= f.govuk_radio_button :response, '4', label: { text: '4' }  %>
+        <%= f.govuk_radio_button :response, '5', label: { text: '5 - strongly disagree' }  %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
@@ -13,11 +13,11 @@
       <%= f.hidden_field :question, value: t('page_titles.recommendation') %>
 
       <%= f.govuk_radio_buttons_fieldset :ratings do %>
-        <%= f.govuk_radio_button :response, '1', label: { text: '1 - strongly agree' }  %>
-        <%= f.govuk_radio_button :response, '2', label: { text: '2' }  %>
-        <%= f.govuk_radio_button :response, '3', label: { text: '3' }  %>
-        <%= f.govuk_radio_button :response, '4', label: { text: '4' }  %>
-        <%= f.govuk_radio_button :response, '5', label: { text: '5 - strongly disagree' }  %>
+        <%= f.govuk_radio_button :answer, '1', label: { text: '1 - strongly agree' }  %>
+        <%= f.govuk_radio_button :answer, '2', label: { text: '2' }  %>
+        <%= f.govuk_radio_button :answer, '3', label: { text: '3' }  %>
+        <%= f.govuk_radio_button :answer, '4', label: { text: '4' }  %>
+        <%= f.govuk_radio_button :answer, '5', label: { text: '5 - strongly disagree' }  %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
     training_with_a_disability: Asking for support if you have a disability or other needs
     suitability_to_work_with_children: Declaring any safeguarding issues
     recommendation: I would recommend this service to a friend or colleague
+    complexity: I found this service unnecessarily complex
     volunteering:
       short: Unpaid experience and volunteering
       long: "Unpaid experience working with children and other volunteering"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,7 @@ en:
     interview_preferences: Interview needs
     training_with_a_disability: Asking for support if you have a disability or other needs
     suitability_to_work_with_children: Declaring any safeguarding issues
+    recommendation: I would recommend this service to a friend or colleague
     volunteering:
       short: Unpaid experience and volunteering
       long: "Unpaid experience working with children and other volunteering"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -301,6 +301,10 @@ Rails.application.routes.draw do
         post '/' => 'safeguarding#update'
         get '/review' => 'safeguarding#show', as: :review_safeguarding
       end
+
+      scope '/satisfaction-survey' do
+        get '/' => 'satisfaction_survey#index', as: :start_satisfaction_survey
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,7 +304,7 @@ Rails.application.routes.draw do
 
       scope '/satisfaction-survey' do
         get '/recommendation' => 'satisfaction_survey#recommendation', as: :satisfaction_survey_recommendation
-        post 'recommendation' => 'satisfaction_survey#submit_recommendation', as: :satisfaction_survey_submit_recommendation
+        post '/recommendation' => 'satisfaction_survey#submit_recommendation', as: :satisfaction_survey_submit_recommendation
 
         get '/complexity' => 'satisfaction_survey#complexity', as: :satisfaction_survey_complexity
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,7 +303,8 @@ Rails.application.routes.draw do
       end
 
       scope '/satisfaction-survey' do
-        get '/' => 'satisfaction_survey#index', as: :start_satisfaction_survey
+        get '/recommendation' => 'satisfaction_survey#recommendation', as: :satisfaction_survey_recommendation
+        post 'recommendation' => 'satisfaction_survey#submit_recommendation', as: :satisfaction_survey_submit_recommendation
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,6 +305,8 @@ Rails.application.routes.draw do
       scope '/satisfaction-survey' do
         get '/recommendation' => 'satisfaction_survey#recommendation', as: :satisfaction_survey_recommendation
         post 'recommendation' => 'satisfaction_survey#submit_recommendation', as: :satisfaction_survey_submit_recommendation
+
+        get '/complexity' => 'satisfaction_survey#complexity', as: :satisfaction_survey_complexity
       end
     end
   end

--- a/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
+++ b/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
@@ -1,8 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
+  it { is_expected.to validate_presence_of(:question) }
+
+
   describe '#save' do
-    context 'when the user respodns with strongly agree or strongly disagree' do
+    context 'when not valid' do
+      it 'return false' do
+        application_form = double
+
+        form = described_class.new({})
+        expect(form.save(application_form)).to eq(false)
+      end
+    end
+
+    context 'when the user responds with strongly agree or strongly disagree' do
       it 'only saves the number in the string and updates the satisfaction_survey on the application_form' do
         application_form = create(:application_form)
         described_class.new(question: 'How was your experience', response: '1 - strongly agree').save(application_form)

--- a/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
+++ b/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
@@ -14,16 +14,7 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
       end
     end
 
-    context 'when the user responds with strongly agree or strongly disagree' do
-      it 'only saves the number in the string and updates the satisfaction_survey on the application_form' do
-        application_form = create(:application_form)
-        described_class.new(question: 'How was your experience', answer: '1 - strongly agree').save(application_form)
-
-        expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '1' })
-      end
-    end
-
-    context 'when the user responds with any other answer' do
+    context 'when valid' do
       it 'updates the satisfaction_survey on the application_form with their answer' do
         application_form = create(:application_form)
         described_class.new(question: 'How was your experience', answer: '2').save(application_form)

--- a/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
+++ b/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
     context 'when the user responds with strongly agree or strongly disagree' do
       it 'only saves the number in the string and updates the satisfaction_survey on the application_form' do
         application_form = create(:application_form)
-        described_class.new(question: 'How was your experience', response: '1 - strongly agree').save(application_form)
+        described_class.new(question: 'How was your experience', answer: '1 - strongly agree').save(application_form)
 
         expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '1' })
       end
     end
 
-    context 'when the user responds with any other response' do
-      it 'updates the satisfaction_survey on the application_form with their response' do
+    context 'when the user responds with any other answer' do
+      it 'updates the satisfaction_survey on the application_form with their answer' do
         application_form = create(:application_form)
-        described_class.new(question: 'How was your experience', response: '2').save(application_form)
+        described_class.new(question: 'How was your experience', answer: '2').save(application_form)
 
         expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '2' })
       end

--- a/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
+++ b/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
+  describe '#save' do
+    context 'when the user respodns with strongly agree or strongly disagree' do
+      it 'only saves the number in the string and updates the satisfaction_survey on the application_form' do
+        application_form = create(:application_form)
+        described_class.new(question: 'How was your experience', response: '1 - strongly agree').save(application_form)
+
+        expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '1' })
+      end
+    end
+
+    context 'when the user responds with any other response' do
+      it 'updates the satisfaction_survey on the application_form with their response' do
+        application_form = create(:application_form)
+        described_class.new(question: 'How was your experience', response: '2').save(application_form)
+
+        expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '2' })
+      end
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'Candidate satisfaction survey' do
     when_i_choose_1
     and_click_continue
     then_i_see_the_complexity_page
-
   end
 
   def given_the_satisfaction_survey_flag_is_active

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe 'Candidate satisfaction survey' do
 
     when_they_click_give_feedback
     then_they_should_see_the_recommendation_page
+
+    when_i_choose_1
+    and_click_continue
+    then_i_see_the_complexity_page
+
   end
 
   def given_the_satisfaction_survey_flag_is_active
@@ -36,6 +41,18 @@ RSpec.describe 'Candidate satisfaction survey' do
   end
 
   def then_they_should_see_the_recommendation_page
-    expect(page).to have_content('I would recommend this service to a friend or colleague')
+    expect(page).to have_content(t('page_titles.recommendation'))
+  end
+
+  def when_i_choose_1
+    choose '1 - strongly agree'
+  end
+
+  def and_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_see_the_complexity_page
+    expect(page).to have_content(t('page_titles.complexity'))
   end
 end

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate satisfaction survey' do
+  include CandidateHelper
+
+  scenario 'Candidate completes the survey' do
+    given_the_satisfaction_survey_flag_is_active
+    and_the_training_with_a_disability_flag_is_active
+
+    when_the_candidate_completes_and_submits_their_application
+    then_they_should_be_asked_to_give_feedback
+
+    when_they_click_give_feedback
+    then_they_should_see_the_recommendation_page
+  end
+
+  def given_the_satisfaction_survey_flag_is_active
+    FeatureFlag.activate('satisfaction_survey')
+  end
+
+  def and_the_training_with_a_disability_flag_is_active
+    FeatureFlag.activate('training_with_a_disability')
+  end
+
+  def when_the_candidate_completes_and_submits_their_application
+    candidate_completes_application_form
+    candidate_submits_application
+  end
+
+  def then_they_should_be_asked_to_give_feedback
+    expect(page).to have_content('Your feedback will help us improve.')
+  end
+
+  def when_they_click_give_feedback
+    click_link 'Give feedback'
+  end
+
+  def then_they_should_see_the_recommendation_page
+    expect(page).to have_content('I would recommend this service to a friend or colleague')
+  end
+end


### PR DESCRIPTION
## Context

Candidates need a way to give us feedback on our service. To do this we're going to add a satisfaction survey. This PR adds the initial page of this flow.

## Changes proposed in this pull request

- Adds a feature flag 
- Adds a Give feedback button to the submit success page
- Adds the first page which asks if they would recommend the service

Before

![image](https://user-images.githubusercontent.com/42515961/78113267-63ff1800-73f7-11ea-99c5-cb722c2c9622.png)

After

![image](https://user-images.githubusercontent.com/42515961/78113090-20a4a980-73f7-11ea-9291-b09bf6d84609.png)

![image](https://user-images.githubusercontent.com/42515961/78113122-2b5f3e80-73f7-11ea-9ec6-1e936888bd09.png)


## Guidance to review

https://bat-design-history.netlify.com/apply-for-teacher-training/satisfaction-survey

I've just taken it far enough to get the tests to pass on the complexity view so I can keep this PR fairly self-contained.

Happy with the approach?

## Link to Trello card

https://trello.com/c/tO5B8iK1/1257-dev-survey-to-candidates-when-they-have-submitted-an-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
