### PR TITLE
Rename ProviderUsersProvider to ProviderPermissions

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -5,8 +5,8 @@ class Provider < ApplicationRecord
   has_many :application_choices, through: :course_options
   has_many :accredited_courses, class_name: 'Course', inverse_of: :accrediting_provider, foreign_key: :accrediting_provider_id
 
-  has_many :provider_users_providers, dependent: :destroy
-  has_many :provider_users, through: :provider_users_providers
+  has_many :provider_permissions, dependent: :destroy
+  has_many :provider_users, through: :provider_permissions
   has_many :provider_agreements
 
   enum region_code: {

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -1,4 +1,6 @@
-class ProviderUsersProvider < ActiveRecord::Base
+class ProviderPermissions < ActiveRecord::Base
+  self.table_name = 'provider_users_providers'
+
   belongs_to :provider_user
   belongs_to :provider
 

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -1,6 +1,6 @@
 class ProviderUser < ActiveRecord::Base
-  has_many :provider_users_providers, dependent: :destroy
-  has_many :providers, through: :provider_users_providers
+  has_many :provider_permissions, dependent: :destroy
+  has_many :providers, through: :provider_permissions
 
   validates :dfe_sign_in_uid, uniqueness: true, allow_nil: true
 

--- a/config/initializers/inflector.rb
+++ b/config/initializers/inflector.rb
@@ -1,4 +1,5 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym('DfE')
   inflect.irregular 'chaser_sent', 'chasers_sent'
+  inflect.irregular 'provider_permissions', 'provider_permissions'
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -429,7 +429,7 @@ FactoryBot.define do
     end
   end
 
-  factory :provider_users_provider do
+  factory :provider_permissions do
     provider
     provider_user
   end

--- a/spec/services/send_chase_email_to_provider_spec.rb
+++ b/spec/services/send_chase_email_to_provider_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SendChaseEmailToProvider do
     let(:provider_id) { application_choice.provider.id }
 
     before do
-      create(:provider_users_provider, provider_id: application_choice.provider.id, provider_user_id: provider_user.id)
+      create(:provider_permissions, provider_id: application_choice.provider.id, provider_user_id: provider_user.id)
       described_class.call(application_choice: application_choice)
     end
 

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'A candidate withdraws her application' do
     form = create(:completed_application_form, :with_completed_references, candidate: current_candidate)
     @application_choice = create(:application_choice, :awaiting_provider_decision, application_form: form)
     @provider_user = create(:provider_user)
-    create(:provider_users_provider, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
+    create(:provider_permissions, provider_id: @application_choice.provider.id, provider_user_id: @provider_user.id)
   end
 
   def when_i_visit_the_application_dashboard

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature 'An application is waiting for decision for 20 working days' do
   def and_i_am_a_provider_user_at_the_course_provider
     @provider_user = create(:provider_user)
     provider_id = @submitted_application_choice.provider.id
-    create(:provider_users_provider, provider_id: provider_id, provider_user_id: @provider_user.id)
+    create(:provider_permissions, provider_id: provider_id, provider_user_id: @provider_user.id)
   end
 
   def when_the_application_is_getting_close_to_the_reject_by_default_date


### PR DESCRIPTION
## Context

`new`ing up a `ProviderUsersProvider` to work with provider permissions is a bit clunky, so rename the model to `ProviderPermissions`

## Changes proposed in this pull request

Rename the model. As the model is not yet explicitly referenced anywhere, renaming is a question of setting `self.table_name` and updating associations.

## Guidance to review

- Does this make sense?
- Is the `ProviderPermissions` the right name?
- Do we need to rename the table too?

## Link to Trello card

Follow-up on https://trello.com/c/mPGFKdgO/1840-create-permissions-model-for-providerusers

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
