### PR TITLE
Update change offer flow user experience

### DIFF
--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -18,17 +18,17 @@ module ProviderInterface
         },
         {
           key: 'Provider',
-          value: application_choice.offered_course.provider.name,
+          value: course_option.course.provider.name,
           change_path: change_path(:provider), action: 'training provider'
         },
         {
           key: 'Course',
-          value: application_choice.offered_course.name_and_code,
+          value: course_option.course.name_and_code,
           change_path: change_path(:course), action: 'course'
         },
         {
           key: 'Location',
-          value: application_choice.offered_site.name_and_address,
+          value: course_option.site.name_and_address,
           change_path: change_path(:course_option), action: 'location'
         },
       ]
@@ -38,14 +38,17 @@ module ProviderInterface
       Rails.application.routes.url_helpers
     end
 
+    # TODO: paths produced preserve the current (unsaved) provider/course/option selection
     def change_path(target)
-      case target
-      when :provider
-        paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id) if show_provider_link?
-      when :course
-        paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id) if show_course_link?
-      when :course_option
-        paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id) if show_course_option_link?
+      if new_course_option
+        case target
+        when :provider
+          paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id) if show_provider_link?
+        when :course
+          paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id) if show_course_link?
+        when :course_option
+          paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id) if show_course_option_link?
+        end
       end
     end
 
@@ -62,8 +65,14 @@ module ProviderInterface
     end
 
     def new_course_option
-      @course_option ||= CourseOption.find(@course_option_id) if @course_option_id
-      @course_option unless @course_option && @course_option.id != application_choice.offered_option.id
+      if @course_option_id
+        @new_course_option ||= CourseOption.find(@course_option_id)
+        @new_course_option if @course_option_id != application_choice.offered_option.id
+      end
+    end
+
+    def course_option
+      new_course_option || application_choice.offered_option
     end
   end
 end

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -8,6 +8,9 @@ module ProviderInterface
       @header = header
       @course_option_id = extra_arguments[:course_option_id]
       @entry = extra_arguments[:entry]
+      @available_providers = extra_arguments[:available_providers]
+      @available_courses = extra_arguments[:available_courses]
+      @available_course_options = extra_arguments[:available_course_options]
     end
 
     def rows
@@ -53,15 +56,15 @@ module ProviderInterface
     end
 
     def show_provider_link?
-      @entry == 'provider'
+      @entry == 'provider' && @available_providers && @available_providers.count > 1
     end
 
     def show_course_link?
-      @entry != 'course_option'
+      @entry != 'course_option' && @available_courses && @available_courses.count > 1
     end
 
     def show_course_option_link?
-      true
+      @available_course_options && @available_course_options.count > 1
     end
 
     def new_course_option

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -5,9 +5,11 @@ module ProviderInterface
 
     def initialize(application_choice:, header: 'Your offer', options: {})
       @application_choice = application_choice
+      @course_option = application_choice.offered_option
       @header = header
-      @course_option_id = options[:new_course_option_id]
-      @entry = options[:entry]
+      @change_provider_path = options[:change_provider_path]
+      @change_course_path = options[:change_course_path]
+      @change_course_option_path = options[:change_course_option_path]
     end
 
     def rows
@@ -18,68 +20,20 @@ module ProviderInterface
         },
         {
           key: 'Provider',
-          value: course_option.course.provider.name,
-          change_path: change_path(:provider), action: 'training provider'
+          value: @course_option.course.provider.name,
+          change_path: @change_provider_path, action: 'training provider'
         },
         {
           key: 'Course',
-          value: course_option.course.name_and_code,
-          change_path: change_path(:course), action: 'course'
+          value: @course_option.course.name_and_code,
+          change_path: @change_course_path, action: 'course'
         },
         {
           key: 'Location',
-          value: course_option.site.name_and_address,
-          change_path: change_path(:course_option), action: 'location'
+          value: @course_option.site.name_and_address,
+          change_path: @change_course_option_path, action: 'location'
         },
       ]
-    end
-
-    def paths
-      Rails.application.routes.url_helpers
-    end
-
-    # paths produced preserve the current (unsaved) provider/course/option selection
-    def change_path(target)
-      if new_course_option
-        case target
-        when :provider
-          paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id, current_selection_params) if show_provider_link?
-        when :course
-          paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id, current_selection_params) if show_course_link?
-        when :course_option
-          paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id, current_selection_params)
-        end
-      end
-    end
-
-    def show_provider_link?
-      @entry == 'provider'
-    end
-
-    def show_course_link?
-      @entry != 'course_option'
-    end
-
-    def new_course_option
-      if @course_option_id
-        @new_course_option ||= CourseOption.find(@course_option_id)
-        @new_course_option if @course_option_id != application_choice.offered_option.id
-      end
-    end
-
-    def course_option
-      new_course_option || application_choice.offered_option
-    end
-
-    def current_selection_params
-      {
-        provider_interface_change_offer_form: {
-          provider_id: course_option.course.provider.id,
-          course_id: course_option.course.id,
-          course_option_id: course_option.id,
-        },
-        entry: @entry,
-      }
     end
   end
 end

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -38,16 +38,16 @@ module ProviderInterface
       Rails.application.routes.url_helpers
     end
 
-    # TODO: paths produced preserve the current (unsaved) provider/course/option selection
+    # paths produced preserve the current (unsaved) provider/course/option selection
     def change_path(target)
       if new_course_option
         case target
         when :provider
-          paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id) if show_provider_link?
+          paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id, current_selection_params) if show_provider_link?
         when :course
-          paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id) if show_course_link?
+          paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id, current_selection_params) if show_course_link?
         when :course_option
-          paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id) if show_course_option_link?
+          paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id, current_selection_params) if show_course_option_link?
         end
       end
     end
@@ -73,6 +73,17 @@ module ProviderInterface
 
     def course_option
       new_course_option || application_choice.offered_option
+    end
+
+    def current_selection_params
+      {
+        provider_interface_change_offer_form: {
+          provider_id: course_option.course.provider.id,
+          course_id: course_option.course.id,
+          course_option_id: course_option.id,
+        },
+        entry: @entry,
+      }
     end
   end
 end

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -1,16 +1,13 @@
 module ProviderInterface
   class OfferSummaryListComponent < ActionView::Component::Base
     include ViewHelper
-    attr_reader :application_choice, :header
+    attr_reader :application_choice, :header, :options
 
-    def initialize(application_choice:, header: 'Your offer', extra_arguments: {})
+    def initialize(application_choice:, header: 'Your offer', options: {})
       @application_choice = application_choice
       @header = header
-      @course_option_id = extra_arguments[:course_option_id]
-      @entry = extra_arguments[:entry]
-      @available_providers = extra_arguments[:available_providers]
-      @available_courses = extra_arguments[:available_courses]
-      @available_course_options = extra_arguments[:available_course_options]
+      @course_option_id = options[:new_course_option_id]
+      @entry = options[:entry]
     end
 
     def rows
@@ -50,21 +47,17 @@ module ProviderInterface
         when :course
           paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id, current_selection_params) if show_course_link?
         when :course_option
-          paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id, current_selection_params) if show_course_option_link?
+          paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id, current_selection_params)
         end
       end
     end
 
     def show_provider_link?
-      @entry == 'provider' && @available_providers && @available_providers.count > 1
+      @entry == 'provider'
     end
 
     def show_course_link?
-      @entry != 'course_option' && @available_courses && @available_courses.count > 1
-    end
-
-    def show_course_option_link?
-      @available_course_options && @available_course_options.count > 1
+      @entry != 'course_option'
     end
 
     def new_course_option

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -3,9 +3,11 @@ module ProviderInterface
     include ViewHelper
     attr_reader :application_choice, :header
 
-    def initialize(application_choice:, header: 'Your offer')
+    def initialize(application_choice:, header: 'Your offer', extra_arguments: {})
       @application_choice = application_choice
       @header = header
+      @course_option_id = extra_arguments[:course_option_id]
+      @entry = extra_arguments[:entry]
     end
 
     def rows
@@ -17,16 +19,51 @@ module ProviderInterface
         {
           key: 'Provider',
           value: application_choice.offered_course.provider.name,
+          change_path: change_path(:provider), action: 'training provider'
         },
         {
           key: 'Course',
           value: application_choice.offered_course.name_and_code,
+          change_path: change_path(:course), action: 'course'
         },
         {
           key: 'Location',
           value: application_choice.offered_site.name_and_address,
+          change_path: change_path(:course_option), action: 'location'
         },
       ]
+    end
+
+    def paths
+      Rails.application.routes.url_helpers
+    end
+
+    def change_path(target)
+      case target
+      when :provider
+        paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id) if show_provider_link?
+      when :course
+        paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id) if show_course_link?
+      when :course_option
+        paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id) if show_course_option_link?
+      end
+    end
+
+    def show_provider_link?
+      @entry == 'provider'
+    end
+
+    def show_course_link?
+      @entry != 'course_option'
+    end
+
+    def show_course_option_link?
+      true
+    end
+
+    def new_course_option
+      @course_option ||= CourseOption.find(@course_option_id) if @course_option_id
+      @course_option unless @course_option && @course_option.id != application_choice.offered_option.id
     end
   end
 end

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,6 +1,7 @@
-<% status_box_component = status_box_component_to_render.new(application_choice: @application_choice) -%>
-<% if status_box_component.render? -%>
-  <div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
-    <%= render status_box_component %>
-  </div>
-<% end -%>
+<div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
+  <% if extra_arguments.empty? %>
+    <%= render status_box_component_to_render.new(application_choice: application_choice) %>
+  <% else %>
+    <%= render status_box_component_to_render.new(extra_arguments.merge(application_choice: application_choice)) %>
+  <% end %>
+</div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,4 +1,4 @@
-<% status_box_component = status_box_component_to_render.new(@options) %>
+<% status_box_component = status_box_component_to_render.new(application_choice: @application_choice, options: @options) %>
 <% if status_box_component.render? -%>
   <div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
     <%= render status_box_component %>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,7 +1,6 @@
-<div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
-  <% if @extra_arguments.empty? %>
-    <%= render status_box_component_to_render.new(application_choice: application_choice) %>
-  <% else %>
-    <%= render status_box_component_to_render.new(@extra_arguments.merge(application_choice: application_choice)) %>
-  <% end %>
-</div>
+<% status_box_component = status_box_component_to_render.new(@extra_arguments.merge(application_choice: application_choice)) %>
+<% if status_box_component.render? -%>
+  <div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
+    <%= render status_box_component %>
+  </div>
+<% end -%>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,7 +1,7 @@
 <div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
-  <% if extra_arguments.empty? %>
+  <% if @extra_arguments.empty? %>
     <%= render status_box_component_to_render.new(application_choice: application_choice) %>
   <% else %>
-    <%= render status_box_component_to_render.new(extra_arguments.merge(application_choice: application_choice)) %>
+    <%= render status_box_component_to_render.new(@extra_arguments.merge(application_choice: application_choice)) %>
   <% end %>
 </div>

--- a/app/components/provider_interface/status_box_component.html.erb
+++ b/app/components/provider_interface/status_box_component.html.erb
@@ -1,4 +1,4 @@
-<% status_box_component = status_box_component_to_render.new(@extra_arguments.merge(application_choice: application_choice)) %>
+<% status_box_component = status_box_component_to_render.new(@options) %>
 <% if status_box_component.render? -%>
   <div data-qa="app-status-box" class="govuk-!-margin-bottom-8">
     <%= render status_box_component %>

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -4,10 +4,9 @@ module ProviderInterface
 
     attr_reader :application_choice
 
-    def initialize(application_choice:, extra_arguments: nil)
-      @application_choice = application_choice
-      @extra_arguments = extra_arguments
-      @extra_arguments ||= {}
+    def initialize(options)
+      @options = options
+      @application_choice = @options[:application_choice]
     end
 
     def application_status

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -4,9 +4,10 @@ module ProviderInterface
 
     attr_reader :application_choice
 
-    def initialize(application_choice:, extra_arguments: {})
+    def initialize(application_choice:, extra_arguments: nil)
       @application_choice = application_choice
       @extra_arguments = extra_arguments
+      @extra_arguments ||= {}
     end
 
     def application_status

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -2,11 +2,11 @@ module ProviderInterface
   class StatusBoxComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :application_choice
+    attr_reader :application_choice, :options
 
-    def initialize(options)
+    def initialize(application_choice:, options: {})
+      @application_choice = application_choice
       @options = options
-      @application_choice = @options[:application_choice]
     end
 
     def application_status

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -2,11 +2,11 @@ module ProviderInterface
   class StatusBoxComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :application_choice, :extra_arguments
+    attr_reader :application_choice
 
-    def initialize(application_choice:, extra_arguments: nil)
+    def initialize(application_choice:, extra_arguments: {})
       @application_choice = application_choice
-      @extra_arguments = extra_arguments || {}
+      @extra_arguments = extra_arguments
     end
 
     def application_status

--- a/app/components/provider_interface/status_box_component.rb
+++ b/app/components/provider_interface/status_box_component.rb
@@ -2,10 +2,11 @@ module ProviderInterface
   class StatusBoxComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :application_choice
+    attr_reader :application_choice, :extra_arguments
 
-    def initialize(application_choice:)
+    def initialize(application_choice:, extra_arguments: nil)
       @application_choice = application_choice
+      @extra_arguments = extra_arguments || {}
     end
 
     def application_status

--- a/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
+++ b/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
+++ b/app/components/provider_interface/status_box_components/awaiting_provider_decision_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
+++ b/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
+++ b/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/declined_component.rb
+++ b/app/components/provider_interface/status_box_components/declined_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/declined_component.rb
+++ b/app/components/provider_interface/status_box_components/declined_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/enrolled_component.rb
+++ b/app/components/provider_interface/status_box_components/enrolled_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/enrolled_component.rb
+++ b/app/components/provider_interface/status_box_components/enrolled_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -5,11 +5,11 @@ module ProviderInterface
       attr_reader :application_choice
       attr_reader :available_providers, :available_courses, :available_course_options
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
-        @available_providers = args[:available_providers]
-        @available_courses = args[:available_courses]
-        @available_course_options = args[:available_course_options]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @available_providers = options[:available_providers]
+        @available_courses = options[:available_courses]
+        @available_course_options = options[:available_course_options]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -3,9 +3,13 @@ module ProviderInterface
     class OfferComponent < ActionView::Component::Base
       include ViewHelper
       attr_reader :application_choice
+      attr_reader :available_providers, :available_courses, :available_course_options
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
+        @available_providers = args[:available_providers]
+        @available_courses = args[:available_courses]
+        @available_course_options = args[:available_course_options]
       end
 
       def render?
@@ -45,10 +49,25 @@ module ProviderInterface
         return nil unless FeatureFlag.active?('provider_change_response')
 
         case target
-        when :provider then paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id)
-        when :course then paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id)
-        when :course_option then paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id)
+        when :provider
+          paths.provider_interface_application_choice_change_offer_edit_provider_path(application_choice.id, entry: 'provider') if show_provider_link?
+        when :course
+          paths.provider_interface_application_choice_change_offer_edit_course_path(application_choice.id, entry: 'course') if show_course_link?
+        when :course_option
+          paths.provider_interface_application_choice_change_offer_edit_course_option_path(application_choice.id, entry: 'course_option') if show_course_option_link?
         end
+      end
+
+      def show_provider_link?
+        available_providers.count > 1 if available_providers
+      end
+
+      def show_course_link?
+        available_courses.count > 1 if available_courses
+      end
+
+      def show_course_option_link?
+        available_course_options.count > 1 if available_course_options
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.rb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.rb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/recruited_component.rb
+++ b/app/components/provider_interface/status_box_components/recruited_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/recruited_component.rb
+++ b/app/components/provider_interface/status_box_components/recruited_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/rejected_component.rb
+++ b/app/components/provider_interface/status_box_components/rejected_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/rejected_component.rb
+++ b/app/components/provider_interface/status_box_components/rejected_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/withdrawn_component.rb
+++ b/app/components/provider_interface/status_box_components/withdrawn_component.rb
@@ -4,8 +4,8 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(application_choice:)
-        @application_choice = application_choice
+      def initialize(args)
+        @application_choice = args[:application_choice]
       end
 
       def render?

--- a/app/components/provider_interface/status_box_components/withdrawn_component.rb
+++ b/app/components/provider_interface/status_box_components/withdrawn_component.rb
@@ -4,8 +4,9 @@ module ProviderInterface
       include ViewHelper
       attr_reader :application_choice
 
-      def initialize(args)
-        @application_choice = args[:application_choice]
+      def initialize(application_choice:, options: {})
+        @application_choice = application_choice
+        @options = options
       end
 
       def render?

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -22,17 +22,19 @@ module ProviderInterface
 
     def show
       available_providers = current_provider_user.providers
+
       @application_choice = GetApplicationChoicesForProviders.call(
         providers: available_providers,
       ).find(params[:application_choice_id])
 
-      if @application_choice.offer?
-        @extra_statusbox_arguments = \
-          GetAllChangeOptionsFromOfferedOption.new(
-            application_choice: @application_choice,
-            available_providers: available_providers,
-          ).call
-      end
+      @status_box_options = if @application_choice.offer?
+                              GetAllChangeOptionsFromOfferedOption.new(
+                                application_choice: @application_choice,
+                                available_providers: available_providers,
+                              ).call.merge(application_choice: @application_choice)
+                            else
+                              { application_choice: @application_choice }
+                            end
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -21,9 +21,18 @@ module ProviderInterface
     end
 
     def show
+      available_providers = current_provider_user.providers
       @application_choice = GetApplicationChoicesForProviders.call(
-        providers: current_provider_user.providers,
+        providers: available_providers,
       ).find(params[:application_choice_id])
+
+      if @application_choice.offer?
+        @extra_statusbox_arguments = \
+          GetAllChangeOptionsFromOfferedOption.new(
+            application_choice: @application_choice,
+            available_providers: available_providers,
+          ).call
+      end
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -31,9 +31,9 @@ module ProviderInterface
                               GetAllChangeOptionsFromOfferedOption.new(
                                 application_choice: @application_choice,
                                 available_providers: available_providers,
-                              ).call.merge(application_choice: @application_choice)
+                              ).call
                             else
-                              { application_choice: @application_choice }
+                              {}
                             end
     end
   end

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -36,9 +36,12 @@ module ProviderInterface
       if @change_offer_form.valid?
         return redirect_to_confirm_new_offer if @change_offer_form.new_offer?
 
+        @future_application_choice = @application_choice.dup
+        @future_application_choice.offered_course_option_id = @change_offer_form.course_option_id
+
         @extra_arguments = \
           GetAllChangeOptionsFromOfferedOption.new(
-            application_choice: @application_choice,
+            application_choice: @future_application_choice,
             available_providers: current_provider_user.providers,
           ).call.merge(
             course_option_id: @change_offer_form.course_option_id,

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -39,14 +39,10 @@ module ProviderInterface
         @future_application_choice = @application_choice.dup
         @future_application_choice.offered_course_option_id = @change_offer_form.course_option_id
 
-        @extra_arguments = \
-          GetAllChangeOptionsFromOfferedOption.new(
-            application_choice: @future_application_choice,
-            available_providers: current_provider_user.providers,
-          ).call.merge(
-            course_option_id: @change_offer_form.course_option_id,
-            entry: @change_offer_form.entry,
-          )
+        @change_options = {
+          new_course_option_id: @change_offer_form.course_option_id,
+          entry: @change_offer_form.entry,
+        }
       else
         render_step_for_invalid_form
       end

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -39,9 +39,23 @@ module ProviderInterface
         @future_application_choice = @application_choice.dup
         @future_application_choice.offered_course_option_id = @change_offer_form.course_option_id
 
-        @change_options = {
-          new_course_option_id: @change_offer_form.course_option_id,
-          entry: @change_offer_form.entry,
+        paths = Rails.application.routes.url_helpers
+        entry = @change_offer_form.entry
+
+        current_selection_params = \
+          {
+            provider_interface_change_offer_form: {
+              provider_id: course_option.course.provider.id,
+              course_id: course_option.course.id,
+              course_option_id: course_option.id,
+            },
+            entry: entry,
+          }
+
+        @change_path_options = {
+          change_provider_path: (paths.provider_interface_application_choice_change_offer_edit_provider_path(@application_choice.id, current_selection_params) if entry == 'provider'),
+          change_course_path: (paths.provider_interface_application_choice_change_offer_edit_course_path(@application_choice.id, current_selection_params) if entry != 'course_option'),
+          change_course_option_path: paths.provider_interface_application_choice_change_offer_edit_course_option_path(@application_choice.id, current_selection_params),
         }
       else
         render_step_for_invalid_form

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -6,13 +6,15 @@ module ProviderInterface
 
     def edit_provider
       @change_offer_form.step = :provider
-      set_alternative_providers
+
+      render_providers
     end
 
     def edit_course
       @change_offer_form.step = :course
+
       if @change_offer_form.valid?
-        set_alternative_courses
+        render_courses
       else
         render_providers
       end
@@ -20,8 +22,9 @@ module ProviderInterface
 
     def edit_course_option
       @change_offer_form.step = :course_option
+
       if @change_offer_form.valid?
-        set_alternative_course_options
+        render_course_options
       else
         render_courses
       end
@@ -64,16 +67,37 @@ module ProviderInterface
 
     def render_providers
       set_alternative_providers
+      @page_title = \
+        if @application_choice.offer? && @change_offer_form.entry == 'provider'
+          'Change training provider'
+        else
+          'Select alternative training provider'
+        end
+
       render :edit_provider
     end
 
     def render_courses
       set_alternative_courses
+      @page_title = \
+        if @application_choice.offer? && @change_offer_form.entry == 'course'
+          'Change course'
+        else
+          'Select alternative course'
+        end
+
       render :edit_course
     end
 
     def render_course_options
       set_alternative_course_options
+      @page_title = \
+        if @application_choice.offer? && @change_offer_form.entry == 'course_option'
+          'Change location'
+        else
+          'Select location'
+        end
+
       render :edit_course_option
     end
 

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -1,7 +1,7 @@
 module ProviderInterface
   class ChangeOfferForm
     include ActiveModel::Model
-    attr_accessor :application_choice, :step, :provider_id, :course_id, :course_option_id
+    attr_accessor :application_choice, :step, :provider_id, :course_id, :course_option_id, :entry
 
     validates :application_choice, presence: true
 

--- a/app/services/get_all_change_options_from_offered_option.rb
+++ b/app/services/get_all_change_options_from_offered_option.rb
@@ -12,6 +12,7 @@ class GetAllChangeOptionsFromOfferedOption
         open_on_apply: true,
         provider: application_choice.offered_course.provider,
         study_mode: study_mode_for_other_courses,
+        recruitment_cycle_year: application_choice.offered_course.recruitment_cycle_year,
       ).order(:name)
 
     @available_course_options = \

--- a/app/services/get_all_change_options_from_offered_option.rb
+++ b/app/services/get_all_change_options_from_offered_option.rb
@@ -1,0 +1,39 @@
+class GetAllChangeOptionsFromOfferedOption
+  attr_accessor :application_choice, :available_providers
+  attr_accessor :available_courses, :available_course_options
+
+  def initialize(application_choice:, available_providers: nil)
+    @application_choice = application_choice
+
+    @available_providers = available_providers || [application_choice.offered_course.provider]
+
+    @available_courses = \
+      Course.where(
+        open_on_apply: true,
+        provider: application_choice.offered_course.provider,
+        study_mode: study_mode_for_other_courses,
+      ).order(:name)
+
+    @available_course_options = \
+      CourseOption.where(
+        course: application_choice.offered_course,
+        study_mode: application_choice.offered_option.study_mode, # preserving study_mode, for now
+        # TODO: check vacancy_status, e.g. 'B'
+      ).includes(:site).order('sites.name')
+  end
+
+  def call
+    {
+      available_providers: available_providers,
+      available_courses: available_courses,
+      available_course_options: available_course_options,
+    }
+  end
+
+private
+
+  def study_mode_for_other_courses
+    current_study_mode = @application_choice.offered_option.study_mode
+    [current_study_mode, :full_time_or_part_time]
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -23,6 +23,28 @@
   </div>
 <% end -%>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
+      <span class="govuk-caption-xl"><%= @application_choice.application_form.support_reference %></span>
+      <%= @application_choice.application_form.full_name %>
+    </h1>
+    <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
+      <%= govuk_link_to(
+        'Download application (PDF)',
+        provider_interface_application_choice_path(@application_choice.id, format: :pdf),
+        download: @application_choice.application_form.support_reference
+      ) %>
+    </p>
+
+    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, extra_arguments: @extra_statusbox_arguments) %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
+  </div>
+<% end -%>
+
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
   <%= @application_choice.application_form.full_name %>
   <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -23,28 +23,6 @@
   </div>
 <% end -%>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-      <span class="govuk-caption-xl"><%= @application_choice.application_form.support_reference %></span>
-      <%= @application_choice.application_form.full_name %>
-    </h1>
-    <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
-      <%= govuk_link_to(
-        'Download application (PDF)',
-        provider_interface_application_choice_path(@application_choice.id, format: :pdf),
-        download: @application_choice.application_form.support_reference
-      ) %>
-    </p>
-
-    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, extra_arguments: @extra_statusbox_arguments) %>
-  </div>
-
-  <div class="govuk-grid-column-one-third">
-    <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
-  </div>
-<% end -%>
-
 <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
   <%= @application_choice.application_form.full_name %>
   <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
@@ -60,7 +38,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice) %>
+    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, extra_arguments: @extra_statusbox_arguments) %>
 
     <h2 class="govuk-heading-l" id="course-info">Application</h2>
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -38,7 +38,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= render ProviderInterface::StatusBoxComponent.new(@status_box_options) %>
+    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, options: @status_box_options) %>
 
     <h2 class="govuk-heading-l" id="course-info">Application</h2>
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -38,7 +38,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <%= render ProviderInterface::StatusBoxComponent.new(application_choice: @application_choice, extra_arguments: @extra_statusbox_arguments) %>
+    <%= render ProviderInterface::StatusBoxComponent.new(@status_box_options) %>
 
     <h2 class="govuk-heading-l" id="course-info">Application</h2>
     <%= render PersonalDetailsComponent.new(application_form: @application_choice.application_form) %>

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -7,7 +7,7 @@
       Check and confirm changes to offer
     </h1>
     <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
-    <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your new offer', options: @change_options) %>
+    <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @future_application_choice, header: 'Your new offer', options: @change_path_options) %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -5,7 +5,7 @@
 	Check and confirm changes to offer
 </h1>
 <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
-<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @future_application_choice, header: 'Your new offer') %>
+<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your new offer', extra_arguments: @extra_arguments) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -7,7 +7,7 @@
       Check and confirm changes to offer
     </h1>
     <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
-    <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your new offer', extra_arguments: @extra_arguments) %>
+    <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your new offer', options: @change_options) %>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -1,24 +1,28 @@
 <% content_for :before_content, govuk_back_link_to(request.referer) %>
 
-<h1 class="govuk-heading-xl">
-	<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-	Check and confirm changes to offer
-</h1>
-<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
-<%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your new offer', extra_arguments: @extra_arguments) %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: @change_offer_form,
-          url: provider_interface_application_choice_change_offer_path(@application_choice.id),
-          method: :patch do |f| %>
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+      Check and confirm changes to offer
+    </h1>
+    <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your existing offer') %>
+    <%= render ProviderInterface::OfferSummaryListComponent.new(application_choice: @application_choice, header: 'Your new offer', extra_arguments: @extra_arguments) %>
 
-      <%= f.hidden_field :provider_id %>
-      <%= f.hidden_field :course_id %>
-      <%= f.hidden_field :course_option_id %>
-      <%= f.govuk_submit 'Change offer' %>
-    <% end %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_with model: @change_offer_form,
+              url: provider_interface_application_choice_change_offer_path(@application_choice.id),
+              method: :patch do |f| %>
 
-    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+          <%= f.hidden_field :provider_id %>
+          <%= f.hidden_field :course_id %>
+          <%= f.hidden_field :course_option_id %>
+          <%= f.govuk_submit 'Change offer' %>
+        <% end %>
+
+        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+      </div>
+    </div>
   </div>
 </div>

--- a/app/views/provider_interface/offer_changes/edit_course.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course.html.erb
@@ -3,10 +3,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
-          url: provider_interface_application_choice_change_offer_edit_course_option_path(@application_choice.id),
+          url: provider_interface_application_choice_change_offer_edit_course_option_path(@application_choice.id, entry: params[:entry]),
           method: :get do |f| %>
 
       <%= f.hidden_field :provider_id %>
+      <%= f.hidden_field :entry %>
       <%= f.govuk_radio_buttons_fieldset :course_id do %>
 
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">

--- a/app/views/provider_interface/offer_changes/edit_course.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
-          url: provider_interface_application_choice_change_offer_edit_course_option_path(@application_choice.id, entry: params[:entry]),
+          url: provider_interface_application_choice_change_offer_edit_course_option_path(@application_choice.id),
           method: :get do |f| %>
 
       <%= f.hidden_field :provider_id %>
@@ -12,13 +12,13 @@
 
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">
-					  <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-					  <%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' course') %>
-				  </h1>
+            <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
+              <%= @page_title %>
+          </h1>
         </legend>
 
         <% @alternative_courses.each do |course| %>
-          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint_text: nil %>
+          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint_text: course.description %>
         <% end %>
       <% end %>
 

--- a/app/views/provider_interface/offer_changes/edit_course_option.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course_option.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
-          url: provider_interface_application_choice_change_offer_confirmation_path(@application_choice.id, entry: params[:entry]),
+          url: provider_interface_application_choice_change_offer_confirmation_path(@application_choice.id),
           method: :get do |f| %>
 
       <%= f.hidden_field :provider_id %>
@@ -13,7 +13,7 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">
             <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-            <%= (@application_choice.offer? ? 'Change' : 'Select').concat(' location') %>
+            <%= @page_title %>
           </h1>
         </legend>
 

--- a/app/views/provider_interface/offer_changes/edit_course_option.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course_option.html.erb
@@ -3,11 +3,12 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @change_offer_form,
-          url: provider_interface_application_choice_change_offer_confirmation_path(@application_choice.id),
+          url: provider_interface_application_choice_change_offer_confirmation_path(@application_choice.id, entry: params[:entry]),
           method: :get do |f| %>
 
       <%= f.hidden_field :provider_id %>
       <%= f.hidden_field :course_id %>
+      <%= f.hidden_field :entry %>
       <%= f.govuk_radio_buttons_fieldset :course_option_id do %>
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">

--- a/app/views/provider_interface/offer_changes/edit_provider.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_provider.html.erb
@@ -7,6 +7,7 @@
           url: provider_interface_application_choice_change_offer_edit_course_path(@application_choice.id),
           method: :get do |f| %>
 
+      <%= f.hidden_field :entry %>
       <%= f.govuk_radio_buttons_fieldset :provider_id do %>
 
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">

--- a/app/views/provider_interface/offer_changes/edit_provider.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_provider.html.erb
@@ -13,7 +13,7 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">
             <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
-            <%= (@application_choice.offer? ? 'Change' : 'Select alternative').concat(' provider') %>
+            <%= @page_title %>
           </h1>
         </legend>
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -447,6 +447,12 @@ FactoryBot.define do
         create(:provider).provider_users << user
       end
     end
+
+    trait :with_two_providers do
+      after(:create) do |user, _evaluator|
+        2.times { create(:provider).provider_users << user }
+      end
+    end
   end
 
   factory :provider_permissions do

--- a/spec/services/get_all_change_options_from_offered_option_spec.rb
+++ b/spec/services/get_all_change_options_from_offered_option_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe GetAllChangeOptionsFromOfferedOption do
+  include CourseOptionHelpers
+
+  let(:provider_user) { create(:provider_user, :with_two_providers) }
+  let(:available_providers) { provider_user.providers }
+  let(:course_option) { course_option_for_provider_code(provider_code: available_providers.first.code) }
+  let(:application_choice) { create(:application_choice, :with_offer, course_option: course_option) }
+
+  let(:service) {
+    GetAllChangeOptionsFromOfferedOption.new(
+      application_choice: application_choice,
+      available_providers: available_providers,
+    )
+  }
+
+  describe '#call' do
+    let(:returned_hash) { service.call }
+
+    it 'returns a hash of available providers, courses and course_options' do
+      expect(returned_hash.keys).to \
+        eq [:available_providers, :available_courses, :available_course_options]
+    end
+
+    it 'includes all providers associated with the user' do
+      create(:provider)
+      expect(returned_hash[:available_providers]).to eq(provider_user.providers)
+    end
+
+    it 'includes all courses offered by current option\'s provider (subject to status, study_mode and year)' do
+      provider = course_option.course.provider
+      true_alternative = create(:course, :open_on_apply, :full_time, provider: provider)
+      not_open = create(:course, provider: provider, open_on_apply: false)
+      wrong_year = create(:course, :open_on_apply, provider: provider, recruitment_cycle_year: 2019)
+      part_time_only = create(:course, :open_on_apply, :part_time, provider: provider)
+      both_study_modes = create(:course, :open_on_apply, :with_both_study_modes, provider: provider)
+
+      expect(returned_hash[:available_courses]).to include(course_option.course)
+      expect(returned_hash[:available_courses]).to include(true_alternative)
+      expect(returned_hash[:available_courses]).to include(both_study_modes)
+      expect(returned_hash[:available_courses]).not_to include(not_open)
+      expect(returned_hash[:available_courses]).not_to include(wrong_year)
+      expect(returned_hash[:available_courses]).not_to include(part_time_only)
+    end
+
+    it 'includes all course options for current course (subject to study_mode)' do
+      course = course_option.course
+      true_alternative = create(:course_option, course: course)
+      part_time = create(:course_option, :part_time, course: course)
+
+      expect(returned_hash[:available_course_options]).to include(course_option)
+      expect(returned_hash[:available_course_options]).to include(true_alternative)
+      expect(returned_hash[:available_course_options]).not_to include(part_time)
+    end
+  end
+end

--- a/spec/services/get_all_change_options_from_offered_option_spec.rb
+++ b/spec/services/get_all_change_options_from_offered_option_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe GetAllChangeOptionsFromOfferedOption do
 
     it 'returns a hash of available providers, courses and course_options' do
       expect(returned_hash.keys).to \
-        eq [:available_providers, :available_courses, :available_course_options]
+        eq %i(available_providers available_courses available_course_options)
     end
 
     it 'includes all providers associated with the user' do


### PR DESCRIPTION
### Context

The current 'change offer' flow works well but additional UI/UX tweaks have been planned to improve the user experience. This PR focuses on modifying existing offers: in a nutshell, it hides 'Change' links when no options exist for the current provider user and makes some text conditional based on the initial trigger of the 'change offer' flow.

The guiding principle behind these changes is "hide links not relevant to this user or available choices". For example, if a provider user is only associated with one provider, they shouldn't see the 'Change provider' link when editing an offer. Likewise, if a provider only offers one course or one location, there is no point prompting the user to change course or location for an existing offer. Finally, if a user is trying to change the course of an offer, there is no point showing them the change provider option at the end of the flow.

### Changes proposed in this pull request

1. This work introduces the notion of an entry point to the 'change offer' flow, capturing it and preserving it via a query param across the different parts of the multi-step process. This param, `entry`, is the basis for conditional text within the different steps.
2. The relevant component `provider_interface/status_box_components/offer_component.rb` is also modified to hide 'Change' links if no other valid options exist for the current provider user (e.g. if the user is only associated with one provider, no 'change provider' link is shown. Similar checks are performed for the the availability of courses and locations.
3. Headings at the various stages are now conditional on the `entry` point of the flow. 
4. The confirmation page at the end of the flow now contains conditional 'Change' links, based on what the entry point to the flow was. Support for these links has been added to `app/components/provider_interface/offer_summary_list_component.rb`

### Guidance to review

Refactorings:

- `components/provider_interface/offer_summary_list_component.rb` now accepts `options` so that it can be used to display Change links on the change offer confirmation page.
- `components/provider_interface/status_box_component.rb` also accepts `options` now, for the sub-components that need them. For offers, specifically, these are used to hide any Change links that are meaningless because no alternative options exist. The logic in this component is different to the logic in `OfferSummaryListComponent` because the status box component is the beginning of the process, while `OfferSummaryListComponent` with change links is used at the end.
- A new service `GetAllChangeOptionsFromOfferedOption` is introduced to obtain and feed the relevant data to the components above.

The views within `app/views/provider_interface/offer_changes/` are also used by another flow, that of changing the course details while making the initial offer. This should be unaffected by the current PR.

### Link to Trello card

[1789 - Update "offer" flows with new designs for consistency](https://trello.com/c/E144qHwK)

### Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
