### PR TITLE
Reorder the status options in providers app filter

### DIFF
--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -82,21 +82,6 @@ module ProviderInterface
         input_config: [
           {
             type: 'checkbox',
-            text: 'Accepted',
-            name: 'pending_conditions',
-          },
-          {
-            type: 'checkbox',
-            text: 'Conditions met',
-            name: 'recruited',
-          },
-          {
-            type: 'checkbox',
-            text: 'Declined',
-            name: 'declined',
-          },
-          {
-            type: 'checkbox',
             text: 'New',
             name: 'awaiting_provider_decision',
           },
@@ -112,6 +97,16 @@ module ProviderInterface
           },
           {
             type: 'checkbox',
+            text: 'Accepted',
+            name: 'pending_conditions',
+          },
+          {
+            type: 'checkbox',
+            text: 'Declined',
+            name: 'declined',
+          },
+          {
+            type: 'checkbox',
             text: 'Application withdrawn',
             name: 'withdrawn',
           },
@@ -119,6 +114,16 @@ module ProviderInterface
             type: 'checkbox',
             text: 'Withdrawn by us',
             name: 'offer_withdrawn',
+          },
+          {
+            type: 'checkbox',
+            text: 'Conditions met',
+            name: 'recruited',
+          },
+          {
+            type: 'checkbox',
+            text: 'Enrolled',
+            name: 'enrolled',
           },
         ],
       }

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -77,55 +77,62 @@ module ProviderInterface
     end
 
     def status_filters
+      status_options = [
+        {
+          type: 'checkbox',
+          text: 'New',
+          name: 'awaiting_provider_decision',
+        },
+        {
+          type: 'checkbox',
+          text: 'Offered',
+          name: 'offer',
+        },
+        {
+          type: 'checkbox',
+          text: 'Accepted',
+          name: 'pending_conditions',
+        },
+        {
+          type: 'checkbox',
+          text: 'Conditions met',
+          name: 'recruited',
+        },
+        {
+          type: 'checkbox',
+          text: 'Enrolled',
+          name: 'enrolled',
+        },
+        {
+          type: 'checkbox',
+          text: 'Rejected',
+          name: 'rejected',
+        },
+        {
+          type: 'checkbox',
+          text: 'Declined',
+          name: 'declined',
+        },
+        {
+          type: 'checkbox',
+          text: 'Application withdrawn',
+          name: 'withdrawn',
+        },
+        {
+          type: 'checkbox',
+          text: 'Conditions not met',
+          name: 'conditions_not_met',
+        },
+        {
+          type: 'checkbox',
+          text: 'Withdrawn by us',
+          name: 'offer_withdrawn',
+        },
+      ]
+
       {
         heading: 'status',
-        input_config: [
-          {
-            type: 'checkbox',
-            text: 'New',
-            name: 'awaiting_provider_decision',
-          },
-          {
-            type: 'checkbox',
-            text: 'Offered',
-            name: 'offer',
-          },
-          {
-            type: 'checkbox',
-            text: 'Rejected',
-            name: 'rejected',
-          },
-          {
-            type: 'checkbox',
-            text: 'Accepted',
-            name: 'pending_conditions',
-          },
-          {
-            type: 'checkbox',
-            text: 'Declined',
-            name: 'declined',
-          },
-          {
-            type: 'checkbox',
-            text: 'Application withdrawn',
-            name: 'withdrawn',
-          },
-          {
-            type: 'checkbox',
-            text: 'Withdrawn by us',
-            name: 'offer_withdrawn',
-          },
-          {
-            type: 'checkbox',
-            text: 'Conditions met',
-            name: 'recruited',
-          },
-          {
-            type: 'checkbox',
-            text: 'Enrolled',
-            name: 'enrolled',
-          },
-        ],
+        input_config: status_options,
       }
     end
 

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -28,13 +28,23 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
           },
           {
             type: 'checkbox',
-            text: 'Rejected',
-            name: 'rejected',
+            text: 'Accepted',
+            name: 'pending_conditions',
           },
           {
             type: 'checkbox',
-            text: 'Accepted',
-            name: 'pending_conditions',
+            text: 'Conditions met',
+            name: 'recruited',
+          },
+          {
+            type: 'checkbox',
+            text: 'Enrolled',
+            name: 'enrolled',
+          },
+          {
+            type: 'checkbox',
+            text: 'Rejected',
+            name: 'rejected',
           },
           {
             type: 'checkbox',
@@ -48,18 +58,13 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
           },
           {
             type: 'checkbox',
+            text: 'Conditions not met',
+            name: 'conditions_not_met',
+          },
+          {
+            type: 'checkbox',
             text: 'Withdrawn by us',
             name: 'offer_withdrawn',
-          },
-          {
-            type: 'checkbox',
-            text: 'Conditions met',
-            name: 'recruited',
-          },
-          {
-            type: 'checkbox',
-            text: 'Enrolled',
-            name: 'enrolled',
           },
         ],
       },

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -18,21 +18,6 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
         input_config: [
           {
             type: 'checkbox',
-            text: 'Accepted',
-            name: 'pending_conditions',
-          },
-          {
-            type: 'checkbox',
-            text: 'Conditions met',
-            name: 'recruited',
-          },
-          {
-            type: 'checkbox',
-            text: 'Declined',
-            name: 'declined',
-          },
-          {
-            type: 'checkbox',
             text: 'New',
             name: 'awaiting_provider_decision',
           },
@@ -48,6 +33,16 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
           },
           {
             type: 'checkbox',
+            text: 'Accepted',
+            name: 'pending_conditions',
+          },
+          {
+            type: 'checkbox',
+            text: 'Declined',
+            name: 'declined',
+          },
+          {
+            type: 'checkbox',
             text: 'Application withdrawn',
             name: 'withdrawn',
           },
@@ -55,6 +50,16 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
             type: 'checkbox',
             text: 'Withdrawn by us',
             name: 'offer_withdrawn',
+          },
+          {
+            type: 'checkbox',
+            text: 'Conditions met',
+            name: 'recruited',
+          },
+          {
+            type: 'checkbox',
+            text: 'Enrolled',
+            name: 'enrolled',
           },
         ],
       },


### PR DESCRIPTION
## Context

We want to display status filter options (a list of checkboxes) in application journey order rather than alphabetical.

## Changes proposed in this pull request

- [x] Update the order of hard-coded list of status filter values
- [x] Include `Enrolled` in the list

## Guidance to review

- The natural order of statuses is not really linear (it's a graph) so I've tried to do what seems logical. 

Before:

![image](https://user-images.githubusercontent.com/450843/78120131-59498080-7401-11ea-8a1c-77e735846fd2.png)


After:

![image](https://user-images.githubusercontent.com/450843/78149431-e86c8d80-742d-11ea-8f46-6425fe0d9f6c.png)


## Link to Trello card

https://trello.com/c/ZR0Rp3eS/1831-sort-status-filters-in-order-of-application-journey
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
