### PR TITLE
Don't call side-effecting code from inside transactions

### DIFF
--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -11,8 +11,9 @@ class InviteProviderUser
     ActiveRecord::Base.transaction do
       @provider_user.save!
       invite_user_to_dfe_sign_in
-      send_welcome_email
     end
+
+    send_welcome_email
   end
 
   def dfe_invite_url

--- a/app/services/receive_reference.rb
+++ b/app/services/receive_reference.rb
@@ -10,10 +10,11 @@ class ReceiveReference
   def save!
     ActiveRecord::Base.transaction do
       @reference.update!(feedback: @feedback, feedback_status: 'feedback_provided')
-      CandidateMailer.reference_received(@reference).deliver_later
-      RefereeMailer.reference_confirmation_email(application_form, reference).deliver_later
       progress_application_if_enough_references_have_been_submitted
     end
+
+    CandidateMailer.reference_received(@reference).deliver_later
+    RefereeMailer.reference_confirmation_email(application_form, reference).deliver_later
   end
 
 private

--- a/app/services/reject_application.rb
+++ b/app/services/reject_application.rb
@@ -21,8 +21,9 @@ class RejectApplication
         rejected_at: Time.zone.now,
       )
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
-      StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     end
+
+    StateChangeNotifier.call(:reject_application, application_choice: @application_choice)
     SendCandidateRejectionEmail.new(application_choice: @application_choice).call
   rescue Workflow::NoTransitionAllowed
     errors.add(

--- a/app/services/reject_application_by_default.rb
+++ b/app/services/reject_application_by_default.rb
@@ -10,9 +10,9 @@ class RejectApplicationByDefault
       application_choice.update(rejected_by_default: true, rejected_at: Time.zone.now)
       ApplicationStateChange.new(application_choice).reject_by_default!
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
-      StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice)
-
-      SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
     end
+
+    StateChangeNotifier.call(:reject_application_by_default, application_choice: application_choice)
+    SendRejectByDefaultEmailToProvider.new(application_choice: application_choice).call
   end
 end

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -13,8 +13,9 @@ class SendApplicationToProvider
       application_choice.update!(sent_to_provider_at: Time.zone.now)
       SetRejectByDefault.new(application_choice).call
       ApplicationStateChange.new(application_choice).send_to_provider!
-      StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice)
-      SendNewApplicationEmailToProvider.new(application_choice: application_choice).call
     end
+
+    StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice)
+    SendNewApplicationEmailToProvider.new(application_choice: application_choice).call
   end
 end

--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -8,10 +8,10 @@ class WithdrawApplication
       ApplicationStateChange.new(application_choice).withdraw!
       application_choice.update!(withdrawn_at: Time.zone.now)
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
-
-      StateChangeNotifier.call(:withdraw, application_choice: application_choice)
-      send_email_notification_to_provider_users(application_choice)
     end
+
+    StateChangeNotifier.call(:withdraw, application_choice: application_choice)
+    send_email_notification_to_provider_users(application_choice)
   end
 
 private


### PR DESCRIPTION
## Context

I was curious whether we sent an email to the accredited body's users when an application is sent to the provider (we don't) and noticed there was no spec for us notifying the provider.

While adding this spec, I then noticed the email was sent inside an `ActiveRecord::Transaction` block, which seems not to be a good idea for two reasons

1. the state of the object might not have been committed by the time the email is composed, which could result in the email having out of date data in it
2. emails will be sent twice in the event the transaction rolls back and is retried. This happens in a few places in our code, so this PR goes on to push emails and slack notifications out of `ActiveRecord::Transaction` blocks where they will only execute if the transaction completes successfully.

## Guidance to review

Do these changes make sense?

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
