### PR TITLE
Build the complexity page of the satisfaction survey

### DIFF
--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -10,8 +10,6 @@ module CandidateInterface
       if @survey.save(current_application)
         redirect_to candidate_interface_satisfaction_survey_complexity_path
       else
-        @survey = SatisfactionSurveyForm.new
-
         render :recommendation
       end
     end
@@ -38,7 +36,13 @@ module CandidateInterface
 
     def survey_params
       params.require(:candidate_interface_satisfaction_survey_form)
-        .permit(:question, :answer)
+        .permit(:answer).merge!(question: get_question_asked_from_params)
+    end
+
+    def get_question_asked_from_params
+      # removes 'submit_' from the controller action
+      page_title = params['action'].split('_').drop(1).join('_')
+      t("page_titles.#{page_title}")
     end
   end
 end

--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -24,13 +24,15 @@ module CandidateInterface
       @survey = SatisfactionSurveyForm.new(survey_params)
 
       if @survey.save(current_application)
-        redirect_to candidate_interface_satisfaction_survey_complexity_path
+        redirect_to candidate_interface_satisfaction_survey_ease_of_use_path
       else
         @survey = SatisfactionSurveyForm.new
 
         render :complexity
       end
     end
+
+    def ease_of_use; end
 
   private
 

--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -16,7 +16,21 @@ module CandidateInterface
       end
     end
 
-    def complexity; end
+    def complexity
+      @survey = SatisfactionSurveyForm.new
+    end
+
+    def submit_complexity
+      @survey = SatisfactionSurveyForm.new(survey_params)
+
+      if @survey.save(current_application)
+        redirect_to candidate_interface_satisfaction_survey_complexity_path
+      else
+        @survey = SatisfactionSurveyForm.new
+
+        render :complexity
+      end
+    end
 
   private
 

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -6,11 +6,11 @@ module CandidateInterface
 
     QUESTIONS_WE_ASK = [
       I18n.t('page_titles.recommendation'),
-      I18n.t('page_titles.complexity')
+      I18n.t('page_titles.complexity'),
     ].freeze
 
     validates :question, presence: true
-    validates :question, inclusion: { in: QUESTIONS_WE_ASK, allow_blank: false }
+    validates :question, inclusion: { in: QUESTIONS_WE_ASK, allow_blank: false, message: 'Choose one of the options' }
 
     def save(application_form)
       return false unless valid?

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -9,7 +9,24 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      application_form.update(satisfaction_survey: { @question => @answer })
+      if question_already_answered?(application_form)
+        application_form.satisfaction_survey[@question] = @answer
+        application_form.save
+      elsif application_form.satisfaction_survey.present?
+        application_form.update!(satisfaction_survey: merge_satisfaction_survey_and_answer(application_form))
+      else
+        application_form.update!(satisfaction_survey: { @question => @answer })
+      end
+    end
+
+  private
+
+    def question_already_answered?(application_form)
+      application_form.satisfaction_survey&.keys&.include?(@question)
+    end
+
+    def merge_satisfaction_survey_and_answer(application_form)
+      application_form.satisfaction_survey.merge!({ @question => @answer })
     end
   end
 end

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -4,7 +4,13 @@ module CandidateInterface
 
     attr_accessor :question, :answer
 
+    QUESTIONS_WE_ASK = [
+      'I would recommend this service to a friend or colleague',
+      'I found this service unnecessarily complex',
+    ].freeze
+
     validates :question, presence: true
+    validates :question, inclusion: { in: QUESTIONS_WE_ASK, allow_blank: false }
 
     def save(application_form)
       return false unless valid?

--- a/app/models/candidate_interface/satisfaction_survey_form.rb
+++ b/app/models/candidate_interface/satisfaction_survey_form.rb
@@ -5,8 +5,8 @@ module CandidateInterface
     attr_accessor :question, :answer
 
     QUESTIONS_WE_ASK = [
-      'I would recommend this service to a friend or colleague',
-      'I found this service unnecessarily complex',
+      I18n.t('page_titles.recommendation'),
+      I18n.t('page_titles.complexity')
     ].freeze
 
     validates :question, presence: true
@@ -15,14 +15,9 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      if question_already_answered?(application_form)
-        application_form.satisfaction_survey[@question] = @answer
-        application_form.save
-      elsif application_form.satisfaction_survey.present?
-        application_form.update!(satisfaction_survey: merge_satisfaction_survey_and_answer(application_form))
-      else
-        application_form.update!(satisfaction_survey: { @question => @answer })
-      end
+      application_form.satisfaction_survey ||= {}
+      application_form.satisfaction_survey[@question] = @answer
+      application_form.save
     end
 
   private

--- a/app/views/candidate_interface/satisfaction_survey/_form.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/_form.html.erb
@@ -1,5 +1,3 @@
-<%= f.hidden_field :question, value: t('page_titles.recommendation') %>
-
 <%= f.govuk_radio_buttons_fieldset :ratings do %>
   <%= f.govuk_radio_button :answer, '1', label: { text: '1 - strongly agree' }  %>
   <%= f.govuk_radio_button :answer, '2', label: { text: '2' }  %>

--- a/app/views/candidate_interface/satisfaction_survey/_form.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/_form.html.erb
@@ -1,0 +1,11 @@
+<%= f.hidden_field :question, value: t('page_titles.recommendation') %>
+
+<%= f.govuk_radio_buttons_fieldset :ratings do %>
+  <%= f.govuk_radio_button :answer, '1', label: { text: '1 - strongly agree' }  %>
+  <%= f.govuk_radio_button :answer, '2', label: { text: '2' }  %>
+  <%= f.govuk_radio_button :answer, '3', label: { text: '3' }  %>
+  <%= f.govuk_radio_button :answer, '4', label: { text: '4' }  %>
+  <%= f.govuk_radio_button :answer, '5', label: { text: '5 - strongly disagree' }  %>
+<% end %>
+
+<%= f.govuk_submit 'Continue' %>

--- a/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
@@ -1,1 +1,16 @@
-I found this service unnecessarily complex
+<% content_for :title, t('page_titles.complexity') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_recommendation_path) %>
+
+<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_complexity_path, method: :post do |f| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-xl">
+        <%= t('page_titles.complexity') %>
+      </h2>
+
+      <%= render 'form', f: f %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
@@ -10,6 +10,8 @@
         <%= t('page_titles.complexity') %>
       </h2>
 
+      <%= f.hidden_field :question, value: t('page_titles.complexity') %>
+
       <%= render 'form', f: f %>
     </div>
   </div>

--- a/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, t('page_titles.complexity') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.complexity'), @survey.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_recommendation_path) %>
 
 <%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_complexity_path, method: :post do |f| %>
+  <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -9,8 +10,6 @@
       <h2 class="govuk-heading-xl">
         <%= t('page_titles.complexity') %>
       </h2>
-
-      <%= f.hidden_field :question, value: t('page_titles.complexity') %>
 
       <%= render 'form', f: f %>
     </div>

--- a/app/views/candidate_interface/satisfaction_survey/ease_of_use.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/ease_of_use.html.erb
@@ -1,0 +1,1 @@
+I thought this service was easy to use

--- a/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
@@ -1,7 +1,8 @@
-<% content_for :title, t('page_titles.recommendation') %>
+<% content_for :title, title_with_error_prefix(t('page_titles.recommendation'), @survey.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
 <%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_recommendation_path, method: :post do |f| %>
+  <%= f.govuk_error_summary %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -9,8 +10,6 @@
       <h2 class="govuk-heading-xl">
         <%= t('page_titles.recommendation') %>
       </h2>
-
-      <%= f.hidden_field :question, value: t('page_titles.recommendation') %>
 
       <%= render 'form', f: f %>
     </div>

--- a/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
@@ -10,17 +10,7 @@
         <%= t('page_titles.recommendation') %>
       </h2>
 
-      <%= f.hidden_field :question, value: t('page_titles.recommendation') %>
-
-      <%= f.govuk_radio_buttons_fieldset :ratings do %>
-        <%= f.govuk_radio_button :answer, '1', label: { text: '1 - strongly agree' }  %>
-        <%= f.govuk_radio_button :answer, '2', label: { text: '2' }  %>
-        <%= f.govuk_radio_button :answer, '3', label: { text: '3' }  %>
-        <%= f.govuk_radio_button :answer, '4', label: { text: '4' }  %>
-        <%= f.govuk_radio_button :answer, '5', label: { text: '5 - strongly disagree' }  %>
-      <% end %>
-
-      <%= f.govuk_submit 'Continue' %>
+      <%= render 'form', f: f %>
     </div>
   </div>
 <% end %>

--- a/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
@@ -10,6 +10,8 @@
         <%= t('page_titles.recommendation') %>
       </h2>
 
+      <%= f.hidden_field :question, value: t('page_titles.recommendation') %>
+
       <%= render 'form', f: f %>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
     suitability_to_work_with_children: Declaring any safeguarding issues
     recommendation: I would recommend this service to a friend or colleague
     complexity: I found this service unnecessarily complex
+    ease_of_use: I thought this service was easy to use
     volunteering:
       short: Unpaid experience and volunteering
       long: "Unpaid experience working with children and other volunteering"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -307,6 +307,7 @@ Rails.application.routes.draw do
         post '/recommendation' => 'satisfaction_survey#submit_recommendation', as: :satisfaction_survey_submit_recommendation
 
         get '/complexity' => 'satisfaction_survey#complexity', as: :satisfaction_survey_complexity
+        post '/complexity' => 'satisfaction_survey#submit_complexity', as: :satisfaction_survey_submit_complexity
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,8 @@ Rails.application.routes.draw do
 
         get '/complexity' => 'satisfaction_survey#complexity', as: :satisfaction_survey_complexity
         post '/complexity' => 'satisfaction_survey#submit_complexity', as: :satisfaction_survey_submit_complexity
+
+        get '/ease-of-use' => 'satisfaction_survey#ease_of_use', as: :satisfaction_survey_ease_of_use
       end
     end
   end

--- a/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
+++ b/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
     context 'when question is not in the QUESTIONS_ASKED constant' do
       it 'is not valid' do
         application_form = create(:application_form)
-        expect(described_class.new(question: 'This is an invalid question', response: '2').save(application_form)).to be_falsey
+        expect(described_class.new(question: 'This is an invalid question', answer: '2').save(application_form)).to be_falsey
       end
     end
   end
@@ -23,21 +23,21 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
     end
 
     context 'when the the satisfcation_survey is nil' do
-      it 'updates the satisfaction_survey on the application_form with their response' do
+      it 'updates the satisfaction_survey on the application_form with their answer' do
         application_form = create(:application_form)
-        described_class.new(question: 'I would recommend this service to a friend or colleague', response: '2').save(application_form)
+        described_class.new(question: 'I would recommend this service to a friend or colleague', answer: '2').save(application_form)
 
         expect(application_form.satisfaction_survey).to eq({ 'I would recommend this service to a friend or colleague' => '2' })
       end
     end
 
     context 'when the the satisfcation_survey is present and the question exists as a key' do
-      it 'updates their response' do
+      it 'updates their answer' do
         application_form = create(:application_form, satisfaction_survey: {
           'I would recommend this service to a friend or colleague' => '2',
           'I found this service unnecessarily complex' => '4',
           })
-        described_class.new(question: 'I would recommend this service to a friend or colleague', response: '3').save(application_form)
+        described_class.new(question: 'I would recommend this service to a friend or colleague', answer: '3').save(application_form)
 
         expect(application_form.satisfaction_survey).to eq(
           {
@@ -49,9 +49,9 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
     end
 
     context 'when the the satisfcation_survey is present and the question does not exist as a key' do
-      it 'adds their response to the satisfaction survey' do
+      it 'adds their answer to the satisfaction survey' do
         application_form = create(:application_form, satisfaction_survey: { 'I would recommend this service to a friend or colleague' => '2' })
-        described_class.new(question: 'I found this service unnecessarily complex', response: '3').save(application_form)
+        described_class.new(question: 'I found this service unnecessarily complex', answer: '3').save(application_form)
 
         expect(application_form.satisfaction_survey).to eq(
           {

--- a/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
+++ b/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
@@ -14,12 +14,59 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
       end
     end
 
+<<<<<<< HEAD
     context 'when valid' do
       it 'updates the satisfaction_survey on the application_form with their answer' do
         application_form = create(:application_form)
         described_class.new(question: 'How was your experience', answer: '2').save(application_form)
+=======
+    context 'when the satisfcation_survey is nil and the user responds with strongly agree or strongly disagree' do
+      it 'only saves the number in the string and updates the satisfaction_survey on the application_form' do
+        application_form = create(:application_form)
+        described_class.new(question: 'How was your experience', response: '1 - strongly agree').save(application_form)
+
+        expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '1' })
+      end
+    end
+
+    context 'when the the satisfcation_survey is nil and user responds with any other response' do
+      it 'updates the satisfaction_survey on the application_form with their response' do
+        application_form = create(:application_form)
+        described_class.new(question: 'How was your experience', response: '2').save(application_form)
+>>>>>>> Adds logic for adding new values to the survey and editing previous responses
 
         expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '2' })
+      end
+    end
+
+    context 'when the the satisfcation_survey is present and the question exists as a key' do
+      it 'updates their response' do
+        application_form = create(:application_form, satisfaction_survey: {
+          'How was your experience' => '2',
+          'I found this service unnecessarily complex' => '4',
+          })
+        described_class.new(question: 'How was your experience', response: '3').save(application_form)
+
+        expect(application_form.satisfaction_survey).to eq(
+          {
+            'How was your experience' => '3',
+            'I found this service unnecessarily complex' => '4',
+          },
+        )
+      end
+    end
+
+    context 'when the the satisfcation_survey is present and the question does not exist as a key' do
+      it 'adds their response to the satisfaction survey' do
+        application_form = create(:application_form, satisfaction_survey: { 'How was your experience' => '2' })
+        described_class.new(question: 'I found this service unnecessarily complex', response: '3').save(application_form)
+
+        expect(application_form.satisfaction_survey).to eq(
+          {
+            'How was your experience' => '2',
+            'I found this service unnecessarily complex' => '3',
+          },
+        )
       end
     end
   end

--- a/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
+++ b/spec/models/candidate_interface/satisfaction_survey_form_spec.rb
@@ -1,8 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
-  it { is_expected.to validate_presence_of(:question) }
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:question) }
 
+    context 'when question is not in the QUESTIONS_ASKED constant' do
+      it 'is not valid' do
+        application_form = create(:application_form)
+        expect(described_class.new(question: 'This is an invalid question', response: '2').save(application_form)).to be_falsey
+      end
+    end
+  end
 
   describe '#save' do
     context 'when not valid' do
@@ -14,42 +22,26 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
       end
     end
 
-<<<<<<< HEAD
-    context 'when valid' do
-      it 'updates the satisfaction_survey on the application_form with their answer' do
-        application_form = create(:application_form)
-        described_class.new(question: 'How was your experience', answer: '2').save(application_form)
-=======
-    context 'when the satisfcation_survey is nil and the user responds with strongly agree or strongly disagree' do
-      it 'only saves the number in the string and updates the satisfaction_survey on the application_form' do
-        application_form = create(:application_form)
-        described_class.new(question: 'How was your experience', response: '1 - strongly agree').save(application_form)
-
-        expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '1' })
-      end
-    end
-
-    context 'when the the satisfcation_survey is nil and user responds with any other response' do
+    context 'when the the satisfcation_survey is nil' do
       it 'updates the satisfaction_survey on the application_form with their response' do
         application_form = create(:application_form)
-        described_class.new(question: 'How was your experience', response: '2').save(application_form)
->>>>>>> Adds logic for adding new values to the survey and editing previous responses
+        described_class.new(question: 'I would recommend this service to a friend or colleague', response: '2').save(application_form)
 
-        expect(application_form.satisfaction_survey).to eq({ 'How was your experience' => '2' })
+        expect(application_form.satisfaction_survey).to eq({ 'I would recommend this service to a friend or colleague' => '2' })
       end
     end
 
     context 'when the the satisfcation_survey is present and the question exists as a key' do
       it 'updates their response' do
         application_form = create(:application_form, satisfaction_survey: {
-          'How was your experience' => '2',
+          'I would recommend this service to a friend or colleague' => '2',
           'I found this service unnecessarily complex' => '4',
           })
-        described_class.new(question: 'How was your experience', response: '3').save(application_form)
+        described_class.new(question: 'I would recommend this service to a friend or colleague', response: '3').save(application_form)
 
         expect(application_form.satisfaction_survey).to eq(
           {
-            'How was your experience' => '3',
+            'I would recommend this service to a friend or colleague' => '3',
             'I found this service unnecessarily complex' => '4',
           },
         )
@@ -58,12 +50,12 @@ RSpec.describe CandidateInterface::SatisfactionSurveyForm, type: :model do
 
     context 'when the the satisfcation_survey is present and the question does not exist as a key' do
       it 'adds their response to the satisfaction survey' do
-        application_form = create(:application_form, satisfaction_survey: { 'How was your experience' => '2' })
+        application_form = create(:application_form, satisfaction_survey: { 'I would recommend this service to a friend or colleague' => '2' })
         described_class.new(question: 'I found this service unnecessarily complex', response: '3').save(application_form)
 
         expect(application_form.satisfaction_survey).to eq(
           {
-            'How was your experience' => '2',
+            'I would recommend this service to a friend or colleague' => '2',
             'I found this service unnecessarily complex' => '3',
           },
         )

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe 'Candidate satisfaction survey' do
     when_i_choose_1
     and_click_continue
     then_i_see_the_complexity_page
+
+    when_i_choose_5
+    and_click_continue
+    then_i_see_the_ease_of_use_page
   end
 
   def given_the_satisfaction_survey_flag_is_active
@@ -53,5 +57,13 @@ RSpec.describe 'Candidate satisfaction survey' do
 
   def then_i_see_the_complexity_page
     expect(page).to have_content(t('page_titles.complexity'))
+  end
+
+  def when_i_choose_5
+    choose '5 - strongly disagree'
+  end
+
+  def then_i_see_the_ease_of_use_page
+    expect(page).to have_content(t('page_titles.ease_of_use'))
   end
 end


### PR DESCRIPTION
## Context

**Do not merge until 1806 is merged**

This is the next page in the satisfaction survey flow.

## Changes proposed in this pull request

- Add the complexity page
- Update the SatisfactionSurvey to add/amend additional rows to the hash for the user's response 
- Adds a validation to check that the value of the question parameter is a question that we ask them.

![image](https://user-images.githubusercontent.com/42515961/78137215-d6ceba00-741c-11ea-8116-2c0d7a21e60e.png)


## Guidance to review

In the SatisfactionSurvey model, I've added in logic for if a user clicks back and edits their previous response.

## Link to Trello card

https://trello.com/c/tO5B8iK1/1257-dev-survey-to-candidates-when-they-have-submitted-an-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
