### PR TITLE
Change wording of "conditions not met" in the timeline

### DIFF
--- a/app/components/provider_interface/application_timeline_component.rb
+++ b/app/components/provider_interface/application_timeline_component.rb
@@ -18,7 +18,7 @@ module ProviderInterface
       'declined' => 'Offer declined',
       'recruited' => 'Recruited',
       'enrolled' => 'Enrolled',
-      'conditions_not_met' => 'Conditions not met',
+      'conditions_not_met' => 'Conditions marked not met',
     }.freeze
 
     def render?


### PR DESCRIPTION
It's a bit confusing to see "Conditions not met by Emma", where Emma is the provider user, not the candidate. Change it to "Conditions marked not met".
