### PR TITLE
Add selectable scope to CourseOption model

### DIFF
--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -7,7 +7,7 @@ module CandidateInterface
     validate :candidate_can_only_apply_to_3_courses, on: :save
 
     def available_sites
-      relation = CourseOption.includes(:site).where(course_id: course.id)
+      relation = CourseOption.selectable.includes(:site).where(course_id: course.id)
       relation = relation.where(study_mode: study_mode)
       relation.sort_by { |course_option| course_option.site.name }
     end

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -9,6 +9,8 @@ class CourseOption < ApplicationRecord
   validates :vacancy_status, presence: true
   validate :validate_providers
 
+  scope :selectable, -> { where(invalidated_by_find: false) }
+
   enum study_mode: {
     full_time: 'full_time',
     part_time: 'part_time',

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -19,4 +19,13 @@ RSpec.describe CourseOption, type: :model do
       end
     end
   end
+
+  describe '.selectable' do
+    it 'returns only course options where invalidated_by_find is false' do
+      expected_course_option = create(:course_option, invalidated_by_find: false)
+      create(:course_option, invalidated_by_find: true)
+
+      expect(CourseOption.selectable).to match_array [expected_course_option]
+    end
+  end
 end


### PR DESCRIPTION

## Context

When we sync with Find, occasionally some course options may be get
marked as invalidated_by_find if the site they represent is no longer a
valid choice for that course.

In the majority of cases, these course options will be deleted. A
minority, however, may have been chosen by a candidate at some point and
are therefore associated with their application. We don't delete those,
and instead follow a manual process to fix them.

In order to prevent any other candidates selecting these invalidated
options, introduce a scope to the CourseOption model that filters them
out. Use this scope in the site selection form.

## Changes proposed in this pull request
n/a

## Guidance to review
n/a

## Link to Trello card
n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
