### PR TITLE
Simplify input arguments to the filter components

### DIFF
--- a/app/components/previews/provider_interface/filter_component_preview.rb
+++ b/app/components/previews/provider_interface/filter_component_preview.rb
@@ -1,31 +1,27 @@
 module ProviderInterface
   class FilterComponentPreview < ActionView::Component::Preview
     def fully_selected
-      render_component_for(path: :provider_interface_applications_path,
-                           available_filters: available_filters,
+      render_component_for(available_filters: available_filters,
                            applied_filters: applied_filters_full,
                            params_for_current_state: params_for_current_state)
     end
 
     def partially_selected
-      render_component_for(path: :provider_interface_applications_path,
-                           available_filters: available_filters,
+      render_component_for(available_filters: available_filters,
                            applied_filters: applied_filters_partial,
                            params_for_current_state: params_for_current_state)
     end
 
     def empty
-      render_component_for(path: :provider_interface_applications_path,
-                           available_filters: available_filters,
+      render_component_for(available_filters: available_filters,
                            applied_filters: {},
                            params_for_current_state: params_for_current_state)
     end
 
   private
 
-    def render_component_for(path:, available_filters:, applied_filters:, params_for_current_state:)
-      render ProviderInterface::FilterComponent.new(path: path,
-                                                    available_filters: available_filters,
+    def render_component_for(available_filters:, applied_filters:, params_for_current_state:)
+      render ProviderInterface::FilterComponent.new(available_filters: available_filters,
                                                     applied_filters: applied_filters,
                                                     params_for_current_state: params_for_current_state)
     end

--- a/app/components/provider_interface/current_filters_component.html.erb
+++ b/app/components/provider_interface/current_filters_component.html.erb
@@ -1,17 +1,15 @@
 <div class="moj-filter__selected">
 
   <div class="moj-filter__selected-heading">
-
     <div class="moj-filter__heading-title">
       <h2 class="govuk-heading-m">Selected filters</h2>
     </div>
 
     <div class="moj-filter__heading-action">
     <p class="govuk-body">
-       <%= link_to "Clear", filtering_page_path(params_for_current_state.except(:filter_selections)), class: "govuk-link govuk-link--no-visited-state" %>
+       <%= link_to "Clear", '?' + params_for_current_state.except(:filter_selections).to_query, class: "govuk-link govuk-link--no-visited-state" %>
     </p>
     </div>
-
   </div>
 
   <% applied_filters.each do |applied_filters_key, input_config_values| %>
@@ -24,10 +22,14 @@
     <% input_config_values.each do |input_config_name, _| %>
         <li>
           <%= link_to retrieve_tag_text(applied_filters_key, input_config_name),
-                                        filtering_page_path(params_for_current_state.merge({filter_selections: build_tag_url_query_params(
-                                                                                heading: applied_filters_key,
-                                                                                tag_value: input_config_name)})),
-                                        class: "moj-filter__tag", id: "tag-#{input_config_name}" %>
+              '?' +
+                params_for_current_state.merge(
+                  filter_selections: build_tag_url_query_params(
+                    heading: applied_filters_key,
+                    tag_value: input_config_name,
+                  )
+                ).to_query,
+              class: "moj-filter__tag", id: "tag-#{input_config_name}" %>
         </li>
       <% end %>
     </ul>

--- a/app/components/provider_interface/current_filters_component.rb
+++ b/app/components/provider_interface/current_filters_component.rb
@@ -2,13 +2,12 @@ module ProviderInterface
   class CurrentFiltersComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :applied_filters, :params_for_current_state, :path
+    attr_reader :applied_filters, :params_for_current_state
 
-    def initialize(path:, available_filters:, applied_filters:, params_for_current_state:)
+    def initialize(available_filters:, applied_filters:, params_for_current_state:)
       @params_for_current_state = params_for_current_state
       @applied_filters = applied_filters
       @available_filters = available_filters
-      @path = path
     end
 
     def build_tag_url_query_params(heading:, tag_value:)
@@ -29,10 +28,6 @@ module ProviderInterface
           end
         end
       end
-    end
-
-    def filtering_page_path(*args)
-      send(@path, *args)
     end
   end
 end

--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -10,20 +10,19 @@
 
       <div class="moj-filter__content">
       <% if applied_filters.any? %>
-             <%= render ProviderInterface::CurrentFiltersComponent.new(path: path,
-                                                                       available_filters: available_filters,
-                                                                       applied_filters: applied_filters,
-                                                                       params_for_current_state: params_for_current_state) %>
+        <%= render ProviderInterface::CurrentFiltersComponent.new(
+          available_filters: available_filters,
+          applied_filters: applied_filters,
+          params_for_current_state: params_for_current_state,
+        ) %>
      <% end %>
 
-
         <div class="moj-filter__options">
-          <form method="get" action=<%= filtering_page_path %>>
+          <form method="get">
             <%= submit_tag "Apply filters", class: "govuk-button" %>
             <% params_for_current_state.except(:filter_selections).each do |key, value| %>
               <input class="govuk-checkboxes__input" id=<%= key %> name=<%= key %> type="hidden" value=<%= value %> %>
             <% end %>
-
 
             <% available_filters.each do |filter_group| %>
                 <div class="govuk-form-group">

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -2,10 +2,9 @@ module ProviderInterface
   class FilterComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :params_for_current_state, :available_filters, :applied_filters, :path
+    attr_reader :params_for_current_state, :available_filters, :applied_filters
 
-    def initialize(path:, available_filters:, applied_filters:, params_for_current_state:)
-      @path = path
+    def initialize(available_filters:, applied_filters:, params_for_current_state:)
       @available_filters = available_filters
       @applied_filters = applied_filters
       @params_for_current_state = params_for_current_state
@@ -13,10 +12,6 @@ module ProviderInterface
 
     def checkbox_checked?(heading:, name:)
       applied_filters.dig(heading, name) ? true : false
-    end
-
-    def filtering_page_path(*args)
-      send(@path, *args)
     end
 
     def is_candidates_name_search_field?(filter_group)

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -23,10 +23,11 @@
 <% if FeatureFlag.active?('provider_application_filters') %>
   <div class='moj-filter-layout'>
     <% if @page_state.filter_visible.eql?('true') %>
-      <%= render ProviderInterface::FilterComponent.new(path: :provider_interface_applications_path,
-                                                        available_filters: @page_state.available_filters,
-                                                        applied_filters: @page_state.filter_selections,
-                                                        params_for_current_state: @page_state.to_h) %>
+      <%= render ProviderInterface::FilterComponent.new(
+        available_filters: @page_state.available_filters,
+        applied_filters: @page_state.filter_selections,
+        params_for_current_state: @page_state.to_h,
+      ) %>
     <% end %>
 
     <div class='moj-filter-layout__content'>
@@ -61,4 +62,3 @@
   <% end %>
 
 <% end %>
-

--- a/spec/components/provider_interface/current_filters_component_spec.rb
+++ b/spec/components/provider_interface/current_filters_component_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ProviderInterface::CurrentFiltersComponent do
-  let(:path) { :provider_interface_applications_path }
-
+RSpec.describe ProviderInterface::CurrentFiltersComponent, type: :view do
   let(:applied_filters_partial) do
     {
       'status' => {
@@ -115,39 +113,43 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
   end
 
   it 'includes tags that match what has been selected for' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.css('.moj-filter-tags').text).to include('Accepted', 'New', 'Rejected', 'Application withdrawn', 'The Beach Teaching School')
     expect(result.css('.moj-filter-tags').text).not_to include('Declined', 'Conditions met', 'Somerset SCITT consortium')
   end
 
   it 'has a clear button when filters have been selected' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.text).to include('Clear')
   end
 
   it 'can return a full text of a applied_filters value from the available_filters' do
-    filter_component = described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    filter_component = described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(filter_component.retrieve_tag_text('status', 'offer_withdrawn')).to eq('Withdrawn by us')
     expect(filter_component.retrieve_tag_text('provider', '2')).to eq('The Beach Teaching School')
   end
 
   it 'can create hash for a tag url that doesn\'t include that tag\'s params' do
-    filter_component = described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    filter_component = described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
     hash = filter_component.build_tag_url_query_params(heading: 'status',
                                                tag_value: 'withdrawn')
@@ -156,10 +158,11 @@ RSpec.describe ProviderInterface::CurrentFiltersComponent do
   end
 
   it 'can create a tag url that doesn\'t include that tag\'s values' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.css('#tag-rejected').attr('href').value).not_to include('rejected')
     expect(result.css('#tag-rejected').attr('href').value).to include('2')

--- a/spec/components/provider_interface/filter_component_spec.rb
+++ b/spec/components/provider_interface/filter_component_spec.rb
@@ -135,10 +135,11 @@ RSpec.describe ProviderInterface::FilterComponent do
   end
 
   it 'marks checkboxes as checked if they have already been pre-selected' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
 
     expect(result.css('#status-accepted').attr('checked').value).to eq('checked')
@@ -152,10 +153,11 @@ RSpec.describe ProviderInterface::FilterComponent do
   end
 
   it 'on initial load all of the checkboxes are unchecked' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: {},
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: {},
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.css('#status-accepted').attr('checked')).to eq(nil)
     expect(result.css('#status-recruited').attr('checked')).to eq(nil)
@@ -168,29 +170,32 @@ RSpec.describe ProviderInterface::FilterComponent do
   end
 
   it 'when filters have been selected filters dialogue to appear' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.text).to include('Selected filters')
   end
 
   it 'selected filters dialogue should not appear if is nothing filtered for' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: {},
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: {},
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.text).not_to include('Selected filters')
   end
 
 
   it 'returns the params_for_current_state as hidden fields' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters,
-                                        applied_filters: applied_filters_partial,
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters,
+      applied_filters: applied_filters_partial,
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.css('#sort_by').attr('value').value).to eq('desc')
     expect(result.css('#sort_order').attr('value').value).to eq('last-updated')
@@ -199,10 +204,11 @@ RSpec.describe ProviderInterface::FilterComponent do
   end
 
   it 'does not render a filter if there is only one possible filter in a filter_group' do
-    result = render_inline described_class.new(path: path,
-                                        available_filters: available_filters_only_one_provider,
-                                        applied_filters: {},
-                                        params_for_current_state: params_for_current_state)
+    result = render_inline described_class.new(
+      available_filters: available_filters_only_one_provider,
+      applied_filters: {},
+      params_for_current_state: params_for_current_state,
+    )
 
     expect(result.to_html).not_to include('Provider')
     expect(result.to_html).to include('Status')


### PR DESCRIPTION
## Context

I'm looking to reuse the provider applications filter component in the support interface. Doing some tidy up to get familiar with the code.

## Changes proposed in this pull request

We don't need the `path` argument because we can construct all the URLs we want without it. This cleans up the code and makes it easier to reuse the code in other contexts like the support interface.

## Guidance to review

Nothing in particular.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
