### PR TITLE
Upgrade heroku review app databases

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,7 @@
       "size": "hobby"
     }
   },
-  "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
+  "addons": ["heroku-postgresql:hobby-basic", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {
       "url": "heroku/ruby"


### PR DESCRIPTION
## Context

We're close to hitting the 10k limit on the hobby-dev database on review apps, and while there are optimisations we can do to lower the number of rows, in the interim it's easier to bump to the $9 per month tier.

## Changes proposed in this pull request

Change the Heroku review apps to use hobby-basic databases.

## Guidance to review

This will probably not take effect for existing review apps; they'll keep sending us emails until everything is merged.

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)