### PR TITLE
Deduplicate state names in provider applications filter

### DIFF
--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -77,58 +77,24 @@ module ProviderInterface
     end
 
     def status_filters
-      status_options = [
+      status_options = %w[
+        awaiting_provider_decision
+        offer
+        pending_conditions
+        recruited
+        enrolled
+        rejected
+        declined
+        withdrawn
+        conditions_not_met
+        offer_withdrawn
+      ].map do |state_name|
         {
           type: 'checkbox',
-          text: 'New',
-          name: 'awaiting_provider_decision',
-        },
-        {
-          type: 'checkbox',
-          text: 'Offered',
-          name: 'offer',
-        },
-        {
-          type: 'checkbox',
-          text: 'Accepted',
-          name: 'pending_conditions',
-        },
-        {
-          type: 'checkbox',
-          text: 'Conditions met',
-          name: 'recruited',
-        },
-        {
-          type: 'checkbox',
-          text: 'Enrolled',
-          name: 'enrolled',
-        },
-        {
-          type: 'checkbox',
-          text: 'Rejected',
-          name: 'rejected',
-        },
-        {
-          type: 'checkbox',
-          text: 'Declined',
-          name: 'declined',
-        },
-        {
-          type: 'checkbox',
-          text: 'Application withdrawn',
-          name: 'withdrawn',
-        },
-        {
-          type: 'checkbox',
-          text: 'Conditions not met',
-          name: 'conditions_not_met',
-        },
-        {
-          type: 'checkbox',
-          text: 'Withdrawn by us',
-          name: 'offer_withdrawn',
-        },
-      ]
+          text: I18n.t!("provider_application_states.#{state_name}"),
+          name: state_name,
+        }
+      end
 
       {
         heading: 'status',


### PR DESCRIPTION
## Context

We currently duplicate the names of the states in the provider applications filter. 

## Changes proposed in this pull request

This makes it use the locale files so that if we change them, we only have to change them once.

## Guidance to review

Check that before & after are the same (or trust me).

## Link to Trello card

https://trello.com/c/ZR0Rp3eS/1831-sort-status-filters-in-order-of-application-journey

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
