### PR TITLE
Small change to font size for application-card component

### DIFF
--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -19,7 +19,7 @@
     width: 100%;
 
     dd, dt {
-      font-size: govuk-font(16);
+      @include govuk-font($size: 14);
       color: govuk-colour('dark-grey');
       display: inline;
     }
@@ -28,7 +28,7 @@
 
   &__provider {
     dd {
-      font-size: govuk-font(16);
+      @include govuk-font($size: 14);
     }
   }
 


### PR DESCRIPTION
## Context

Noticed that the font-size of some of the text in the application card didn't match the design. Turns out that we were calling `govuk-font` sass method incorrectly.

instead of
`font-size: govuk-font(16)` (note 16 was incorrect in any case).

you just need to include:
`@include govuk-font($size: 14)`

## Changes proposed in this pull request

**Design:**
<img width="636" alt="Screenshot 2020-04-02 at 16 13 59" src="https://user-images.githubusercontent.com/13377553/78265914-fb9a5e80-74fc-11ea-9b50-faa88f7a8c36.png">
- You can see that the course name is lager than the provider name, accredited body / date lines

**Currently:**
<img width="589" alt="Screenshot 2020-04-02 at 16 19 33" src="https://user-images.githubusercontent.com/13377553/78266493-c4787d00-74fd-11ea-9e4d-bb0a613d6605.png">
- all the same size.

**Proposed:**
<img width="590" alt="Screenshot 2020-04-02 at 16 18 47" src="https://user-images.githubusercontent.com/13377553/78266418-aa3e9f00-74fd-11ea-93a5-9aba4f1fcc79.png">


## Guidance to review

- load the provider applications page - does it look right to you?

## Link to Trello card

N/A

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
