### PR TITLE
Temporarily fix console tab-complete warnings

### DIFF
--- a/config/initializers/active_support_backports.rb
+++ b/config/initializers/active_support_backports.rb
@@ -1,0 +1,24 @@
+# Fix IRB deprecation warning on tab-completion.
+#
+# Backports the fix for https://github.com/rails/rails/issues/37097
+# from https://github.com/rails/rails/pull/37100
+#
+# Backports proposed fix for https://github.com/rails/rails/pull/37468
+# from https://github.com/rails/rails/pull/37468
+module ActiveSupportBackports
+  warn "[DEPRECATED] #{self} should no longer be needed. Please remove!" if Rails.version >= '6.1'
+
+  def self.prepended(base)
+    base.class_eval do
+      delegate :hash, :instance_methods, :respond_to?, to: :target
+    end
+  end
+end
+
+module ActiveSupport
+  class Deprecation
+    class DeprecatedConstantProxy
+      prepend ActiveSupportBackports
+    end
+  end
+end


### PR DESCRIPTION
## Context

Under our current runtime environment (Ruby 2.6.5/Rails 6.0.2.2),
the following deprecation warning is seen when tab-completing:

DEPRECATION WARNING: SourceAnnotationExtractor is deprecated! Use
Rails::SourceAnnotationExtractor instead. (called from require at
bin/rails:4)

This is fixed in Rails master and is expected to appear in release
6.0.3. As it's quite annoying and makes console output harder to read
(due to lack of whitespace between the warning and the current cursor
position), add a temporary patch. The patch will start warning us when
it's definitely no longer needed.

Code for the patch taken from this Rails issue:

https://github.com/rails/rails/issues/37775



<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
n/a
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
n/a
## Link to Trello card

<!-- http://trello.com/123-example-card -->
n/a
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
