### PR TITLE
Provider users with the appropriate permissions can invite other provider users

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -8,7 +8,7 @@
   </h3>
 
   <dl>
-    <div class="app-application-card__provider" >
+    <div class="app-application-card__primary" >
       <dt class="govuk-visually-hidden">Provider:</dt>
       <dd class="govuk-body"><%= course_provider_name %></dd>
     </div>

--- a/app/components/provider_interface/user_list_card_component.html.erb
+++ b/app/components/provider_interface/user_list_card_component.html.erb
@@ -1,0 +1,21 @@
+<div class="app-application-card">
+
+  <h3 class="govuk-heading-m">
+    <%= full_name %>
+  </h3>
+
+  <dl>
+    <div class="app-application-card__provider" >
+      <dt class="govuk-visually-hidden">Email Address:</dt>
+      <dd class="govuk-body"><%= email_address %></dd>
+    </div>
+
+    <div class="app-application-card__footer">
+      <div class="app-application-card__secondary">
+        <dd class="govuk-body">
+          <%= providers_text %>
+        </dd>
+      </div>
+    </div>
+  </dl>
+</div>

--- a/app/components/provider_interface/user_list_card_component.rb
+++ b/app/components/provider_interface/user_list_card_component.rb
@@ -2,18 +2,19 @@ module ProviderInterface
   class UserListCardComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_accessor :full_name, :email_address, :providers_text
-
+    attr_reader :provider_user, :full_name, :email_address
 
     def initialize(provider_user:)
+      @provider_user = provider_user
       @full_name = provider_user.full_name
       @email_address = provider_user.email_address
-      @providers_text = calculate_providers_text(provider_user.providers)
     end
 
-    def calculate_providers_text(providers)
-      return providers.first if providers.size == 1
-      return "#{providers.first.name} and #{TextCardinalizer.call(providers.size - 1)} more"
+    def providers_text
+      providers = provider_user.providers
+      return providers.first.name if providers.size == 1
+
+      "#{providers.first.name} and #{TextCardinalizer.call(providers.size - 1)} more"
     end
   end
 end

--- a/app/components/provider_interface/user_list_card_component.rb
+++ b/app/components/provider_interface/user_list_card_component.rb
@@ -1,0 +1,19 @@
+module ProviderInterface
+  class UserListCardComponent < ActionView::Component::Base
+    include ViewHelper
+
+    attr_accessor :full_name, :email_address, :providers_text
+
+
+    def initialize(provider_user:)
+      @full_name = provider_user.full_name
+      @email_address = provider_user.email_address
+      @providers_text = calculate_providers_text(provider_user.providers)
+    end
+
+    def calculate_providers_text(providers)
+      return providers.first if providers.size == 1
+      return "#{providers.first.name} and #{TextCardinalizer.call(providers.size - 1)} more"
+    end
+  end
+end

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -1,0 +1,38 @@
+module ProviderInterface
+  class ProviderUsersController < ProviderInterfaceController
+    def index
+      # TODO: A scope for this?
+      @provider_users = ProviderUser
+        .joins(:provider_users_providers)
+        .where('provider_users_providers.provider': current_provider_user.providers)
+    end
+
+    def new
+      @form = ProviderUserForm.new
+      @form.current_provider_user = current_provider_user
+    end
+
+    def create
+      @form = ProviderUserForm.new(provider_user_params)
+      provider_user = @form.build
+      render :new && return unless provider_user
+
+      service = InviteProviderUser.new(provider_user: provider_user)
+      begin
+        service.save_and_invite!
+        flash[:success] = 'Provider user created'
+        redirect_to provider_interface_provider_users_path
+      rescue DfeSignInApiError => e # show errors from api
+        e.errors.each { |error| @form.errors.add(:base, error) }
+        render :new
+      end
+    end
+
+  private
+
+    def provider_user_params
+      params.require(:provider_interface_provider_user_form)
+            .permit(:email_address, :first_name, :last_name, provider_ids: [])
+    end
+  end
+end

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ProviderUsersController < ProviderInterfaceController
+    before_action :requires_provider_add_provider_users_feature_flag, only: %i[new create]
+
     def index
       # TODO: A scope for this?
       @provider_users = ProviderUser
@@ -33,6 +35,10 @@ module ProviderInterface
     def provider_user_params
       params.require(:provider_interface_provider_user_form)
             .permit(:email_address, :first_name, :last_name, provider_ids: [])
+    end
+
+    def requires_provider_add_provider_users_feature_flag
+      raise unless FeatureFlag.active?('provider_add_provider_users')
     end
   end
 end

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -3,10 +3,7 @@ module ProviderInterface
     before_action :requires_provider_add_provider_users_feature_flag, only: %i[new create]
 
     def index
-      # TODO: A scope for this?
-      @provider_users = ProviderUser
-        .joins(:provider_users_providers)
-        .where('provider_users_providers.provider': current_provider_user.providers)
+      @provider_users = ProviderUser.visible_to(current_provider_user)
     end
 
     def new

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -19,7 +19,7 @@ module ProviderInterface
       service = InviteProviderUser.new(provider_user: provider_user)
       begin
         service.save_and_invite!
-        flash[:success] = 'Provider user created'
+        flash[:success] = 'Provider user invited'
         redirect_to provider_interface_provider_users_path
       rescue DfeSignInApiError => e # show errors from api
         e.errors.each { |error| @form.errors.add(:base, error) }

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -7,12 +7,13 @@ module ProviderInterface
     end
 
     def new
-      @form = ProviderUserForm.new
-      @form.current_provider_user = current_provider_user
+      @form = ProviderUserForm.new(current_provider_user: current_provider_user)
     end
 
     def create
-      @form = ProviderUserForm.new(provider_user_params)
+      @form = ProviderUserForm.new(
+        provider_user_params.merge(current_provider_user: current_provider_user),
+      )
       provider_user = @form.build
       render :new && return unless provider_user
 

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -7,6 +7,11 @@ module ProviderInterface
     end
 
     def new
+      unless current_provider_user.can_manage_users?
+        flash[:warning] = 'You need specific permissions to manage other providers.'
+        return redirect_to provider_interface_provider_users_path
+      end
+
       @form = ProviderUserForm.new(current_provider_user: current_provider_user)
     end
 

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -26,7 +26,7 @@
 
   }
 
-  &__provider {
+  &__primary {
     dd {
       @include govuk-font($size: 14);
     }

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -37,15 +37,34 @@ class NavigationItems
     end
 
     def for_provider_interface(current_provider_user)
-      if current_provider_user
-        [
-          NavigationItem.new(current_provider_user.email_address, nil, false),
-          NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
-        ]
+      if FeatureFlag.active?('provider_add_provider_users')
+        if current_provider_user && current_provider_user.provider_permissions.any?
+          [
+            NavigationItem.new(current_provider_user.email_address, nil, false),
+            NavigationItem.new('Users', provider_interface_provider_users_path, false),
+            NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
+          ]
+        elsif current_provider_user
+          [
+            NavigationItem.new(current_provider_user.email_address, nil, false),
+            NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
+          ]
+        else
+          [
+            NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
+          ]
+        end
       else
-        [
-          NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
-        ]
+        if current_provider_user
+          [
+            NavigationItem.new(current_provider_user.email_address, nil, false),
+            NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
+          ]
+        else
+          [
+            NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
+          ]
+        end
       end
     end
 
@@ -60,7 +79,7 @@ class NavigationItems
       ]
     end
 
-  private
+    private
 
     def is_active(current_controller, active_controllers)
       current_controller.controller_name.in?(Array.wrap(active_controllers))

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -37,33 +37,15 @@ class NavigationItems
     end
 
     def for_provider_interface(current_provider_user)
-      if FeatureFlag.active?('provider_add_provider_users')
-        if current_provider_user && current_provider_user.provider_permissions.any?
-          [
-            NavigationItem.new(current_provider_user.email_address, nil, false),
-            NavigationItem.new('Users', provider_interface_provider_users_path, false),
-            NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
-          ]
-        elsif current_provider_user
-          [
-            NavigationItem.new(current_provider_user.email_address, nil, false),
-            NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
-          ]
-        else
-          [
-            NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
-          ]
-        end
-      elsif current_provider_user
-        [
-          NavigationItem.new(current_provider_user.email_address, nil, false),
-          NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
-        ]
-      else
-        [
-          NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
-        ]
+      return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
+
+      items = [NavigationItem.new(current_provider_user.email_address, nil, false)]
+
+      if FeatureFlag.active?('provider_add_provider_users') && current_provider_user.can_manage_users?
+        items << NavigationItem.new('Users', provider_interface_provider_users_path, false)
       end
+
+      items << NavigationItem.new('Sign out', provider_interface_sign_out_path, false)
     end
 
     def for_api_docs(current_controller)

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -54,17 +54,15 @@ class NavigationItems
             NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
           ]
         end
+      elsif current_provider_user
+        [
+          NavigationItem.new(current_provider_user.email_address, nil, false),
+          NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
+        ]
       else
-        if current_provider_user
-          [
-            NavigationItem.new(current_provider_user.email_address, nil, false),
-            NavigationItem.new('Sign out', provider_interface_sign_out_path, false),
-          ]
-        else
-          [
-            NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
-          ]
-        end
+        [
+          NavigationItem.new('Sign in', provider_interface_sign_in_path, false),
+        ]
       end
     end
 
@@ -79,7 +77,7 @@ class NavigationItems
       ]
     end
 
-    private
+  private
 
     def is_active(current_controller, active_controllers)
       current_controller.controller_name.in?(Array.wrap(active_controllers))

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -26,6 +26,14 @@ class Provider < ApplicationRecord
 
   audited
 
+  scope :with_users_manageable_by, ->(provider_user) {
+    joins(provider_permissions: :provider_user)
+      .where(ProviderPermissions.table_name => {
+        provider_user_id: provider_user.id,
+        manage_users: true,
+      })
+  }
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -26,14 +26,6 @@ class Provider < ApplicationRecord
 
   audited
 
-  scope :with_users_manageable_by, ->(provider_user) {
-    joins(provider_permissions: :provider_user)
-      .where(ProviderPermissions.table_name => {
-        provider_user_id: provider_user.id,
-        manage_users: true,
-      })
-  }
-
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -12,7 +12,10 @@ module ProviderInterface
 
     def permitted_providers
       return unless provider_ids.any?
-      return if (provider_ids & available_providers.pluck(:id)) == provider_ids
+
+      provider_ids.delete('') # TODO: why does this have a blank value?
+
+      return if (provider_ids.map(&:to_i) & available_providers.pluck(:id).map(&:to_i)) == provider_ids.map(&:to_i)
 
       errors.add(:provider_ids, 'insufficient permissions to manage users for this provider')
     end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -2,10 +2,19 @@ module ProviderInterface
   class ProviderUserForm < SupportInterface::ProviderUserForm
     attr_accessor :current_provider_user
 
+    validate :permitted_providers
+
     def available_providers
       @available_providers ||= Provider
         .with_users_manageable_by(current_provider_user)
         .order(name: :asc)
+    end
+
+    def permitted_providers
+      return unless provider_ids.any?
+      return if (provider_ids & available_providers.pluck(:id)) == provider_ids
+
+      errors.add(:provider_ids, 'insufficient permissions to manage users for this provider')
     end
   end
 end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -49,13 +49,11 @@ module ProviderInterface
     def provider_ids
       return [] unless @provider_ids
 
-      @provider_ids.reject(&:blank?)
+      @provider_ids.reject(&:blank?).map(&:to_i)
     end
 
     def available_providers
-      @available_providers ||= Provider
-        .with_users_manageable_by(current_provider_user)
-        .order(name: :asc)
+      @available_providers ||= ProviderOptionsService.new(current_provider_user).providers_with_manageable_users
     end
 
   private
@@ -76,8 +74,7 @@ module ProviderInterface
     end
 
     def provider_ids_valid?
-      integer_provider_ids = provider_ids.map(&:to_i)
-      (integer_provider_ids & available_providers.pluck(:id)) == integer_provider_ids
+      (provider_ids & available_providers.pluck(:id)) == provider_ids
     end
   end
 end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -1,0 +1,12 @@
+module ProviderInterface
+  class ProviderUserForm < SupportInterface::ProviderUserForm
+    attr_accessor :current_provider_user
+
+    def available_providers
+      @available_providers ||= Provider.joins(provider_users_providers: :provider_user)
+        .where('provider_users_providers.provider_user': current_provider_user)
+        .where('provider_users_providers.manage_users': true)
+        .order(name: :asc)
+    end
+  end
+end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -3,9 +3,8 @@ module ProviderInterface
     attr_accessor :current_provider_user
 
     def available_providers
-      @available_providers ||= Provider.joins(provider_users_providers: :provider_user)
-        .where('provider_users_providers.provider_user': current_provider_user)
-        .where('provider_users_providers.manage_users': true)
+      @available_providers ||= Provider
+        .with_users_manageable_by(current_provider_user)
         .order(name: :asc)
     end
   end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -10,14 +10,18 @@ module ProviderInterface
         .order(name: :asc)
     end
 
+  private
+
     def permitted_providers
       return unless provider_ids.any?
-
-      provider_ids.delete('') # TODO: why does this have a blank value?
-
-      return if (provider_ids.map(&:to_i) & available_providers.pluck(:id).map(&:to_i)) == provider_ids.map(&:to_i)
+      return if provider_ids_valid?
 
       errors.add(:provider_ids, 'insufficient permissions to manage users for this provider')
+    end
+
+    def provider_ids_valid?
+      integer_provider_ids = provider_ids.map(&:to_i)
+      (integer_provider_ids & available_providers.pluck(:id)) == integer_provider_ids
     end
   end
 end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -1,8 +1,56 @@
 module ProviderInterface
-  class ProviderUserForm < SupportInterface::ProviderUserForm
-    attr_accessor :current_provider_user
+  class ProviderUserForm
+    include ActiveModel::Model
+    include ActiveModel::Validations
 
+    attr_accessor :first_name, :last_name, :provider_user, :current_provider_user
+    attr_writer :provider_ids
+    attr_reader :email_address
+
+    validates :email_address, :first_name, :last_name, presence: true
+    validates :email_address, email: true
+    validates :provider_ids, presence: true
+    validate :email_is_unique
     validate :permitted_providers
+
+    def build
+      return unless valid?
+
+      @provider_user ||= ProviderUser.new
+      @provider_user.first_name = first_name
+      @provider_user.last_name = last_name
+      @provider_user.email_address = email_address
+      @provider_user.provider_ids = provider_ids
+      @provider_user if @provider_user.valid?
+    end
+
+    def save
+      @provider_user.save! if build
+    end
+
+    def email_address=(raw_email_address)
+      @email_address = raw_email_address.downcase.strip
+    end
+
+    def persisted?
+      @provider_user && @provider_user.persisted?
+    end
+
+    def self.from_provider_user(provider_user)
+      new(
+        provider_user: provider_user,
+        first_name: provider_user.first_name,
+        last_name: provider_user.last_name,
+        email_address: provider_user.email_address,
+        provider_ids: provider_user.provider_ids,
+      )
+    end
+
+    def provider_ids
+      return [] unless @provider_ids
+
+      @provider_ids.reject(&:blank?)
+    end
 
     def available_providers
       @available_providers ||= Provider
@@ -12,11 +60,19 @@ module ProviderInterface
 
   private
 
+    def email_is_unique
+      return if persisted? && provider_user.email_address == email_address
+
+      return unless ProviderUser.exists?(email_address: email_address)
+
+      errors.add(:email_address, 'This email address is already in use')
+    end
+
     def permitted_providers
       return unless provider_ids.any?
       return if provider_ids_valid?
 
-      errors.add(:provider_ids, 'insufficient permissions to manage users for this provider')
+      errors.add(:provider_ids, 'Insufficient permissions to manage users for this provider')
     end
 
     def provider_ids_valid?

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -34,6 +34,10 @@ class ProviderUser < ActiveRecord::Base
     "#{first_name} #{last_name}" if first_name.present? && last_name.present?
   end
 
+  def can_manage_users?
+    provider_permissions.exists?(manage_users: true)
+  end
+
 private
 
   def downcase_email_address

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -9,6 +9,11 @@ class ProviderUser < ActiveRecord::Base
   audited except: [:last_signed_in_at]
   has_associated_audits
 
+  scope :visible_to, ->(provider_user) {
+    joins(:provider_permissions)
+      .where(ProviderPermissions.table_name => { provider_id: provider_user.providers.pluck(:id) })
+  }
+
   def self.load_from_session(session)
     dfe_sign_in_user = DfESignInUser.load_from_session(session)
     return unless dfe_sign_in_user

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -3,7 +3,8 @@ module SupportInterface
     include ActiveModel::Model
     include ActiveModel::Validations
 
-    attr_accessor :first_name, :last_name, :provider_ids, :provider_user
+    attr_accessor :first_name, :last_name, :provider_user
+    attr_writer :provider_ids
     attr_reader :email_address
 
     validates :email_address, :first_name, :last_name, presence: true
@@ -46,6 +47,12 @@ module SupportInterface
         email_address: provider_user.email_address,
         provider_ids: provider_user.provider_ids,
       )
+    end
+
+    def provider_ids
+      return [] unless @provider_ids
+
+      @provider_ids.reject(&:blank?)
     end
 
   private

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -28,6 +28,7 @@ class FeatureFlag
     edit_course_choices
     satisfaction_survey
     group_providers_by_region
+    provider_add_provider_users
   ].freeze
 
   def self.activate(feature_name)

--- a/app/services/provider_interface/provider_options_service.rb
+++ b/app/services/provider_interface/provider_options_service.rb
@@ -29,5 +29,15 @@ module ProviderInterface
         )
         .distinct
     end
+
+    def providers_with_manageable_users
+      Provider.
+        joins(provider_permissions: :provider_user)
+          .where(ProviderPermissions.table_name => {
+            provider_user_id: provider_user.id,
+            manage_users: true,
+          })
+        .order(name: :asc)
+    end
   end
 end

--- a/app/services/text_cardinalizer.rb
+++ b/app/services/text_cardinalizer.rb
@@ -1,0 +1,17 @@
+class TextCardinalizer
+  CARDINALIZE_MAPPING = %w[
+    zero one two three four five six seven eight nine ten
+  ].freeze
+
+  def self.call(value)
+    text_cardinalize(value)
+  end
+
+  class << self
+  private
+
+    def text_cardinalize(value)
+      CARDINALIZE_MAPPING[value] || value.to_s
+    end
+  end
+end

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -1,5 +1,7 @@
 <% content_for :title, 'Provider users' %>
 
+<h1 class="govuk-heading-xl">Users</h1>
+
 <% if FeatureFlag.active?('provider_add_provider_users') -%>
   <%= link_to 'Invite user', provider_interface_provider_users_new_path, class: 'govuk-button' %>
 <% end -%>
@@ -19,6 +21,6 @@
 
 <div class="govuk-body">
 <% @provider_users.each do |provider_user| %>
-  <p><%= provider_user.full_name || '---' %><br/><%= provider_user.email_address %><hr/></p>
+  <%= render ProviderInterface::UserListCardComponent.new(provider_user: provider_user) %>
 <% end %>
 </div>

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for :title, 'Provider users' %>
+
+<%= link_to 'Invite user', provider_interface_provider_users_new_path, class: 'govuk-button' %>
+
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', provider_interface_provider_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Provider users
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<div class="govuk-body">
+<% @provider_users.each do |provider_user| %>
+  <p><%= provider_user.full_name || '---' %><br/><%= provider_user.email_address %><hr/></p>
+<% end %>
+</div>

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -1,6 +1,8 @@
 <% content_for :title, 'Provider users' %>
 
-<%= link_to 'Invite user', provider_interface_provider_users_new_path, class: 'govuk-button' %>
+<% if FeatureFlag.active?('provider_add_provider_users') -%>
+  <%= link_to 'Invite user', provider_interface_provider_users_new_path, class: 'govuk-button' %>
+<% end -%>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Provider users' %>
+<% content_for :title, 'Users' %>
 
 <h1 class="govuk-heading-xl">Users</h1>
 

--- a/app/views/provider_interface/provider_users/new.html.erb
+++ b/app/views/provider_interface/provider_users/new.html.erb
@@ -1,0 +1,32 @@
+<% content_for :title, 'Provider users' %>
+
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', provider_interface_provider_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Invite user
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: provider_interface_provider_users_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h1 class='govuk-heading-xl'>Invite provider user</h1>
+
+      <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
+      <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
+
+      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
+
+      <%= f.govuk_submit 'Invite provider user' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users/new.html.erb
+++ b/app/views/provider_interface/provider_users/new.html.erb
@@ -24,7 +24,7 @@
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
       <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
 
-      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
+      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }  %>
 
       <%= f.govuk_submit 'Invite provider user' %>
     <% end %>

--- a/app/views/provider_interface/provider_users/new.html.erb
+++ b/app/views/provider_interface/provider_users/new.html.erb
@@ -20,8 +20,8 @@
 
       <h1 class='govuk-heading-xl'>Invite provider user</h1>
 
-      <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
-      <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
+      <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
+      <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
       <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>

--- a/app/views/provider_interface/provider_users/new.html.erb
+++ b/app/views/provider_interface/provider_users/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Provider users' %>
+<% content_for :title, 'Invite user' %>
 
 <% content_for :before_content do %>
   <div class="govuk-breadcrumbs">
@@ -18,7 +18,7 @@
     <%= form_with model: @form, url: provider_interface_provider_users_path do |f| %>
       <%= f.govuk_error_summary %>
 
-      <h1 class='govuk-heading-xl'>Invite provider user</h1>
+      <h1 class='govuk-heading-xl'>Invite user</h1>
 
       <%= f.govuk_text_field :first_name, label: { text: 'First name', size: 'm' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
@@ -26,7 +26,7 @@
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }  %>
 
-      <%= f.govuk_submit 'Invite provider user' %>
+      <%= f.govuk_submit 'Invite user' %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,6 +168,16 @@ en:
           attributes:
             conditions_met:
               blank: Please specify if the candidate has met the conditions of the offer
+        provider_interface/provider_user_form:
+          attributes:
+            email_address:
+              blank: Email address can’t be blank
+            first_name:
+              blank: First name can’t be blank
+            last_name:
+              blank: Last name can’t be blank
+            provider_ids:
+              blank: Please specify a provider
         change_offer:
           attributes:
             course_option_id:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,11 +171,11 @@ en:
         provider_interface/provider_user_form:
           attributes:
             email_address:
-              blank: Email address can’t be blank
+              blank: Enter the user's email address
             first_name:
-              blank: First name can’t be blank
+              blank: Enter the user's first name
             last_name:
-              blank: Last name can’t be blank
+              blank: Enter the user's last name
             provider_ids:
               blank: Please specify a provider
         change_offer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -431,6 +431,10 @@ Rails.application.routes.draw do
 
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
+
+    get '/provider-users' => 'provider_users#index'
+    get '/provider-users/new' => 'provider_users#new'
+    post '/provider-users' => 'provider_users#create'
   end
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -10,6 +10,8 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
     u.providers = [ApplicationChoice.first.provider]
   end
   SupportUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com')
+
+  ProviderPermissions.update_all(manage_users: true) if FeatureFlag.active?('provider_add_provider_users')
 end
 
 desc 'Sync some pilot-enabled providers and open all their courses'

--- a/spec/components/provider_interface/user_list_card_component_spec.rb
+++ b/spec/components/provider_interface/user_list_card_component_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::UserListCardComponent do
+  include CourseOptionHelpers
+
+  let(:providers) do
+    [
+      create(:provider,
+             code: 'ABC',
+             name: 'Hoth Teacher Training'),
+      create(:provider,
+             code: 'DEF',
+             name: 'Yavin Teacher Training'),
+      create(:provider,
+             code: 'GHI',
+             name: 'Endor Teacher Training')
+    ]
+  end
+
+  let(:provider_user) do
+    create(:provider_user,
+           first_name: 'Wesley',
+           last_name: 'Antellies',
+           email_address: 'wes@test.com',
+           providers: providers)
+  end
+
+  let(:result) { render_inline described_class.new(provider_user: provider_user) }
+
+  let(:card) { result.css('.app-application-card').to_html }
+
+  describe 'rendering' do
+    it 'renders the name of the provider user' do
+      expect(card).to include('Wesley Antellies')
+    end
+
+    it 'renders the provider user\'s email' do
+      expect(card).to include('wes@test.com')
+    end
+
+    it 'renders the name of the first provider the provider user has management rights for and a cardinal number representing the rest' do
+      expect(card).to include('Hoth Teacher Training and two more')
+    end
+  end
+end

--- a/spec/components/provider_interface/user_list_card_component_spec.rb
+++ b/spec/components/provider_interface/user_list_card_component_spec.rb
@@ -5,41 +5,44 @@ RSpec.describe ProviderInterface::UserListCardComponent do
 
   let(:providers) do
     [
-      create(:provider,
-             code: 'ABC',
-             name: 'Hoth Teacher Training'),
-      create(:provider,
-             code: 'DEF',
-             name: 'Yavin Teacher Training'),
-      create(:provider,
-             code: 'GHI',
-             name: 'Endor Teacher Training')
+      build_stubbed(:provider, name: 'Hoth Teacher Training'),
+      build_stubbed(:provider, name: 'Yavin Teacher Training'),
+      build_stubbed(:provider, name: 'Endor Teacher Training'),
     ]
   end
 
-  let(:provider_user) do
-    create(:provider_user,
-           first_name: 'Wesley',
-           last_name: 'Antellies',
-           email_address: 'wes@test.com',
-           providers: providers)
-  end
-
-  let(:result) { render_inline described_class.new(provider_user: provider_user) }
-
+  let(:provider_user) { build_stubbed(:provider_user, providers: providers) }
+  let(:instance) { described_class.new(provider_user: provider_user) }
+  let(:result) { render_inline instance }
   let(:card) { result.css('.app-application-card').to_html }
 
   describe 'rendering' do
     it 'renders the name of the provider user' do
-      expect(card).to include('Wesley Antellies')
+      expect(card).to include(provider_user.full_name)
     end
 
     it 'renders the provider user\'s email' do
-      expect(card).to include('wes@test.com')
+      expect(card).to include(provider_user.email_address)
     end
 
-    it 'renders the name of the first provider the provider user has management rights for and a cardinal number representing the rest' do
+    it 'renders the name of the first provider and a cardinal number representing the rest' do
       expect(card).to include('Hoth Teacher Training and two more')
+    end
+  end
+
+  describe '#providers_text' do
+    context 'when one provider exists' do
+      let(:providers) { [create(:provider)] }
+
+      it 'renders the name of the first provider' do
+        expect(instance.providers_text).to eq(providers.first.name)
+      end
+    end
+
+    context 'when more than one provider exists' do
+      it 'renders the name of the first provider and cardinal number for others' do
+        expect(instance.providers_text).to eq('Hoth Teacher Training and two more')
+      end
     end
   end
 end

--- a/spec/models/provider_interface/provider_user_form_spec.rb
+++ b/spec/models/provider_interface/provider_user_form_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderUserForm do
+  let(:provider_user) { create(:provider_user, :with_provider) }
+  let(:provider) { provider_user.providers.first }
+  let(:manageable_user) { create(:provider_user, providers: [provider]) }
+  let(:provider_ids) { [provider.id] }
+  let(:form_params) { { current_provider_user: provider_user, provider_ids: provider_ids } }
+
+  subject(:provider_user_form) { described_class.new(form_params) }
+
+  before { provider_user.providers.first.provider_permissions.update(manage_users: true) }
+
+  describe 'validations' do
+    context 'with provider_ids for providers the current user cannot manage' do
+      let(:another_provider) { create(:provider) }
+      let(:provider_ids) { [provider.id, another_provider.id] }
+
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:provider_ids]).not_to be_empty
+      end
+    end
+
+    context 'with provider_ids for providers the current user can manage' do
+      it 'is valid' do
+        provider_user_form.valid?
+        expect(provider_user_form.errors[:provider_ids]).to be_empty
+      end
+    end
+  end
+
+  describe '#available_providers' do
+    it 'returns a collection of providers the current provider user can assign to other users' do
+      expect(provider_user_form.available_providers).to eq([provider])
+    end
+  end
+end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -63,4 +63,18 @@ RSpec.describe ProviderUser, type: :model do
       expect(provider_user.associated_audits.first.audited_changes['provider_id']).to eq provider.id
     end
   end
+
+  describe 'can_manage_users?' do
+    let(:provider_user) { create :provider_user, :with_provider }
+
+    it 'is false for users without the manage users permission' do
+      expect(provider_user.can_manage_users?).to be false
+    end
+
+    it 'is true for users with the manage users permission' do
+      provider_user.provider_permissions.first.update(manage_users: true)
+
+      expect(provider_user.can_manage_users?).to be true
+    end
+  end
 end

--- a/spec/services/provider_interface/provider_options_service_spec.rb
+++ b/spec/services/provider_interface/provider_options_service_spec.rb
@@ -55,4 +55,14 @@ RSpec.describe ProviderInterface::ProviderOptionsService do
       ])
     end
   end
+
+  describe '#providers_with_manageable_users' do
+    let(:provider_user) { create(:provider_user, providers: @providers) }
+
+    before { provider_user.provider_permissions.find_by(provider: @providers.last).update(manage_users: true) }
+
+    it 'returns providers with users manageable by the provider user' do
+      expect(described_class.new(provider_user).providers_with_manageable_users).to eq([@providers.last])
+    end
+  end
 end

--- a/spec/services/text_cardinalizer_spec.rb
+++ b/spec/services/text_cardinalizer_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe TextCardinalizer do
+  it 'can return the cardinal text value of a number up to ten' do
+    expect(TextCardinalizer.call(0)).to match('zero')
+    expect(TextCardinalizer.call(1)).to match('one')
+    expect(TextCardinalizer.call(2)).to match('two')
+    expect(TextCardinalizer.call(3)).to match('three')
+    expect(TextCardinalizer.call(4)).to match('four')
+    expect(TextCardinalizer.call(5)).to match('five')
+    expect(TextCardinalizer.call(6)).to match('six')
+    expect(TextCardinalizer.call(7)).to match('seven')
+    expect(TextCardinalizer.call(8)).to match('eight')
+    expect(TextCardinalizer.call(9)).to match('nine')
+    expect(TextCardinalizer.call(10)).to match('ten')
+  end
+
+  it 'will revert to number literal written numbers after ten' do
+    expect(TextCardinalizer.call(11)).to match('11')
+  end
+end

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider invites a new provider user' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'Provider sends invite to user' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_can_manage_applications_for_two_providers
+    and_i_can_manage_users_for_a_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_users_index
+    and_i_click_invite_user
+    and_i_fill_in_and_submit_invite_details
+
+    then_a_new_provider_user_is_created
+    and_the_user_should_be_sent_a_welcome_email
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_i_can_manage_users_for_a_provider
+    @provider_user.provider_users_providers.find_by(provider: @provider).update(manage_users: true)
+  end
+
+  def when_i_visit_the_provider_users_index
+    visit provider_interface_provider_users_path
+  end
+
+  def and_i_click_invite_user
+    click_on 'Invite user'
+  end
+
+  def and_i_fill_in_and_submit_invite_details
+    set_dsi_api_response(success: true)
+    @email_address = "jane.smith+#{rand(1000)}@example.com"
+
+    fill_in 'First name', with: 'Jane'
+    fill_in 'Last name', with: 'Smith'
+    fill_in 'Email address', with: @email_address
+
+    expect(page).not_to have_content(@another_provider.name_and_code)
+
+    check @provider.name_and_code
+
+    click_on 'Invite provider user'
+  end
+
+  def then_a_new_provider_user_is_created
+    @new_provider_user = ProviderUser.find_by(email_address: @email_address)
+    expect(@new_provider_user).not_to be nil
+    expect(@new_provider_user.providers).to include(@provider)
+  end
+
+  def and_the_user_should_be_sent_a_welcome_email
+    open_email(@email_address)
+    expect(current_email.subject).to have_content t('provider_account_created.email.subject')
+  end
+end

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -9,6 +9,7 @@ RSpec.feature 'Provider invites a new provider user' do
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider
     and_i_sign_in_to_the_provider_interface
+    and_the_provider_add_provider_users_feature_is_enabled
 
     when_i_visit_the_provider_users_index
     and_i_click_invite_user
@@ -31,6 +32,10 @@ RSpec.feature 'Provider invites a new provider user' do
 
   def and_i_can_manage_users_for_a_provider
     @provider_user.provider_users_providers.find_by(provider: @provider).update(manage_users: true)
+  end
+
+  def and_the_provider_add_provider_users_feature_is_enabled
+    FeatureFlag.activate('provider_add_provider_users')
   end
 
   def when_i_visit_the_provider_users_index

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -6,17 +6,21 @@ RSpec.feature 'Provider invites a new provider user' do
 
   scenario 'Provider sends invite to user' do
     given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_add_provider_users_feature_is_enabled
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider
     and_i_sign_in_to_the_provider_interface
-    and_the_provider_add_provider_users_feature_is_enabled
 
-    when_i_visit_the_provider_users_index
+    when_i_click_on_the_users_link
     and_i_click_invite_user
     and_i_fill_in_and_submit_invite_details
 
     then_a_new_provider_user_is_created
     and_the_user_should_be_sent_a_welcome_email
+  end
+
+  def when_i_click_on_the_users_link
+    click_on("Users")
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -36,10 +40,6 @@ RSpec.feature 'Provider invites a new provider user' do
 
   def and_the_provider_add_provider_users_feature_is_enabled
     FeatureFlag.activate('provider_add_provider_users')
-  end
-
-  def when_i_visit_the_provider_users_index
-    visit provider_interface_provider_users_path
   end
 
   def and_i_click_invite_user

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Provider invites a new provider user' do
   end
 
   def when_i_click_on_the_users_link
-    click_on("Users")
+    click_on('Users')
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature 'Provider invites a new provider user' do
   end
 
   def and_i_can_manage_users_for_a_provider
-    @provider_user.provider_users_providers.find_by(provider: @provider).update(manage_users: true)
+    @provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
   end
 
   def and_the_provider_add_provider_users_feature_is_enabled

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -65,6 +65,7 @@ RSpec.feature 'Provider invites a new provider user' do
     @new_provider_user = ProviderUser.find_by(email_address: @email_address)
     expect(@new_provider_user).not_to be nil
     expect(@new_provider_user.providers).to include(@provider)
+    expect(page).to have_content('Provider user invited')
   end
 
   def and_the_user_should_be_sent_a_welcome_email

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature 'Provider invites a new provider user' do
 
     check @provider.name_and_code
 
-    click_on 'Invite provider user'
+    click_on 'Invite user'
   end
 
   def then_a_new_provider_user_is_created


### PR DESCRIPTION
## Context

We want to enable provider users to onboard/invite other provider users.
This needs to be restricted by a specific permission and also within the context of the providers the current provider user can see.

See  https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1800 and https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1807 for some low level implementation details.
 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Using the `manage_users` permission in `ProviderPermissions` we allow certain users to invite other provider users.
We use the existing `InviteProviderUser` service and email template to create the user and send an invite.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/78573841-159bb000-7821-11ea-8b16-6233cb4ed853.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

You'll need the `provider_add_provider_users` feature flag on and to set `manage_users: true` for at least one `ProviderPermissions` record for the current provider user.

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/Cms7JJCh/1841-providerusers-with-the-appropriate-permissions-can-invite-other-providerusers

Paired with @willmcb on this feature.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
