### PR TITLE
Currently available courses page should group providers by region

### DIFF
--- a/app/components/grouped_provider_courses_component.html.erb
+++ b/app/components/grouped_provider_courses_component.html.erb
@@ -1,0 +1,21 @@
+<% courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= t("provider_regions.#{region_code}") %></h2>
+  <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+    <% courses_by_provider.each_with_index do |provider, index| %>
+      <section class="govuk-accordion__section">
+        <header class="govuk-accordion__section-header">
+          <h2 class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= index %>"><%= provider.provider_name %></span>
+          </h2>
+        </header>
+        <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
+          <ul class="govuk-list govuk-list--bullet">
+            <% provider.courses.sort_by(&:name).each do |course| %>
+              <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
+            <% end %>
+          </ul>
+        </div>
+      </section>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/grouped_provider_courses_component.rb
+++ b/app/components/grouped_provider_courses_component.rb
@@ -1,0 +1,13 @@
+class GroupedProviderCoursesComponent < ActionView::Component::Base
+  include ViewHelper
+
+  validates :courses_by_provider_and_region, presence: true
+
+  def initialize(courses_by_provider_and_region:)
+    @courses_by_provider_and_region = courses_by_provider_and_region
+  end
+
+private
+
+  attr_reader :courses_by_provider_and_region
+end

--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -18,15 +18,16 @@ module CandidateInterface
       render_content_page :terms_candidate
     end
 
-    def providers
-      provider_courses = Struct.new(:provider_name, :courses)
+    ProviderCourses = Struct.new(:region_code, :provider_name, :courses)
 
-      @courses_by_provider = Course
+    def providers
+      @courses_by_provider_and_region = Course
         .open_on_apply
         .includes(:provider)
-        .group_by { |c| c.provider.name }
-        .sort_by { |provider_name, _| provider_name }
-        .map { |provider_name, courses| provider_courses.new(provider_name, courses) }
+        .order('providers.region_code', 'providers.name')
+        .group_by { |course| [course.provider.region_code, course.provider.name] }
+        .map { |region_provider, courses| ProviderCourses.new(region_provider[0], region_provider[1], courses) }
+        .group_by(&:region_code)
     end
   end
 end

--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -18,15 +18,35 @@ module CandidateInterface
       render_content_page :terms_candidate
     end
 
-    ProviderCourses = Struct.new(:region_code, :provider_name, :courses)
+    ProviderCourses = Struct.new(:provider_name, :courses)
+    RegionProviderCourses = Struct.new(:region_code, :provider_name, :courses)
 
     def providers
-      @courses_by_provider_and_region = Course
+      if FeatureFlag.active?('group_providers_by_region')
+        @courses_by_provider_and_region = courses_grouped_by_provider_and_region
+      else
+        @courses_by_provider = courses_grouped_by_provider
+      end
+    end
+
+  private
+
+    def courses_grouped_by_provider
+      Course
+        .open_on_apply
+        .includes(:provider)
+        .group_by { |c| c.provider.name }
+        .sort_by { |provider_name, _| provider_name }
+        .map { |provider_name, courses| ProviderCourses.new(provider_name, courses) }
+    end
+
+    def courses_grouped_by_provider_and_region
+      Course
         .open_on_apply
         .includes(:provider)
         .order('providers.region_code', 'providers.name')
         .group_by { |course| [course.provider.region_code, course.provider.name] }
-        .map { |region_provider, courses| ProviderCourses.new(region_provider[0], region_provider[1], courses) }
+        .map { |region_provider, courses| RegionProviderCourses.new(region_provider[0], region_provider[1], courses) }
         .group_by(&:region_code)
     end
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -27,6 +27,7 @@ class FeatureFlag
     timeline
     edit_course_choices
     satisfaction_survey
+    group_providers_by_region
   ].freeze
 
   def self.activate(feature_name)

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -21,9 +21,9 @@
     </ul>
     <p class="govuk-body"><%= govuk_link_to 'Use UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %></p>
 
-    <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-      <% @courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
-        <h3><%= t("provider_regions.#{region_code}") %></h3>
+    <% @courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= t("provider_regions.#{region_code}") %></h2>
+      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
         <% courses_by_provider.each_with_index do |provider, index| %>
           <section class="govuk-accordion__section">
             <header class="govuk-accordion__section-header">
@@ -40,7 +40,7 @@
             </div>
           </section>
         <% end %>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -22,21 +22,24 @@
     <p class="govuk-body"><%= govuk_link_to 'Use UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %></p>
 
     <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-      <% @courses_by_provider.each_with_index do |provider, index| %>
-        <section class="govuk-accordion__section">
-          <header class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading">
-              <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= index %>"><%= provider.provider_name %></span>
-            </h2>
-          </header>
-          <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
-            <ul class="govuk-list govuk-list--bullet">
-              <% provider.courses.sort_by(&:name).each do |course| %>
-                <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
-              <% end %>
-            </ul>
-          </div>
-        </section>
+      <% @courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
+        <h3><%= region_code %></h3>
+        <% courses_by_provider.each_with_index do |provider, index| %>
+          <section class="govuk-accordion__section">
+            <header class="govuk-accordion__section-header">
+              <h2 class="govuk-accordion__section-heading">
+                <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= index %>"><%= provider.provider_name %></span>
+              </h2>
+            </header>
+            <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
+              <ul class="govuk-list govuk-list--bullet">
+                <% provider.courses.sort_by(&:name).each do |course| %>
+                  <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
+                <% end %>
+              </ul>
+            </div>
+          </section>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -22,27 +22,7 @@
     <p class="govuk-body"><%= govuk_link_to 'Use UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %></p>
 
     <% if FeatureFlag.active?('group_providers_by_region') %>
-      <% @courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= t("provider_regions.#{region_code}") %></h2>
-        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-          <% courses_by_provider.each_with_index do |provider, index| %>
-            <section class="govuk-accordion__section">
-              <header class="govuk-accordion__section-header">
-                <h2 class="govuk-accordion__section-heading">
-                  <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= index %>"><%= provider.provider_name %></span>
-                </h2>
-              </header>
-              <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
-                <ul class="govuk-list govuk-list--bullet">
-                  <% provider.courses.sort_by(&:name).each do |course| %>
-                    <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
-                  <% end %>
-                </ul>
-              </div>
-            </section>
-          <% end %>
-        </div>
-      <% end %>
+      <%= render GroupedProviderCoursesComponent.new(courses_by_provider_and_region: @courses_by_provider_and_region) %>
     <% else %>
       <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
         <% @courses_by_provider.each_with_index do |provider, index| %>

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -21,10 +21,31 @@
     </ul>
     <p class="govuk-body"><%= govuk_link_to 'Use UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %></p>
 
-    <% @courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= t("provider_regions.#{region_code}") %></h2>
+    <% if FeatureFlag.active?('group_providers_by_region') %>
+      <% @courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= t("provider_regions.#{region_code}") %></h2>
+        <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
+          <% courses_by_provider.each_with_index do |provider, index| %>
+            <section class="govuk-accordion__section">
+              <header class="govuk-accordion__section-header">
+                <h2 class="govuk-accordion__section-heading">
+                  <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= index %>"><%= provider.provider_name %></span>
+                </h2>
+              </header>
+              <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
+                <ul class="govuk-list govuk-list--bullet">
+                  <% provider.courses.sort_by(&:name).each do |course| %>
+                    <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </section>
+          <% end %>
+        </div>
+      <% end %>
+    <% else %>
       <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-        <% courses_by_provider.each_with_index do |provider, index| %>
+        <% @courses_by_provider.each_with_index do |provider, index| %>
           <section class="govuk-accordion__section">
             <header class="govuk-accordion__section-header">
               <h2 class="govuk-accordion__section-heading">

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -23,7 +23,7 @@
 
     <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
       <% @courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
-        <h3><%= region_code %></h3>
+        <h3><%= t("provider_regions.#{region_code}") %></h3>
         <% courses_by_provider.each_with_index do |provider, index| %>
           <section class="govuk-accordion__section">
             <header class="govuk-accordion__section-header">

--- a/config/locales/provider_regions.yml
+++ b/config/locales/provider_regions.yml
@@ -7,7 +7,7 @@ en:
     north_east: 'North East'
     north_west: 'North West'
     scotland: 'Scotland'
-    south_east: 'South_East'
+    south_east: 'South East'
     south_west: 'South West'
     wales: 'Wales'
     west_midlands: 'West Midlands'

--- a/config/locales/provider_regions.yml
+++ b/config/locales/provider_regions.yml
@@ -1,0 +1,14 @@
+en:
+  provider_regions:
+    east_midlands: 'East Midlands'
+    eastern: 'Eastern'
+    london: 'London'
+    no_region: 'No Region'
+    north_east: 'North East'
+    north_west: 'North West'
+    scotland: 'Scotland'
+    south_east: 'South_East'
+    south_west: 'South West'
+    wales: 'Wales'
+    west_midlands: 'West Midlands'
+    yorkshire_and_the_humber: 'Yorkshire and Humber'

--- a/config/locales/provider_regions.yml
+++ b/config/locales/provider_regions.yml
@@ -11,4 +11,4 @@ en:
     south_west: 'South West'
     wales: 'Wales'
     west_midlands: 'West Midlands'
-    yorkshire_and_the_humber: 'Yorkshire and Humber'
+    yorkshire_and_the_humber: 'Yorkshire and the Humber'

--- a/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe 'A candidate can view all providers and courses on Apply' do
   scenario 'seeing the list of courses grouped by provider and region' do
     given_the_pilot_is_open
     and_the_create_account_or_sign_in_page_feature_flag_is_active
-    and_there_are_providers_with_courses_on_find
+    and_there_are_providers_with_courses_on_apply
+
+    when_i_visit_the_available_courses_page
+    then_i_should_see_the_available_courses_grouped_by_providers
+
+    when_group_by_region_feature_is_active
 
     when_i_visit_the_available_courses_page
     then_i_should_see_the_available_providers_grouped_by_region
@@ -16,11 +21,15 @@ RSpec.describe 'A candidate can view all providers and courses on Apply' do
     FeatureFlag.activate('pilot_open')
   end
 
+  def when_group_by_region_feature_is_active
+    FeatureFlag.activate('group_providers_by_region')
+  end
+
   def and_the_create_account_or_sign_in_page_feature_flag_is_active
     FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
-  def and_there_are_providers_with_courses_on_find
+  def and_there_are_providers_with_courses_on_apply
     @st_ives = create :provider, code: 'SIC', name: 'St Ives College', region_code: :south_west, sync_courses: true
     create :course, :open_on_apply, name: 'Mathematics', provider: @st_ives
     create :course, :open_on_apply, name: 'Chemistry', provider: @st_ives
@@ -29,6 +38,14 @@ RSpec.describe 'A candidate can view all providers and courses on Apply' do
 
   def when_i_visit_the_available_courses_page
     visit candidate_interface_providers_path
+  end
+
+  def then_i_should_see_the_available_courses_grouped_by_providers
+    expect(page).not_to have_content 'South West'
+    expect(page).to have_content 'St Ives College'
+    expect(page).to have_content 'Mathematics'
+    expect(page).to have_content 'Chemistry'
+    expect(page).to have_content 'Physics'
   end
 
   def then_i_should_see_the_available_providers_grouped_by_region

--- a/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe 'A candidate can view all providers and courses on Apply' do
+  include FindAPIHelper
+
+  scenario 'seeing the list of courses grouped by provider and region' do
+    given_the_pilot_is_open
+    and_the_create_account_or_sign_in_page_feature_flag_is_active
+    and_there_are_providers_with_courses_on_find
+
+    when_i_visit_the_available_courses_page
+    then_i_should_see_the_available_providers_grouped_by_region
+  end
+
+  def given_the_pilot_is_open
+    FeatureFlag.activate('pilot_open')
+  end
+
+  def and_the_create_account_or_sign_in_page_feature_flag_is_active
+    FeatureFlag.activate('create_account_or_sign_in_page')
+  end
+
+  def and_there_are_providers_with_courses_on_find
+    @st_ives = create :provider, code: 'SIC', name: 'St Ives College', region_code: :south_west, sync_courses: true
+    create :course, :open_on_apply, name: 'Mathematics', provider: @st_ives
+    create :course, :open_on_apply, name: 'Chemistry', provider: @st_ives
+    create :course, :open_on_apply, name: 'Physics', provider: @st_ives
+  end
+
+  def when_i_visit_the_available_courses_page
+    visit candidate_interface_providers_path
+  end
+
+  def then_i_should_see_the_available_providers_grouped_by_region
+    expect(page).to have_content 'South West'
+    expect(page).to have_content 'St Ives College'
+    expect(page).to have_content 'Mathematics'
+    expect(page).to have_content 'Chemistry'
+    expect(page).to have_content 'Physics'
+  end
+end


### PR DESCRIPTION
## Context

As the list of providers and courses on Apply grows we need to make the list of available providers and courses easier to navigate. It makes sense to group the providers into regions.

## Changes proposed in this pull request

- [x] Group courses by provider region and change views to present an accordian per region under region headings.
- [x] Feature flag
- [x] New system spec
- [x] Refactor to components?
  
## Guidance to review

- Does the grouping logic make sense? I've moved the sorting into the DB and but the grouping happens in Ruby code still.
- I think we will run into issues with performance in the longer-term with this design (and the previous one) as more providers become available on Apply. Not sure what we can do to mitigate that without changing the design to present a subset of the results or load subsets on demand. Any thoughts on this welcome.

In mine tests I found the performance to be OK with 1000 and 5000 courses. Both page loads took about a second and it didn't degrade significantly with increased numbers of courses. So I think this is OK for now - we are probably going to have to address usability before performance.

![image](https://user-images.githubusercontent.com/450843/78301150-93657000-7530-11ea-9c57-96a163cf088b.png) 

## Link to Trello card

https://trello.com/c/luWz8uHE/975-dev-currently-available-providers-page-grouped-by-region

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
