### PR TITLE
Flag accredited bodies not on Apply when opening courses

### DIFF
--- a/app/components/support_interface/provider_courses_table_component.html.erb
+++ b/app/components/support_interface/provider_courses_table_component.html.erb
@@ -39,7 +39,12 @@
           <% end %>
         </td>
         <% if accredited_bodies_vary? %>
-          <td class='govuk-table__cell'><%= course[:accredited_body] %></td>
+          <td class='govuk-table__cell'><%= course[:accredited_body] %>
+            <% unless course[:accredited_body_onboarded] %>
+              <br />
+              (No users on Apply)
+            <% end %>
+          </td>
         <% end %>
       </tr>
     <% end %>

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -17,6 +17,7 @@ module SupportInterface
           apply_from_find_link: link_to_apply_from_find_page(course),
           link_to_find_course_page: link_to_find_course_page(course),
           accredited_body: link_to_provider_page(course.accredited_provider),
+          accredited_body_onboarded: course.accredited_provider&.onboarded?,
         }
       end
     end

--- a/app/controllers/support_interface/providers_controller.rb
+++ b/app/controllers/support_interface/providers_controller.rb
@@ -14,7 +14,7 @@ module SupportInterface
     end
 
     def courses
-      @provider = Provider.includes(:courses).find(params[:provider_id])
+      @provider = Provider.includes(courses: [:accredited_provider]).find(params[:provider_id])
     end
 
     def vacancies

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -37,4 +37,13 @@ class Provider < ApplicationRecord
   def application_forms
     ApplicationForm.where(id: application_choices.select(:application_form_id))
   end
+
+  def onboarded?
+    provider_agreements.any?
+  end
+
+  def all_associated_accredited_providers_onboarded?
+    accredited_providers = courses.map(&:accredited_provider).uniq.compact
+    accredited_providers.all?(&:onboarded?)
+  end
 end

--- a/app/views/support_interface/providers/courses.html.erb
+++ b/app/views/support_interface/providers/courses.html.erb
@@ -10,6 +10,18 @@
 
     <p class="govuk-body">This will toggle every course on this provider to be available through Apply.</p>
 
+    <% unless @provider.all_associated_accredited_providers_onboarded? %>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          Some of this provider’s courses are ratified by an accredited body
+          which does not yet participate in the beta. The accredited body might
+          expect to manage applications to those courses. Check before clicking
+          this button.
+        </strong>
+      </div>
+    <% end %>
     <%= f.govuk_submit "Open #{pluralize(@provider.courses.size, 'course')}" %>
   <% end %>
 <% end %>

--- a/spec/components/support_interface/provider_courses_table_component_spec.rb
+++ b/spec/components/support_interface/provider_courses_table_component_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SupportInterface::ProviderCoursesTableComponent do
       expect(fields['Apply from Find']).to match(/DfE & UCAS/)
       expect(fields['Page on Find']).to match(/Find course page/)
       expect(fields).to have_key('Accredited body')
-      expect(fields['Accredited body']).to eq('Accredited University (AU1)')
+      expect(fields['Accredited body']).to match(/Accredited University \(AU1\)/)
     end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Provider, type: :model do
+  describe '#onboarded?' do
+    it 'depends on the presence of a signed Data sharing agreement' do
+      provider_with_dsa = create(:provider, :with_signed_agreement)
+      provider_without_dsa = create(:provider)
+
+      expect(provider_with_dsa).to be_onboarded
+      expect(provider_without_dsa).not_to be_onboarded
+    end
+  end
+
+  describe '#all_associated_accredited_providers_onboarded?' do
+    let(:provider) { create(:provider) }
+
+    subject(:result) { provider.all_associated_accredited_providers_onboarded? }
+
+    it 'returns true when the accredited bodies are all onboarded' do
+      create(:course, provider: provider, accredited_provider: create(:provider, :with_signed_agreement))
+
+      expect(result).to be true
+    end
+
+    it 'returns false when some accredited bodies are onboarded' do
+      create(:course, provider: provider, accredited_provider: create(:provider, :with_signed_agreement))
+      create(:course, provider: provider, accredited_provider: create(:provider))
+
+      expect(result).to be false
+    end
+
+    it 'returns false when there are no accredited bodies' do
+      create(:course, provider: provider, accredited_provider: create(:provider))
+
+      expect(result).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Context

Some accredited bodies are responsible for sifting, making offers etc for applications to courses they ratify. During a meeting about access controls, it was pointed out that it would be bad if we opened courses for a provider but the accredited body responsible for some of those courses was locked out. We should help ourselves not to make this mistake.

## Changes proposed in this pull request

![Screenshot 2020-04-02 at 22 48 37](https://user-images.githubusercontent.com/642279/78303268-408db780-7534-11ea-838b-26064bd39ad4.png)

## Guidance to review

- I used the presence of a `ProviderAgreement` as a proxy for the provider being onboarded. I think this is probably good enough? It ought to also cover providers who are set up as clients of the API (it doesn't yet, but https://trello.com/c/qerAetcs/1855-api-access-should-depend-on-the-presence-of-a-dsa)
- No tests 🤠. We don't really have a place for this simple logic to live. Maybe it's simple enough?

## Link to Trello card

https://trello.com/c/L7Y8vxNf/1856-add-a-note-to-the-support-console-warning-that-we-should-be-careful-when-opening-all-courses-for-providers-with-accredited-bodie

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
