### PR TITLE
Add final pages of the candidate satisfaction survey flow

### DIFF
--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -96,6 +96,15 @@ module CandidateInterface
       post_route_action(candidate_interface_satisfaction_survey_contact_path, :other_information)
     end
 
+    def contact
+      @survey = SatisfactionSurveyForm.new
+    end
+
+    def submit_contact
+      post_route_action(candidate_interface_satisfaction_survey_thank_you_path, :contact)
+    end
+
+    def thank_you; end
 
   private
 

--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -88,6 +88,15 @@ module CandidateInterface
       post_route_action(candidate_interface_satisfaction_survey_other_information_path, :improvements)
     end
 
+    def other_information
+      @survey = SatisfactionSurveyForm.new
+    end
+
+    def submit_other_information
+      post_route_action(candidate_interface_satisfaction_survey_contact_path, :other_information)
+    end
+
+
   private
 
     def survey_params

--- a/app/controllers/candidate_interface/satisfaction_survey_controller.rb
+++ b/app/controllers/candidate_interface/satisfaction_survey_controller.rb
@@ -80,7 +80,13 @@ module CandidateInterface
       post_route_action(candidate_interface_satisfaction_survey_improvements_path, :needed_additional_learning)
     end
 
-    def improvements; end
+    def improvements
+      @survey = SatisfactionSurveyForm.new
+    end
+
+    def submit_improvements
+      post_route_action(candidate_interface_satisfaction_survey_other_information_path, :improvements)
+    end
 
   private
 

--- a/app/views/candidate_interface/satisfaction_survey/_survey_page.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/_survey_page.html.erb
@@ -9,8 +9,18 @@
       <h2 class="govuk-heading-xl">
         <%= title %>
       </h2>
-
+    <% if five_radio_buttons %>
       <%= render 'form', f: f %>
+    <% elsif text_area %>
+      <%= f.govuk_text_area :answer, label: { text: '' }, rows: 8, max_words: 400 %>
+      <%= f.govuk_submit 'Continue' %>
+    <% else %>
+      <%= f.govuk_radio_buttons_fieldset :ratings do %>
+        <%= f.govuk_radio_button :answer, 'yes', label: { text: 'Yes, you can contact me' }  %>
+        <%= f.govuk_radio_button :answer, 'no', label: { text: 'No, do not contact me' }  %>
+      <% end %>
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/candidate_interface/satisfaction_survey/adaptability.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/adaptability.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.adaptability'),
   url: candidate_interface_satisfaction_survey_submit_adaptability_path,
-  previous_url: candidate_interface_satisfaction_survey_consistency_path %>
+  previous_url: candidate_interface_satisfaction_survey_consistency_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/awkward.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/awkward.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.awkward'),
   url: candidate_interface_satisfaction_survey_submit_awkward_path,
-  previous_url: candidate_interface_satisfaction_survey_adaptability_path %>
+  previous_url: candidate_interface_satisfaction_survey_adaptability_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/complexity.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.complexity'),
   url: candidate_interface_satisfaction_survey_submit_complexity_path,
-  previous_url: candidate_interface_satisfaction_survey_recommendation_path %>
+  previous_url: candidate_interface_satisfaction_survey_recommendation_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/confidence.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/confidence.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.confidence'),
   url: candidate_interface_satisfaction_survey_submit_confidence_path,
-  previous_url: candidate_interface_satisfaction_survey_awkward_path %>
+  previous_url: candidate_interface_satisfaction_survey_awkward_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/consistency.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/consistency.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.consistency'),
   url: candidate_interface_satisfaction_survey_submit_consistency_path,
-  previous_url: candidate_interface_satisfaction_survey_organisation_path %>
+  previous_url: candidate_interface_satisfaction_survey_organisation_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/contact.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/contact.html.erb
@@ -1,21 +1,6 @@
-<% content_for :title, t('page_titles.contact') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_other_information_path) %>
-
-<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_contact_path, method: :post do |f| %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-
-      <h2 class="govuk-heading-xl">
-        <%= t('page_titles.contact') %>
-      </h2>
-
-      <%= f.govuk_radio_buttons_fieldset :ratings do %>
-        <%= f.govuk_radio_button :answer, 'yes', label: { text: 'Yes, you can contact me' }  %>
-        <%= f.govuk_radio_button :answer, 'no', label: { text: 'No, do not contact me' }  %>
-      <% end %>
-
-      <%= f.govuk_submit 'Continue' %>
-    </div>
-  </div>
-<% end %>
+<%= render 'survey_page',
+  title: t('page_titles.contact'),
+  url: candidate_interface_satisfaction_survey_submit_contact_path,
+  previous_url: candidate_interface_satisfaction_survey_other_information_path,
+  five_radio_buttons: false,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/contact.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/contact.html.erb
@@ -10,8 +10,6 @@
         <%= t('page_titles.contact') %>
       </h2>
 
-      <%= f.hidden_field :question, value: t('page_titles.contact') %>
-
       <%= f.govuk_radio_buttons_fieldset :ratings do %>
         <%= f.govuk_radio_button :answer, 'yes', label: { text: 'Yes, you can contact me' }  %>
         <%= f.govuk_radio_button :answer, 'no', label: { text: 'No, do not contact me' }  %>

--- a/app/views/candidate_interface/satisfaction_survey/contact.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/contact.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, t('page_titles.contact') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_other_information_path) %>
+
+<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_contact_path, method: :post do |f| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-xl">
+        <%= t('page_titles.contact') %>
+      </h2>
+
+      <%= f.hidden_field :question, value: t('page_titles.contact') %>
+
+      <%= f.govuk_radio_buttons_fieldset :ratings do %>
+        <%= f.govuk_radio_button :answer, 'yes', label: { text: 'Yes, you can contact me' }  %>
+        <%= f.govuk_radio_button :answer, 'no', label: { text: 'No, do not contact me' }  %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/candidate_interface/satisfaction_survey/ease_of_use.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/ease_of_use.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.ease_of_use'),
   url: candidate_interface_satisfaction_survey_submit_ease_of_use_path,
-  previous_url: candidate_interface_satisfaction_survey_complexity_path %>
+  previous_url: candidate_interface_satisfaction_survey_complexity_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/help_needed.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/help_needed.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.help_needed'),
   url: candidate_interface_satisfaction_survey_submit_help_needed_path,
-  previous_url: candidate_interface_satisfaction_survey_ease_of_use_path %>
+  previous_url: candidate_interface_satisfaction_survey_ease_of_use_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/improvements.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/improvements.html.erb
@@ -1,1 +1,19 @@
-If you could improve anything on Apply for teacher training what would it be?
+<% content_for :title, t('page_titles.improvements') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_needed_additional_learning_path) %>
+
+<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_improvements_path, method: :post do |f| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-xl">
+        <%= t('page_titles.improvements') %>
+      </h2>
+
+      <%= f.hidden_field :question, value: t('page_titles.improvements') %>
+      <%= f.govuk_text_area :answer, label: { text: '' }, rows: 8, max_words: 400 %>
+    </div>
+  </div>
+
+  <%= f.govuk_submit 'Continue' %>
+<% end %>

--- a/app/views/candidate_interface/satisfaction_survey/improvements.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/improvements.html.erb
@@ -1,18 +1,6 @@
-<% content_for :title, t('page_titles.improvements') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_needed_additional_learning_path) %>
-
-<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_improvements_path, method: :post do |f| %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-
-      <h2 class="govuk-heading-xl">
-        <%= t('page_titles.improvements') %>
-      </h2>
-
-      <%= f.govuk_text_area :answer, label: { text: '' }, rows: 8, max_words: 400 %>
-    </div>
-  </div>
-
-  <%= f.govuk_submit 'Continue' %>
-<% end %>
+<%= render 'survey_page',
+  title: t('page_titles.improvements'),
+  url: candidate_interface_satisfaction_survey_submit_improvements_path,
+  previous_url: candidate_interface_satisfaction_survey_needed_additional_learning_path,
+  five_radio_buttons: false,
+  text_area: true %>

--- a/app/views/candidate_interface/satisfaction_survey/improvements.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/improvements.html.erb
@@ -10,7 +10,6 @@
         <%= t('page_titles.improvements') %>
       </h2>
 
-      <%= f.hidden_field :question, value: t('page_titles.improvements') %>
       <%= f.govuk_text_area :answer, label: { text: '' }, rows: 8, max_words: 400 %>
     </div>
   </div>

--- a/app/views/candidate_interface/satisfaction_survey/needed_additional_learning.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/needed_additional_learning.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.needed_additional_learning'),
   url: candidate_interface_satisfaction_survey_submit_needed_additional_learning_path,
-  previous_url: candidate_interface_satisfaction_survey_confidence_path %>
+  previous_url: candidate_interface_satisfaction_survey_confidence_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/organisation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/organisation.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.organisation'),
   url: candidate_interface_satisfaction_survey_submit_organisation_path,
-  previous_url: candidate_interface_satisfaction_survey_help_needed_path %>
+  previous_url: candidate_interface_satisfaction_survey_help_needed_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/other_information.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/other_information.html.erb
@@ -10,7 +10,6 @@
         <%= t('page_titles.other_information') %>
       </h2>
 
-      <%= f.hidden_field :question, value: t('page_titles.other_information') %>
       <%= f.govuk_text_area :answer, label: { text: '' }, rows: 8, max_words: 400 %>
     </div>
   </div>

--- a/app/views/candidate_interface/satisfaction_survey/other_information.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/other_information.html.erb
@@ -1,0 +1,19 @@
+<% content_for :title, t('page_titles.other_information') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_improvements_path) %>
+
+<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_other_information_path, method: :post do |f| %>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h2 class="govuk-heading-xl">
+        <%= t('page_titles.other_information') %>
+      </h2>
+
+      <%= f.hidden_field :question, value: t('page_titles.other_information') %>
+      <%= f.govuk_text_area :answer, label: { text: '' }, rows: 8, max_words: 400 %>
+    </div>
+  </div>
+
+  <%= f.govuk_submit 'Continue' %>
+<% end %>

--- a/app/views/candidate_interface/satisfaction_survey/other_information.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/other_information.html.erb
@@ -1,18 +1,6 @@
-<% content_for :title, t('page_titles.other_information') %>
-<% content_for :before_content, govuk_back_link_to(candidate_interface_satisfaction_survey_improvements_path) %>
-
-<%= form_with model: @survey, url: candidate_interface_satisfaction_survey_submit_other_information_path, method: :post do |f| %>
-
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-
-      <h2 class="govuk-heading-xl">
-        <%= t('page_titles.other_information') %>
-      </h2>
-
-      <%= f.govuk_text_area :answer, label: { text: '' }, rows: 8, max_words: 400 %>
-    </div>
-  </div>
-
-  <%= f.govuk_submit 'Continue' %>
-<% end %>
+<%= render 'survey_page',
+  title: t('page_titles.other_information'),
+  url: candidate_interface_satisfaction_survey_submit_other_information_path,
+  previous_url: candidate_interface_satisfaction_survey_improvements_path,
+  five_radio_buttons: false,
+  text_area: true %>

--- a/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/recommendation.html.erb
@@ -1,4 +1,6 @@
 <%= render 'survey_page',
   title: t('page_titles.recommendation'),
   url: candidate_interface_satisfaction_survey_submit_recommendation_path,
-  previous_url: candidate_interface_application_form_path %>
+  previous_url: candidate_interface_application_form_path,
+  five_radio_buttons: true,
+  text_area: false %>

--- a/app/views/candidate_interface/satisfaction_survey/thank_you.html.erb
+++ b/app/views/candidate_interface/satisfaction_survey/thank_you.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, t('page_titles.thank_you') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h2 class="govuk-heading-xl">
+      <%= t('page_titles.thank_you') %>
+    </h2>
+
+    <%= govuk_link_to 'Go to your application dashboard', candidate_interface_application_form_path %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -341,6 +341,9 @@ Rails.application.routes.draw do
 
         get '/improvements' => 'satisfaction_survey#improvements', as: :satisfaction_survey_improvements
         post '/improvements' => 'satisfaction_survey#submit_improvements', as: :satisfaction_survey_submit_improvements
+
+        get '/other_information' => 'satisfaction_survey#other_information', as: :satisfaction_survey_other_information
+        post '/other_information' => 'satisfaction_survey#submit_other_information', as: :satisfaction_survey_submit_other_information
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -340,6 +340,7 @@ Rails.application.routes.draw do
         post '/needed-additional-learning' => 'satisfaction_survey#submit_needed_additional_learning', as: :satisfaction_survey_submit_needed_additional_learning
 
         get '/improvements' => 'satisfaction_survey#improvements', as: :satisfaction_survey_improvements
+        post '/improvements' => 'satisfaction_survey#submit_improvements', as: :satisfaction_survey_submit_improvements
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -342,8 +342,13 @@ Rails.application.routes.draw do
         get '/improvements' => 'satisfaction_survey#improvements', as: :satisfaction_survey_improvements
         post '/improvements' => 'satisfaction_survey#submit_improvements', as: :satisfaction_survey_submit_improvements
 
-        get '/other_information' => 'satisfaction_survey#other_information', as: :satisfaction_survey_other_information
-        post '/other_information' => 'satisfaction_survey#submit_other_information', as: :satisfaction_survey_submit_other_information
+        get '/other-information' => 'satisfaction_survey#other_information', as: :satisfaction_survey_other_information
+        post '/other-information' => 'satisfaction_survey#submit_other_information', as: :satisfaction_survey_submit_other_information
+
+        get '/contact' => 'satisfaction_survey#contact', as: :satisfaction_survey_contact
+        post '/contact' => 'satisfaction_survey#submit_contact', as: :satisfaction_survey_submit_contact
+
+        get '/thank-you' => 'satisfaction_survey#thank_you', as: :satisfaction_survey_thank_you
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -52,18 +52,18 @@ RSpec.describe 'Candidate satisfaction survey' do
     when_i_choose_1
     and_click_continue
     then_i_see_the_improvements_page
-    #
-    # when_i_give_my_feedback
-    # and_click_continue
-    # then_i_see_the_other_information_page
-    #
-    # when_i_give_my_other_feedback
-    # and_click_continue
-    # then_i_see_the_contact_page
-    #
-    # when_i_choose_1
-    # and_click_continue
-    # then_i_see_the_thank_you_page
+
+    when_i_give_my_feedback
+    and_click_continue
+    then_i_see_the_other_information_page
+
+    when_i_give_my_other_feedback
+    and_click_continue
+    then_i_see_the_contact_page
+
+    when_i_choose_1
+    and_click_continue
+    then_i_see_the_thank_you_page
   end
 
   def given_the_satisfaction_survey_flag_is_active
@@ -144,7 +144,7 @@ RSpec.describe 'Candidate satisfaction survey' do
   end
 
   def when_i_give_my_feedback
-    fill_in 'No it was perfect.'
+    page.find('#candidate-interface-satisfaction-survey-form-answer-field').set('No it was perfect.')
   end
 
   def then_i_see_the_other_information_page

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'Candidate satisfaction survey' do
   end
 
   def when_i_give_my_other_feedback
-    fill_in 'None.'
+    page.find('#candidate-interface-satisfaction-survey-form-answer-field').set('None.')
   end
 
   def then_i_see_the_contact_page

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Candidate satisfaction survey' do
     and_click_continue
     then_i_see_the_contact_page
 
-    when_i_choose_1
+    when_i_choose_yes
     and_click_continue
     then_i_see_the_thank_you_page
   end
@@ -159,8 +159,8 @@ RSpec.describe 'Candidate satisfaction survey' do
     expect(page).to have_content(t('page_titles.contact'))
   end
 
-  def when_i_click_yes
-    choose 'Yes'
+  def when_i_choose_yes
+    choose 'Yes, you can contact me'
   end
 
   def then_i_see_the_thank_you_page

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe 'Candidate satisfaction survey' do
     when_i_choose_yes
     and_click_continue
     then_i_see_the_thank_you_page
+    and_my_survey_should_reflect_the_results_i_input
   end
 
   def given_the_satisfaction_survey_flag_is_active
@@ -165,5 +166,29 @@ RSpec.describe 'Candidate satisfaction survey' do
 
   def then_i_see_the_thank_you_page
     expect(page).to have_content(t('page_titles.thank_you'))
+  end
+
+  # i normally wouldn't test something like this in system spec, but as we don't show them any
+  # result i thought we probably should. I know the model tests cover the logic, but
+  # it's a large journey to not check the desired behaviour of.
+
+  def and_my_survey_should_reflect_the_results_i_input
+    expect(ApplicationForm.last.satisfaction_survey).to eq(
+      {
+        'I would recommend this service to a friend or colleague' => '1',
+        'I found this service unnecessarily complex' => '5',
+        'I thought this service was easy to use' => '1',
+        'I needed help using this service' => '1',
+        'I found all the parts of this service well-organised' => '1',
+        'I thought there was too much inconsistency in this website' => '1',
+        'I would imagine that people would learn to use this website very quickly' => '1',
+        'I found this website very awkward to use' => '1',
+        'I felt confident using this service' => '1',
+        'I needed to learn a lot of things before I could get going with this website' => '1',
+        'If you could improve anything on Apply for teacher training what would it be?' => 'No it was perfect.',
+        'Is there anything else you would like to tell us?' => 'None.',
+        'Are you happy for us to contact you with follow-up questions to your feedback?' => 'yes',
+      },
+    )
   end
 end

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -168,10 +168,6 @@ RSpec.describe 'Candidate satisfaction survey' do
     expect(page).to have_content(t('page_titles.thank_you'))
   end
 
-  # i normally wouldn't test something like this in system spec, but as we don't show them any
-  # result i thought we probably should. I know the model tests cover the logic, but
-  # it's a large journey to not check the desired behaviour of.
-
   def and_my_survey_should_reflect_the_results_i_input
     expect(ApplicationForm.last.satisfaction_survey).to eq(
       {


### PR DESCRIPTION
## Context

Last PR to add the candidate satisfaction survey.

Previous PRs #1806, #1811 and #1820 

Candidates need to be able to give feedback on their experience using our service.

This adds the final 4 pages of the flow. 

1. Asks how their experience was using the service (textarea)
2. Asks if they would like to add any other feedback (textarea),
3. Asks for permission to contact them 
4. Thanks them for completing the survey 

## Changes proposed in this pull request

- Adds page asking them how they would improve the service

![image](https://user-images.githubusercontent.com/42515961/78341552-d30f7480-758f-11ea-9c1c-3500c19f3fe2.png)

- Adds page that asks if they want to say anything else

![image](https://user-images.githubusercontent.com/42515961/78341581-dacf1900-758f-11ea-8b60-1bbfbe2733f2.png)

- Adds page that asks if we can contact them

![image](https://user-images.githubusercontent.com/42515961/78341605-e3275400-758f-11ea-8ef0-32e513d6fb36.png)

- Adds page that thanks them for filling the survey in

![image](https://user-images.githubusercontent.com/42515961/78341628-ecb0bc00-758f-11ea-9176-8386e087c273.png)

## Guidance to review

Have a click through the whole flow. Try the backlinks etc.

## Link to Trello card

https://trello.com/c/tO5B8iK1/1257-dev-survey-to-candidates-when-they-have-submitted-an-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
