### PR TITLE
Remove hidden field for id in edit other qualification page

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -32,7 +32,7 @@ module CandidateInterface
     end
 
     def update
-      @qualification = OtherQualificationForm.new(other_qualification_params)
+      @qualification = OtherQualificationForm.new(other_qualifcations_update_params)
 
       if @qualification.update(current_application)
         current_application.update!(other_qualifications_completed: false)
@@ -53,6 +53,13 @@ module CandidateInterface
       params.require(:candidate_interface_other_qualification_form).permit(
         :id, :qualification_type, :subject, :institution_name, :grade, :award_year
       )
+        .transform_values(&:strip)
+    end
+
+    def other_qualifcations_update_params
+      params.require(:candidate_interface_other_qualification_form).permit(
+        :qualification_type, :subject, :institution_name, :grade, :award_year
+      ).merge!(id: params[:id])
         .transform_values(&:strip)
     end
   end

--- a/app/views/candidate_interface/other_qualifications/base/edit.html.erb
+++ b/app/views/candidate_interface/other_qualifications/base/edit.html.erb
@@ -12,8 +12,6 @@
 
       <%= render 'candidate_interface/other_qualifications/shared/instructions' %>
 
-      <%= f.hidden_field :id, value: @qualification.id %>
-
       <%= render 'form', f: f %>
 
       <%= f.govuk_submit t('application_form.other_qualification.base.button') %>


### PR DESCRIPTION
## Context

We're still passing Id through a hidden field on the edit other qualification page.


## Changes proposed in this pull request

- Refactor to grab it from the query string params.

## Link to Trello card

https://trello.com/c/kDK3DZnr/1228-dev-content-qualifications-prompt-candidates-to-input-all

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
