### PR TITLE
Correction to copy on support for disability page

### DIFF
--- a/app/views/candidate_interface/training_with_a_disability/edit.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/edit.html.erb
@@ -25,7 +25,6 @@
         <h2 class="govuk-heading-m">It’s against the law to discriminate</h2>
         <p class="govuk-body">If you’re disabled, <%= govuk_link_to 'it’s against the law to discriminate against you', 'https://getintoteaching.education.gov.uk/train-to-teach-with-a-disability' %>. Training providers must not:</p>
         <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
-          <li>organising equipment like a hearing loop or an adapted keyboard</li>
           <li>ask disability or health questions if they’re not relevant to your ability to become a teacher</li>
           <li>reject your application because you’re disabled</li>
         </ul>


### PR DESCRIPTION
## Context

During copy review an error was spotted.

## Changes proposed in this pull request

Before:

![image](https://user-images.githubusercontent.com/450843/78381825-d1fd3800-75cd-11ea-9e93-effedeeecdc8.png)

After:

![image](https://user-images.githubusercontent.com/450843/78381475-5307ff80-75cd-11ea-9ced-29d6f5f7138c.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/HTdtOhLC/1259-dev-correct-guidance-on-the-support-for-disability-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
