### PR TITLE
Expose applications that need support intervention

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -49,7 +49,6 @@ module CandidateInterface
     attr_reader :application_form
 
     def course_row(course_choice)
-      url = "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course_choice.provider.code}/#{course_choice.course.code}"
       change_path = if FeatureFlag.active?('edit_course_choices') && has_multiple_courses?(course_choice)
                       candidate_interface_course_choices_course_path(
                         course_choice.provider.id,
@@ -59,7 +58,7 @@ module CandidateInterface
 
       {
         key: 'Course',
-        value: govuk_link_to("#{course_choice.offered_course.name} (#{course_choice.offered_course.code})", url, target: '_blank', rel: 'noopener'),
+        value: govuk_link_to("#{course_choice.offered_course.name} (#{course_choice.offered_course.code})", course_choice.offered_course.find_url, target: '_blank', rel: 'noopener'),
         action: "course choice for #{course_choice.course.name_and_code}",
         change_path: change_path,
       }

--- a/app/components/grouped_provider_courses_component.html.erb
+++ b/app/components/grouped_provider_courses_component.html.erb
@@ -11,7 +11,7 @@
         <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
           <ul class="govuk-list govuk-list--bullet">
             <% provider.courses.sort_by(&:name).each do |course| %>
-              <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
+              <li><%= govuk_link_to course.name_and_code, course.find_url %></li>
             <% end %>
           </ul>
         </div>

--- a/app/components/support_interface/provider_courses_table_component.rb
+++ b/app/components/support_interface/provider_courses_table_component.rb
@@ -43,7 +43,7 @@ module SupportInterface
 
     def link_to_find_course_page(course)
       if course.exposed_in_find?
-        govuk_link_to 'Find course page', "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}"
+        govuk_link_to 'Find course page', course.find_url
       end
     end
 

--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -8,6 +8,10 @@ module SupportInterface
       @application_form = application_form
     end
 
+    def action_required
+      @monitor = SupportInterface::ApplicationMonitor.new
+    end
+
     def audit
       @application_form = application_form
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -55,4 +55,8 @@ class Course < ApplicationRecord
   def full?
     course_options.all?(&:no_vacancies?)
   end
+
+  def find_url
+    @find_url ||= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{code}"
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -57,6 +57,6 @@ class Course < ApplicationRecord
   end
 
   def find_url
-    @find_url ||= "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{code}"
+    "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{code}"
   end
 end

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -12,9 +12,15 @@ module SupportInterface
       ).map(&:application_form)
     end
 
-    def applications_to_full_courses
+    def applications_to_removed_sites
       active_applications.where(
         course_option: CourseOption.where(invalidated_by_find: true),
+      ).map(&:application_form)
+    end
+
+    def applications_to_courses_with_sites_without_vacancies
+      active_applications.where(
+        course_option: CourseOption.where(vacancy_status: 'no_vacancies'),
       ).map(&:application_form)
     end
 

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -1,21 +1,27 @@
 module SupportInterface
   class ApplicationMonitor
     def applications_to_disabled_courses
-      ApplicationChoice.where(
+      active_applications.where(
         course_option: CourseOption.joins(:course).where('courses.open_on_apply' => false),
       ).map(&:application_form)
     end
 
     def applications_to_hidden_courses
-      ApplicationChoice.where(
+      active_applications.where(
         course_option: CourseOption.joins(:course).where('courses.open_on_apply' => true, 'courses.exposed_in_find' => false),
       ).map(&:application_form)
     end
 
     def applications_to_full_courses
-      ApplicationChoice.where(
+      active_applications.where(
         course_option: CourseOption.where(invalidated_by_find: true),
       ).map(&:application_form)
+    end
+
+  private
+
+    def active_applications
+      ApplicationChoice.where('status NOT IN (?)', %w[rejected declined withdrawn enrolled conditions_not_met])
     end
   end
 end

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -1,0 +1,21 @@
+module SupportInterface
+  class ApplicationMonitor
+    def applications_to_disabled_courses
+      ApplicationChoice.where(
+        course_option: CourseOption.joins(:course).where('courses.open_on_apply' => false),
+      ).map(&:application_form)
+    end
+
+    def applications_to_hidden_courses
+      ApplicationChoice.where(
+        course_option: CourseOption.joins(:course).where('courses.open_on_apply' => true, 'courses.exposed_in_find' => false),
+      ).map(&:application_form)
+    end
+
+    def applications_to_full_courses
+      ApplicationChoice.where(
+        course_option: CourseOption.where(invalidated_by_find: true),
+      ).map(&:application_form)
+    end
+  end
+end

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -35,7 +35,7 @@
             <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
               <ul class="govuk-list govuk-list--bullet">
                 <% provider.courses.sort_by(&:name).each do |course| %>
-                  <li><%= govuk_link_to course.name_and_code, "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{course.provider.code}/#{course.code}" %></li>
+                  <li><%= govuk_link_to course.name_and_code, course.find_url %></li>
                 <% end %>
               </ul>
             </div>

--- a/app/views/candidate_interface/course_choices/full.html.erb
+++ b/app/views/candidate_interface/course_choices/full.html.erb
@@ -19,10 +19,7 @@
       </li>
       <li>
         contact
-        <%= govuk_link_to(
-          @course.provider.name,
-          "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}#section-contact"
-        ) %>
+        <%= govuk_link_to @course.provider.name, "#{@course.find_url}#section-contact" %>
       to see if the course will re-open or discuss alternatives
       </li>
     </ul>

--- a/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
+++ b/app/views/candidate_interface/find_course_selections/confirm_selection.html.erb
@@ -8,7 +8,7 @@
       </h1>
 
       <div class="govuk-inset-text govuk-!-margin-top-0">
-        <%= link_to "https://find-postgraduate-teacher-training.education.gov.uk/course/#{@course_selection_form.course.provider.code}/#{@course_selection_form.course.code}",
+        <%= link_to @course_selection_form.course.find_url,
                     class: 'govuk-!-font-weight-bold govuk-link',
                     style: 'text-decoration: none' do %>
         <span class="govuk-!-font-size-19">

--- a/app/views/support_interface/application_forms/action_required.html.erb
+++ b/app/views/support_interface/application_forms/action_required.html.erb
@@ -1,0 +1,13 @@
+<% content_for :title, 'Applications - action required' %>
+
+<h2 class='govuk-heading-m'>Applications to courses that no longer are available on Apply</h2>
+
+<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @monitor.applications_to_disabled_courses) %>
+
+<h2 class='govuk-heading-m'>Applications to courses that have been removed from Find, but were open on Apply</h2>
+
+<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @monitor.applications_to_hidden_courses) %>
+
+<h2 class='govuk-heading-m'>List of applications that are made to courses that no longer have vacancies</h2>
+
+<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @monitor.applications_to_full_courses) %>

--- a/app/views/support_interface/application_forms/action_required.html.erb
+++ b/app/views/support_interface/application_forms/action_required.html.erb
@@ -10,4 +10,8 @@
 
 <h2 class='govuk-heading-m'>List of applications that are made to courses that no longer have vacancies</h2>
 
-<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @monitor.applications_to_full_courses) %>
+<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @monitor.applications_to_courses_with_sites_without_vacancies) %>
+
+<h2 class='govuk-heading-m'>List of applications that are made to sites that no longer exist</h2>
+
+<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @monitor.applications_to_removed_sites) %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -37,8 +37,8 @@
   <h2 class="govuk-heading-l govuk-!-margin-top-8">Course choices</h2>
   <% @application_form.application_choices.includes(:course, :provider, :site, :offered_course_option).each do |application_choice| %>
     <% rows = [
-      { key: 'Course', value: application_choice.offered_course.name_and_code },
-      { key: 'Provider', value: application_choice.offered_course.provider.name_and_code },
+      { key: 'Course', value: govuk_link_to(application_choice.offered_course.name_and_code, support_interface_course_path(application_choice.offered_course)) },
+      { key: 'Provider', value: govuk_link_to(application_choice.offered_course.provider.name_and_code, support_interface_provider_path(application_choice.offered_course.provider)) },
       { key: 'Location', value: application_choice.offered_option.site.name_and_code },
       { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) },
     ] %>

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -6,7 +6,7 @@
 
 <%= render(SummaryCardComponent.new(rows: {
   'Name' => @course.name_and_code,
-  'Provider' => @course.provider.name_and_code,
+  'Provider' => govuk_link_to(@course.provider.name_and_code, support_interface_provider_path(@course.provider)),
   'Accredited body' => @course.accredited_provider&.name_and_code || 'None',
   'Level' => @course.level.humanize,
   'Recruitment cycle year' => @course.recruitment_cycle_year,

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -13,6 +13,8 @@
   'Last updated' => @course.updated_at.to_s(:govuk_date_and_time),
   'Study modes' => @course.study_mode.humanize,
   'Financial support' => @course.financial_support,
+  'Info page' => govuk_link_to('View on Find', @course.find_url),
+  'Start on Apply' => govuk_link_to('View on Apply (candidate)', candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code)),
 })) %>
 
 <h2 class='govuk-heading-m'>Settings</h2>

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -5,6 +5,7 @@
 <ul class='govuk-body'>
   <li><%= govuk_link_to 'Performance dashboard', integrations_performance_path %> (public)</li>
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
+  <li><%= govuk_link_to 'Applications that require action', support_interface_action_required_path %></li>
 </ul>
 
 <h2 class='govuk-heading-l'>Downloads for analysis</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -419,6 +419,7 @@ Rails.application.routes.draw do
     get '/email-log', to: 'email_log#index', as: :email_log
 
     get '/applications' => 'application_forms#index'
+    get '/applications/action-required' => 'application_forms#action_required', as: :action_required
     get '/applications/:application_form_id' => 'application_forms#show', as: :application_form
     get '/applications/:application_form_id/add-course' => 'application_forms#select_course_to_add', as: :add_course_to_application
     post '/applications/:application_form_id/add-course' => 'application_forms#add_course'

--- a/spec/services/support_interface/application_monitor_spec.rb
+++ b/spec/services/support_interface/application_monitor_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ApplicationMonitor do
+  describe '#applications_to_disabled_courses' do
+    it 'returns applications to courses that have been disabled' do
+      application_to_open_course = create(:application_choice)
+      application_to_open_course.course.update! open_on_apply: true
+      application_to_closed_course = create(:application_choice)
+      application_to_closed_course.course.update! open_on_apply: false
+
+      applications = described_class.new.applications_to_disabled_courses
+
+      expect(applications.map(&:id)).not_to include(application_to_open_course.application_form_id)
+      expect(applications.map(&:id)).to include(application_to_closed_course.application_form_id)
+    end
+  end
+
+  describe '#applications_to_hidden_courses' do
+    it 'returns applications to courses that have been remove from Find' do
+      application_to_visible_course = create(:application_choice)
+      application_to_visible_course.course.update! open_on_apply: true, exposed_in_find: true
+      application_to_hidden_course = create(:application_choice)
+      application_to_hidden_course.course.update! open_on_apply: true, exposed_in_find: false
+
+      applications = described_class.new.applications_to_hidden_courses
+
+      expect(applications.map(&:id)).not_to include(application_to_visible_course.application_form_id)
+      expect(applications.map(&:id)).to include(application_to_hidden_course.application_form_id)
+    end
+  end
+
+  describe '#applications_to_full_courses' do
+    it 'returns applications to courses that have marked as no longer having vacancies' do
+      with_vacancies = create(:application_choice, course_option: create(:course_option, invalidated_by_find: false))
+      without_vacancies = create(:application_choice, course_option: create(:course_option, invalidated_by_find: true))
+
+      applications = described_class.new.applications_to_full_courses
+
+      expect(applications.map(&:id)).not_to include(with_vacancies.application_form_id)
+      expect(applications.map(&:id)).to include(without_vacancies.application_form_id)
+    end
+  end
+end

--- a/spec/services/support_interface/application_monitor_spec.rb
+++ b/spec/services/support_interface/application_monitor_spec.rb
@@ -3,23 +3,26 @@ require 'rails_helper'
 RSpec.describe SupportInterface::ApplicationMonitor do
   describe '#applications_to_disabled_courses' do
     it 'returns applications to courses that have been disabled' do
-      application_to_open_course = create(:application_choice)
+      application_to_open_course = create(:application_choice, status: 'awaiting_provider_decision')
       application_to_open_course.course.update! open_on_apply: true
-      application_to_closed_course = create(:application_choice)
+      application_to_closed_course = create(:application_choice, status: 'awaiting_provider_decision')
       application_to_closed_course.course.update! open_on_apply: false
+      rejected_application_to_closed_course = create(:application_choice, status: 'rejected')
+      rejected_application_to_closed_course.course.update! open_on_apply: false
 
       applications = described_class.new.applications_to_disabled_courses
 
       expect(applications.map(&:id)).not_to include(application_to_open_course.application_form_id)
+      expect(applications.map(&:id)).not_to include(rejected_application_to_closed_course.application_form_id)
       expect(applications.map(&:id)).to include(application_to_closed_course.application_form_id)
     end
   end
 
   describe '#applications_to_hidden_courses' do
     it 'returns applications to courses that have been remove from Find' do
-      application_to_visible_course = create(:application_choice)
+      application_to_visible_course = create(:application_choice, status: 'awaiting_provider_decision')
       application_to_visible_course.course.update! open_on_apply: true, exposed_in_find: true
-      application_to_hidden_course = create(:application_choice)
+      application_to_hidden_course = create(:application_choice, status: 'awaiting_provider_decision')
       application_to_hidden_course.course.update! open_on_apply: true, exposed_in_find: false
 
       applications = described_class.new.applications_to_hidden_courses
@@ -31,8 +34,8 @@ RSpec.describe SupportInterface::ApplicationMonitor do
 
   describe '#applications_to_full_courses' do
     it 'returns applications to courses that have marked as no longer having vacancies' do
-      with_vacancies = create(:application_choice, course_option: create(:course_option, invalidated_by_find: false))
-      without_vacancies = create(:application_choice, course_option: create(:course_option, invalidated_by_find: true))
+      with_vacancies = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: false))
+      without_vacancies = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: true))
 
       applications = described_class.new.applications_to_full_courses
 

--- a/spec/services/support_interface/application_monitor_spec.rb
+++ b/spec/services/support_interface/application_monitor_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SupportInterface::ApplicationMonitor do
   end
 
   describe '#applications_to_hidden_courses' do
-    it 'returns applications to courses that have been remove from Find' do
+    it 'returns applications to courses that have been removed from Find' do
       application_to_visible_course = create(:application_choice, status: 'awaiting_provider_decision')
       application_to_visible_course.course.update! open_on_apply: true, exposed_in_find: true
       application_to_hidden_course = create(:application_choice, status: 'awaiting_provider_decision')
@@ -32,15 +32,27 @@ RSpec.describe SupportInterface::ApplicationMonitor do
     end
   end
 
-  describe '#applications_to_full_courses' do
+  describe '#applications_to_courses_with_sites_without_vacancies' do
     it 'returns applications to courses that have marked as no longer having vacancies' do
-      with_vacancies = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: false))
-      without_vacancies = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: true))
+      with_vacancies = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, vacancy_status: 'vacancies'))
+      without_vacancies = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, vacancy_status: 'no_vacancies'))
 
-      applications = described_class.new.applications_to_full_courses
+      applications = described_class.new.applications_to_courses_with_sites_without_vacancies
 
       expect(applications.map(&:id)).not_to include(with_vacancies.application_form_id)
       expect(applications.map(&:id)).to include(without_vacancies.application_form_id)
+    end
+  end
+
+  describe '#applications_to_removed_sites' do
+    it 'returns applications to sites that have been removed from Find' do
+      with_okay_site = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: false))
+      with_removed_site = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: true))
+
+      applications = described_class.new.applications_to_removed_sites
+
+      expect(applications.map(&:id)).not_to include(with_okay_site.application_form_id)
+      expect(applications.map(&:id)).to include(with_removed_site.application_form_id)
     end
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   end
 
   def then_i_should_be_redirected_to_the_course_on_find
-    expect(page.current_url).to eq("https://find-postgraduate-teacher-training.education.gov.uk/course/#{@course.provider.code}/#{@course.code}")
+    expect(page.current_url).to eq("https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{@course.provider.code}/#{@course.code}")
   end
 
   def when_i_return_to_the_course_selection_page


### PR DESCRIPTION
## Context

There are ~3~ 4 situations in which applications need manual intervention:

- The course is removed from Apply
- The course is removed from Find
- The course's site is removed from Find
- The course is full

## Changes proposed in this pull request

Add a page with applications that need intervention. It's fairly MVP! Also a few UI tweaks to make it easier to navigate the support section.

<img width="1552" alt="Screenshot 2020-04-06 at 14 44 15" src="https://user-images.githubusercontent.com/233676/78568588-390f2c80-781a-11ea-964f-a96109b5d6f0.png">

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/fRAKJt36/1264-expose-applications-that-need-support-intervention

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
