### PR TITLE
Support users can download the satisfaction survey results in a CSV

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -59,5 +59,19 @@ module SupportInterface
 
       send_data csv, filename: "referee-survey-#{Time.zone.today}.csv", disposition: :attachment
     end
+
+    def candidate_survey
+      answers = SupportInterface::CandidateSurveyExport.new.call
+
+      csv = CSV.generate do |rows|
+        rows << answers&.first&.keys
+
+        answers&.each do |answer|
+          rows << answer.values
+        end
+      end
+
+      send_data csv, filename: "candidate-survey-#{Time.zone.today}.csv", disposition: :attachment
+    end
   end
 end

--- a/app/services/support_interface/candidate_survey_export.rb
+++ b/app/services/support_interface/candidate_survey_export.rb
@@ -1,0 +1,36 @@
+module SupportInterface
+  class CandidateSurveyExport
+    def call
+      application_forms = ApplicationForm.where.not(satisfaction_survey: nil)
+
+      output = []
+
+      application_forms.includes(:candidate).each do |application_form|
+        survey = application_form.satisfaction_survey
+
+        answer = {
+          'Name' => application_form.full_name,
+          'Email_address' => application_form.candidate.email_address,
+          'Phone number' => application_form.phone_number,
+          I18n.t('page_titles.recommendation') => survey[I18n.t('page_titles.recommendation')],
+          I18n.t('page_titles.complexity') => survey[I18n.t('page_titles.complexity')],
+          I18n.t('page_titles.ease_of_use') => survey[I18n.t('page_titles.ease_of_use')],
+          I18n.t('page_titles.help_needed') => survey[I18n.t('page_titles.help_needed')],
+          I18n.t('page_titles.organisation') => survey[I18n.t('page_titles.organisation')],
+          I18n.t('page_titles.consistency') => survey[I18n.t('page_titles.consistency')],
+          I18n.t('page_titles.adaptability') => survey[I18n.t('page_titles.adaptability')],
+          I18n.t('page_titles.awkward') => survey[I18n.t('page_titles.awkward')],
+          I18n.t('page_titles.confidence') => survey[I18n.t('page_titles.confidence')],
+          I18n.t('page_titles.needed_additional_learning') => survey[I18n.t('page_titles.needed_additional_learning')],
+          I18n.t('page_titles.improvements') => survey[I18n.t('page_titles.improvements')],
+          I18n.t('page_titles.other_information') => survey[I18n.t('page_titles.other_information')],
+          I18n.t('page_titles.contact') => survey[I18n.t('page_titles.contact')],
+        }
+
+        output << answer
+      end
+
+      output
+    end
+  end
+end

--- a/app/services/support_interface/candidate_survey_export.rb
+++ b/app/services/support_interface/candidate_survey_export.rb
@@ -8,24 +8,15 @@ module SupportInterface
       application_forms.includes(:candidate).each do |application_form|
         survey = application_form.satisfaction_survey
 
+        survey_fields = CandidateInterface::SatisfactionSurveyForm::QUESTIONS_WE_ASK
+          .index_with { |question| survey[question] }
+
+
         answer = {
           'Name' => application_form.full_name,
           'Email_address' => application_form.candidate.email_address,
           'Phone number' => application_form.phone_number,
-          I18n.t('page_titles.recommendation') => survey[I18n.t('page_titles.recommendation')],
-          I18n.t('page_titles.complexity') => survey[I18n.t('page_titles.complexity')],
-          I18n.t('page_titles.ease_of_use') => survey[I18n.t('page_titles.ease_of_use')],
-          I18n.t('page_titles.help_needed') => survey[I18n.t('page_titles.help_needed')],
-          I18n.t('page_titles.organisation') => survey[I18n.t('page_titles.organisation')],
-          I18n.t('page_titles.consistency') => survey[I18n.t('page_titles.consistency')],
-          I18n.t('page_titles.adaptability') => survey[I18n.t('page_titles.adaptability')],
-          I18n.t('page_titles.awkward') => survey[I18n.t('page_titles.awkward')],
-          I18n.t('page_titles.confidence') => survey[I18n.t('page_titles.confidence')],
-          I18n.t('page_titles.needed_additional_learning') => survey[I18n.t('page_titles.needed_additional_learning')],
-          I18n.t('page_titles.improvements') => survey[I18n.t('page_titles.improvements')],
-          I18n.t('page_titles.other_information') => survey[I18n.t('page_titles.other_information')],
-          I18n.t('page_titles.contact') => survey[I18n.t('page_titles.contact')],
-        }
+        }.merge(survey_fields)
 
         output << answer
       end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -51,3 +51,13 @@
 <p class='govuk-body'>
   <%= govuk_link_to 'Download referee survey results (CSV)', support_interface_referee_survey_path %>
 </p>
+
+<h3 class='govuk-heading-m'>Candidate survey</h3>
+
+<p class='govuk-body'>
+  This provides the compiled results of all the candidate satisfaction surveys
+</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download candidate survey results (CSV)', support_interface_candidate_survey_path %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -502,6 +502,8 @@ Rails.application.routes.draw do
     get '/performance/submitted-application-choices', to: 'performance#submitted_application_choices', as: :submitted_application_choices
     get '/performance/referee-survey', to: 'performance#referee_survey', as: :referee_survey
     get '/performance/providers', to: 'performance#providers_export', as: :providers_export
+    get '/performance/candidate-survey', to: 'performance#candidate_survey', as: :candidate_survey
+
 
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -66,6 +66,26 @@ FactoryBot.define do
         end
       end
 
+      trait :with_survey_completed do
+        satisfaction_survey {
+          {
+             I18n.t('page_titles.recommendation') => [*1..5].sample.to_s,
+             I18n.t('page_titles.complexity') => [*1..5].sample.to_s,
+             I18n.t('page_titles.ease_of_use') => [*1..5].sample.to_s,
+             I18n.t('page_titles.help_needed') => [*1..5].sample.to_s,
+             I18n.t('page_titles.organisation') => [*1..5].sample.to_s,
+             I18n.t('page_titles.consistency') => [*1..5].sample.to_s,
+             I18n.t('page_titles.adaptability') => [*1..5].sample.to_s,
+             I18n.t('page_titles.awkward') => [*1..5].sample.to_s,
+             I18n.t('page_titles.confidence') => [*1..5].sample.to_s,
+             I18n.t('page_titles.needed_additional_learning') => [*1..5].sample.to_s,
+             I18n.t('page_titles.improvements') => Faker::Lorem.paragraph_by_chars(number: 400),
+             I18n.t('page_titles.other_information') => Faker::Lorem.paragraph_by_chars(number: 400),
+             I18n.t('page_titles.contact') => %w[yes no].sample,
+           }
+        }
+      end
+
       after(:build) do |application_form, evaluator|
         if evaluator.with_gces
           create(:gcse_qualification, application_form: application_form, subject: 'maths')

--- a/spec/services/support_interface/candidate_survey_export_spec.rb
+++ b/spec/services/support_interface/candidate_survey_export_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::CandidateSurveyExport do
+  describe '#call' do
+    it 'returns a hash of candidates satisfaction survey answers' do
+      application_form1 = create(:completed_application_form, :with_survey_completed)
+      application_form2 = create(:completed_application_form, :with_survey_completed)
+      application_form3 = create(:completed_application_form, :with_survey_completed)
+      create(:completed_application_form)
+
+
+      expect(described_class.new.call).to match_array([return_expected_hash(application_form1), return_expected_hash(application_form2), return_expected_hash(application_form3)])
+    end
+  end
+
+private
+
+  def return_expected_hash(application_form)
+    survey = application_form.satisfaction_survey
+
+    {
+      'Name' => application_form.full_name,
+      'Email_address' => application_form.candidate.email_address,
+      'Phone number' => application_form.phone_number,
+      I18n.t('page_titles.recommendation') => survey[I18n.t('page_titles.recommendation').to_s],
+      I18n.t('page_titles.complexity') => survey[I18n.t('page_titles.complexity').to_s],
+      I18n.t('page_titles.ease_of_use') => survey[I18n.t('page_titles.ease_of_use').to_s],
+      I18n.t('page_titles.help_needed') => survey[I18n.t('page_titles.help_needed').to_s],
+      I18n.t('page_titles.organisation') => survey[I18n.t('page_titles.organisation').to_s],
+      I18n.t('page_titles.consistency') => survey[I18n.t('page_titles.consistency').to_s],
+      I18n.t('page_titles.adaptability') => survey[I18n.t('page_titles.adaptability').to_s],
+      I18n.t('page_titles.awkward') => survey[I18n.t('page_titles.awkward').to_s],
+      I18n.t('page_titles.confidence') => survey[I18n.t('page_titles.confidence').to_s],
+      I18n.t('page_titles.needed_additional_learning') => survey[I18n.t('page_titles.needed_additional_learning').to_s],
+      I18n.t('page_titles.improvements') => survey[I18n.t('page_titles.improvements').to_s],
+      I18n.t('page_titles.other_information') => survey[I18n.t('page_titles.other_information').to_s],
+      I18n.t('page_titles.contact') => survey[I18n.t('page_titles.contact').to_s],
+    }
+  end
+end

--- a/spec/services/support_interface/candidate_survey_export_spec.rb
+++ b/spec/services/support_interface/candidate_survey_export_spec.rb
@@ -18,23 +18,14 @@ private
   def return_expected_hash(application_form)
     survey = application_form.satisfaction_survey
 
+    survey_fields = CandidateInterface::SatisfactionSurveyForm::QUESTIONS_WE_ASK
+      .index_with { |question| survey[question] }
+
+
     {
       'Name' => application_form.full_name,
       'Email_address' => application_form.candidate.email_address,
       'Phone number' => application_form.phone_number,
-      I18n.t('page_titles.recommendation') => survey[I18n.t('page_titles.recommendation').to_s],
-      I18n.t('page_titles.complexity') => survey[I18n.t('page_titles.complexity').to_s],
-      I18n.t('page_titles.ease_of_use') => survey[I18n.t('page_titles.ease_of_use').to_s],
-      I18n.t('page_titles.help_needed') => survey[I18n.t('page_titles.help_needed').to_s],
-      I18n.t('page_titles.organisation') => survey[I18n.t('page_titles.organisation').to_s],
-      I18n.t('page_titles.consistency') => survey[I18n.t('page_titles.consistency').to_s],
-      I18n.t('page_titles.adaptability') => survey[I18n.t('page_titles.adaptability').to_s],
-      I18n.t('page_titles.awkward') => survey[I18n.t('page_titles.awkward').to_s],
-      I18n.t('page_titles.confidence') => survey[I18n.t('page_titles.confidence').to_s],
-      I18n.t('page_titles.needed_additional_learning') => survey[I18n.t('page_titles.needed_additional_learning').to_s],
-      I18n.t('page_titles.improvements') => survey[I18n.t('page_titles.improvements').to_s],
-      I18n.t('page_titles.other_information') => survey[I18n.t('page_titles.other_information').to_s],
-      I18n.t('page_titles.contact') => survey[I18n.t('page_titles.contact').to_s],
-    }
+    }.merge(survey_fields)
   end
 end

--- a/spec/system/support_interface/candidate_survey_csv_spec.rb
+++ b/spec/system/support_interface/candidate_survey_csv_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate survey CSV' do
+  include DfESignInHelpers
+
+  scenario 'support user can download a CSV with the candidate satisfaction survey results' do
+    given_i_am_a_support_user
+    and_there_are_candidate_survey_results
+
+    when_i_visit_the_service_performance_page
+    and_i_click_on_download_candidate_survey_results
+    then_i_should_be_able_to_download_a_csv
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_candidate_survey_results
+    create_list(:completed_application_form, 3, :with_survey_completed)
+  end
+
+  def when_i_visit_the_service_performance_page
+    visit support_interface_performance_path
+  end
+
+  def and_i_click_on_download_candidate_survey_results
+    click_link 'Download candidate satisfcation survey results (CSV)'
+  end
+
+  def then_i_should_be_able_to_download_a_csv
+    expect(page).to have_content ApplicationForm.first.full_name
+    expect(page).to have_content ApplicationForm.second.full_name
+    expect(page).to have_content ApplicationForm.third.full_name
+  end
+end

--- a/spec/system/support_interface/candidate_survey_csv_spec.rb
+++ b/spec/system/support_interface/candidate_survey_csv_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Candidate survey CSV' do
   end
 
   def and_i_click_on_download_candidate_survey_results
-    click_link 'Download candidate satisfcation survey results (CSV)'
+    click_link 'Download candidate survey results (CSV)'
   end
 
   def then_i_should_be_able_to_download_a_csv


### PR DESCRIPTION
## Context

In previous PRs a candidate satisfaction survey was added. This is a follow-up PR which allows support users to be able to download these surveys into a CSV from the Service Performance page.

## Changes proposed in this pull request

- CSV capability for the results of the candidate satisfaction survey.

Before 

![image](https://user-images.githubusercontent.com/42515961/78574497-f94c4300-7821-11ea-8211-44bc7535c6a6.png)


After

![image](https://user-images.githubusercontent.com/42515961/78574376-d1f57600-7821-11ea-8ee8-8ecbc217880c.png)


![image](https://user-images.githubusercontent.com/42515961/78574451-edf91780-7821-11ea-95a5-1e6eb0484ffe.png)


## Guidance to review

- Add a survey via the candidate interact flow
- Click the candidate survey link in the performance page
- Have a look at the CSV. Is it correct?

## Link to Trello card

https://trello.com/c/ralnmC06/1015-dev-download-survey-responses-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
