### PR TITLE
Fix for safeguarding false positives 

### DIFF
--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,7 +1,3 @@
 <h2 class="govuk-heading-m govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
 
-<% if has_disclosed_safeguarding_issues? %>
-  <p class="govuk-body">The candidate has shared information related to safeguarding. Please contact them directly for more details.</p>
-<% else %>
-  <p class="govuk-body">No information shared</p>
-<% end %>
+<p class="govuk-body"><%= message %></p>

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -2,30 +2,17 @@ module ProviderInterface
   class SafeguardingDeclarationComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :application_form
+    attr_reader :safeguarding_status
 
     def initialize(application_form:)
-      @application_form = application_form
+      @safeguarding_status = SafeguardingStatus.new(
+        application_form: application_form,
+        i18n_key: 'provider_interface.safeguarding_declaration_component',
+      )
     end
 
     def message
-      if has_no_answer?
-        I18n.t('provider_interface.safeguarding_declaration_component.no_answer_message')
-      elsif has_disclosed_safeguarding_issues?
-        I18n.t('provider_interface.safeguarding_declaration_component.has_disclosed_message')
-      else
-        I18n.t('provider_interface.safeguarding_declaration_component.no_info_message')
-      end
-    end
-
-  private
-
-    def has_disclosed_safeguarding_issues?
-      @application_form.safeguarding_issues != 'No'
-    end
-
-    def has_no_answer?
-      @application_form.safeguarding_issues.blank?
+      safeguarding_status.message
     end
   end
 end

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -2,17 +2,13 @@ module ProviderInterface
   class SafeguardingDeclarationComponent < ActionView::Component::Base
     include ViewHelper
 
-    attr_reader :safeguarding_status
+    attr_reader :message
 
     def initialize(application_form:)
-      @safeguarding_status = SafeguardingStatus.new(
-        application_form: application_form,
+      @message = SafeguardingStatus.new(
+        status: application_form.safeguarding_issues_status,
         i18n_key: 'provider_interface.safeguarding_declaration_component',
-      )
-    end
-
-    def message
-      safeguarding_status.message
+      ).message
     end
   end
 end

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -8,8 +8,28 @@ module ProviderInterface
       @application_form = application_form
     end
 
+    HAS_DISCLOSED_MESSAGE = 'The candidate has shared information related to safeguarding. Please contact them directly for more details.'.freeze
+    NO_ANSWER_MESSAGE = 'Not answered'.freeze
+    NO_INFO_MESSAGE = 'No information shared'.freeze
+
+    def message
+      if has_no_answer?
+        NO_ANSWER_MESSAGE
+      elsif has_disclosed_safeguarding_issues?
+        HAS_DISCLOSED_MESSAGE
+      else
+        NO_INFO_MESSAGE
+      end
+    end
+
+  private
+
     def has_disclosed_safeguarding_issues?
       @application_form.safeguarding_issues != 'No'
+    end
+
+    def has_no_answer?
+      @application_form.safeguarding_issues.blank?
     end
   end
 end

--- a/app/components/provider_interface/safeguarding_declaration_component.rb
+++ b/app/components/provider_interface/safeguarding_declaration_component.rb
@@ -8,17 +8,13 @@ module ProviderInterface
       @application_form = application_form
     end
 
-    HAS_DISCLOSED_MESSAGE = 'The candidate has shared information related to safeguarding. Please contact them directly for more details.'.freeze
-    NO_ANSWER_MESSAGE = 'Not answered'.freeze
-    NO_INFO_MESSAGE = 'No information shared'.freeze
-
     def message
       if has_no_answer?
-        NO_ANSWER_MESSAGE
+        I18n.t('provider_interface.safeguarding_declaration_component.no_answer_message')
       elsif has_disclosed_safeguarding_issues?
-        HAS_DISCLOSED_MESSAGE
+        I18n.t('provider_interface.safeguarding_declaration_component.has_disclosed_message')
       else
-        NO_INFO_MESSAGE
+        I18n.t('provider_interface.safeguarding_declaration_component.no_info_message')
       end
     end
 

--- a/app/components/support_interface/safeguarding_issues_component.html.erb
+++ b/app/components/support_interface/safeguarding_issues_component.html.erb
@@ -1,0 +1,1 @@
+<p class="govuk-body"><%= message %></p>

--- a/app/components/support_interface/safeguarding_issues_component.rb
+++ b/app/components/support_interface/safeguarding_issues_component.rb
@@ -6,17 +6,13 @@ module SupportInterface
       @application_form = application_form
     end
 
-    HAS_DISCLOSED_MESSAGE = 'The candidate has shared information related to safeguarding.'.freeze
-    NO_ANSWER_MESSAGE = 'Not answered.'.freeze
-    NO_INFO_MESSAGE = 'No information shared.'.freeze
-
     def message
       if has_no_answer?
-        NO_ANSWER_MESSAGE
+        I18n.t('support_interface.safeguarding_issues_component.no_answer_message')
       elsif has_disclosed_safeguarding_issues?
-        HAS_DISCLOSED_MESSAGE
+        I18n.t('support_interface.safeguarding_issues_component.has_disclosed_message')
       else
-        NO_INFO_MESSAGE
+        I18n.t('support_interface.safeguarding_issues_component.no_info_message')
       end
     end
 

--- a/app/components/support_interface/safeguarding_issues_component.rb
+++ b/app/components/support_interface/safeguarding_issues_component.rb
@@ -1,0 +1,33 @@
+module SupportInterface
+  class SafeguardingIssuesComponent < ActionView::Component::Base
+    attr_reader :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    HAS_DISCLOSED_MESSAGE = 'The candidate has shared information related to safeguarding.'.freeze
+    NO_ANSWER_MESSAGE = 'Not answered.'.freeze
+    NO_INFO_MESSAGE = 'No information shared.'.freeze
+
+    def message
+      if has_no_answer?
+        NO_ANSWER_MESSAGE
+      elsif has_disclosed_safeguarding_issues?
+        HAS_DISCLOSED_MESSAGE
+      else
+        NO_INFO_MESSAGE
+      end
+    end
+
+  private
+
+    def has_disclosed_safeguarding_issues?
+      @application_form.safeguarding_issues != 'No'
+    end
+
+    def has_no_answer?
+      @application_form.safeguarding_issues.blank?
+    end
+  end
+end

--- a/app/components/support_interface/safeguarding_issues_component.rb
+++ b/app/components/support_interface/safeguarding_issues_component.rb
@@ -1,16 +1,12 @@
 module SupportInterface
   class SafeguardingIssuesComponent < ActionView::Component::Base
-    attr_reader :safeguarding_status
+    attr_reader :message
 
     def initialize(application_form:)
-      @safeguarding_status = SafeguardingStatus.new(
-        application_form: application_form,
+      @message = SafeguardingStatus.new(
+        status: application_form.safeguarding_issues_status,
         i18n_key: 'support_interface.safeguarding_issues_component',
-      )
-    end
-
-    def message
-      safeguarding_status.message
+      ).message
     end
   end
 end

--- a/app/components/support_interface/safeguarding_issues_component.rb
+++ b/app/components/support_interface/safeguarding_issues_component.rb
@@ -1,29 +1,16 @@
 module SupportInterface
   class SafeguardingIssuesComponent < ActionView::Component::Base
-    attr_reader :application_form
+    attr_reader :safeguarding_status
 
     def initialize(application_form:)
-      @application_form = application_form
+      @safeguarding_status = SafeguardingStatus.new(
+        application_form: application_form,
+        i18n_key: 'support_interface.safeguarding_issues_component',
+      )
     end
 
     def message
-      if has_no_answer?
-        I18n.t('support_interface.safeguarding_issues_component.no_answer_message')
-      elsif has_disclosed_safeguarding_issues?
-        I18n.t('support_interface.safeguarding_issues_component.has_disclosed_message')
-      else
-        I18n.t('support_interface.safeguarding_issues_component.no_info_message')
-      end
-    end
-
-  private
-
-    def has_disclosed_safeguarding_issues?
-      @application_form.safeguarding_issues != 'No'
-    end
-
-    def has_no_answer?
-      @application_form.safeguarding_issues.blank?
+      safeguarding_status.message
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -28,8 +28,6 @@ class ApplicationForm < ApplicationRecord
     never_asked: 'never_asked',
   }
 
-  validates :safeguarding_issues, presence: true, if: :has_safeguarding_issues_to_declare?
-
   before_create -> {
     self.support_reference ||= GenerateSupportRef.call
   }

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -28,6 +28,8 @@ class ApplicationForm < ApplicationRecord
     never_asked: 'never_asked',
   }
 
+  validates :safeguarding_issues, presence: true, if: :has_safeguarding_issues_to_declare?
+
   before_create -> {
     self.support_reference ||= GenerateSupportRef.call
   }

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -21,6 +21,13 @@ class ApplicationForm < ApplicationRecord
     apply_2: 'apply_2',
   }
 
+  enum safeguarding_issues_status: {
+    not_answered_yet: 'not_answered_yet',
+    no_safeguarding_issues_to_declare: 'no_safeguarding_issues_to_declare',
+    has_safeguarding_issues_to_declare: 'has_safeguarding_issues_to_declare',
+    never_asked: 'never_asked',
+  }
+
   before_create -> {
     self.support_reference ||= GenerateSupportRef.call
   }

--- a/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
+++ b/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
@@ -8,15 +8,12 @@ module CandidateInterface
     validates :safeguarding_issues, word_count: { maximum: 400 }
 
     def self.build_from_application(application_form)
-      if (application_form.safeguarding_issues == 'Yes') || (application_form.safeguarding_issues == 'No')
-        new(share_safeguarding_issues: application_form.safeguarding_issues)
-      elsif application_form.safeguarding_issues.present?
-        new(
-          share_safeguarding_issues: 'Yes',
-          safeguarding_issues: application_form.safeguarding_issues,
-        )
+      if application_form.has_safeguarding_issues_to_declare?
+        new(share_safeguarding_issues: 'Yes', safeguarding_issues: application_form.safeguarding_issues)
+      elsif application_form.no_safeguarding_issues_to_declare?
+        new(share_safeguarding_issues: 'No')
       else
-        new(share_safeguarding_issues: nil, safeguarding_issues: nil)
+        new(share_safeguarding_issues: nil)
       end
     end
 
@@ -24,9 +21,15 @@ module CandidateInterface
       return false unless valid?
 
       if share_safeguarding_issues == 'Yes' && safeguarding_issues.present?
-        application_form.update(safeguarding_issues: safeguarding_issues)
+        application_form.update(
+          safeguarding_issues: safeguarding_issues,
+          safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+        )
       else
-        application_form.update(safeguarding_issues: share_safeguarding_issues)
+        application_form.update(
+          safeguarding_issues: nil,
+          safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+        )
       end
     end
   end

--- a/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
+++ b/app/models/candidate_interface/safeguarding_issues_declaration_form.rb
@@ -20,7 +20,7 @@ module CandidateInterface
     def save(application_form)
       return false unless valid?
 
-      if share_safeguarding_issues == 'Yes' && safeguarding_issues.present?
+      if share_safeguarding_issues == 'Yes'
         application_form.update(
           safeguarding_issues: safeguarding_issues,
           safeguarding_issues_status: :has_safeguarding_issues_to_declare,

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -163,7 +163,8 @@ module CandidateInterface
     end
 
     def safeguarding_completed?
-      @application_form.safeguarding_issues.present?
+      @application_form.no_safeguarding_issues_to_declare? ||
+        @application_form.has_safeguarding_issues_to_declare?
     end
 
   private

--- a/app/services/safeguarding_status.rb
+++ b/app/services/safeguarding_status.rb
@@ -1,0 +1,28 @@
+class SafeguardingStatus
+  attr_reader :application_form, :i18n_key
+
+  def initialize(application_form:, i18n_key:)
+    @application_form = application_form
+    @i18n_key = i18n_key
+  end
+
+  def message
+    if has_no_answer?
+      I18n.t("#{i18n_key}.no_answer_message")
+    elsif has_disclosed_safeguarding_issues?
+      I18n.t("#{i18n_key}.has_disclosed_message")
+    else
+      I18n.t("#{i18n_key}.no_info_message")
+    end
+  end
+
+private
+
+  def has_disclosed_safeguarding_issues?
+    @application_form.safeguarding_issues != 'No'
+  end
+
+  def has_no_answer?
+    @application_form.safeguarding_issues.blank?
+  end
+end

--- a/app/services/safeguarding_status.rb
+++ b/app/services/safeguarding_status.rb
@@ -1,28 +1,12 @@
 class SafeguardingStatus
-  attr_reader :application_form, :i18n_key
+  attr_reader :status, :i18n_key
 
-  def initialize(application_form:, i18n_key:)
-    @application_form = application_form
+  def initialize(status:, i18n_key:)
+    @status = status
     @i18n_key = i18n_key
   end
 
   def message
-    if has_no_answer?
-      I18n.t("#{i18n_key}.no_answer_message")
-    elsif has_disclosed_safeguarding_issues?
-      I18n.t("#{i18n_key}.has_disclosed_message")
-    else
-      I18n.t("#{i18n_key}.no_info_message")
-    end
-  end
-
-private
-
-  def has_disclosed_safeguarding_issues?
-    @application_form.safeguarding_issues != 'No'
-  end
-
-  def has_no_answer?
-    @application_form.safeguarding_issues.blank?
+    I18n.t("#{i18n_key}.#{status}")
   end
 end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -95,7 +95,7 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
 
-<%= render SafeguardingIssuesComponent.new(application_form: @application_form) %>
+<%= render SupportInterface::SafeguardingIssuesComponent.new(application_form: @application_form) %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Request feedback</h2>
 

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -93,6 +93,10 @@
 
 <%= render PersonalStatementComponent.new(application_form: @application_form) %>
 
+<h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
+
+<%= render SafeguardingIssuesComponent.new(application_form: @application_form) %>
+
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Request feedback</h2>
 
 <p class="govuk-body">Ask the candidate to fill out a survey.</p>

--- a/config/locales/safeguarding.yml
+++ b/config/locales/safeguarding.yml
@@ -1,0 +1,11 @@
+en:
+  provider_interface:
+    safeguarding_declaration_component:
+      has_disclosed_message: 'The candidate has shared information related to safeguarding. Please contact them directly for more details.'
+      no_answer_message: 'Not answered.'
+      no_info_message: 'No information shared.'
+  support_interface:
+    safeguarding_issues_component:
+      has_disclosed_message: 'The candidate has shared information related to safeguarding.'
+      no_answer_message: 'Not answered.'
+      no_info_message: 'No information shared.'

--- a/config/locales/safeguarding.yml
+++ b/config/locales/safeguarding.yml
@@ -1,9 +1,10 @@
 en:
   provider_interface:
     safeguarding_declaration_component:
-      has_disclosed_message: 'The candidate has shared information related to safeguarding. Please contact them directly for more details.'
-      no_answer_message: 'Not answered.'
-      no_info_message: 'No information shared.'
+      has_safeguarding_issues_to_declare: 'The candidate has shared information related to safeguarding. Please contact them directly for more details.'
+      not_answered_yet: 'Not answered yet.'
+      never_asked: 'Never asked.'
+      no_safeguarding_issues_to_declare: 'No information shared.'
   support_interface:
     safeguarding_issues_component:
       has_disclosed_message: 'The candidate has shared information related to safeguarding.'

--- a/config/locales/safeguarding.yml
+++ b/config/locales/safeguarding.yml
@@ -7,6 +7,7 @@ en:
       no_safeguarding_issues_to_declare: 'No information shared.'
   support_interface:
     safeguarding_issues_component:
-      has_disclosed_message: 'The candidate has shared information related to safeguarding.'
-      no_answer_message: 'Not answered.'
-      no_info_message: 'No information shared.'
+      has_safeguarding_issues_to_declare: 'The candidate has shared information related to safeguarding.'
+      not_answered_yet: 'Not answered yet.'
+      never_asked: 'Never asked.'
+      no_safeguarding_issues_to_declare: 'No information shared.'

--- a/db/migrate/20200408231958_backfill_application_forms_safeguarding_issues_status.rb
+++ b/db/migrate/20200408231958_backfill_application_forms_safeguarding_issues_status.rb
@@ -1,0 +1,11 @@
+class BackfillApplicationFormsSafeguardingIssuesStatus < ActiveRecord::Migration[6.0]
+  def up
+    execute "UPDATE application_forms SET safeguarding_issues_status = 'never_asked' WHERE submitted_at IS NOT NULL AND (safeguarding_issues IS NULL OR safeguarding_issues = '')"
+    execute "UPDATE application_forms SET safeguarding_issues_status = 'no_safeguarding_issues_to_declare' WHERE safeguarding_issues = 'No'"
+    execute "UPDATE application_forms SET safeguarding_issues_status = 'has_safeguarding_issues_to_declare' WHERE NOT safeguarding_issues = 'No' AND safeguarding_issues IS NOT NULL AND NOT safeguarding_issues = ''"
+  end
+
+  def down
+    execute "UPDATE application_forms SET safeguarding_issues_status = 'not_answered_yet'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_08_221253) do
+ActiveRecord::Schema.define(version: 2020_04_08_231958) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -6,47 +6,59 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
   let(:has_not_shared_text) { 'No information shared' }
   let(:has_not_answered_text) { 'Not answered' }
 
-
-  context 'when the candidate has entered "Yes" as an answer to the safeguarding question' do
+  context 'when the candidate was never asked the safeguarding question' do
     it 'displays the correct text' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
-
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: 'never_asked',
+      )
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include(heading)
-      expect(result.text).to include(has_shared_text)
+      expect(result.text).to include('Never asked.')
     end
   end
 
   context 'when the candidate has shared information related to safeguarding' do
     it 'displays the correct text' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: 'I have a criminal conviction.',
+        safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
+      )
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include(heading)
-      expect(result.text).to include(has_shared_text)
+      expect(result.text).to include('The candidate has shared information related to safeguarding. Please contact them directly for more details.')
     end
   end
 
   context 'when the candidate has not shared information related to safeguarding' do
     it 'displays the correct text' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
-
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: 'no_safeguarding_issues_to_declare',
+      )
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include(heading)
-      expect(result.text).to include(has_not_shared_text)
+      expect(result.text).to include('No information shared.')
     end
   end
 
   context 'when the candidate has not answered the safeguarding question' do
     it 'displays the correct text' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: nil)
-
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: 'not_answered_yet',
+      )
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include(heading)
-      expect(result.text).to include(has_not_answered_text)
+      expect(result.text).to include('Not answered yet')
     end
   end
 end

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
   end
 
   context 'when the candidate has not shared information related to safeguarding' do
-    it 'displays the corrent text' do
+    it 'displays the correct text' do
       application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
 
       result = render_inline(described_class.new(application_form: application_form))
@@ -40,7 +40,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
   end
 
   context 'when the candidate has not answered the safeguarding question' do
-    it 'displays the corrent text' do
+    it 'displays the correct text' do
       application_form = build_stubbed(:application_form, safeguarding_issues: nil)
 
       result = render_inline(described_class.new(application_form: application_form))

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -2,9 +2,6 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
   let(:heading) { 'Criminal convictions and professional misconduct' }
-  let(:has_shared_text) { 'The candidate has shared information related to safeguarding. Please contact them directly for more details.' }
-  let(:has_not_shared_text) { 'No information shared' }
-  let(:has_not_answered_text) { 'Not answered' }
 
   context 'when the candidate was never asked the safeguarding question' do
     it 'displays the correct text' do

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
   let(:heading) { 'Criminal convictions and professional misconduct' }
   let(:has_shared_text) { 'The candidate has shared information related to safeguarding. Please contact them directly for more details.' }
   let(:has_not_shared_text) { 'No information shared' }
+  let(:has_not_answered_text) { 'Not answered' }
 
 
   context 'when the candidate has entered "Yes" as an answer to the safeguarding question' do
@@ -35,6 +36,17 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
 
       expect(result.text).to include(heading)
       expect(result.text).to include(has_not_shared_text)
+    end
+  end
+
+  context 'when the candidate has not answered the safeguarding question' do
+    it 'displays the corrent text' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: nil)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include(heading)
+      expect(result.text).to include(has_not_answered_text)
     end
   end
 end

--- a/spec/components/safeguarding_review_component_spec.rb
+++ b/spec/components/safeguarding_review_component_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe SafeguardingReviewComponent do
   context 'when safeguarding issues has a value of "Yes"' do
     it 'displays "Yes" for sharing safeguarding issues and "Not entered" for relevant information' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      )
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
 
@@ -16,7 +20,11 @@ RSpec.describe SafeguardingReviewComponent do
 
   context 'when safeguarding issues has a value of "No"' do
     it 'displays "No" for sharing safeguarding issues and "Not entered" for relevant information' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+      )
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
 
@@ -28,7 +36,11 @@ RSpec.describe SafeguardingReviewComponent do
 
   context 'when safeguarding issues has details' do
     it 'displays "Yes" for sharing safeguarding issues and the details for relevant information' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: 'I have a criminal conviction.',
+        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      )
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form))
 
@@ -41,7 +53,11 @@ RSpec.describe SafeguardingReviewComponent do
 
   context 'when editable' do
     it 'renders the component with change links' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      )
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form, editable: true))
 
@@ -52,7 +68,11 @@ RSpec.describe SafeguardingReviewComponent do
 
   context 'when not editable' do
     it 'renders the component without change links' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      )
 
       result = render_inline(SafeguardingReviewComponent.new(application_form: application_form, editable: false))
 

--- a/spec/components/support_interface/safeguarding_issues_component_spec.rb
+++ b/spec/components/support_interface/safeguarding_issues_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SupportInterface::SafeguardingIssuesComponent do
 
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(described_class::HAS_DISCLOSED_MESSAGE)
+      expect(result.text).to include(I18n.t('support_interface.safeguarding_issues_component.has_disclosed_message'))
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe SupportInterface::SafeguardingIssuesComponent do
 
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(described_class::NO_INFO_MESSAGE)
+      expect(result.text).to include(I18n.t('support_interface.safeguarding_issues_component.no_info_message'))
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe SupportInterface::SafeguardingIssuesComponent do
 
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(described_class::NO_ANSWER_MESSAGE)
+      expect(result.text).to include(I18n.t('support_interface.safeguarding_issues_component.no_answer_message'))
     end
   end
 end

--- a/spec/components/support_interface/safeguarding_issues_component_spec.rb
+++ b/spec/components/support_interface/safeguarding_issues_component_spec.rb
@@ -1,33 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::SafeguardingIssuesComponent do
-  context 'when the candidate has shared information related to safeguarding' do
+  context 'when the candidate was never asked the safeguarding question' do
     it 'displays the correct text' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
-
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: 'never_asked',
+      )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(I18n.t('support_interface.safeguarding_issues_component.has_disclosed_message'))
+      expect(result.text).to include('Never asked.')
+    end
+  end
+
+  context 'when the candidate has shared information related to safeguarding' do
+    it 'displays the correct text' do
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: 'I have a criminal conviction.',
+        safeguarding_issues_status: 'has_safeguarding_issues_to_declare',
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include('The candidate has shared information related to safeguarding.')
     end
   end
 
   context 'when the candidate has not shared information related to safeguarding' do
     it 'displays the correct text' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
-
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: 'no_safeguarding_issues_to_declare',
+      )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(I18n.t('support_interface.safeguarding_issues_component.no_info_message'))
+      expect(result.text).to include('No information shared.')
     end
   end
 
   context 'when the candidate has not answered the safeguarding question' do
     it 'displays the correct text' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: nil)
-
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: 'not_answered_yet',
+      )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(I18n.t('support_interface.safeguarding_issues_component.no_answer_message'))
+      expect(result.text).to include('Not answered yet')
     end
   end
 end

--- a/spec/components/support_interface/safeguarding_issues_component_spec.rb
+++ b/spec/components/support_interface/safeguarding_issues_component_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::SafeguardingIssuesComponent do
+  context 'when the candidate has shared information related to safeguarding' do
+    it 'displays the correct text' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include(described_class::HAS_DISCLOSED_MESSAGE)
+    end
+  end
+
+  context 'when the candidate has not shared information related to safeguarding' do
+    it 'displays the correct text' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include(described_class::NO_INFO_MESSAGE)
+    end
+  end
+
+  context 'when the candidate has not answered the safeguarding question' do
+    it 'displays the correct text' do
+      application_form = build_stubbed(:application_form, safeguarding_issues: nil)
+
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.text).to include(described_class::NO_ANSWER_MESSAGE)
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -87,4 +87,18 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe 'validations' do
+    context 'has safeguarding issues to declare' do
+      subject(:application_form) { described_class.new(safeguarding_issues_status: :has_safeguarding_issues_to_declare) }
+
+      it { is_expected.to validate_presence_of(:safeguarding_issues) }
+    end
+
+    context 'does not have safeguarding issues to declare' do
+      subject(:application_form) { described_class.new(safeguarding_issues_status: :no_safeguarding_issues_to_declare) }
+
+      it { is_expected.not_to validate_presence_of(:safeguarding_issues) }
+    end
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -87,18 +87,4 @@ RSpec.describe ApplicationForm do
       end
     end
   end
-
-  describe 'validations' do
-    context 'has safeguarding issues to declare' do
-      subject(:application_form) { described_class.new(safeguarding_issues_status: :has_safeguarding_issues_to_declare) }
-
-      it { is_expected.to validate_presence_of(:safeguarding_issues) }
-    end
-
-    context 'does not have safeguarding issues to declare' do
-      subject(:application_form) { described_class.new(safeguarding_issues_status: :no_safeguarding_issues_to_declare) }
-
-      it { is_expected.not_to validate_presence_of(:safeguarding_issues) }
-    end
-  end
 end

--- a/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
+++ b/spec/models/candidate_interface/safeguarding_issues_declaration_form_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
   describe '.build_from_application' do
     context 'when safeguarding issues does not have a value' do
       it 'creates an object based on the application form' do
-        application_form = build_stubbed(:application_form, safeguarding_issues: nil)
+        application_form = build_stubbed(
+          :application_form,
+          safeguarding_issues: nil,
+          safeguarding_issues_status: :not_answered_yet,
+        )
 
         form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
 
@@ -13,9 +17,13 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
       end
     end
 
-    context 'when safeguarding issues has a value of "Yes"' do
+    context 'when application has safeguarding issues declared but not value' do
       it 'creates an object based on the application form' do
-        application_form = build_stubbed(:application_form, safeguarding_issues: 'Yes')
+        application_form = build_stubbed(
+          :application_form,
+          safeguarding_issues: nil,
+          safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+        )
 
         form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
 
@@ -24,9 +32,13 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
       end
     end
 
-    context 'when safeguarding issues has a value of "No"' do
+    context 'when application has declared no safeguarding issues' do
       it 'creates an object based on the application form' do
-        application_form = build_stubbed(:application_form, safeguarding_issues: 'No')
+        application_form = build_stubbed(
+          :application_form,
+          safeguarding_issues: nil,
+          safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+        )
 
         form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
 
@@ -35,14 +47,18 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
       end
     end
 
-    context 'when safeguarding issues has details' do
+    context 'when application has safeguarding issues declared and a value' do
       it 'creates an object based on the application form' do
-        application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+        application_form = build_stubbed(
+          :application_form,
+          safeguarding_issues: 'I have a criminal conviction',
+          safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+        )
 
         form = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
 
         expect(form.share_safeguarding_issues).to eq('Yes')
-        expect(form.safeguarding_issues).to eq('I have a criminal conviction.')
+        expect(form.safeguarding_issues).to eq('I have a criminal conviction')
       end
     end
   end
@@ -70,7 +86,8 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
         form.save(application_form)
 
-        expect(application_form.safeguarding_issues).to eq('No')
+        expect(application_form.safeguarding_issues).to be_nil
+        expect(application_form.safeguarding_issues_status.to_sym).to eq :no_safeguarding_issues_to_declare
       end
     end
 
@@ -92,7 +109,8 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
         form.save(application_form)
 
-        expect(application_form.safeguarding_issues).to eq('Yes')
+        expect(application_form.safeguarding_issues_status.to_sym).to eq :has_safeguarding_issues_to_declare
+        expect(application_form.safeguarding_issues).to eq ''
       end
 
       it 'updates safeguarding issues of the application form to provided issues if nil' do
@@ -103,7 +121,8 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
         form.save(application_form)
 
-        expect(application_form.safeguarding_issues).to eq('Yes')
+        expect(application_form.safeguarding_issues_status.to_sym).to eq :has_safeguarding_issues_to_declare
+        expect(application_form.safeguarding_issues).to eq nil
       end
     end
 
@@ -125,7 +144,8 @@ RSpec.describe CandidateInterface::SafeguardingIssuesDeclarationForm, type: :mod
 
         form.save(application_form)
 
-        expect(application_form.safeguarding_issues).to eq('I have a criminal conviction.')
+        expect(application_form.safeguarding_issues_status.to_sym).to eq :has_safeguarding_issues_to_declare
+        expect(application_form.safeguarding_issues).to eq 'I have a criminal conviction.'
       end
     end
   end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -258,16 +258,48 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#safeguarding_completed?' do
-    it 'returns false if safeguarding issues is nil' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: nil)
+    it 'returns false if safeguarding issues is not answered yet' do
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: :not_answered_yet,
+      )
 
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter.safeguarding_completed?).to eq(false)
     end
 
-    it 'returns true if safeguarding issues has a value' do
-      application_form = build_stubbed(:application_form, safeguarding_issues: 'I have a criminal conviction.')
+    it 'returns false if safeguarding issues question was not asked' do
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: :never_asked,
+      )
+
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.safeguarding_completed?).to eq(false)
+    end
+
+    it 'returns true if safeguarding issues are declared' do
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: 'I have a criminal conviction',
+        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
+      )
+
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter.safeguarding_completed?).to eq(true)
+    end
+
+    it 'returns true if safeguarding issues are denied' do
+      application_form = build_stubbed(
+        :application_form,
+        safeguarding_issues: nil,
+        safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+      )
 
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -63,16 +63,19 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def and_my_organisation_has_received_an_application
     course_option = course_option_for_provider_code(provider_code: 'ABC')
-    application_form = create(:application_form,
-                              submitted_at: Time.zone.now,
-                              becoming_a_teacher: 'This is my personal statement',
-                              subject_knowledge: 'This is my subject knowledge',
-                              interview_preferences: 'Any date is fine',
-                              further_information: 'Nothing further to add',
-                              english_main_language: true,
-                              other_language_details: 'I also speak Spanish and German',
-                              disclose_disability: true,
-                              disability_disclosure: 'I am hard of hearing')
+    application_form = create(
+      :application_form,
+      submitted_at: Time.zone.now,
+      becoming_a_teacher: 'This is my personal statement',
+      subject_knowledge: 'This is my subject knowledge',
+      interview_preferences: 'Any date is fine',
+      further_information: 'Nothing further to add',
+      english_main_language: true,
+      other_language_details: 'I also speak Spanish and German',
+      disclose_disability: true,
+      disability_disclosure: 'I am hard of hearing',
+      safeguarding_issues: 'I have something to say...',
+    )
 
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)
     create_list(:application_qualification, 2, application_form: application_form, level: :gcse)

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
       disclose_disability: true,
       disability_disclosure: 'I am hard of hearing',
       safeguarding_issues: 'I have something to say...',
+      safeguarding_issues_status: :has_safeguarding_issues_to_declare,
     )
 
     create_list(:application_qualification, 1, application_form: application_form, level: :degree)


### PR DESCRIPTION
## Context

There have been at least two support calls about safeguarding being flagged to providers when no such declaration was made by the candidate. This we believe is due to `null` values for applications that pre-date the addition of the `application_forms#safeguarding_issues` column.

## Changes proposed in this pull request

- [x] Add a `ApplicationForm#safeguarding_issues_status` attribute and use `ApplicationForm#safeguarding_issues` just for the text of any safeguarding issue. In other words stop using special string values (`Yes` and `No`) in `ApplicationForm#safeguarding_issues`.
- [x] Give support users visibility of safeguarding issues by adding it to the application detail view.

## Guidance to review

- Does the upgrade cover all the cases? (unanswered questions, never asked as well as yes and no answers).
- Does the copy make sense? (Tried to be consistent with https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1828)
- I think we need to revisit `ApplicationReference#safeguarding_concerns` and break that into two attributes `safeguarding_concerns` and `safeguarding_concerns_status` too but I think it's best to do in a separate PR.
- There is a migration in this PR but it doesn't alter the schema so it's not going to cause any 'missing column' issues. Is this OK?
- This feature isn't switched on in production. Does this PR leak any new functionality?

Provider interface:

![image](https://user-images.githubusercontent.com/450843/78648226-9d31ff00-78b3-11ea-8b1b-474107ec365e.png)

Support interface:

![image](https://user-images.githubusercontent.com/450843/78648436-e2563100-78b3-11ea-8836-7b680ebde570.png)

## Link to Trello card

https://trello.com/c/cl0rRz5F/1263-dev-suitability-to-work-with-children-incorrectly-flagged-to-providers-twice

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
