### PR TITLE
Revert "Upgrade heroku review app databases"

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,7 +23,7 @@
       "size": "hobby"
     }
   },
-  "addons": ["heroku-postgresql:hobby-basic", "heroku-redis:hobby-dev"],
+  "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"],
   "buildpacks": [
     {
       "url": "heroku/ruby"


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-postgraduate-teacher-training#1817 because it does nothing.

> Steve Hook: https://devcenter.heroku.com/articles/add-ons-supporting-review-and-ci-apps - this suggests that Heroku ignore the plan specified in app.json for review and CI apps. So it does look like we need to live within the 10K limit.