### PR TITLE
Warn candidates about unavailable course options

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -8,7 +8,9 @@
     <p class='govuk-body'>You can:</p>
     <ul class='govuk-list govuk-list--bullet'>
       <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
-      <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <% if course_change_path(course_choice) %>
+        <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <% end %>
       <li>
         <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
         to discuss alternatives
@@ -19,7 +21,9 @@
     <p class='govuk-body'>You can:</p>
     <ul class='govuk-list govuk-list--bullet'>
       <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
-      <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <% if course_change_path(course_choice) %>
+        <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <% end %>
       <li>
         <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
         to see if the course will re-open or discuss alternatives
@@ -29,9 +33,13 @@
     <p class='app-review-warning--primary-message'>Your chosen site for '<%= course_choice.course.name_and_code %>' has no vacancies.</p>
     <p class='govuk-body'>You can:</p>
     <ul class='govuk-list govuk-list--bullet'>
-      <li><%= govuk_link_to 'pick a new location', site_change_path(course_choice) %></li>
+      <% if site_change_path(course_choice) %>
+        <li><%= govuk_link_to 'pick a new location', site_change_path(course_choice) %></li>
+      <% end %>
       <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
-      <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <% if course_change_path(course_choice) %>
+        <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <% end %>
       <li>
         <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
         to see if the course will re-open or discuss alternatives

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,50 +1,52 @@
 <% @course_choices.each do |course_choice| %>
   <% show_warning = course_choice.course_not_available? || course_choice.course_full? || course_choice.chosen_site_full? %>
-  <div class='qa-application-choice-<%= course_choice.id %> <%= show_warning ? 'app-review-warning'  : '' %>'>
+  <div class='qa-application-choice-<%= course_choice.id %> <%= show_warning && FeatureFlag.active?('unavailable_course_option_warnings')? 'app-review-warning'  : '' %>'>
 
-  <% if course_choice.course_not_available? %>
-    <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it is not running.</p>
-    <p class='govuk-body'><%= course_choice.provider.name %> have decided not to run this course.</p>
-    <p class='govuk-body'>You can:</p>
-    <ul class='govuk-list govuk-list--bullet'>
-      <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
-      <% if course_change_path(course_choice) %>
-        <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
-      <% end %>
-      <li>
-        <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
-        to discuss alternatives
-      </li>
-    </ul>
-  <% elsif course_choice.course_full? %>
-    <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it has no vacancies.</p>
-    <p class='govuk-body'>You can:</p>
-    <ul class='govuk-list govuk-list--bullet'>
-      <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
-      <% if course_change_path(course_choice) %>
-        <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
-      <% end %>
-      <li>
-        <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
-        to see if the course will re-open or discuss alternatives
-      </li>
-    </ul>
-  <% elsif course_choice.chosen_site_full? %>
-    <p class='app-review-warning--primary-message'>Your chosen site for '<%= course_choice.course.name_and_code %>' has no vacancies.</p>
-    <p class='govuk-body'>You can:</p>
-    <ul class='govuk-list govuk-list--bullet'>
-      <% if site_change_path(course_choice) %>
-        <li><%= govuk_link_to 'pick a new location', site_change_path(course_choice) %></li>
-      <% end %>
-      <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
-      <% if course_change_path(course_choice) %>
-        <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
-      <% end %>
-      <li>
-        <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
-        to see if the course will re-open or discuss alternatives
-      </li>
-    </ul>
+  <% if FeatureFlag.active?('unavailable_course_option_warnings') %>
+    <% if course_choice.course_not_available? %>
+      <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it is not running.</p>
+      <p class='govuk-body'><%= course_choice.provider.name %> have decided not to run this course.</p>
+      <p class='govuk-body'>You can:</p>
+      <ul class='govuk-list govuk-list--bullet'>
+        <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
+        <% if course_change_path(course_choice) %>
+          <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+        <% end %>
+        <li>
+          <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
+          to discuss alternatives
+        </li>
+      </ul>
+    <% elsif course_choice.course_full? %>
+      <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it has no vacancies.</p>
+      <p class='govuk-body'>You can:</p>
+      <ul class='govuk-list govuk-list--bullet'>
+        <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
+        <% if course_change_path(course_choice) %>
+          <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+        <% end %>
+        <li>
+          <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
+          to see if the course will re-open or discuss alternatives
+        </li>
+      </ul>
+    <% elsif course_choice.chosen_site_full? %>
+      <p class='app-review-warning--primary-message'>Your chosen site for '<%= course_choice.course.name_and_code %>' has no vacancies.</p>
+      <p class='govuk-body'>You can:</p>
+      <ul class='govuk-list govuk-list--bullet'>
+        <% if site_change_path(course_choice) %>
+          <li><%= govuk_link_to 'pick a new location', site_change_path(course_choice) %></li>
+        <% end %>
+        <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
+        <% if course_change_path(course_choice) %>
+          <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+        <% end %>
+        <li>
+          <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
+          to see if the course will re-open or discuss alternatives
+        </li>
+      </ul>
+    <% end %>
   <% end %>
 
   <%= render(SummaryCardComponent.new(rows: course_choice_rows(course_choice), editable: @editable)) do %>

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,5 +1,44 @@
 <% @course_choices.each do |course_choice| %>
-  <div class='qa-application-choice-<%= course_choice.id %>'>
+  <% show_warning = course_choice.course_not_available? || course_choice.course_full? || course_choice.chosen_site_full? %>
+  <div class='qa-application-choice-<%= course_choice.id %> <%= show_warning ? 'app-review-warning'  : '' %>'>
+
+  <% if course_choice.course_not_available? %>
+    <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it is not running.</p>
+    <p class='govuk-body'><%= course_choice.provider.name %> have decided not to run this course.</p>
+    <p class='govuk-body'>You can:</p>
+    <ul class='govuk-list govuk-list--bullet'>
+      <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
+      <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <li>
+        <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
+        to discuss alternatives
+      </li>
+    </ul>
+  <% elsif course_choice.course_full? %>
+    <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it has no vacancies.</p>
+    <p class='govuk-body'>You can:</p>
+    <ul class='govuk-list govuk-list--bullet'>
+      <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
+      <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <li>
+        <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
+        to see if the course will re-open or discuss alternatives
+      </li>
+    </ul>
+  <% elsif course_choice.chosen_site_full? %>
+    <p class='app-review-warning--primary-message'>Your chosen site for '<%= course_choice.course.name_and_code %>' has no vacancies.</p>
+    <p class='govuk-body'>You can:</p>
+    <ul class='govuk-list govuk-list--bullet'>
+      <li><%= govuk_link_to 'pick a new location', site_change_path(course_choice) %></li>
+      <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
+      <li><%= govuk_link_to 'change to another course', course_change_path(course_choice) %></li>
+      <li>
+        <%= govuk_link_to 'contact the training provider', "#{course_choice.course.find_url}#section-contact" %>
+        to see if the course will re-open or discuss alternatives
+      </li>
+    </ul>
+  <% end %>
+
   <%= render(SummaryCardComponent.new(rows: course_choice_rows(course_choice), editable: @editable)) do %>
     <%= render(SummaryCardHeaderComponent.new(title: course_choice.offered_course.provider.name, heading_level: @heading_level)) do %>
       <div class='app-summary-card__actions'>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -44,41 +44,45 @@ module CandidateInterface
       @show_incomplete && !@application_form.course_choices_completed && @editable
     end
 
+    def course_change_path(course_choice)
+      if FeatureFlag.active?('edit_course_choices') && has_multiple_courses?(course_choice)
+        candidate_interface_course_choices_course_path(
+          course_choice.provider.id,
+          course_choice_id: course_choice.id,
+        )
+      end
+    end
+
+    def site_change_path(course_choice)
+      if FeatureFlag.active?('edit_course_choices') && has_multiple_sites?(course_choice)
+        candidate_interface_course_choices_site_path(
+          course_choice.provider.id,
+          course_choice.course.id,
+          course_choice.offered_option.study_mode,
+          course_choice_id: course_choice.id,
+        )
+      end
+    end
+
   private
 
     attr_reader :application_form
 
     def course_row(course_choice)
-      change_path = if FeatureFlag.active?('edit_course_choices') && has_multiple_courses?(course_choice)
-                      candidate_interface_course_choices_course_path(
-                        course_choice.provider.id,
-                        course_choice_id: course_choice.id,
-                      )
-                    end
-
       {
         key: 'Course',
         value: govuk_link_to("#{course_choice.offered_course.name} (#{course_choice.offered_course.code})", course_choice.offered_course.find_url, target: '_blank', rel: 'noopener'),
         action: "course choice for #{course_choice.course.name_and_code}",
-        change_path: change_path,
+        change_path: course_change_path(course_choice),
       }
     end
 
     def location_row(course_choice)
-      change_path = if FeatureFlag.active?('edit_course_choices') && has_multiple_sites?(course_choice)
-                      candidate_interface_course_choices_site_path(
-                        course_choice.provider.id,
-                        course_choice.course.id,
-                        course_choice.offered_option.study_mode,
-                        course_choice_id: course_choice.id,
-                      )
-                    end
-
       {
         key: 'Location',
         value: "#{course_choice.offered_site.name}\n#{course_choice.offered_site.full_address}",
         action: "location for #{course_choice.course.name_and_code}",
-        change_path: change_path,
+        change_path: site_change_path(course_choice),
       }
     end
 

--- a/app/frontend/styles/_review_warning.scss
+++ b/app/frontend/styles/_review_warning.scss
@@ -1,0 +1,13 @@
+.app-review-warning {
+  @include govuk-responsive-margin(4, "bottom");
+  @include govuk-text-colour;
+  @include govuk-font($size: 19);
+  border: solid govuk-colour("blue");
+  border-width: 0 0 0 $govuk-border-width;
+  padding-left: govuk-spacing(3);
+
+  &--primary-message {
+    @include govuk-typography-weight-bold;
+    color: govuk-colour("blue");
+  }
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -52,6 +52,7 @@ $govuk-breakpoints: (
 @import "_provider";
 @import "_application-card";
 @import "_application-tabs";
+@import "_review_warning";
 
 // Support
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -48,6 +48,18 @@ class ApplicationChoice < ApplicationRecord
     offered_option.site
   end
 
+  def course_not_available?
+    course_option.course_not_available?
+  end
+
+  def course_full?
+    course_option.course_full?
+  end
+
+  def chosen_site_full?
+    course_option.no_vacancies?
+  end
+
 private
 
   def generate_alphanumeric_id

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -28,4 +28,12 @@ class CourseOption < ApplicationRecord
 
     errors.add(:site, 'must have the same Provider as the course')
   end
+
+  def course_not_available?
+    !course.exposed_in_find?
+  end
+
+  def course_full?
+    course.course_options.vacancies.blank?
+  end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,7 @@ class FeatureFlag
     satisfaction_survey
     group_providers_by_region
     provider_add_provider_users
+    unavailable_course_option_warnings
   ].freeze
 
   def self.activate(feature_name)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -221,6 +221,10 @@ FactoryBot.define do
     trait :part_time do
       study_mode { :part_time }
     end
+
+    trait :no_vacancies do
+      vacancy_status { 'no_vacancies' }
+    end
   end
 
   factory :course do

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe CourseOption, type: :model do
-  subject(:course_option) { create(:course_option) }
-
   describe 'a valid course option' do
+    subject(:course_option) { create(:course_option) }
+
     it { is_expected.to belong_to :course }
     it { is_expected.to belong_to :site }
     it { is_expected.to validate_presence_of :vacancy_status }
@@ -21,11 +21,67 @@ RSpec.describe CourseOption, type: :model do
   end
 
   describe '.selectable' do
+    subject(:course_option) { create(:course_option) }
+
     it 'returns only course options where invalidated_by_find is false' do
       expected_course_option = create(:course_option, invalidated_by_find: false)
       create(:course_option, invalidated_by_find: true)
 
       expect(CourseOption.selectable).to match_array [expected_course_option]
+    end
+  end
+
+  describe '#course_not_available?' do
+    it 'returns true if course is not exposed in find' do
+      option = build_stubbed(
+        :course_option,
+        course: build_stubbed(:course, exposed_in_find: false),
+      )
+      expect(option.course_not_available?).to be true
+    end
+
+    it 'returns false if course is exposed in find' do
+      option = build_stubbed(
+        :course_option,
+        course: build_stubbed(:course, exposed_in_find: true),
+      )
+      expect(option.course_not_available?).to be false
+    end
+  end
+
+  describe '#course_full?' do
+    let(:course) { course_option_under_test.course }
+
+    context 'course option has vacancies' do
+      let(:course_option_under_test) { create(:course_option) }
+
+      it 'returns false if sibling course_options have no vacancies' do
+        create(:course_option, :no_vacancies, course: course)
+
+        expect(course_option_under_test.course_full?).to be false
+      end
+
+      it 'returns false if sibling course_options have vacancies' do
+        create(:course_option, course: course)
+
+        expect(course_option_under_test.course_full?).to be false
+      end
+    end
+
+    context 'course option has no vacancies' do
+      let(:course_option_under_test) { create(:course_option, :no_vacancies) }
+
+      it 'returns true if sibling course_options have no vacancies' do
+        create(:course_option, :no_vacancies, course: course)
+
+        expect(course_option_under_test.course_full?).to be true
+      end
+
+      it 'returns false if sibling course_options have vacancies' do
+        create(:course_option, course: course)
+
+        expect(course_option_under_test.course_full?).to be false
+      end
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.feature 'Candidate reviewing an application with unavailable course options' do
+  include CandidateHelper
+
+  scenario 'sees warning messages for unavailable course options' do
+    given_i_am_signed_in
+    and_i_chose_course_options_that_have_since_become_unavailable
+
+    when_i_visit_the_review_application_page
+
+    then_i_see_a_warning_for_the_course_that_is_not_running
+    then_i_see_a_warning_for_the_course_with_no_vacancies
+    then_i_see_a_warning_for_the_course_with_no_vacancies_at_my_chosen_site
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def and_i_chose_course_options_that_have_since_become_unavailable
+    @option_where_course_not_running = create(
+      :course_option,
+      course: create(:course, exposed_in_find: false),
+    )
+
+    @option_where_course_has_no_vacancies = create(
+      :course_option,
+      :no_vacancies,
+      course: create(:course, exposed_in_find: true),
+    )
+    create(:course_option, :no_vacancies, course: @option_where_course_has_no_vacancies.course)
+
+    @option_where_no_vacancies_at_chosen_site = create(
+      :course_option,
+      :no_vacancies,
+      course: create(:course, exposed_in_find: true),
+    )
+    create(:course_option, course: @option_where_no_vacancies_at_chosen_site.course)
+
+    [
+      @option_where_course_not_running,
+      @option_where_course_has_no_vacancies,
+      @option_where_no_vacancies_at_chosen_site,
+    ].each do |option|
+      create(
+        :application_choice,
+        application_form: @current_candidate.current_application,
+        course_option: option,
+      )
+    end
+  end
+
+  def when_i_visit_the_review_application_page
+    visit candidate_interface_application_form_path
+    click_link 'Check your answers before submitting'
+  end
+
+  def then_i_see_a_warning_for_the_course_that_is_not_running
+    warning_message = \
+      "You cannot apply to '#{@option_where_course_not_running.course.name_and_code}' because it is not running"
+    expect(page).to have_content warning_message
+  end
+
+  def then_i_see_a_warning_for_the_course_with_no_vacancies
+    warning_message = \
+      "You cannot apply to '#{@option_where_course_has_no_vacancies.course.name_and_code}' because it has no vacancies"
+    expect(page).to have_content warning_message
+  end
+
+  def then_i_see_a_warning_for_the_course_with_no_vacancies_at_my_chosen_site
+    warning_message = \
+      "Your chosen site for '#{@option_where_no_vacancies_at_chosen_site.course.name_and_code}' has no vacancies."
+    expect(page).to have_content warning_message
+  end
+end

--- a/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
 
   scenario 'sees warning messages for unavailable course options' do
     given_i_am_signed_in
+    and_the_unavailable_course_option_warnings_feature_is_active
     and_i_chose_course_options_that_have_since_become_unavailable
 
     when_i_visit_the_review_application_page
@@ -16,6 +17,10 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_unavailable_course_option_warnings_feature_is_active
+    FeatureFlag.activate('unavailable_course_option_warnings')
   end
 
   def and_i_chose_course_options_that_have_since_become_unavailable


### PR DESCRIPTION
## Context

To help ensure candidates are applying only to courses that are
available and have vacancies, we want to display warnings on the
application review page if a course choice falls into one of several
states that makes them unavailable.

## Changes proposed in this pull request

- Add methods to ApplicationChoice that evaluate the three states we
  deem a course option to be unavailable.
- Add markup for these warnings to the CourseChoicesReviewComponent
  template.

![Screenshot 2020-04-07 at 15 49 05](https://user-images.githubusercontent.com/519250/78683582-5e1da100-78e7-11ea-96c3-9aea61797610.png)



## Guidance to review

* Left the three warnings in the CourseChoicesReviewComponent template, but planning to extract this into its own component when implementing the validation error part of this story.

## Link to Trello card

https://trello.com/c/tCV8YrX0

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
