### PR TITLE
Implement the new tabbed design for the provider ui single application page

### DIFF
--- a/app/components/sub_navigation_component.html.erb
+++ b/app/components/sub_navigation_component.html.erb
@@ -1,13 +1,15 @@
-<nav class="moj-sub-navigation" aria-label="Sub navigation">
-  <ul class="moj-sub-navigation__list">
+<div class="govuk-tabs app-tabs">
+  <ul class="govuk-tabs__list">
     <% items.each do |item| %>
-      <li class="moj-sub-navigation__item">
-        <% if item[:current] || current_page?(item.fetch(:url)) %>
-          <%= govuk_link_to item.fetch(:name), item.fetch(:url), class: 'moj-sub-navigation__link', 'aria-current': 'page' %>
-        <% else %>
-          <%= govuk_link_to item.fetch(:name), item.fetch(:url), class: 'moj-sub-navigation__link' %>
-        <% end %>
-      </li>
+      <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>
+        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected app-tabs__list-item--selected">
+          <%= govuk_link_to item[:name], item[:url],  class: "govuk-tabs__tab app-tabs__tab", aria: { selected: "true" }, role:"tab" %>
+        </li>
+      <% else %>
+        <li class="govuk-tabs__list-item">
+          <%= govuk_link_to item[:name], item[:url],  class: "govuk-tabs__tab app-tabs__tab", role:"tab" %>
+        </li>
+      <% end %>
     <% end %>
   </ul>
-</nav>
+</div>

--- a/app/frontend/styles/_application-tabs.scss
+++ b/app/frontend/styles/_application-tabs.scss
@@ -1,0 +1,16 @@
+.app-tabs {
+  margin-top: govuk-spacing(8);
+
+  &__tab {
+    font-weight: bold !important;
+    text-align: left !important;
+    text-decoration: none !important;
+  }
+
+  &__list-item--selected {
+    background-color: govuk-colour("white") !important;
+    border-top: govuk-spacing(1) solid $govuk-link-colour !important;
+    color: $govuk-text-colour !important;
+    padding-top: govuk-spacing(2) !important;
+  }
+}

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -51,6 +51,7 @@ $govuk-breakpoints: (
 @import "_filter";
 @import "_provider";
 @import "_application-card";
+@import "_application-tabs";
 
 // Support
 @import "~@ministryofjustice/frontend/moj/components/sub-navigation/sub-navigation";

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -27,6 +27,7 @@
   <%= @application_choice.application_form.full_name %>
   <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
 </h1>
+
 <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
   <%= govuk_link_to(
     'Download application (PDF)',

--- a/spec/components/sub_navigation_component_spec.rb
+++ b/spec/components/sub_navigation_component_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe SubNavigationComponent do
+  let(:items) {
+    [{ name: 'Application', url: '#', current: true },
+     { name: 'Notes', url: '#' },
+     { name: 'Timeline', url: '#' }]
+  }
+
+  context 'nav tabs appearing as selected' do
+    it 'when the item is "current" then that tab is selected' do
+      result = render_inline(described_class.new(items: items))
+
+      expect(result.css('.govuk-tabs__list-item--selected').text).to include('Application')
+    end
+  end
+
+  context 'rendering tabs' do
+    it 'renders all of the nav tabs specified in the items hash passed to it' do
+      result = render_inline(described_class.new(items: items))
+
+      expect(result.text).to include('Application')
+      expect(result.text).to include('Notes')
+      expect(result.text).to include('Timeline')
+    end
+  end
+end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature 'Docs' do
   end
 
   def then_i_see_the_provider_flow_documentation
-    within '.moj-sub-navigation' do
+    within '.govuk-tabs' do
       expect(page).to have_title 'Provider application flow'
     end
   end
@@ -45,7 +45,7 @@ RSpec.feature 'Docs' do
   end
 
   def when_i_click_on_candidate_flow_documentation
-    within '.moj-sub-navigation' do
+    within '.govuk-tabs' do
       click_on 'Candidate application flow'
     end
   end


### PR DESCRIPTION
## Context

Adds tabs component to application. This was deemed as a precursor / blocker for the notes work as discussed in the notes kick off - as such it was bumped up in priority.

## Changes proposed in this pull request

**Before**
<img width="918" alt="Screenshot 2020-04-07 at 16 38 23" src="https://user-images.githubusercontent.com/13377553/78689427-3978f780-78ee-11ea-9151-1f718e2d375e.png">

**After**
<img width="928" alt="Screenshot 2020-04-07 at 16 37 42" src="https://user-images.githubusercontent.com/13377553/78689326-1fd7b000-78ee-11ea-9ad5-11b9c639e928.png">

## Guidance to review

I have used the pattern defined elsewhere in the app to control if a tab is selected, or not (see `SubNavigationComponent` for an example). In short the component accepts a hash of 'items' that are interrogated to render the tabs. Which tab is selected depends on the presence of a `current: true` hash value that should differ depending on the page. Does this make sense? Do you like this implementation?

I have included the component in `app/views/provider_interface/application_choices/show.html.erb` as I needed to get the screenshots - however as the Notes and Timeline `show` views / routes don't exist yet these tabs have `#` as url values and lead nowhere thus far. 

Happy to remove the `TagsComponent` from rendering here until the other views are available if you think this is better (for instance there would be the chance that this goes live and the application show tabs have dead links in them - not a good look). 

This is also the reason why I haven't amended any system tests to check for tabs functionality.

## Link to Trello card

https://trello.com/c/U6usyWvE/1865-implement-the-new-tabbed-design-for-the-provider-ui-single-application-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
