### PR TITLE
Fix missing validation errors for equality_and_diversity FF

### DIFF
--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -122,7 +122,7 @@ module CandidateInterface
     end
 
     def redirect_to_review_unless_ready_to_submit
-      redirect_to candidate_interface_application_review_path unless ready_to_submit?
+      redirect_to candidate_interface_application_submit_show_path unless ready_to_submit?
     end
 
     def redirect_to_review_unless_feature_flag_active

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -6,7 +6,13 @@ RSpec.feature 'Entering their equality and diversity information' do
   scenario 'Candidate submits equality and diversity information' do
     given_i_am_signed_in
     and_the_equality_and_diversity_feature_flag_is_active
-    and_i_have_an_application_form_that_is_ready_to_submit
+    and_i_have_an_application_form_that_is_not_ready_to_submit
+    and_i_am_on_the_review_page
+
+    when_i_click_on_continue
+    then_i_see_validation_errors
+
+    when_i_have_an_application_form_that_is_ready_to_submit
     and_i_am_on_the_review_page
 
     when_i_click_on_continue
@@ -93,15 +99,19 @@ RSpec.feature 'Entering their equality and diversity information' do
     FeatureFlag.activate('equality_and_diversity')
   end
 
-  def and_i_have_an_application_form_that_is_ready_to_submit
+  def and_i_have_an_application_form_that_is_not_ready_to_submit
     @application = create(
       :completed_application_form,
       :with_completed_references,
       candidate: @current_candidate,
       submitted_at: nil,
-      references_count: 2,
+      references_count: 1,
       with_gces: true,
     )
+  end
+
+  def when_i_have_an_application_form_that_is_ready_to_submit
+    create :reference, application_form: @application
   end
 
   def and_i_am_on_the_review_page
@@ -110,6 +120,11 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def when_i_click_on_continue
     click_link 'Continue'
+  end
+
+  def then_i_see_validation_errors
+    expect(page).to have_content('There is a problem')
+    expect(page).to have_content('Add 2 referees to your application')
   end
 
   def then_i_see_the_equality_and_diversity_page


### PR DESCRIPTION
## Context

The error summary on the "Review your application" page doesn't show when the `equality_and_diversity` feature flag is on. 

## Changes proposed in this pull request

- [x] Redirect to `ApplicationForm#submit_show` rather than `review` just as the original submit action does. (`submit_show` finds the errors and then renders the `review` template).
- [x] Update system spec

## Guidance to review

- Are there any other cases where this could be a problem?
- Can we simplify the flow between submission steps and the various actions?

## Link to Trello card

https://trello.com/c/EfbebMO0/1151-fix-error-summary-not-showing-on-the-review-your-application-when-equality-and-diversity-feature-is-on
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
