### PR TITLE
Handle case of nil region_code in grouped providers

### DIFF
--- a/app/components/grouped_provider_courses_component.html.erb
+++ b/app/components/grouped_provider_courses_component.html.erb
@@ -1,5 +1,5 @@
 <% courses_by_provider_and_region.each do |region_code, courses_by_provider| %>
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= t("provider_regions.#{region_code}") %></h2>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2 govuk-!-margin-top-8"><%= label_for(region_code) %></h2>
   <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
     <% courses_by_provider.each_with_index do |provider, index| %>
       <section class="govuk-accordion__section">

--- a/app/components/grouped_provider_courses_component.rb
+++ b/app/components/grouped_provider_courses_component.rb
@@ -7,6 +7,10 @@ class GroupedProviderCoursesComponent < ActionView::Component::Base
     @courses_by_provider_and_region = courses_by_provider_and_region
   end
 
+  def label_for(region_code)
+    region_code.present? ? I18n.t("provider_regions.#{region_code}") : I18n.t('provider_regions.no_region')
+  end
+
 private
 
   attr_reader :courses_by_provider_and_region

--- a/app/components/grouped_provider_courses_component.rb
+++ b/app/components/grouped_provider_courses_component.rb
@@ -8,7 +8,7 @@ class GroupedProviderCoursesComponent < ActionView::Component::Base
   end
 
   def label_for(region_code)
-    region_code.present? ? I18n.t("provider_regions.#{region_code}") : I18n.t('provider_regions.no_region')
+    region_code.present? ? I18n.t("provider_regions.#{region_code}") : I18n.t('provider_regions.no_region_specified')
   end
 
 private

--- a/config/locales/provider_regions.yml
+++ b/config/locales/provider_regions.yml
@@ -4,6 +4,7 @@ en:
     eastern: 'Eastern'
     london: 'London'
     no_region: 'No region'
+    no_region_specified: 'No region specified'
     north_east: 'North East'
     north_west: 'North West'
     scotland: 'Scotland'

--- a/config/locales/provider_regions.yml
+++ b/config/locales/provider_regions.yml
@@ -3,7 +3,7 @@ en:
     east_midlands: 'East Midlands'
     eastern: 'Eastern'
     london: 'London'
-    no_region: 'No Region'
+    no_region: 'No region'
     north_east: 'North East'
     north_west: 'North West'
     scotland: 'Scotland'

--- a/spec/components/grouped_provider_courses_component_spec.rb
+++ b/spec/components/grouped_provider_courses_component_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe GroupedProviderCoursesComponent do
+  before do
+    @courses_by_provider_and_region = {
+      'north_west' => [
+        CandidateInterface::ContentController::RegionProviderCourses.new('north_west', 'Northerly College', []),
+        CandidateInterface::ContentController::RegionProviderCourses.new('north_west', 'Westerly Sixth Form', []),
+      ],
+      'south_east' => [
+        CandidateInterface::ContentController::RegionProviderCourses.new('south_east', 'Southerly College', []),
+        CandidateInterface::ContentController::RegionProviderCourses.new('south_east', 'Easterly Sixth Form', []),
+      ],
+      nil => [
+        CandidateInterface::ContentController::RegionProviderCourses.new(nil, 'Wimbley College', []),
+        CandidateInterface::ContentController::RegionProviderCourses.new(nil, 'Worbley Sixth Form', []),
+      ],
+    }
+  end
+
+  it 'renders all the region headings' do
+    result = render_inline(
+      described_class.new(courses_by_provider_and_region: @courses_by_provider_and_region),
+    )
+    expect(result.css('h2').text).to include('South East')
+    expect(result.css('h2').text).to include('North West')
+    expect(result.css('h2').text).to include('No Region')
+  end
+end

--- a/spec/components/grouped_provider_courses_component_spec.rb
+++ b/spec/components/grouped_provider_courses_component_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe GroupedProviderCoursesComponent do
     )
     expect(result.css('h2').text).to include('South East')
     expect(result.css('h2').text).to include('North West')
-    expect(result.css('h2').text).to include('No Region')
+    expect(result.css('h2').text).to include('No region')
   end
 end


### PR DESCRIPTION
## Context

There are a small number of providers that do not have `region_code` values when we sync them from the Find API. We don't handle these properly in the grouped providers interface. This PR fixes that bug.

## Changes proposed in this pull request

- [x] Treat `region_code` `nil` values as 'No Region'.

![image](https://user-images.githubusercontent.com/450843/78911499-49274600-7a7e-11ea-8ee4-98f5a09748ba.png)

## Guidance to review

- Do we need a special category for `nil` region codes?

## Link to Trello card

https://trello.com/c/9qiEqzo0/1299-ensure-providers-without-a-regioncode-are-shown-on-providers-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
