### PR TITLE
Fix for out-of-order migrations

### DIFF
--- a/db/migrate/20200330153007_rename_courses_accrediting_provider_id_part1.rb
+++ b/db/migrate/20200330153007_rename_courses_accrediting_provider_id_part1.rb
@@ -1,5 +1,9 @@
 class RenameCoursesAccreditingProviderIdPart1 < ActiveRecord::Migration[6.0]
   def up
+    unless column_exists?(:courses, :accredited_provider_id)
+      add_column :courses, :accredited_provider_id, :integer, null: true
+    end
+
     execute 'UPDATE courses SET accredited_provider_id = accrediting_provider_id'
   end
 

--- a/db/migrate/20200331091319_add_courses_accredited_provider_id.rb
+++ b/db/migrate/20200331091319_add_courses_accredited_provider_id.rb
@@ -1,5 +1,11 @@
 class AddCoursesAccreditedProviderId < ActiveRecord::Migration[6.0]
-  def change
+  def up
+    return if column_exists?(:courses, :accredited_provider_id)
+
     add_column :courses, :accredited_provider_id, :integer, null: true
+  end
+
+  def down
+    remove_column :courses, :accredited_provider_id
   end
 end


### PR DESCRIPTION
## Context

`20200330153007_rename_courses_accrediting_provider_id_part1` depends on `20200331091319_add_courses_accredited_provider_id` but with the original timestamps they ran in the wrong order.

These migrations already ran on production in the correct order but are causing problems in some local branches and review apps.

## Changes proposed in this pull request

- [x] Modify the logic in each migration to allow for them being run in the wrong order.

## Guidance to review

Modified the original migrations rather than flipping the timestamps because that would have caused a different problem in any branch that had already run one of the migrations sucessfully.

I tested it by reset the DB back to 29th March. Then running the migrations (in the wrong order).

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
