### PR TITLE
Temporarily disable provider authorisation

### DIFF
--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -15,7 +15,7 @@ class ChangeOffer
   end
 
   def save
-    @auth.assert_can_change_offer! application_choice: @application_choice, course_option_id: @course_option_id
+    # @auth.assert_can_change_offer! application_choice: @application_choice, course_option_id: @course_option_id
     if valid?
       attributes = {
         offered_course_option_id: @course_option_id,

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -33,7 +33,7 @@ class MakeAnOffer
   def save
     return unless valid?
 
-    @auth.assert_can_make_offer!(application_choice: application_choice, course_option_id: @course_option_id)
+    # @auth.assert_can_make_offer!(application_choice: application_choice, course_option_id: @course_option_id)
 
     ApplicationStateChange.new(application_choice).make_offer!
     application_choice.offered_course_option = offered_course_option

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       )
     end
 
-    it 'returns an error when specifying a course from a different provider' do
+    xit 'returns an error when specifying a course from a different provider' do
       application_choice = create_application_choice_for_currently_authenticated_provider(
         status: 'awaiting_provider_decision',
       )

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe MakeAnOffer, sidekiq: true do
   end
 
   describe 'authorisation' do
-    it 'raises error if actor is not authorised' do
+    xit 'raises error if actor is not authorised' do
       application_choice = create(:application_choice, status: :awaiting_provider_decision)
       unrelated_user = create(:provider_user)
       new_offer = MakeAnOffer.new(actor: unrelated_user, application_choice: application_choice)


### PR DESCRIPTION
## Context

We discovered that we show accredited courses to providers but don't allow them to make offers on them. The logic looks tricky and we have a live provider that has triggered a 500, so for now we'll disable this and fix it tomorrow.

## Changes proposed in this pull request

Disable the call to `assert_can_make_offer` in `make_an_offer` and `assert_can_change_offer` in `change_offer`.

## Guidance to review

Trust.

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/1603184950/?project=1765973&referrer=slack

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)