### PR TITLE
Providers can make offers on courses they ratify

### DIFF
--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -15,7 +15,7 @@ class ChangeOffer
   end
 
   def save
-    # @auth.assert_can_change_offer! application_choice: @application_choice, course_option_id: @course_option_id
+    @auth.assert_can_change_offer! application_choice: @application_choice, course_option_id: @course_option_id
     if valid?
       attributes = {
         offered_course_option_id: @course_option_id,

--- a/app/services/make_an_offer.rb
+++ b/app/services/make_an_offer.rb
@@ -33,7 +33,7 @@ class MakeAnOffer
   def save
     return unless valid?
 
-    # @auth.assert_can_make_offer!(application_choice: application_choice, course_option_id: @course_option_id)
+    @auth.assert_can_make_offer!(application_choice: application_choice, course_option_id: @course_option_id)
 
     ApplicationStateChange.new(application_choice).make_offer!
     application_choice.offered_course_option = offered_course_option

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -10,17 +10,17 @@ class ProviderAuthorisation
 
     supplied_course_option = CourseOption.find(course_option_id) if course_option_id
     if supplied_course_option && course_option_id != application_choice.course_option.id
-      application_choice_belongs_to_user_providers?(application_choice: application_choice) && \
+      application_choice_visible_to_user?(application_choice: application_choice) && \
         course_option_belongs_to_user_providers?(course_option: supplied_course_option)
     else
-      application_choice_belongs_to_user_providers?(application_choice: application_choice)
+      application_choice_visible_to_user?(application_choice: application_choice)
     end
   end
 
   def can_change_offer?(application_choice:, course_option_id:)
     new_course_option = CourseOption.find course_option_id
     @actor.is_a?(SupportUser) || \
-      application_choice_belongs_to_user_providers?(application_choice: application_choice) && \
+      application_choice_visible_to_user?(application_choice: application_choice) && \
         course_option_belongs_to_user_providers?(course_option: new_course_option)
   end
 
@@ -37,8 +37,8 @@ class ProviderAuthorisation
 
 private
 
-  def application_choice_belongs_to_user_providers?(application_choice:)
-    @actor.providers.include?(application_choice.course.provider)
+  def application_choice_visible_to_user?(application_choice:)
+    GetApplicationChoicesForProviders.call(providers: @actor.providers).include?(application_choice)
   end
 
   def course_option_belongs_to_user_providers?(course_option:)

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       )
     end
 
-    xit 'returns an error when specifying a course from a different provider' do
+    it 'returns an error when specifying a course from a different provider' do
       application_choice = create_application_choice_for_currently_authenticated_provider(
         status: 'awaiting_provider_decision',
       )

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe MakeAnOffer, sidekiq: true do
   end
 
   describe 'authorisation' do
-    xit 'raises error if actor is not authorised' do
+    it 'raises error if actor is not authorised' do
       application_choice = create(:application_choice, status: :awaiting_provider_decision)
       unrelated_user = create(:provider_user, :with_provider)
       new_offer = MakeAnOffer.new(actor: unrelated_user, application_choice: application_choice)

--- a/spec/services/make_an_offer_spec.rb
+++ b/spec/services/make_an_offer_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe MakeAnOffer, sidekiq: true do
   describe 'authorisation' do
     xit 'raises error if actor is not authorised' do
       application_choice = create(:application_choice, status: :awaiting_provider_decision)
-      unrelated_user = create(:provider_user)
+      unrelated_user = create(:provider_user, :with_provider)
       new_offer = MakeAnOffer.new(actor: unrelated_user, application_choice: application_choice)
       expect { new_offer.save }.to raise_error(ProviderAuthorisation::NotAuthorisedError)
     end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe ProviderAuthorisation do
         auth_context = ProviderAuthorisation.new(actor: provider_user)
         expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_truthy
       end
+
+      it 'is true when the user is associated with the accredited provider for this course' do
+        course_option = course_option_for_accredited_provider(provider: create(:provider), accredited_provider: provider)
+        application_choice = create(:application_choice, :awaiting_provider_decision, course_option: course_option)
+
+        auth_context = ProviderAuthorisation.new(actor: provider_user)
+
+        expect(auth_context.can_make_offer?(application_choice: application_choice)).to be_truthy
+      end
     end
 
     context 'with support user' do
@@ -79,7 +88,7 @@ RSpec.describe ProviderAuthorisation do
     end
 
     it 'is false if user is not associated with the provider for the new course option' do
-      auth_context = ProviderAuthorisation.new(actor: create(:provider_user))
+      auth_context = ProviderAuthorisation.new(actor: create(:provider_user, :with_provider))
       expect(auth_context.can_change_offer?(application_choice: application_choice, course_option_id: other_course_option.id)).to be_falsy
     end
 


### PR DESCRIPTION
## Context

This recently bit a provider who was associated with the accredited body for a course. They can see the choice and all the UI associated with offers, but they got a 500 when they tried to make the offer.

https://sentry.io/organizations/dfe-bat/issues/1603184950/?project=1765973&referrer=slack

We also need to fix the fact the user saw a 500 (though it did surface this error to us this time): https://trello.com/c/DRw9n8KJ/1892-show-a-sensible-error-when-a-provider-user-tries-to-make-an-offer-on-a-course-they-dont-have-permission-to.

## Changes proposed in this pull request

When we decide whether to make an offer, use the existing GetApplicationChoicesForProviders service to see if they can see this application. If they can, OK.

## Guidance to review

Is it correct?

## Link to Trello card

https://trello.com/c/DRw9n8KJ/1892-show-a-sensible-error-when-a-provider-user-tries-to-make-an-offer-on-a-course-they-dont-have-permission-to

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
