### PR TITLE
Log logstash-logger buffer errors to STDOUT

### DIFF
--- a/app/lib/logstash_logging.rb
+++ b/app/lib/logstash_logging.rb
@@ -26,6 +26,10 @@ class LogstashLogging
     # Log destination: log to STDOUT, plus to a remote Logstash server, if required
     logstash_logger = \
       if ENV['LOGSTASH_REMOTE'] == 'true'
+        # temporary additional STDOUT logger for troubleshooting bg process log loss
+        buffer_logger = Logger.new(STDOUT)
+        buffer_logger.level = Logger::WARN
+
         LogStashLogger.new(
           type: :multi_delegator,
           outputs: [
@@ -37,6 +41,7 @@ class LogstashLogging
               ssl_enable: ENV.fetch('LOGSTASH_SSL') == 'true',
             },
           ],
+          buffer_logger: buffer_logger,
         )
       else
         LogStashLogger.new(type: :stdout)


### PR DESCRIPTION
## Context

May shed more light on remaining Sidekiq/clockwork-related log loss. Errors will appear in container logs.

## Changes proposed in this pull request

Adds a STDOUT logger specifically for logstash-logger buffer errors/warnings.

## Guidance to review

It works.

## Link to Trello card

https://trello.com/c/RfRtKhJR

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
