### PR TITLE
Amend the deployment guide so that people move their own cards rather than deployer

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,7 +61,7 @@ checklist](deployment_checklist.md) before declaring the deploy finished.
 
 ## 7. Move deploy cards to done
 
-Tell your team mates that their work has gone out, and move over all of the cards in "Ready to deploy" to "Product review & launch 🚀" on the [Candidate board](https://trello.com/b/aRIgjf0y/candidate-team-board) and [ProVendor board](https://trello.com/b/5IiPW0Ok/team-board-apply).
+Tell your team mates that their work has gone out. They should now move over their deployed cards in "Ready to deploy" to "Product review & launch 🚀" on the [Candidate board](https://trello.com/b/aRIgjf0y/candidate-team-board) and/or [ProVendor board](https://trello.com/b/5IiPW0Ok/team-board-apply).
 
 ## Rolling back
 


### PR DESCRIPTION
Amended guidance for people to move their own cards to 'product review and launch' rather than the person doing the deployment.

## Context

- Came up as an issue during a team retro, action was to amend deployment guidance.

## Guidance to review

- Does this wording make sense?

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
