### PR TITLE
Only alert about invalid course options the first time

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -153,10 +153,14 @@ private
     part_of_an_application = invalid_course_options.where(id: chosen_course_option_ids)
     return if part_of_an_application.size.zero?
 
-    part_of_an_application.update_all(invalidated_by_find: true)
-    Raven.capture_message(
-      "#{part_of_an_application.count} invalid course options chosen by candidates.",
-    )
+    part_of_an_application.each do |course_option|
+      unless course_option.invalidated_by_find
+        Raven.capture_message(
+          "Course option #{course_option.id}, which is chosen by candidates, is now invalid.",
+        )
+      end
+      course_option.update!(invalidated_by_find: true)
+    end
   end
 
   class CourseVacancyStatus

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe SyncProviderFromFind do
         expect(CourseOption.exists?(invalid_course_option_one.id)).to eq false
         expect(invalid_course_option_two.reload).to be_invalidated_by_find
         expect(valid_course_option.reload).not_to be_invalidated_by_find
-        expect(Raven).to have_received(:capture_message).with(/1 invalid course option/)
+        expect(Raven).to have_received(:capture_message).with(/is now invalid/)
       end
     end
   end


### PR DESCRIPTION
## Context

We tell Sentry to throw an alert into Slack every time we sync from Find if we discover new course options that are now invalid.

However, this means it can alert multiple times in a row for the same course options.

We should only be alerted for newly invalidated course options.

## Changes proposed in this pull request

Only alert about invalid course options the first time.

We also now log the course option ID in the error message.

## Guidance to review

Does this make sense? Is the `course_option.id` enough for us to go on?

## Link to Trello card

https://trello.com/c/LsWXpfTY/1310-sentry-alerts-us-on-slack-about-invalid-course-options-multiple-times

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)