### PR TITLE
Fix bug when user does not select other qualification type

### DIFF
--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -16,7 +16,7 @@ module CandidateInterface
   private
 
     def other_qualification_type_params
-      params.require(:candidate_interface_other_qualification_type_form).permit(
+      params.fetch(:candidate_interface_other_qualification_type_form, {}).permit(
         :qualification_type,
       )
     end

--- a/app/views/candidate_interface/other_qualifications/type/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/type/new.html.erb
@@ -12,7 +12,7 @@
 
       <%= render 'candidate_interface/other_qualifications/shared/instructions' %>
 
-      <%= f.govuk_radio_buttons_fieldset :choose_qualification_type, legend: { text: 'What type of qualification do you want to add?', tag: 'span' } do %>
+      <%= f.govuk_radio_buttons_fieldset :qualification_type, legend: { text: 'What type of qualification do you want to add?', tag: 'span' } do %>
         <%= f.govuk_radio_button :qualification_type, 'GCSE', label: { text: 'GCSE' } %>
         <%= f.govuk_radio_button :qualification_type, 'A level', label: { text: 'A level' } %>
         <%= f.govuk_radio_button :qualification_type, 'AS level', label: { text: 'AS level' } %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -461,6 +461,10 @@ en:
               blank: Enter your graduation year
               invalid: Enter a real graduation year
               greater_than_limit: 'Enter a year before %{date}'
+        candidate_interface/other_qualification_type_form:
+          attributes:
+            qualification_type:
+              blank: Enter the type of qualification
         candidate_interface/other_qualification_form:
           attributes:
             qualification_type:

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_with_prompting_flag_on_spec.rb
@@ -11,6 +11,10 @@ RSpec.feature 'Entering their other qualifications' do
     when_i_click_on_other_qualifications
     then_i_see_the_select_qualification_type_page
 
+    when_i_do_not_select_any_type_option
+    and_i_click_continue
+    then_i_see_the_qualification_type_error
+
     when_i_select_add_a_level_qualification
     and_i_click_continue
     then_i_see_the_other_qualifications_form
@@ -278,5 +282,11 @@ RSpec.feature 'Entering their other qualifications' do
 
   def and_that_the_section_is_completed
     expect(page).to have_css('#academic-and-other-relevant-qualifications-badge-id', text: 'Completed')
+  end
+
+  def when_i_do_not_select_any_type_option; end
+
+  def then_i_see_the_qualification_type_error
+    expect(page).to have_content 'Enter the type of qualification'
   end
 end


### PR DESCRIPTION
## Context
We call `params.require(:candidate_interface_other_qualification_type_form)`, which is nil if the candidate does not select anything in the page, which causes the require call to throw.

## Changes proposed in this pull request

We use `.fetch(:foo, {})` in other places in the app, so use it here.

## Guidance to review

Read the system spec.

## Link to Trello card

https://sentry.io/organizations/dfe-bat/issues/1601413864/?project=1765973

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)