### PR TITLE
Specify unique course names in a spec requiring them

### DIFF
--- a/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
@@ -77,13 +77,13 @@ RSpec.describe 'Candidate edits course choices' do
 
   def and_there_is_a_course_with_one_course_option
     @provider = create(:provider)
-    create(:course, provider: @provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
+    create(:course, name: 'English', provider: @provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
 
     course_option_for_provider(provider: @provider, course: @provider.courses.first)
   end
 
   def and_there_is_a_course_with_multiple_course_options
-    create(:course, :with_both_study_modes, provider: @provider, exposed_in_find: true, open_on_apply: true)
+    create(:course, :with_both_study_modes, name: 'Maths', provider: @provider, exposed_in_find: true, open_on_apply: true)
 
     # Sites with full time study mode
     course_option_for_provider(provider: @provider, course: @provider.courses.second, study_mode: 'full_time')
@@ -95,7 +95,7 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def and_there_is_a_course_with_both_study_modes_but_one_site
-    create(:course, :with_both_study_modes, provider: @provider, exposed_in_find: true, open_on_apply: true)
+    create(:course, :with_both_study_modes, name: 'Entomology', provider: @provider, exposed_in_find: true, open_on_apply: true)
 
     site = create(:site, provider: @provider)
 


### PR DESCRIPTION
## Context

We saw some intermittent spec failures for this spec.

I think this is because occasional collisions in Faker would cause assertions like 'the name of the third course should not appear' to fail from time to time

## Changes proposed in this pull request

Give the course names unique strings at the point of creation, instead of relying on Faker to generate them

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/jU6gucuI/1884-fix-transient-spec-failure

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
