### PR TITLE
check if a RG exists in Azure before determining if full deployment is required

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -102,75 +102,77 @@ jobs:
 
                 #Check if RG exists
                 Get-AzResourceGroup -Name $resourceGroupName -ErrorVariable rgDoesntExist -ErrorAction SilentlyContinue
-                if($rgDoesntExist){
-                  $fullDeployment = $true
-                  Write-Host "##vso[task.setvariable variable=fullDeployment]$fullDeployment"
-                  return
-                }
-
-                #Get array of deployment files, which if changed, should trigger a full ARM deployment.
-                #Add pipeline files to array
-                $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/contents?ref=$env:COMMIT_HASH"
-                $gitApiResponse = Invoke-RestMethod -Method Get -Uri $gitContentsUri -Headers @{Authorization = $encodedAccessToken}
-                $deploymentFiles = $gitApiResponse | Where-Object {$_.name -like "azure-pipelines*.yml"} | Select-Object -ExpandProperty Name
-                #Add ARM template files to array
-                $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/contents/azure?ref=$env:COMMIT_HASH"
-                $gitApiResponse = Invoke-RestMethod -Method Get -Uri $gitContentsUri -Headers @{Authorization = $encodedAccessToken}
-                $deploymentFiles += $gitApiResponse | Where-Object {$_.name -like "*.json"} | Select-Object -ExpandProperty Name | Foreach-Object { "azure/$_" }
-                write-host ("DEBUG - Deployment files to compare changes against: {0}" -f [system.string]::Join(", ", $deploymentFiles))
-
-                #Get the timestamp of the last deployment to the defined Azure environment from Azure API
-                $lastDeployment = (Get-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName | Where-Object {$_.DeploymentName -Like "template-*"})[0].Timestamp
-
-                #Get the commit hash for the current version deployed in the environment
-                $currentDeployedCommit = (Get-AzResourceGroup -Name $resourceGroupName).Tags.Version
-                 
-                #Get the timestamp of the last update to the variable groups corresponding to the environment defined
-                $variableGroupUri = "https://dev.azure.com/dfe-ssp/Become-A-Teacher/_apis/distributedtask/variablegroups"
-                $variableGroups = Invoke-RestMethod -Method Get -Uri $variableGroupUri -Headers @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
-                $variableGroupLastEdit += ($variableGroups.value | Where-Object {$_.name -like "APPLY - ENV - $environment"}).modifiedOn
-                $variableGroupLastEdit += ($variableGroups.value | Where-Object {$_.name -eq "APPLY - Shared Variables"}).modifiedOn
-                $variableGroupLastEdit += ($variableGroups.value | Where-Object {$_.name -eq "Docker Shared Variables"}).modifiedOn
-                $variableGroupLastEditTimestamp = Get-Date -Year ($variableGroupLastEdit | sort -descending)[0].substring(0,4) `
-                  -Month ($variableGroupLastEdit | sort -descending)[0].substring(5,2) `
-                  -Day ($variableGroupLastEdit | sort -descending)[0].substring(8,2) `
-                  -Hour ($variableGroupLastEdit | sort -descending)[0].substring(11,2) `
-                  -Minute ($variableGroupLastEdit | sort -descending)[0].substring(14,2) `
-                  -Second ($variableGroupLastEdit | sort -descending)[0].substring(17,2)
-
-                #Get the list of files changed in the commit the build was triggered from. If this is a re-run of the same build we will just look at the files changed in that commit"
-                if ( $currentDeployedCommit -eq $env:COMMIT_HASH ) {
-                  $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/commits/$env:COMMIT_HASH"
-                } else {
-                  $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/compare/$currentDeployedCommit...$env:COMMIT_HASH"
-                }
-                $gitChangedFiles = (Invoke-RestMethod -Method Get -Uri $gitCompareUri -Headers @{Authorization = $encodedAccessToken}).files.filename
-                if ( $gitChangedFiles.length -gt 0 ) {
-                  write-host ("DEBUG - Changed files list: {0}" -f [system.string]::Join(", ", $gitChangedFiles))
-                } else {
-                  write-host ("DEBUG - No files changed in commit.")
-                }
-
-                if ( $lastDeployment -lt $variableGroupLastEditTimestamp ) {
-                  write-host "Full ARM deployment required - Variable group changes detected."
-                  $fullDeployment = $true
-                }
-                else {
-                  if ( $gitChangedFiles.length -gt 0 ) {
-                    foreach ( $file in $deploymentFiles ) {
-                      if ( $gitChangedFiles -contains $file ) {
-                        $fullDeployment = $true
-                        break
-                      }
-                    }
-                    if ( $fullDeployment -eq $false ) {
-                      write-host "No ARM deployment required."
-                    } else {
-                      write-host "Full ARM deployment required - Template/pipeline file changes detected."
-                    }
+                if(!$rgDoesntExist){
+                  #RG exists, proceed with other checks
+                  #Get array of deployment files, which if changed, should trigger a full ARM deployment.
+                  #Add pipeline files to array
+                  $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/contents?ref=$env:COMMIT_HASH"
+                  $gitApiResponse = Invoke-RestMethod -Method Get -Uri $gitContentsUri -Headers @{Authorization = $encodedAccessToken}
+                  $deploymentFiles = $gitApiResponse | Where-Object {$_.name -like "azure-pipelines*.yml"} | Select-Object -ExpandProperty Name
+                  #Add ARM template files to array
+                  $gitContentsUri = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/contents/azure?ref=$env:COMMIT_HASH"
+                  $gitApiResponse = Invoke-RestMethod -Method Get -Uri $gitContentsUri -Headers @{Authorization = $encodedAccessToken}
+                  $deploymentFiles += $gitApiResponse | Where-Object {$_.name -like "*.json"} | Select-Object -ExpandProperty Name | Foreach-Object { "azure/$_" }
+                  write-host ("DEBUG - Deployment files to compare changes against: {0}" -f [system.string]::Join(", ", $deploymentFiles))
+  
+                  #Get the timestamp of the last deployment to the defined Azure environment from Azure API
+                  $lastDeployment = (Get-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName | Where-Object {$_.DeploymentName -Like "template-*"})[0].Timestamp
+  
+                  #Get the commit hash for the current version deployed in the environment
+                  $currentDeployedCommit = (Get-AzResourceGroup -Name $resourceGroupName).Tags.Version
+                   
+                  #Get the timestamp of the last update to the variable groups corresponding to the environment defined
+                  $variableGroupUri = "https://dev.azure.com/dfe-ssp/Become-A-Teacher/_apis/distributedtask/variablegroups"
+                  $variableGroups = Invoke-RestMethod -Method Get -Uri $variableGroupUri -Headers @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
+                  $variableGroupLastEdit += ($variableGroups.value | Where-Object {$_.name -like "APPLY - ENV - $environment"}).modifiedOn
+                  $variableGroupLastEdit += ($variableGroups.value | Where-Object {$_.name -eq "APPLY - Shared Variables"}).modifiedOn
+                  $variableGroupLastEdit += ($variableGroups.value | Where-Object {$_.name -eq "Docker Shared Variables"}).modifiedOn
+                  $variableGroupLastEditTimestamp = Get-Date -Year ($variableGroupLastEdit | sort -descending)[0].substring(0,4) `
+                    -Month ($variableGroupLastEdit | sort -descending)[0].substring(5,2) `
+                    -Day ($variableGroupLastEdit | sort -descending)[0].substring(8,2) `
+                    -Hour ($variableGroupLastEdit | sort -descending)[0].substring(11,2) `
+                    -Minute ($variableGroupLastEdit | sort -descending)[0].substring(14,2) `
+                    -Second ($variableGroupLastEdit | sort -descending)[0].substring(17,2)
+  
+                  #Get the list of files changed in the commit the build was triggered from. If this is a re-run of the same build we will just look at the files changed in that commit"
+                  if ( $currentDeployedCommit -eq $env:COMMIT_HASH ) {
+                    $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/commits/$env:COMMIT_HASH"
                   } else {
-                    write-host "No ARM deployment required. No files or pipeline variables changed."
+                    $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/compare/$currentDeployedCommit...$env:COMMIT_HASH"
                   }
+                  $gitChangedFiles = (Invoke-RestMethod -Method Get -Uri $gitCompareUri -Headers @{Authorization = $encodedAccessToken}).files.filename
+                  if ( $gitChangedFiles.length -gt 0 ) {
+                    write-host ("DEBUG - Changed files list: {0}" -f [system.string]::Join(", ", $gitChangedFiles))
+                  } else {
+                    write-host ("DEBUG - No files changed in commit.")
+                  }
+  
+                  if ( $lastDeployment -lt $variableGroupLastEditTimestamp ) {
+                    write-host "Full ARM deployment required - Variable group changes detected."
+                    $fullDeployment = $true
+                  }
+                  else {
+                    if ( $gitChangedFiles.length -gt 0 ) {
+                      foreach ( $file in $deploymentFiles ) {
+                        if ( $gitChangedFiles -contains $file ) {
+                          $fullDeployment = $true
+                          break
+                        }
+                      }
+                      if ( $fullDeployment -eq $false ) {
+                        write-host "No ARM deployment required."
+                      } else {
+                        write-host "Full ARM deployment required - Template/pipeline file changes detected."
+                      }
+                    } else {
+                      write-host "No ARM deployment required. No files or pipeline variables changed."
+                    }
+                  }
+                }
+                else{
+                  #RG not found, so do a full deployment
+                  $fullDeployment = $true
+                  Write-Host "Full ARM deployment required as $resourceGroupName not found in subscription."
                 }
                 
                 Write-Host "##vso[task.setvariable variable=fullDeployment]$fullDeployment"

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -368,3 +368,4 @@ jobs:
               ResourceGroupName: '$(resourceGroupName)'
               Slot: staging
             condition: succeeded()
+            

--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -74,13 +74,13 @@ jobs:
       system.debug: ${{parameters.debug}}
 
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-latest
 
     strategy:
       runOnce:
         deploy:
           steps:
-          - task: AzurePowerShell@3
+          - task: AzurePowerShell@4
             displayName: 'Azure PowerShell Script - Set Deployment Type for Resource Group $(resourceGroupName)'
             condition: succeeded()
             env:
@@ -91,7 +91,7 @@ jobs:
               ScriptType: InlineScript
               azurePowerShellVersion: LatestVersion
               Inline: |
-                Param(
+                param(
                   [string] $resourceGroupName = "$(resourceGroupName)",
                   [string] $environment = "${{parameters.environment}}"
                 )
@@ -99,6 +99,14 @@ jobs:
                 $fullDeployment = $false
                 $encodedAccessToken = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($env:SYSTEM_ACCESSTOKEN))
                 $variableGroupLastEdit = @()
+
+                #Check if RG exists
+                Get-AzResourceGroup -Name $resourceGroupName -ErrorVariable rgDoesntExist -ErrorAction SilentlyContinue
+                if($rgDoesntExist){
+                  $fullDeployment = $true
+                  Write-Host "##vso[task.setvariable variable=fullDeployment]$fullDeployment"
+                  return
+                }
 
                 #Get array of deployment files, which if changed, should trigger a full ARM deployment.
                 #Add pipeline files to array
@@ -112,10 +120,10 @@ jobs:
                 write-host ("DEBUG - Deployment files to compare changes against: {0}" -f [system.string]::Join(", ", $deploymentFiles))
 
                 #Get the timestamp of the last deployment to the defined Azure environment from Azure API
-                $lastDeployment = (Get-AzureRmResourceGroupDeployment -ResourceGroupName $resourceGroupName | Where-Object {$_.DeploymentName -Like "template-*"})[0].Timestamp
+                $lastDeployment = (Get-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName | Where-Object {$_.DeploymentName -Like "template-*"})[0].Timestamp
 
                 #Get the commit hash for the current version deployed in the environment
-                $currentDeployedCommit = (Get-AzureRmResourceGroup -Name $resourceGroupName).Tags.Version
+                $currentDeployedCommit = (Get-AzResourceGroup -Name $resourceGroupName).Tags.Version
                  
                 #Get the timestamp of the last update to the variable groups corresponding to the environment defined
                 $variableGroupUri = "https://dev.azure.com/dfe-ssp/Become-A-Teacher/_apis/distributedtask/variablegroups"
@@ -302,7 +310,7 @@ jobs:
                   }
                 }
 
-          - task: AzurePowerShell@3
+          - task: AzurePowerShell@4
             displayName: 'Azure PowerShell Script - Tag resource group: $(resourceGroupName)'
             condition: succeeded()
             inputs:
@@ -323,7 +331,7 @@ jobs:
 
                 (ConvertFrom-Json $commonResourceTags).psobject.properties | Foreach { $tags[$_.Name] = $_.Value }
 
-                Set-AzureRmResourceGroup -Name $resourceGroupName -Tag $tags
+                Set-AzResourceGroup -Name $resourceGroupName -Tag $tags
 
 
           - task: AzureAppServiceManage@0

--- a/azure/template.json
+++ b/azure/template.json
@@ -841,7 +841,10 @@
                         "value": "[parameters('commonResourceTags')]"
                     }
                 }
-            }
+            },
+            "dependsOn" : [
+                "storage-account"
+            ]
         },
         {
             "apiVersion": "2017-05-10",


### PR DESCRIPTION
## Context

Currently the deployment would fail if a RG doesn't already exists, so we need to make changes to the scripts to check if a RG exists.

## Changes proposed in this pull request

Check if a RG exists in a azure subscription, before proceeding to make further checks to determine if a full ARM deployment is required.

## Guidance to review

Changing inline powershell scripts to determine if a azure RG exists.

## Link to Trello card

https://trello.com/c/A3Am3PcM/1897-bug-creating-new-azure-environment-fails-because-resource-group-doesnt-exist

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
