### PR TITLE
Attempt to fix a flakey system spec for courses changes

### DIFF
--- a/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def when_i_click_to_change_the_course_for_the_first_course_choice
-    click_link "Change course choice for #{@provider.courses.third.name}"
+    click_link "Change course choice for #{@provider.courses.third.name_and_code}"
   end
 
   def and_i_choose_the_single_site_course_as_my_first_course_choice
@@ -144,19 +144,19 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def and_i_should_see_a_change_course_link
-    expect(page).to have_content("Change course choice for #{@provider.courses.third.name}")
+    expect(page).to have_content("Change course choice for #{@provider.courses.third.name_and_code}")
   end
 
   def and_i_should_see_the_updated_change_course_link
-    expect(page).to have_content("Change course choice for #{@provider.courses.first.name}")
+    expect(page).to have_content("Change course choice for #{@provider.courses.first.name_and_code}")
   end
 
   def and_i_should_not_see_a_change_location_link
-    expect(page).not_to have_content("Change location for #{@provider.courses.first.name}")
+    expect(page).not_to have_content("Change location for #{@provider.courses.first.name_and_code}")
   end
 
   def and_i_should_not_see_a_change_study_mode_link
-    expect(page).not_to have_content("Change study mode for #{@provider.courses.first.name}")
+    expect(page).not_to have_content("Change study mode for #{@provider.courses.first.name_and_code}")
   end
 
   def when_i_click_to_add_another_course
@@ -187,11 +187,11 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def and_i_should_see_a_change_location_link
-    expect(page).to have_content("Change location for #{@provider.courses.second.name}")
+    expect(page).to have_content("Change location for #{@provider.courses.second.name_and_code}")
   end
 
   def and_i_should_see_a_change_study_mode_link
-    expect(page).to have_content("Change study mode for #{@provider.courses.second.name}")
+    expect(page).to have_content("Change study mode for #{@provider.courses.second.name_and_code}")
   end
 
   def and_i_choose_the_single_site_course_as_my_third_course_choice
@@ -200,15 +200,15 @@ RSpec.describe 'Candidate edits course choices' do
   end
 
   def and_i_should_see_another_change_study_mode_link
-    expect(page).to have_content("Change study mode for #{@provider.courses.third.name}")
+    expect(page).to have_content("Change study mode for #{@provider.courses.third.name_and_code}")
   end
 
   def and_i_should_not_see_another_change_location_link
-    expect(page).not_to have_content("Change location for #{@provider.courses.third.name}")
+    expect(page).not_to have_content("Change location for #{@provider.courses.third.name_and_code}")
   end
 
   def when_i_click_to_change_the_location_of_the_second_course_choice
-    click_link "Change location for #{@provider.courses.second.name}"
+    click_link "Change location for #{@provider.courses.second.name_and_code}"
   end
 
   def and_i_choose_the_second_site


### PR DESCRIPTION
## Context

Looks like this is failing when there are duplicate course names generated by the factories. e.g. https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=57595&view=ms.vss-test-web.build-test-results-tab&runId=1215328&resultId=101138&paneView=debug

## Changes proposed in this pull request

- [x] Do content matches on the course name and code so that we get an exact match.

## Guidance to review

- Is there a better way?

## Link to Trello card

n/a

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
