### PR TITLE
Support users can grant permissions to provider users

### DIFF
--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -20,15 +20,16 @@ module ProviderInterface
         provider_user_params.merge(current_provider_user: current_provider_user),
       )
       provider_user = @form.build
-      render :new and return unless provider_user
+      service = SaveAndInviteProviderUser.new(
+        form: @form,
+        save_service: SaveProviderUser.new(provider_user: provider_user),
+        invite_service: InviteProviderUser.new(provider_user: provider_user),
+      )
 
-      InviteProviderUser.new(provider_user: provider_user).save_and_invite!
+      render :new and return unless service.call
 
       flash[:success] = 'Provider user invited'
       redirect_to provider_interface_provider_users_path
-    rescue DfeSignInApiError => e
-      handle_dsi_error(e)
-      render :new
     end
 
   private
@@ -40,14 +41,6 @@ module ProviderInterface
 
     def requires_provider_add_provider_users_feature_flag
       raise unless FeatureFlag.active?('provider_add_provider_users')
-    end
-
-    def handle_dsi_error(form, exception)
-      Raven.capture_exception(exception)
-      form.errors.add(
-        :base,
-        'A problem occurred inviting this user. Please try again. If problems persist, please contact support.',
-      )
     end
   end
 end

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -31,10 +31,11 @@ module SupportInterface
 
     def update
       provider_user = ProviderUser.find(params[:id])
+      provider_user.assign_attributes(provider_user_params.except(:permissions))
       @form = ProviderUserForm.from_provider_user(provider_user)
-      @form.assign_attributes provider_user_params
+      service = SaveProviderUser.new(provider_user: provider_user, permissions: permissions_params)
 
-      if @form.save
+      if service.call!
         flash[:success] = 'Provider user updated'
         redirect_to edit_support_interface_provider_user_path(provider_user)
       else

--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -48,7 +48,8 @@ module SupportInterface
   private
 
     def provider_user_params
-      params.require(:support_interface_provider_user_form).permit(:email_address, :first_name, :last_name, provider_ids: [])
+      params.require(:support_interface_provider_user_form)
+        .permit(:email_address, :first_name, :last_name, :manage_users, provider_ids: [])
     end
   end
 end

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -5,4 +5,6 @@ class ProviderPermissions < ActiveRecord::Base
   belongs_to :provider
 
   audited associated_with: :provider_user
+
+  scope :manage_users, -> { where(manage_users: true) }
 end

--- a/app/models/provider_permissions_options.rb
+++ b/app/models/provider_permissions_options.rb
@@ -1,0 +1,17 @@
+class ProviderPermissionsOptions
+  include ActiveModel::Model
+
+  VALID_PERMISSIONS = %i[manage_users].freeze
+
+  attr_accessor(*VALID_PERMISSIONS)
+
+  def self.valid?(permission_name)
+    VALID_PERMISSIONS.include?(permission_name.to_sym)
+  end
+
+  def self.reset_attributes
+    {}.tap do |hsh|
+      VALID_PERMISSIONS.each { |p| hsh[p] = false }
+    end
+  end
+end

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -50,6 +50,7 @@ module SupportInterface
         last_name: provider_user.last_name,
         email_address: provider_user.email_address,
         provider_ids: provider_user.provider_ids,
+        manage_users: provider_user.can_manage_users?,
       )
     end
 

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -24,7 +24,11 @@ module SupportInterface
     end
 
     def save
-      @provider_user.save! if build
+      if build
+        @provider_user.save!
+        assign_manage_users_permissions if manage_users
+        @provider_user
+      end
     end
 
     def email_address=(raw_email_address)
@@ -63,6 +67,13 @@ module SupportInterface
       return unless ProviderUser.exists?(email_address: email_address)
 
       errors.add(:email_address, 'This email address is already in use')
+    end
+
+    def assign_manage_users_permissions
+      ProviderPermissions.where(
+        provider_user_id: provider_user.id,
+        provider_id: provider_ids,
+      ).update_all(manage_users: true)
     end
   end
 end

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -47,7 +47,7 @@ module SupportInterface
         last_name: provider_user.last_name,
         email_address: provider_user.email_address,
         provider_ids: provider_user.provider_ids,
-        permissions: permissions(provider_user),
+        permissions: permissions_for(provider_user),
       )
     end
 
@@ -57,10 +57,10 @@ module SupportInterface
       @provider_ids.reject(&:blank?)
     end
 
-    def self.permissions(provider_user)
-      {
-        manage_users: ProviderPermissions.manage_users.where(provider_user: provider_user).pluck(:provider_id),
-      }
+    def self.permissions_for(provider_user)
+      provider_permissions = ProviderPermissions.manage_users.where(provider_user: provider_user)
+
+      OpenStruct.new({ manage_users: provider_permissions.pluck(:provider_id) })
     end
 
   private

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -60,7 +60,7 @@ module SupportInterface
     def self.permissions_for(provider_user)
       provider_permissions = ProviderPermissions.manage_users.where(provider_user: provider_user)
 
-      OpenStruct.new({ manage_users: provider_permissions.pluck(:provider_id) })
+      ProviderPermissionsOptions.new(manage_users: provider_permissions.pluck(:provider_id))
     end
 
   private

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -24,10 +24,6 @@ module SupportInterface
       @provider_user if @provider_user.valid?
     end
 
-    def save
-      @provider_user.save! if build
-    end
-
     def email_address=(raw_email_address)
       @email_address = raw_email_address.downcase.strip
     end

--- a/app/services/invite_provider_user.rb
+++ b/app/services/invite_provider_user.rb
@@ -7,11 +7,8 @@ class InviteProviderUser
     @provider_user = provider_user
   end
 
-  def save_and_invite!
-    ActiveRecord::Base.transaction do
-      @provider_user.save!
-      invite_user_to_dfe_sign_in
-    end
+  def call!
+    invite_user_to_dfe_sign_in
 
     send_welcome_email
   end

--- a/app/services/save_and_invite_provider_user.rb
+++ b/app/services/save_and_invite_provider_user.rb
@@ -1,0 +1,20 @@
+class SaveAndInviteProviderUser
+  attr_reader :form, :save_service, :invite_service
+
+  def initialize(form:, save_service:, invite_service:)
+    @form = form
+    @save_service = save_service
+    @invite_service = invite_service
+  end
+
+  def call
+    if form.valid?
+      ActiveRecord::Base.transaction do
+        save_service.call!
+        invite_service.call!
+      end
+    end
+  rescue DfeSignInApiError => e
+    e.errors.each { |error| form.errors.add(:base, error) }
+  end
+end

--- a/app/services/save_and_invite_provider_user.rb
+++ b/app/services/save_and_invite_provider_user.rb
@@ -14,7 +14,10 @@ class SaveAndInviteProviderUser
         invite_service.call!
       end
     end
-  rescue DfeSignInApiError => e
-    e.errors.each { |error| form.errors.add(:base, error) }
+  rescue DfeSignInApiError
+    form.errors.add(
+      :base,
+      'A problem occurred inviting this user. Please try again. If problems persist, please contact support.',
+    )
   end
 end

--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -10,6 +10,8 @@ class SaveProviderUser
     @provider_user.reload
   end
 
+private
+
   def update_permissions
     ActiveRecord::Base.transaction do
       ProviderPermissions
@@ -25,12 +27,15 @@ class SaveProviderUser
   end
 
   def sanitized_permissions(permissions)
-    return {} unless @provider_user
+    result = {}
+    return result unless @provider_user
 
-    permissions.select do |permission_name, provider_ids|
-      provider_ids.map!(&:to_i)
-      ProviderPermissionsOptions.valid?(permission_name) &&
-        (provider_ids & @provider_user.provider_ids) == provider_ids
+    permissions.each do |permission_name, provider_ids|
+      if ProviderPermissionsOptions.valid?(permission_name)
+        result[permission_name] = provider_ids.map(&:to_i) & @provider_user.provider_ids
+      end
     end
+
+    result
   end
 end

--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -1,0 +1,33 @@
+class SaveProviderUser
+  VALID_PERMISSIONS = %i[manage_users].freeze
+
+  def initialize(provider_user:, permissions: {})
+    @provider_user = provider_user
+    @permissions = sanitized_permissions(permissions)
+  end
+
+  def call!
+    @provider_user.save!
+    update_permissions
+    @provider_user.reload
+  end
+
+  def update_permissions
+    @permissions.each do |permission, provider_ids|
+      ProviderPermissions.where(
+        provider_user: @provider_user,
+        provider_id: provider_ids,
+      ).update_all(permission => true)
+    end
+  end
+
+  def sanitized_permissions(permissions)
+    return {} unless @provider_user
+
+    permissions.select do |permission_name, provider_ids|
+      provider_ids.map!(&:to_i)
+      VALID_PERMISSIONS.include?(permission_name.to_sym) &&
+        (provider_ids & @provider_user.provider_ids) == provider_ids
+    end
+  end
+end

--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -1,6 +1,4 @@
 class SaveProviderUser
-  VALID_PERMISSIONS = %i[manage_users].freeze
-
   def initialize(provider_user:, permissions: {})
     @provider_user = provider_user
     @permissions = sanitized_permissions(permissions)
@@ -16,7 +14,7 @@ class SaveProviderUser
     ActiveRecord::Base.transaction do
       ProviderPermissions
         .where(provider_user: @provider_user)
-        .update_all(reset_permissions_attrs)
+        .update_all(ProviderPermissionsOptions.reset_attributes)
 
       @permissions.each do |permission, provider_ids|
         ProviderPermissions
@@ -31,14 +29,8 @@ class SaveProviderUser
 
     permissions.select do |permission_name, provider_ids|
       provider_ids.map!(&:to_i)
-      VALID_PERMISSIONS.include?(permission_name.to_sym) &&
+      ProviderPermissionsOptions.valid?(permission_name) &&
         (provider_ids & @provider_user.provider_ids) == provider_ids
-    end
-  end
-
-  def reset_permissions_attrs
-    {}.tap do |hash|
-      VALID_PERMISSIONS.each { |p| hash[p] = false }
     end
   end
 end

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -2,22 +2,10 @@
   <div class="app-checkboxes-scroll" %>
     <% f.object.available_providers.each do |provider| %>
       <%= f.govuk_check_box :provider_ids, provider.id, label: { text: provider.name_and_code } do %>
-        <%= f.fields_for :permissions do |pm| %>
+        <%= f.fields_for :permissions, f.object.permissions  do |pm| %>
           <%= pm.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-						<div class="govuk-checkboxes__item">
-<%# FIXME: Needs refactor, FormBuilder doesn't like the hash lookup for permissions hence the manual check box tag. %>
-							<%= check_box_tag(
-								'support_interface_provider_user_form[permissions][manage_users][]',
-								provider.id,
-								(f.object.permissions || {}).fetch(:manage_users, []).include?(provider.id),
-								class: 'govuk-checkboxes__input',
-								id: "support-interface-provider-user-form-permissions-manage-users-#{provider.id}-field",
-            	) %>
-
-							<label for="support-interface-provider-user-form-permissions-manage-users-<%= provider.id %>-field"
-										 class="govuk-label govuk-checkboxes__label">Manage users</label>
-						</div>
-          <% end %>
+            <%= pm.govuk_check_box :manage_users, provider.id, label: { text: 'Manage users' } %>
+					<% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,0 +1,13 @@
+<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Provider' } do %>
+  <div class="app-checkboxes-scroll" %>
+    <% f.object.available_providers.each do |provider| %>
+      <%= f.govuk_check_box :provider_ids, provider.id, label: { text: provider.name_and_code } do %>
+        <%= f.fields_for :permissions do |pm| %>
+          <%= pm.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
+            <%= pm.govuk_check_box :manage_users, provider.id, label: { text: 'Manage users' } %>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -4,7 +4,19 @@
       <%= f.govuk_check_box :provider_ids, provider.id, label: { text: provider.name_and_code } do %>
         <%= f.fields_for :permissions do |pm| %>
           <%= pm.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-            <%= pm.govuk_check_box :manage_users, provider.id, label: { text: 'Manage users' } %>
+						<div class="govuk-checkboxes__item">
+<%# FIXME: Needs refactor, FormBuilder doesn't like the hash lookup for permissions hence the manual check box tag. %>
+							<%= check_box_tag(
+								'support_interface_provider_user_form[permissions][manage_users][]',
+								provider.id,
+								(f.object.permissions || {}).fetch(:manage_users, []).include?(provider.id),
+								class: 'govuk-checkboxes__input',
+								id: "support-interface-provider-user-form-permissions-manage-users-#{provider.id}-field",
+            	) %>
+
+							<label for="support-interface-provider-user-form-permissions-manage-users-<%= provider.id %>-field"
+										 class="govuk-label govuk-checkboxes__label">Manage users</label>
+						</div>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -33,6 +33,8 @@
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
 
+      <%= f.govuk_check_box :manage_users, false, label: { text: 'Allow this user to invite others' } %>
+
       <%= f.govuk_submit 'Update user' %>
     <% end %>
   </div>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -31,9 +31,7 @@
       <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
 
-      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
-
-      <%= f.govuk_check_box :manage_users, @form.manage_users, label: { text: 'Allow this user to invite others' } %>
+      <%= render 'provider_options', f: f %>
 
       <%= f.govuk_submit 'Update user' %>
     <% end %>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -33,7 +33,7 @@
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
 
-      <%= f.govuk_check_box :manage_users, false, label: { text: 'Allow this user to invite others' } %>
+      <%= f.govuk_check_box :manage_users, @form.manage_users, label: { text: 'Allow this user to invite others' } %>
 
       <%= f.govuk_submit 'Update user' %>
     <% end %>

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -25,9 +25,7 @@
       <%= f.govuk_text_field :first_name, label: { text: 'First name' } %>
       <%= f.govuk_text_field :last_name, label: { text: 'Last name' } %>
 
-      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
-
-      <%= f.govuk_check_box :manage_users, false, label: { text: 'Allow this user to invite others' } %>
+      <%= render 'provider_options', f: f %>
 
       <%= f.govuk_submit 'Add provider user' %>
     <% end %>

--- a/app/views/support_interface/provider_users/new.html.erb
+++ b/app/views/support_interface/provider_users/new.html.erb
@@ -27,6 +27,8 @@
 
       <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }, classes: 'app-checkboxes-scroll' %>
 
+      <%= f.govuk_check_box :manage_users, false, label: { text: 'Allow this user to invite others' } %>
+
       <%= f.govuk_submit 'Add provider user' %>
     <% end %>
   </div>

--- a/spec/models/support_interface/provider_user_form_spec.rb
+++ b/spec/models/support_interface/provider_user_form_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe SupportInterface::ProviderUserForm do
 
     before { provider_user.provider_permissions.first.update(manage_users: true) }
 
-    it 'returns provider permissions for the given user as an OpenStruct' do
+    it 'returns provider permissions for the given user' do
       permissions = described_class.permissions_for(provider_user)
 
-      expect(permissions).to be_a(OpenStruct)
+      expect(permissions).to be_a(ProviderPermissionsOptions)
       expect(permissions.manage_users).to eq(provider_user.providers.map(&:id))
     end
   end

--- a/spec/models/support_interface/provider_user_form_spec.rb
+++ b/spec/models/support_interface/provider_user_form_spec.rb
@@ -32,6 +32,19 @@ RSpec.describe SupportInterface::ProviderUserForm do
     end
   end
 
+  describe '.permissions_for' do
+    let(:provider_user) { create(:provider_user, :with_provider) }
+
+    before { provider_user.provider_permissions.first.update(manage_users: true) }
+
+    it 'returns provider permissions for the given user as an OpenStruct' do
+      permissions = described_class.permissions_for(provider_user)
+
+      expect(permissions).to be_a(OpenStruct)
+      expect(permissions.manage_users).to eq(provider_user.providers.map(&:id))
+    end
+  end
+
   describe '#save' do
     context 'with invalid params' do
       it 'returns nil' do

--- a/spec/models/support_interface/provider_user_form_spec.rb
+++ b/spec/models/support_interface/provider_user_form_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::ProviderUserForm do
+  let(:email_address) { 'provider@example.com' }
+  let(:provider_ids) { [] }
+  let(:form_params) do
+    {
+      first_name: 'Jane',
+      last_name: 'Smith',
+      email_address: email_address,
+      provider_ids: provider_ids,
+    }
+  end
+
+  subject(:provider_user_form) { described_class.new(form_params) }
+
+  describe 'validations' do
+    context 'email address exists' do
+      before { allow(ProviderUser).to receive(:exists?).with(email_address: email_address).and_return(true) }
+
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:email_address]).not_to be_empty
+      end
+    end
+
+    context 'provider_ids are blank' do
+      it 'is invalid' do
+        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form.errors[:provider_ids]).not_to be_empty
+      end
+    end
+  end
+
+  describe '#save' do
+    context 'with invalid params' do
+      it 'returns nil' do
+        expect(provider_user_form.save).to be nil
+      end
+    end
+
+    context 'with valid params' do
+      let(:provider) { create(:provider) }
+      let(:provider_ids) { [provider.id] }
+
+      it 'saves a new ProviderUser' do
+        provider_user_form.save
+        provider_user = ProviderUser.last
+
+        expect(provider_user_form.persisted?).to be true
+        expect(provider_user.providers).to eq([provider])
+      end
+    end
+  end
+end

--- a/spec/models/support_interface/provider_user_form_spec.rb
+++ b/spec/models/support_interface/provider_user_form_spec.rb
@@ -44,25 +44,4 @@ RSpec.describe SupportInterface::ProviderUserForm do
       expect(permissions.manage_users).to eq(provider_user.providers.map(&:id))
     end
   end
-
-  describe '#save' do
-    context 'with invalid params' do
-      it 'returns nil' do
-        expect(provider_user_form.save).to be nil
-      end
-    end
-
-    context 'with valid params' do
-      let(:provider) { create(:provider) }
-      let(:provider_ids) { [provider.id] }
-
-      it 'saves a new ProviderUser' do
-        provider_user_form.save
-        provider_user = ProviderUser.last
-
-        expect(provider_user_form.persisted?).to be true
-        expect(provider_user.providers).to eq([provider])
-      end
-    end
-  end
 end

--- a/spec/services/save_and_invite_provider_user_spec.rb
+++ b/spec/services/save_and_invite_provider_user_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe SaveAndInviteProviderUser do
+  let(:provider) { create(:provider) }
+  let(:form) {
+    SupportInterface::ProviderUserForm.new(
+      email_address: 'test+invite_provider_user@example.com',
+      first_name: 'Firstname',
+      last_name: 'Lastname',
+      provider_ids: [provider.id],
+    )
+  }
+  let(:permissions) { { manage_users: [provider.id] } }
+  let(:provider_user) { form.build }
+  let(:save_service) { SaveProviderUser.new(provider_user: provider_user, permissions: permissions) }
+  let(:invite_service) { InviteProviderUser.new(provider_user: provider_user) }
+
+  describe '#initialize' do
+    it 'requires a form, create service and invite service' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+      expect {
+        described_class.new(form: form, save_service: save_service, invite_service: invite_service)
+      }.not_to raise_error
+    end
+  end
+
+  describe '#call!' do
+    subject(:service) do
+      described_class.new(form: form, save_service: save_service, invite_service: invite_service)
+    end
+
+    context 'an error occurs in create service' do
+      before do
+        allow(save_service).to receive(:call!).and_raise(ActiveRecord::RecordInvalid)
+        allow(invite_service).to receive(:call!)
+      end
+
+      it 'exits the transactioni and raises the error' do
+        expect { service.call }.to raise_error(ActiveRecord::RecordInvalid)
+
+        expect(invite_service).not_to have_received(:call!)
+      end
+    end
+
+    context 'an error occurs in invite service' do
+      before { allow(invite_service).to receive(:call!).and_raise }
+
+      it 'rolls back the transaction and raises the error' do
+        expect { service.call }.to raise_error.and change(ProviderUser, :count).by(0)
+      end
+    end
+
+    context 'a DfeSignInApiError occurs' do
+      let(:bad_response) { instance_double(HTTP::Response, body: { 'errors': %w[bad] }.to_json, status: 500) }
+      let(:exception) { DfeSignInApiError.new(bad_response) }
+
+      before { allow(invite_service).to receive(:call!).and_raise(exception) }
+
+      it 'rolls back the transaction' do
+        expect { service.call }.not_to change(ProviderUser, :count)
+      end
+
+      it 'populates form errors' do
+        service.call
+
+        expect(service.form.errors).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/services/save_provider_user_spec.rb
+++ b/spec/services/save_provider_user_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe SaveProviderUser do
+  let(:provider) { create(:provider) }
+  let(:new_provider_user_from_form) {
+    SupportInterface::ProviderUserForm.new(
+      email_address: 'test+invite_provider_user@example.com',
+      first_name: 'Firstname',
+      last_name: 'Lastname',
+      provider_ids: [provider.id],
+    ).build
+  }
+  let(:permissions) { { manage_users: [provider.id] } }
+
+  describe '#initialize' do
+    it 'requires a provider_user:' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+      expect { described_class.new(provider_user: ProviderUser.new) }.not_to raise_error
+    end
+  end
+
+  describe '#call!' do
+    subject(:service) do
+      described_class.new(provider_user: new_provider_user_from_form, permissions: permissions)
+    end
+
+    it 'saves the provider user' do
+      expect { service.call! }.to change(ProviderUser, :count).by(1)
+    end
+
+    it 'updates permissions for the saved user' do
+      expect { @provider_user = service.call! }.to change(ProviderPermissions, :count).by(1)
+
+      expected_permissions = ProviderPermissions.where(
+        provider: provider,
+        provider_user: @provider_user,
+        manage_users: true,
+      )
+
+      expect(expected_permissions.count).to eq(1)
+    end
+  end
+end

--- a/spec/services/save_provider_user_spec.rb
+++ b/spec/services/save_provider_user_spec.rb
@@ -39,5 +39,22 @@ RSpec.describe SaveProviderUser do
 
       expect(expected_permissions.count).to eq(1)
     end
+
+    context 'for permissions on unassigned providers' do
+      let(:another_provider) { create(:provider) }
+      let(:permissions) { { manage_users: [provider.id, another_provider.id] } }
+
+      it 'ignores permissions for these providers' do
+        @provider_user = service.call!
+
+        providers_for_permissions = ProviderPermissions.where(
+          provider_user: @provider_user,
+          manage_users: true,
+        ).map(&:provider).flatten
+
+        expect(providers_for_permissions).to include(provider)
+        expect(providers_for_permissions).not_to include(another_provider)
+      end
+    end
   end
 end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -14,6 +14,7 @@ RSpec.feature 'Managing provider users' do
     and_i_click_the_manange_provider_users_link
     and_i_click_the_add_user_link
     and_i_enter_an_existing_email
+    and_i_check_allow_user_to_invite_other_users
     and_i_click_add_user
     then_i_see_an_error
 
@@ -83,6 +84,10 @@ RSpec.feature 'Managing provider users' do
     fill_in 'support_interface_provider_user_form[email_address]', with: 'harrison@example.com'
     fill_in 'support_interface_provider_user_form[first_name]', with: 'Harrison'
     fill_in 'support_interface_provider_user_form[last_name]', with: 'Bergeron'
+  end
+
+  def and_i_check_allow_user_to_invite_other_users
+    check 'Allow this user to invite others'
   end
 
   def and_i_click_add_user

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -36,6 +36,7 @@ RSpec.feature 'Managing provider users' do
     when_they_have_signed_in_at_least_once
     and_i_reload_the_page
     then_their_email_should_be_editable
+    and_they_should_be_able_to_invite_other_users
   end
 
   def given_dfe_signin_is_configured
@@ -139,5 +140,9 @@ RSpec.feature 'Managing provider users' do
 
   def then_their_email_should_be_editable
     expect(page).to have_field 'Email address', disabled: false
+  end
+
+  def and_they_should_be_able_to_invite_other_users
+    expect(page).to have_field('Allow this user to invite others', checked: true)
   end
 end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -132,8 +132,8 @@ RSpec.feature 'Managing provider users' do
   end
 
   def when_they_have_signed_in_at_least_once
-    user = ProviderUser.find_by(email_address: 'harrison@example.com')
-    user.update!(dfe_sign_in_uid: 'ABC123')
+    @user = ProviderUser.find_by(email_address: 'harrison@example.com')
+    @user.update!(dfe_sign_in_uid: 'ABC123')
   end
 
   def and_i_reload_the_page
@@ -145,6 +145,8 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_they_should_be_able_to_manage_users
+    expect(@user.reload.provider_permissions.manage_users.first.provider).to eq(@provider)
+
     within("#support-interface-provider-user-form-provider-ids-#{@provider.id}-conditional") do
       expect(page).to have_checked_field('Manage users')
     end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -14,12 +14,12 @@ RSpec.feature 'Managing provider users' do
     and_i_click_the_manange_provider_users_link
     and_i_click_the_add_user_link
     and_i_enter_an_existing_email
-    and_i_check_allow_user_to_invite_other_users
     and_i_click_add_user
     then_i_see_an_error
 
     and_i_enter_the_users_email_and_name
     and_i_select_a_provider
+    and_i_check_permission_to_manage_users
     and_i_click_add_user
 
     then_i_should_see_the_list_of_provider_users
@@ -36,7 +36,7 @@ RSpec.feature 'Managing provider users' do
     when_they_have_signed_in_at_least_once
     and_i_reload_the_page
     then_their_email_should_be_editable
-    and_they_should_be_able_to_invite_other_users
+    and_they_should_be_able_to_manage_users
   end
 
   def given_dfe_signin_is_configured
@@ -48,7 +48,7 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_providers_exist
-    create(:provider, name: 'Example provider', code: 'ABC')
+    @provider = create(:provider, name: 'Example provider', code: 'ABC')
     create(:provider, name: 'Another provider', code: 'DEF')
   end
 
@@ -68,6 +68,12 @@ RSpec.feature 'Managing provider users' do
     check 'Example provider (ABC)'
   end
 
+  def and_i_check_permission_to_manage_users
+    within("#support-interface-provider-user-form-provider-ids-#{@provider.id}-conditional") do
+      check 'Manage users'
+    end
+  end
+
   def and_i_click_the_add_user_link
     click_link 'Add provider user'
   end
@@ -85,10 +91,6 @@ RSpec.feature 'Managing provider users' do
     fill_in 'support_interface_provider_user_form[email_address]', with: 'harrison@example.com'
     fill_in 'support_interface_provider_user_form[first_name]', with: 'Harrison'
     fill_in 'support_interface_provider_user_form[last_name]', with: 'Bergeron'
-  end
-
-  def and_i_check_allow_user_to_invite_other_users
-    check 'Allow this user to invite others'
   end
 
   def and_i_click_add_user
@@ -142,7 +144,9 @@ RSpec.feature 'Managing provider users' do
     expect(page).to have_field 'Email address', disabled: false
   end
 
-  def and_they_should_be_able_to_invite_other_users
-    expect(page).to have_field('Allow this user to invite others', checked: true)
+  def and_they_should_be_able_to_manage_users
+    within("#support-interface-provider-user-form-provider-ids-#{@provider.id}-conditional") do
+      expect(page).to have_checked_field('Manage users')
+    end
   end
 end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -37,6 +37,10 @@ RSpec.feature 'Managing provider users' do
     and_i_reload_the_page
     then_their_email_should_be_editable
     and_they_should_be_able_to_manage_users
+
+    when_i_remove_manage_users_permissions
+    and_i_click_update_user
+    then_they_should_not_be_able_to_manage_users
   end
 
   def given_dfe_signin_is_configured
@@ -149,6 +153,25 @@ RSpec.feature 'Managing provider users' do
 
     within("#support-interface-provider-user-form-provider-ids-#{@provider.id}-conditional") do
       expect(page).to have_checked_field('Manage users')
+    end
+  end
+
+  def when_i_remove_manage_users_permissions
+    within("#support-interface-provider-user-form-provider-ids-#{@provider.id}-conditional") do
+      uncheck 'Manage users'
+    end
+  end
+
+  def and_i_click_update_user
+    click_on 'Update user'
+  end
+
+  def then_they_should_not_be_able_to_manage_users
+    expect(@user.reload.provider_permissions.manage_users).to be_empty
+
+    within("#support-interface-provider-user-form-provider-ids-#{@provider.id}-conditional") do
+      expect(page).to have_field('Manage users')
+      expect(page).not_to have_checked_field('Manage users')
     end
   end
 end


### PR DESCRIPTION
## Context

We have added a MVP of provider user permissions. We should allow support users to manage these.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Splits `InviteProviderUser` into dual concerns of saving + updating permissions and inviting in separate services
- Introduces a service to call both of the above and handle errors
- Nests permissions per provider available to the provider user

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/79231492-0be7fd00-7e5e-11ea-80fd-5450315e668d.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/KgRyOExk/1842-supportusers-can-grant-permissions-to-providerusers

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
