### PR TITLE
Fix for group deployment deprecation error

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -74,7 +74,7 @@ jobs:
       system.debug: ${{parameters.debug}}
 
     pool:
-      vmImage: windows-latest
+      vmImage: windows-2019
 
     strategy:
       runOnce:
@@ -268,7 +268,7 @@ jobs:
                 }
 
                 foreach ( $container in $containers ) {
-                  $containerConfig = az group deployment show --resource-group $resourceGroupName --name "container-instances-$($container)" | ConvertFrom-Json
+                  $containerConfig = az deployment group show --resource-group $resourceGroupName --name "container-instances-$($container)" | ConvertFrom-Json
 
                   $envVars = @()
                   $secureEnvVars = @()


### PR DESCRIPTION
## Context

At some point between late Thursday 9th and this morning it appears that Microsoft have introduced a deprecation warning message for one of the AzCLI commands used in our pipeline. The warning message wasn't JSON code and the output of this command when piped through the conversion process failed resulting in the error observed by the developers.

## Changes proposed in this pull request

- Fixed the deployment image to use `windows-2019` (which is current latest) instead of `windows-latest` to guard against unexpected issues down the line when MS introduce their next newest image which may not be backwards compatible with out pipeline implementation.
- Switch the `az group deployment` command to `az deployment group` as advised in the deprecation warning message.

## Guidance to review

Successfull deployment outcome can be seen here: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary

## Link to Trello card

N/A - priority bug fix

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
