### PR TITLE
Raise an error if Slack responds with one

### DIFF
--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -5,7 +5,7 @@ class SlackNotificationWorker
 
   def perform(text, url)
     @webhook_url = ENV['STATE_CHANGE_SLACK_URL']
-    Rails.logger.debug "State change notification: #{text}"
+
     if @webhook_url.present?
       message = hyperlink text, url
       post_to_slack message
@@ -36,8 +36,6 @@ private
     }
 
     response = HTTP.post(@webhook_url, body: payload.to_json)
-    Rails.logger.warn "Notification to slack failed: #{response.status}" if !response.status.success?
   rescue StandardError => e
-    Rails.logger.warn "Notification to slack failed: #{e.message}"
   end
 end

--- a/app/workers/slack_notification_worker.rb
+++ b/app/workers/slack_notification_worker.rb
@@ -36,6 +36,11 @@ private
     }
 
     response = HTTP.post(@webhook_url, body: payload.to_json)
-  rescue StandardError => e
+
+    unless response.status.success?
+      raise SlackMessageError, "Slack error: #{response.body}"
+    end
   end
+
+  class SlackMessageError < StandardError; end
 end

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe SlackNotificationWorker do
   describe 'SlackNotificationWorker' do
     let(:text) { 'example text' }
     let(:url) { 'https://example.com/support' }
-    let(:output) { capture_logstash_output(rails_config) { invoke_worker } }
 
     around do |example|
       ClimateControl.modify HOSTING_ENVIRONMENT_NAME: 'TEST' do
@@ -19,14 +18,6 @@ RSpec.describe SlackNotificationWorker do
 
     def invoke_worker
       SlackNotificationWorker.new.perform(text, url)
-    end
-
-    it 'logs it has run to the default Rails logger' do
-      expect(output).not_to be_blank
-    end
-
-    it 'includes the text supplied in the log' do
-      expect(output).to match(text)
     end
 
     it 'does not send a Slack notification if STATE_CHANGE_SLACK_URL is empty' do
@@ -42,13 +33,6 @@ RSpec.describe SlackNotificationWorker do
           invoke_worker
         end
         expect(HTTP).to have_received(:post)
-      end
-
-      it 'warns about Slack notification failures in the logs' do
-        # allow(HTTP).to receive(:post).and_raise(StandardError)
-        ClimateControl.modify STATE_CHANGE_SLACK_URL: webhook_url do
-          expect(output).to match(/Notification to slack failed/)
-        end
       end
 
       it 'includes hyperlinked text, a username and an emoji' do

--- a/spec/workers/slack_notification_worker_spec.rb
+++ b/spec/workers/slack_notification_worker_spec.rb
@@ -1,26 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe SlackNotificationWorker do
-  before do
-    @slack_request = stub_request(:post, "https://example.com/webhook")
-      .to_return(status: 200, headers: {})
-  end
-
   describe '#perform' do
     it 'sends a Slack notification to this webhook if the URL is set' do
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+
       ClimateControl.modify STATE_CHANGE_SLACK_URL: 'https://example.com/webhook' do
         invoke_worker
       end
 
-      expect(@slack_request).to have_been_made
+      expect(slack_request).to have_been_made
     end
 
     it 'does not send a Slack notification if STATE_CHANGE_SLACK_URL is empty' do
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+
       ClimateControl.modify STATE_CHANGE_SLACK_URL: nil do
         invoke_worker
       end
 
-      expect(@slack_request).not_to have_been_made
+      expect(slack_request).not_to have_been_made
+    end
+
+    it 'raises an error if Slack responds with one' do
+      stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 400, headers: {})
+
+      ClimateControl.modify STATE_CHANGE_SLACK_URL: 'https://example.com/webhook' do
+        expect { invoke_worker }.to raise_error(SlackNotificationWorker::SlackMessageError)
+      end
     end
   end
 


### PR DESCRIPTION
## Context

We currently swallow errors from Slack, as well as errors in our ~cod~ code. This means we don't retry message sending to Slack, which could cause weirdness down the line.

## Changes proposed in this pull request

Don't swallow errors, and add explicit errors when Sentry responds with them.

## Guidance to review

Does it make sense?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
