### PR TITLE
Add application form validation errors for unavailable course options

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,7 +1,5 @@
 <% @course_choices.each do |course_choice| %>
-  <% show_warning = course_choice.course_not_available? || course_choice.course_full? || course_choice.chosen_site_full? %>
-  <div class='qa-application-choice-<%= course_choice.id %> <%= show_warning && FeatureFlag.active?('unavailable_course_option_warnings')? 'app-review-warning'  : '' %>' id='course-choice-<%= course_choice.id %>'>
-
+  <div id='course-choice-<%= course_choice.id %>' class='qa-application-choice-<%= course_choice.id %> <%= warning_css_class(course_choice) %>'>
   <% if FeatureFlag.active?('unavailable_course_option_warnings') %>
     <% if course_choice.course_not_available? %>
       <p class='app-review-warning--primary-message'><%= course_choice.course_not_available_error %>.</p>

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,10 +1,10 @@
 <% @course_choices.each do |course_choice| %>
   <% show_warning = course_choice.course_not_available? || course_choice.course_full? || course_choice.chosen_site_full? %>
-  <div class='qa-application-choice-<%= course_choice.id %> <%= show_warning && FeatureFlag.active?('unavailable_course_option_warnings')? 'app-review-warning'  : '' %>'>
+  <div class='qa-application-choice-<%= course_choice.id %> <%= show_warning && FeatureFlag.active?('unavailable_course_option_warnings')? 'app-review-warning'  : '' %>' id='course-choice-<%= course_choice.id %>'>
 
   <% if FeatureFlag.active?('unavailable_course_option_warnings') %>
     <% if course_choice.course_not_available? %>
-      <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it is not running.</p>
+      <p class='app-review-warning--primary-message'><%= course_choice.course_not_available_error %>.</p>
       <p class='govuk-body'><%= course_choice.provider.name %> have decided not to run this course.</p>
       <p class='govuk-body'>You can:</p>
       <ul class='govuk-list govuk-list--bullet'>
@@ -18,7 +18,7 @@
         </li>
       </ul>
     <% elsif course_choice.course_full? %>
-      <p class='app-review-warning--primary-message'>You cannot apply to '<%= course_choice.course.name_and_code %>' because it has no vacancies.</p>
+      <p class='app-review-warning--primary-message'><%= course_choice.course_full_error %>.</p>
       <p class='govuk-body'>You can:</p>
       <ul class='govuk-list govuk-list--bullet'>
         <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
@@ -31,7 +31,7 @@
         </li>
       </ul>
     <% elsif course_choice.chosen_site_full? %>
-      <p class='app-review-warning--primary-message'>Your chosen site for '<%= course_choice.course.name_and_code %>' has no vacancies.</p>
+      <p class='app-review-warning--primary-message'><%= course_choice.chosen_site_full_error %>.</p>
       <p class='govuk-body'>You can:</p>
       <ul class='govuk-list govuk-list--bullet'>
         <% if site_change_path(course_choice) %>

--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,8 +1,8 @@
 <% @course_choices.each do |course_choice| %>
-  <div id='course-choice-<%= course_choice.id %>' class='qa-application-choice-<%= course_choice.id %> <%= warning_css_class(course_choice) %>'>
+  <div id='course-choice-<%= course_choice.id %>' class='qa-application-choice-<%= course_choice.id %> <%= warning_container_css_class(course_choice) %>'>
   <% if FeatureFlag.active?('unavailable_course_option_warnings') %>
     <% if course_choice.course_not_available? %>
-      <p class='app-review-warning--primary-message'><%= course_choice.course_not_available_error %>.</p>
+      <p class='app-review-warning__primary-message'><%= course_choice.course_not_available_error %>.</p>
       <p class='govuk-body'><%= course_choice.provider.name %> have decided not to run this course.</p>
       <p class='govuk-body'>You can:</p>
       <ul class='govuk-list govuk-list--bullet'>
@@ -16,7 +16,7 @@
         </li>
       </ul>
     <% elsif course_choice.course_full? %>
-      <p class='app-review-warning--primary-message'><%= course_choice.course_full_error %>.</p>
+      <p class='app-review-warning__primary-message'><%= course_choice.course_full_error %>.</p>
       <p class='govuk-body'>You can:</p>
       <ul class='govuk-list govuk-list--bullet'>
         <li><%= govuk_link_to 'delete this choice', candidate_interface_confirm_destroy_course_choice_path(course_choice.id) %></li>
@@ -29,7 +29,7 @@
         </li>
       </ul>
     <% elsif course_choice.chosen_site_full? %>
-      <p class='app-review-warning--primary-message'><%= course_choice.chosen_site_full_error %>.</p>
+      <p class='app-review-warning__primary-message'><%= course_choice.chosen_site_full_error %>.</p>
       <p class='govuk-body'>You can:</p>
       <ul class='govuk-list govuk-list--bullet'>
         <% if site_change_path(course_choice) %>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -3,7 +3,15 @@ module CandidateInterface
     include ViewHelper
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, heading_level: 2, show_status: false, show_incomplete: false, missing_error: false)
+    def initialize(
+      application_form:,
+      editable: true,
+      heading_level: 2,
+      show_status: false,
+      show_incomplete: false,
+      missing_error: false,
+      application_choice_error: false
+    )
       @application_form = application_form
       @course_choices = @application_form.application_choices.includes(:course, :site, :provider, :offered_course_option).order(id: :asc)
       @editable = editable
@@ -11,6 +19,7 @@ module CandidateInterface
       @show_status = show_status
       @show_incomplete = show_incomplete
       @missing_error = missing_error
+      @application_choice_error = application_choice_error
     end
 
     def course_choice_rows(course_choice)
@@ -64,13 +73,14 @@ module CandidateInterface
       end
     end
 
-    def warning_css_class(course_choice)
+    def warning_container_css_class(course_choice)
       return unless FeatureFlag.active?('unavailable_course_option_warnings')
 
       if course_choice.course_option_availability_error?
-        'app-review-warning'
+        @application_choice_error ? 'app-review-warning app-review-warning--error' : 'app-review-warning'
       end
     end
+
 
   private
 

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -64,6 +64,14 @@ module CandidateInterface
       end
     end
 
+    def warning_css_class(course_choice)
+      return unless FeatureFlag.active?('unavailable_course_option_warnings')
+
+      if course_choice.course_option_availability_error?
+        'app-review-warning'
+      end
+    end
+
   private
 
     attr_reader :application_form

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -36,6 +36,7 @@ module CandidateInterface
         @further_information_form = FurtherInformationForm.new
       else
         @errors = @application_form_presenter.section_errors
+        @application_choice_errors = @application_form_presenter.application_choice_errors
 
         render :review
       end

--- a/app/frontend/styles/_review_warning.scss
+++ b/app/frontend/styles/_review_warning.scss
@@ -6,8 +6,20 @@
   border-width: 0 0 0 $govuk-border-width;
   padding-left: govuk-spacing(3);
 
-  &--primary-message {
+  &__primary-message {
     @include govuk-typography-weight-bold;
     color: govuk-colour("blue");
+  }
+
+}
+
+.app-review-warning--error {
+  @extend .app-review-warning;
+  border: solid govuk-colour("red");
+  border-width: 0 0 0 $govuk-border-width;
+
+  .app-review-warning__primary-message {
+    @include govuk-typography-weight-bold;
+    color: govuk-colour("red");
   }
 }

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -54,12 +54,24 @@ class ApplicationChoice < ApplicationRecord
     course_option.course_not_available?
   end
 
+  def course_not_available_error
+    I18n.t('errors.application_choices.course_not_available', descriptor: course.provider_and_name_code)
+  end
+
   def course_full?
     course_option.course_full?
   end
 
+  def course_full_error
+    I18n.t('errors.application_choices.course_full', descriptor: course.provider_and_name_code)
+  end
+
   def chosen_site_full?
     course_option.no_vacancies?
+  end
+
+  def chosen_site_full_error
+    I18n.t('errors.application_choices.chosen_site_full', descriptor: course.provider_and_name_code)
   end
 
 private

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -74,6 +74,14 @@ class ApplicationChoice < ApplicationRecord
     I18n.t('errors.application_choices.chosen_site_full', descriptor: course.provider_and_name_code)
   end
 
+  def course_option_availability_error?
+    [
+      course_not_available?,
+      course_full?,
+      chosen_site_full?,
+    ].any?
+  end
+
 private
 
   def generate_alphanumeric_id

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -49,7 +49,7 @@ class Course < ApplicationRecord
   end
 
   def provider_and_name_code
-    "#{provider.name} - #{name} (#{code})"
+    "#{provider.name} - #{name_and_code}"
   end
 
   def both_study_modes_available?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -48,6 +48,10 @@ class Course < ApplicationRecord
     "#{name} (#{code}) – #{accredited_provider&.name}"
   end
 
+  def provider_and_name_code
+    "#{provider.name} - #{name} (#{code})"
+  end
+
   def both_study_modes_available?
     study_mode == 'full_time_or_part_time'
   end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -78,8 +78,12 @@ module CandidateInterface
     end
 
     def ready_to_submit?
-      sections_with_completion.map(&:second).all? &&
-        application_choice_errors.empty?
+      if FeatureFlag.active?('unavailable_course_option_warnings')
+        sections_with_completion.map(&:second).all? &&
+          application_choice_errors.empty?
+      else
+        sections_with_completion.map(&:second).all?
+      end
     end
 
     def application_choices_added?

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -1,8 +1,18 @@
 <% missing_error = @errors && @errors.any? %>
+<% application_choice_error = @application_choice_errors && @application_choice_errors.any? %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Courses</h2>
 
-<%= render(CandidateInterface::CourseChoicesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
+<%= render(
+  CandidateInterface::CourseChoicesReviewComponent.new(
+    application_form: application_form,
+    editable: editable,
+    heading_level: 3,
+    show_incomplete: true,
+    missing_error: missing_error,
+    application_choice_error: application_choice_error,
+  )
+) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">About you</h2>
 

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, title_with_error_prefix(t('review_application.title'), @errors && @errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
-<% unless @errors.nil? %>
+<% if !@errors.nil? || !@application_choice_errors.nil? %>
   <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
       There is a problem

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -13,6 +13,10 @@
             <a href="<%= "#missing-#{section}-error" %>"><%= t("review_application.#{section}.incomplete", minimum_references: ApplicationForm::MINIMUM_COMPLETE_REFERENCES) %></a>
           </li>
         <% end %>
+
+        <% @application_choice_errors.each do |error| %>
+          <li><%= link_to error.message, error.anchor %></li>
+        <% end %>
       </ul>
     </div>
   </div>

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -1,7 +1,7 @@
 <% content_for :title, title_with_error_prefix(t('review_application.title'), @errors && @errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 
-<% if !@errors.nil? || !@application_choice_errors.nil? %>
+<% if @errors.present? || @application_choice_errors.present? %>
   <div class="govuk-error-summary" tabindex="-1" role="alert" data-module="govuk-error-summary" aria-labelledby="error-summary-title">
     <h2 id="error-summary-title" class="govuk-error-summary__title">
       There is a problem

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,6 +246,10 @@ en:
     messages:
       too_many_words: Must be %{count} words or fewer
       too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course_name_and_code}.
+    application_choices:
+      course_not_available: You cannot apply to '%{descriptor}' because it is not running
+      course_full: You cannot apply to '%{descriptor}' because it has no vacancies
+      chosen_site_full: Your chosen site for '%{descriptor}' has no vacancies
   date:
     formats:
       long: "%e %B %Y"

--- a/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -9,10 +9,12 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
     and_i_chose_course_options_that_have_since_become_unavailable
 
     when_i_visit_the_review_application_page
-
     then_i_see_a_warning_for_the_course_that_is_not_running
     then_i_see_a_warning_for_the_course_with_no_vacancies
     then_i_see_a_warning_for_the_course_with_no_vacancies_at_my_chosen_site
+
+    when_i_submit_the_application
+    then_i_see_error_messages_for_the_things_i_was_warned_about
   end
 
   def given_i_am_signed_in
@@ -62,20 +64,38 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
   end
 
   def then_i_see_a_warning_for_the_course_that_is_not_running
-    warning_message = \
-      "You cannot apply to '#{@option_where_course_not_running.course.name_and_code}' because it is not running"
-    expect(page).to have_content warning_message
+    expect(page).to have_content course_not_running_message
   end
 
   def then_i_see_a_warning_for_the_course_with_no_vacancies
-    warning_message = \
-      "You cannot apply to '#{@option_where_course_has_no_vacancies.course.name_and_code}' because it has no vacancies"
-    expect(page).to have_content warning_message
+    expect(page).to have_content course_has_no_vacancies_message
   end
 
   def then_i_see_a_warning_for_the_course_with_no_vacancies_at_my_chosen_site
-    warning_message = \
-      "Your chosen site for '#{@option_where_no_vacancies_at_chosen_site.course.name_and_code}' has no vacancies."
-    expect(page).to have_content warning_message
+    expect(page).to have_content chosen_site_has_no_vacancies_message
+  end
+
+  def when_i_submit_the_application
+    click_link 'Continue'
+  end
+
+  def then_i_see_error_messages_for_the_things_i_was_warned_about
+    within('.govuk-error-summary') do
+      expect(page).to have_content course_not_running_message
+    end
+  end
+
+private
+
+  def course_not_running_message
+    "You cannot apply to '#{@option_where_course_not_running.course.provider_and_name_code}' because it is not running"
+  end
+
+  def course_has_no_vacancies_message
+    "You cannot apply to '#{@option_where_course_has_no_vacancies.course.provider_and_name_code}' because it has no vacancies"
+  end
+
+  def chosen_site_has_no_vacancies_message
+    "Your chosen site for '#{@option_where_no_vacancies_at_chosen_site.course.provider_and_name_code}' has no vacancies"
   end
 end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
If course options are unavailable, stop candidates from submitting their
application form and show them an error detailing the problem.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
![Screenshot_2020-04-15 Error Review your application - Apply for teacher training - GOV UK](https://user-images.githubusercontent.com/519250/79315401-c3325180-7efa-11ea-906e-623dcc4019af.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Was planning to extract the inline warnings (app/components/candidate_interface/course_choices_review_component.html.erb) into their own component, but PR's fairly large so will do that in a followup refactor. 
- Needs specific DB state for chosen course options to test locally, see methods on ApplicationChoice for more detail.

## Link to Trello card

https://trello.com/c/tCV8YrX0

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
