### PR TITLE
Remove SUPPORT_USERNAME and SUPPORT_PASSWORD ENV vars

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,2 @@
 FIND_BASE_URL=https://api2.publish-teacher-training-courses.service.gov.uk/api/v3/
-SUPPORT_USERNAME=test
-SUPPORT_PASSWORD=test
 HOSTING_ENVIRONMENT_NAME=development

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,5 @@
 REDIS_URL=redis://localhost:6379/9
 FIND_BASE_URL=http://find-test/api/v3/
-SUPPORT_USERNAME=test
-SUPPORT_PASSWORD=test
 HOSTING_ENVIRONMENT_NAME=test
 STATE_CHANGE_SLACK_URL=https://example.com/slack-webhook
 GOVUK_NOTIFY_CALLBACK_API_KEY=test

--- a/azure/template.json
+++ b/azure/template.json
@@ -655,14 +655,6 @@
                                 "value": "[parameters('basicAuthPassword')]"
                             },
                             {
-                                "name": "SUPPORT_USERNAME",
-                                "value": "[parameters('supportUsername')]"
-                            },
-                            {
-                                "name": "SUPPORT_PASSWORD",
-                                "secureValue": "[parameters('supportPassword')]"
-                            },
-                            {
                                 "name": "AUTHORISED_HOSTS",
                                 "value": "[variables('rubyAuthHosts')]"
                             },

--- a/docker-compose.azure.yml
+++ b/docker-compose.azure.yml
@@ -12,8 +12,6 @@ services:
       - GOVUK_NOTIFY_API_KEY
       - BASIC_AUTH_USERNAME
       - BASIC_AUTH_PASSWORD
-      - SUPPORT_USERNAME
-      - SUPPORT_PASSWORD
       - SECRET_KEY_BASE=${railsSecretKeyBase}
       - AUTHORISED_HOSTS
       - SENTRY_DSN


### PR DESCRIPTION
These ENV vars are unused because Support access is authenticated via DfE Sign-in now.

We also still have ENV vars for basic auth on the candidate interface, which I think are superseded by the `pilot_open` flag. We should remove those too.

Once this is deployed we can remove these vars from each env in Azure too.

https://dfe-ssp.visualstudio.com/Become-A-Teacher/_library?itemType=VariableGroups