### PR TITLE
Tweak logstash buffer settings to prevent full buffers

### DIFF
--- a/app/lib/logstash_logging.rb
+++ b/app/lib/logstash_logging.rb
@@ -26,10 +26,6 @@ class LogstashLogging
     # Log destination: log to STDOUT, plus to a remote Logstash server, if required
     logstash_logger = \
       if ENV['LOGSTASH_REMOTE'] == 'true'
-        # temporary additional STDOUT logger for troubleshooting bg process log loss
-        buffer_logger = Logger.new(STDOUT)
-        buffer_logger.level = Logger::WARN
-
         LogStashLogger.new(
           type: :multi_delegator,
           outputs: [
@@ -41,7 +37,8 @@ class LogstashLogging
               ssl_enable: ENV.fetch('LOGSTASH_SSL') == 'true',
             },
           ],
-          buffer_logger: buffer_logger,
+          buffer_max_items: 200, # buffer capacity, max number of items, default: 50
+          buffer_max_interval: 2, # max number of seconds between flushes, default: 5
         )
       else
         LogStashLogger.new(type: :stdout)


### PR DESCRIPTION
## Context

During my investigation into Logit log loss, I observed a few cases of `Buffer Full` in the logs. While this is not the main cause of log loss (this seems to be TCP-related), we should probably increase the size of the buffer. 

## Changes proposed in this pull request

This PR raises `buffer_max_items` to 200 (we've been using the default of 50) and drops `buffer_max_interval` to 2 (we've been using the default of 5 seconds), to reduce the possibility of a full buffer.

## Guidance to review

It's only a configuration change.

## Link to Trello card

https://trello.com/c/e1YIWE8s

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
