### PR TITLE
Extend RBD/DBD date freeze until 29 May 2020

### DIFF
--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -2,7 +2,7 @@ Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).m
   BusinessTime::Config.holidays << holiday[:date]
 end
 
-(Date.new(2020, 3, 23)..Date.new(2020, 4, 20)).each do |date|
+(Date.new(2020, 3, 23)..Date.new(2020, 5, 29)).each do |date|
   BusinessTime::Config.holidays << date
 end
 


### PR DESCRIPTION


## Context

UCAS have extended the coronavirus-related date freeze. Update the span
of custom holidays we've added to the business_time initializer to
support this.

To be followed by a run of `RecalculateDatesWorker` in production.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
na
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
na
## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/oykk30Zw/1315-extend-rbd-dbd-date-freeze-until-friday-29-may-2020
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
