### PR TITLE
Improve Slack message when candidates sign up

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -1,5 +1,13 @@
 class StateChangeNotifier
-  def self.call(event, candidate: nil, application_choice: nil, application_form: nil)
+  def self.sign_up(candidate)
+    helpers = Rails.application.routes.url_helpers
+    text = "New sign-up [candidate_id: #{candidate.id}]"
+    url = helpers.support_interface_candidate_url(candidate)
+
+    send(text, url)
+  end
+
+  def self.call(event, application_choice: nil, application_form: nil)
     helpers = Rails.application.routes.url_helpers
 
     if application_choice
@@ -10,9 +18,6 @@ class StateChangeNotifier
     end
 
     case event
-    when :magic_link_sign_up
-      text = "New sign-up [candidate_id: #{candidate.id}]"
-      url = helpers.support_interface_candidate_url(candidate)
     when :submit_application
       text = "#{application_form.first_name} has just submitted their application"
       url = helpers.support_interface_application_form_url(application_form)
@@ -47,6 +52,10 @@ class StateChangeNotifier
       raise 'StateChangeNotifier: unsupported state transition event'
     end
 
+    send(text, url)
+  end
+
+  def self.send(text, url)
     if RequestStore.store[:disable_slack_messages]
       Rails.logger.info "Sending Slack messages disabled (message: `#{text}`)"
       return

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -1,7 +1,8 @@
 class StateChangeNotifier
   def self.sign_up(candidate)
     helpers = Rails.application.routes.url_helpers
-    text = "New sign-up [candidate_id: #{candidate.id}]"
+    candidate_number = Candidate.where(hide_in_reporting: false).count
+    text = ":sparkles: The #{candidate_number.ordinalize} candidate just signed up"
     url = helpers.support_interface_candidate_url(candidate)
 
     send(text, url)

--- a/app/services/magic_link_sign_up.rb
+++ b/app/services/magic_link_sign_up.rb
@@ -3,6 +3,6 @@ class MagicLinkSignUp
     magic_link_token = MagicLinkToken.new
     AuthenticationMailer.sign_up_email(candidate: candidate, token: magic_link_token.raw).deliver_later
     candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.zone.now)
-    StateChangeNotifier.call(:magic_link_sign_up, candidate: candidate)
+    StateChangeNotifier.sign_up(candidate)
   end
 end

--- a/spec/lib/state_change_notifier_spec.rb
+++ b/spec/lib/state_change_notifier_spec.rb
@@ -14,20 +14,6 @@ RSpec.describe StateChangeNotifier do
 
     before { allow(SlackNotificationWorker).to receive(:perform_async) }
 
-    describe ':magic_link_sign_up' do
-      before { StateChangeNotifier.call(:magic_link_sign_up, candidate: candidate) }
-
-      it 'mentions the candidate\'s id' do
-        arg1 = "New sign-up [candidate_id: #{candidate.id}]"
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(arg1, anything)
-      end
-
-      it 'links the notification to support interface' do
-        arg2 = helpers.support_interface_candidate_url(candidate)
-        expect(SlackNotificationWorker).to have_received(:perform_async).with(anything, arg2)
-      end
-    end
-
     describe ':submit_application' do
       before { StateChangeNotifier.call(:submit_application, application_form: application_form) }
 

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -13,6 +13,7 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     and_i_fill_in_the_eligiblity_form_with_yes
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
+    and_a_slack_message_is_sent
 
     when_the_magic_link_token_is_overwritten
     and_i_click_on_the_link_in_my_email
@@ -76,6 +77,10 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
   def then_i_receive_an_email_inviting_me_to_sign_up
     open_email(@email)
     expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
+  end
+
+  def and_a_slack_message_is_sent
+    expect_slack_message_with_text 'New sign-up'
   end
 
   def when_the_magic_link_token_is_overwritten

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -80,7 +80,7 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
   end
 
   def and_a_slack_message_is_sent
-    expect_slack_message_with_text 'New sign-up'
+    expect_slack_message_with_text ':sparkles: The 1st candidate just signed up'
   end
 
   def when_the_magic_link_token_is_overwritten


### PR DESCRIPTION
## Context

The signup messages currently look like this:

<img width="676" alt="Screenshot 2020-04-15 at 17 29 04" src="https://user-images.githubusercontent.com/233676/79362541-9f90fa80-7f3e-11ea-8ecc-b4c6e99ad66b.png">

## Changes proposed in this pull request

Make them look like:

> ✨ The 982th candidate just signed up

This is more typographically pleasing, provides a visual queue that about the type of message and uses a meaningful number in the message (so we can celebrate the 1000th real sign up).

## Guidance to review

However you want.

## Link to Trello card

https://trello.com/c/mGLdC4yg/185-post-new-sign-ups-to-slack-every-10th-candidate

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
