### PR TITLE
Add 'notes' feature flag; move Timeline to its own tab

### DIFF
--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
+    before_action :set_application_choice_and_sub_navigation_items, except: %i[index]
+
     def index
       @page_state = ProviderApplicationsPageState.new(
         params: params,
@@ -21,12 +23,6 @@ module ProviderInterface
     end
 
     def show
-      available_providers = current_provider_user.providers
-
-      @application_choice = GetApplicationChoicesForProviders.call(
-        providers: available_providers,
-      ).find(params[:application_choice_id])
-
       @status_box_options = if @application_choice.offer?
                               GetAllChangeOptionsFromOfferedOption.new(
                                 application_choice: @application_choice,
@@ -35,6 +31,51 @@ module ProviderInterface
                             else
                               {}
                             end
+    end
+
+    def notes
+      redirect_to(action: :show) unless FeatureFlag.active?('notes')
+    end
+
+    def timeline
+      redirect_to(action: :show) unless FeatureFlag.active?('timeline')
+    end
+
+  private
+
+    def available_providers
+      current_provider_user.providers
+    end
+
+    def set_application_choice_and_sub_navigation_items
+      @application_choice = get_application_choice
+      @sub_navigation_items = get_sub_navigation_items
+    end
+
+    def get_application_choice
+      GetApplicationChoicesForProviders.call(
+        providers: available_providers,
+      ).find(params[:application_choice_id])
+    end
+
+    def get_sub_navigation_items
+      sub_navigation_items = [
+        { name: 'Application', url: provider_interface_application_choice_path(@application_choice) },
+      ]
+
+      if FeatureFlag.active?('notes')
+        sub_navigation_items.push(
+          { name: 'Notes', url: provider_interface_application_choice_notes_path(@application_choice) },
+        )
+      end
+
+      if FeatureFlag.active?('timeline')
+        sub_navigation_items.push(
+          { name: 'Timeline', url: provider_interface_application_choice_timeline_path(@application_choice) },
+        )
+      end
+
+      sub_navigation_items
     end
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,6 +25,7 @@ class FeatureFlag
     provider_interface_work_breaks
     referee_type
     replacement_referee_with_referee_type
+    notes
     timeline
     edit_course_choices
     satisfaction_survey

--- a/app/views/provider_interface/application_choices/_application_choice_header.html.erb
+++ b/app/views/provider_interface/application_choices/_application_choice_header.html.erb
@@ -1,0 +1,18 @@
+<% if @application_choice.status == 'awaiting_provider_decision' -%>
+  <div class="app-banner">
+    <div class="app-banner__message">
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+        You have <%= days_to_respond_to(@application_choice) %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
+      </h2>
+    </div>
+  </div>
+<% end -%>
+
+<h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
+  <%= @application_choice.application_form.full_name %>
+  <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
+</h1>
+
+<% if @sub_navigation_items.count > 1 %>
+  <%= render SubNavigationComponent.new(items: @sub_navigation_items) %>
+<% end %>

--- a/app/views/provider_interface/application_choices/notes.html.erb
+++ b/app/views/provider_interface/application_choices/notes.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Notes" %>
+
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Applications', provider_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to @application_choice.application_form.full_name, provider_interface_application_choice_path(@application_choice), class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Notes
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<%= render 'application_choice_header' %>
+
+<% raise 'Notes are wip' %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -13,20 +13,7 @@
   </div>
 <% end %>
 
-<% if @application_choice.status == 'awaiting_provider_decision' -%>
-  <div class="app-banner">
-    <div class="app-banner__message">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
-        You have <%= days_to_respond_to(@application_choice) %> days to send a response. <%= govuk_link_to 'Respond to application', provider_interface_application_choice_respond_path(@application_choice) %>.
-      </h2>
-    </div>
-  </div>
-<% end -%>
-
-<h1 class="govuk-heading-xl govuk-!-margin-bottom-1">
-  <%= @application_choice.application_form.full_name %>
-  <%= render(ProviderInterface::ApplicationStatusTagComponent.new(application_choice: @application_choice)) %>
-</h1>
+<%= render 'application_choice_header' %>
 
 <p class="govuk-body govuk-!-margin-bottom-9 app-!-print-display-none">
   <%= govuk_link_to(
@@ -115,8 +102,5 @@
         <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference) %>
       <% end %>
     <% end %>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>
   </div>
 </div>

--- a/app/views/provider_interface/application_choices/timeline.html.erb
+++ b/app/views/provider_interface/application_choices/timeline.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Timeline" %>
+
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Applications', provider_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to @application_choice.application_form.full_name, provider_interface_application_choice_path(@application_choice), class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Timeline
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<%= render 'application_choice_header' %>
+
+<%= render ProviderInterface::ApplicationTimelineComponent.new(application_choice: @application_choice) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,6 +410,8 @@ Rails.application.routes.draw do
 
     get '/applications' => 'application_choices#index'
     get '/applications/:application_choice_id' => 'application_choices#show', as: :application_choice
+    get '/applications/:application_choice_id/notes' => 'application_choices#notes', as: :application_choice_notes
+    get '/applications/:application_choice_id/timeline' => 'application_choices#timeline', as: :application_choice_timeline
     get '/applications/:application_choice_id/respond' => 'decisions#respond', as: :application_choice_respond
     post '/applications/:application_choice_id/respond' => 'decisions#submit_response', as: :application_choice_submit_response
     get '/applications/:application_choice_id/offer' => 'decisions#new_offer', as: :application_choice_new_offer


### PR DESCRIPTION
## Context

In preparation for adding the 'Provider user adds notes against an application choice' flow, we need to move the Timeline to its own tab/view and add a `notes` feature flag. 

## Changes proposed in this pull request

This PR refactors `provider_interface/application_choices_controller.rb` and associated views to use:
- a separate view for the timeline component,
- a common `_application_choice_header.html` partial, for banners, status tags and newly introduced `SubNavigationComponent`, and
- a controller `before_action` setting `@application_choice` and `@sub_navigation_items` 

Page title and breadcrumbs are still set within the corresponding views. The `before_action` checks `notes` and `timeline` feature flags, so it's possible for the single application view to look like this:

![image](https://user-images.githubusercontent.com/107591/79366850-c8b48980-7f44-11ea-9a85-d3333948dfc7.png)

## Guidance to review

- Should I have created a new `notes_controller.rb`? I thought about it, but notes will only be attached to `application_choices` and it's easier to reuse controller code and partials across the three views/tabs ([Application, Notes, Timeline]) if they are all part of `application_choices_controller`. Furthermore, if we decide to attach notes to other things, chances are the relevant views will be custom to these contexts, so a scoped pattern like `.../application_choices/1970/notes` makes sense.
- Do the adjusted page titles and breadcrumbs make sense? I've kept the Application title and breadcrumbs the same, but 'Notes' or 'Timeline' are appended to both title and breadcrumbs when a provider user navigates to these views (see image).

![image](https://user-images.githubusercontent.com/107591/79366604-65c2f280-7f44-11ea-8fa0-e523d18b8dc2.png)

## Link to Trello card

https://trello.com/c/mscEDZr5

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
