### PR TITLE
Prevent support users from adding more than 3 courses

### DIFF
--- a/app/controllers/support_interface/change_course_controller.rb
+++ b/app/controllers/support_interface/change_course_controller.rb
@@ -1,5 +1,7 @@
 module SupportInterface
   class ChangeCourseController < SupportInterfaceController
+    before_action :make_sure_course_can_be_added, only: %w[select_course_to_add add_course]
+
     def options
       @pick_option_form = SupportInterface::ChangeCourseForm.new(application_form: application_form)
     end
@@ -39,6 +41,15 @@ module SupportInterface
 
     def application_form
       @_application_form ||= ApplicationForm.find(params[:application_form_id])
+    end
+
+    def make_sure_course_can_be_added
+      pick_option_form = SupportInterface::ChangeCourseForm.new(application_form: application_form)
+
+      unless pick_option_form.can_add_course?
+        flash[:warning] = 'This application already has 3 courses'
+        redirect_to support_interface_change_course_path(application_form)
+      end
     end
   end
 end

--- a/app/models/support_interface/change_course_form.rb
+++ b/app/models/support_interface/change_course_form.rb
@@ -4,5 +4,9 @@ module SupportInterface
     attr_accessor :change_type, :application_form
 
     validates_presence_of :change_type
+
+    def can_add_course?
+      application_form.application_choices.count < 3
+    end
   end
 end

--- a/app/views/support_interface/change_course/options.html.erb
+++ b/app/views/support_interface/change_course/options.html.erb
@@ -7,10 +7,19 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_radio_buttons_fieldset :change_type, legend: { size: 'xl', text: t('support_interface.change_course.page_title'), tag: 'h1' } do %>
-        <%= f.govuk_radio_button :change_type, :add_course, label: { text: 'Add a course' } %>
+        <% if @pick_option_form.can_add_course? %>
+          <%= f.govuk_radio_button :change_type, :add_course, label: { text: 'Add a course' } %>
+        <% end %>
+
         <%= f.govuk_radio_button :change_type, :replace_course, label: { text: 'Replace a course*' }, hint_text: 'This feature will be available soon' %>
         <%= f.govuk_radio_button :change_type, :remove_course, label: { text: 'Withdraw from a course*' }, hint_text: 'This feature will be available soon' %>
         <%= f.govuk_radio_button :change_type, :cancel_application, label: { text: 'Withdraw from all courses and cancel application*' }, hint_text: 'This feature will be available soon' %>
+      <% end %>
+
+      <% if !@pick_option_form.can_add_course? %>
+        <div class='govuk-body'>
+          You can no longer add a course because this application already has 3.
+        </div>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/spec/system/support_interface/adding_a_course_spec.rb
+++ b/spec/system/support_interface/adding_a_course_spec.rb
@@ -11,6 +11,7 @@ RSpec.feature 'Adding a course' do
     and_i_select_the_option_to_add_a_course
     and_i_fill_in_the_course_option_id_for_the_desired_course
     then_the_new_course_is_added_to_the_application
+    and_i_can_no_longer_add_a_course_because_3_is_the_max
   end
 
   def given_i_am_a_support_user
@@ -20,6 +21,7 @@ RSpec.feature 'Adding a course' do
   def and_there_is_a_candidate_who_wants_a_course_added
     @application_form = create(:completed_application_form)
 
+    create(:application_choice, status: 'awaiting_references', application_form: @application_form)
     create(:application_choice, status: 'awaiting_references', application_form: @application_form)
 
     @new_course_option = create(:course_option, course: create(:course, name: 'A new course'))
@@ -45,5 +47,15 @@ RSpec.feature 'Adding a course' do
 
   def then_the_new_course_is_added_to_the_application
     expect(page).to have_content 'A new course'
+  end
+
+  def and_i_can_no_longer_add_a_course_because_3_is_the_max
+    click_on 'Make changes to courses'
+
+    expect(page).to have_content 'You can no longer add a course because this application already has 3'
+
+    visit support_interface_add_course_to_application_path(@application_form)
+
+    expect(page).to have_content 'This application already has 3 courses'
   end
 end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1880.

## Changes proposed in this pull request

We can currently add more than 3 choices to an application, while this shouldn't be possible. This removes the option from the new page to make a change to the courses.

When a course already has 3 choices, the support user will see this:

![image](https://user-images.githubusercontent.com/233676/79447753-3bbb1000-7fd8-11ea-82f1-924e6fbd1d5e.png)


## Guidance to review

Does it make sense? Any content suggestions?

## Link to Trello card

https://trello.com/c/fmTuhZ0y

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
