### PR TITLE
Inform candidates referees will see their answer for how they know them 

### DIFF
--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -301,10 +301,10 @@ en:
       relationship:
         label: What is your relationship to this referee and how long have you known them?
         hint_text:
-          academic: For example, ‘He was my course supervisor at university. I’ve known him for a year’.
-          professional: For example, ‘He was my line manager in my last job. I’ve known him for 2 years’.
-          school_based: For example, ‘She’s the deputy head at the school where I currently volunteer. I’ve known her for 3 years’.
-          character: For example, ‘She’s the head coach for my athletics club. I’ve known her for 5 years’.
+          academic: For example, ‘He was my course supervisor at university. I’ve known him for a year’. Your referee will get a copy of the information you give and confirm whether it’s accurate.
+          professional: For example, ‘He was my line manager in my last job. I’ve known him for 2 years’. Your referee will get a copy of the information you give and confirm whether it’s accurate.
+          school_based: For example, ‘She’s the deputy head at the school where I currently volunteer. I’ve known her for 3 years’. Your referee will get a copy of the information you give and confirm whether it’s accurate.
+          character: For example, ‘She’s the head coach for my athletics club. I’ve known her for 5 years’. Your referee will get a copy of the information you give and confirm whether its accurate.
       review:
         button: Continue
       sure_delete_entry: Yes I’m sure - delete this referee


### PR DESCRIPTION
## Context

At the moment candidates may not be aware that referees see what they input for what their relationship to the referee is.

We should tell the candidate this.

Emma signed off the content 

## Changes proposed in this pull request

Before 

![image](https://user-images.githubusercontent.com/42515961/79458947-79c12f80-7fea-11ea-9649-b7e58a205afb.png)


After

![image](https://user-images.githubusercontent.com/42515961/79458912-6d3cd700-7fea-11ea-84b6-af0a3b75b87e.png)

## Link to Trello card

https://trello.com/c/aqWYlyZO/1306-dev-tell-candidates-that-the-referee-will-see-their-answer-for-what-is-your-relationship-to-this-referee-and-how-long-have-you-k

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
