### PR TITLE
Specify Ruby from .ruby-version for GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,10 +47,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: 'Set up Ruby 2.6'
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6
+      - name: 'Set up Ruby from .ruby-version'
+        uses: ruby/setup-ruby@v1
 
       - name: 'Install PostgreSQL 11 client'
         run: |
@@ -125,10 +123,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: 'Set up Ruby 2.6'
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6
+      - name: 'Set up Ruby from .ruby-version'
+        uses: ruby/setup-ruby@v1
 
       - name: 'Install PostgreSQL 11 client'
         run: |
@@ -171,10 +167,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gem-
 
-      - name: 'Set up Ruby 2.6'
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6
+      - name: 'Set up Ruby from .ruby-version'
+        uses: ruby/setup-ruby@v1
 
       - name: 'Install PostgreSQL 11 client'
         run: |
@@ -207,10 +201,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gem-
 
-      - name: 'Set up Ruby 2.6'
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.6
+      - name: 'Set up Ruby from .ruby-version'
+        uses: ruby/setup-ruby@v1
 
       - name: 'Install PostgreSQL 11 client'
         run: |


### PR DESCRIPTION
## Context

A GH actions build broke for want of Ruby 2.6.5 which is specified in `.ruby-version`

## Changes proposed in this pull request

Use `.ruby-version` to set the version, a feature of https://github.com/ruby/setup-ruby (as opposed to https://github.com/actions/setup-ruby)

## Guidance to review

Does this PR pass the GitHub checks?
