### PR TITLE
Allow provider users to amend existing provider users.

### DIFF
--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -24,7 +24,7 @@ module ProviderInterface
         form: @form,
         save_service: SaveProviderUser.new(provider_user: provider_user),
         invite_service: InviteProviderUser.new(provider_user: provider_user),
-        new_user: !@form.persisted?,
+        new_user: @form.existing_provider_user.blank?,
       )
 
       render :new and return unless service.call

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -24,6 +24,7 @@ module ProviderInterface
         form: @form,
         save_service: SaveProviderUser.new(provider_user: provider_user),
         invite_service: InviteProviderUser.new(provider_user: provider_user),
+        new_user: !@form.persisted?,
       )
 
       render :new and return unless service.call

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -10,13 +10,17 @@ module ProviderInterface
     validates :email_address, :first_name, :last_name, presence: true
     validates :email_address, email: true
     validates :provider_ids, presence: true
-    validate :email_is_unique
     validate :permitted_providers
 
     def build
       return unless valid?
 
-      @provider_user ||= ProviderUser.new
+      if existing_provider_user
+        @provider_user = existing_provider_user
+      else
+        @provider_user ||= ProviderUser.new
+      end
+
       @provider_user.first_name = first_name
       @provider_user.last_name = last_name
       @provider_user.email_address = email_address
@@ -58,12 +62,8 @@ module ProviderInterface
 
   private
 
-    def email_is_unique
-      return if persisted? && provider_user.email_address == email_address
-
-      return unless ProviderUser.exists?(email_address: email_address)
-
-      errors.add(:email_address, 'This email address is already in use')
+    def existing_provider_user
+      @existing_provider_user ||= ProviderUser.find_by(email_address: email_address)
     end
 
     def permitted_providers

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -7,7 +7,8 @@ module ProviderInterface
     attr_writer :provider_ids
     attr_reader :email_address
 
-    validates :email_address, :first_name, :last_name, presence: true
+    validates :first_name, :last_name, presence: true, if: -> { existing_provider_user.blank? }
+    validates :email_address, presence: true
     validates :email_address, email: true
     validates :provider_ids, presence: true
     validate :permitted_providers
@@ -64,15 +65,13 @@ module ProviderInterface
     end
 
     def build_from_existing_user
-      @first_name = existing_provider_user.first_name
-      @last_name = existing_provider_user.last_name
-      @email_address = existing_provider_user.email_address
-
       existing_provider_user.provider_ids += provider_ids
       existing_provider_user
     end
 
     def existing_provider_user
+      return if email_address.blank?
+
       @existing_provider_user ||= ProviderUser.find_by(email_address: email_address)
     end
 

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -13,18 +13,8 @@ module ProviderInterface
     validate :permitted_providers
 
     def build
-      return unless valid?
+      @provider_user = existing_provider_user ? build_from_existing_user : build_new_user
 
-      if existing_provider_user
-        @provider_user = existing_provider_user
-      else
-        @provider_user ||= ProviderUser.new
-      end
-
-      @provider_user.first_name = first_name
-      @provider_user.last_name = last_name
-      @provider_user.email_address = email_address
-      @provider_user.provider_ids = provider_ids
       @provider_user if @provider_user.valid?
     end
 
@@ -61,6 +51,26 @@ module ProviderInterface
     end
 
   private
+
+    def build_new_user
+      return unless valid?
+
+      provider_user ||= ProviderUser.new
+      provider_user.first_name = first_name
+      provider_user.last_name = last_name
+      provider_user.email_address = email_address
+      provider_user.provider_ids = provider_ids
+      provider_user
+    end
+
+    def build_from_existing_user
+      @first_name = existing_provider_user.first_name
+      @last_name = existing_provider_user.last_name
+      @email_address = existing_provider_user.email_address
+
+      existing_provider_user.provider_ids += provider_ids
+      existing_provider_user
+    end
 
     def existing_provider_user
       @existing_provider_user ||= ProviderUser.find_by(email_address: email_address)

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -51,6 +51,12 @@ module ProviderInterface
       @available_providers ||= ProviderOptionsService.new(current_provider_user).providers_with_manageable_users
     end
 
+    def existing_provider_user
+      return if email_address.blank?
+
+      @existing_provider_user ||= ProviderUser.find_by(email_address: email_address)
+    end
+
   private
 
     def build_new_user
@@ -67,12 +73,6 @@ module ProviderInterface
     def build_from_existing_user
       existing_provider_user.provider_ids += provider_ids
       existing_provider_user
-    end
-
-    def existing_provider_user
-      return if email_address.blank?
-
-      @existing_provider_user ||= ProviderUser.find_by(email_address: email_address)
     end
 
     def permitted_providers

--- a/app/services/save_and_invite_provider_user.rb
+++ b/app/services/save_and_invite_provider_user.rb
@@ -1,23 +1,29 @@
 class SaveAndInviteProviderUser
-  attr_reader :form, :save_service, :invite_service
+  attr_reader :form, :save_service, :invite_service, :new_user
 
-  def initialize(form:, save_service:, invite_service:)
+  def initialize(form:, save_service:, invite_service:, new_user: true)
     @form = form
     @save_service = save_service
     @invite_service = invite_service
+    @new_user = new_user
   end
 
   def call
-    if form.valid?
+    return false unless form.valid?
+
+    begin
       ActiveRecord::Base.transaction do
         save_service.call!
-        invite_service.call!
+        invite_service.call! if new_user
       end
+    rescue DfeSignInApiError
+      form.errors.add(
+        :base,
+        'A problem occurred inviting this user. Please try again. If problems persist, please contact support.',
+      )
+      return false
     end
-  rescue DfeSignInApiError
-    form.errors.add(
-      :base,
-      'A problem occurred inviting this user. Please try again. If problems persist, please contact support.',
-    )
+
+    true
   end
 end

--- a/spec/models/provider_interface/provider_user_form_spec.rb
+++ b/spec/models/provider_interface/provider_user_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ProviderInterface::ProviderUserForm do
       let(:provider_ids) { [provider.id, another_provider.id] }
 
       it 'is invalid' do
-        expect(provider_user_form.valid?).to be false
+        expect(provider_user_form).not_to be_valid
         expect(provider_user_form.errors[:provider_ids]).not_to be_empty
       end
     end
@@ -26,6 +26,26 @@ RSpec.describe ProviderInterface::ProviderUserForm do
       it 'is valid' do
         provider_user_form.valid?
         expect(provider_user_form.errors[:provider_ids]).to be_empty
+      end
+    end
+
+    context 'name fields' do
+      it 'are required' do
+        provider_user_form.valid?
+
+        expect(provider_user_form.errors[:first_name]).not_to be_empty
+        expect(provider_user_form.errors[:last_name]).not_to be_empty
+      end
+    end
+
+    context 'with email address of an existing user' do
+      let(:email_address) { 'provider@example.com' }
+      let(:existing_user) { create(:provider_user, :with_provider, email_address: email_address) }
+
+      before { form_params[:email_address] = existing_user.email_address }
+
+      it 'is valid' do
+        expect(provider_user_form).to be_valid
       end
     end
   end

--- a/spec/models/provider_interface/provider_user_form_spec.rb
+++ b/spec/models/provider_interface/provider_user_form_spec.rb
@@ -35,4 +35,32 @@ RSpec.describe ProviderInterface::ProviderUserForm do
       expect(provider_user_form.available_providers).to eq([provider])
     end
   end
+
+  describe '#build' do
+    let(:email_address) { 'provider@example.com' }
+    let(:form_params) do
+      {
+        first_name: 'Jane',
+        last_name: 'Smith',
+        email_address: email_address,
+        provider_ids: provider_ids,
+        current_provider_user: provider_user,
+      }
+    end
+
+    context 'for a new user' do
+      it 'returns a new user' do
+        expect(provider_user_form.build.persisted?).to be false
+      end
+    end
+
+    context 'for an existing user' do
+      let!(:existing_user) { create(:provider_user, :with_provider, email_address: email_address) }
+
+      it 'modifies and returns the existing user' do
+        expect(provider_user_form.build.persisted?).to be true
+        expect(provider_user_form.build).to eq(existing_user)
+      end
+    end
+  end
 end

--- a/spec/services/save_and_invite_provider_user_spec.rb
+++ b/spec/services/save_and_invite_provider_user_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe SaveAndInviteProviderUser do
   describe '#initialize' do
     it 'requires a form, create service and invite service' do
       expect { described_class.new }.to raise_error(ArgumentError)
+
       expect {
         described_class.new(form: form, save_service: save_service, invite_service: invite_service)
       }.not_to raise_error
@@ -27,6 +28,14 @@ RSpec.describe SaveAndInviteProviderUser do
   describe '#call!' do
     subject(:service) do
       described_class.new(form: form, save_service: save_service, invite_service: invite_service)
+    end
+
+    context 'form is invalid' do
+      it 'returns false' do
+        allow(form).to receive(:valid?).and_return(false)
+
+        expect(service.call).to eq(false)
+      end
     end
 
     context 'an error occurs in create service' do
@@ -42,10 +51,10 @@ RSpec.describe SaveAndInviteProviderUser do
     end
 
     context 'an error occurs in invite service' do
-      before { allow(invite_service).to receive(:call!).and_raise }
+      before { allow(invite_service).to receive(:call!).and_raise(Exception) }
 
       it 'rolls back the transaction and raises the error' do
-        expect { service.call }.to raise_error.and change(ProviderUser, :count).by(0)
+        expect { service.call }.to raise_error(Exception).and change(ProviderUser, :count).by(0)
       end
     end
 

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -82,15 +82,17 @@ RSpec.feature 'Provider invites a new provider user' do
   end
 
   def and_i_add_a_provider_for_an_existing_user
-    fill_in 'First name', with: 'Jane'
-    fill_in 'Last name', with: 'Smith'
     fill_in 'Email address', with: @email_address
     check @another_provider.name_and_code
+
     click_on 'Invite user'
   end
 
   def then_the_provider_is_assigned_to_the_user
     expect(page).to have_content('Provider user invited')
-    expect(@new_provider_user.reload.providers).to include(@another_provider)
+
+    @existing_provider_user = ProviderUser.find_by(email_address: @email_address)
+    expect(@existing_provider_user.providers).to include(@provider)
+    expect(@existing_provider_user.providers).to include(@another_provider)
   end
 end

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -17,6 +17,11 @@ RSpec.feature 'Provider invites a new provider user' do
 
     then_a_new_provider_user_is_created
     and_the_user_should_be_sent_a_welcome_email
+
+    when_i_can_manage_users_for_another_provider
+    and_i_click_invite_user
+    and_i_add_a_provider_for_an_existing_user
+    then_the_provider_is_assigned_to_the_user
   end
 
   def when_i_click_on_the_users_link
@@ -57,7 +62,6 @@ RSpec.feature 'Provider invites a new provider user' do
     expect(page).not_to have_content(@another_provider.name_and_code)
 
     check @provider.name_and_code
-
     click_on 'Invite user'
   end
 
@@ -71,5 +75,22 @@ RSpec.feature 'Provider invites a new provider user' do
   def and_the_user_should_be_sent_a_welcome_email
     open_email(@email_address)
     expect(current_email.subject).to have_content t('provider_account_created.email.subject')
+  end
+
+  def when_i_can_manage_users_for_another_provider
+    @provider_user.provider_permissions.find_by(provider: @another_provider).update(manage_users: true)
+  end
+
+  def and_i_add_a_provider_for_an_existing_user
+    fill_in 'First name', with: 'Jane'
+    fill_in 'Last name', with: 'Smith'
+    fill_in 'Email address', with: @email_address
+    check @another_provider.name_and_code
+    click_on 'Invite user'
+  end
+
+  def then_the_provider_is_assigned_to_the_user
+    expect(page).to have_content('Provider user invited')
+    expect(@new_provider_user.reload.providers).to include(@another_provider)
   end
 end


### PR DESCRIPTION
## Context

When a managing provider user attempts to add a user who already exists they currently get a validation error on email uniqueness. There's a need for managing users for a provider to onboard users from a different provider (and are therefore not visible to the managing user).

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

This PR allows the `create` action to detect an existing user and amend their details. This is different from editing a user as mentioned in the user need above. We have future work to allow editing a provider user.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/eAbezhne/1894-dont-refuse-when-a-provideruser-tries-to-add-another-whos-already-in-the-system
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
