### PR TITLE
Increase frequency of clockwork checks to every minute

### DIFF
--- a/config/clock.rb
+++ b/config/clock.rb
@@ -6,7 +6,7 @@ require 'clockwork'
 class Clock
   include Clockwork
 
-  every(5.minutes, 'ClockworkCheck') { ClockworkCheck.perform_async }
+  every(1.minute, 'ClockworkCheck') { ClockworkCheck.perform_async }
   every(15.minutes, 'SyncAllFromFind') { SyncAllFromFind.perform_async }
   every(1.hour, 'DetectInvariants') { DetectInvariants.perform_async }
   every(1.hour, 'SendApplicationsToProvider', at: '**:05') { SendApplicationsToProviderWorker.perform_async }

--- a/spec/support_specs/clockwork_spec.rb
+++ b/spec/support_specs/clockwork_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Clockwork do
       expect(Clockwork::Test.ran_job?('ClockworkCheck')).to be_truthy
     end
 
-    it 'runs the job every 5 minutes over the course of an hour' do
+    it 'runs the job every 1 minute over the course of an hour' do
       start_time = Time.zone.local(2019, 11, 7, 2, 0, 0)
       end_time = Time.zone.local(2019, 11, 7, 3, 0, 0)
       Clockwork::Test.run(
@@ -32,7 +32,7 @@ RSpec.describe Clockwork do
         tick_speed: 1.minute,
         file: './config/clock.rb',
       )
-      expect(Clockwork::Test.times_run('ClockworkCheck')).to eq 12
+      expect(Clockwork::Test.times_run('ClockworkCheck')).to eq 60
     end
 
     it 'enqueues a background ClockworkCheck job' do


### PR DESCRIPTION
## Context

Making this change to investigate whether the observed sidekiq log loss is (partly) caused by the default Azure idle outbound flow timeout of 4 minutes.

See https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-outbound-rules-overview#idletimeout

## Changes proposed in this pull request

Change the frequency of `ClockworkCheck` job from every 5 minutes to every minute.

## Guidance to review

Very simple change.

## Link to Trello card

https://trello.com/c/GsHLdUFh

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
