### PR TITLE
Fix sentry error when there are no candidate survey responses

### DIFF
--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -34,9 +34,15 @@ module SupportInterface
 
     def candidate_survey
       answers = SupportInterface::CandidateSurveyExport.new.call
-      csv = to_csv(answers)
 
-      send_data csv, filename: "candidate-survey-#{Time.zone.today}.csv", disposition: :attachment
+      if answers.present?
+        csv = to_csv(answers)
+        send_data csv, filename: "candidate-survey-#{Time.zone.today}.csv", disposition: :attachment
+      else
+        flash[:warning] = 'No candidates have filled in the survey'
+
+        redirect_to support_interface_performance_path
+      end
     end
 
     def applications_export_for_ucas

--- a/spec/services/support_interface/candidate_survey_export_spec.rb
+++ b/spec/services/support_interface/candidate_survey_export_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe SupportInterface::CandidateSurveyExport do
       application_form3 = create(:completed_application_form, :with_survey_completed)
       create(:completed_application_form)
 
-
       expect(described_class.new.call).to match_array([return_expected_hash(application_form1), return_expected_hash(application_form2), return_expected_hash(application_form3)])
     end
   end
@@ -20,8 +19,6 @@ private
 
     survey_fields = CandidateInterface::SatisfactionSurveyForm::QUESTIONS_WE_ASK
       .index_with { |question| survey[question] }
-
-
     {
       'Name' => application_form.full_name,
       'Email_address' => application_form.candidate.email_address,

--- a/spec/system/support_interface/candidate_survey_csv_spec.rb
+++ b/spec/system/support_interface/candidate_survey_csv_spec.rb
@@ -5,7 +5,12 @@ RSpec.feature 'Candidate survey CSV' do
 
   scenario 'support user can download a CSV with the candidate satisfaction survey results' do
     given_i_am_a_support_user
-    and_there_are_candidate_survey_results
+
+    when_i_visit_the_service_performance_page
+    and_i_click_on_download_candidate_survey_results
+    then_i_should_be_informed_there_are_no_survey_results
+
+    given_there_are_candidate_survey_results
 
     when_i_visit_the_service_performance_page
     and_i_click_on_download_candidate_survey_results
@@ -16,16 +21,20 @@ RSpec.feature 'Candidate survey CSV' do
     sign_in_as_support_user
   end
 
-  def and_there_are_candidate_survey_results
-    create_list(:completed_application_form, 3, :with_survey_completed)
-  end
-
   def when_i_visit_the_service_performance_page
     visit support_interface_performance_path
   end
 
   def and_i_click_on_download_candidate_survey_results
     click_link 'Download candidate survey results (CSV)'
+  end
+
+  def then_i_should_be_informed_there_are_no_survey_results
+    expect(page).to have_content('No candidates have filled in the survey')
+  end
+
+  def given_there_are_candidate_survey_results
+    create_list(:completed_application_form, 3, :with_survey_completed)
   end
 
   def then_i_should_be_able_to_download_a_csv


### PR DESCRIPTION
## Context

Currently, no candidates have completed the candidate satisfaction survey. When someone clicks on the download CSV link we get a sentry error.


## Changes proposed in this pull request

Display a flash message saying there are no responses if none are present.

## Guidance to review

None really

## Link to Trello card

https://trello.com/c/Y4gti43x/1322-candidate-survey-error-when-there-are-no-answers

https://trello.com/c/JhGZgjcV/1321-dev-cant-download-user-satisfaction-survey-from-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
