### PR TITLE
Only sync a single provider on Heroku review apps

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -18,7 +18,8 @@ desc 'Sync some pilot-enabled providers and open all their courses'
 task sync_dev_providers_and_open_courses: :environment do
   puts 'Syncing data from Find...'
 
-  %w[1N1 2LR C58 C85].each do |code|
+  provider_codes = HostingEnvironment.review? ? %w[1N1] : %w[1N1 2LR C58 C85]
+  provider_codes.each do |code|
     SyncProviderFromFind.call(provider_code: code, sync_courses: true)
   end
 


### PR DESCRIPTION
This is to stop the deluge of daily emails that warn about us reaching the database row limit.
