### PR TITLE
Amend business time holiday to end on the 28th of May

### DIFF
--- a/config/initializers/business_time.rb
+++ b/config/initializers/business_time.rb
@@ -2,7 +2,7 @@ Holidays.between(Date.civil(2019, 1, 1), 2.years.from_now, :gb_eng, :observed).m
   BusinessTime::Config.holidays << holiday[:date]
 end
 
-(Date.new(2020, 3, 23)..Date.new(2020, 5, 29)).each do |date|
+(Date.new(2020, 3, 23)..Date.new(2020, 5, 28)).each do |date|
   BusinessTime::Config.holidays << date
 end
 


### PR DESCRIPTION
## Context

We misinterpreted what UCAS meant by "after the 29th of May" (language is hard) and as such our calculations are off by one.

## Changes proposed in this pull request

Amend the date.

## Guidance to review

This sets the RBD on all applications made during the business time holiday to the 24/07 (Friday) instead of 27/07 (Monday). This aligns with UCAS' logic.

## Link to Trello card

https://trello.com/c/oykk30Zw/1315-extend-rbd-dbd-date-freeze-until-friday-29-may-2020

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)