### PR TITLE
Add a script to generate a Notify-compliant list of email data

### DIFF
--- a/app/models/provider_emails_for_application_choices.rb
+++ b/app/models/provider_emails_for_application_choices.rb
@@ -1,0 +1,46 @@
+class ProviderEmailsForApplicationChoices
+  def initialize(choice_ids)
+    @choice_ids = choice_ids
+  end
+
+  def as_hash
+    @_as_hash ||= @choice_ids.reduce({}, &method(:choice_reducer))
+  end
+
+  def as_csv
+    require 'csv'
+
+    CSV.generate do |csv|
+      csv << ['email address', 'name', 'affected applications']
+
+      as_hash.each do |(email, attrs)|
+        csv << [email, attrs[:name], attrs[:affected_applications].join("\n")]
+      end
+    end
+  end
+
+private
+
+  def choice_to_string(choice)
+    name = choice.application_form.full_name
+    ref = choice.application_form.support_reference
+    status = I18n.t("provider_application_states.#{choice.status}")
+    url = "https://www.apply-for-teacher-training.education.gov.uk/provider/applications/#{choice.id}"
+    "* #{name} (#{ref}) (#{status}) — #{url}"
+  end
+
+  # build a hash like this
+  # { email@example.com: {name: "Bob Example", affected_applications: ["* Ella Candidate (ABC123) (Rejected) — http://..."]}}
+  def choice_reducer(emails_to_choices, choice_id)
+    choice = ApplicationChoice.find(choice_id)
+    affected_providers = [choice.course.provider, choice.course.accredited_provider].compact
+    interested_users = affected_providers.flat_map(&:provider_users).uniq
+
+    interested_users.each do |user|
+      emails_to_choices[user.email_address] ||= { name: (user.full_name or 'Colleague'), affected_applications: [] }
+      emails_to_choices[user.email_address][:affected_applications].push(choice_to_string(choice))
+    end
+
+    emails_to_choices
+  end
+end

--- a/spec/models/provider_emails_for_application_choices_spec.rb
+++ b/spec/models/provider_emails_for_application_choices_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe ProviderEmailsForApplicationChoices do
+  include CourseOptionHelpers
+
+  describe '#as_hash' do
+    it 'groups affected applications by email address' do
+      provider_user = create(:provider_user, :with_provider, email_address: 'bob@example.com')
+      option = course_option_for_provider(provider: provider_user.providers.first)
+      choice1 = create(:submitted_application_choice, course_option: option)
+      choice2 = create(:submitted_application_choice, course_option: option)
+
+      result = ProviderEmailsForApplicationChoices.new([choice1.id, choice2.id]).as_hash
+
+      expect(result.keys).to eq ['bob@example.com']
+      expect(result['bob@example.com'][:affected_applications].count).to eq 2
+    end
+
+    it 'includes email addresses of users from the course’s accredited bodies' do
+      provider_user = create(:provider_user, :with_provider, email_address: 'provider-pamela@example.com')
+      accredited_provider_user = create(:provider_user, :with_provider, email_address: 'ratifying-roger@example.com')
+      option = course_option_for_accredited_provider(
+        provider: provider_user.providers.first,
+        accredited_provider: accredited_provider_user.providers.first,
+      )
+      choice = create(:submitted_application_choice, course_option: option)
+
+      result = ProviderEmailsForApplicationChoices.new([choice.id]).as_hash
+
+      expect(result.keys).to match_array(['provider-pamela@example.com', 'ratifying-roger@example.com'])
+    end
+  end
+
+  describe '#as_csv' do
+    it 'renders the correct csv structure' do
+      provider_user = create(:provider_user, :with_provider, first_name: 'Pamela', last_name: 'Provider', email_address: 'pamela@example.com')
+      application_form = create(:completed_application_form,
+                                first_name: 'Ciara',
+                                last_name: 'Candidate',
+                                support_reference: 'ABC123')
+
+      option = course_option_for_provider(provider: provider_user.providers.first)
+      application_choice = create(:submitted_application_choice, application_form: application_form, course_option: option)
+
+      result = ProviderEmailsForApplicationChoices.new([application_choice.id]).as_csv
+
+      expect(result).to include "email address,name,affected applications\n"
+      expect(result).to include 'pamela@example.com,Pamela Provider,* Ciara Candidate (ABC123) (New)'
+      expect(result).to include "https://www.apply-for-teacher-training.education.gov.uk/provider/applications/#{application_choice.id}\n"
+    end
+  end
+end


### PR DESCRIPTION
This is for a mass mailout to providers affected by a data consistency
issue. It's here so it can be tested and reviewed. It will be deleted
once it's done.

https://trello.com/c/uzzUmCB3/1906-comms-to-providers-following-safeguarding-bug