### PR TITLE
Add audit logs for ProviderUsers and SupportUsers to support

### DIFF
--- a/app/controllers/support_interface/provider_users_controller.rb
+++ b/app/controllers/support_interface/provider_users_controller.rb
@@ -43,6 +43,10 @@ module SupportInterface
       end
     end
 
+    def audits
+      @provider_user = ProviderUser.find(params[:provider_user_id])
+    end
+
   private
 
     def provider_user_params

--- a/app/controllers/support_interface/support_users_controller.rb
+++ b/app/controllers/support_interface/support_users_controller.rb
@@ -4,6 +4,10 @@ module SupportInterface
       @support_users = params[:removed] == 'true' ? SupportUser.discarded : SupportUser.kept
     end
 
+    def show
+      @support_user = SupportUser.find(params[:id])
+    end
+
     def new
       @support_user = SupportUser.new
     end
@@ -22,6 +26,7 @@ module SupportInterface
     def confirm_destroy
       @support_user = SupportUser.find(params[:id])
     end
+
     alias confirm_restore confirm_destroy
 
     def destroy

--- a/app/models/support_user.rb
+++ b/app/models/support_user.rb
@@ -15,6 +15,10 @@ class SupportUser < ActiveRecord::Base
     SupportUser.kept.find_by(dfe_sign_in_uid: dfe_sign_in_user.dfe_sign_in_uid)
   end
 
+  def display_name
+    [first_name, last_name].join(' ').presence || email_address
+  end
+
 private
 
   def downcase_email_address

--- a/app/views/support_interface/provider_users/audits.html.erb
+++ b/app/views/support_interface/provider_users/audits.html.erb
@@ -1,0 +1,30 @@
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Users', support_interface_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= link_to 'Provider users', support_interface_provider_users_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Edit provider user
+      </li>
+    </ol>
+  </div>
+
+  <%= render SubNavigationComponent.new(items: [
+    { name: 'Details', url: edit_support_interface_provider_user_path(@provider_user) },
+    { name: 'Audit trail', url: support_interface_provider_user_audits_path(@provider_user), current: true },
+  ]) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <h1 class='govuk-heading-xl'>
+    <%= @provider_user.email_address %>
+  </h1>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @provider_user) %>
+  </div>
+</div>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -12,6 +12,11 @@
       </li>
     </ol>
   </div>
+
+  <%= render SubNavigationComponent.new(items: [
+    { name: 'Details', url: support_interface_provider_user_path(@form.provider_user), current: true },
+    { name: 'Audit trail', url: support_interface_provider_user_audits_path(@form.provider_user) },
+  ]) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -35,7 +40,5 @@
 
       <%= f.govuk_submit 'Update user' %>
     <% end %>
-
-    <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @form.provider_user) %>
   </div>
 </div>

--- a/app/views/support_interface/provider_users/edit.html.erb
+++ b/app/views/support_interface/provider_users/edit.html.erb
@@ -35,5 +35,7 @@
 
       <%= f.govuk_submit 'Update user' %>
     <% end %>
+
+    <%= render SupportInterface::AuditTrailComponent.new(audited_thing: @form.provider_user) %>
   </div>
 </div>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -33,7 +33,7 @@
     <% @support_users.each do |support_user| %>
       <tr class='govuk-table__row'>
         <td class='govuk-table__cell'>
-          <%= govuk_link_to support_user.display_name, edit_support_interface_support_user_path(support_user) %>
+          <%= govuk_link_to support_user.display_name, support_interface_support_user_path(support_user) %>
         </td>
         <td class='govuk-table__cell'>
           <%= support_user.dfe_sign_in_uid %>

--- a/app/views/support_interface/support_users/index.html.erb
+++ b/app/views/support_interface/support_users/index.html.erb
@@ -33,7 +33,7 @@
     <% @support_users.each do |support_user| %>
       <tr class='govuk-table__row'>
         <td class='govuk-table__cell'>
-          <%= support_user.email_address %>
+          <%= govuk_link_to support_user.display_name, edit_support_interface_support_user_path(support_user) %>
         </td>
         <td class='govuk-table__cell'>
           <%= support_user.dfe_sign_in_uid %>

--- a/app/views/support_interface/support_users/show.html.erb
+++ b/app/views/support_interface/support_users/show.html.erb
@@ -1,0 +1,3 @@
+<% content_for :title, @support_user.display_name %>
+
+<%= render SupportInterface::AuditTrailComponent.new(audited_thing: @support_user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -533,7 +533,10 @@ Rails.application.routes.draw do
       delete '/restore/:id' => 'support_users#restore', as: :restore_support_user
 
       resources :support_users, only: %i[index new create show], path: :support
-      resources :provider_users, only: %i[index new create edit update], path: :provider
+
+      resources :provider_users, only: %i[index new create edit update], path: :provider do
+        get '/audits' => 'provider_users#audits'
+      end
     end
 
     get '/sign-in' => 'sessions#new'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -532,7 +532,7 @@ Rails.application.routes.draw do
       get '/restore/:id' => 'support_users#confirm_restore', as: :confirm_restore_support_user
       delete '/restore/:id' => 'support_users#restore', as: :restore_support_user
 
-      resources :support_users, only: %i[index new create], path: :support
+      resources :support_users, only: %i[index new create show], path: :support
       resources :provider_users, only: %i[index new create edit update], path: :provider
     end
 

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -29,7 +29,6 @@ RSpec.feature 'Managing provider users' do
     when_the_user_has_not_signed_in_yet
     and_i_click_on_that_user
     then_their_email_should_not_be_editable
-    and_i_should_see_the_audit_trail_for_that_user_record
 
     when_i_add_them_to_another_organisation
     then_i_see_that_they_have_been_added_to_that_organisation
@@ -42,6 +41,9 @@ RSpec.feature 'Managing provider users' do
     when_i_remove_manage_users_permissions
     and_i_click_update_user
     then_they_should_not_be_able_to_manage_users
+
+    when_i_click_the_audit_trail_tab
+    then_i_should_see_the_audit_trail_for_that_user_record
   end
 
   def given_dfe_signin_is_configured
@@ -136,7 +138,11 @@ RSpec.feature 'Managing provider users' do
     expect(page).to have_content 'The email address is not editable'
   end
 
-  def and_i_should_see_the_audit_trail_for_that_user_record
+  def when_i_click_the_audit_trail_tab
+    click_on 'Audit trail'
+  end
+
+  def then_i_should_see_the_audit_trail_for_that_user_record
     expect(page).to have_content 'Create Provider User'
     expect(page).to have_content 'email_address harrison@example.com'
   end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -4,7 +4,7 @@ RSpec.feature 'Managing provider users' do
   include DfESignInHelpers
   include DsiAPIHelper
 
-  scenario 'creating a new provider user' do
+  scenario 'creating a new provider user', with_audited: true do
     given_dfe_signin_is_configured
     and_i_am_a_support_user
     and_providers_exist
@@ -29,6 +29,7 @@ RSpec.feature 'Managing provider users' do
     when_the_user_has_not_signed_in_yet
     and_i_click_on_that_user
     then_their_email_should_not_be_editable
+    and_i_should_see_the_audit_trail_for_that_user_record
 
     when_i_add_them_to_another_organisation
     then_i_see_that_they_have_been_added_to_that_organisation
@@ -133,6 +134,11 @@ RSpec.feature 'Managing provider users' do
   def then_their_email_should_not_be_editable
     expect(page).to have_field 'Email address', disabled: true
     expect(page).to have_content 'The email address is not editable'
+  end
+
+  def and_i_should_see_the_audit_trail_for_that_user_record
+    expect(page).to have_content 'Create Provider User'
+    expect(page).to have_content 'email_address harrison@example.com'
   end
 
   def when_they_have_signed_in_at_least_once

--- a/spec/system/support_interface/managing_support_users_spec.rb
+++ b/spec/system/support_interface/managing_support_users_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.feature 'Managing support users' do
   include DfESignInHelpers
 
-  scenario 'creating a new support user' do
+  scenario 'creating a new support user', with_audited: true do
     given_i_am_a_support_user
 
     when_i_visit_the_support_console
@@ -16,7 +16,11 @@ RSpec.feature 'Managing support users' do
     then_i_should_see_the_list_of_support_users
     and_i_should_see_the_user_i_created
 
-    when_i_submit_the_same_email_address_again
+    when_i_click_on_the_user
+    then_i_can_see_the_audit_history
+
+    when_i_go_back_to_the_manage_support_users_page
+    and_i_submit_the_same_email_address_again
     then_i_see_an_error
   end
 
@@ -57,10 +61,24 @@ RSpec.feature 'Managing support users' do
     expect(page).to have_content('harrison@example.com')
   end
 
-  def when_i_submit_the_same_email_address_again
+  def when_i_go_back_to_the_manage_support_users_page
+    click_link 'Users'
+    click_link 'Support users'
+  end
+
+  def and_i_submit_the_same_email_address_again
     and_i_click_the_add_user_link
     and_i_enter_the_users_email_and_dsi_uid
     and_i_click_add_user
+  end
+
+  def when_i_click_on_the_user
+    click_on 'harrison@example.com'
+  end
+
+  def then_i_can_see_the_audit_history
+    expect(page).to have_content('Create Support User')
+    expect(page).to have_content('email_address harrison@example.com')
   end
 
   def then_i_see_an_error


### PR DESCRIPTION
## Context

We have no way to see this information at the moment.

## Changes proposed in this pull request

### `ProviderUsers`

![Screenshot 2020-04-17 at 15 33 12](https://user-images.githubusercontent.com/642279/79580870-8e242b80-80c1-11ea-8e71-326d8ba688b2.png)
![Screenshot 2020-04-17 at 15 33 16](https://user-images.githubusercontent.com/642279/79580917-9d0ade00-80c1-11ea-92f0-d5d5a6cc6ee0.png)

### `SupportUsers`

![Screenshot 2020-04-17 at 15 32 38](https://user-images.githubusercontent.com/642279/79580847-8795b400-80c1-11ea-922b-8b885fe3feb3.png)
![Screenshot 2020-04-17 at 15 32 41](https://user-images.githubusercontent.com/642279/79580947-a8f6a000-80c1-11ea-98d4-bbace2aa9e02.png)

## Guidance to review

## Link to Trello card

https://trello.com/c/ZEmtkqEN/1927-add-audit-trails-for-providerusers-and-supportusers-to-support

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
