### PR TITLE
Limit amount of referees to 10

### DIFF
--- a/app/components/candidate_interface/additional_referees_start_component.html.erb
+++ b/app/components/candidate_interface/additional_referees_start_component.html.erb
@@ -3,7 +3,7 @@
 </h1>
 
 <p class="govuk-body">
-  <% if reference_status.number_of_references_that_currently_need_replacing == 1 %>
+  <% if reference_status.references_that_needed_to_be_replaced.count == 1 %>
     <%= reason_for_replacement(references_that_need_replacement.first) %>.
   <% else %>
     Your referees have not given us a reference:

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -8,7 +8,7 @@
 
 <% @application_form.application_references.includes(:application_form).each do |referee| %>
   <%= render(SummaryCardComponent.new(rows: referee_rows(referee), editable: @editable)) do %>
-    <%= render(SummaryCardHeaderComponent.new(title: t('application_form.referees.nth_referee')[referee.ordinal], heading_level: @heading_level)) do %>
+    <%= render(SummaryCardHeaderComponent.new(title: "#{TextOrdinalizer::ORDINALIZE_MAPPING[referee.ordinal]&.capitalize} referee", heading_level: @heading_level)) do %>
 
       <% if FeatureFlag.active?('candidate_can_cancel_reference') && referee.feedback_requested? %>
         <div class="app-summary-card__actions">

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -91,6 +91,8 @@ module CandidateInterface
 
     def contact_support
       @maximum_referees = ApplicationForm::MAXIMUM_REFERENCES
+
+      redirect_to candidate_interface_review_referees_path unless current_application.application_references.count >= @maximum_referees
     end
 
   private

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class AdditionalRefereesController < CandidateInterfaceController
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
-    before_action :redirect_to_contact_support_if_at_maximum_reference_count, only: %i[type update_type new create confirm]
+    before_action :redirect_to_contact_support_if_at_maximum_reference_count, only: %i[type update_type new create]
 
     def type
       @page_title = page_title_for_new_page
@@ -116,13 +116,13 @@ module CandidateInterface
     end
 
     def redirect_to_dashboard_if_no_references_needed
-      return if !reference_status.still_more_references_needed?
+      return if reference_status.still_more_references_needed?
 
       redirect_to candidate_interface_application_form_path
     end
 
     def redirect_to_contact_support_if_at_maximum_reference_count
-      redirect_to candidate_interface_additional_referee_contact_support_path if at_maximum_referee_count && reference_status.still_more_references_needed?
+      redirect_to candidate_interface_additional_referee_contact_support_path if at_maximum_referee_count && reference_status.needs_to_draft_another_reference?
     end
 
     def at_maximum_referee_count

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class AdditionalRefereesController < CandidateInterfaceController
     rescue_from ActiveRecord::RecordNotFound, with: :render_404
+    before_action :redirect_to_contact_support_if_at_maximum_reference_count, only: %i[type update_type new create confirm]
 
     def type
       @page_title = page_title_for_new_page
@@ -88,6 +89,10 @@ module CandidateInterface
       end
     end
 
+    def contact_support
+      @maximum_referees = ApplicationForm::MAXIMUM_REFERENCES
+    end
+
   private
 
     def current_reference
@@ -111,9 +116,17 @@ module CandidateInterface
     end
 
     def redirect_to_dashboard_if_no_references_needed
-      return if reference_status.still_more_references_needed?
+      return if !reference_status.still_more_references_needed?
 
       redirect_to candidate_interface_application_form_path
+    end
+
+    def redirect_to_contact_support_if_at_maximum_reference_count
+      redirect_to candidate_interface_additional_referee_contact_support_path if at_maximum_referee_count && reference_status.still_more_references_needed?
+    end
+
+    def at_maximum_referee_count
+      current_application.application_references.count >= ApplicationForm::MAXIMUM_REFERENCES
     end
 
     def redirect_to_confirm_or_show_another_reference_form

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -122,11 +122,7 @@ module CandidateInterface
     end
 
     def redirect_to_contact_support_if_at_maximum_reference_count
-      redirect_to candidate_interface_additional_referee_contact_support_path if at_maximum_referee_count && reference_status.needs_to_draft_another_reference?
-    end
-
-    def at_maximum_referee_count
-      current_application.application_references.count >= ApplicationForm::MAXIMUM_REFERENCES
+      redirect_to candidate_interface_additional_referee_contact_support_path if current_application.application_references.count >= ApplicationForm::MAXIMUM_REFERENCES
     end
 
     def redirect_to_confirm_or_show_another_reference_form

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -31,7 +31,7 @@ module CandidateInterface
     end
 
     def more_reference_needed?
-      ReferenceStatus.new(current_application).still_more_references_needed?
+      ReferenceStatus.new(current_application).needs_a_replacement_reference?
     end
 
     def show_pilot_holding_page_if_not_open

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -3,6 +3,7 @@ module CandidateInterface
     before_action :redirect_to_dashboard_if_submitted, except: %i[confirm_cancel cancel]
     before_action :set_referee, only: %i[edit update confirm_destroy destroy confirm_cancel cancel]
     before_action :set_referees, only: %i[type update_type new create index review]
+    before_action :set_nth_referee, only: %i[type new]
 
     def index
       unless @referees.empty?
@@ -11,8 +12,6 @@ module CandidateInterface
     end
 
     def type
-      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[(@referees.count + 1)].capitalize} referee"
-
       if params[:id]
         set_referee_id
 
@@ -42,7 +41,6 @@ module CandidateInterface
 
     def new
       @referee = current_candidate.current_application.application_references.build(referee_type: params[:type])
-      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[(@referees.count + 1)].capitalize} referee"
     end
 
     def create
@@ -119,6 +117,10 @@ module CandidateInterface
       @referees = current_candidate.current_application
                                     .application_references
                                     .includes(:application_form)
+    end
+
+    def set_nth_referee
+      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[(@referees.count + 1)].capitalize} referee"
     end
 
     def referee_type_param

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -11,6 +11,8 @@ module CandidateInterface
     end
 
     def type
+      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[(@referees.count + 1)].capitalize} referee"
+
       if params[:id]
         set_referee_id
 
@@ -40,6 +42,7 @@ module CandidateInterface
 
     def new
       @referee = current_candidate.current_application.application_references.build(referee_type: params[:type])
+      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[(@referees.count + 1)].capitalize} referee"
     end
 
     def create
@@ -55,7 +58,9 @@ module CandidateInterface
       end
     end
 
-    def edit; end
+    def edit
+      @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[@referee.ordinal].capitalize} referee"
+    end
 
     def update
       if @referee.update(referee_params)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -14,6 +14,7 @@ class ApplicationForm < ApplicationRecord
   has_many :application_work_history_breaks
 
   MINIMUM_COMPLETE_REFERENCES = 2
+  MAXIMUM_REFERENCES = 10
   DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
 
   enum phase: {

--- a/app/services/reference_status.rb
+++ b/app/services/reference_status.rb
@@ -10,11 +10,11 @@ class ReferenceStatus
   end
 
   def number_of_references_that_currently_need_replacing
-    references_that_needed_to_be_replaced.size - replacement_references.reject(&:not_requested_yet?).size
+    ApplicationForm::MINIMUM_COMPLETE_REFERENCES - non_overdue_references.select { |reference| reference.feedback_provided? || reference.feedback_requested? }.size
   end
 
   def needs_to_draft_another_reference?
-    (number_of_references_that_currently_need_replacing - references_currently_not_requested_yet.size).positive?
+    (number_of_references_that_currently_need_replacing - replacement_references.select(&:not_requested_yet?).size).positive?
   end
 
   def references_that_needed_to_be_replaced
@@ -28,16 +28,16 @@ class ReferenceStatus
 
 private
 
-  def references_currently_not_requested_yet
-    application_references.select(&:not_requested_yet?)
-  end
-
   def replacement_references
     application_references.select(&:replacement?)
   end
 
   def feedback_completed?
     application_references.select(&:feedback_provided?).size == 2
+  end
+
+  def non_overdue_references
+    application_references.reject(&:feedback_overdue?)
   end
 
   def application_references

--- a/app/services/reference_status.rb
+++ b/app/services/reference_status.rb
@@ -17,6 +17,10 @@ class ReferenceStatus
     (number_of_references_that_currently_need_replacing - replacement_references.select(&:not_requested_yet?).size).positive?
   end
 
+  def needs_a_replacement_reference?
+    (references_that_needed_to_be_replaced.size - replacement_references.reject(&:not_requested_yet?).size).positive?
+  end
+
   def references_that_needed_to_be_replaced
     refused = application_references.select(&:feedback_refused?)
     bounced = application_references.select(&:email_bounced?)

--- a/app/views/candidate_interface/additional_referees/contact_support.html.erb
+++ b/app/views/candidate_interface/additional_referees/contact_support.html.erb
@@ -1,0 +1,15 @@
+<%= content_for :title, t('page_titles.maximum_referees') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('page_titles.maximum_referees') %></h1>
+    <p class="govuk-body">
+      You have already added <%= @maximum_referees %> referees
+    </p>
+    <p class="govuk-body">
+      To add another referee, please contact the Becoming a Teacher team:
+      <%= bat_contact_mail_to %>.
+    </p>
+  </div>
+</div>

--- a/app/views/candidate_interface/additional_referees/contact_support.html.erb
+++ b/app/views/candidate_interface/additional_referees/contact_support.html.erb
@@ -5,11 +5,10 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= t('page_titles.maximum_referees') %></h1>
     <p class="govuk-body">
-      You have already added <%= @maximum_referees %> referees
+      You’ve already reached the limit of <%= @maximum_referees %> referees.
     </p>
     <p class="govuk-body">
-      To add another referee, please contact the Becoming a Teacher team:
-      <%= bat_contact_mail_to %>.
+      If this is a problem, contact us at: <%= bat_contact_mail_to %>.
     </p>
   </div>
 </div>

--- a/app/views/candidate_interface/referees/edit.html.erb
+++ b/app/views/candidate_interface/referees/edit.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl">
-          <%= t('page_titles.nth_referee')[@referee.ordinal] %>
+          <%= @nth_referee %>
         </span>
         <% if @referee.referee_type %>
           Details of <%= @referee.referee_type.downcase.dasherize %> referee

--- a/app/views/candidate_interface/referees/new.html.erb
+++ b/app/views/candidate_interface/referees/new.html.erb
@@ -8,7 +8,7 @@
 
       <h1 class="govuk-heading-xl">
         <span class="govuk-caption-xl">
-          <%= t('page_titles.nth_referee')[(@referees.count + 1)] %>
+          <%= @nth_referee %>
         </span>
         <% if @referee.referee_type %>
           Details of <%= @referee.referee_type.downcase.dasherize %> referee

--- a/app/views/candidate_interface/referees/type.html.erb
+++ b/app/views/candidate_interface/referees/type.html.erb
@@ -6,11 +6,7 @@
     <%= form_with model: @reference_type_form, url: candidate_interface_update_referees_type_path(id: @id), method: :post do |f| %>
       <%= f.govuk_error_summary %>
       <h1 class="govuk-heading-xl">
-        <% if @referee %>
-            <%= t('page_titles.nth_referee')[@referee.ordinal] %>
-        <% else %>
-            <%= t('page_titles.nth_referee')[(@referees.count + 1)] %>
-        <% end %>
+        <%= @nth_referee%>
       </h1>
 
       <p class="govuk-body">Referees should not be family members, partners or friends.</p>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -309,18 +309,6 @@ en:
         button: Continue
       sure_delete_entry: Yes I’m sure - delete this referee
       sure_cancel_entry: Yes I'm sure - cancel this reference request
-      nth_referee:
-        - (should never appear)
-        - First referee
-        - Second referee
-        - Third referee
-        - Fourth referee
-        - Fifth referee
-        - Sixth referee
-        - Seventh referee
-        - Eighth referee
-        - Ninth referee
-        - Tenth referee
       chase: Chase this referee and notify the candidate
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -317,6 +317,10 @@ en:
         - Fourth referee
         - Fifth referee
         - Sixth referee
+        - Seventh referee
+        - Eighth referee
+        - Ninth referee
+        - Tenth referee
       chase: Chase this referee and notify the candidate
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,7 +95,7 @@ en:
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?
     add_referee: Details of referee
-    maximum_referees: You have already added the maxiumum amount of referees
+    maximum_referees: You have already added the maximum amount of referees
     nth_referee:
       - (should never appear)
       - First referee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,10 +96,6 @@ en:
     referee_cancel: Are you sure you want to cancel this request for a reference?
     add_referee: Details of referee
     maximum_referees: You have already added the maximum amount of referees
-    nth_referee:
-      - (should never appear)
-      - First referee
-      - Second referee
     give_a_reference:
       confirmation: Your reference has been submitted
       finish: Thank you

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,7 +95,7 @@ en:
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?
     add_referee: Details of referee
-    maximum_referees: You have already added the maximum amount of referees
+    maximum_referees: You cannot add any more referees
     give_a_reference:
       confirmation: Your reference has been submitted
       finish: Thank you

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,6 +95,7 @@ en:
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?
     add_referee: Details of referee
+    maximum_referees: You have already added the maxiumum amount of referees
     nth_referee:
       - (should never appear)
       - First referee

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,6 +288,8 @@ Rails.application.routes.draw do
 
         get '/confirm' => 'additional_referees#confirm', as: :confirm_additional_referees
         post '/confirm' => 'additional_referees#request_references'
+
+        get '/contact-support' => 'additional_referees#contact_support', as: :additional_referee_contact_support
       end
 
       scope '/equality-and-diversity' do

--- a/spec/components/candidate_interface/additional_referees_start_component_spec.rb
+++ b/spec/components/candidate_interface/additional_referees_start_component_spec.rb
@@ -70,12 +70,13 @@ RSpec.describe CandidateInterface::AdditionalRefereesStartComponent do
       ]
     end
 
-    it 'has a page content that requests new referees' do
+    it 'has a page content that requests a new referee' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-heading-xl').text).to include('You need to add 2 new referees')
-      expect(result.css('.govuk-button').text).to include('Add new referees')
-      expect(result.css('.govuk-link').text).to include('Continue without adding new referees')
+
+      expect(result.css('.govuk-heading-xl').text).to include('You need to add a new referee')
+      expect(result.css('.govuk-button').text).to include('Add a new referee')
+      expect(result.css('.govuk-link').text).to include('Continue without adding a new referee')
     end
 
     it 'gives a reason for all failed referee requests' do

--- a/spec/services/reference_status_spec.rb
+++ b/spec/services/reference_status_spec.rb
@@ -102,4 +102,56 @@ RSpec.describe ReferenceStatus do
       expect(status.needs_to_draft_another_reference?).to be(true)
     end
   end
+
+  describe '#needs_a_replacement_reference?' do
+    it 'is false if references do not need to be replaced' do
+      application_form = create(:application_form)
+      create(:reference, :complete, application_form: application_form)
+      create(:reference, :requested, application_form: application_form)
+
+      status = ReferenceStatus.new(application_form.reload)
+
+      expect(status.needs_a_replacement_reference?).to be(false)
+    end
+
+    it 'is true if a reference is overdue' do
+      application_form = create(:application_form)
+      create(:reference, :complete, application_form: application_form)
+      create(:reference, :requested, application_form: application_form, requested_at: Time.zone.now - 30.days)
+
+      status = ReferenceStatus.new(application_form.reload)
+
+      expect(status.needs_a_replacement_reference?).to be(true)
+    end
+
+    it 'is true if a reference is refused' do
+      application_form = create(:application_form)
+      create(:reference, :complete, application_form: application_form)
+      create(:reference, :refused, application_form: application_form)
+
+      status = ReferenceStatus.new(application_form.reload)
+
+      expect(status.needs_a_replacement_reference?).to be(true)
+    end
+
+    it 'is true if a reference is cancelled' do
+      application_form = create(:application_form)
+      create(:reference, :complete, application_form: application_form)
+      create(:reference, :cancelled, application_form: application_form)
+
+      status = ReferenceStatus.new(application_form.reload)
+
+      expect(status.needs_a_replacement_reference?).to be(true)
+    end
+
+    it 'is true if an email bounced for a reference' do
+      application_form = create(:application_form)
+      create(:reference, :complete, application_form: application_form)
+      create(:reference, :email_bounced, application_form: application_form)
+
+      status = ReferenceStatus.new(application_form.reload)
+
+      expect(status.needs_a_replacement_reference?).to be(true)
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
+++ b/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
@@ -15,6 +15,13 @@ RSpec.describe 'Cancelling a reference' do
     then_i_should_see_the_add_referee_type_page
     and_the_referee_should_be_sent_a_cancelation_email
     and_a_slack_notification_is_sent
+
+    given_that_i_have_10_references
+
+    when_i_visit_the_application_complete_page
+    and_i_click_delete_on_my_last_reference
+    and_i_click_to_confirm_the_cancellation
+    then_i_am_told_to_contact_support_to_add_another_refernce
   end
 
   def given_i_have_completed_and_submitted_my_application
@@ -43,6 +50,10 @@ RSpec.describe 'Cancelling a reference' do
     click_button t('application_form.referees.sure_cancel_entry')
   end
 
+  def and_i_click_to_confirm_the_cancellation
+    when_i_click_to_confirm_the_cancellation
+  end
+
   def then_i_should_see_the_add_referee_type_page
     expect(page).to have_current_path(candidate_interface_additional_referee_type_path)
   end
@@ -55,5 +66,23 @@ RSpec.describe 'Cancelling a reference' do
 
   def and_a_slack_notification_is_sent
     expect_slack_message_with_text "Candidate #{@reference.application_form.first_name} has cancelled one of their references"
+  end
+
+  def given_that_i_have_10_references
+    create_list(:reference, 7, application_form: @reference.application_form, feedback_status: 'cancelled')
+    create(:reference, application_form: @reference.application_form, feedback_status: 'feedback_requested')
+  end
+
+  def when_i_visit_the_application_complete_page
+    visit candidate_interface_application_complete_path
+  end
+
+  def and_i_click_delete_on_my_last_reference
+    @last_reference = ApplicationReference.last
+    click_link "Cancel referee #{@last_reference.name}"
+  end
+
+  def then_i_am_told_to_contact_support_to_add_another_refernce
+    expect(page).to have_content t('page_titles.maximum_referees')
   end
 end


### PR DESCRIPTION
## Context

At the moment there is no limit on how many times a candidate can cancel their referee request and adds new ones.

We also don't have anything in place for the seventh referee onwards in the nth referee locales so the table name is blank (see before image)


## Changes proposed in this pull request

- Limit the number of referees a candidate can have associated with their application to 10
- Redirects them to a page asking them to contact the support team page if they try to add an 11th referee or cancel a reference request and already have 10 referees

Before 

![image](https://user-images.githubusercontent.com/42515961/79689745-ad9c8f00-824e-11ea-8841-687de96935e4.png)



After

![image](https://user-images.githubusercontent.com/42515961/79689753-c3aa4f80-824e-11ea-8e0e-b204a62a58a6.png)

![image](https://user-images.githubusercontent.com/42515961/79689805-0835eb00-824f-11ea-923a-1ce31e133204.png)



## Guidance to review

The designs will need a review (ux and content)

## Link to Trello card

https://trello.com/c/CXTNkMUo/1323-dev-limit-amount-of-referees-a-candidate-can-have-to-10

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
