### PR TITLE
Send application_submitted provider email in after_commit callback

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -2,6 +2,8 @@ class ApplicationChoice < ApplicationRecord
   include Chased
 
   before_create :set_initial_status
+  after_commit :send_new_application_email_to_provider, on: :update
+  attr_accessor :allow_new_application_email
 
   belongs_to :application_form, touch: true
   belongs_to :course_option
@@ -29,6 +31,12 @@ class ApplicationChoice < ApplicationRecord
     withdrawn: 'withdrawn',
     conditions_not_met: 'conditions_not_met',
   }
+
+  def send_new_application_email_to_provider
+    if allow_new_application_email
+      SendNewApplicationEmailToProvider.new(application_choice: self).call
+    end
+  end
 
   def edit_by_expired?
     edit_by.present? && edit_by < Time.zone.now

--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -9,6 +9,7 @@ class SendApplicationToProvider
   def call
     return false unless application_choice.application_complete?
 
+    application_choice.allow_new_application_email = true
     ActiveRecord::Base.transaction do
       application_choice.update!(sent_to_provider_at: Time.zone.now)
       SetRejectByDefault.new(application_choice).call
@@ -16,6 +17,5 @@ class SendApplicationToProvider
     end
 
     StateChangeNotifier.call(:send_application_to_provider, application_choice: application_choice)
-    SendNewApplicationEmailToProvider.new(application_choice: application_choice).call
   end
 end

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe SendApplicationToProvider do
   def application_choice(status: 'application_complete')
     @application_choice ||= create(
       :submitted_application_choice,
+      reject_by_default_at: nil,
+      reject_by_default_days: nil,
       status: status,
       edit_by: 2.business_days.ago,
     )
@@ -59,6 +61,7 @@ RSpec.describe SendApplicationToProvider do
     expect {
       SendApplicationToProvider.new(application_choice: application_choice).call
     }.to change { ActionMailer::Base.deliveries.count }.by(1)
+
 
     expect(ActionMailer::Base.deliveries.first.to.first).to eq(user.email_address)
   end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
In several of our environments, including production, we see the
following exception:

    ActionView::Template::Error
    wrong number of arguments (given 1, expected 0)

It appears intermittently and occurs when trying to send the
ProviderMailer#application_submitted email. Its source is this line
in the email template:

    @application.rbd_date.to_s(:govuk_date)

The error occurs because the `rbd_date` is nil (this is just a struct
attribute that holds the `reject_by_default_at` value of the
application_choice record). When inspecting a sample of the application
choice records that are subject to this error, the
`reject_by_default_at` value appears to be correctly populated.

The email is sent as part of the SendApplicationToProvider service
object, which updates the `reject_by_default_at` just before doing an async
send of the email. The error above is possibly due to a worker
attempting to send the email before the database commit that stores the
RBD value has finished.



## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Attempt to fix this by sending the email in an after_commit callback on
the ApplicationChoice model. Pass in a temporary flag on the model so
that the email is only sent in this particular scenario.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Also considered:
- Raising a custom exception in the mailer when rbd date is blank and configuring Sentry to ignore it. Decided against this as it potentially masks actual problems with rbd date population, and there doesn't seem to be a way to access retry counts (eg - to only raise if this is the first or second attempt) in these mailers without defining a custom worker to do the sending.
- Defining an after_commit callback on the instance at runtime (in the body of the SendApplicationToProvider service object). Doesn't appear to be possible in Rails.

Other ideas welcome.

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/8g0yXIfH
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
