### PR TITLE
Remove the `show_new_referee_needed` flag

### DIFF
--- a/app/components/candidate_interface/new_references_needed_component.rb
+++ b/app/components/candidate_interface/new_references_needed_component.rb
@@ -9,8 +9,7 @@ module CandidateInterface
     end
 
     def render?
-      FeatureFlag.active?('show_new_referee_needed') &&
-        reference_status.still_more_references_needed?
+      reference_status.still_more_references_needed?
     end
 
   private

--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -7,7 +7,7 @@ module CandidateInterface
       service.execute
 
       if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
-        if more_reference_needed? && FeatureFlag.active?('show_new_referee_needed')
+        if more_reference_needed?
           redirect_to candidate_interface_additional_referee_path
         elsif current_candidate.current_application.blank_application? && FeatureFlag.active?('before_you_start')
           redirect_to candidate_interface_before_you_start_path

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -17,7 +17,6 @@ class FeatureFlag
     provider_application_filters
     provider_change_response
     provider_view_safeguarding
-    show_new_referee_needed
     suitability_to_work_with_children
     training_with_a_disability
     work_breaks

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -4,11 +4,8 @@ Dear <%= @application_form.first_name %>,
 
 <%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name, referee_email: @reference.email_address) %>
 
-<% if FeatureFlag.active?('show_new_referee_needed') %>
 Please add a new referee:
+
 <%= candidate_sign_in_url(@candidate) %>
-<% else %>
-Please reply to this email with the name and email address of a new referee, and tell us how you know them.
-<% end %>
 
 We can’t send your application to your teacher training providers without 2 complete references.

--- a/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Candidate needs to provide a new referee' do
 
   scenario "Candidate provides a new referee because one didn't respond" do
     FeatureFlag.activate('pilot_open')
-    FeatureFlag.activate('show_new_referee_needed')
     FeatureFlag.activate('replacement_referee_with_referee_type')
     FeatureFlag.activate('covid_19')
 

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
 
   scenario "Candidate provides a new referee because 2 didn't respond" do
     FeatureFlag.activate('pilot_open')
-    FeatureFlag.activate('show_new_referee_needed')
     FeatureFlag.activate('replacement_referee_with_referee_type')
 
     given_i_am_signed_in_as_a_candidate

--- a/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
+++ b/spec/system/provider_interface/provider_acts_as_candidate_on_sandbox_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe 'A Provider can log in as a candidate' do
 
     when_i_visit_that_application_in_the_provider_interface
     and_the_application_has_a_referee_that_rejected_to_give_feedback
-    and_the_show_new_referee_needed_feature_flag_is_active
     and_i_click_on_the_sign_in_button
 
     then_i_am_redirected_to_the_candidate_additional_referee_path
@@ -62,10 +61,6 @@ RSpec.describe 'A Provider can log in as a candidate' do
 
   def and_the_application_has_a_referee_that_rejected_to_give_feedback
     @application_choice.application_form.application_references << create(:reference, :refused)
-  end
-
-  def and_the_show_new_referee_needed_feature_flag_is_active
-    FeatureFlag.activate('show_new_referee_needed')
   end
 
   def then_i_am_redirected_to_the_candidate_additional_referee_path

--- a/spec/system/support_interface/sign_in_as_candidate_spec.rb
+++ b/spec/system/support_interface/sign_in_as_candidate_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Sign in as candidate' do
 
     when_i_visit_the_application_form_page
     and_the_application_has_a_referee_that_rejected_to_give_feedback
-    and_the_show_new_referee_needed_feature_flag_is_active
     and_click_the_sign_in_button
 
     then_i_am_redirected_to_the_candidate_interface_additional_referee_path
@@ -42,10 +41,6 @@ RSpec.feature 'Sign in as candidate' do
   def and_the_application_has_a_referee_that_rejected_to_give_feedback
     @application.application_references << create(:reference, :refused)
     @application.application_references << create(:reference, :refused)
-  end
-
-  def and_the_show_new_referee_needed_feature_flag_is_active
-    FeatureFlag.activate('show_new_referee_needed')
   end
 
   def then_i_am_redirected_to_the_candidate_interface_additional_referee_path


### PR DESCRIPTION
## Context

This feature has been live for a while, time to remove it.

## Changes proposed in this pull request


## Guidance to review

Does it remove the flag correctly?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
