### PR TITLE
Fix intermittent exception when sending application to provider

### DIFF
--- a/app/services/send_application_to_provider.rb
+++ b/app/services/send_application_to_provider.rb
@@ -1,4 +1,3 @@
-# This worker will be scheduled to run nightly
 class SendApplicationToProvider
   attr_accessor :application_choice
 

--- a/app/services/send_applications_to_provider.rb
+++ b/app/services/send_applications_to_provider.rb
@@ -1,4 +1,3 @@
-# This worker will be scheduled to run nightly
 class SendApplicationsToProvider
   def call
     GetApplicationFormsReadyToSendToProviders.call.each do |application_form|

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -15,9 +15,11 @@ class SubmitReference
       raise 'Can\'t submit a reference without answers to all questions'
     end
 
-    @reference.update!(feedback_status: 'feedback_provided')
-
-    progress_application_if_enough_references_have_been_submitted
+    if enough_references_have_been_submitted?
+      progress_applications
+    else
+      reference_feedback_provided!
+    end
 
     CandidateMailer.reference_received(@reference).deliver_later
     RefereeMailer.reference_confirmation_email(application_form, reference).deliver_later
@@ -25,23 +27,28 @@ class SubmitReference
 
 private
 
-  def progress_application_if_enough_references_have_been_submitted
-    return unless there_are_now_enough_references_to_progress?
+  # Only progress the applications if the reference that is being submitted is
+  # the 2nd referee, since there might be more than 2 references per form. We
+  # don't want to send the references to the provider *again* when the 3rd or
+  # 4th reference is submitted.
+  def enough_references_have_been_submitted?
+    (
+      application_form.application_references.feedback_provided + [@reference]
+    ).uniq.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+  end
 
+  def reference_feedback_provided!
+    @reference.update!(feedback_status: 'feedback_provided')
+  end
+
+  def progress_applications
     ActiveRecord::Base.transaction do
+      reference_feedback_provided!
       application_form.application_choices.each do |application_choice|
         ApplicationStateChange.new(application_choice).references_complete!
       end
     end
 
     SendApplicationsToProvider.new.call
-  end
-
-  # Only progress the applications if the reference that is being submitted is
-  # the 2nd referee, since there might be more than 2 references per form. We
-  # don't want to send the references to the provider *again* when the 3rd or
-  # 4th reference is submitted.
-  def there_are_now_enough_references_to_progress?
-    application_form.application_references.feedback_provided.count == ApplicationForm::MINIMUM_COMPLETE_REFERENCES
   end
 end


### PR DESCRIPTION
## Context

In several of our environments, including production, we see the
following exception:

    ActionView::Template::Error
    wrong number of arguments (given 1, expected 0)

It appears intermittently and occurs when trying to send the
ProviderMailer#application_submitted email. Its source is this line
in the email template:

    @application.rbd_date.to_s(:govuk_date)

The error occurs because the rbd_date is nil (this is just a struct
attribute that holds the reject_by_default_at value of the
application_choice record).

The likely cause of this seems to be the transaction nesting that occurs
when SubmitReference calls the SendApplicationsToProvider service. The
call to this service is part of the top-level transaction. It iterates
over eligible application forms and calls SendApplicationToProvider for
each of their application choices. This service then contains database
changes wrapped in another transaction, followed by async delivery of
the application_submitted email.

Because these database changes are only committed when the top-level
transaction block closes, it seems likely that on some occasions a
Sidekiq worker is attempting to send the email before the
reject_by_default_at is present in the database record.

Shout out to @tijmenb for identifying the root cause.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
This PR removes the transaction nesting, and instead leaves a linear
series of database updates and transactions for each discrete step of
the SubmitReference process.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? --> 
na

## Link to Trello card
https://trello.com/c/8g0yXIfH
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
