### PR TITLE
Deduplicate the list of ProviderUsers we show to providers who can manage users

### DIFF
--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -13,6 +13,7 @@ class ProviderUser < ActiveRecord::Base
   scope :visible_to, ->(provider_user) {
     joins(:provider_permissions)
       .where(ProviderPermissions.table_name => { provider_id: provider_user.providers.pluck(:id) })
+      .distinct
   }
 
   def self.load_from_session(session)

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -11,9 +11,13 @@ class ProviderUser < ActiveRecord::Base
   has_associated_audits
 
   scope :visible_to, ->(provider_user) {
-    joins(:provider_permissions)
-      .where(ProviderPermissions.table_name => { provider_id: provider_user.providers.pluck(:id) })
-      .distinct
+    providers_that_user_can_manage = provider_user.provider_permissions.manage_users.select(:provider_id)
+
+    users_that_user_can_see = ProviderPermissions.where(
+      provider_id: providers_that_user_can_manage,
+    ).select(:provider_user_id)
+
+    where(id: users_that_user_can_see)
   }
 
   def self.load_from_session(session)

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -82,8 +82,9 @@ RSpec.describe ProviderUser, type: :model do
     it 'returns provider users with access to the same providers as the passed user' do
       provider = create(:provider)
 
-      user_a = create(:provider_user, providers: [provider])
+      user_a = create(:provider_user)
       user_b = create(:provider_user, providers: [provider])
+      create(:provider_permissions, provider_user: user_a, provider: provider, manage_users: true)
 
       expect(ProviderUser.visible_to(user_a)).to include(user_b)
       expect(ProviderUser.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
@@ -93,11 +94,28 @@ RSpec.describe ProviderUser, type: :model do
       provider_a = create(:provider)
       provider_b = create(:provider)
 
-      user_a = create(:provider_user, providers: [provider_a, provider_b])
+      user_a = create(:provider_user)
       user_b = create(:provider_user, providers: [provider_a, provider_b])
+
+      create(:provider_permissions, provider_user: user_a, provider: provider_a, manage_users: true)
+      create(:provider_permissions, provider_user: user_a, provider: provider_b, manage_users: true)
 
       expect(ProviderUser.visible_to(user_a)).to include(user_b)
       expect(ProviderUser.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
+    end
+
+    it 'returns only users for providers for which the passed user has manage_users permission' do
+      provider_a = create(:provider)
+      provider_b = create(:provider)
+
+      user_a = create(:provider_user)
+      create(:provider_permissions, provider_user: user_a, provider: provider_a, manage_users: true)
+      create(:provider_permissions, provider_user: user_a, provider: provider_b, manage_users: false)
+      user_b = create(:provider_user, providers: [provider_a])
+      user_c = create(:provider_user, providers: [provider_b])
+
+      expect(ProviderUser.visible_to(user_a)).to include(user_b)
+      expect(ProviderUser.visible_to(user_a)).not_to include(user_c)
     end
   end
 end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -77,4 +77,14 @@ RSpec.describe ProviderUser, type: :model do
       expect(provider_user.can_manage_users?).to be true
     end
   end
+
+  describe '.visible_to' do
+    it 'returns provider users with access to the same providers as the passed user' do
+      provider = create(:provider)
+      user_a = create(:provider_user, providers: [provider])
+      user_b = create(:provider_user, providers: [provider])
+
+      expect(ProviderUser.visible_to(user_a)).to include(user_b)
+    end
+  end
 end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -81,10 +81,23 @@ RSpec.describe ProviderUser, type: :model do
   describe '.visible_to' do
     it 'returns provider users with access to the same providers as the passed user' do
       provider = create(:provider)
+
       user_a = create(:provider_user, providers: [provider])
       user_b = create(:provider_user, providers: [provider])
 
       expect(ProviderUser.visible_to(user_a)).to include(user_b)
+      expect(ProviderUser.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
+    end
+
+    it 'returns only one record per user' do
+      provider_a = create(:provider)
+      provider_b = create(:provider)
+
+      user_a = create(:provider_user, providers: [provider_a, provider_b])
+      user_b = create(:provider_user, providers: [provider_a, provider_b])
+
+      expect(ProviderUser.visible_to(user_a)).to include(user_b)
+      expect(ProviderUser.visible_to(user_a).count).to eq(2) # user_a can see themselves plus user_b
     end
   end
 end


### PR DESCRIPTION
## Context

The list of provider users was confusing as users appeared in it multiple times

![Screenshot 2020-04-21 at 10 12 42](https://user-images.githubusercontent.com/642279/79870535-0862f180-83db-11ea-8a7d-a07944e3ddff.png)

## Changes proposed in this pull request

- `DISTINCT` the ProviderUser.visible_to scope so it only returns each user once
- show only users for providers the current user has permission to manage

## Guidance to review

Is it right to limit the scope to `manage_users: true` relationships?

## Link to Trello card

https://trello.com/c/H5qgGRbo/2011-provider-users-appear-multiple-times-in-the-list-managing-users-can-see

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
