### PR TITLE
Separate permanent and temporary feature flags

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,35 +1,40 @@
 class FeatureFlag
-  FEATURES = %w[
-    add_additional_courses_page
+  PERMANENT_SETTINGS = %w[
     banner_about_problems_with_dfe_sign_in
     banner_for_ucas_downtime
-    candidate_can_cancel_reference
-    create_account_or_sign_in_page
     covid_19
+    force_ok_computer_to_fail
+    pilot_open
+  ].freeze
+
+  TEMPORARY_FEATURE_FLAGS = %w[
+    add_additional_courses_page
+    before_you_start
+    candidate_can_cancel_reference
     check_full_courses
     confirm_conditions
+    create_account_or_sign_in_page
+    edit_course_choices
     equality_and_diversity
-    force_ok_computer_to_fail
+    group_providers_by_region
     improved_expired_token_flow
-    pilot_open
+    notes
     prompt_for_additional_qualifications
+    provider_add_provider_users
     provider_application_filters
     provider_change_response
-    provider_view_safeguarding
-    suitability_to_work_with_children
-    work_breaks
-    before_you_start
     provider_interface_work_breaks
+    provider_view_safeguarding
     referee_type
     replacement_referee_with_referee_type
-    notes
-    timeline
-    edit_course_choices
     satisfaction_survey
-    group_providers_by_region
-    provider_add_provider_users
+    suitability_to_work_with_children
+    timeline
     unavailable_course_option_warnings
+    work_breaks
   ].freeze
+
+  FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze
 
   def self.activate(feature_name)
     raise unless feature_name.in?(FEATURES)


### PR DESCRIPTION
## Context

We are currently misusing the feature flags system (a bit) for global options, like whether or not the pilot is open or not.

## Changes proposed in this pull request

This separates them out to make clear which feature flags need to be cleaned up at some point.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
