### PR TITLE
Remove referee types features flags

### DIFF
--- a/app/components/candidate_interface/additional_referees_start_component.html.erb
+++ b/app/components/candidate_interface/additional_referees_start_component.html.erb
@@ -17,12 +17,10 @@
 
 <p class="govuk-body">We can’t send your application to your teacher training providers without 2 complete references.</p>
 
-<% new_referees_path = FeatureFlag.active?('replacement_referee_with_referee_type') ? candidate_interface_additional_referee_type_path : candidate_interface_new_additional_referee_path %>
-
 <% if reference_status.number_of_references_that_currently_need_replacing == 1 %>
-  <p> <%= govuk_button_link_to 'Add a new referee', new_referees_path %></p>
+  <p> <%= govuk_button_link_to 'Add a new referee', candidate_interface_additional_referee_type_path %></p>
   <p class="govuk-body"><%= govuk_link_to 'Continue without adding a new referee', candidate_interface_application_complete_path %></p>
 <% else %>
-   <%= govuk_button_link_to 'Add new referees', new_referees_path %>
+   <%= govuk_button_link_to 'Add new referees', candidate_interface_additional_referee_type_path %>
   <p class="govuk-body"><%= govuk_link_to 'Continue without adding new referees', candidate_interface_application_complete_path %></p>
 <% end %>

--- a/app/components/candidate_interface/new_references_needed_component.html.erb
+++ b/app/components/candidate_interface/new_references_needed_component.html.erb
@@ -1,13 +1,10 @@
 <div class="app-banner app-banner--info" aria-labelledby="info-message">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m" id="info-message">
-
-      <% new_referees_path = FeatureFlag.active?('replacement_referee_with_referee_type') ? candidate_interface_additional_referee_type_path : candidate_interface_new_additional_referee_path %>
-
       <% if reference_status.number_of_references_that_currently_need_replacing == 1 %>
-        You need to <%= govuk_link_to 'give details of a new referee', new_referees_path %>
+        You need to <%= govuk_link_to 'give details of a new referee', candidate_interface_additional_referee_type_path %>
       <% else %>
-        You need to <%= govuk_link_to 'give details of 2 new referees', new_referees_path %>
+        You need to <%= govuk_link_to 'give details of 2 new referees', candidate_interface_additional_referee_type_path %>
       <% end %>
     </h2>
   </div>

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -14,7 +14,7 @@ module CandidateInterface
       [
         name_row(referee),
         email_row(referee),
-        (reference_type_row(referee) if FeatureFlag.active?('referee_type')),
+        reference_type_row(referee),
         relationship_row(referee),
         feedback_status_row(referee),
       ].compact

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -36,13 +36,8 @@ module CandidateInterface
     def new
       redirect_to_confirm_if_no_more_reference_needed
 
-      if FeatureFlag.active?('replacement_referee_with_referee_type')
-        @reference = current_candidate.current_application.application_references.build(referee_type: params[:type])
-        @page_title = "Details of your new #{@reference.referee_type.downcase.dasherize} referee"
-      else
-        @page_title = page_title_for_new_page
-        @reference = ApplicationReference.new
-      end
+      @reference = current_candidate.current_application.application_references.build(referee_type: params[:type])
+      @page_title = "Details of your new #{@reference.referee_type.downcase.dasherize} referee"
     end
 
     def show; end
@@ -51,7 +46,7 @@ module CandidateInterface
       redirect_to_confirm_if_no_more_reference_needed
       reference = current_application.application_references.build(referee_params.merge(replacement: true))
 
-      reference.referee_type = params[:type] if FeatureFlag.active?('replacement_referee_with_referee_type')
+      reference.referee_type = params[:type]
 
       if reference.save
         redirect_to_confirm_or_show_another_reference_form
@@ -81,11 +76,7 @@ module CandidateInterface
 
     def edit
       @reference = current_reference
-      @page_title = if FeatureFlag.active?('replacement_referee_with_referee_type')
-                      "Details of your new #{@reference.referee_type.downcase.dasherize} referee"
-                    else
-                      page_title_for_new_page
-                    end
+      @page_title = "Details of your new #{@reference.referee_type.downcase.dasherize} referee"
     end
 
     def update
@@ -127,11 +118,7 @@ module CandidateInterface
 
     def redirect_to_confirm_or_show_another_reference_form
       if reference_status.needs_to_draft_another_reference?
-        if FeatureFlag.active?('replacement_referee_with_referee_type')
-          redirect_to candidate_interface_additional_referee_type_path(second: true)
-        else
-          redirect_to candidate_interface_new_additional_referee_path(second: true)
-        end
+        redirect_to candidate_interface_additional_referee_type_path(second: true)
       else
         redirect_to candidate_interface_confirm_additional_referees_path
       end

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -39,18 +39,14 @@ module CandidateInterface
     end
 
     def new
-      @referee = if FeatureFlag.active?('referee_type')
-                   current_candidate.current_application.application_references.build(referee_type: params[:type])
-                 else
-                   current_candidate.current_application.application_references.build
-                 end
+      @referee = current_candidate.current_application.application_references.build(referee_type: params[:type])
     end
 
     def create
       @referee = current_candidate.current_application
                                   .application_references
                                   .build(referee_params)
-      @referee.referee_type = params[:type] if FeatureFlag.active?('referee_type')
+      @referee.referee_type = params[:type]
 
       if @referee.save
         redirect_to candidate_interface_review_referees_path

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,8 +24,6 @@ class FeatureFlag
     provider_change_response
     provider_interface_work_breaks
     provider_view_safeguarding
-    referee_type
-    replacement_referee_with_referee_type
     satisfaction_survey
     suitability_to_work_with_children
     timeline

--- a/app/views/candidate_interface/additional_referees/confirm.html.erb
+++ b/app/views/candidate_interface/additional_referees/confirm.html.erb
@@ -25,12 +25,12 @@
         action: "relationship for #{reference.name}",
         change_path: candidate_interface_edit_additional_referee_path(reference),
       },
-      ({
+      {
         key: 'Reference type',
         value: reference.referee_type ? reference.referee_type.capitalize.dasherize : '',
         action: "reference type for #{reference.name}",
         change_path: candidate_interface_additional_referee_type_path(reference.id),
-      } if FeatureFlag.active?('replacement_referee_with_referee_type')),
+      },
     ].compact
     ) do %>
     <%= render SummaryCardHeaderComponent.new(title: reference.name) %>

--- a/app/views/candidate_interface/additional_referees/new.html.erb
+++ b/app/views/candidate_interface/additional_referees/new.html.erb
@@ -1,7 +1,4 @@
 <% content_for :title, title_with_error_prefix(@page_title, @reference.errors.any?) %>
-<% if FeatureFlag.active?('replacement_referee_with_referee_type') %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_additional_referee_type_path, 'Back') %>
-<% else %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back') %>
-<% end %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_additional_referee_type_path, 'Back') %>
+
 <%= render 'form', reference: @reference, page_title: @page_title, url: candidate_interface_new_additional_referee_path(type: @reference.referee_type) %>

--- a/app/views/candidate_interface/referees/_intro.html.erb
+++ b/app/views/candidate_interface/referees/_intro.html.erb
@@ -7,9 +7,5 @@
 </ul>
 
 <p class="govuk-body">
-  <% if FeatureFlag.active?('referee_type') %>
-    <%= govuk_button_link_to 'Continue', candidate_interface_referees_type_path %>
-  <% else %>
-    <%= govuk_button_link_to 'Continue', candidate_interface_new_referee_path %>
-  <% end %>
+  <%= govuk_button_link_to 'Continue', candidate_interface_referees_type_path %>
 </p>

--- a/app/views/candidate_interface/referees/edit.html.erb
+++ b/app/views/candidate_interface/referees/edit.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_referee'), @referee.errors.any?) %>
-<% if FeatureFlag.active?('referee_type') %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_review_referees_path, 'Back') %>
-<% else %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
-<% end %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_referees_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/referees/new.html.erb
+++ b/app/views/candidate_interface/referees/new.html.erb
@@ -1,9 +1,5 @@
 <% content_for :title, title_with_error_prefix(t('page_titles.add_referee'), @referee.errors.any?) %>
-<% if FeatureFlag.active?('referee_type') %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_referees_type_path, 'Back') %>
-<% else %>
-  <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
-<% end %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_referees_type_path, 'Back') %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -9,12 +9,10 @@
 
 <%- if @referees.count < ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
 <p>
-  <% new_referee_path = FeatureFlag.active?('referee_type') ? candidate_interface_referees_type_path : candidate_interface_new_referee_path %>
-
   <% if @referees.any? %>
-    <%= govuk_button_link_to t('application_form.referees.add_second_referee'), new_referee_path, class: 'govuk-button--secondary' %>
+    <%= govuk_button_link_to t('application_form.referees.add_second_referee'), candidate_interface_referees_type_path, class: 'govuk-button--secondary' %>
   <% else %>
-    <%= govuk_button_link_to t('application_form.referees.add_referee'), new_referee_path, class: 'govuk-button--secondary' %>
+    <%= govuk_button_link_to t('application_form.referees.add_referee'), candidate_interface_referees_type_path, class: 'govuk-button--secondary' %>
   <% end %>
 </p>
 <%- end %>

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -88,56 +88,36 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       change_name = result.css('.govuk-summary-list__actions')[0].text.strip
       change_email = result.css('.govuk-summary-list__actions')[1].text.strip
-      change_relationship = result.css('.govuk-summary-list__actions')[2].text.strip
+      change_relationship = result.css('.govuk-summary-list__actions')[3].text.strip
 
       expect(change_name).to eq("Change name for #{first_referee.name}")
       expect(change_email).to eq("Change email address for #{first_referee.name}")
       expect(change_relationship).to eq("Change relationship for #{first_referee.name}")
     end
 
-    context 'When referee type feature flag is off' do
-      before do
-        FeatureFlag.deactivate('referee_type')
-      end
+    it "renders component with correct values for a referee's type" do
+      first_referee = application_form.application_references.first
+      result = render_inline(described_class.new(application_form: application_form))
 
-      it "renders component without a referee's type" do
-        first_referee = application_form.application_references.first
-        result = render_inline(described_class.new(application_form: application_form))
-
-        expect(result.css('.govuk-summary-list__key').text).not_to include('Reference type')
-        expect(result.css('.govuk-summary-list__value').to_html).not_to include(first_referee.referee_type.capitalize.dasherize)
-      end
+      expect(result.css('.govuk-summary-list__key').text).to include('Reference type')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(first_referee.referee_type.capitalize.dasherize)
     end
 
-    context 'When referee type feature flag is on' do
-      before do
-        FeatureFlag.activate('referee_type')
-      end
+    it 'can tolerate when referee type is nil' do
+      first_referee = application_form.application_references.first
+      first_referee.update!(referee_type: nil)
+      result = render_inline(described_class.new(application_form: application_form))
 
-      it "renders component with correct values for a referee's type" do
-        first_referee = application_form.application_references.first
-        result = render_inline(described_class.new(application_form: application_form))
+      expect(result.css('.govuk-summary-list__key').text).to include('Reference type')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('')
+    end
 
-        expect(result.css('.govuk-summary-list__key').text).to include('Reference type')
-        expect(result.css('.govuk-summary-list__value').to_html).to include(first_referee.referee_type.capitalize.dasherize)
-      end
+    it 'renders correct text for "Change" links in reference type attribute row' do
+      first_referee = application_form.application_references.first
+      result = render_inline(described_class.new(application_form: application_form))
+      change_reference_type = result.css('.govuk-summary-list__actions')[2].text.strip
 
-      it 'can tolerate when referee type is nil' do
-        first_referee = application_form.application_references.first
-        first_referee.update!(referee_type: nil)
-        result = render_inline(described_class.new(application_form: application_form))
-
-        expect(result.css('.govuk-summary-list__key').text).to include('Reference type')
-        expect(result.css('.govuk-summary-list__value').to_html).to include('')
-      end
-
-      it 'renders correct text for "Change" links in reference type attribute row' do
-        first_referee = application_form.application_references.first
-        result = render_inline(described_class.new(application_form: application_form))
-        change_reference_type = result.css('.govuk-summary-list__actions')[2].text.strip
-
-        expect(change_reference_type).to eq("Change reference type for #{first_referee.name}")
-      end
+      expect(change_reference_type).to eq("Change reference type for #{first_referee.name}")
     end
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -271,9 +271,17 @@ module CandidateHelper
   def candidate_provides_two_referees
     visit candidate_interface_referees_path
     click_link 'Continue'
+
+    choose 'Academic'
+    click_button 'Continue'
+
     candidate_fills_in_referee
     click_button 'Save and continue'
     click_link 'Add a second referee'
+
+    choose 'Professional'
+    click_button 'Continue'
+
     candidate_fills_in_referee(
       name: 'Anne Other',
       email_address: 'anne@other.com',

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -6,6 +6,10 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
   def candidate_provides_two_referees
     visit candidate_interface_referees_path
     click_link 'Continue'
+
+    choose 'Academic'
+    click_button 'Continue'
+
     candidate_fills_in_referee(
       name: 'Refbot One',
       email_address: 'refbot1@example.com',
@@ -13,6 +17,10 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
     )
     click_button 'Save and continue'
     click_link 'Add a second referee'
+
+    choose 'Professional'
+    click_button 'Continue'
+
     candidate_fills_in_referee(
       name: 'Refbot Two',
       email_address: 'refbot2@example.com',

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate adding referees' do
 
   scenario 'Candidate adds references' do
     given_i_am_signed_in
-    and_the_referee_type_feature_flag_is_active
     and_i_visit_the_application_form
 
     given_i_have_no_existing_references_on_the_form
@@ -64,10 +63,6 @@ RSpec.feature 'Candidate adding referees' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_referee_type_feature_flag_is_active
-    FeatureFlag.activate('referee_type')
   end
 
   def given_i_have_no_existing_references_on_the_form

--- a/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
+++ b/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe 'Cancelling a reference' do
   scenario 'candidate cancels a reference request after completing their application' do
     given_i_have_completed_and_submitted_my_application
     and_the_candidate_can_cancel_reference_flag_is_active
-    and_the_referee_type_flag_is_active
 
     when_i_visit_the_application_complete_page
     and_i_click_delete_on_my_first_reference
@@ -25,10 +24,6 @@ RSpec.describe 'Cancelling a reference' do
 
   def and_the_candidate_can_cancel_reference_flag_is_active
     FeatureFlag.activate('candidate_can_cancel_reference')
-  end
-
-  def and_the_referee_type_flag_is_active
-    FeatureFlag.activate('referee_type')
   end
 
   def when_i_visit_the_application_complete_page

--- a/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_new_referee_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Candidate needs to provide a new referee' do
 
   scenario "Candidate provides a new referee because one didn't respond" do
     FeatureFlag.activate('pilot_open')
-    FeatureFlag.activate('replacement_referee_with_referee_type')
     FeatureFlag.activate('covid_19')
 
     given_i_am_signed_in_as_a_candidate

--- a/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_needs_to_provide_two_new_referees_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Candidate needs to provide 2 new referees' do
 
   scenario "Candidate provides a new referee because 2 didn't respond" do
     FeatureFlag.activate('pilot_open')
-    FeatureFlag.activate('replacement_referee_with_referee_type')
 
     given_i_am_signed_in_as_a_candidate
     and_i_have_submitted_my_application


### PR DESCRIPTION
## Context

This removes 2 feature flags that allow candidates to specify the type of referee. It's been live for a while and not likely to be reverted.

## Changes proposed in this pull request

Remove the feature flags. I needed to fix some code in existing specs that relied on the feature flag being off. 

## Guidance to review

Did I remove all the code? Did I remove too much?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
