### PR TITLE
Remove `improved_expired_token_flow` feature flag

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -53,12 +53,7 @@ module ViewHelper
 
   def candidate_sign_in_url(candidate)
     encrypted_candidate_id = Encryptor.encrypt(candidate.id)
-
-    if FeatureFlag.active?('improved_expired_token_flow')
-      candidate_interface_sign_in_url(u: encrypted_candidate_id)
-    else
-      candidate_interface_sign_in_url
-    end
+    candidate_interface_sign_in_url(u: encrypted_candidate_id)
   end
 
   def format_months_to_years_and_months(number_of_months)

--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -28,8 +28,9 @@ class AuthenticationMailer < ApplicationMailer
 private
 
   def magic_link_params(token, candidate)
-    params = { token: token }
-    params[:u] = Encryptor.encrypt(candidate.id) if FeatureFlag.active?('improved_expired_token_flow')
-    params
+    {
+      token: token,
+      u: Encryptor.encrypt(candidate.id),
+    }
   end
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -17,7 +17,6 @@ class FeatureFlag
     edit_course_choices
     equality_and_diversity
     group_providers_by_region
-    improved_expired_token_flow
     notes
     prompt_for_additional_qualifications
     provider_add_provider_users

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -19,21 +19,11 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       expect(mail.body.encoded).to include(t('authentication.sign_up.email.subject'))
     end
 
-    it 'sends an email with a magic link' do
+    it 'sends an email with a magic link and encrypted candidate id' do
+      allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/authenticate?token=#{token}",
+        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
       )
-    end
-
-    context 'with the improved_expired_token_flow feature flag' do
-      before { FeatureFlag.activate('improved_expired_token_flow') }
-
-      it 'sends an email with a magic link and encrypted candidate id' do
-        allow(Encryptor).to receive(:encrypt).and_return('secret')
-        expect(mail.body.encoded).to include(
-          "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
-        )
-      end
     end
 
     it 'sends a request with a Notify reference' do
@@ -59,21 +49,11 @@ RSpec.describe AuthenticationMailer, type: :mailer do
       expect(mail.body.encoded).to include(t('authentication.sign_in.email.subject'))
     end
 
-    it 'sends an email with a magic link' do
+    it 'sends an email with a magic link and encrypted candidate id' do
+      allow(Encryptor).to receive(:encrypt).and_return('secret')
       expect(mail.body.encoded).to include(
-        "http://localhost:3000/candidate/authenticate?token=#{token}",
+        "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
       )
-    end
-
-    context 'with the improved_expired_token_flow feature flag' do
-      before { FeatureFlag.activate('improved_expired_token_flow') }
-
-      it 'sends an email with a magic link and encrypted candidate id' do
-        allow(Encryptor).to receive(:encrypt).and_return('secret')
-        expect(mail.body.encoded).to include(
-          "http://localhost:3000/candidate/authenticate?token=#{token}&u=secret",
-        )
-      end
     end
   end
 

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -36,23 +36,8 @@ RSpec.describe CandidateMailer, type: :mailer do
                     I18n.t!('candidate_mailer.application_submitted.subject'),
                     'heading' => 'Application submitted',
                     'support reference' => 'SUPPORT-REFERENCE',
-                    'RBD time limit' => "to make an offer within #{TimeLimitConfig.limits_for(:reject_by_default).first.limit} working days")
-
-    context 'when the improved_expired_token_flow feature flag is on' do
-      before { FeatureFlag.activate('improved_expired_token_flow') }
-
-      it_behaves_like('a mail with subject and content', :application_submitted,
-                      I18n.t!('candidate_mailer.application_submitted.subject'),
-                      'link to sign in and id' => 'http://localhost:3000/candidate/sign-in?u=example_encrypted_id')
-    end
-
-    context 'when the improved_expired_token_flow feature flag is off' do
-      before { FeatureFlag.deactivate('improved_expired_token_flow') }
-
-      it_behaves_like('a mail with subject and content', :application_submitted,
-                      I18n.t!('candidate_mailer.application_submitted.subject'),
-                      'link to sign in and id' => 'http://localhost:3000/candidate/sign-in')
-    end
+                    'RBD time limit' => "to make an offer within #{TimeLimitConfig.limits_for(:reject_by_default).first.limit} working days",
+                    'link to sign in and id' => 'http://localhost:3000/candidate/sign-in?u=example_encrypted_id')
 
     context 'when the covid-19 feature flag is on' do
       before { FeatureFlag.activate('covid_19') }

--- a/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_clicking_on_expired_link_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Candidate clicks on an expired link' do
   scenario 'Candidate clicks on a link with an id and expired token link in an email' do
     given_the_pilot_is_open
-    and_the_improved_expired_token_flow_feature_flag_is_on
     and_i_am_a_candidate_with_an_application
     and_i_received_the_submitted_application_email
 
@@ -28,10 +27,6 @@ RSpec.feature 'Candidate clicks on an expired link' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_improved_expired_token_flow_feature_flag_is_on
-    FeatureFlag.activate('improved_expired_token_flow')
   end
 
   def and_i_am_a_candidate_with_an_application

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Candidate tries to sign up using magic link with an invalid token' do
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_the_pilot_is_open
-    and_the_improved_expired_token_flow_feature_flag_is_on
     and_the_covid_19_feature_flag_is_active
     and_the_create_account_or_sign_in_page_feature_flag_is_active
 
@@ -30,10 +29,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_improved_expired_token_flow_feature_flag_is_on
-    FeatureFlag.activate('improved_expired_token_flow')
   end
 
   def and_the_covid_19_feature_flag_is_active


### PR DESCRIPTION
## Context

This removes the `improved_expired_token_flow` feature flag. It's been live for a while and is not likely to be turned off.

## Changes proposed in this pull request

It's a fairly straight forward feature flag deletion.

## Guidance to review

Did I remove everything / not too much?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
