### PR TITLE
Prevent candidates from being able to add a course twice

### DIFF
--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -74,7 +74,7 @@ module CandidateInterface
       return if course_id.blank?
 
       if application_form.application_choices.includes([:course]).any? { |application_choice| application_choice.course == course }
-        errors[:base] << "You have already added #{course.name_and_code}"
+        errors[:base] << I18n.t!('errors.application_choices.already_added', course_name_and_code: course.name_and_code)
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -255,6 +255,7 @@ en:
       course_full: You cannot apply to '%{descriptor}' because it has no vacancies
       chosen_site_full: Your chosen site for '%{descriptor}' has no vacancies
       course_closed_on_apply: "'%{course_name_and_code}' at %{provider_name} is not available on Apply for teacher training anymore"
+      already_added: You have already added %{course_name_and_code}
   date:
     formats:
       long: "%e %B %Y"

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_spec.rb
@@ -30,6 +30,9 @@ RSpec.feature 'Selecting a course' do
     and_i_choose_a_course
     then_i_see_a_message_that_ive_already_chosen_the_course
 
+    when_i_visit_the_site_page_for_a_course_i_have_already_selected
+    then_i_see_a_message_that_ive_already_chosen_the_course
+
     given_that_i_am_on_the_course_choices_review_page
     when_i_click_on_add_another_course
     and_i_choose_that_i_know_where_i_want_to_apply
@@ -167,7 +170,7 @@ RSpec.feature 'Selecting a course' do
   end
 
   def then_i_see_a_message_that_ive_already_chosen_the_course
-    expect(page).to have_css('.govuk-error-summary', text: 'You have already added Primary (2XT2)')
+    expect(page).to have_content(I18n.t!('errors.application_choices.already_added', course_name_and_code: @multi_site_course.name_and_code))
   end
 
   def given_that_i_am_on_the_course_choices_review_page
@@ -202,13 +205,6 @@ RSpec.feature 'Selecting a course' do
 
   def when_i_click_continue
     click_button 'Continue'
-  end
-
-  def when_i_click_back
-    # TODO: the back link goes back to the '/candidate/application/courses/provider' instead of going back to the specific provider.
-    # Fix this and use click_link 'Back'
-
-    visit '/candidate/application/courses/provider/R55/courses'
   end
 
   def and_i_delete_one_of_my_course_choice
@@ -250,5 +246,13 @@ RSpec.feature 'Selecting a course' do
 
   def then_the_select_box_has_no_value_selected
     expect(page.find('#candidate-interface-pick-course-form-course-id-field').value).to eq ''
+  end
+
+  def when_i_visit_the_site_page_for_a_course_i_have_already_selected
+    visit candidate_interface_course_choices_site_path(
+      provider_id: @multi_site_course.provider.id,
+      course_id: @multi_site_course.id,
+      study_mode: @multi_site_course.study_mode,
+    )
   end
 end


### PR DESCRIPTION
## Context

One of our candidates was able to add the same course 3 times (within 3 minutes) and submitted their application successfully.

## Changes proposed in this pull request

We validate for this as part of `PickCourseForm`, which works fine for courses without multiple sites. For courses with multiple sites, candidates can get around this by navigating to the sites page directly and submitting it.

This adds checks to the site options page as well as the POST action, and redirects the user to the courses review page with an appropriate error flash.

## Guidance to review

I will investigate if we need something like this for choosing a study mode as well.

### Before

The gif is too large to upload:

- log in as a candidate without any course choices
- choose a course with multiple sites (Gorse SCITT / Arts and Design)
- copy the URL for the site selection page
- choose the first site
- manually go to the site selection page
- choose the first site
- there are now duplicate course choices

### After

![Screen Recording 2020-04-21 at 16 53 03](https://user-images.githubusercontent.com/1650875/79964485-b5dd1000-8482-11ea-9137-925cb04ecd4e.gif)

## Link to Trello card

https://trello.com/c/JYjDiQUm/1387-dev-investigate-why-a-user-was-able-to-add-3-of-the-same-course-to-their-application-mp1198

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)