### PR TITLE
Add accredited body, study mode to the offer section of single application pages

### DIFF
--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -1,6 +1,8 @@
 module ProviderInterface
   class OfferSummaryListComponent < ViewComponent::Base
     include ViewHelper
+    include ProviderInterface::StatusBoxComponents::CourseRows
+
     attr_reader :application_choice, :header, :options
 
     def initialize(application_choice:, header: 'Your offer', options: {})
@@ -18,22 +20,24 @@ module ProviderInterface
           key: 'Candidate name',
           value: application_choice.application_form.full_name,
         },
-        {
-          key: 'Provider',
-          value: @course_option.course.provider.name,
-          change_path: @change_provider_path, action: 'training provider'
-        },
-        {
-          key: 'Course',
-          value: @course_option.course.name_and_code,
-          change_path: @change_course_path, action: 'course'
-        },
-        {
-          key: 'Location',
-          value: @course_option.site.name_and_address,
-          change_path: @change_course_option_path, action: 'location'
-        },
-      ]
+      ] + add_change_links_to(course_rows(course_option: application_choice.offered_option))
+    end
+
+  private
+
+    def add_change_links_to(rows)
+      rows.map do |row|
+        case row[:key]
+        when 'Provider'
+          row.merge(change_path: @change_provider_path, action: 'training provider')
+        when 'Course'
+          row.merge(change_path: @change_course_path, action: 'course')
+        when 'Location'
+          row.merge(change_path: @change_course_option_path, action: 'location')
+        else
+          row
+        end
+      end
     end
   end
 end

--- a/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
+++ b/app/components/provider_interface/status_box_components/conditions_not_met_component.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   module StatusBoxComponents
     class ConditionsNotMetComponent < ViewComponent::Base
       include ViewHelper
+      include StatusBoxComponents::CourseRows
+
       attr_reader :application_choice
 
       def initialize(application_choice:, options: {})
@@ -15,20 +17,7 @@ module ProviderInterface
       end
 
       def rows
-        [
-          {
-            key: 'Provider',
-            value: application_choice.offered_course.provider.name,
-          },
-          {
-            key: 'Course',
-            value: application_choice.offered_course.name_and_code,
-          },
-          {
-            key: 'Location',
-            value: application_choice.offered_site.name_and_address,
-          },
-        ]
+        course_rows(course_option: application_choice.offered_option)
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -12,6 +12,10 @@ module ProviderInterface
             value: course_option.course.name_and_code,
           },
           {
+            key: 'Study mode',
+            value: course_option.full_time? ? 'Full time' : 'Part time',
+          },
+          {
             key: 'Location',
             value: course_option.site.name_and_address,
           },

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -6,17 +6,14 @@ module ProviderInterface
           {
             key: 'Provider',
             value: course_option.provider.name,
-            change_path: change_path(:provider), action: 'training provider'
           },
           {
             key: 'Course',
             value: course_option.course.name_and_code,
-            change_path: change_path(:course), action: 'course'
           },
           {
             key: 'Location',
             value: course_option.site.name_and_address,
-            change_path: change_path(:course_option), action: 'location'
           },
         ]
       end

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   module StatusBoxComponents
     module CourseRows
       def course_rows(course_option:)
-        [
+        rows = [
           {
             key: 'Provider',
             value: course_option.provider.name,
@@ -20,6 +20,15 @@ module ProviderInterface
             value: course_option.site.name_and_address,
           },
         ]
+
+        if course_option.course.accredited_provider.present?
+          rows.push({
+            key: 'Accredited body',
+            value: course_option.course.accredited_provider.name,
+          })
+        end
+
+        rows
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -1,0 +1,25 @@
+module ProviderInterface
+  module StatusBoxComponents
+    module CourseRows
+      def course_rows(course_option:)
+        [
+          {
+            key: 'Provider',
+            value: course_option.provider.name,
+            change_path: change_path(:provider), action: 'training provider'
+          },
+          {
+            key: 'Course',
+            value: course_option.course.name_and_code,
+            change_path: change_path(:course), action: 'course'
+          },
+          {
+            key: 'Location',
+            value: course_option.site.name_and_address,
+            change_path: change_path(:course_option), action: 'location'
+          },
+        ]
+      end
+    end
+  end
+end

--- a/app/components/provider_interface/status_box_components/declined_component.rb
+++ b/app/components/provider_interface/status_box_components/declined_component.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   module StatusBoxComponents
     class DeclinedComponent < ViewComponent::Base
       include ViewHelper
+      include StatusBoxComponents::CourseRows
+
       attr_reader :application_choice
 
       def initialize(application_choice:, options: {})
@@ -20,19 +22,7 @@ module ProviderInterface
             key: 'Offer declined',
             value: application_choice.declined_at.to_s(:govuk_date),
           },
-          {
-            key: 'Provider',
-            value: application_choice.offered_course.provider.name,
-          },
-          {
-            key: 'Course',
-            value: application_choice.offered_course.name_and_code,
-          },
-          {
-            key: 'Location',
-            value: application_choice.offered_site.name_and_address,
-          },
-        ]
+        ] + course_rows(course_option: application_choice.offered_option)
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/enrolled_component.rb
+++ b/app/components/provider_interface/status_box_components/enrolled_component.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   module StatusBoxComponents
     class EnrolledComponent < ViewComponent::Base
       include ViewHelper
+      include StatusBoxComponents::CourseRows
+
       attr_reader :application_choice
 
       def initialize(application_choice:, options: {})
@@ -20,19 +22,7 @@ module ProviderInterface
             key: 'Enrolled',
             value: application_choice.enrolled_at.to_s(:govuk_date),
           },
-          {
-            key: 'Provider',
-            value: application_choice.offered_course.provider.name,
-          },
-          {
-            key: 'Course',
-            value: application_choice.offered_course.name_and_code,
-          },
-          {
-            key: 'Location',
-            value: application_choice.offered_site.name_and_address,
-          },
-        ]
+        ] + course_rows(course_option: application_choice.offered_option)
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -20,15 +20,15 @@ module ProviderInterface
       end
 
       def rows
-        rows = [
+        [
           {
             key: 'Offer made',
             value: application_choice.offered_at.to_s(:govuk_date),
           },
-        ] + add_change_links(course_rows(course_option: application_choice.offered_option))
+        ] + add_change_links_to(course_rows(course_option: application_choice.offered_option))
       end
 
-      def add_change_links(rows)
+      def add_change_links_to(rows)
         rows.map do |row|
           case row[:key]
           when 'Provider'

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   module StatusBoxComponents
     class OfferComponent < ViewComponent::Base
       include ViewHelper
+      include StatusBoxComponents::CourseRows
+
       attr_reader :application_choice
       attr_reader :available_providers, :available_courses, :available_course_options
 
@@ -18,28 +20,30 @@ module ProviderInterface
       end
 
       def rows
-        [
+        rows = [
           {
             key: 'Offer made',
             value: application_choice.offered_at.to_s(:govuk_date),
           },
-          {
-            key: 'Provider',
-            value: application_choice.offered_course.provider.name,
-            change_path: change_path(:provider), action: 'training provider'
-          },
-          {
-            key: 'Course',
-            value: application_choice.offered_course.name_and_code,
-            change_path: change_path(:course), action: 'course'
-          },
-          {
-            key: 'Location',
-            value: application_choice.offered_site.name_and_address,
-            change_path: change_path(:course_option), action: 'location'
-          },
-        ]
+        ] + add_change_links(course_rows(course_option: application_choice.offered_option))
       end
+
+      def add_change_links(rows)
+        rows.map do |row|
+          case row[:key]
+          when 'Provider'
+            row.merge(change_path: change_path(:provider), action: 'training provider')
+          when 'Course'
+            row.merge(change_path: change_path(:course), action: 'course')
+          when 'Location'
+            row.merge(change_path: change_path(:course_option), action: 'location')
+          else
+            row
+          end
+        end
+      end
+
+    private
 
       def paths
         Rails.application.routes.url_helpers

--- a/app/components/provider_interface/status_box_components/pending_conditions_component.rb
+++ b/app/components/provider_interface/status_box_components/pending_conditions_component.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   module StatusBoxComponents
     class PendingConditionsComponent < ViewComponent::Base
       include ViewHelper
+      include StatusBoxComponents::CourseRows
+
       attr_reader :application_choice
 
       def initialize(application_choice:, options: {})
@@ -20,19 +22,7 @@ module ProviderInterface
             key: 'Offer accepted',
             value: application_choice.accepted_at.to_s(:govuk_date),
           },
-          {
-            key: 'Provider',
-            value: application_choice.offered_course.provider.name,
-          },
-          {
-            key: 'Course',
-            value: application_choice.offered_course.name_and_code,
-          },
-          {
-            key: 'Location',
-            value: application_choice.offered_site.name_and_address,
-          },
-        ]
+        ] + course_rows(course_option: application_choice.offered_option)
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/recruited_component.rb
+++ b/app/components/provider_interface/status_box_components/recruited_component.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   module StatusBoxComponents
     class RecruitedComponent < ViewComponent::Base
       include ViewHelper
+      include StatusBoxComponents::CourseRows
+
       attr_reader :application_choice
 
       def initialize(application_choice:, options: {})
@@ -20,19 +22,7 @@ module ProviderInterface
             key: 'Conditions met',
             value: application_choice.recruited_at.to_s(:govuk_date),
           },
-          {
-            key: 'Provider',
-            value: application_choice.offered_course.provider.name,
-          },
-          {
-            key: 'Course',
-            value: application_choice.offered_course.name_and_code,
-          },
-          {
-            key: 'Location',
-            value: application_choice.offered_site.name_and_address,
-          },
-        ]
+        ] + course_rows(course_option: application_choice.offered_option)
       end
     end
   end

--- a/app/components/provider_interface/status_box_components/rejected_component.rb
+++ b/app/components/provider_interface/status_box_components/rejected_component.rb
@@ -2,6 +2,8 @@ module ProviderInterface
   module StatusBoxComponents
     class RejectedComponent < ViewComponent::Base
       include ViewHelper
+      include StatusBoxComponents::CourseRows
+
       attr_reader :application_choice
 
       def initialize(application_choice:, options: {})
@@ -24,19 +26,7 @@ module ProviderInterface
             key: 'Offer withdrawn',
             value: offer_withdrawn_at,
           },
-          {
-            key: 'Provider',
-            value: application_choice.offered_course.provider.name,
-          },
-          {
-            key: 'Course',
-            value: application_choice.offered_course.name_and_code,
-          },
-          {
-            key: 'Location',
-            value: application_choice.offered_site.name_and_address,
-          },
-        ]
+        ] + course_rows(course_option: application_choice.offered_option)
       end
 
       def rejected_rows

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -49,9 +49,9 @@
 
     <%= render SummaryListComponent.new(rows: [
       { key: 'Provider', value: @application_choice.provider.name_and_code },
-      { key: 'Course', value: @application_choice.offered_course.name_and_code },
+      { key: 'Course', value: @application_choice.course.name_and_code },
       { key: 'Cycle', value: @application_choice.course.recruitment_cycle_year },
-      { key: 'Preferred location', value: @application_choice.offered_site.name_and_code },
+      { key: 'Preferred location', value: @application_choice.site.name_and_code },
       { key: 'Study mode', value: @application_choice.course_option.study_mode.humanize },
     ]) %>
 

--- a/spec/components/provider_interface/status_box_components/course_rows_spec.rb
+++ b/spec/components/provider_interface/status_box_components/course_rows_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe ProviderInterface::StatusBoxComponents::CourseRows do
 
     expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Study mode']
   end
+
+  it 'includes the accredited_provider if present' do
+    course = create(:course, accredited_provider: create(:provider))
+    rows = helper.course_rows(course_option: create(:course_option, course: course))
+
+    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Study mode', 'Accredited body']
+  end
 end

--- a/spec/components/provider_interface/status_box_components/course_rows_spec.rb
+++ b/spec/components/provider_interface/status_box_components/course_rows_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::StatusBoxComponents::CourseRows do
+  subject(:helper) do
+    helper = Class.new do
+      include ProviderInterface::StatusBoxComponents::CourseRows
+    end
+
+    helper.new
+  end
+
+  it 'displays information about the offered course' do
+    rows = helper.course_rows(course_option: create(:course_option))
+
+    expect(rows.map { |r| r[:key] }).to match_array %w[Course Location Provider]
+  end
+end

--- a/spec/components/provider_interface/status_box_components/course_rows_spec.rb
+++ b/spec/components/provider_interface/status_box_components/course_rows_spec.rb
@@ -12,6 +12,6 @@ RSpec.describe ProviderInterface::StatusBoxComponents::CourseRows do
   it 'displays information about the offered course' do
     rows = helper.course_rows(course_option: create(:course_option))
 
-    expect(rows.map { |r| r[:key] }).to match_array %w[Course Location Provider]
+    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Study mode']
   end
 end


### PR DESCRIPTION
## Context

This information isn't present on the single application page in Manage.

## Changes proposed in this pull request

- refactor the offer details so we can change them in one place
- change them in that place

This doesn't cover adding the funding type to the offer because there's a bit more to do on that first.

## Guidance to review

See commits.

## Link to Trello card

https://trello.com/c/HS9uplti/1994-build-provider-ui-add-view-of-accredited-body-study-mode-funding-route-to-the-offer-section-of-single-application-page

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
