### PR TITLE
Redirect signed in users to their application form when they click the header

### DIFF
--- a/app/controllers/candidate_interface/start_page_controller.rb
+++ b/app/controllers/candidate_interface/start_page_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class StartPageController < CandidateInterfaceController
     before_action :show_pilot_holding_page_if_not_open
+    before_action :redirect_to_application_if_signed_in
     skip_before_action :authenticate_candidate!
 
     def show; end

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -25,6 +25,10 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     then_i_am_taken_to_the_sign_up_page
     and_i_should_see_an_account_created_flash_message
     and_i_should_not_see_the_covid19_banner
+
+    when_i_click_on_course_choices
+    and_click_on_the_apply_for_teacher_training_link_in_the_header
+    then_i_see_the_application_form_page
   end
 
 
@@ -114,5 +118,17 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def and_i_should_not_see_the_covid19_banner
     expect(page).not_to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
+  end
+
+  def when_i_click_on_course_choices
+    click_link 'Course choices'
+  end
+
+  def and_click_on_the_apply_for_teacher_training_link_in_the_header
+    click_link 'Apply for teacher training'
+  end
+
+  def then_i_see_the_application_form_page
+    expect(page).to have_current_path(candidate_interface_application_form_path)
   end
 end


### PR DESCRIPTION
## Context

Candidates are not being redirected to the app form page when they click the header. They have to reinput their details.


## Changes proposed in this pull request

- Redirect signed-in users to the app form page when they click the header

## Guidance to review

Needs to be deployed quickly as it's fairly disruptive for candidates.

## Link to Trello card

https://trello.com/c/bHnL9JPN/1402-bug-signed-in-users-being-asked-to-input-their-email-again
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
