### PR TITLE
Improve visibility of validation errors

### DIFF
--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -51,6 +51,7 @@ module CandidateInterface
       if reference.save
         redirect_to_confirm_or_show_another_reference_form
       else
+        track_validation_error(reference)
         @reference = reference
         render :new
       end
@@ -83,6 +84,7 @@ module CandidateInterface
       if current_reference.update(referee_params)
         redirect_to_confirm_or_show_another_reference_form
       else
+        track_validation_error(current_reference)
         @reference = current_reference
         render :edit
       end

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -21,7 +21,11 @@ module CandidateInterface
 
       if params[:id]
         @id = params[:id]
-        return redirect_to action: 'type', id: @id unless @reference_type_form.valid?
+
+        unless @reference_type_form.valid?
+          track_validation_error(@reference_type_form)
+          return redirect_to action: 'type', id: @id
+        end
 
         @reference_type_form.save(current_referee(@id))
 

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -46,6 +46,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_application_submit_success_path
       else
+        track_validation_error(@further_information_form)
         render :submit_show
       end
     end

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -16,8 +16,6 @@ module CandidateInterface
       Raven.extra_context(application_support_url: support_interface_application_form_url(current_application))
     end
 
-  private
-
     def track_validation_error(form)
       ValidationError.create!(
         form_object: form.class.name,
@@ -28,11 +26,16 @@ module CandidateInterface
     rescue StandardError => e
       # Never crash validation error tracking
       Raven.capture_exception(e)
-      puts "Error during track_validation_error: #{e}"
     end
+
+  private
 
     def redirect_to_dashboard_if_submitted
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
+    end
+
+    def redirect_to_dashboard_if_not_amendable
+      redirect_to candidate_interface_application_complete_path if current_application.submitted? && !current_application.amendable?
     end
 
     def redirect_to_application_form_unless_submitted

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -17,6 +17,8 @@ module CandidateInterface
     end
 
     def track_validation_error(form)
+      return unless FeatureFlag.active?('track_validation_errors')
+
       ValidationError.create!(
         form_object: form.class.name,
         request_path: request.path,

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -22,7 +22,7 @@ module CandidateInterface
       ValidationError.create!(
         form_object: form.class.name,
         request_path: request.path,
-        candidate: current_candidate,
+        user: current_candidate,
         details: form.errors.messages.map { |field, messages| [field, { messages: messages, value: form.public_send(field) }] }.to_h,
       )
     rescue => e

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -25,8 +25,9 @@ module CandidateInterface
         user: current_candidate,
         details: form.errors.messages.map { |field, messages| [field, { messages: messages, value: form.public_send(field) }] }.to_h,
       )
-    rescue => e
+    rescue StandardError => e
       # Never crash validation error tracking
+      Raven.capture_exception(e)
       puts "Error during track_validation_error: #{e}"
     end
 

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -18,6 +18,18 @@ module CandidateInterface
 
   private
 
+    def track_validation_error(form)
+      ValidationError.create!(
+        form_object: form.class.name,
+        request_path: request.path,
+        candidate: current_candidate,
+        details: form.errors.messages.map { |field, messages| [field, { messages: messages, value: form.public_send(field) }] }.to_h,
+      )
+    rescue => e
+      # Never crash validation error tracking
+      puts "Error during track_validation_error: #{e}"
+    end
+
     def redirect_to_dashboard_if_submitted
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
     end

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -14,6 +14,7 @@ module CandidateInterface
       if @contact_details_form.save_address(current_application)
         redirect_to candidate_interface_contact_details_review_path
       else
+        track_validation_error(@contact_details_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -22,6 +22,7 @@ module CandidateInterface
           redirect_to candidate_interface_contact_details_edit_address_path
         end
       else
+        track_validation_error(@contact_details_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -255,6 +255,7 @@ module CandidateInterface
         redirect_to candidate_interface_application_form_path
       else
         @course_choices = current_candidate.current_application.application_choices
+        track_validation_error(@application_form)
 
         render :review
       end

--- a/app/controllers/candidate_interface/degrees/base_controller.rb
+++ b/app/controllers/candidate_interface/degrees/base_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
       if qualification
         redirect_to candidate_interface_degrees_grade_path(qualification.id)
       else
+        track_validation_error(@degree)
         render_new
       end
     end
@@ -32,6 +33,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_degrees_review_path
       else
+        track_validation_error(@degree)
         render_new
       end
     end

--- a/app/controllers/candidate_interface/degrees/grade_controller.rb
+++ b/app/controllers/candidate_interface/degrees/grade_controller.rb
@@ -23,6 +23,7 @@ module CandidateInterface
           redirect_to candidate_interface_degrees_review_path
         end
       else
+        track_validation_error(@degree)
         render :new
       end
     end

--- a/app/controllers/candidate_interface/degrees/year_controller.rb
+++ b/app/controllers/candidate_interface/degrees/year_controller.rb
@@ -19,6 +19,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_degrees_review_path
       else
+        track_validation_error(@degree)
         render :new
       end
     end

--- a/app/controllers/candidate_interface/gcse/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_controller.rb
@@ -13,6 +13,7 @@ module CandidateInterface
         redirect_to next_gcse_path
       else
         @application_qualification = details_form
+        track_validation_error(@application_qualification)
 
         render :edit
       end

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
       if @application_qualification.save_base(current_candidate.current_application)
         redirect_to next_gcse_path
       else
+        track_validation_error(@application_qualification)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/gcse/year_controller.rb
+++ b/app/controllers/candidate_interface/gcse/year_controller.rb
@@ -13,6 +13,7 @@ module CandidateInterface
         redirect_to candidate_interface_gcse_review_path
       else
         @application_qualification = details_form
+        track_validation_error(@application_qualification)
 
         render :edit
       end

--- a/app/controllers/candidate_interface/other_qualifications/base_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/base_controller.rb
@@ -22,6 +22,7 @@ module CandidateInterface
       if @qualification.save(current_application)
         redirect_to candidate_interface_review_other_qualifications_path
       else
+        track_validation_error(@qualification)
         render :new
       end
     end
@@ -39,6 +40,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_review_other_qualifications_path
       else
+        track_validation_error(@qualification)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/other_qualifications/details_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/details_controller.rb
@@ -40,6 +40,7 @@ module CandidateInterface
       else
         qualifications = OtherQualificationForm.build_all_from_application(current_application)
         @type = qualifications.last.qualification_type
+        track_validation_error(@qualification)
 
         render :new
       end

--- a/app/controllers/candidate_interface/other_qualifications/type_controller.rb
+++ b/app/controllers/candidate_interface/other_qualifications/type_controller.rb
@@ -11,6 +11,7 @@ module CandidateInterface
       if @qualification_type.save(current_application)
         redirect_to candidate_interface_new_other_qualification_details_path(id: current_application.application_qualifications.last.id)
       else
+        track_validation_error(@qualification_type)
         render :new
       end
     end

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
       if @personal_details_form.save(current_application)
         render :show
       else
+        track_validation_error(@personal_details_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
@@ -14,6 +14,7 @@ module CandidateInterface
       if @becoming_a_teacher_form.save(current_application)
         render :show
       else
+        track_validation_error(@becoming_a_teacher_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -14,6 +14,7 @@ module CandidateInterface
       if @interview_preferences_form.save(current_application)
         redirect_to candidate_interface_interview_preferences_show_path
       else
+        track_validation_error(@interview_preferences_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
       if @subject_knowledge_form.save(current_application)
         render :show
       else
+        track_validation_error(@subject_knowledge_form)
         @course_names = chosen_course_names
         render :edit
       end

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -51,6 +51,7 @@ module CandidateInterface
       if @referee.save
         redirect_to candidate_interface_review_referees_path
       else
+        track_validation_error(@referee)
         render :new
       end
     end
@@ -61,6 +62,7 @@ module CandidateInterface
       if @referee.update(referee_params)
         redirect_to candidate_interface_review_referees_path
       else
+        track_validation_error(@referee)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -26,7 +26,10 @@ module CandidateInterface
       if params[:id]
         set_referee_id
 
-        return redirect_to action: 'type', id: @id unless @reference_type_form.valid?
+        unless @reference_type_form.valid?
+          track_validation_error(@reference_type_form)
+          return redirect_to action: 'type', id: @id
+        end
 
         @reference_type_form.save(@referee)
 

--- a/app/controllers/candidate_interface/sign_up_controller.rb
+++ b/app/controllers/candidate_interface/sign_up_controller.rb
@@ -22,6 +22,7 @@ module CandidateInterface
         add_identity_to_log @sign_up_form.candidate.id
         redirect_to candidate_interface_check_email_sign_up_path
       else
+        track_validation_error(@sign_up_form)
         render :new
       end
     end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -15,6 +15,7 @@ module CandidateInterface
         @application_form = current_application
         redirect_to candidate_interface_training_with_a_disability_show_path
       else
+        track_validation_error(@training_with_a_disability_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/volunteering/base_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/base_controller.rb
@@ -14,6 +14,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_review_volunteering_path
       else
+        track_validation_error(@volunteering_role)
         render :new
       end
     end
@@ -31,6 +32,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_review_volunteering_path
       else
+        track_validation_error(@volunteering_role)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/volunteering/experience_controller.rb
+++ b/app/controllers/candidate_interface/volunteering/experience_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
           redirect_to candidate_interface_new_volunteering_role_path
         end
       else
+        track_validation_error(@volunteering_experience_form)
         render :show
       end
     end

--- a/app/controllers/candidate_interface/work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/work_history/break_controller.rb
@@ -25,6 +25,7 @@ module CandidateInterface
       if @work_break.save(current_application)
         redirect_to candidate_interface_work_history_show_path
       else
+        track_validation_error(@work_break)
         render :new
       end
     end
@@ -39,6 +40,7 @@ module CandidateInterface
       if @work_break.update(current_work_history_break)
         redirect_to candidate_interface_work_history_show_path
       else
+        track_validation_error(@work_break)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/work_history/breaks_controller.rb
+++ b/app/controllers/candidate_interface/work_history/breaks_controller.rb
@@ -14,6 +14,7 @@ module CandidateInterface
       if @work_breaks_form.save(current_application)
         redirect_to candidate_interface_work_history_show_path
       else
+        track_validation_error(@work_breaks_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/work_history/edit_controller.rb
+++ b/app/controllers/candidate_interface/work_history/edit_controller.rb
@@ -32,6 +32,7 @@ module CandidateInterface
         end
         current_application.update!(work_history_completed: false)
       else
+        track_validation_error(@work_experience_form)
         render :new
       end
     end
@@ -54,6 +55,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_work_history_show_path
       else
+        track_validation_error(@work_experience_form)
         render :edit
       end
     end

--- a/app/controllers/candidate_interface/work_history/explanation_controller.rb
+++ b/app/controllers/candidate_interface/work_history/explanation_controller.rb
@@ -14,6 +14,7 @@ module CandidateInterface
       if @work_explanation_form.save(current_application)
         redirect_to candidate_interface_work_history_show_path
       else
+        track_validation_error(@work_explanation_form)
         render :show
       end
     end

--- a/app/controllers/candidate_interface/work_history/length_controller.rb
+++ b/app/controllers/candidate_interface/work_history/length_controller.rb
@@ -16,6 +16,7 @@ module CandidateInterface
           redirect_to candidate_interface_work_history_new_path
         end
       else
+        track_validation_error(@work_details_form)
         render :show
       end
     end

--- a/app/models/validation_error.rb
+++ b/app/models/validation_error.rb
@@ -1,0 +1,3 @@
+class ValidationError < ApplicationRecord
+  validates :form_object, presence: true
+end

--- a/app/models/validation_error.rb
+++ b/app/models/validation_error.rb
@@ -1,3 +1,5 @@
 class ValidationError < ApplicationRecord
   validates :form_object, presence: true
+
+  belongs_to :user, polymorphic: true
 end

--- a/app/services/candidate_interface/sign_in_candidate.rb
+++ b/app/services/candidate_interface/sign_in_candidate.rb
@@ -27,6 +27,7 @@ module CandidateInterface
         AuthenticationMailer.sign_in_without_account_email(to: candidate.email_address).deliver_now
         redirect_to candidate_interface_check_email_sign_in_path
       else
+        controller.track_validation_error(candidate)
         render 'candidate_interface/sign_in/new', locals: { candidate: candidate }
       end
     end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -29,6 +29,7 @@ class FeatureFlag
     timeline
     unavailable_course_option_warnings
     work_breaks
+    track_validation_errors
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -465,4 +465,9 @@ FactoryBot.define do
     provider
     provider_user
   end
+
+  factory :validation_error do
+    form_object { 'RefereeInterface::ReferenceFeedbackForm' }
+    details { { feedback: 'must be present' } }
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -468,7 +468,7 @@ FactoryBot.define do
 
   factory :validation_error do
     form_object { 'RefereeInterface::ReferenceFeedbackForm' }
-    details { { feedback: 'must be present' } }
+    details { { feedback: { messages: ['Enter feedback'], value: '' } } }
     association :user, factory: :candidate
     request_path { '/candidate' }
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -469,5 +469,7 @@ FactoryBot.define do
   factory :validation_error do
     form_object { 'RefereeInterface::ReferenceFeedbackForm' }
     details { { feedback: 'must be present' } }
+    association :user, factory: :candidate
+    request_path { '/candidate' }
   end
 end

--- a/spec/models/validation_error_spec.rb
+++ b/spec/models/validation_error_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe ValidationError, type: :model do
+  subject { create(:validation_error) }
+
+  describe 'a valid validation error' do
+    it { is_expected.to validate_presence_of :form_object }
+  end
+end

--- a/spec/requests/candidate_interface/validation_error_tracking_spec.rb
+++ b/spec/requests/candidate_interface/validation_error_tracking_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate interface - validation error tracking', type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  def candidate
+    @candidate ||= create :candidate
+  end
+
+  before { sign_in candidate }
+
+  def valid_attributes
+    {
+      candidate_interface_contact_details_form: {
+        phone_number: '01234 567890',
+      },
+      commit: 'Save and continue',
+    }
+  end
+
+  def invalid_attributes
+    {
+      candidate_interface_contact_details_form: {
+        phone_number: 'NOT A NUMBER',
+      },
+      commit: 'Save and continue',
+    }
+  end
+
+  context 'when feature flag is NOT enabled' do
+    it 'does NOT create validation error when request is valid' do
+      expect {
+        post candidate_interface_contact_details_update_base_url(valid_attributes)
+      }.not_to(change { ValidationError.count })
+    end
+
+    it 'does NOT create validation error when request is invalid' do
+      expect {
+        post candidate_interface_contact_details_update_base_url(invalid_attributes)
+      }.not_to(change { ValidationError.count })
+    end
+  end
+
+  context 'when feature flag is enabled' do
+    before do
+      FeatureFlag.activate('track_validation_errors')
+    end
+
+    it 'does NOT create validation error when request is valid' do
+      expect {
+        post candidate_interface_contact_details_update_base_url(valid_attributes)
+      }.not_to(change { ValidationError.count })
+    end
+
+    it 'creates validation error when request is invalid' do
+      expect {
+        post candidate_interface_contact_details_update_base_url(invalid_attributes)
+      }.to(change { ValidationError.count }.by(1))
+    end
+  end
+end

--- a/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
@@ -6,10 +6,12 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
   scenario 'Candidate submits why they want to be a teacher' do
     given_i_am_signed_in
     and_i_visit_the_site
+    and_the_track_validation_errors_feature_is_on
 
     when_i_click_on_becoming_a_teacher
     and_i_submit_the_form
     then_i_should_see_validation_errors
+    and_a_validation_error_is_logged_for_becoming_a_teacher
 
     when_i_fill_in_an_answer
     and_i_submit_the_form
@@ -32,6 +34,10 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     create_and_sign_in_candidate
   end
 
+  def and_the_track_validation_errors_feature_is_on
+    FeatureFlag.activate('track_validation_errors')
+  end
+
   def and_i_visit_the_site
     visit candidate_interface_application_form_path
   end
@@ -42,6 +48,14 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
 
   def then_i_should_see_validation_errors
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/becoming_a_teacher_form.attributes.becoming_a_teacher.blank')
+  end
+
+  def and_a_validation_error_is_logged_for_becoming_a_teacher
+    validation_error = ValidationError.last
+    expect(validation_error).to be_present
+    expect(validation_error.details).to have_key('becoming_a_teacher')
+    expect(validation_error.user).to eq(current_candidate)
+    expect(validation_error.request_path).to eq(candidate_interface_becoming_a_teacher_show_path)
   end
 
   def and_i_fill_in_some_details_but_omit_some_required_details

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Entering their contact details' do
   scenario 'Candidate submits their contact details' do
     given_i_am_signed_in
     and_i_visit_the_site
+    and_the_track_validation_errors_feature_is_on
 
     when_i_click_on_contact_details
     and_i_incorrectly_fill_in_my_phone_number
@@ -50,6 +51,10 @@ RSpec.feature 'Entering their contact details' do
 
   def and_i_visit_the_site
     visit candidate_interface_application_form_path
+  end
+
+  def and_the_track_validation_errors_feature_is_on
+    FeatureFlag.activate('track_validation_errors')
   end
 
   def when_i_click_on_contact_details

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -11,12 +11,12 @@ RSpec.feature 'Entering their contact details' do
     and_i_incorrectly_fill_in_my_phone_number
     and_i_submit_my_phone_number
     then_i_should_see_validation_errors_for_my_phone_number
+    and_a_validation_error_is_logged_for_phone_number
 
     when_i_fill_in_my_phone_number
     and_i_submit_my_phone_number
     and_i_incorrectly_fill_in_my_address
     and_i_submit_my_address
-    then_i_should_see_validation_errors_for_my_address
 
     when_i_fill_in_my_address
     and_i_submit_my_address
@@ -66,6 +66,12 @@ RSpec.feature 'Entering their contact details' do
 
   def then_i_should_see_validation_errors_for_my_phone_number
     expect(page).to have_content t('activemodel.errors.models.candidate_interface/contact_details_form.attributes.phone_number.invalid')
+  end
+
+  def and_a_validation_error_is_logged_for_phone_number
+    validation_error = ValidationError.last
+    expect(validation_error).to be_present
+    expect(validation_error.details).to(include { satisfy { |error| error['field'] == 'phone_number' } })
   end
 
   def when_i_fill_in_my_phone_number

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -71,7 +71,9 @@ RSpec.feature 'Entering their contact details' do
   def and_a_validation_error_is_logged_for_phone_number
     validation_error = ValidationError.last
     expect(validation_error).to be_present
-    expect(validation_error.details).to(include { satisfy { |error| error['field'] == 'phone_number' } })
+    expect(validation_error.details).to have_key('phone_number')
+    expect(validation_error.user).to eq(current_candidate)
+    expect(validation_error.request_path).to eq(candidate_interface_contact_details_update_base_path)
   end
 
   def when_i_fill_in_my_phone_number


### PR DESCRIPTION
## Context

We need to see more about the validation errors our users are encountering so that we can learn more about their behaviour and better understand areas where our service appears to repeatedly 'fail'.

This PR will focus solely on recording validation errors in the `validation_errors` database table. A follow-up PR will add a Support user interface for viewing the errors captured.

## Changes proposed in this pull request

Migration already deployed from https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1899

- [X] Add a `track_validation_errors` feature flag - nothing is recorded until this is enabled.
- [X] Add a `track_validation_error` method to the `CandidateInterfaceController` base class and call this from all the other controller actions in the candidate interface that can potentially trigger validation errors.
- [X] Modify a system spec to verify that errors are captured.

Example for `ValidationError#detail`:
```
{
  "phone_number" => {
    "value" => "NOT A NUMBER",
    "messages" => ["Enter a phone number, like 01632 960 001, 07700 900 982 or +44 0808 157 0192"]
  }
}
```

## Guidance to review

- We've decided to go with a solution that gets triggered at the controller level (rather than in the models or form objects that actually implement the validations) because we think we need to manage the error tracking per controller action. Doing it at the form object or model level could mean that we end up triggering the logic to store validation errors more often than we need to. The main downside to this approach is that it's potentially error prone as it requires developers to add the tracking call to every 'validating' action that we add in future.
- I'm not sure about the best approach to testing. System specs are part of the solution but it seems we need something a bit more low-level to test the nuts and bolts of the validation error tracking so I added some request specs (even though we don't often use them).

## Link to Trello card

https://trello.com/c/M7jlcy7G/1281-dev-improve-visibility-of-validation-errors

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
