### PR TITLE
Fix course option drop down

### DIFF
--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -22,16 +22,19 @@ module CandidateInterface
       @dropdown_available_courses ||= begin
         courses = provider.courses.exposed_in_find.includes(:accredited_provider)
 
-        courses_with_names = courses.map(&:name)
-        courses_with_descriptions = courses.map(&:name_and_description)
+        courses_with_names = courses.map(&:name).map(&:downcase)
+        courses_with_descriptions = courses.map(&:name_and_description).map(&:downcase)
+        courses_with_name_provider_and_description = courses.map(&:name_provider_and_description).map(&:downcase)
 
         courses_with_unambiguous_names = courses.map do |course|
-          name = if courses_with_names.count(course.name) == 1
+          name = if courses_with_names.count(course.name.downcase) == 1
                    course.name_and_code
-                 elsif courses_with_descriptions.count(course.name_and_description) == 1
+                 elsif courses_with_descriptions.count(course.name_and_description.downcase) == 1
                    course.name_code_and_description
-                 else
+                 elsif courses_with_name_provider_and_description.count(course.name_provider_and_description.downcase) == 1
                    course.name_code_and_provider
+                 else
+                   course.name_and_code
                  end
 
           DropdownOption.new(course.id, name)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -36,6 +36,10 @@ class Course < ApplicationRecord
     "#{name} #{accredited_provider&.name}"
   end
 
+  def name_provider_and_description
+    "#{name} #{accredited_provider&.name} #{description}"
+  end
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/spec/models/candidate_interface/pick_course_form_spec.rb
+++ b/spec/models/candidate_interface/pick_course_form_spec.rb
@@ -69,6 +69,19 @@ RSpec.describe CandidateInterface::PickCourseForm do
       end
     end
 
+    context 'when courses have the same accredited provider, name and description' do
+      it 'prioritises showing the description over the accredited provider name' do
+        provider = create(:provider)
+        provider2 = create(:provider, name: 'BIG SCITT')
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+
+        form = described_class.new(provider_id: provider.id)
+
+        expect(form.dropdown_available_courses.map(&:name)).to eql(['Maths (123)', 'Maths (456)'])
+      end
+    end
+
     context 'with multiple ambigious names' do
       it 'returns the correct values' do
         provider = create(:provider)


### PR DESCRIPTION
## Context

Some self accredited courses (accrediting provider is nil) fall into the else clause below. This breaks the dropdown (see image)

![image](https://user-images.githubusercontent.com/42515961/79985673-dfa62f00-84a2-11ea-8301-d63e9088d86c.png)

For example, Gorse has courses which only differ in age range

## Changes proposed in this pull request

- Show course.name_and_code if a course has the same name, description and accrediting provider
- Alter the logic to not be case sensitive

Before 

![image](https://user-images.githubusercontent.com/42515961/79986195-95717d80-84a3-11ea-9219-73d80c516e15.png)


After

![image](https://user-images.githubusercontent.com/42515961/79986147-7ffc5380-84a3-11ea-8573-dc2bda11e2ed.png)


## Guidance to review

Find exposes age range on their API. I think we should be pulling that in and using it in the above situation. 

Am waiting to hear back from. Paul on what he thinks. This is a good interim solution though.

## Link to Trello card

https://trello.com/c/oBXczcGK/1403-bug-course-options-dropdown-is-not-behaving-corrrectly

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
