### PR TITLE
Make course.funding_type an enum

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -21,6 +21,12 @@ class Course < ApplicationRecord
     further_education: 'Further education',
   }, _suffix: :course
 
+  enum funding_type: {
+    fee: 'fee',
+    salary: 'salary',
+    apprenticeship: 'apprenticeship',
+  }
+
   # also copied from Find
   enum study_mode: {
     full_time: 'F',

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -12,6 +12,7 @@
   'Recruitment cycle year' => @course.recruitment_cycle_year,
   'Last updated' => @course.updated_at.to_s(:govuk_date_and_time),
   'Study modes' => @course.study_mode.humanize,
+  'Funding type' => Course.human_attribute_name("funding_type.#{@course.funding_type}"),
   'Financial support' => @course.financial_support,
   'Info page' => govuk_link_to('View on Find', @course.find_url),
   'Start on Apply' => govuk_link_to('View on Apply (candidate)', candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code)),

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -198,6 +198,10 @@ en:
         scottish_national_5: Scottish National 5
         other_uk: Other UK
         missing: I don’t have this qualification yet
+      course/funding_type:
+        fee: Fee
+        salary: Salary
+        apprenticeship: Apprenticeship
     errors:
       models:
         candidate:


### PR DESCRIPTION
## Context

I went to render `funding_type` on the provider interface and it seemed to want to be an enum.

## Changes proposed in this pull request

- funding_type only ever has one of three values, so make it an enum
- add it next to `financial_support` (currently always `nil`) in support

## Guidance to review

I understand from Find that `financial_support` (bursaries and whatnot) is distinct from `funding_type` so I'm not replacing it, just leaving it be (although it's always `nil`).

## Link to Trello card

https://trello.com/c/HS9uplti/1994-build-provider-ui-add-view-of-accredited-body-study-mode-funding-route-to-the-offer-section-of-single-application-page

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
