### PR TITLE
Providers have UI to change offers to rejections

### DIFF
--- a/app/components/provider_interface/status_box_components/rejected_component.html.erb
+++ b/app/components/provider_interface/status_box_components/rejected_component.html.erb
@@ -2,7 +2,18 @@
   <h2 class="govuk-heading-l">Offer</h2>
   <%= render SummaryListComponent.new(rows: offer_withdrawn_rows) %>
   <%= render ProviderInterface::ConditionsComponent.new(application_choice: application_choice) %>
+  <% if FeatureFlag.active?('provider_change_response') %>
+    <p class="govuk-body govuk-!-margin-bottom-0 app-!-print-display-none">
+      <%= govuk_link_to 'Undo withdrawal and make offer', provider_interface_application_choice_new_offer_path(@application_choice.id) %>
+    </p>
+  <% end %>
 <% else %>
   <h2 class="govuk-heading-l">Candidate’s application rejected</h2>
   <%= render SummaryListComponent.new(rows: rejected_rows) %>
+  <% if FeatureFlag.active?('provider_change_response') %>
+    <p class="govuk-body govuk-!-margin-bottom-0 app-!-print-display-none">
+      <%= govuk_link_to 'Change rejection to offer', provider_interface_application_choice_new_offer_path(@application_choice.id) %>
+    </p>
+  <% end %>
 <% end %>
+

--- a/spec/system/provider_interface/provider_rejects_application_spec.rb
+++ b/spec/system/provider_interface/provider_rejects_application_spec.rb
@@ -23,6 +23,9 @@ RSpec.feature 'Provider rejects application' do
     when_i_confirm_the_rejection
     then_i_am_back_to_the_application_page
     and_i_can_see_the_application_has_just_been_rejected
+
+    when_the_change_response_feature_is_activated
+    then_i_can_see_a_link_to_make_an_offer_on_the_application
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -74,5 +77,14 @@ RSpec.feature 'Provider rejects application' do
 
   def and_i_can_see_the_application_has_just_been_rejected
     expect(page).to have_content 'Application successfully rejected'
+  end
+
+  def when_the_change_response_feature_is_activated
+    FeatureFlag.activate('provider_change_response')
+  end
+
+  def then_i_can_see_a_link_to_make_an_offer_on_the_application
+    page.refresh
+    expect(page).to have_link 'Change rejection to offer'
   end
 end


### PR DESCRIPTION
## Context

Providers need to do this and it's allowed. They can't do it, though, because there's no link to the flow they need: https://ukgovernmentdfe.slack.com/archives/CPH8J9G65/p1587483378323800

## Changes proposed in this pull request

Add a `Make an offer` link to the single application page when the application is in a rejected or withdrawn-by-us state

![Screenshot 2020-04-22 at 16 51 45](https://user-images.githubusercontent.com/642279/80005238-36b7fe00-84bb-11ea-8818-d4b3cf4ae0ea.png)

## Guidance to review

This is not quite as good as it could be because the user doesn't get the full "respond to application" flow which would allow them to change the provider, course etc — the link takes them straight to the "set conditions" page, ie the last step. To make a change like that, the provider would need to first make the offer, then use the "Change" links to correct it.

I did this because the "respond" flow also includes a "reject application" option in it, which leads to a "the application is not ready for that action" dead end. In due course it would probably be good to change "Make an offer" to "Change decision" and populate those radios accordingly, but hopefully this will do in the short term.

## Link to Trello card

https://trello.com/c/zf8GFsC4/2017-provide-a-link-for-providers-to-re-make-an-offer-after-theyve-rejected-a-candidate

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
