### PR TITLE
Update dates in the UCAS downtime component

### DIFF
--- a/app/components/candidate_interface/ucas_downtime_component.html.erb
+++ b/app/components/candidate_interface/ucas_downtime_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-banner app-banner--warning govuk-!-margin-bottom-7">
   <div class="app-banner__message">
     <h2 class="govuk-heading-m">UCAS planned maintenance</h2>
-    <p class="govuk-body">UCAS services won’t be available from 6pm on Friday 20 March until Sunday 22 March.</p>
+    <p class="govuk-body">UCAS services won’t be available from 6pm on Friday 24 April until Sunday 26 April.</p>
   </div>
 </div>

--- a/spec/components/candidate_interface/ucas_downtime_component_spec.rb
+++ b/spec/components/candidate_interface/ucas_downtime_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe CandidateInterface::UcasDowntimeComponent do
 
       result = render_inline(CandidateInterface::UcasDowntimeComponent.new)
 
-      expect(result.text).to include('UCAS services won’t be available from 6pm on Friday 20 March until Sunday 22 March.')
+      expect(result.text).to include('UCAS services won’t be available from 6pm on Friday 24 April until Sunday 26 April.')
     end
   end
 


### PR DESCRIPTION
## Context

UCAS is down this weekend.

## Changes proposed in this pull request

- Update the dates in the component to reflect the latest downtime (24-26)

![image](https://user-images.githubusercontent.com/42515961/80074902-c607f480-8541-11ea-9d6d-71344396afa5.png)


## Guidance to review
The feature flag needs to be switched on.

## Link to Trello card

https://trello.com/b/aRIgjf0y/candidate-team-board

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
