### PR TITLE
Mark emails that we can't send to GOV.UK Notify

### DIFF
--- a/app/components/support_interface/email_log_row_component.rb
+++ b/app/components/support_interface/email_log_row_component.rb
@@ -31,6 +31,7 @@ module SupportInterface
         pending: 'govuk-tag--yellow',
         unknown: 'govuk-tag--grey',
         delivered: 'govuk-tag--green',
+        notify_error: 'govuk-tag--red',
         permanent_failure: 'govuk-tag--red',
         temporary_failure: 'govuk-tag--pink',
         technical_failure: 'govuk-tag--orange',

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,16 @@
 class ApplicationMailer < Mail::Notify::Mailer
   GENERIC_NOTIFY_TEMPLATE = '2744ea53-34f1-431f-8173-8388fadd826a'.freeze
 
+  rescue_from Notifications::Client::RequestError do
+    # WARNING: this needs to be a block, otherwise the exception won't be
+    # re-raised and we won't be notified via Sentry, and the job won't retry.
+    #
+    # @see https://github.com/rails/rails/issues/39018
+    email = Email.find(self.headers['email-log-id'].to_s)
+    email.update!(delivery_status: 'notify_error')
+    raise
+  end
+
   def notify_email(headers)
     headers = headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
     view_mail(GENERIC_NOTIFY_TEMPLATE, headers)

--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -7,7 +7,12 @@ class Email < ApplicationRecord
     # Email predates implementation of GOV.UK Notify callback
     not_tracked: 'not_tracked',
 
-    # Email has been sent, but we're waiting on callback from GOV.UK Notify
+    # We got an error when trying to send the email to GOV.UK Notify. For example,
+    # this can happen when Notify is temporarily down, when we use the wrong API key,
+    # or the email address is invalid.
+    notify_error: 'notify_error',
+
+    # Email has likely been sent, but we're waiting on callback from GOV.UK Notify
     pending: 'pending',
 
     # DEPRECATED - do not use

--- a/app/views/anonymous/test_notify_error.text.erb
+++ b/app/views/anonymous/test_notify_error.text.erb
@@ -1,0 +1,1 @@
+This is used by the ApplicationMailer spec.

--- a/lib/email_log_interceptor.rb
+++ b/lib/email_log_interceptor.rb
@@ -7,7 +7,7 @@ class EmailLogInterceptor
       mail.header['reference'] = notify_reference
     end
 
-    Email.create!(
+    logged_email = Email.create!(
       to: mail.to.first,
       subject: mail.subject,
       body: mail.body.encoded,
@@ -17,6 +17,8 @@ class EmailLogInterceptor
       mail_template: mail.header['rails_mail_template'].value,
       delivery_status: 'pending',
     )
+
+    mail.header['email-log-id'] = logged_email.id
   rescue StandardError => e
     # Email logging should not stop the actual email sending
     Rails.logger.info("Exception occured when trying to log email: #{e.message}")

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer, sidekiq: true do
+  describe '.rescue_from' do
+    fake_mailer = Class.new(ApplicationMailer) do
+      self.delivery_method = :notify
+      self.notify_settings = {
+        api_key: 'not-real-e1f4c969-b675-4a0d-a14d-623e7c2d3fd8-24fea27b-824e-4259-b5ce-1badafe98150',
+      }
+
+      def test_notify_error
+        notify_email(
+          to: 'test@example.com',
+          subject: 'Some subject',
+        )
+      end
+    end
+
+    it 'marks errors as failed and re-raises the error' do
+      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
+        .to_return(status: 404)
+
+      expect {
+        fake_mailer.test_notify_error.deliver_now
+      }.to raise_error(Notifications::Client::NotFoundError)
+
+      expect(Email.last.delivery_status).to eql('notify_error')
+    end
+  end
+end


### PR DESCRIPTION
## Context

This marks emails in the email log with the delivery status `notify_error` if we encounter an error sending the email to GOV.UK Notify. It comes on the back of the recent PaaS incident that took down the service for a couple of hours. We currently just retry errors from Notify, but we never mark the failed email in the email log as such, which means it will forever have the status "pending". 

## Changes proposed in this pull request

Note that we `rescue_from` all Notify exceptions. I originally tried to distinguish between client errors like invalid API key or email address (anything descendent from `Notifications::Client::ClientError`) and server errors (`Notifications::Client::ServerError`). 

The idea was that we could have separate statuses for each, and perhaps skip the retries for client errors. However, this is not going to work because the way GOV.UK Notify system behaved during the incident.

We did see some Bad Gateway errors, which raised a ServerError (https://sentry.io/organizations/dfe-bat/issues/1568629644). But other errors were 404
(https://sentry.io/organizations/dfe-bat/issues/1623747428) and a 400 (https://sentry.io/organizations/dfe-bat/issues/1569990518). This means we can't reliably distinguish between client and server errors from Notify, and we'll have to treat them the same.

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/TcOj7XwZ

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
