### PR TITLE
Make Email#notify_reference unique

### DIFF
--- a/app/mailers/authentication_mailer.rb
+++ b/app/mailers/authentication_mailer.rb
@@ -5,7 +5,7 @@ class AuthenticationMailer < ApplicationMailer
     notify_email(
       to: candidate.email_address,
       subject: t('authentication.sign_up.email.subject'),
-      reference: "#{HostingEnvironment.environment_name}-sign_up_email-#{candidate.id}",
+      reference: "#{HostingEnvironment.environment_name}-sign_up_email-#{candidate.id}-#{SecureRandom.hex}",
     )
   end
 

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -8,7 +8,7 @@ class RefereeMailer < ApplicationMailer
     notify_email(
       to: reference.email_address,
       subject: t('reference_request.subject.initial', candidate_name: @candidate_name),
-      reference: "#{HostingEnvironment.environment_name}-reference_request-#{reference.id}",
+      reference: "#{HostingEnvironment.environment_name}-reference_request-#{reference.id}-#{SecureRandom.hex}",
       template_name: :reference_request_email,
       application_form_id: reference.application_form_id,
     )

--- a/spec/mailers/authentication_mailer_spec.rb
+++ b/spec/mailers/authentication_mailer_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AuthenticationMailer, type: :mailer do
         mail.deliver_now
       end
 
-      expect(mail[:reference].value).to eq("example_env-sign_up_email-#{candidate.id}")
+      expect(mail[:reference].value).to start_with("example_env-sign_up_email-#{candidate.id}")
     end
   end
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RefereeMailer, type: :mailer do
         mail.deliver_now
       end
 
-      expect(mail[:reference].value).to eq("example_env-reference_request-#{reference.id}")
+      expect(mail[:reference].value).to start_with("example_env-reference_request-#{reference.id}")
     end
   end
 

--- a/spec/system/support_interface/email_log_spec.rb
+++ b/spec/system/support_interface/email_log_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Email log' do
     ).deliver_now
 
     open_email('harry@example.com')
-    expect(current_email.header('reference')).to eql("#{HostingEnvironment.environment_name}-sign_up_email-#{@candidate.id}")
+    expect(current_email.header('reference')).to start_with("#{HostingEnvironment.environment_name}-sign_up_email-#{@candidate.id}-")
   end
 
   def and_an_email_with_an_application_id_is_sent


### PR DESCRIPTION
## Context

This appends a random string to the notify reference for emails with a stable reference. We need this because when an email fails to send (GOV.UK Notify returns an error), we'll start retrying. This causes multiple emails in the log with the same `notify_reference`.

When getting the callback from Notify it becomes tricky to determine which of the emails the delivery receipt is for. This was raised by @duncanjbrown in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1927#discussion_r413645825.

## Changes proposed in this pull request

Update the reference.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TcOj7XwZ/1405-wrap-up-tuesdays-incident-where-govuk-notify-was-down

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
