### PR TITLE
Providers can assign permissions to their own users

### DIFF
--- a/app/components/provider_interface/provider_permissions_list_component.html.erb
+++ b/app/components/provider_interface/provider_permissions_list_component.html.erb
@@ -1,0 +1,14 @@
+<% visible_provider_permissions.each do |provider_permission| %>
+  <h4><%= provider_permission.provider.name %></h4>
+  <ul id="provider-<%= provider_permission.provider.id %>-enabled-permissions">
+    <% ProviderPermissionsOptions::VALID_PERMISSIONS.each do |permission_name| %>
+      <li>
+        <% if provider_permission.send(permission_name) %>
+          <%= permission_name.to_s.humanize %>
+        <% else %>
+            No permissions
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/components/provider_interface/provider_permissions_list_component.rb
+++ b/app/components/provider_interface/provider_permissions_list_component.rb
@@ -1,0 +1,15 @@
+module ProviderInterface
+  class ProviderPermissionsListComponent < ViewComponent::Base
+    include ViewHelper
+    attr_reader :provider_permissions, :possible_permissions
+
+    def initialize(provider_permissions:, possible_permissions:)
+      @provider_permissions = provider_permissions
+      @possible_permissions = possible_permissions
+    end
+
+    def visible_provider_permissions
+      possible_permissions & provider_permissions
+    end
+  end
+end

--- a/app/components/provider_interface/provider_user_details_component.html.erb
+++ b/app/components/provider_interface/provider_user_details_component.html.erb
@@ -1,0 +1,2 @@
+<h2 class="govuk-heading-xl"><%= header %></h2>
+<%= render SummaryListComponent.new(rows: rows) %>

--- a/app/components/provider_interface/provider_user_details_component.rb
+++ b/app/components/provider_interface/provider_user_details_component.rb
@@ -1,0 +1,35 @@
+module ProviderInterface
+  class ProviderUserDetailsComponent < ViewComponent::Base
+    include ViewHelper
+    attr_reader :header
+
+    def initialize(provider_user:, provider_permissions:, possible_permissions:)
+      @provider_user = provider_user
+      @provider_permissions = provider_permissions
+      @header = provider_user.full_name
+      @possible_permissions = possible_permissions
+    end
+
+    def rows
+      [
+        { key: 'Name', value: @provider_user.full_name },
+        { key: 'Email', value: @provider_user.email_address },
+        permissions_row,
+      ]
+    end
+
+    def permissions_row
+      {
+        key: 'Permissions',
+        value: render(
+          ProviderInterface::ProviderPermissionsListComponent.new(
+            provider_permissions: @provider_permissions,
+            possible_permissions: @possible_permissions,
+          ),
+        ),
+        change_path: provider_interface_provider_user_edit_providers_path(@provider_user),
+        action: 'Change',
+      }
+    end
+  end
+end

--- a/app/components/provider_interface/user_list_card_component.html.erb
+++ b/app/components/provider_interface/user_list_card_component.html.erb
@@ -1,7 +1,7 @@
 <div class="app-application-card">
 
   <h3 class="govuk-heading-m">
-    <%= full_name %>
+    <%= govuk_link_to(full_name, provider_interface_provider_user_path(@provider_user)) %>
   </h3>
 
   <dl>

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -1,9 +1,23 @@
 module ProviderInterface
   class ProviderUsersController < ProviderInterfaceController
-    before_action :requires_provider_add_provider_users_feature_flag, only: %i[new create]
+    before_action :requires_provider_add_provider_users_feature_flag
+    before_action :redirect_unless_permitted_to_manage_users
 
     def index
       @provider_users = ProviderUser.visible_to(current_provider_user)
+    end
+
+    def show
+      @provider_user = ProviderUser.visible_to(current_provider_user).find_by(id: params[:id])
+
+      redirect_to(action: :index) and return unless @provider_user
+
+      form = ProviderUserForm.new(
+        provider_user: @provider_user,
+        current_provider_user: current_provider_user,
+      )
+      @possible_permissions = form.possible_permissions
+      @provider_permissions = form.provider_permissions
     end
 
     def new
@@ -17,12 +31,18 @@ module ProviderInterface
 
     def create
       @form = ProviderUserForm.new(
-        provider_user_params.merge(current_provider_user: current_provider_user),
+        provider_user_params.merge(
+          current_provider_user: current_provider_user,
+          provider_permissions: provider_permissions_params,
+        ),
       )
       provider_user = @form.build
       service = SaveAndInviteProviderUser.new(
         form: @form,
-        save_service: SaveProviderUser.new(provider_user: provider_user),
+        save_service: SaveProviderUser.new(
+          provider_user: provider_user,
+          provider_permissions: @form.provider_permissions,
+        ),
         invite_service: InviteProviderUser.new(provider_user: provider_user),
         new_user: @form.existing_provider_user.blank?,
       )
@@ -33,15 +53,56 @@ module ProviderInterface
       redirect_to provider_interface_provider_users_path
     end
 
+    def edit_providers
+      provider_user = ProviderUser.visible_to(current_provider_user).find_by(id: params[:provider_user_id])
+      @form = ProviderUserForm.from_provider_user(provider_user)
+      @form.current_provider_user = current_provider_user
+    end
+
+    def update_providers
+      provider_user = ProviderUser
+        .visible_to(current_provider_user)
+        .find_by(id: params[:provider_user_id])
+
+      @form = ProviderUserForm.new(
+        provider_user: provider_user,
+        current_provider_user: current_provider_user,
+        provider_permissions: provider_permissions_params,
+      )
+
+      service = SaveProviderUser.new(
+        provider_user: provider_user,
+        provider_permissions: @form.provider_permissions,
+        deselected_provider_permissions: @form.deselected_provider_permissions,
+      )
+
+      render :edit_providers and return unless @form.valid? && service.call!
+
+      flash[:success] = 'Providers updated'
+      redirect_to provider_interface_provider_user_path(provider_user)
+    end
+
   private
 
     def provider_user_params
       params.require(:provider_interface_provider_user_form)
-            .permit(:email_address, :first_name, :last_name, provider_ids: [])
+            .permit(:email_address, :first_name, :last_name)
+    end
+
+    def provider_permissions_params
+      params.require(:provider_interface_provider_user_form)
+            .permit(provider_permissions_forms: {})
+            .fetch(:provider_permissions_forms, {})
+            .to_h
     end
 
     def requires_provider_add_provider_users_feature_flag
       raise unless FeatureFlag.active?('provider_add_provider_users')
+    end
+
+    def redirect_unless_permitted_to_manage_users
+      can_manage_users = ProviderPermissions.exists?(provider_user: current_provider_user, manage_users: true)
+      redirect_to root_path, warning: 'You do not have sufficient permissions to manage other users' unless can_manage_users
     end
   end
 end

--- a/app/models/provider_permissions_form.rb
+++ b/app/models/provider_permissions_form.rb
@@ -1,0 +1,9 @@
+class ProviderPermissionsForm
+  include ActiveModel::Model
+
+  attr_accessor :active
+  attr_accessor :provider_permission
+
+  delegate :provider, :manage_users, to: :provider_permission
+  delegate :id, to: :provider
+end

--- a/app/models/provider_permissions_options.rb
+++ b/app/models/provider_permissions_options.rb
@@ -5,13 +5,28 @@ class ProviderPermissionsOptions
 
   attr_accessor(*VALID_PERMISSIONS)
 
+  def initialize(permissions_attributes = {})
+    super(permissions_attributes)
+    @permissions_attributes = permissions_attributes
+  end
+
   def self.valid?(permission_name)
     VALID_PERMISSIONS.include?(permission_name.to_sym)
   end
 
-  def self.reset_attributes
-    {}.tap do |hsh|
-      VALID_PERMISSIONS.each { |p| hsh[p] = false }
+  def self.for_provider_user(provider_user)
+    permissions_attributes = {}
+    scope = ProviderPermissions.where(provider_user: provider_user)
+
+    VALID_PERMISSIONS.each do |permission_name|
+      provider_ids = scope.where(permission_name => true).pluck(:provider_id)
+      permissions_attributes[permission_name] = provider_ids if provider_ids.any?
     end
+
+    new(permissions_attributes)
+  end
+
+  def for_provider(provider)
+    @permissions_attributes.select { |_, provider_ids| provider_ids.include?(provider.id) }.keys
   end
 end

--- a/app/services/save_provider_user.rb
+++ b/app/services/save_provider_user.rb
@@ -1,47 +1,40 @@
 class SaveProviderUser
-  def initialize(provider_user:, permissions: {})
+  def initialize(provider_user:, provider_permissions: [], deselected_provider_permissions: [])
     @provider_user = provider_user
-    @permissions = sanitized_permissions(permissions)
+    @provider_permissions = provider_permissions
+    @deselected_provider_permissions = deselected_provider_permissions
   end
 
   def call!
     @provider_user.save!
-    update_permissions!
+    update_provider_permissions!
     @provider_user.reload
   end
 
 private
 
-  def update_permissions!
-    unselected_permissions = ProviderPermissions
-      .where(provider_user: @provider_user)
-      .where.not(provider_id: @permissions.values.flatten)
-
+  def update_provider_permissions!
     ActiveRecord::Base.transaction do
-      ProviderPermissionsOptions::VALID_PERMISSIONS.each do |permission_name|
-        unselected_permissions.where(permission_name => true).each do |permission|
-          permission.update!(permission_name => false)
-        end
-      end
-
-      @permissions.each do |permission_name, provider_ids|
-        ProviderPermissions
-          .where(provider_user: @provider_user, provider_id: provider_ids, permission_name => false)
-          .each { |permission| permission.update!(permission_name => true) }
-      end
+      destroy_deselected_provider_permissions!
+      add_new_provider_permissions!
+      updated_existing_provider_permissions!
     end
   end
 
-  def sanitized_permissions(permissions)
-    result = {}
-    return result unless @provider_user
+  def destroy_deselected_provider_permissions!
+    @deselected_provider_permissions.each(&:destroy!)
+  end
 
-    permissions.each do |permission_name, provider_ids|
-      if ProviderPermissionsOptions.valid?(permission_name)
-        result[permission_name] = provider_ids.map(&:to_i) & @provider_user.provider_ids
-      end
+  def add_new_provider_permissions!
+    new_provider_permissions = @provider_permissions - @provider_user.provider_permissions
+    new_provider_permissions.each do |pp|
+      pp.provider_user_id = @provider_user.id if pp.provider_user_id.blank?
+      pp.save!
     end
+  end
 
-    result
+  def updated_existing_provider_permissions!
+    existing_provider_permissions = @provider_permissions & @provider_user.provider_permissions
+    existing_provider_permissions.each { |p| p.save! if p.changed? }
   end
 end

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -1,0 +1,34 @@
+<legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+  <h1 class="govuk-fieldset__heading">
+    <span class="govuk-caption-xl"><%= @form.provider_user.full_name %></span>
+    Change permissions
+  </h1>
+</legend>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @form, url: provider_interface_provider_user_update_providers_path do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Provider' } do %>
+        <div class="app-checkboxes-scroll">
+          <% f.object.forms_for_possible_permissions.each do |permission_form| %>
+            <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
+              <%= pf.govuk_check_box :active, true, multiple: false,
+                                     label: { text: permission_form.provider.name_and_code } do %>
+                <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+                  <%= ppf.hidden_field :provider_id %>
+                  <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
+                    <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+                  <% end %>
+                <% end %>
+              <% end %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
+
+      <%= f.govuk_submit 'Update providers' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -3,7 +3,7 @@
 <h1 class="govuk-heading-xl">Users</h1>
 
 <% if FeatureFlag.active?('provider_add_provider_users') -%>
-  <%= link_to 'Invite user', provider_interface_provider_users_new_path, class: 'govuk-button' %>
+  <%= link_to 'Invite user', new_provider_interface_provider_user_path, class: 'govuk-button' %>
 <% end -%>
 
 <% content_for :before_content do %>

--- a/app/views/provider_interface/provider_users/new.html.erb
+++ b/app/views/provider_interface/provider_users/new.html.erb
@@ -24,7 +24,16 @@
       <%= f.govuk_text_field :last_name, label: { text: 'Last name', size: 'm' } %>
       <%= f.govuk_text_field :email_address, label: { text: 'Email address', size: 'm' } %>
 
-      <%= f.govuk_collection_check_boxes :provider_ids, @form.available_providers, :id, :name_and_code, legend: { text: 'Provider' }  %>
+      <% f.object.forms_for_possible_permissions.each do |permission_form| %>
+        <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
+          <%= pf.govuk_check_box :active, true, multiple: false,
+                                 label: { text: permission_form.provider.name_and_code } do %>
+            <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+              <%= ppf.hidden_field :provider_id %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
 
       <%= f.govuk_submit 'Invite user' %>
     <% end %>

--- a/app/views/provider_interface/provider_users/show.html.erb
+++ b/app/views/provider_interface/provider_users/show.html.erb
@@ -1,0 +1,5 @@
+<%= render ProviderInterface::ProviderUserDetailsComponent.new(
+  provider_user: @provider_user,
+  provider_permissions: @provider_user.provider_permissions,
+  possible_permissions: @possible_permissions,
+) %>

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,11 +1,15 @@
 <%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Provider' } do %>
   <div class="app-checkboxes-scroll" %>
-    <% f.object.available_providers.each do |provider| %>
-      <%= f.govuk_check_box :provider_ids, provider.id, label: { text: provider.name_and_code } do %>
-        <%= f.fields_for :permissions, f.object.permissions  do |pm| %>
-          <%= pm.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
-            <%= pm.govuk_check_box :manage_users, provider.id, label: { text: 'Manage users' } %>
-					<% end %>
+    <% f.object.forms_for_possible_permissions.each do |permission_form| %>
+      <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>
+        <%= pf.govuk_check_box :active, true, multiple: false,
+                               label: { text: permission_form.provider.name_and_code } do %>
+          <%= pf.fields_for :provider_permission, permission_form.provider_permission do |ppf| %>
+            <%= ppf.hidden_field :provider_id %>
+            <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
+              <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,7 +142,7 @@ en:
               blank: First name can’t be blank
             last_name:
               blank: Last name can’t be blank
-            provider_ids:
+            provider_permissions:
               blank: Please specify a provider
         support_interface/new_offer_form:
           attributes:
@@ -185,7 +185,7 @@ en:
               blank: Enter the user's first name
             last_name:
               blank: Enter the user's last name
-            provider_ids:
+            provider_permissions:
               blank: Please specify a provider
         change_offer:
           attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -448,9 +448,10 @@ Rails.application.routes.draw do
     get '/sign-in/check-email', to: 'sessions#check_your_email', as: :check_your_email
     get '/sign-in-by-email' => 'sessions#authenticate_with_token', as: :authenticate_with_token
 
-    get '/provider-users' => 'provider_users#index'
-    get '/provider-users/new' => 'provider_users#new'
-    post '/provider-users' => 'provider_users#create'
+    resources :provider_users, only: %i[index new create show], path: 'provider-users' do
+      get 'edit-providers' => 'provider_users#edit_providers', as: :edit_providers
+      patch 'update-providers' => 'provider_users#update_providers', as: :update_providers
+    end
   end
 
   get '/auth/dfe/callback' => 'dfe_sign_in#callback'

--- a/spec/components/provider_interface/provider_permissions_list_component_spec.rb
+++ b/spec/components/provider_interface/provider_permissions_list_component_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::ProviderPermissionsListComponent do
+  let(:providers) do
+    [
+      build_stubbed(:provider, id: 10),
+      build_stubbed(:provider, id: 11),
+      build_stubbed(:provider, id: 12),
+      build_stubbed(:provider, id: 13),
+    ]
+  end
+
+  let(:provider_permissions) do
+    [
+      build_stubbed(:provider_permissions, id: 1, manage_users: true, provider: providers[0]),
+      build_stubbed(:provider_permissions, id: 2, provider: providers[1]),
+      build_stubbed(:provider_permissions, id: 3, manage_users: true, provider: providers[2]),
+      build_stubbed(:provider_permissions, id: 4, manage_users: true, provider: providers[3]),
+    ]
+  end
+
+  let(:possible_permissions) do
+    provider_permissions[0..2]
+  end
+
+  it 'renders the correct permissions per provider' do
+    result = render_inline(
+      described_class.new(
+        provider_permissions: provider_permissions,
+        possible_permissions: possible_permissions,
+      ),
+    )
+
+    expect(result.text).to include(providers[0].name)
+    expect(result.css('#provider-10-enabled-permissions').text).to include('Manage users')
+    expect(result.text).to include(providers[1].name)
+    expect(result.css('#provider-11-enabled-permissions').text).to include('No permissions')
+    expect(result.text).to include(providers[2].name)
+    expect(result.css('#provider-12-enabled-permissions').text).to include('Manage users')
+  end
+
+  it 'does not expose permissions for non visible providers' do
+    result = render_inline(
+      described_class.new(
+        provider_permissions: provider_permissions,
+        possible_permissions: possible_permissions,
+      ),
+    )
+
+    expect(result.text).not_to include(providers[3].name)
+  end
+end

--- a/spec/models/provider_permissions_options_spec.rb
+++ b/spec/models/provider_permissions_options_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe ProviderPermissionsOptions, type: :model do
+  describe '.valid?' do
+    context 'with a valid permission name' do
+      it 'is true' do
+        expect(described_class.valid?(:manage_users)).to be true
+      end
+    end
+
+    context 'with an invalid permission name' do
+      it 'is false' do
+        expect(described_class.valid?(:not_a_permission)).to be false
+      end
+    end
+  end
+
+  describe '.for_provider_user' do
+    let(:provider) { create(:provider) }
+    let(:another_provider) { create(:provider) }
+    let(:provider_user) { create(:provider_user, providers: [provider]) }
+
+    before do
+      provider_user.provider_permissions.first.update(manage_users: true)
+      provider_user.providers << create(:provider)
+    end
+
+    it 'returns an instance based on permissions for the user' do
+      result = described_class.for_provider_user(provider_user)
+
+      expect(result).to be_a(described_class)
+      expect(result.manage_users).to eq([provider.id])
+    end
+  end
+
+  describe '#for_provider' do
+    let(:provider) { build_stubbed(:provider, id: 2) }
+    let(:permissions) { described_class.new(manage_users: [2]) }
+
+    it 'returns permission names enabled for the provider' do
+      expect(permissions.for_provider(provider)).to eq(%i[manage_users])
+    end
+
+    context 'with no active permissions' do
+      it 'returns an empty array' do
+        another_provider = build_stubbed(:provider, id: 100)
+        expect(permissions.for_provider(another_provider)).to eq([])
+      end
+    end
+  end
+end

--- a/spec/models/support_interface/provider_user_form_spec.rb
+++ b/spec/models/support_interface/provider_user_form_spec.rb
@@ -2,13 +2,23 @@ require 'rails_helper'
 
 RSpec.describe SupportInterface::ProviderUserForm do
   let(:email_address) { 'provider@example.com' }
-  let(:provider_ids) { [] }
+  let(:provider) { build_stubbed(:provider, id: 2) }
+  let(:provider_permissions) do
+    {
+      provider.id => {
+        provider_permission: {
+          provider_id: provider.id,
+        },
+        active: true,
+      },
+    }
+  end
   let(:form_params) do
     {
       first_name: 'Jane',
       last_name: 'Smith',
       email_address: email_address,
-      provider_ids: provider_ids,
+      provider_permissions: provider_permissions,
     }
   end
 
@@ -24,24 +34,13 @@ RSpec.describe SupportInterface::ProviderUserForm do
       end
     end
 
-    context 'provider_ids are blank' do
+    context 'provider permissions must be present' do
+      let(:provider_permissions) { {} }
+
       it 'is invalid' do
         expect(provider_user_form.valid?).to be false
-        expect(provider_user_form.errors[:provider_ids]).not_to be_empty
+        expect(provider_user_form.errors[:provider_permissions]).not_to be_empty
       end
-    end
-  end
-
-  describe '.permissions_for' do
-    let(:provider_user) { create(:provider_user, :with_provider) }
-
-    before { provider_user.provider_permissions.first.update(manage_users: true) }
-
-    it 'returns provider permissions for the given user' do
-      permissions = described_class.permissions_for(provider_user)
-
-      expect(permissions).to be_a(ProviderPermissionsOptions)
-      expect(permissions.manage_users).to eq(provider_user.providers.map(&:id))
     end
   end
 end

--- a/spec/requests/provider_interface/managing_provider_users_spec.rb
+++ b/spec/requests/provider_interface/managing_provider_users_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.describe 'ProviderUserController actions' do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    FeatureFlag.activate('provider_add_provider_users')
+
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  context 'when the user is not permitted to manage users' do
+    it 'redirects GET requests to index' do
+      get provider_interface_provider_users_path
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'redirects GET requests to show' do
+      another_user = create(:provider_user, providers: [provider])
+      get provider_interface_provider_user_path(another_user)
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it 'redirects GET requests to edit-providers' do
+      another_user = create(:provider_user, providers: [provider])
+      get provider_interface_provider_user_edit_providers_path(another_user)
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context 'when the user is permitted to manage users' do
+    before { provider_user.provider_permissions.update_all(manage_users: true) }
+
+    it 'GET requests to provider users paths respond successfully' do
+      get provider_interface_provider_users_path
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  context 'POST update_providers when no providers are selected' do
+    let(:provider_user_to_edit) { create(:provider_user, providers: [provider]) }
+
+    before { provider_user.provider_permissions.update_all(manage_users: true) }
+
+    it 'renders the edit form with errors' do
+      patch(
+        provider_interface_provider_user_update_providers_path(provider_user_to_edit),
+        params: {
+          provider_interface_provider_user_form: {
+            provider_permissions_forms: {
+              provider.id => { provider_permission: { provider_id: provider.id } },
+            },
+          },
+        },
+      )
+
+      expect(response).to have_http_status(:success)
+
+      errors = request.controller_instance.instance_variable_get(:@form).errors
+      expect(errors[:provider_permissions]).not_to be_empty
+    end
+  end
+end

--- a/spec/services/save_and_invite_provider_user_spec.rb
+++ b/spec/services/save_and_invite_provider_user_spec.rb
@@ -1,16 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe SaveAndInviteProviderUser do
-  let(:provider) { create(:provider) }
   let(:form) {
     SupportInterface::ProviderUserForm.new(
       email_address: 'test+invite_provider_user@example.com',
       first_name: 'Firstname',
       last_name: 'Lastname',
-      provider_ids: [provider.id],
+      provider_permissions: { '10' => { provider_permission: { provider_id: 10 }, active: true } },
     )
   }
-  let(:permissions) { { manage_users: [provider.id] } }
   let(:provider_user) { form.build }
   let(:save_service) { instance_double(SaveProviderUser, call!: true) }
   let(:invite_service) { instance_double(InviteProviderUser, call!: true) }

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing provider user permissions' do
+  include DfESignInHelpers
+
+  scenario 'Provider manages permissions for users' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_add_provider_users_feature_is_enabled
+    and_i_can_manage_applications_for_two_providers
+    and_i_can_manage_users_for_a_provider
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_click_on_the_users_link
+    and_i_click_on_a_user
+    and_i_click_change_providers_and_permissions
+
+    then_i_see_providers_and_permissions
+    and_i_add_permission_to_manage_users_for_a_provider_user
+    then_i_can_see_the_new_permission_for_the_provider_user
+    and_i_click_change_providers_and_permissions
+
+    when_i_remove_a_permissions_from_a_provider_user
+    then_i_cant_see_the_permission_for_the_provider_user
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_can_manage_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @managing_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_i_can_manage_users_for_a_provider
+    @managed_user = create(:provider_user, providers: [@provider])
+    @managing_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
+  end
+
+  def and_the_provider_add_provider_users_feature_is_enabled
+    FeatureFlag.activate('provider_add_provider_users')
+  end
+
+  def when_i_click_on_the_users_link
+    click_on('Users')
+  end
+
+  def and_i_click_on_a_user
+    click_on(@managed_user.full_name)
+  end
+
+  def and_i_click_change_providers_and_permissions
+    click_on('Change')
+  end
+
+  def then_i_see_providers_and_permissions
+    within(permissions_fields_id_for_provider(@provider)) do
+      expect(page).to have_unchecked_field 'Manage users'
+    end
+  end
+
+  def and_i_add_permission_to_manage_users_for_a_provider_user
+    expect(page).not_to have_checked_field 'Manage users'
+
+    within(permissions_fields_id_for_provider(@provider)) do
+      check 'Manage users'
+    end
+
+    click_on 'Update providers'
+  end
+
+  def then_i_can_see_the_new_permission_for_the_provider_user
+    expect(page).to have_content 'Providers updated'
+
+    within("#provider-#{@provider.id}-enabled-permissions") do
+      expect(page).to have_content 'Manage users'
+    end
+
+    expect(@managed_user.provider_permissions.first.manage_users).to be true
+  end
+
+  def when_i_remove_a_permissions_from_a_provider_user
+    within(permissions_fields_id_for_provider(@provider)) do
+      expect(page).to have_checked_field 'Manage users'
+      uncheck 'Manage users'
+    end
+
+    click_on 'Update providers'
+  end
+
+  def then_i_cant_see_the_permission_for_the_provider_user
+    expect(page).to have_content 'Providers updated'
+    expect(page).not_to have_content 'Manage users'
+
+    expect(@managed_user.provider_permissions.first.manage_users).to be false
+  end
+
+  def permissions_fields_id_for_provider(provider)
+    "#provider-interface-provider-user-form-provider-permissions-forms-#{provider.id}-active-true-conditional"
+  end
+end

--- a/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
+++ b/spec/system/provider_interface/providers_can_view_managed_users_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.feature 'Provider invites a new provider user' do
+  include DfESignInHelpers
+  include DsiAPIHelper
+
+  scenario 'Provider use can see their individual users permissions' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_add_provider_users_feature_is_enabled
+    and_i_can_manage_applications_for_two_providers
+    and_i_can_manage_users_for_a_provider
+    and_i_sign_in_to_the_provider_interface
+    and_i_have_some_providers_that_can_managed_users
+
+    when_i_click_on_the_users_link
+    and_i_click_on_a_users_name
+    and_i_cannot_see_providers_i_do_not_belong_to
+    the_users_details_should_be_visible
+  end
+
+  def and_i_have_some_providers_that_can_managed_users
+    @current_provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+
+    @provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
+    @non_visible_provider = create(:provider)
+
+    @manageable_user = create(:provider_user, providers: [@provider, @non_visible_provider])
+
+    @current_provider_user.provider_permissions.update_all(manage_users: true)
+
+    @manageable_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_the_provider_add_provider_users_feature_is_enabled
+    FeatureFlag.activate('provider_add_provider_users')
+  end
+
+  def and_i_can_manage_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @current_provider_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_i_can_manage_users_for_a_provider
+    @current_provider_user.provider_permissions.find_by(provider: @provider).update(manage_users: true)
+  end
+
+  def when_i_click_on_the_users_link
+    click_on('Users')
+  end
+
+  def and_i_click_on_a_users_name
+    click_link(@manageable_user.full_name, match: :first)
+  end
+
+  def and_i_cannot_see_providers_i_do_not_belong_to
+    expect(page).not_to have_content(@non_visible_provider.name)
+  end
+
+  def the_users_details_should_be_visible
+    expect(page).to have_content(@manageable_user.full_name)
+    expect(page).to have_content('Permissions')
+    expect(page).to have_content('Manage users')
+    expect(page).to have_content('Example Provider')
+    expect(page).not_to have_content('Another Provider')
+  end
+end


### PR DESCRIPTION
## Context

Provider users can invite other provider users if they have the required permissions. We need a way for managing provider users to grant permissions to others.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a details page per provider user listing their providers and permissions
- Adds a way to update these providers and permissions.

Paired with @willmcb on this feature.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/80093652-c8c41300-855c-11ea-81e0-4ae805d7185f.png)

and to update providers and permissions...

![image](https://user-images.githubusercontent.com/93511/80093695-e2655a80-855c-11ea-8732-ea66d83392de.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
I think we need to make labels consistent when editing providers and permissions. The design focuses on changing permissions but adding and removing Providers is an inherent part of the nested checkbox layout. So it might be necessary to review labeling and phrasing around Providers and Permissions.

## Link to Trello card

https://trello.com/c/BTWwpO0Y/2004-providers-with-the-manageusers-permission-can-edit-users-associated-with-their-organisation

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
