### PR TITLE
Add age range to course option dropdown where appropriate

### DIFF
--- a/app/models/candidate_interface/pick_course_form.rb
+++ b/app/models/candidate_interface/pick_course_form.rb
@@ -25,6 +25,7 @@ module CandidateInterface
         courses_with_names = courses.map(&:name).map(&:downcase)
         courses_with_descriptions = courses.map(&:name_and_description).map(&:downcase)
         courses_with_name_provider_and_description = courses.map(&:name_provider_and_description).map(&:downcase)
+        courses_with_name_description_provider_and_age_range = courses.map(&:name_description_provider_and_age_range).map(&:downcase)
 
         courses_with_unambiguous_names = courses.map do |course|
           name = if courses_with_names.count(course.name.downcase) == 1
@@ -33,6 +34,8 @@ module CandidateInterface
                    course.name_code_and_description
                  elsif courses_with_name_provider_and_description.count(course.name_provider_and_description.downcase) == 1
                    course.name_code_and_provider
+                 elsif courses_with_name_description_provider_and_age_range.count(course.name_description_provider_and_age_range.downcase) == 1 && course.age_range.present?
+                   course.name_code_and_age_range
                  else
                    course.name_and_code
                  end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -58,6 +58,14 @@ class Course < ApplicationRecord
     "#{name} (#{code}) – #{accredited_provider&.name}"
   end
 
+  def name_code_and_age_range
+    "#{name} (#{code}) – #{age_range}"
+  end
+
+  def name_description_provider_and_age_range
+    "#{name} #{description} #{accredited_provider&.name} #{age_range}"
+  end
+
   def provider_and_name_code
     "#{provider.name} - #{name_and_code}"
   end

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -130,6 +130,7 @@ private
     course.exposed_in_find = find_course.findable?
     course.subject_codes = find_course.subject_codes
     course.funding_type = find_course.funding_type
+    course.age_range = find_course.age_range_in_years.humanize
   end
 
   def add_accredited_provider(course, find_accredited_provider)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -237,6 +237,7 @@ FactoryBot.define do
     description { 'PGCE with QTS full time' }
     course_length { 'OneYear' }
     start_date { Faker::Date.between(from: 1.month.from_now, to: 1.year.from_now) }
+    age_range { '4 to 8' }
 
     subject_codes { [Faker::Alphanumeric.alphanumeric(number: 2, min_alpha: 1).upcase] }
 

--- a/spec/models/candidate_interface/pick_course_form_spec.rb
+++ b/spec/models/candidate_interface/pick_course_form_spec.rb
@@ -70,7 +70,20 @@ RSpec.describe CandidateInterface::PickCourseForm do
     end
 
     context 'when courses have the same accredited provider, name and description' do
-      it 'prioritises showing the description over the accredited provider name' do
+      it 'returns the course name_code_and_age_range' do
+        provider = create(:provider)
+        provider2 = create(:provider, name: 'BIG SCITT')
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+        create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '456', age_range: '8 to 12', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)
+
+        form = described_class.new(provider_id: provider.id)
+
+        expect(form.dropdown_available_courses.map(&:name)).to eql(['Maths (123) – 4 to 8', 'Maths (456) – 8 to 12'])
+      end
+    end
+
+    context 'when courses have the same accredited provider, name, description and age range' do
+      it 'returns course name and code' do
         provider = create(:provider)
         provider2 = create(:provider, name: 'BIG SCITT')
         create(:course, exposed_in_find: true, open_on_apply: true, name: 'Maths', code: '123', description: 'PGCE with QTS full time', provider: provider, accredited_provider: provider2)

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -51,6 +51,7 @@ RSpec.describe SyncProviderFromFind do
         expect(course_option.course.description).to eq 'PGCE with QTS full time'
         expect(course_option.course.start_date).to eq Time.zone.local(2020, 10, 31)
         expect(course_option.course.course_length).to eq 'OneYear'
+        expect(course_option.course.age_range).to eq '4 to 8'
         expect(course_option.site.name).to eq 'Main site'
         expect(course_option.site.address_line1).to eq 'Gorse SCITT'
         expect(course_option.site.address_line2).to eq 'C/O The Bruntcliffe Academy'

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -11,7 +11,8 @@ module FindAPIHelper
     course_length: 'OneYear',
     region_code: 'north_west',
     site_address_line2: 'C/O The Bruntcliffe Academy',
-    funding_type: 'fee'
+    funding_type: 'fee',
+    age_range_in_years: '4 to 8'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -68,6 +69,7 @@ module FindAPIHelper
                 'findable?': findable,
                 'accrediting_provider': nil,
                 'funding_type': funding_type,
+                'age_range_in_years': age_range_in_years,
               },
               'relationships': {
                 'sites': {
@@ -135,7 +137,8 @@ module FindAPIHelper
     description: 'PGCE with QTS full time',
     start_date: Time.zone.local(2020, 10, 31),
     course_length: 'OneYear',
-    region_code: 'north_west'
+    region_code: 'north_west',
+    age_range_in_years: '4 to 8'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -195,6 +198,7 @@ module FindAPIHelper
                   'provider_code': accredited_provider_code,
                 },
                 'funding_type': 'fee',
+                'age_range_in_years': age_range_in_years,
               },
               'relationships': {
                 'sites': {
@@ -247,7 +251,9 @@ module FindAPIHelper
     description: 'PGCE with QTS full time',
     start_date: Time.zone.local(2020, 10, 31),
     course_length: 'OneYear',
-    region_code: 'north_west'
+    region_code: 'north_west',
+    age_range_in_years: '4 to 8'
+
   )
     response_hash = {
       status: 200,
@@ -317,6 +323,7 @@ module FindAPIHelper
               'findable?': findable,
               'accrediting_provider': nil,
               'funding_type': 'fee',
+              'age_range_in_years': age_range_in_years,
             },
             'relationships': {
               'sites': {


### PR DESCRIPTION
## Context

When a course has the same name, description and accrediting provider, we need an additional way to differentiate between similar courses. Age range can do this

## Changes proposed in this pull request

- Use age range in the dropdown the if courses have the same name, description and accredited provider, but different age ranges

![image](https://user-images.githubusercontent.com/42515961/80101313-22323f00-8569-11ea-8b0c-e4e4fa52c217.png)


## Guidance to review

None really

## Link to Trello card

https://trello.com/c/wkRqk3tz/1401-use-age-range-to-differentitate-courses-in-dropdown

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
