### PR TITLE
Add safe operator to age_range.humanize 

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -130,7 +130,7 @@ private
     course.exposed_in_find = find_course.findable?
     course.subject_codes = find_course.subject_codes
     course.funding_type = find_course.funding_type
-    course.age_range = find_course.age_range_in_years.humanize
+    course.age_range = find_course.age_range_in_years&.humanize
   end
 
   def add_accredited_provider(course, find_accredited_provider)


### PR DESCRIPTION
## Context

We're getting a sentry error due to age_range often being nil


## Changes proposed in this pull request

- Add a safe operator to age_range

## Guidance to review
none

## Link to Trello card

https://trello.com/c/wkRqk3tz/1401-use-age-range-to-differentitate-courses-in-dropdown

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
