### PR TITLE
Fix delivery status of emails currently stuck in pending 

### DIFF
--- a/app/models/email.rb
+++ b/app/models/email.rb
@@ -15,6 +15,9 @@ class Email < ApplicationRecord
     # Email has likely been sent, but we're waiting on callback from GOV.UK Notify
     pending: 'pending',
 
+    # We did not try to deliver the email, for example to @example.com addresses
+    skipped: 'skipped',
+
     # DEPRECATED - do not use
     unknown: 'unknown',
 

--- a/db/migrate/20200424081737_update_older_emails.rb
+++ b/db/migrate/20200424081737_update_older_emails.rb
@@ -1,0 +1,11 @@
+class UpdateOlderEmails < ActiveRecord::Migration[6.0]
+  def up
+    skipped = Email.pending.where('emails.to LIKE ?', '%example%')
+    skipped.update_all(delivery_status: 'skipped')
+
+    emails_during_notify_incident = Email.pending.where(updated_at: DateTime.parse('2020-04-21 17:00:00')..DateTime.parse('2020-04-21 23:59:00'))
+    emails_during_notify_incident.update_all(delivery_status: 'notify_error')
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_23_092335) do
+ActiveRecord::Schema.define(version: 2020_04_24_081737) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/lib/email_log_interceptor.rb
+++ b/lib/email_log_interceptor.rb
@@ -15,7 +15,7 @@ class EmailLogInterceptor
       application_form_id: mail.header['application_form_id']&.value,
       mailer: mail.header['rails_mailer'].value,
       mail_template: mail.header['rails_mail_template'].value,
-      delivery_status: 'pending',
+      delivery_status: mail.perform_deliveries ? 'pending' : 'skipped',
     )
 
     mail.header['email-log-id'] = logged_email.id

--- a/spec/lib/email_log_interceptor_spec.rb
+++ b/spec/lib/email_log_interceptor_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe EmailLogInterceptor do
+  describe '.delivering_email' do
+    it 'marks non-delivered mails as skipped' do
+      mail = generate_email
+      mail.perform_deliveries = false
+
+      described_class.delivering_email(mail)
+
+      expect(Email.last.delivery_status).to eql('skipped')
+    end
+
+    it 'marks mail that we intend to deliver as pending' do
+      mail = generate_email
+      mail.perform_deliveries = true
+
+      described_class.delivering_email(mail)
+
+      expect(Email.last.delivery_status).to eql('pending')
+    end
+
+    def generate_email
+      mail = Mail::Message.new(to: ['test@example.com'], subject: 'Foo', headers: { rails_mailer: 'foo', rails_mail_template: 'bar' })
+    end
+  end
+end

--- a/spec/lib/email_log_interceptor_spec.rb
+++ b/spec/lib/email_log_interceptor_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe EmailLogInterceptor do
     end
 
     def generate_email
-      mail = Mail::Message.new(to: ['test@example.com'], subject: 'Foo', headers: { rails_mailer: 'foo', rails_mail_template: 'bar' })
+      Mail::Message.new(to: ['test@example.com'], subject: 'Foo', headers: { rails_mailer: 'foo', rails_mail_template: 'bar' })
     end
   end
 end


### PR DESCRIPTION
## Context

We have a bunch of emails that seem stuck in pending:

https://www.apply-for-teacher-training.education.gov.uk/support/email-log?delivery_status=pending

## Changes proposed in this pull request

- Mark emails that we don't intend to deliver as skipped, and backfill
- Backfill email delivery status that errored during the Notify incident, which is a backfill for https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1927

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/TcOj7XwZ/1405-wrap-up-tuesdays-incident-where-govuk-notify-was-down

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
