### PR TITLE
Send an email when you log into support with a new device

### DIFF
--- a/app/mailers/previews/support_mailer_preview.rb
+++ b/app/mailers/previews/support_mailer_preview.rb
@@ -1,0 +1,11 @@
+class SupportMailerPreview < ActionMailer::Preview
+  def confirm_sign_in
+    SupportMailer.confirm_sign_in(
+      FactoryBot.build_stubbed(:support_user),
+      device: {
+        ip_address: Faker::Internet.ip_v4_address,
+        user_agent: Faker::Internet.user_agent,
+      },
+    )
+  end
+end

--- a/app/mailers/support_mailer.rb
+++ b/app/mailers/support_mailer.rb
@@ -1,0 +1,11 @@
+class SupportMailer < ApplicationMailer
+  def confirm_sign_in(support_user, device:)
+    @support_user = support_user
+    @device = device
+
+    notify_email(
+      to: support_user.email_address,
+      subject: 'New sign in to Support for Apply for teacher training',
+    )
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,6 +26,7 @@ class FeatureFlag
     provider_view_safeguarding
     satisfaction_survey
     suitability_to_work_with_children
+    support_sign_in_confirmation_email
     timeline
     unavailable_course_option_warnings
     work_breaks

--- a/app/views/support_mailer/confirm_sign_in.text.erb
+++ b/app/views/support_mailer/confirm_sign_in.text.erb
@@ -1,0 +1,12 @@
+Dear <%= @support_user.display_name %>
+
+# New sign in to Support for Apply for teacher training
+
+We detected you signed into Support for Apply on a new device.
+
+IP address: <%= @device[:ip_address] %>
+Browser: <%= @device[:user_agent] %>
+
+If this was you, you can ignore this email.
+
+If this wasn't you, contact the development team immediately.

--- a/app/views/support_mailer/confirm_sign_in.text.erb
+++ b/app/views/support_mailer/confirm_sign_in.text.erb
@@ -9,4 +9,4 @@ Browser: <%= @device[:user_agent] %>
 
 If this was you, you can ignore this email.
 
-If this wasn't you, contact the development team immediately.
+If this wasn’t you, contact the development team immediately.

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
   include DfESignInHelpers
 
   scenario 'signing in successfully' do
+    FeatureFlag.activate('support_sign_in_confirmation_email')
+
     given_i_have_a_dfe_sign_in_account_and_support_authorisation
 
     when_i_visit_the_support_interface_users_path
@@ -13,11 +15,15 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
     when_i_sign_in_via_dfe_sign_in
 
     then_i_should_be_redirected_to_the_support_interface_users_path
+    and_i_should_have_received_an_email_about_the_new_login
     and_i_should_see_my_email_address
     and_my_profile_details_are_refreshed
 
     when_i_click_sign_out
     then_i_should_see_the_login_page_again
+
+    when_i_sign_in_via_dfe_sign_in
+    and_i_should_not_have_received_an_email_about_the_new_login
   end
 
   def given_i_have_a_dfe_sign_in_account_and_support_authorisation
@@ -47,6 +53,12 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
     expect(page).to have_current_path support_interface_users_path(some_key: 'some_value')
   end
 
+  def and_i_should_have_received_an_email_about_the_new_login
+    open_email('user@apply-support.com')
+    expect(current_email.subject).to have_content('New sign in to Support for Apply for teacher training')
+    clear_emails
+  end
+
   def and_i_should_see_my_email_address
     expect(page).to have_content('user@apply-support.com')
   end
@@ -62,5 +74,10 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
 
   def then_i_should_see_the_login_page_again
     expect(page).to have_button('Sign in using DfE Sign-in')
+  end
+
+  def and_i_should_not_have_received_an_email_about_the_new_login
+    open_email('user@apply-support.com')
+    expect(current_email).to be_nil
   end
 end


### PR DESCRIPTION
## Context

We'd like to make the Support UI more secure, eventually using 2FA. This is a step towards that:  on first login in we send users a notification and we save a long-lived cookie with the User ID. On subsequent logins, we check if the user ID matches. If it does, we don't send a new confirmation email. The cookie is valid forever.

## Changes proposed in this pull request

This hooks into the DfE Signin flow to send the email. It also adds a preview for the email itself.

<img width="865" alt="Screenshot 2020-04-24 at 11 50 22" src="https://user-images.githubusercontent.com/233676/80205001-ce376100-8621-11ea-9568-0f5537ff18da.png">

## Guidance to review

Will this work?

## Link to Trello card

https://trello.com/c/bUJp6Bf5

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
