### PR TITLE
Add system spec for sync provider from find

### DIFF
--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -12,7 +12,8 @@ module FindAPIHelper
     region_code: 'north_west',
     site_address_line2: 'C/O The Bruntcliffe Academy',
     funding_type: 'fee',
-    age_range_in_years: '4 to 8'
+    age_range_in_years: '4 to 8',
+    vac_status: 'full_time_vacancies'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -93,7 +94,7 @@ module FindAPIHelper
               'id': '222',
               'type': 'site_statuses',
               'attributes': {
-                'vac_status': 'full_time_vacancies',
+                'vac_status': vac_status,
                 'publish': 'published',
                 'status': 'running',
                 'has_vacancies?': true,

--- a/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
+++ b/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe 'Sync from find' do
+  include FindAPIHelper
+
+  scenario 'a site is removed between syncs' do
+    given_there_is_a_course_on_find_with_multiple_sites
+
+    when_sync_provider_from_find_is_called
+    then_the_correct_course_options_are_created_on_apply
+
+    when_find_says_that_a_site_is_no_longer_listed_for_that_course
+    and_sync_provider_from_find_is_called
+    then_the_course_option_for_that_site_is_deleted
+
+    given_there_is_a_course_on_find_with_multiple_sites
+    and_sync_provider_from_find_has_been_called
+    and_raven_can_capture_exceptions
+
+    when_find_says_that_a_site_is_no_longer_listed_for_that_course
+    and_that_site_is_part_of_an_application
+    and_sync_provider_from_find_is_called
+    then_the_affected_course_options_invalidated_by_find_attribute_is_set_to_true
+    and_raven_captures_an_exception
+  end
+
+  def given_there_is_a_course_on_find_with_multiple_sites
+    stub_find_api_provider_200_with_multiple_sites(provider_name: 'ABC College', provider_code: 'ABC', study_mode: 'full_time')
+  end
+
+  def when_sync_provider_from_find_is_called
+    SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', sync_courses: true)
+  end
+
+  def then_the_correct_course_options_are_created_on_apply
+    @provider = Provider.find_by!(code: 'ABC')
+
+    expect(@provider.courses.first.course_options.count).to eq 2
+  end
+
+  def when_find_says_that_a_site_is_no_longer_listed_for_that_course
+    stub_find_api_provider_200(provider_name: 'ABC College', provider_code: 'ABC', study_mode: 'full_time')
+  end
+
+  def then_the_course_option_for_that_site_is_deleted
+    expect(@provider.courses.first.course_options.count).to eq 1
+  end
+
+  def and_sync_provider_from_find_has_been_called
+    when_sync_provider_from_find_is_called
+  end
+
+  def and_that_site_is_part_of_an_application
+    @course_option = @provider.courses.first.course_options.last
+    create(:application_choice, course_option: @course_option)
+  end
+
+  def and_sync_provider_from_find_is_called
+    when_sync_provider_from_find_is_called
+  end
+
+  def and_raven_can_capture_exceptions
+    allow(Raven).to receive(:capture_message)
+  end
+
+  def then_the_affected_course_options_invalidated_by_find_attribute_is_set_to_true
+    expect(@provider.courses.first.course_options.count).to eq 2
+    expect(@course_option.reload.invalidated_by_find).to eq true
+  end
+
+  def and_raven_captures_an_exception
+    expect(Raven).to have_received(:capture_message).with("Course option #{@course_option.id}, which is chosen by candidates, is now invalid.")
+  end
+end

--- a/spec/system/sync_provider_from_find/study_mode_changes_spec.rb
+++ b/spec/system/sync_provider_from_find/study_mode_changes_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe 'Sync from find' do
+  include FindAPIHelper
+
+  scenario 'a courses study mode changes between syncs' do
+    given_there_is_a_full_time_course_on_find
+
+    when_sync_provider_from_find_is_called
+    then_the_correct_course_option_is_created_on_apply
+
+    given_the_course_becomes_full_time_and_part_time
+
+    when_sync_provider_from_find_is_called
+    then_a_part_time_course_option_is_created_with_vacancies
+
+    given_the_course_returns_to_full_time
+
+    when_sync_provider_from_find_is_called
+    then_the_part_time_course_option_is_set_to_no_vacancies
+  end
+
+  def given_there_is_a_full_time_course_on_find
+    stub_find_api_provider_200(provider_name: 'ABC College', provider_code: 'ABC', study_mode: 'full_time')
+  end
+
+  def when_sync_provider_from_find_is_called
+    SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC', sync_courses: true)
+  end
+
+  def then_the_correct_course_option_is_created_on_apply
+    @provider = Provider.find_by!(code: 'ABC')
+
+    expect(@provider.courses.first.course_options.count).to eq 1
+    expect(@provider.courses.first.course_options.first.study_mode).to eq 'full_time'
+    expect(@provider.courses.first.course_options.first.vacancy_status).to eq 'vacancies'
+  end
+
+  def given_the_course_becomes_full_time_and_part_time
+    stub_find_api_provider_200(provider_name: 'ABC College', provider_code: 'ABC', study_mode: 'full_time_or_part_time', vac_status: 'both_full_time_and_part_time_vacancies')
+  end
+
+  def then_a_part_time_course_option_is_created_with_vacancies
+    expect(@provider.courses.first.course_options.count).to eq 2
+    expect(@provider.courses.first.course_options.last.study_mode).to eq 'part_time'
+    expect(@provider.courses.first.course_options.last.vacancy_status).to eq 'vacancies'
+  end
+
+  def given_the_course_returns_to_full_time
+    stub_find_api_provider_200(provider_name: 'ABC College', provider_code: 'ABC', study_mode: 'full_time')
+  end
+
+  def then_the_part_time_course_option_is_set_to_no_vacancies
+    expect(@provider.courses.first.course_options.count).to eq 2
+    expect(@provider.courses.first.course_options.last.study_mode).to eq 'part_time'
+    expect(@provider.courses.first.course_options.last.vacancy_status).to eq 'no_vacancies'
+  end
+end


### PR DESCRIPTION
## Context

The sync has some complex behaviour that's worth surfacing and making more obvious to any developers who have to work on it. One way of doing that is with a system spec.

Write a spec that covers how the sync handles:

- A site no longer being available for a given course between syncs.
- A course study_mode changing between syncs, and how this affects course options created in the first sync.

## Changes proposed in this pull request

- Add tests demonstrating the above behviour


## Guidance to review

Is this sitting in the right place? I'm not 100% sure where it should go?

## Link to Trello card

https://trello.com/c/adHlQT3h/1249-dev-add-system-spec-for-find-sync

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
