### PR TITLE
Remove the add_additional_courses feature flag

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -291,7 +291,7 @@ module CandidateInterface
         @course_choices = current_candidate.current_application.application_choices
         flash[:success] = "You’ve added #{@course_choices.last.course.name_and_code} to your application"
 
-        if @course_choices.count.between?(1, 2) && FeatureFlag.active?('add_additional_courses_page')
+        if @course_choices.count.between?(1, 2)
           redirect_to candidate_interface_course_choices_add_another_course_path
         else
           redirect_to candidate_interface_course_choices_index_path

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,7 +8,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %w[
-    add_additional_courses_page
     before_you_start
     candidate_can_cancel_reference
     check_full_courses

--- a/app/views/candidate_interface/course_choices/review.html.erb
+++ b/app/views/candidate_interface/course_choices/review.html.erb
@@ -14,10 +14,8 @@
     <div class="govuk-grid-column-two-thirds">
       <% if @course_choices.count.present? %>
         <% if @course_choices.count.between?(1, 2) %>
-          <% unless FeatureFlag.active?('add_additional_courses_page') %>
-            <h2 class="govuk-heading-m">Do you want to add another course?</h2>
-            <%= render 'guidance' %>
-          <% end %>
+          <h2 class="govuk-heading-m">Do you want to add another course?</h2>
+          <%= render 'guidance' %>
           <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
         <% end %>
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -110,12 +110,8 @@ module CandidateHelper
     choose 'Primary (2XT2)'
     click_button 'Continue'
 
-    if FeatureFlag.active?('add_additional_courses_page')
-      choose 'No, not at the moment'
-      click_button 'Continue'
-
-      click_on 'Course choices'
-    end
+    choose 'No, not at the moment'
+    click_button 'Continue'
 
     check t('application_form.courses.complete.completed_checkbox')
     click_button 'Continue'

--- a/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe 'Candidate edits course choices' do
     and_i_choose_a_provider
     and_i_choose_the_third_course_as_my_first_course_choice
     and_i_choose_the_full_time_study_mode
+    then_i_should_see_the_add_another_course_page
+
+    when_i_choose_no_not_at_the_moment
     then_i_should_be_on_the_course_choice_review_page
     and_i_should_see_a_change_course_link
 
@@ -35,6 +38,9 @@ RSpec.describe 'Candidate edits course choices' do
     and_i_choose_the_multi_site_course_as_my_second_course_choice
     and_i_choose_the_full_time_study_mode
     and_i_choose_the_first_site
+    then_i_should_see_the_add_another_course_page
+
+    when_i_choose_no_not_at_the_moment
     then_i_should_be_on_the_course_choice_review_page
     and_i_should_see_the_first_site
     and_i_should_see_a_change_location_link
@@ -226,6 +232,15 @@ RSpec.describe 'Candidate edits course choices' do
 
   def and_i_choose_part_time_study_mode
     choose 'Part time'
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_the_add_another_course_page
+    expect(page).to have_current_path(candidate_interface_course_choices_add_another_course_path)
+  end
+
+  def when_i_choose_no_not_at_the_moment
+    choose 'No, not at the moment'
     click_button 'Continue'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_sees_add_additional_courses_after_adding_course_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe 'Add additional courses flow' do
   include CourseOptionHelpers
 
   scenario 'Candidate is signed in' do
-    given_that_add_additional_courses_page_is_active
-    and_there_are_course_options
+    given_there_are_course_options
     and_i_am_signed_in
 
     when_i_visit_my_application_page
@@ -46,11 +45,7 @@ RSpec.describe 'Add additional courses flow' do
     and_i_should_receive_a_message_that_ive_added_the_third_course
   end
 
-  def given_that_add_additional_courses_page_is_active
-    FeatureFlag.activate('add_additional_courses_page')
-  end
-
-  def and_there_are_course_options
+  def given_there_are_course_options
     @provider = create(:provider)
     create_list(:course, 3, provider: @provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
     course_option_for_provider(provider: @provider, course: @provider.courses.first)


### PR DESCRIPTION
## Context

This feature flag has been active on production quite a while now and should be removed
 
## Changes proposed in this pull request

- Remove the add_additional_courses feature flag

## Guidance to review

None really

## Link to Trello card

https://trello.com/c/Cj3BIcVy/1409-remove-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
