### PR TITLE
Remove before_you_start feature flag

### DIFF
--- a/app/controllers/candidate_interface/after_sign_in_controller.rb
+++ b/app/controllers/candidate_interface/after_sign_in_controller.rb
@@ -9,7 +9,7 @@ module CandidateInterface
       if service.candidate_does_not_have_a_course_from_find || service.candidate_has_submitted_application
         if more_reference_needed?
           redirect_to candidate_interface_additional_referee_path
-        elsif current_candidate.current_application.blank_application? && FeatureFlag.active?('before_you_start')
+        elsif current_candidate.current_application.blank_application?
           redirect_to candidate_interface_before_you_start_path
         else
           redirect_to candidate_interface_application_form_path

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,7 +8,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %w[
-    before_you_start
     candidate_can_cancel_reference
     check_full_courses
     confirm_conditions

--- a/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -2,8 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'A new candidate is encouraged to select a course' do
   scenario 'Candidate is redirected to the before you start page on their first sign in' do
-    given_the_before_you_start_flag_is_active
-    and_the_pilot_is_open
+    given_the_pilot_is_open
     and_the_create_account_or_sign_in_page_feature_flag_is_active
 
     when_i_visit_apply
@@ -44,11 +43,7 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
     and_i_should_not_see_an_account_created_flash_message
   end
 
-  def given_the_before_you_start_flag_is_active
-    FeatureFlag.activate('before_you_start')
-  end
-
-  def and_the_pilot_is_open
+  def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
   end
 

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -21,13 +21,12 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     when_i_click_the_button_to_send_me_a_sign_in_email
     then_i_receive_an_email_inviting_me_to_sign_in
     and_i_click_on_the_link_in_my_email
-    then_i_am_taken_to_the_sign_up_page
+    then_i_see_the_before_you_start_page
     and_i_should_see_an_account_created_flash_message
     and_i_should_not_see_the_covid19_banner
 
-    when_i_click_on_course_choices
-    and_click_on_the_apply_for_teacher_training_link_in_the_header
-    then_i_see_the_application_form_page
+    when_click_on_the_apply_for_teacher_training_link_in_the_header
+    then_i_should_see_the_application_page
   end
 
 
@@ -103,8 +102,8 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     expect(current_email.subject).to have_content t('authentication.sign_in.email.subject')
   end
 
-  def then_i_am_taken_to_the_sign_up_page
-    expect(page).to have_current_path(candidate_interface_application_form_path)
+  def then_i_see_the_before_you_start_page
+    expect(page).to have_current_path(candidate_interface_before_you_start_path)
   end
 
   def and_i_should_see_an_account_created_flash_message
@@ -115,15 +114,11 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     expect(page).not_to have_content 'There might be a delay in processing your application due to the impact of coronavirus (COVID-19)'
   end
 
-  def when_i_click_on_course_choices
-    click_link 'Course choices'
-  end
-
-  def and_click_on_the_apply_for_teacher_training_link_in_the_header
+  def when_click_on_the_apply_for_teacher_training_link_in_the_header
     click_link 'Apply for teacher training'
   end
 
-  def then_i_see_the_application_form_page
+  def then_i_should_see_the_application_page
     expect(page).to have_current_path(candidate_interface_application_form_path)
   end
 end


### PR DESCRIPTION
## Context

This feature flag has been active on production quite a while now and should be removed
 
## Changes proposed in this pull request

- Remove the before_you_start feature flag

## Guidance to review

None really

## Link to Trello card

https://trello.com/c/Cj3BIcVy/1409-remove-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
