### PR TITLE
Remove satisfaction_survey feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -24,7 +24,6 @@ class FeatureFlag
     provider_change_response
     provider_interface_work_breaks
     provider_view_safeguarding
-    satisfaction_survey
     suitability_to_work_with_children
     timeline
     unavailable_course_option_warnings

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -35,10 +35,8 @@
     <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your provider(s) when this editing period is over.</p>
     <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
 
-    <% if FeatureFlag.active?('satisfaction_survey') %>
-      <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
-      <p class="govuk-body">Your feedback will help us improve.</p>
-      <%= govuk_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path, class: 'govuk-button' %>
-    <% end %>
+    <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
+    <p class="govuk-body">Your feedback will help us improve.</p>
+    <%= govuk_link_to 'Give feedback', candidate_interface_satisfaction_survey_recommendation_path, class: 'govuk-button' %>
   </div>
 </div>

--- a/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_the_satisfaction_survey_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe 'Candidate satisfaction survey' do
   include CandidateHelper
 
   scenario 'Candidate completes the survey' do
-    given_the_satisfaction_survey_flag_is_active
-
-    when_the_candidate_completes_and_submits_their_application
+    given_the_candidate_completes_and_submits_their_application
     then_they_should_be_asked_to_give_feedback
 
     when_they_click_give_feedback
@@ -66,11 +64,7 @@ RSpec.describe 'Candidate satisfaction survey' do
     and_my_survey_should_reflect_the_results_i_input
   end
 
-  def given_the_satisfaction_survey_flag_is_active
-    FeatureFlag.activate('satisfaction_survey')
-  end
-
-  def when_the_candidate_completes_and_submits_their_application
+  def given_the_candidate_completes_and_submits_their_application
     candidate_completes_application_form
     candidate_submits_application
   end


### PR DESCRIPTION
## Context

This feature flag has been active on production quite a while now and should be removed
 
## Changes proposed in this pull request

- Remove the satisfaction_survey feature flag

## Guidance to review

None really

## Link to Trello card

https://trello.com/c/Cj3BIcVy/1409-remove-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
