### PR TITLE
Add UCAS 1st of June recalculation to RecalculateDates worker

### DIFF
--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -28,30 +28,35 @@ class RecalculateDates
     # For the second freeze period, UCAS have introduced a manual adjustment to
     # how RBDs and DBDs should be recalculated.
     #
-    start_of_second_freeze = DateTime.parse('2020-04-20 00:00:00')
-    end_of_second_freeze = DateTime.parse('2020-05-31 23:59:59')
+    start_of_second_freeze = DateTime.parse('2020-04-20')
+    end_of_second_freeze = DateTime.parse('2020-05-31')
     #
     # Any RBDs and DBDs that were *initially* recalculated to fall between the
     # 20th of April and the 31st of May must be manually adjusted to the
     # 1st of June.
     #
-    adjustment_date = DateTime.parse('2020-06-01 23:59:59')
+    adjustment_date = DateTime.parse('2020-06-01 23:59:59 +0100')
     #
-    # The choices that require adjustment should all have RBDs and DBDs that
+    # For RBDs, the choices that require adjustment should all have RBDs that
     # fall in the ~6 week period after the end of the second freeze.
     #
     duration_of_freeze = end_of_second_freeze - start_of_second_freeze # ~6.weeks
-    period_to_adjust = end_of_second_freeze..(end_of_second_freeze + duration_of_freeze)
+    period_to_adjust_rbd = end_of_second_freeze..(end_of_second_freeze + duration_of_freeze)
+    #
+    # For DBDs, the choices that require adjustment should all have DBDs that
+    # fall in the <=9 business day period after the end of the second freeze.
+    #
+    period_to_adjust_dbd = end_of_second_freeze..(9.business_days.after(end_of_second_freeze))
 
     Audited.audit_class.as_user('RecalculateDates worker UCAS 1st June adjustment') do
       ApplicationChoice
-        .where(reject_by_default_at: period_to_adjust)
+        .where(reject_by_default_at: period_to_adjust_rbd)
         .find_each do |application_choice|
           application_choice.update!(reject_by_default_at: adjustment_date)
         end
 
       ApplicationChoice
-        .where(decline_by_default_at: period_to_adjust)
+        .where(decline_by_default_at: period_to_adjust_dbd)
         .find_each do |application_choice|
           application_choice.update!(decline_by_default_at: adjustment_date)
         end

--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -18,5 +18,43 @@ class RecalculateDates
         SetDeclineByDefault.new(application_form: application_form).call
       end
     end
+
+    ucas_1st_june_adjustment
+  end
+
+  def ucas_1st_june_adjustment
+    # All code related to the UCAS adjustment can be removed 2020-06-01.
+    #
+    # For the second freeze period, UCAS have introduced a manual adjustment to
+    # how RBDs and DBDs should be recalculated.
+    #
+    start_of_second_freeze = DateTime.parse('2020-04-20 00:00:00')
+    end_of_second_freeze = DateTime.parse('2020-05-31 23:59:59')
+    #
+    # Any RBDs and DBDs that were *initially* recalculated to fall between the
+    # 20th of April and the 31st of May must be manually adjusted to the
+    # 1st of June.
+    #
+    adjustment_date = DateTime.parse('2020-06-01 23:59:59')
+    #
+    # The choices that require adjustment should all have RBDs and DBDs that
+    # fall in the ~6 week period after the end of the second freeze.
+    #
+    duration_of_freeze = end_of_second_freeze - start_of_second_freeze # ~6.weeks
+    period_to_adjust = end_of_second_freeze..(end_of_second_freeze + duration_of_freeze)
+
+    Audited.audit_class.as_user('RecalculateDates worker UCAS 1st June adjustment') do
+      ApplicationChoice
+        .where(reject_by_default_at: period_to_adjust)
+        .find_each do |application_choice|
+          application_choice.update!(reject_by_default_at: adjustment_date)
+        end
+
+      ApplicationChoice
+        .where(decline_by_default_at: period_to_adjust)
+        .find_each do |application_choice|
+          application_choice.update!(decline_by_default_at: adjustment_date)
+        end
+    end
   end
 end


### PR DESCRIPTION
## Context

To ensure that RBD/DBD dates are consistent with UCAS approach, we need to update our worker.

All applications that had an RBD or DBD that fell between the 20th of April and 31st of May *before* we made that period a working day freeze should instead be recalculated for the end of the 1st of June.

## Changes proposed in this pull request

Add adjustment logic to `RecalculateDates` worker.

## Guidance to review

Nothing in particular.

## Link to Trello card

https://trello.com/c/G1yFCFZK/1384-recalculate-rbd-dbd-based-off-ucas-decision

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)