### PR TITLE
Support interface for validation error tracking

### DIFF
--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -8,6 +8,7 @@ module SupportInterface
       @form_object = params[:form_object]
       @validation_errors = ValidationError
         .where(form_object: @form_object)
+        .includes('user')
         .order('created_at DESC')
         .page(params[:page] || 1)
     end

--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -3,5 +3,9 @@ module SupportInterface
     def index
       @grouped_counts = ValidationError.group(:form_object).order('count_all DESC').count
     end
+
+    def show
+      @validation_errors = ValidationError.where(form_object: params[:form_object]).order('created_at DESC')
+    end
   end
 end

--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -1,0 +1,7 @@
+module SupportInterface
+  class ValidationErrorsController < SupportInterfaceController
+    def index
+      @grouped_counts = ValidationError.group(:form_object).order('count_all DESC').count
+    end
+  end
+end

--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -5,7 +5,8 @@ module SupportInterface
     end
 
     def show
-      @validation_errors = ValidationError.where(form_object: params[:form_object]).order('created_at DESC')
+      @form_object = params[:form_object]
+      @validation_errors = ValidationError.where(form_object: @form_object).order('created_at DESC')
     end
   end
 end

--- a/app/controllers/support_interface/validation_errors_controller.rb
+++ b/app/controllers/support_interface/validation_errors_controller.rb
@@ -6,7 +6,10 @@ module SupportInterface
 
     def show
       @form_object = params[:form_object]
-      @validation_errors = ValidationError.where(form_object: @form_object).order('created_at DESC')
+      @validation_errors = ValidationError
+        .where(form_object: @form_object)
+        .order('created_at DESC')
+        .page(params[:page] || 1)
     end
   end
 end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -6,6 +6,7 @@
   <li><%= govuk_link_to 'Performance dashboard', integrations_performance_path %> (public)</li>
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
   <li><%= govuk_link_to 'Applications that require action', support_interface_action_required_path %></li>
+  <li><%= govuk_link_to 'Validation errors', support_interface_validation_errors_path %></li>
 </ul>
 
 <h2 class='govuk-heading-l'>Downloads for analysis</h2>

--- a/app/views/support_interface/validation_errors/index.html.erb
+++ b/app/views/support_interface/validation_errors/index.html.erb
@@ -1,7 +1,7 @@
 <ul>
   <% @grouped_counts.each do |form_object, count| %>
     <li>
-      <a href='<%= candidate_interface_validation_error_path(form_object) %>'><%= form_object %></a><%= "(#{count})" %>
+      <a href='<%= support_interface_validation_error_path(form_object) %>'><%= form_object %></a><%= "(#{count})" %>
     </li>
   <% end %>
 </ul>

--- a/app/views/support_interface/validation_errors/index.html.erb
+++ b/app/views/support_interface/validation_errors/index.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% @grouped_counts.each do |form_object, count| %>
+    <li>
+      <a href='<%= candidate_interface_validation_error_path(form_object) %>'><%= form_object %></a><%= "(#{count})" %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/support_interface/validation_errors/index.html.erb
+++ b/app/views/support_interface/validation_errors/index.html.erb
@@ -11,7 +11,7 @@
   <% @grouped_counts.each do |form_object, count| %>
     <tr class="govuk-table__row">
       <td class="govuk-table__cell">
-        <a href='<%= support_interface_validation_error_path(form_object) %>'><%= form_object %></a>
+        <%= govuk_link_to form_object, support_interface_validation_error_path(form_object) %>
       </td>
       <td class="govuk-table__cell">
         <%= count %>

--- a/app/views/support_interface/validation_errors/index.html.erb
+++ b/app/views/support_interface/validation_errors/index.html.erb
@@ -1,7 +1,22 @@
-<ul>
+<% content_for :title, 'Validation errors' %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Form or model</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Error count</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
   <% @grouped_counts.each do |form_object, count| %>
-    <li>
-      <a href='<%= support_interface_validation_error_path(form_object) %>'><%= form_object %></a><%= "(#{count})" %>
-    </li>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <a href='<%= support_interface_validation_error_path(form_object) %>'><%= form_object %></a>
+      </td>
+      <td class="govuk-table__cell">
+        <%= count %>
+      </td>
+    </tr>
   <% end %>
-</ul>
+  </tbody>
+</table>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -22,6 +22,9 @@
         <%= validation_error.request_path %>
       </td>
       <td class="govuk-table__cell">
+        <% validation_error.details.each do |attribute, _details| %>
+          <%= render SummaryListComponent.new(rows: [{ attribute: attribute }]) %>
+        <% end %>
       </td>
     </tr>
   <% end %>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -1,0 +1,5 @@
+<%= @validation_errors.each do |validation_error| %>
+  <%= validation_error.created_at %>
+  <%= validation_error.request_path %>
+  <%= validation_error.details.to_s %>
+<% end %>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -1,5 +1,29 @@
-<%= @validation_errors.each do |validation_error| %>
-  <%= validation_error.created_at %>
-  <%= validation_error.request_path %>
-  <%= validation_error.details.to_s %>
-<% end %>
+<% content_for :title, "Validation errors for #{@form_object}" %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-table__header">Time</th>
+      <th class="govuk-table__header govuk-table__header">Candidate</th>
+      <th class="govuk-table__header govuk-table__header">Request path</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Errors</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @validation_errors.each do |validation_error| %>
+    <tr class="govuk-table__row">
+      <td class="govuk-table__cell">
+        <%= validation_error.created_at.to_s(:govuk_date_and_time) %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= validation_error.user&.email_address %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= validation_error.request_path %>
+      </td>
+      <td class="govuk-table__cell">
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -22,8 +22,12 @@
         <%= validation_error.request_path %>
       </td>
       <td class="govuk-table__cell">
-        <% validation_error.details.each do |attribute, _details| %>
-          <%= render SummaryListComponent.new(rows: [{ attribute: attribute }]) %>
+        <% validation_error.details.each do |attribute, details| %>
+          <%= render SummaryListComponent.new(rows: [
+            { key: 'Attribute', value: attribute },
+            { key: 'Value', value: details['value'] },
+            { key: 'Errors', value: details['messages'] },
+          ]) %>
         <% end %>
       </td>
     </tr>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -25,7 +25,7 @@
         <% validation_error.details.each do |attribute, details| %>
           <%= render SummaryListComponent.new(rows: [
             { key: 'Attribute', value: attribute },
-            { key: 'Value', value: details['value'] },
+            { key: 'Value', value: details['value'].inspect },
             { key: 'Errors', value: details['messages'] },
           ]) %>
         <% end %>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -34,3 +34,4 @@
   <% end %>
   </tbody>
 </table>
+<%= render(PaginatorComponent.new(scope: @validation_errors)) %>

--- a/app/views/support_interface/validation_errors/show.html.erb
+++ b/app/views/support_interface/validation_errors/show.html.erb
@@ -1,5 +1,18 @@
 <% content_for :title, "Validation errors for #{@form_object}" %>
 
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Validation errors', support_interface_validation_errors_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= @form_object %>
+      </li>
+    </ol>
+  </div>
+<% end %>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -530,8 +530,8 @@ Rails.application.routes.draw do
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task
 
-    get '/validation_errors' => 'validation_errors#index', as: :validation_errors
-    get '/validation_errors/:form_object' => 'validation_errors#show', as: :validation_error
+    get '/validation-errors' => 'validation_errors#index', as: :validation_errors
+    get '/validation-errors/:form_object' => 'validation_errors#show', as: :validation_error
 
     scope '/users' do
       get '/' => 'users#index', as: :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -527,10 +527,10 @@ Rails.application.routes.draw do
     get '/performance/applications-export-for-ucas', to: 'performance#applications_export_for_ucas', as: :applications_export_for_ucas
     get '/performance/active-provider-users', to: 'performance#active_provider_users', as: :active_provider_users
 
-
-
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task
+
+    get '/validation_errors' => 'validation_errors#index', as: :validation_errors
 
     scope '/users' do
       get '/' => 'users#index', as: :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -531,6 +531,7 @@ Rails.application.routes.draw do
     post '/tasks/:task' => 'tasks#run', as: :run_task
 
     get '/validation_errors' => 'validation_errors#index', as: :validation_errors
+    get '/validation_errors/:form_object' => 'validation_errors#show', as: :validation_error
 
     scope '/users' do
       get '/' => 'users#index', as: :users

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Validation errors' do
 
   def then_i_should_see_a_list_of_error_groups
     expect(page).to have_content(@validation_error.form_object)
-    expect(page).to have_content('(1)')
+    expect(page).to have_content('1')
   end
 
   def when_i_click_on_a_group
@@ -43,6 +43,6 @@ RSpec.feature 'Validation errors' do
   def then_i_should_see_a_list_of_individual_errors
     expect(page).to have_current_path(support_interface_validation_error_path(@validation_error.form_object))
     expect(page).to have_content(@validation_error.request_path)
-    expect(page).to have_content(@validation_error.created_at)
+    expect(page).to have_content('24 April 2020 at 12:35pm')
   end
 end

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -12,6 +12,9 @@ RSpec.feature 'Validation errors' do
 
     when_i_click_on_a_group
     then_i_should_see_a_list_of_individual_errors
+
+    when_i_click_on_link_in_breadcrumb_trail
+    then_i_should_be_back_on_index_page
   end
 
   def given_i_am_a_support_user
@@ -52,7 +55,15 @@ RSpec.feature 'Validation errors' do
     expect(page).to have_content(@validation_error.request_path)
     expect(page).to have_content('24 April 2020 at 12:35pm')
     expect(page).to have_content(/Attribute\s+award_year/)
-    expect(page).to have_content(/Value\s+2222/)
+    expect(page).to have_content(/Value\s+"2222"/)
     expect(page).to have_content(/Errors\s+Enter a year before 2022/)
+  end
+
+  def when_i_click_on_link_in_breadcrumb_trail
+    click_link 'Validation errors'
+  end
+
+  def then_i_should_be_back_on_index_page
+    expect(page).to have_current_path(support_interface_validation_errors_path)
   end
 end

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -1,11 +1,21 @@
 require 'rails_helper'
 
 RSpec.feature 'Validation errors' do
+  include CandidateHelper
   include DfESignInHelpers
 
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 4, 24, 12, 35, 46)) do
+      example.run
+    end
+  end
+
   scenario 'Review validation errors' do
+    given_i_am_a_candidate
+    and_the_track_validation_errors_feature_is_on
+    and_i_enter_invalid_contact_details
+
     given_i_am_a_support_user
-    and_there_are_some_validation_errors
 
     when_i_navigate_to_the_validation_errors_page
     then_i_should_see_a_list_of_error_groups
@@ -17,22 +27,23 @@ RSpec.feature 'Validation errors' do
     then_i_should_be_back_on_index_page
   end
 
-  def given_i_am_a_support_user
-    sign_in_as_support_user
+  def given_i_am_a_candidate
+    create_and_sign_in_candidate
   end
 
-  def and_there_are_some_validation_errors
-    @candidate = create(:candidate, email_address: 'bob@example.com')
-    @validation_error = create(
-      :validation_error,
-      form_object: 'CandidateInterface::DegreeForm',
-      details: {
-        award_year: { value: '2222', messages: ['Enter a year before 2022'] },
-      },
-      request_path: '/candidate/application/degrees/51/year',
-      created_at: Time.zone.local(2020, 4, 24, 12, 35, 42),
-      user: @candidate,
-    )
+  def and_the_track_validation_errors_feature_is_on
+    FeatureFlag.activate('track_validation_errors')
+  end
+
+  def and_i_enter_invalid_contact_details
+    visit candidate_interface_application_form_path
+    click_link t('page_titles.contact_details')
+    fill_in t('application_form.contact_details.phone_number.label'), with: 'ABCDEF'
+    click_button t('application_form.contact_details.base.button')
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
   end
 
   def when_i_navigate_to_the_validation_errors_page
@@ -42,6 +53,7 @@ RSpec.feature 'Validation errors' do
   end
 
   def then_i_should_see_a_list_of_error_groups
+    @validation_error = ValidationError.last
     expect(page).to have_content(@validation_error.form_object)
     expect(page).to have_content('1')
   end
@@ -54,9 +66,9 @@ RSpec.feature 'Validation errors' do
     expect(page).to have_current_path(support_interface_validation_error_path(@validation_error.form_object))
     expect(page).to have_content(@validation_error.request_path)
     expect(page).to have_content('24 April 2020 at 12:35pm')
-    expect(page).to have_content(/Attribute\s+award_year/)
-    expect(page).to have_content(/Value\s+"2222"/)
-    expect(page).to have_content(/Errors\s+Enter a year before 2022/)
+    expect(page).to have_content(/Attribute\s+phone_number/)
+    expect(page).to have_content(/Value\s+"ABCDEF"/)
+    expect(page).to have_content(/Errors\s+Enter a phone number/)
   end
 
   def when_i_click_on_link_in_breadcrumb_trail

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Validation errors' do
   end
 
   def and_there_are_some_validation_errors
-    create :validation_error
+    @validation_error = create :validation_error
   end
 
   def when_i_visit_the_validation_errors_page
@@ -27,14 +27,15 @@ RSpec.feature 'Validation errors' do
   end
 
   def then_i_should_see_a_list_of_error_groups
-    pending
+    expect(page).to have_content(@validation_error.form_object)
+    expect(page).to have_content('(1)')
   end
 
   def when_i_click_on_a_group
-    pending
+    click_on(@validation_error.form_object)
   end
 
   def then_i_should_see_a_list_of_individual_errors
-    pending
+    expect(page).to have_current_path(candidate_interface_validation_error_path(@validation_error.form_object))
   end
 end

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature 'Validation errors' do
     given_i_am_a_support_user
     and_there_are_some_validation_errors
 
-    when_i_visit_the_validation_errors_page
+    when_i_navigate_to_the_validation_errors_page
     then_i_should_see_a_list_of_error_groups
 
     when_i_click_on_a_group
@@ -25,8 +25,10 @@ RSpec.feature 'Validation errors' do
     )
   end
 
-  def when_i_visit_the_validation_errors_page
-    visit support_interface_validation_errors_path
+  def when_i_navigate_to_the_validation_errors_page
+    visit support_interface_path
+    click_link 'Performance'
+    click_link 'Validation errors'
   end
 
   def then_i_should_see_a_list_of_error_groups

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -19,9 +19,16 @@ RSpec.feature 'Validation errors' do
   end
 
   def and_there_are_some_validation_errors
+    @candidate = create(:candidate, email_address: 'bob@example.com')
     @validation_error = create(
       :validation_error,
+      form_object: 'CandidateInterface::DegreeForm',
+      details: {
+        award_year: { value: '2222', messages: ['Enter a year before 2022'] },
+      },
+      request_path: '/candidate/application/degrees/51/year',
       created_at: Time.zone.local(2020, 4, 24, 12, 35, 42),
+      user: @candidate,
     )
   end
 
@@ -44,6 +51,8 @@ RSpec.feature 'Validation errors' do
     expect(page).to have_current_path(support_interface_validation_error_path(@validation_error.form_object))
     expect(page).to have_content(@validation_error.request_path)
     expect(page).to have_content('24 April 2020 at 12:35pm')
-    expect(page).to have_content('feedback')
+    expect(page).to have_content(/Attribute\s+award_year/)
+    expect(page).to have_content(/Value\s+2222/)
+    expect(page).to have_content(/Errors\s+Enter a year before 2022/)
   end
 end

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.feature 'Validation errors' do
+  include DfESignInHelpers
+
+  scenario 'Review validation errors' do
+    given_i_am_a_support_user
+    and_there_are_some_validation_errors
+
+    when_i_visit_the_validation_errors_page
+    then_i_should_see_a_list_of_error_groups
+
+    when_i_click_on_a_group
+    then_i_should_see_a_list_of_individual_errors
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_some_validation_errors
+    create :validation_error
+  end
+
+  def when_i_visit_the_validation_errors_page
+    visit support_interface_validation_errors_path
+  end
+
+  def then_i_should_see_a_list_of_error_groups
+    pending
+  end
+
+  def when_i_click_on_a_group
+    pending
+  end
+
+  def then_i_should_see_a_list_of_individual_errors
+    pending
+  end
+end

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -44,5 +44,6 @@ RSpec.feature 'Validation errors' do
     expect(page).to have_current_path(support_interface_validation_error_path(@validation_error.form_object))
     expect(page).to have_content(@validation_error.request_path)
     expect(page).to have_content('24 April 2020 at 12:35pm')
+    expect(page).to have_content('feedback')
   end
 end

--- a/spec/system/support_interface/validation_errors_spec.rb
+++ b/spec/system/support_interface/validation_errors_spec.rb
@@ -19,7 +19,10 @@ RSpec.feature 'Validation errors' do
   end
 
   def and_there_are_some_validation_errors
-    @validation_error = create :validation_error
+    @validation_error = create(
+      :validation_error,
+      created_at: Time.zone.local(2020, 4, 24, 12, 35, 42),
+    )
   end
 
   def when_i_visit_the_validation_errors_page
@@ -36,6 +39,8 @@ RSpec.feature 'Validation errors' do
   end
 
   def then_i_should_see_a_list_of_individual_errors
-    expect(page).to have_current_path(candidate_interface_validation_error_path(@validation_error.form_object))
+    expect(page).to have_current_path(support_interface_validation_error_path(@validation_error.form_object))
+    expect(page).to have_content(@validation_error.request_path)
+    expect(page).to have_content(@validation_error.created_at)
   end
 end


### PR DESCRIPTION
## Context

We need to see more about the validation errors our users are encountering so that we can learn more about their behaviour and better understand areas where our service appears to repeatedly 'fail'.

This PR follows on from https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1922 and adds a front-end to the support interface for viewing validation errors.

## Changes proposed in this pull request

- Link from existing Performance page to a new validation index page. This summarise the errors logged grouped by form object or model (the thing that's validated).
![image](https://user-images.githubusercontent.com/450843/80360553-6bd79e00-8877-11ea-8eb2-538f4d2a3cf9.png)

- Detail page for individual form objects/models listing all the validation errors for that object.
![image](https://user-images.githubusercontent.com/450843/80366032-79ddec80-8880-11ea-8464-9de9715f66cb.png)

- Pagination on the detail page because the number of validation errors is unlimited. 

## Guidance to review

- Does it make sense to group validation errors by form object or model? We could also group by request path or not at all.
- There is no pagination on the index page because the number of items it lists is limited to the number of validatable form objects and models in the application.
- The entries on the detail page are laid out in a table. It's getting pretty congested - some of the columns are too narrow. So would like to get a better solution for this.
- For the candidate that triggered the change I'm just displaying the candidate email address. It may be a lot more useful to have the candidate name and reference but those are attributes of the application form (of which there could be more than one per candidate). A link to the application form would also be nice. So should we also be capturing the application form as well as the candidate?

## Link to Trello card

https://trello.com/c/M7jlcy7G/1281-dev-improve-visibility-of-validation-errors

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
