### PR TITLE
Change submit application link to a button

### DIFF
--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -100,14 +100,8 @@
       </li>
     </ul>
 
-    <h2 class="govuk-heading-m govuk-!-font-size-27">Review and submit</h2>
-    <ul class="app-task-list govuk-!-margin-bottom-8">
-      <li class="app-task-list__item">
-        <%= govuk_link_to 'Check your answers before submitting',
-                          candidate_interface_application_review_path,
-                          class: 'app-task-list__task-name' %>
-      </li>
-    </ul>
+    <h2 class="govuk-heading-m govuk-!-font-size-27">Check and submit</h2>
+    <%= govuk_button_link_to 'Check and submit your application', candidate_interface_application_review_path %>
   </div>
 
   <div class="govuk-grid-column-one-third">

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -79,7 +79,7 @@ module CandidateHelper
   end
 
   def candidate_submits_application
-    click_link 'Check your answers before submitting'
+    click_link 'Check and submit your application'
     click_link 'Continue'
     choose 'No' # "Is there anything else you would like to tell us?"
 

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -65,7 +65,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
   end
 
   def when_i_click_on_check_your_answers
-    click_link 'Check your answers before submitting'
+    click_link 'Check and submit your application'
   end
 
   def then_i_should_see_all_sections_are_complete

--- a/spec/system/candidate_interface/candidate_entering_disability_info.rb
+++ b/spec/system/candidate_interface/candidate_entering_disability_info.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Entering their disability information' do
   end
 
   def when_i_click_on_check_your_answers
-    click_link 'Check your answers before submitting'
+    click_link 'Check and submit your application'
   end
 
   def when_i_submit_my_application

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -24,7 +24,7 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   def when_i_visit_the_review_application_page
     visit candidate_interface_application_form_path
-    click_link 'Check your answers before submitting'
+    click_link 'Check and submit your application'
   end
 
   def then_i_should_be_able_to_click_through_and_complete_each_section_but_science_gcse

--- a/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_application_with_unavailable_course_options_spec.rb
@@ -68,7 +68,7 @@ RSpec.feature 'Candidate reviewing an application with unavailable course option
 
   def when_i_visit_the_review_application_page
     visit candidate_interface_application_form_path
-    click_link 'Check your answers before submitting'
+    click_link 'Check and submit your application'
   end
 
   def then_i_see_a_warning_for_the_course_that_is_not_running

--- a/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_viewing_a_science_gcse_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Candidate viewing Science GCSE' do
   end
 
   def when_i_click_on_check_your_answers
-    click_link 'Check your answers before submitting'
+    click_link 'Check and submit your application'
   end
 
   def then_i_see_science_gcse_is_missing_below_the_section

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature 'Candidate submits the application' do
     and_the_covid_19_feature_flag_is_on
 
     when_i_have_completed_my_application
+
     and_i_review_my_application
 
     then_i_should_see_all_sections_are_complete
@@ -160,7 +161,7 @@ RSpec.feature 'Candidate submits the application' do
   end
 
   def when_i_click_on_check_your_answers
-    click_link 'Check your answers before submitting'
+    click_link 'Check and submit your application'
   end
 
   def and_i_confirm_my_application


### PR DESCRIPTION
## Context

Currently, on the application form page, to submit their application, a candidate has to click on a link.

This should display as a button to be in line with the prototype.

## Changes proposed in this pull request

- Change to show a button

Before 

![image](https://user-images.githubusercontent.com/42515961/80360814-cd980800-8877-11ea-81dc-86e960579f48.png)

After

![image](https://user-images.githubusercontent.com/42515961/80360848-e0124180-8877-11ea-9c8a-a5df216be7ff.png)

## Link to Trello card

https://trello.com/c/gmsQj8ot/1393-make-the-link-to-check-and-submit-on-the-application-form-page-a-button-instead-of-a-link

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
