### PR TITLE
Update candidate_sign_in_url helper to return magic link 

### DIFF
--- a/app/controllers/candidate_interface/sign_in_controller.rb
+++ b/app/controllers/candidate_interface/sign_in_controller.rb
@@ -4,12 +4,8 @@ module CandidateInterface
     before_action :redirect_to_application_if_signed_in, except: %i[authenticate]
 
     def new
-      if params[:u]
-        redirect_to candidate_interface_expired_sign_in_path(u: params[:u])
-      else
-        candidate = Candidate.new
-        render 'candidate_interface/sign_in/new', locals: { candidate: candidate }
-      end
+      candidate = Candidate.new
+      render 'candidate_interface/sign_in/new', locals: { candidate: candidate }
     end
 
     def create

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -51,11 +51,6 @@ module ViewHelper
     dates.edit_by.to_s(:govuk_date).strip
   end
 
-  def candidate_sign_in_url(candidate)
-    raw_token = candidate.refresh_magic_link_token!
-    candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token)
-  end
-
   def format_months_to_years_and_months(number_of_months)
     duration_parts = ActiveSupport::Duration.build(number_of_months.months).parts
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -52,14 +52,8 @@ module ViewHelper
   end
 
   def candidate_sign_in_url(candidate)
-    encrypted_candidate_id = Encryptor.encrypt(candidate.id)
-    magic_link_token = MagicLinkToken.new
-    candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.zone.now)
-
-    candidate_interface_authenticate_url(
-      token: magic_link_token.raw,
-      u: encrypted_candidate_id,
-    )
+    raw_token = candidate.refresh_magic_link_token!
+    candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token)
   end
 
   def format_months_to_years_and_months(number_of_months)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -53,7 +53,13 @@ module ViewHelper
 
   def candidate_sign_in_url(candidate)
     encrypted_candidate_id = Encryptor.encrypt(candidate.id)
-    candidate_interface_sign_in_url(u: encrypted_candidate_id)
+    magic_link_token = MagicLinkToken.new
+    candidate.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.zone.now)
+
+    candidate_interface_authenticate_url(
+      token: magic_link_token.raw,
+      u: encrypted_candidate_id,
+    )
   end
 
   def format_months_to_years_and_months(number_of_months)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,6 +1,4 @@
 class CandidateMailer < ApplicationMailer
-  helper :view
-
   def application_submitted(application_form)
     email_for_candidate(application_form)
   end
@@ -198,4 +196,10 @@ private
       application_form_id: application_form.id,
     )
   end
+
+  def candidate_magic_link(candidate)
+    raw_token = candidate.refresh_magic_link_token!
+    candidate_interface_authenticate_url(u: candidate.encrypted_id, token: raw_token)
+  end
+  helper_method :candidate_magic_link
 end

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -28,6 +28,19 @@ class Candidate < ApplicationRecord
     application_forms.max_by(&:updated_at)
   end
 
+  def refresh_magic_link_token!
+    magic_link_token = MagicLinkToken.new
+    update!(
+      magic_link_token: magic_link_token.encrypted,
+      magic_link_token_sent_at: Time.zone.now,
+    )
+    magic_link_token.raw
+  end
+
+  def encrypted_id
+    Encryptor.encrypt(id)
+  end
+
 private
 
   def downcase_email

--- a/app/views/candidate_mailer/application_rejected_offers_made.erb
+++ b/app/views/candidate_mailer/application_rejected_offers_made.erb
@@ -10,7 +10,7 @@ You’ve received the following offers:
 <% end %>
 
 <% if FeatureFlag.active?('covid_19') %>
-If you don’t reply by <%= @decline_by_default_at %> your application will be withdrawn. 
+If you don’t reply by <%= @decline_by_default_at %> your application will be withdrawn.
 <% else %>
 If you don’t reply within <%= @dbd_days %> working days, your applications will be withdrawn.
 <% end %>
@@ -19,16 +19,16 @@ If you don’t reply within <%= @dbd_days %> working days, your applications wil
 
 <% if FeatureFlag.active?('covid_19') %>
 You’ve received an offer for a place on <%= @offers.first.course_option.course.name_and_code %> at <%= @offers.first.course_option.course.provider.name%>.
-If you don’t reply by <%= @decline_by_default_at %> your application will be withdrawn. 
+If you don’t reply by <%= @decline_by_default_at %> your application will be withdrawn.
 <% else %>
 You now have <%= @dbd_days %> working days to make a decision about your offer for a place on <%= @offers.first.course_option.course.name_and_code %> at <%= @offers.first.course_option.course.provider.name%>.
 <% end %>
-  
+
 <% end %>
 
 Sign in to your account to respond:
 
-<%= candidate_sign_in_url(@candidate) %>
+<%= candidate_magic_link(@candidate) %>
 
 <% if @offers.count > 1  %>
 

--- a/app/views/candidate_mailer/application_sent_to_provider.text.erb
+++ b/app/views/candidate_mailer/application_sent_to_provider.text.erb
@@ -7,7 +7,7 @@ Your application is now with your teacher training <%= 'provider'.pluralize(@app
 <% if FeatureFlag.active?('covid_19') %>
 They’ll be in touch with you if they want to arrange an interview.
 
-Due to the impact of coronavirus, this may take some time. 
+Due to the impact of coronavirus, this may take some time.
 <% else %>
 We’ve asked them to make a final decision within <%= @application_form.application_choices.first.reject_by_default_days %> working days.
 
@@ -16,4 +16,4 @@ They’ll be in touch with you sooner if they want to arrange an interview.
 
 Sign in to Apply for teacher training to review your application:
 
-<%= candidate_sign_in_url(@candidate) %>
+<%= candidate_magic_link(@candidate) %>

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -12,7 +12,7 @@ Your application reference is <%= @application_form.support_reference %>.
 
 You can track the progress of your <%= 'application'.pluralize(@application_form.application_choices.count) %> here:
 
-<%= candidate_sign_in_url(@candidate) %>
+<%= candidate_magic_link(@candidate) %>
 
 # Making changes to your application
 
@@ -30,7 +30,7 @@ You can withdraw your application to your <%= 'course'.pluralize(@application_fo
 
 Sign in to your account and click ‘withdraw’ next to the course(s) you want to withdraw:
 
-<%= candidate_sign_in_url(@candidate) %>
+<%= candidate_magic_link(@candidate) %>
 
 # References
 

--- a/app/views/candidate_mailer/changed_offer.text.erb
+++ b/app/views/candidate_mailer/changed_offer.text.erb
@@ -14,7 +14,7 @@ Contact <%= @previous_offer.course.provider.name %> directly if you have any que
 
 You can sign in to Apply for teacher training to check the status of your application(s):
 
-<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
 # Give feedback or report a problem
 

--- a/app/views/candidate_mailer/chase_candidate_decision.text.erb
+++ b/app/views/candidate_mailer/chase_candidate_decision.text.erb
@@ -26,7 +26,7 @@ If you don’t reply within <%= @dbd_days %> working days, your applications wil
 
 Sign in to your account to respond:
 
-<%= candidate_sign_in_url(@application_form.candidate) %>
+<%= candidate_magic_link(@application_form.candidate) %>
 
 # Give feedback or report a problem
 

--- a/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
+++ b/app/views/candidate_mailer/new_offer/decisions_pending.text.erb
@@ -20,7 +20,7 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 
 ^You can respond to the offer now. If you accept the offer, your other teacher training application(s) will be withdrawn. Sign in to your account if you want to respond:
 
-<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
 # Give feedback or report a problem
 

--- a/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
+++ b/app/views/candidate_mailer/new_offer/multiple_offers.text.erb
@@ -15,7 +15,7 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
 <% if FeatureFlag.active?('covid_19') %>
-If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn. 
+If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
 <% else %>
 You have 10 working days to make a decision. If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
 <% end %>
@@ -28,7 +28,7 @@ You have 10 working days to make a decision. If you don’t reply by <%= @applic
 
 Sign in to your account to respond:
 
-<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
 # Give feedback or report a problem
 

--- a/app/views/candidate_mailer/new_offer/single_offer.text.erb
+++ b/app/views/candidate_mailer/new_offer/single_offer.text.erb
@@ -15,14 +15,14 @@ Contact <%= @provider_name %> directly if you have any questions about this.
 # Make a decision by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>
 
 <% if FeatureFlag.active?('covid_19') %>
-If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn. 
+If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
 <% else %>
 You have 10 working days to make a decision. If you don’t reply by <%= @application_choice.decline_by_default_at&.to_s(:govuk_date) %>, your application will be withdrawn.
 <% end %>
 
 Sign in to your account to respond:
 
-<%= candidate_sign_in_url(@application_choice.application_form.candidate) %>
+<%= candidate_magic_link(@application_choice.application_form.candidate) %>
 
 # Give feedback or report a problem
 

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -6,6 +6,6 @@ Dear <%= @application_form.first_name %>,
 
 Please add a new referee:
 
-<%= candidate_sign_in_url(@candidate) %>
+<%= candidate_magic_link(@candidate) %>
 
 We can’t send your application to your teacher training providers without 2 complete references.

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe CandidateMailer, type: :mailer do
   include CourseOptionHelpers
-  include ViewHelper
+  include TestHelpers::MailerSetupHelper
 
   subject(:mailer) { described_class }
 
@@ -45,28 +45,36 @@ RSpec.describe CandidateMailer, type: :mailer do
         name: 'Scott Knowles',
         email_address: 'ting@canpaint.com',
         application_form: build_stubbed(:application_form, first_name: 'Tyrell', last_name: 'Wellick'),
-)
+      )
+
+      magic_link_stubbing(@reference.application_form.candidate)
     end
 
     context 'when referee has not responded' do
-      it_behaves_like('a new reference request mail with subject and content', :not_responded,
-                      I18n.t!('candidate_mailer.new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'),
-                      'heading' => 'Dear Tyrell',
-                      'explanation' => I18n.t!('candidate_mailer.new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles'))
+      it_behaves_like(
+        'a new reference request mail with subject and content', :not_responded,
+        I18n.t!('candidate_mailer.new_referee_request.not_responded.subject', referee_name: 'Scott Knowles'),
+        'heading' => 'Dear Tyrell',
+        'explanation' => I18n.t!('candidate_mailer.new_referee_request.not_responded.explanation', referee_name: 'Scott Knowles')
+      )
     end
 
     context 'when referee has refused' do
-      it_behaves_like('a new reference request mail with subject and content', :refused,
-                      I18n.t!('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Scott Knowles'),
-                      'heading' => 'Dear Tyrell',
-                      'explanation' => I18n.t!('candidate_mailer.new_referee_request.refused.explanation', referee_name: 'Scott Knowles'))
+      it_behaves_like(
+        'a new reference request mail with subject and content', :refused,
+        I18n.t!('candidate_mailer.new_referee_request.refused.subject', referee_name: 'Scott Knowles'),
+        'heading' => 'Dear Tyrell',
+        'explanation' => I18n.t!('candidate_mailer.new_referee_request.refused.explanation', referee_name: 'Scott Knowles')
+      )
     end
 
     context 'when email address of referee has bounced' do
-      it_behaves_like('a new reference request mail with subject and content', :email_bounced,
-                      I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
-                      'heading' => 'Dear Tyrell',
-                      'explanation' => "Our email requesting a reference didn’t reach Scott Knowles.\r\n\r\nWe emailed the referee using this address: ting@canpaint.com")
+      it_behaves_like(
+        'a new reference request mail with subject and content', :email_bounced,
+        I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
+        'heading' => 'Dear Tyrell',
+        'explanation' => "Our email requesting a reference didn’t reach Scott Knowles.\r\n\r\nWe emailed the referee using this address: ting@canpaint.com"
+      )
     end
   end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -22,8 +22,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
   before do
     setup_application
-    allow(@candidate).to receive(:refresh_magic_link_token!).and_return('raw_token')
-    allow(@candidate).to receive(:encrypted_id).and_return('encrypted_id')
+    magic_link_stubbing(@candidate)
   end
 
   describe '.application_submitted' do

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe CandidateMailer, type: :mailer do
   include CourseOptionHelpers
-  include ViewHelper
   include TestHelpers::MailerSetupHelper
 
   subject(:mailer) { described_class }

--- a/spec/models/candidate_spec.rb
+++ b/spec/models/candidate_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Candidate, type: :model do
-  subject { create(:candidate) }
-
   describe 'a valid candidate' do
+    subject { create(:candidate) }
+
     it { is_expected.to validate_presence_of :email_address }
     it { is_expected.to validate_length_of(:email_address).is_at_most(100) }
     it { is_expected.to validate_uniqueness_of(:email_address).case_insensitive }
@@ -61,6 +61,42 @@ RSpec.describe Candidate, type: :model do
       candidate = create(:candidate)
 
       expect(candidate.course_from_find).to eq(nil)
+    end
+  end
+
+  describe '#refresh_magic_link_token!' do
+    let(:candidate) { create(:candidate) }
+    let(:magic_link_token) {
+      instance_double(
+        MagicLinkToken, raw: 'RAW', encrypted: 'ENCRYPTED'
+      )
+    }
+
+    before do
+      allow(MagicLinkToken).to receive(:new).and_return(magic_link_token)
+    end
+
+    it 'persists the encrypted token and refresh time' do
+      Timecop.freeze(Time.zone.local(1955, 11, 5)) do
+        candidate.refresh_magic_link_token!
+
+        expect(candidate.magic_link_token).to eq 'ENCRYPTED'
+        expect(candidate.magic_link_token_sent_at).to eq Time.zone.local(1955, 11, 5)
+      end
+    end
+
+    it 'returns the raw token' do
+      expect(candidate.refresh_magic_link_token!).to eq 'RAW'
+    end
+  end
+
+  describe '#encrypted_id' do
+    let(:candidate) { create(:candidate) }
+
+    it 'invokes Encryptor to encrypt id' do
+      allow(Encryptor).to receive(:encrypt).with(candidate.id).and_return 'encrypted id value'
+
+      expect(candidate.encrypted_id).to eq 'encrypted id value'
     end
   end
 end

--- a/spec/support/test_helpers/mailer_setup_helper.rb
+++ b/spec/support/test_helpers/mailer_setup_helper.rb
@@ -46,5 +46,10 @@ module TestHelpers
 
       application_form.application_choices = application_form.application_choices + [first_application_choice_with_offer, second_application_choice_with_offer]
     end
+
+    def magic_link_stubbing(candidate)
+      allow(candidate).to receive(:refresh_magic_link_token!).and_return('raw_token')
+      allow(candidate).to receive(:encrypted_id).and_return('encrypted_id')
+    end
   end
 end

--- a/spec/system/candidate_interface/application_choices_are_delivered_to_providers_spec.rb
+++ b/spec/system/candidate_interface/application_choices_are_delivered_to_providers_spec.rb
@@ -7,6 +7,8 @@ RSpec.feature 'Candidate application choices are delivered to providers' do
     when_my_application_is_delivered_to_the_provider
 
     then_i_should_receive_an_email_saying_my_application_is_under_consideration
+
+    and_i_can_sign_in_to_my_account_via_the_email
   end
 
   def given_my_application_is_ready_to_send_to_providers
@@ -21,5 +23,13 @@ RSpec.feature 'Candidate application choices are delivered to providers' do
     open_email(@application_choice.application_form.candidate.email_address)
 
     expect(current_email.subject).to end_with(t('candidate_mailer.application_sent_to_provider.subject'))
+  end
+
+  def and_i_can_sign_in_to_my_account_via_the_email
+    candidate = @application_choice.application_form.candidate
+    open_email(candidate.email_address)
+
+    current_email.find_css('a').first.click
+    expect(page).to have_content 'Application dashboard'
   end
 end

--- a/spec/system/candidate_interface/candidate_clicking_on_expired_magic_link_spec.rb
+++ b/spec/system/candidate_interface/candidate_clicking_on_expired_magic_link_spec.rb
@@ -1,27 +1,19 @@
 require 'rails_helper'
 
-RSpec.feature 'Candidate clicks on an expired link' do
+RSpec.feature 'Candidate clicks on an expired magic link' do
   scenario 'Candidate clicks on a link with an id and expired token link in an email' do
     given_the_pilot_is_open
     and_i_am_a_candidate_with_an_application
     and_i_received_the_submitted_application_email
 
-    when_i_click_on_the_sign_in_link_with_an_id
+    when_i_click_on_an_expired_magic_link
     then_i_am_redirected_to_the_expired_link_page
-
     when_i_click_the_button_to_send_me_a_sign_in_email
     then_i_receive_a_sign_in_email
     and_i_see_the_check_your_email_page
 
-    when_i_visit_the_sign_in_page_with_an_invalid_id_parameter
-    then_i_am_taken_to_the_sign_in_page
-
-    when_i_visit_the_expired_sign_in_page_without_u_parameter
-    then_i_am_taken_to_the_sign_in_page
-
     when_i_fill_in_the_sign_in_form
-
-    when_i_click_on_the_sign_in_link_with_token_after_one_hour
+    when_i_click_on_an_expired_magic_link
     then_i_am_redirected_to_the_expired_link_page
   end
 
@@ -38,9 +30,12 @@ RSpec.feature 'Candidate clicks on an expired link' do
     CandidateMailer.application_submitted(@application_form).deliver_now
   end
 
-  def when_i_click_on_the_sign_in_link_with_an_id
-    open_email(@candidate.email_address)
-    current_email.find_css('a').first.click
+  def when_i_click_on_an_expired_magic_link
+    Timecop.travel(Time.zone.now + 1.hour + 1.minute) do
+      open_email(@candidate.email_address)
+
+      current_email.find_css('a').first.click
+    end
   end
 
   def then_i_am_redirected_to_the_expired_link_page
@@ -60,28 +55,9 @@ RSpec.feature 'Candidate clicks on an expired link' do
     expect(page).to have_content('Check your email')
   end
 
-  def when_i_visit_the_sign_in_page_with_an_invalid_id_parameter
-    visit candidate_interface_sign_in_path(u: 'unencrypted_candidate_id')
-  end
-
-  def then_i_am_taken_to_the_sign_in_page
-    expect(page).to have_content(t('page_titles.sign_in'))
-  end
-
-  def when_i_visit_the_expired_sign_in_page_without_u_parameter
-    visit candidate_interface_expired_sign_in_path
-  end
-
   def when_i_fill_in_the_sign_in_form
+    visit candidate_interface_sign_in_path
     fill_in t('authentication.sign_up.email_address.label'), with: @candidate.email_address
     click_on 'Continue'
-  end
-
-  def when_i_click_on_the_sign_in_link_with_token_after_one_hour
-    Timecop.travel(Time.zone.now + 1.hour + 1.minute) do
-      open_email(@candidate.email_address)
-
-      current_email.find_css('a').first.click
-    end
   end
 end

--- a/spec/system/candidate_interface/decline_by_default_spec.rb
+++ b/spec/system/candidate_interface/decline_by_default_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Decline by default' do
     expected_subject = I18n.t('chase_candidate_decision_email.subject_singular')
     expect(current_email.subject).to include(expected_subject)
 
-    expect(current_email.body).to include('http://localhost:3000/candidate/sign-in')
+    expect(current_email.body).to include('http://localhost:3000/candidate/authenticate')
   end
 
   def and_when_the_decline_by_default_limit_has_been_exceeded


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
This helper is used by several CandidateMailer emails. Currently it
returns the URL for the sign in page, with an encrypted candidate id in
the params. This simply redirects candidates to an 'expired token' page
from where they have to click a button to get a magic link.
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
Improve this experience by changing the helper to return a magic
link instead, ie - an authentication endpoint with the encrypted candidate id
and a sign in token in the params. This allows the candidate to
authenticate immediately if they click the link before token expiry.
It's then only after token expiry that they see the 'expired token'
page.
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Submitting an application is probably the easiest way to see one of the CandidateMailer emails. 

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/ap98xn4c
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
