### PR TITLE
Remove group_providers_by_region feature flag

### DIFF
--- a/app/controllers/candidate_interface/content_controller.rb
+++ b/app/controllers/candidate_interface/content_controller.rb
@@ -22,23 +22,10 @@ module CandidateInterface
     RegionProviderCourses = Struct.new(:region_code, :provider_name, :courses)
 
     def providers
-      if FeatureFlag.active?('group_providers_by_region')
-        @courses_by_provider_and_region = courses_grouped_by_provider_and_region
-      else
-        @courses_by_provider = courses_grouped_by_provider
-      end
+      @courses_by_provider_and_region = courses_grouped_by_provider_and_region
     end
 
   private
-
-    def courses_grouped_by_provider
-      Course
-        .open_on_apply
-        .includes(:provider)
-        .group_by { |c| c.provider.name }
-        .sort_by { |provider_name, _| provider_name }
-        .map { |provider_name, courses| ProviderCourses.new(provider_name, courses) }
-    end
 
     def courses_grouped_by_provider_and_region
       Course

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -14,7 +14,6 @@ class FeatureFlag
     create_account_or_sign_in_page
     edit_course_choices
     equality_and_diversity
-    group_providers_by_region
     notes
     provider_add_provider_users
     provider_application_filters

--- a/app/views/candidate_interface/content/providers.html.erb
+++ b/app/views/candidate_interface/content/providers.html.erb
@@ -20,28 +20,6 @@
       <li>some of your chosen providers are not available on <%= service_name %> and you don’t want to use 2 different services.</li>
     </ul>
     <p class="govuk-body"><%= govuk_link_to 'Use UCAS', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do' %></p>
-
-    <% if FeatureFlag.active?('group_providers_by_region') %>
-      <%= render GroupedProviderCoursesComponent.new(courses_by_provider_and_region: @courses_by_provider_and_region) %>
-    <% else %>
-      <div class="govuk-accordion" data-module="govuk-accordion" id="accordion-default">
-        <% @courses_by_provider.each_with_index do |provider, index| %>
-          <section class="govuk-accordion__section">
-            <header class="govuk-accordion__section-header">
-              <h2 class="govuk-accordion__section-heading">
-                <span class="govuk-accordion__section-button" id="accordion-default-heading-<%= index %>"><%= provider.provider_name %></span>
-              </h2>
-            </header>
-            <div class="govuk-accordion__section-content" id="accordion-default-content-<%= index %>" aria-labelledby="accordion-default-heading-<%= index %>">
-              <ul class="govuk-list govuk-list--bullet">
-                <% provider.courses.sort_by(&:name).each do |course| %>
-                  <li><%= govuk_link_to course.name_and_code, course.find_url %></li>
-                <% end %>
-              </ul>
-            </div>
-          </section>
-        <% end %>
-      </div>
-    <% end %>
+    <%= render GroupedProviderCoursesComponent.new(courses_by_provider_and_region: @courses_by_provider_and_region) %>
   </div>
 </div>

--- a/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
@@ -9,20 +9,11 @@ RSpec.describe 'A candidate can view all providers and courses on Apply' do
     and_there_are_providers_with_courses_on_apply
 
     when_i_visit_the_available_courses_page
-    then_i_should_see_the_available_courses_grouped_by_providers
-
-    when_group_by_region_feature_is_active
-
-    when_i_visit_the_available_courses_page
     then_i_should_see_the_available_providers_grouped_by_region
   end
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def when_group_by_region_feature_is_active
-    FeatureFlag.activate('group_providers_by_region')
   end
 
   def and_the_create_account_or_sign_in_page_feature_flag_is_active
@@ -38,14 +29,6 @@ RSpec.describe 'A candidate can view all providers and courses on Apply' do
 
   def when_i_visit_the_available_courses_page
     visit candidate_interface_providers_path
-  end
-
-  def then_i_should_see_the_available_courses_grouped_by_providers
-    expect(page).not_to have_content 'South West'
-    expect(page).to have_content 'St Ives College'
-    expect(page).to have_content 'Mathematics'
-    expect(page).to have_content 'Chemistry'
-    expect(page).to have_content 'Physics'
   end
 
   def then_i_should_see_the_available_providers_grouped_by_region


### PR DESCRIPTION
## Context

This feature flag has been okayed to be removed

## Changes proposed in this pull request

- Remove group_providers_by_region feature flag

## Link to Trello card

https://trello.com/c/ikeQzOZ2/1408-retire-the-groupprovidersbyregion-feature-flag

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
