### PR TITLE
Remove check_full_courses feature flag

### DIFF
--- a/app/controllers/candidate_interface/course_choices_controller.rb
+++ b/app/controllers/candidate_interface/course_choices_controller.rb
@@ -84,7 +84,7 @@ module CandidateInterface
 
       if !@pick_course.open_on_apply?
         redirect_to candidate_interface_course_choices_ucas_with_course_path(@pick_course.provider_id, @pick_course.course_id)
-      elsif @pick_course.full? && FeatureFlag.active?('check_full_courses')
+      elsif @pick_course.full?
         redirect_to candidate_interface_course_choices_full_path(
           @pick_course.provider_id,
           @pick_course.course_id,

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,7 +9,6 @@ class FeatureFlag
 
   TEMPORARY_FEATURE_FLAGS = %w[
     candidate_can_cancel_reference
-    check_full_courses
     confirm_conditions
     create_account_or_sign_in_page
     edit_course_choices

--- a/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_selecting_a_course_that_is_full_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Selecting a full course' do
   include CandidateHelper
 
   scenario 'Candidate selects a full course' do
-    given_check_full_courses_is_active
     given_i_am_signed_in
     and_there_is_a_full_course
     when_i_select_the_full_course
@@ -13,10 +12,6 @@ RSpec.describe 'Selecting a full course' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def given_check_full_courses_is_active
-    FeatureFlag.activate('check_full_courses')
   end
 
   def and_there_is_a_full_course


### PR DESCRIPTION
## Context

This feature flag has been okayed to be removed

## Changes proposed in this pull request

- Remove check_full_courses feature flag

## Link to Trello card

https://trello.com/c/ikeQzOZ2/1408-retire-the-groupprovidersbyregion-feature-flag

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
