### PR TITLE
Better expose unavailable courses in Support

### DIFF
--- a/app/components/support_interface/application_choice_component.html.erb
+++ b/app/components/support_interface/application_choice_component.html.erb
@@ -1,0 +1,43 @@
+<% course_name_and_status = capture do %>
+  <%= govuk_link_to(
+    application_choice.offered_course.name_and_code,
+    support_interface_course_path(application_choice.offered_course)
+  ) %>
+
+  <% if application_choice.course_not_available? %>
+    <%= render TagComponent.new(text: 'Course removed from Find', type: 'yellow') %>
+  <% end %>
+
+  <% if application_choice.course_closed_on_apply? %>
+    <%= render TagComponent.new(text: 'Course closed on Apply', type: 'yellow') %>
+  <% end %>
+
+  <% if application_choice.course_full? %>
+    <%= render TagComponent.new(text: 'Course is full', type: 'yellow') %>
+  <% end %>
+<% end %>
+
+<% location_and_status = capture do %>
+  <%= application_choice.offered_option.site.name_and_code %>
+
+  <% if application_choice.chosen_site_full? %>
+    <%= render TagComponent.new(text: 'No vacancies at location', type: 'yellow') %>
+  <% end %>
+<% end %>
+
+<% rows = [
+  { key: 'Provider', value: govuk_link_to(application_choice.offered_course.provider.name_and_code, support_interface_provider_path(application_choice.offered_course.provider)) },
+  { key: 'Course', value: course_name_and_status },
+  { key: 'Location', value: location_and_status },
+  { key: 'Study mode', value: application_choice.offered_option.study_mode.humanize },
+  { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) },
+] %>
+
+<% rows << { key: 'Reason for rejection', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>
+<% rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at %>
+<% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at %>
+<% rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at %>
+
+<%= render SummaryCardComponent.new(rows: rows) do %>
+  <%= render SummaryCardHeaderComponent.new(title: "Application choice ##{application_choice.id}") %>
+<% end %>

--- a/app/components/support_interface/application_choice_component.rb
+++ b/app/components/support_interface/application_choice_component.rb
@@ -1,0 +1,11 @@
+module SupportInterface
+  class ApplicationChoiceComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :application_choice
+
+    def initialize(application_choice)
+      @application_choice = application_choice
+    end
+  end
+end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -36,20 +36,7 @@
 <% if @application_form.application_choices.any? %>
   <h2 class="govuk-heading-l govuk-!-margin-top-8">Course choices</h2>
   <% @application_form.application_choices.includes(:course, :provider, :site, :offered_course_option).each do |application_choice| %>
-    <% rows = [
-      { key: 'Course', value: govuk_link_to(application_choice.offered_course.name_and_code, support_interface_course_path(application_choice.offered_course)) },
-      { key: 'Provider', value: govuk_link_to(application_choice.offered_course.provider.name_and_code, support_interface_provider_path(application_choice.offered_course.provider)) },
-      { key: 'Location', value: application_choice.offered_option.site.name_and_code },
-      { key: 'Status', value: render(SupportInterface::ApplicationStatusTagComponent.new(application_choice: application_choice)) },
-    ] %>
-    <% rows << { key: 'Reason for rejection', value: application_choice.rejection_reason } if application_choice.rejection_reason.present? %>
-    <% rows << { key: 'Sent to provider at', value: application_choice.sent_to_provider_at.to_s(:govuk_date_and_time) } if application_choice.sent_to_provider_at %>
-    <% rows << { key: 'Reject by default at', value: application_choice.reject_by_default_at.to_s(:govuk_date_and_time) } if application_choice.reject_by_default_at %>
-    <% rows << { key: 'Decline by default at', value: application_choice.decline_by_default_at.to_s(:govuk_date_and_time) } if application_choice.decline_by_default_at %>
-
-    <%= render SummaryCardComponent.new(rows: rows) do %>
-      <%= render SummaryCardHeaderComponent.new(title: application_choice.offered_course.name_and_code) %>
-    <% end %>
+    <%= render SupportInterface::ApplicationChoiceComponent.new(application_choice) %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
## Context

When a course becomes unavailble, we show this to candidates (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1841).

## Changes proposed in this pull request

This exposes the same information in the support UI - but for applications in all states, not just when they're unsubmitted.

It also extracts a component to make the change easier, and adds the missing "study mode" attribute to the table.

### Before

![image](https://user-images.githubusercontent.com/233676/80687145-c3694a00-8ac1-11ea-8163-89d308b1e0c2.png)

### After

It looks like this when *everything* is wrong (this will never happen in practice):

![image](https://user-images.githubusercontent.com/233676/80687053-987ef600-8ac1-11ea-9ea0-3c3f8da5ddd2.png)


## Guidance to review


## Link to Trello card

https://trello.com/c/fRAKJt36

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
