### PR TITLE
Remove create_account_or_sign_in_page feature flag

### DIFF
--- a/app/controllers/candidate_interface/apply_from_find_controller.rb
+++ b/app/controllers/candidate_interface/apply_from_find_controller.rb
@@ -33,14 +33,10 @@ module CandidateInterface
 
       if @apply_on_ucas_or_apply.valid?
         if @apply_on_ucas_or_apply.apply?
-          if FeatureFlag.active?('create_account_or_sign_in_page')
-            redirect_to candidate_interface_create_account_or_sign_in_path(
-              providerCode: @apply_on_ucas_or_apply.provider_code,
-              courseCode: @apply_on_ucas_or_apply.course_code,
-            )
-          else
-            redirect_to candidate_interface_eligibility_path(providerCode: @apply_on_ucas_or_apply.provider_code, courseCode: @apply_on_ucas_or_apply.course_code)
-          end
+          redirect_to candidate_interface_create_account_or_sign_in_path(
+            providerCode: @apply_on_ucas_or_apply.provider_code,
+            courseCode: @apply_on_ucas_or_apply.course_code,
+          )
         else
           redirect_to UCAS.apply_url
         end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -10,7 +10,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = %w[
     candidate_can_cancel_reference
     confirm_conditions
-    create_account_or_sign_in_page
     download_dataset1_from_support_page
     edit_course_choices
     equality_and_diversity

--- a/app/views/candidate_interface/start_page/show.html.erb
+++ b/app/views/candidate_interface/start_page/show.html.erb
@@ -33,17 +33,11 @@
       <%= govuk_link_to('Learn more about eligibility for teacher training', 'https://getintoteaching.education.gov.uk/eligibility-for-teacher-training', target: :_blank) %>.
     </p>
 
-    <% start_location = FeatureFlag.active?('create_account_or_sign_in_page') ? candidate_interface_create_account_or_sign_in_path : candidate_interface_eligibility_path %>
-    <%= link_to start_location, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-4 govuk-button--start', 'data-module': 'govuk-button' do %>
+    <%= link_to candidate_interface_create_account_or_sign_in_path, role: 'button', class: 'govuk-button govuk-!-margin-top-4 govuk-!-margin-bottom-4 govuk-button--start', 'data-module': 'govuk-button' do %>
       <%= t('application_form.begin_button') %>
       <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
         <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
       </svg>
-    <% end %>
-
-    <% unless FeatureFlag.active?('create_account_or_sign_in_page') %>
-      <p class="govuk-body">or</p>
-      <p class="govuk-body"><%= govuk_link_to 'Sign in to an existing application', candidate_interface_sign_in_path %></p>
     <% end %>
   </div>
 </div>

--- a/spec/system/candidate_interface/candidate_eligibility_spec.rb
+++ b/spec/system/candidate_interface/candidate_eligibility_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Candidate eligibility' do
   scenario 'Candidate confirms that they are eligible' do
     given_the_pilot_is_open
-    and_the_create_account_or_sign_in_page_feature_flag_is_active
 
     when_i_click_start_on_the_start_page
     and_i_confirm_i_am_not_already_signed_up
@@ -20,10 +19,6 @@ RSpec.feature 'Candidate eligibility' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_create_account_or_sign_in_page_feature_flag_is_active
-    FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
   def when_i_click_start_on_the_start_page

--- a/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
+++ b/spec/system/candidate_interface/candidate_is_redirected_to_before_you_start_page_on_first_sign_in_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'A new candidate is encouraged to select a course' do
   scenario 'Candidate is redirected to the before you start page on their first sign in' do
     given_the_pilot_is_open
-    and_the_create_account_or_sign_in_page_feature_flag_is_active
 
     when_i_visit_apply
     and_i_click_start_now
@@ -45,10 +44,6 @@ RSpec.feature 'A new candidate is encouraged to select a course' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_create_account_or_sign_in_page_feature_flag_is_active
-    FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
   def when_i_visit_apply

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
   scenario 'Candidate signs in and receives an email inviting them to sign up' do
     given_the_pilot_is_open
     and_the_covid_19_feature_flag_is_active
-    and_the_create_account_or_sign_in_page_feature_flag_is_active
 
     given_i_am_a_candidate_without_an_account
 
@@ -36,10 +35,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
 
   def and_the_covid_19_feature_flag_is_active
     FeatureFlag.activate('covid_19')
-  end
-
-  def and_the_create_account_or_sign_in_page_feature_flag_is_active
-    FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
   def given_i_am_a_candidate_without_an_account

--- a/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_apply_from_find_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   scenario 'seeing their course information on the landing page' do
     given_the_pilot_is_open
-    and_the_create_account_or_sign_in_page_feature_flag_is_active
 
     when_i_arrive_from_find_with_invalid_course_parameters
     then_i_should_see_an_error_page
@@ -44,10 +43,6 @@ RSpec.describe 'A candidate arriving from Find with a course and provider code' 
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_create_account_or_sign_in_page_feature_flag_is_active
-    FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
   def when_i_arrive_from_find_with_invalid_course_parameters

--- a/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_existing_user_with_course_params_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
   include CourseOptionHelpers
   scenario 'candidate is not signed in and retains their course selection through the sign in process' do
     given_the_pilot_is_open
-    and_the_create_account_or_sign_in_page_feature_flag_is_active
 
     # Single site course
     and_i_am_an_existing_candidate_on_apply
@@ -58,10 +57,6 @@ RSpec.describe 'An existing candidate arriving from Find with a course and provi
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_create_account_or_sign_in_page_feature_flag_is_active
-    FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
   def and_the_course_i_selected_only_has_one_site

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_and_cancel_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Candidate tries to sign in after selecting a course in find without an account then says no to selecting the course' do
   scenario 'Candidate signs in and recieves an email inviting them to sign up and is prompted to select the course' do
     given_the_pilot_is_open
-    and_the_create_account_or_sign_in_page_feature_flag_is_active
 
     given_i_am_a_candidate_without_an_account
     and_there_is_a_course_with_multiple_sites
@@ -25,10 +24,6 @@ RSpec.feature 'Candidate tries to sign in after selecting a course in find witho
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_create_account_or_sign_in_page_feature_flag_is_active
-    FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
   def given_i_am_a_candidate_without_an_account

--- a/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_new_user_with_course_params_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
 
     when_i_arrive_from_find_to_a_course_that_is_open_on_apply
     and_i_choose_to_apply_on_apply
+    and_i_choose_i_need_an_account
 
     when_i_fill_in_the_eligiblity_form_with_yes
 
@@ -65,6 +66,11 @@ RSpec.describe 'A new candidate arriving from Find with a course and provider co
 
   def and_i_choose_to_apply_on_apply
     choose 'Yes, I want to apply using the new service'
+    click_on 'Continue'
+  end
+
+  def and_i_choose_i_need_an_account
+    choose 'No, I need to create an account'
     click_on 'Continue'
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_view_available_courses_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'A candidate can view all providers and courses on Apply' do
 
   scenario 'seeing the list of courses grouped by provider and region' do
     given_the_pilot_is_open
-    and_the_create_account_or_sign_in_page_feature_flag_is_active
     and_there_are_providers_with_courses_on_apply
 
     when_i_visit_the_available_courses_page
@@ -14,10 +13,6 @@ RSpec.describe 'A candidate can view all providers and courses on Apply' do
 
   def given_the_pilot_is_open
     FeatureFlag.activate('pilot_open')
-  end
-
-  def and_the_create_account_or_sign_in_page_feature_flag_is_active
-    FeatureFlag.activate('create_account_or_sign_in_page')
   end
 
   def and_there_are_providers_with_courses_on_apply


### PR DESCRIPTION
## Context

This feature flag has been okayed to be removed

## Changes proposed in this pull request

- Remove create_account_or_sign_in_page feature flag

## Link to Trello card

https://trello.com/c/5HQsECxf/1411-retire-the-createaccountorsigninpage-feature-flag

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
