### PR TITLE
Remove missed code from unless block

### DIFF
--- a/app/views/candidate_interface/course_choices/review.html.erb
+++ b/app/views/candidate_interface/course_choices/review.html.erb
@@ -14,8 +14,6 @@
     <div class="govuk-grid-column-two-thirds">
       <% if @course_choices.count.present? %>
         <% if @course_choices.count.between?(1, 2) %>
-          <h2 class="govuk-heading-m">Do you want to add another course?</h2>
-          <%= render 'guidance' %>
           <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
         <% end %>
 


### PR DESCRIPTION
## Context

While removing the add_additional_courses feature flag a block of code between an unless block was accidentally not removed.

## Changes proposed in this pull request

-Remove the block

## Link to Trello card

https://trello.com/c/Cj3BIcVy/1409-remove-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
