### PR TITLE
Docker build performance improvments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ ARG DEV_PACKAGES="postgresql-dev git nodejs yarn graphviz ttf-ubuntu-font-family
 ARG RUBY_PACKAGES="tzdata"
 ARG bundleWithout=""
 
-ENV BUNDLER_VERSION="2.0.2"
-ENV BUNDLE_PATH="/gems"
-ENV BUNDLE_WITHOUT=${bundleWithout}
-ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine
+ENV BUNDLER_VERSION="2.1.4" \
+    BUNDLE_PATH="/gems" \
+    BUNDLE_WITHOUT=${bundleWithout} \
+    WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine
 
 RUN apk update && \
     apk upgrade && \
@@ -48,20 +48,21 @@ CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0
 FROM common-build-env AS prod-minify
 
 ARG APP_HOME=/app
+ARG GEM_PATH=ruby/2.6.0/
 
-ENV RAILS_ENV=production
 # These variables are required for running Rails processes like assets:precompile
-ENV GOVUK_NOTIFY_API_KEY=TestKey
-ENV AUTHORISED_HOSTS=dummy.build.domain
-ENV SECRET_KEY_BASE=TestKey
-ENV GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey
+ENV RAILS_ENV=production \
+    GOVUK_NOTIFY_API_KEY=TestKey \
+    AUTHORISED_HOSTS=dummy.build.domain \
+    SECRET_KEY_BASE=TestKey \
+    GOVUK_NOTIFY_CALLBACK_API_KEY=TestKey
 
 WORKDIR $APP_HOME
 
-RUN rm -rf $BUNDLE_PATH/cache/*.gem && \
-    find $BUNDLE_PATH/gems/ -name "*.c" -delete && \
-    find $BUNDLE_PATH/gems/ -name "*.h" -delete && \
-    find $BUNDLE_PATH/gems/ -name "*.o" -delete
+RUN rm -rf $BUNDLE_PATH/$GEM_PATH/cache/*.gem && \
+    find $BUNDLE_PATH/$GEM_PATH/gems -name "*.c" -delete && \
+    find $BUNDLE_PATH/$GEM_PATH/gems -name "*.h" -delete && \
+    find $BUNDLE_PATH/$GEM_PATH/gems -name "*.o" -delete
 
 COPY . .
 
@@ -77,11 +78,11 @@ ARG bundleWithout=""
 ARG APP_HOME=/app
 ARG PACKAGES="tzdata postgresql-client graphviz"
 
-ENV RAILS_ENV=production
-ENV BUNDLE_WITHOUT=${bundleWithout}
-ENV BUNDLE_PATH="/gems"
-ENV BUNDLER_VERSION="2.0.2"
-ENV WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine
+ENV RAILS_ENV=production \
+    BUNDLE_WITHOUT=${bundleWithout} \
+    BUNDLE_PATH="/gems" \
+    BUNDLER_VERSION="2.1.4" \
+    WKHTMLTOPDF_GEM=wkhtmltopdf-binary-edge-alpine
 
 WORKDIR $APP_HOME
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ setup: build ## Set up a clean database and node_modules folder for running the 
 .PHONY: az_setup
 az_setup: ## Set up a clean database and node_modules folder for running the app or the specs in docker
 	touch .env ## Create an empty .env file if it doesn't exist
-	docker-compose run --rm web /bin/sh -c "bundle exec rake db:setup"
+	docker-compose run --rm web bundle exec rake db:setup
 
 .PHONY: test
 test: ## Run the linters and specs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ variables:
 - group: APPLY - Shared Variables
 - name: imageName
   value: 'apply-for-postgraduate-teacher-training'
+- name: pipelineDockerCachePath
+  value: $(Pipeline.Workspace)/.docker
 - name: debug
   value: true
 - name: deployOnly
@@ -37,14 +39,48 @@ stages:
         echo '##vso[task.setvariable variable=compose_file]docker-compose.yml:docker-compose.azure.yml'
         docker_path=$(dockerHubUsername)/$(imageName)
         echo "##vso[task.setvariable variable=docker_path;]$docker_path"
+        mkdir $(pipelineDockerCachePath)
       displayName: 'Configure build environment'
 
-    - script: docker pull $(docker_path):build || true
-      displayName: 'Pull cached intermediate Docker images'
+    - task: Cache@2
+      inputs:
+        key: 'docker | "$(Agent.OS)" | ./Gemfile | ./Gemfile.lock | ./package.json | ./yarn.lock | ./Dockerfile'
+        restoreKeys: |
+          docker | "$(Agent.OS)"
+          docker
+        path: $(pipelineDockerCachePath)
+        cacheHitVar: DOCKER_CACHE_RESTORED
+      displayName: 'Docker image cache'
+      condition: eq(variables.dockerCacheEnable, 'true')
 
-    - script: make build
+    - script: |
+        echo "Loading images from pipeline cache if present..."
+        if [ $(find $(pipelineDockerCachePath) -name "*.tar.gz" | wc -l) -gt 0 ]
+        then
+          #Load images from cache if present
+          for archive in $(find $(pipelineDockerCachePath) -name "*.tar.gz")
+          do
+            docker load < $archive
+          done
+          #Tag images from reference file
+          while read REPOSITORY TAG IMAGE_ID
+          do 
+            docker tag "$IMAGE_ID" "$REPOSITORY:$TAG"
+          done < $(pipelineDockerCachePath)/images_manifest.txt
+  
+          echo "Cached images loaded."
+        else
+          echo "No images file found in local cache."
+        fi
+      displayName: 'Load Docker images from pipeline cache'
+      condition: and(eq(variables.DOCKER_CACHE_RESTORED, 'true'), eq(variables.dockerCacheEnable, 'true'))
+
+    - script: |
+         make build
       displayName: 'Build Docker image'
       env:
+        DOCKER_BUILDKIT: $(dockerBuildkitState)
+        COMPOSE_DOCKER_CLI_BUILD: $(dockerBuildkitState)
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         railsSecretKeyBase: $(railsSecretKeyBase)
@@ -57,9 +93,15 @@ stages:
 
     - script: |
         mkdir $(System.DefaultWorkingDirectory)/docker_images
-        docker save $(dockerHubUsername)/$(imageName) | gzip > $(System.DefaultWorkingDirectory)/docker_images/$(imageName)_images.tar.gz
+        docker save $(docker history -q $(dockerHubUsername)/$(imageName) | grep -v "<missing>") | gzip > $(System.DefaultWorkingDirectory)/docker_images/$(imageName).tar.gz
         docker images $(dockerHubUsername)/$(imageName) | sed 1d | awk '{print $1 " " $2 " " $3}' > $(System.DefaultWorkingDirectory)/docker_images/images_manifest.txt
-      displayName: 'Export Docker image'
+      displayName: 'Export Docker image pipeline artifact'
+      condition: succeeded()
+
+    - script: |
+        cp $(System.DefaultWorkingDirectory)/docker_images/$(imageName).tar.gz $(System.DefaultWorkingDirectory)/docker_images/images_manifest.txt $(pipelineDockerCachePath)/
+      displayName: 'Update Docker pipeline cache'
+      condition: and(succeeded(), ne(variables.DOCKER_CACHE_RESTORED, 'true'), eq(variables.dockerCacheEnable, 'true'))
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Docker image artifact'
@@ -95,7 +137,7 @@ stages:
         artifact: 'docker_artifacts'
 
     - script: |
-        docker load < $(Pipeline.Workspace)/$(imageName)_images.tar.gz
+        docker load < $(Pipeline.Workspace)/$(imageName).tar.gz
         while read REPOSITORY TAG IMAGE_ID
         do
            docker tag "$IMAGE_ID" "$REPOSITORY:$TAG"
@@ -103,6 +145,8 @@ stages:
         make az_setup
       displayName: 'Load Docker image & setup container'
       env:
+        DOCKER_BUILDKIT: $(dockerBuildkitState)
+        COMPOSE_DOCKER_CLI_BUILD: $(dockerBuildkitState)
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         railsSecretKeyBase: $(railsSecretKeyBase)
@@ -227,7 +271,7 @@ stages:
         artifact: 'docker_artifacts'
 
     - script: |
-        docker load < $(Pipeline.Workspace)/$(imageName)_images.tar.gz
+        docker load < $(Pipeline.Workspace)/$(imageName).tar.gz
         while read REPOSITORY TAG IMAGE_ID
         do
            docker tag "$IMAGE_ID" "$REPOSITORY:$TAG"
@@ -235,6 +279,8 @@ stages:
         make az_setup
       displayName: 'Load Docker image & setup container'
       env:
+        DOCKER_BUILDKIT: $(dockerBuildkitState)
+        COMPOSE_DOCKER_CLI_BUILD: $(dockerBuildkitState)
         dockerHubUsername: $(dockerHubUsername)
         dockerHubImageName: $(imageName)
         railsSecretKeyBase: $(railsSecretKeyBase)
@@ -318,7 +364,7 @@ stages:
         artifact: 'docker_artifacts'
 
     - script: |
-        docker load < $(Pipeline.Workspace)/$(imageName)_images.tar.gz
+        docker load < $(Pipeline.Workspace)/$(imageName).tar.gz
         while read REPOSITORY TAG IMAGE_ID
         do
            docker tag "$IMAGE_ID" "$REPOSITORY:$TAG"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,39 +42,6 @@ stages:
         mkdir $(pipelineDockerCachePath)
       displayName: 'Configure build environment'
 
-    - task: Cache@2
-      inputs:
-        key: 'docker | "$(Agent.OS)" | ./Gemfile | ./Gemfile.lock | ./package.json | ./yarn.lock | ./Dockerfile'
-        restoreKeys: |
-          docker | "$(Agent.OS)"
-          docker
-        path: $(pipelineDockerCachePath)
-        cacheHitVar: DOCKER_CACHE_RESTORED
-      displayName: 'Docker image cache'
-      condition: eq(variables.dockerCacheEnable, 'true')
-
-    - script: |
-        echo "Loading images from pipeline cache if present..."
-        if [ $(find $(pipelineDockerCachePath) -name "*.tar.gz" | wc -l) -gt 0 ]
-        then
-          #Load images from cache if present
-          for archive in $(find $(pipelineDockerCachePath) -name "*.tar.gz")
-          do
-            docker load < $archive
-          done
-          #Tag images from reference file
-          while read REPOSITORY TAG IMAGE_ID
-          do 
-            docker tag "$IMAGE_ID" "$REPOSITORY:$TAG"
-          done < $(pipelineDockerCachePath)/images_manifest.txt
-  
-          echo "Cached images loaded."
-        else
-          echo "No images file found in local cache."
-        fi
-      displayName: 'Load Docker images from pipeline cache'
-      condition: and(eq(variables.DOCKER_CACHE_RESTORED, 'true'), eq(variables.dockerCacheEnable, 'true'))
-
     - script: |
          make build
       displayName: 'Build Docker image'
@@ -97,11 +64,6 @@ stages:
         docker images $(dockerHubUsername)/$(imageName) | sed 1d | awk '{print $1 " " $2 " " $3}' > $(System.DefaultWorkingDirectory)/docker_images/images_manifest.txt
       displayName: 'Export Docker image pipeline artifact'
       condition: succeeded()
-
-    - script: |
-        cp $(System.DefaultWorkingDirectory)/docker_images/$(imageName).tar.gz $(System.DefaultWorkingDirectory)/docker_images/images_manifest.txt $(pipelineDockerCachePath)/
-      displayName: 'Update Docker pipeline cache'
-      condition: and(succeeded(), ne(variables.DOCKER_CACHE_RESTORED, 'true'), eq(variables.dockerCacheEnable, 'true'))
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Docker image artifact'


### PR DESCRIPTION
## Context

The build pipeline duration has steadily been increasing in duration and this PR aims to stem some of that creep in duration with optimisations to the build pipeline stage.

## Changes proposed in this pull request

Two key introductions:
1. Added BuildKit - This feature allows parallel building of stages in a multi stage Docker image. This option can be turned on/off by setting the `dockerBuildkitState` variable to 1/0 respectively in the pipeline variables. This is configured in the `APPLY - Shared Variables` variable group in AZDO. Enabling this feature knocks approximately two minutes off the build.
1. ~~Added Docker image caching feature - This feature is configurable by setting the `dockerCacheEnable` variable to true/false in the `APPLY - Shared Variables` variable group in AZDO. This feature when enabled will save the docker image and its intermediate layers to a file stored in an Azure pipeline cache which can then be loaded at the start of subsequent builds to save having to install the gems and run Bundler unnecessarily every time on a given branch. The cache will only update if any of the `Dockerfile`, `Gemfile` or `package.json` files change. Local testing showed this to save as much as another three minutes from the build pipeline. At present this feature is currently disabled because AZDO agents are configured to immediately remove all intermediate layers when a build completes meaning caching can't be leveraged on subsequent runs at present, however should this change the feature can easily be turned on.~~
1. Upversion Bundler to 2.1.4 to remove a warning that was present in the builds
1. Optimised the Dockerfile to remove unnecessary levels of layers from the build cache.

## Guidance to review

Builds from this branch can be seen here: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build?definitionId=49&_a=summary&repositoryFilter=37&branchFilter=8449

## Link to Trello card

https://trello.com/c/UWxiLzcl/1190-reduce-duration-of-devops-pipeline-build-stage

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
