### PR TITLE
Switch codebase to use CourseOption#site_still_valid

### DIFF
--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -9,7 +9,7 @@ class CourseOption < ApplicationRecord
   validates :vacancy_status, presence: true
   validate :validate_providers
 
-  scope :selectable, -> { where(invalidated_by_find: false) }
+  scope :selectable, -> { where(site_still_valid: true) }
 
   enum study_mode: {
     full_time: 'full_time',
@@ -41,10 +41,16 @@ class CourseOption < ApplicationRecord
     course.course_options.vacancies.blank?
   end
 
+  # >> Temporary methods - to be removed
   def invalidated_by_find=(value)
     self[:invalidated_by_find] = value
     if self.attributes.keys.include? 'site_still_valid'
       self[:site_still_valid] = !value
     end
   end
+
+  def self.columns
+    super.reject { |c| c.name == 'invalidated_by_find' }
+  end
+  # <<
 end

--- a/app/services/support_interface/application_monitor.rb
+++ b/app/services/support_interface/application_monitor.rb
@@ -14,7 +14,7 @@ module SupportInterface
 
     def applications_to_removed_sites
       active_applications.where(
-        course_option: CourseOption.where(invalidated_by_find: true),
+        course_option: CourseOption.where(site_still_valid: false),
       ).map(&:application_form)
     end
 

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -157,12 +157,12 @@ private
     return if part_of_an_application.size.zero?
 
     part_of_an_application.each do |course_option|
-      unless course_option.invalidated_by_find
+      if course_option.site_still_valid
         Raven.capture_message(
           "Course option #{course_option.id}, which is chosen by candidates, is now invalid.",
         )
       end
-      course_option.update!(invalidated_by_find: true)
+      course_option.update!(site_still_valid: false)
     end
   end
 

--- a/db/migrate/20200428202959_sync_data_between_invalidated_by_find_and_site_still_valid.rb
+++ b/db/migrate/20200428202959_sync_data_between_invalidated_by_find_and_site_still_valid.rb
@@ -1,0 +1,9 @@
+class SyncDataBetweenInvalidatedByFindAndSiteStillValid < ActiveRecord::Migration[6.0]
+  def up
+    execute('UPDATE course_options SET site_still_valid = NOT invalidated_by_find')
+  end
+
+  def down
+    execute('UPDATE course_options SET site_still_valid = true')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_28_093710) do
+ActiveRecord::Schema.define(version: 2020_04_28_202959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe CourseOption, type: :model do
   describe '.selectable' do
     subject(:course_option) { create(:course_option) }
 
-    it 'returns only course options where invalidated_by_find is false' do
-      expected_course_option = create(:course_option, invalidated_by_find: false)
-      create(:course_option, invalidated_by_find: true)
+    it 'returns only course options where site_still_valid is true' do
+      expected_course_option = create(:course_option, site_still_valid: true)
+      create(:course_option, site_still_valid: false)
 
       expect(CourseOption.selectable).to match_array [expected_course_option]
     end

--- a/spec/services/support_interface/application_monitor_spec.rb
+++ b/spec/services/support_interface/application_monitor_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe SupportInterface::ApplicationMonitor do
 
   describe '#applications_to_removed_sites' do
     it 'returns applications to sites that have been removed from Find' do
-      with_okay_site = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: false))
-      with_removed_site = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, invalidated_by_find: true))
+      with_okay_site = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, site_still_valid: true))
+      with_removed_site = create(:application_choice, status: 'awaiting_provider_decision', course_option: create(:course_option, site_still_valid: false))
 
       applications = described_class.new.applications_to_removed_sites
 

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -181,8 +181,8 @@ RSpec.describe SyncProviderFromFind do
         SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
         expect(CourseOption.exists?(invalid_course_option_one.id)).to eq false
-        expect(invalid_course_option_two.reload).to be_invalidated_by_find
-        expect(valid_course_option.reload).not_to be_invalidated_by_find
+        expect(invalid_course_option_two.reload).not_to be_site_still_valid
+        expect(valid_course_option.reload).to be_site_still_valid
         expect(Raven).to have_received(:capture_message).with(/is now invalid/)
       end
 

--- a/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
+++ b/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe 'Sync from find' do
     and_raven_can_capture_exceptions
 
     when_find_says_that_a_site_is_no_longer_listed_for_that_course
-    and_that_site_is_part_of_an_application
+    and_the_course_option_for_that_site_is_part_of_an_application
     and_sync_provider_from_find_is_called
-    then_the_affected_course_options_invalidated_by_find_attribute_is_set_to_true
+    then_the_affected_course_option_indicates_that_the_site_is_no_longer_valid
     and_raven_captures_an_exception
   end
 
@@ -50,7 +50,7 @@ RSpec.describe 'Sync from find' do
     when_sync_provider_from_find_is_called
   end
 
-  def and_that_site_is_part_of_an_application
+  def and_the_course_option_for_that_site_is_part_of_an_application
     @course_option = @provider.courses.first.course_options.last
     create(:application_choice, course_option: @course_option)
   end
@@ -63,9 +63,9 @@ RSpec.describe 'Sync from find' do
     allow(Raven).to receive(:capture_message)
   end
 
-  def then_the_affected_course_options_invalidated_by_find_attribute_is_set_to_true
+  def then_the_affected_course_option_indicates_that_the_site_is_no_longer_valid
     expect(@provider.courses.first.course_options.count).to eq 2
-    expect(@course_option.reload.invalidated_by_find).to eq true
+    expect(@course_option.reload.site_still_valid).to eq false
   end
 
   def and_raven_captures_an_exception


### PR DESCRIPTION
~~**DO NOT MERGE UNTIL https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1966 DEPLOYED**~~

## Context
We're renaming invalidated_by_find to site_still_valid so it's clearer
what the purpose of this field is.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

To avoid errors in the frontend and the Find API sync, deploy in three
steps.

1. Add a column with the new name and ensure we write to both when
   updating a record.
2. Migrate old data to new column, and introduce code changes that use
   the new column.
3. Remove old column.

This commit is step 2. It also includes code to ignore
invalidated_by_find from the CourseOption column list, ensuring it
doesn't appear in cached schema definitions.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/IjTL2YNR
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
