### PR TITLE
Remove CourseOption#invalidated_by_find

### DIFF
--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -40,17 +40,4 @@ class CourseOption < ApplicationRecord
   def course_full?
     course.course_options.vacancies.blank?
   end
-
-  # >> Temporary methods - to be removed
-  def invalidated_by_find=(value)
-    self[:invalidated_by_find] = value
-    if attributes.keys.include? 'site_still_valid'
-      self[:site_still_valid] = !value
-    end
-  end
-
-  def self.columns
-    super.reject { |c| c.name == 'invalidated_by_find' }
-  end
-  # <<
 end

--- a/db/migrate/20200501124618_drop_invalidated_by_find_from_course_options.rb
+++ b/db/migrate/20200501124618_drop_invalidated_by_find_from_course_options.rb
@@ -1,0 +1,11 @@
+class DropInvalidatedByFindFromCourseOptions < ActiveRecord::Migration[6.0]
+  def up
+    remove_column :course_options, :invalidated_by_find
+  end
+
+  def down
+    change_table :course_options do |table|
+      table.column :invalidated_by_find, :boolean, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_01_111039) do
+ActiveRecord::Schema.define(version: 2020_05_01_124618) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -189,7 +189,6 @@ ActiveRecord::Schema.define(version: 2020_05_01_111039) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "study_mode", default: "full_time", null: false
-    t.boolean "invalidated_by_find", default: false
     t.boolean "site_still_valid", default: true, null: false
     t.index ["course_id"], name: "index_course_options_on_course_id"
     t.index ["site_id", "course_id", "study_mode"], name: "index_course_options_on_site_id_and_course_id_and_study_mode", unique: true


### PR DESCRIPTION
**DO NOT MERGE UNTIL https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1983 DEPLOYED**

## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We're renaming invalidated_by_find to site_still_valid so it's clearer
what the purpose of this field is.


## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

To avoid errors in the frontend and the Find API sync, deploy in three
steps.

1. Add a column with the new name and ensure we write to both when
   updating a record.
2. Migrate old data to new column, and introduce code changes that use
   the new column.
3. Remove old column.

This commit is step 3. Also removes temporary methods added to aid
migration.
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/IjTL2YNR
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
