### PR TITLE
add new field funding_type to course factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -256,7 +256,7 @@ FactoryBot.define do
     age_range { '4 to 8' }
 
     subject_codes { [Faker::Alphanumeric.alphanumeric(number: 2, min_alpha: 1).upcase] }
-    funding_type { ['fee', 'salary', 'apprenticeship'].sample }
+    funding_type { %w[fee salary apprenticeship].sample }
 
     trait :open_on_apply do
       open_on_apply { true }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -256,6 +256,7 @@ FactoryBot.define do
     age_range { '4 to 8' }
 
     subject_codes { [Faker::Alphanumeric.alphanumeric(number: 2, min_alpha: 1).upcase] }
+    funding_type { ['fee', 'salary', 'apprenticeship'].sample }
 
     trait :open_on_apply do
       open_on_apply { true }


### PR DESCRIPTION
## Context

In PR #1882 we added `subject_codes` and `funding_type` to the `Course` model. 
In PR #1876 we added `subject_codes` to the `:course` factory, but not `funding_type`.
This PR adds `funding_type`, so that test data is still representative.

## Changes proposed in this pull request

1. Add `funding_type` to the :course factory

## Guidance to review

1. From the console, `GenerateTestData.new(1).generate`
2. `ApplicationForm.last.application_choices.map {|ac| ac.course.funding_type }`

You should see that each of the course(s) selected on the generated application form have a `funding_type` values, which should be one of `['fee', 'salary', 'apprenticeship']`

## Link to Trello card

[DEV: Generate export for UCAS data matching](https://trello.com/c/ybZbTUR6/388-dev-generate-export-for-ucas-data-matching)

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
