### PR TITLE
Don't show unavailable course warnings if component is not editable

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.html.erb
+++ b/app/components/candidate_interface/course_choices_review_component.html.erb
@@ -1,6 +1,6 @@
 <% @course_choices.each do |course_choice| %>
   <div id='course-choice-<%= course_choice.id %>' class='qa-application-choice-<%= course_choice.id %> <%= warning_container_css_class(course_choice) %>'>
-  <% if FeatureFlag.active?('unavailable_course_option_warnings') %>
+  <% if FeatureFlag.active?('unavailable_course_option_warnings') && @editable %>
     <% if course_choice.course_not_available? %>
       <p class='app-review-warning__primary-message'><%= course_choice.course_not_available_error %>.</p>
       <p class='govuk-body'><%= course_choice.provider.name %> have decided not to run this course.</p>

--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -74,7 +74,7 @@ module CandidateInterface
     end
 
     def warning_container_css_class(course_choice)
-      return unless FeatureFlag.active?('unavailable_course_option_warnings')
+      return unless FeatureFlag.active?('unavailable_course_option_warnings') && @editable
 
       if course_choice.course_option_availability_error?
         @application_choice_error ? 'app-review-warning app-review-warning--error' : 'app-review-warning'

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -147,6 +147,23 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
         expect(result.css('.govuk-summary-list__actions').text).not_to include('Change')
       end
     end
+
+    context 'when course is unavailable and unavailable_course_option_warnings is active' do
+      it 'renders with the unavailable course text' do
+        FeatureFlag.activate('unavailable_course_option_warnings')
+
+        application_form = create(:application_form)
+        create(
+          :submitted_application_choice,
+          application_form: application_form,
+          course_option: create(:course_option, :no_vacancies),
+        )
+
+        result = render_inline(described_class.new(application_form: application_form, editable: true))
+
+        expect(result.text).to include('it is not running')
+      end
+    end
   end
 
   context 'when course choices are not editable' do
@@ -207,6 +224,23 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
 
       it 'renders without the change link' do
         expect(result.css('.govuk-summary-list__actions').text).not_to include('Change')
+      end
+    end
+
+    context 'when course is unavailable and unavailable_course_option_warnings is active' do
+      it 'renders without the unavailable course text' do
+        FeatureFlag.activate('unavailable_course_option_warnings')
+
+        application_form = create(:application_form)
+        create(
+          :submitted_application_choice,
+          application_form: application_form,
+          course_option: create(:course_option, :no_vacancies),
+        )
+
+        result = render_inline(described_class.new(application_form: application_form, editable: false))
+
+        expect(result.text).not_to include('it is not running')
       end
     end
   end


### PR DESCRIPTION
## Context

This component is used in the dashboard and shouldn't display the warning texts at that stage of the application.

## Changes proposed in this pull request

- Add `&& @editable` and some unit tests to test it

## Guidance to review

###  Before

![Screenshot 2020-04-29 at 11 59 21](https://user-images.githubusercontent.com/1650875/80589808-cd803f80-8a12-11ea-91a4-da1951cf0a04.png)

### After

![Screenshot 2020-04-29 at 11 59 40](https://user-images.githubusercontent.com/1650875/80589820-d1ac5d00-8a12-11ea-9032-a0ac2a0c571d.png)

### Also after (unaffected)

![Screenshot 2020-04-29 at 11 56 06](https://user-images.githubusercontent.com/1650875/80589840-d53fe400-8a12-11ea-9679-97a18a9b8617.png)

![Screenshot 2020-04-29 at 11 56 24](https://user-images.githubusercontent.com/1650875/80589843-d7a23e00-8a12-11ea-81d2-c8fb6ac47bf2.png)


## Link to Trello card

https://trello.com/c/P5rQM6rT/1416-dev-user-is-able-to-see-the-course-full-error-messages-on-the-dashboard

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)