### PR TITLE
Candidates can see rejection reasons on apply again

### DIFF
--- a/app/components/candidate_interface/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons_component.html.erb
@@ -1,0 +1,15 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      See feedback from your previous application
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <% @application_form.application_choices.rejected.each do |application_choice| %>
+      <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
+        <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>
+      <% end %>
+    <% end %>
+  </div>
+</details>

--- a/app/components/candidate_interface/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons_component.html.erb
@@ -6,7 +6,7 @@
   </summary>
 
   <div class="govuk-details__text">
-    <% @application_form.application_choices.rejected.each do |application_choice| %>
+    <% @application_form.application_choices.includes(:course, :provider).rejected.each do |application_choice| %>
       <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
         <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>
       <% end %>

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -1,0 +1,32 @@
+module CandidateInterface
+  class RejectionReasonsComponent < ViewComponent::Base
+    validates :application_form, presence: true
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def application_choice_rows(application_choice)
+      [
+        course_details_row(application_choice),
+        rejection_reasons_row(application_choice),
+      ].compact
+    end
+
+  private
+
+    def course_details_row(application_choice)
+      {
+        key: 'Course',
+        value: application_choice.course.name_code_and_description,
+      }
+    end
+
+    def rejection_reasons_row(application_choice)
+      {
+        key: 'Reasons for rejection',
+        value: application_choice.rejection_reason,
+      }
+    end
+  end
+end

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -1,5 +1,6 @@
 module CandidateInterface
   class RejectionReasonsComponent < ViewComponent::Base
+    include ViewHelper
     validates :application_form, presence: true
 
     def initialize(application_form:)
@@ -18,7 +19,7 @@ module CandidateInterface
     def course_details_row(application_choice)
       {
         key: 'Course',
-        value: application_choice.course.name_code_and_description,
+        value: govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code}) <br>".html_safe, application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') + application_choice.course.description
       }
     end
 

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
       @application_form = current_application
+      @apply_1_application_form = current_candidate.application_forms.apply_1.last
     end
 
     def before_you_start; end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -10,6 +10,11 @@ module CandidateInterface
 
     def before_you_start; end
 
+    def apply_2
+      DuplicateApplication.new(current_application).duplicate
+      redirect_to candidate_interface_application_form_path
+    end
+
     def review
       redirect_to candidate_interface_application_complete_path if current_application.submitted?
       @application_form = current_application

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -20,7 +20,8 @@ class Candidate < ApplicationRecord
   end
 
   def current_application
-    application_form = application_forms.first_or_create!
+    application_form = application_forms.last
+    application_form ||= application_forms.create!
     application_form
   end
 

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -41,9 +41,15 @@ module CandidateInterface
     end
 
     def candidate_can_only_apply_to_3_courses
-      return if application_form.application_choices.count <= 2
+      if application_form.apply_1?
+        return if application_form.application_choices.count <= 2
 
-      errors[:base] << I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course_option.course.name_and_code)
+        errors[:base] << 'You can only apply for up to 3 courses'
+      else
+        return if application_form.application_choices.count == 0
+
+        errors[:base] << 'You can only apply to 1 course'
+      end
     end
   end
 end

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -46,7 +46,7 @@ module CandidateInterface
 
         errors[:base] << 'You can only apply for up to 3 courses'
       else
-        return if application_form.application_choices.count == 0
+        return if application_form.application_choices.count.zero?
 
         errors[:base] << 'You can only apply to 1 course'
       end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -8,6 +8,14 @@ module CandidateInterface
       "Last saved on #{@application_form.updated_at.to_s(:govuk_date_and_time)}"
     end
 
+    def apply_1?
+      @application_form.apply_1?
+    end
+
+    def apply_2?
+      @application_form.apply_2?
+    end
+
     def sections_with_completion
       [
         # "Courses" section

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -6,36 +6,26 @@ class DuplicateApplication
   end
 
   def duplicate
-    attrs = original_application_form.attributes.except(*
-      %w[id created_at updated_at submitted_at course_choices_completed phase]
-    ).merge(
-      phase: 'apply_2'
+    attrs = original_application_form.attributes.except('id', 'created_at', 'updated_at', 'submitted_at', 'course_choices_completed', 'phase').merge(
+      phase: 'apply_2',
     )
 
     new_application_form = ApplicationForm.create!(attrs)
 
     original_application_form.application_work_experiences.each do |w|
-      new_application_form.application_work_experiences.create!(w.attributes.except(*%w[
-        id created_at updated_at application_form_id
-      ]))
+      new_application_form.application_work_experiences.create!(w.attributes.except('id', 'created_at', 'updated_at', 'application_form_id'))
     end
 
     original_application_form.application_volunteering_experiences.each do |w|
-      new_application_form.application_volunteering_experiences.create!(w.attributes.except(*%w[
-        id created_at updated_at application_form_id
-      ]))
+      new_application_form.application_volunteering_experiences.create!(w.attributes.except('id', 'created_at', 'updated_at', 'application_form_id'))
     end
 
     original_application_form.application_qualifications.each do |w|
-      new_application_form.application_qualifications.create!(w.attributes.except(*%w[
-        id created_at updated_at application_form_id
-      ]))
+      new_application_form.application_qualifications.create!(w.attributes.except('id', 'created_at', 'updated_at', 'application_form_id'))
     end
 
     original_application_form.references.each do |w|
-      new_application_form.references.create!(w.attributes.except(*%w[
-        id created_at updated_at application_form_id
-      ]))
+      new_application_form.references.create!(w.attributes.except('id', 'created_at', 'updated_at', 'application_form_id'))
     end
 
     true

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -1,0 +1,43 @@
+class DuplicateApplication
+  attr_reader :original_application_form
+
+  def initialize(original_application_form)
+    @original_application_form = original_application_form
+  end
+
+  def duplicate
+    attrs = original_application_form.attributes.except(*
+      %w[id created_at updated_at submitted_at course_choices_completed phase]
+    ).merge(
+      phase: 'apply_2'
+    )
+
+    new_application_form = ApplicationForm.create!(attrs)
+
+    original_application_form.application_work_experiences.each do |w|
+      new_application_form.application_work_experiences.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    original_application_form.application_volunteering_experiences.each do |w|
+      new_application_form.application_volunteering_experiences.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    original_application_form.application_qualifications.each do |w|
+      new_application_form.application_qualifications.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    original_application_form.references.each do |w|
+      new_application_form.references.create!(w.attributes.except(*%w[
+        id created_at updated_at application_form_id
+      ]))
+    end
+
+    true
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,6 +8,7 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %w[
+    apply_again_rejection_reasons
     candidate_can_cancel_reference
     confirm_conditions
     download_dataset1_from_support_page

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -24,13 +24,8 @@ class SubmitApplication
 private
 
   def send_reference_request_email_to_referees(application_form)
-<<<<<<< HEAD
-    application_form.application_references.includes(:application_form).each do |reference|
-      RefereeMailer.reference_request_email(application_form, reference).deliver_later unless skip_emails
-=======
-    application_form.references.where(feedback: nil).each do |reference|
+    application_form.application_references.where(feedback: nil).each do |reference|
       RefereeMailer.reference_request_email(application_form, reference).deliver_later
->>>>>>> Spike into implementing Apply 2
 
       reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
     end
@@ -60,16 +55,12 @@ private
 
   def submit_application
     application_choices.each do |application_choice|
-<<<<<<< HEAD
-      SubmitApplicationChoice.new(application_choice).call
-=======
       application_choice.edit_by = ApplicationDates.new(application_form).edit_by
       ApplicationStateChange.new(application_choice).submit!
 
       if application_form.apply_2? && application_form.references_complete?
         ApplicationStateChange.new(application_choice).references_complete!
       end
->>>>>>> Spike into implementing Apply 2
     end
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -24,8 +24,13 @@ class SubmitApplication
 private
 
   def send_reference_request_email_to_referees(application_form)
+<<<<<<< HEAD
     application_form.application_references.includes(:application_form).each do |reference|
       RefereeMailer.reference_request_email(application_form, reference).deliver_later unless skip_emails
+=======
+    application_form.references.where(feedback: nil).each do |reference|
+      RefereeMailer.reference_request_email(application_form, reference).deliver_later
+>>>>>>> Spike into implementing Apply 2
 
       reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
     end
@@ -55,7 +60,16 @@ private
 
   def submit_application
     application_choices.each do |application_choice|
+<<<<<<< HEAD
       SubmitApplicationChoice.new(application_choice).call
+=======
+      application_choice.edit_by = ApplicationDates.new(application_form).edit_by
+      ApplicationStateChange.new(application_choice).submit!
+
+      if application_form.apply_2? && application_form.references_complete?
+        ApplicationStateChange.new(application_choice).references_complete!
+      end
+>>>>>>> Spike into implementing Apply 2
     end
   end
 end

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -14,6 +14,14 @@
   Application submitted on <%= submitted_at_date %>. <%= govuk_link_to 'View application', candidate_interface_application_review_submitted_path %>
 </p>
 
+<% if ProcessState.new(@application_form).state == :ended_without_success %>
+  <p class="govuk-body">
+    Too bad, so sad. But you can go into Apply 2:
+
+    <%= button_to 'Go into Apply 2', candidate_interface_apply_2_path, class: 'govuk-button' %>
+  </p>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render(CandidateInterface::ApplicationCompleteContentComponent.new(application_form: @application_form)) %>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -21,7 +21,11 @@
       <%= t('page_titles.course_choices') %>
     </h2>
     <% unless @application_form_presenter.application_choices_added? %>
-      <p class="govuk-body"><%= t('application_form.courses.intro') %></p>
+      <% if @application_form_presenter.apply_1? %>
+        <p class="govuk-body"><%= t('application_form.courses.intro') %></p>
+      <% else %>
+        <p class="govuk-body">You can choose 1 course</p>
+      <% end %>
     <% end %>
     <ul class="app-task-list govuk-!-margin-bottom-8">
       <li class="app-task-list__item">

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -17,6 +17,10 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
+    <% if FeatureFlag.active?('apply_again_rejection_reasons') && @application_form.apply_2? && @apply_1_application_form.application_choices.rejected.present?  %>
+      <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @apply_1_application_form)) %>
+    <% end %>
+
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
       <%= t('page_titles.course_choices') %>
     </h2>

--- a/app/views/candidate_interface/course_choices/_guidance.html.erb
+++ b/app/views/candidate_interface/course_choices/_guidance.html.erb
@@ -1,4 +1,3 @@
-<p class="govuk-body">You can apply for up to 3 courses at this stage of your application.</p>
 <p class="govuk-body">Not all courses and training providers are signed up to this service. If you choose a course that isn’t signed up to <%= service_name %>, you’ll be directed to UCAS to continue your application.</p>
 <p class="govuk-body">You can preview <%= govuk_link_to 'courses currently available', candidate_interface_providers_path %> on <%= service_name %>.</p>
 <p class="govuk-body">Get support by emailing <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>

--- a/app/views/candidate_interface/course_choices/review.html.erb
+++ b/app/views/candidate_interface/course_choices/review.html.erb
@@ -13,13 +13,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @course_choices.count.present? %>
-<<<<<<< HEAD
-        <% if @course_choices.count.between?(1, 2) %>
-=======
         <% if @application_form.apply_1? && @course_choices.count.between?(1, 2) %>
           <h2 class="govuk-heading-m">Do you want to add another course?</h2>
           <%= render 'guidance' %>
->>>>>>> Spike into implementing Apply 2
           <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
         <% end %>
 

--- a/app/views/candidate_interface/course_choices/review.html.erb
+++ b/app/views/candidate_interface/course_choices/review.html.erb
@@ -13,7 +13,13 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @course_choices.count.present? %>
+<<<<<<< HEAD
         <% if @course_choices.count.between?(1, 2) %>
+=======
+        <% if @application_form.apply_1? && @course_choices.count.between?(1, 2) %>
+          <h2 class="govuk-heading-m">Do you want to add another course?</h2>
+          <%= render 'guidance' %>
+>>>>>>> Spike into implementing Apply 2
           <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
         <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,8 @@ Rails.application.routes.draw do
   namespace :candidate_interface, path: '/candidate' do
     get '/' => 'start_page#show', as: :start
 
+    post '/apply-2' => 'application_form#apply_2', as: :apply_2
+
     get '/accessibility', to: 'content#accessibility'
     get '/privacy-policy', to: 'content#privacy_policy', as: :privacy_policy
     get '/cookies', to: 'content#cookies_candidate', as: :cookies

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RejectionReasonsComponent do
+  let(:application_form) { create(:completed_application_form) }
+  let(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
+
+  it "renders component with correct values" do
+    application_choice
+    result = render_inline(described_class.new(application_form: application_form))
+
+    expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
+    expect(result.css('.govuk-summary-list__key').text).to include('Course')
+    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_code_and_description)
+    expect(result.css('.govuk-summary-list__key').text).to include('Reasons for rejection')
+    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
+  end
+end

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
   let(:application_form) { create(:completed_application_form) }
   let(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
 
-  it "renders component with correct values" do
+  it 'renders component with correct values' do
     application_choice
     result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -42,6 +42,7 @@ FactoryBot.define do
       work_history_breaks { Faker::Lorem.paragraph_by_chars(number: 400) }
       volunteering_experience { [true, false, nil].sample }
       safeguarding_issues { 'I have a criminal conviction.' }
+      phase { :apply_1 }
 
       # Checkboxes to mark a section as complete
       course_choices_completed { true }
@@ -328,7 +329,7 @@ FactoryBot.define do
 
     trait :with_rejection do
       status { 'rejected' }
-      rejection_reason { 'candidate did not meet minimum course entry requirements' }
+      rejection_reason { Faker::Lorem.paragraph_by_chars(number: 300) }
       rejected_at { Time.zone.now }
     end
 

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate can see their rejection reasons on apply again' do
+  scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
+    given_apply_again_rejection_reasons_is_active
+    and_i_am_signed_in
+    and_i_have_an_apply1_application_with_3_rejections
+    and_i_have_started_my_apply_again_application_form
+
+    when_i_visit_my_apply_again_application_form
+    then_i_can_see_my_previous_rejection_reasons
+  end
+
+  def given_apply_again_rejection_reasons_is_active
+    FeatureFlag.activate('apply_again_rejection_reasons')
+  end
+
+  def and_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_apply1_application_with_3_rejections
+    @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
+    create_list(:application_choice, 3, :with_rejection, application_form: @application_form)
+  end
+
+  def and_i_have_started_my_apply_again_application_form
+    create(:application_form, candidate: @candidate, phase: :apply_2 )
+  end
+
+  def when_i_visit_my_apply_again_application_form
+    visit candidate_interface_application_form_path
+    save_and_open_page
+  end
+
+  def then_i_can_see_my_previous_rejection_reasons
+    expect(page).to have_content(@application_form.application_choices.first.rejection_reason)
+    expect(page).to have_content(@application_form.application_choices.second.rejection_reason)
+    expect(page).to have_content(@application_form.application_choices.third.rejection_reason)
+  end
+end

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -26,12 +26,11 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
   end
 
   def and_i_have_started_my_apply_again_application_form
-    create(:application_form, candidate: @candidate, phase: :apply_2 )
+    create(:application_form, candidate: @candidate, phase: :apply_2)
   end
 
   def when_i_visit_my_apply_again_application_form
     visit candidate_interface_application_form_path
-    save_and_open_page
   end
 
   def then_i_can_see_my_previous_rejection_reasons


### PR DESCRIPTION
## Context

As a... candidate
I need to... see why my previous application was rejected
So that... I can make amendments when I Apply again

## Changes proposed in this pull request

- if an application form is apply2 and their appy1 has rejections. Show the reasons

![image](https://user-images.githubusercontent.com/42515961/80590633-28666680-8a14-11ea-9be0-ce467f31bbe3.png)

## Guidance to review

I've made this a draft PR as it's still reliant on the implementation Steve is doing and will have to change. I'm not going to bother fixing the unrelated tests as this will be done/change as part of Steve's work.

## Link to Trello card

https://trello.com/c/VQV2ZylK/1392-candidates-can-see-the-reasons-why-their-previous-application-was-rejected-when-they-apply-again

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
