### PR TITLE
Make sure we chase additional referees

### DIFF
--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -71,8 +71,7 @@ module CandidateInterface
       references_to_confirm = not_requested_references.includes(:application_form).to_a
 
       references_to_confirm.each do |reference|
-        RefereeMailer.reference_request_email(current_candidate.current_application, reference).deliver_later
-        reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
+        CandidateInterface::RequestReference.call(reference)
       end
 
       flash[:success] = I18n.t!('additional_referees.feedback_flash', count: references_to_confirm.size)

--- a/app/controllers/candidate_interface/additional_referees_controller.rb
+++ b/app/controllers/candidate_interface/additional_referees_controller.rb
@@ -72,7 +72,7 @@ module CandidateInterface
 
       references_to_confirm.each do |reference|
         RefereeMailer.reference_request_email(current_candidate.current_application, reference).deliver_later
-        reference.update!(feedback_status: 'feedback_requested')
+        reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
       end
 
       flash[:success] = I18n.t!('additional_referees.feedback_flash', count: references_to_confirm.size)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -67,7 +67,7 @@ class TestApplications
 
       without_slack_message_sending do
         fast_forward(1..2)
-        SubmitApplication.new(@application_form, skip_emails: true).call
+        SubmitApplication.new(@application_form).call
         @application_form.update_columns(submitted_at: time)
         @application_form.application_choices.each do |application_choice|
           application_choice.update_columns(edit_by: time + 7.days)

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -1,8 +1,8 @@
 class RefereeMailer < ApplicationMailer
-  def reference_request_email(application_form, reference)
-    @application_form = application_form
+  def reference_request_email(reference)
+    @application_form = reference.application_form
     @reference = reference
-    @candidate_name = application_form.full_name
+    @candidate_name = @application_form.full_name
     @unhashed_token = reference.refresh_feedback_token!
 
     notify_email(

--- a/app/services/candidate_interface/request_reference.rb
+++ b/app/services/candidate_interface/request_reference.rb
@@ -1,0 +1,8 @@
+module CandidateInterface
+  class RequestReference
+    def self.call(reference)
+      RefereeMailer.reference_request_email(reference.application_form, reference).deliver_later
+      reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
+    end
+  end
+end

--- a/app/services/candidate_interface/request_reference.rb
+++ b/app/services/candidate_interface/request_reference.rb
@@ -1,7 +1,7 @@
 module CandidateInterface
   class RequestReference
     def self.call(reference)
-      RefereeMailer.reference_request_email(reference.application_form, reference).deliver_later
+      RefereeMailer.reference_request_email(reference).deliver_later
       reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
     end
   end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -1,12 +1,11 @@
 class SubmitApplication
-  attr_reader :application_form, :application_choices, :skip_emails
+  attr_reader :application_form, :application_choices
 
   REFEREE_BOT_EMAIL_ADDRESSES = ['refbot1@example.com', 'refbot2@example.com'].freeze
 
-  def initialize(application_form, skip_emails: false)
+  def initialize(application_form)
     @application_form = application_form
     @application_choices = application_form.application_choices
-    @skip_emails = skip_emails
   end
 
   def call
@@ -25,7 +24,7 @@ private
 
   def send_reference_request_email_to_referees(application_form)
     application_form.application_references.includes(:application_form).each do |reference|
-      RefereeMailer.reference_request_email(application_form, reference).deliver_later unless skip_emails
+      RefereeMailer.reference_request_email(application_form, reference).deliver_later
 
       reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
     end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -24,9 +24,7 @@ private
 
   def send_reference_request_email_to_referees(application_form)
     application_form.application_references.includes(:application_form).each do |reference|
-      RefereeMailer.reference_request_email(application_form, reference).deliver_later
-
-      reference.update!(feedback_status: 'feedback_requested', requested_at: Time.zone.now)
+      CandidateInterface::RequestReference.call(reference)
     end
   end
 

--- a/spec/mailers/previews/referee_mailer_preview.rb
+++ b/spec/mailers/previews/referee_mailer_preview.rb
@@ -1,9 +1,6 @@
 class RefereeMailerPreview < ActionMailer::Preview
   def reference_request_email
-    application_form = FactoryBot.create(:application_form, first_name: 'Jane', last_name: 'Smith')
-    reference = FactoryBot.create(:reference, application_form: application_form)
-
-    RefereeMailer.reference_request_email(application_form, reference)
+    RefereeMailer.reference_request_email(reference)
   end
 
   def reference_request_chaser_email

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RefereeMailer, type: :mailer do
     end
     let(:reference) { application_form.application_references.first }
     let(:candidate_name) { "#{application_form.first_name} #{application_form.last_name}" }
-    let(:mail) { mailer.reference_request_email(application_form, reference) }
+    let(:mail) { mailer.reference_request_email(reference) }
 
     it 'sends an email with a link to the reference form' do
       mail.deliver_now

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -38,16 +38,6 @@ RSpec.describe SubmitApplication do
       expect(mailer).to have_received(:deliver_later).twice
     end
 
-    it 'DOES NOT send email to referees with `skip_emails` option' do
-      mailer = instance_double(ActionMailer::MessageDelivery, deliver_later: nil)
-      allow(RefereeMailer).to receive(:reference_request_email).and_return(mailer)
-      application_form = create_application_form
-      create(:reference, application_form: application_form)
-      create(:reference, application_form: application_form)
-      SubmitApplication.new(application_form, skip_emails: true).call
-      expect(mailer).not_to have_received(:deliver_later)
-    end
-
     context 'when running in a provider sandbox', sandbox: true do
       it 'autocompletes references and pushes status to `awaiting_provider_decision`' do
         application_form = create_application_form

--- a/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
+++ b/spec/system/referee_interface/referee_can_use_initial_and_chaser_sign_in_links_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Referee can use sign in link in the initial and chaser email' do
   end
 
   def and_i_received_the_initial_reference_request_email
-    RefereeMailer.reference_request_email(@application, @reference).deliver_now
+    RefereeMailer.reference_request_email(@reference).deliver_now
   end
 
   def when_i_click_on_the_link_within_the_initial_email


### PR DESCRIPTION
## Context

Candidates can submit references in 2 ways: during their initial application and also when the reference email bounces, doesn't respond, or is cancelled. 

When sending the email to the referee, the additional referees code doesn't set the `requested_at` timestamp. This timestamp is used to chase the referees after 5 days, and to tell the candidate to replace the referee after 10 days. 

## Changes proposed in this pull request

Set the timestamp in order for the chase / replace flow to work. Do a bunch of tidy up so it's less likely that this happens again.

_A future PR will backfill the existing replacement references_.

## Guidance to review

@stevehook I've removed `skip_emails` in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/93cb5e50fadb111836707e242c4558f62fe286d7. Is that correct?

## Link to Trello card

TBD.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
