### PR TITLE
Show vacancies & current applications on course page

### DIFF
--- a/app/components/support_interface/applications_table_component.html.erb
+++ b/app/components/support_interface/applications_table_component.html.erb
@@ -1,4 +1,4 @@
-<table class="govuk-table">
+<table class="govuk-table" data-qa="applications">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header">Application</th>

--- a/app/components/support_interface/course_choices_table_component.html.erb
+++ b/app/components/support_interface/course_choices_table_component.html.erb
@@ -11,7 +11,13 @@
     <% course_rows.each do |course_option| %>
       <tr class='govuk-table__row'>
         <td class='govuk-table__cell'><%= course_option.id %></td>
-        <td class='govuk-table__cell'><%= govuk_link_to(course_option.course.name_and_code, support_interface_course_path(course_option.course)) %> - <%= course_option.study_mode.humanize %> at <%= course_option.site.name %></td>
+        <td class='govuk-table__cell'>
+          <% unless course_option.site_still_valid? %>
+            <%= render TagComponent.new(text: 'Course no longer offered at this site', type: 'red') %>
+          <% end %>
+
+          <%= govuk_link_to(course_option.course.name_and_code, support_interface_course_path(course_option.course)) %> - <%= course_option.study_mode.humanize %> at <%= course_option.site.name %>
+        </td>
         <td class='govuk-table__cell'>
           <% if course_option.vacancies? %>
             <%= render TagComponent.new(text: 'Vacancies', type: 'green') %>

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -81,4 +81,12 @@ class Course < ApplicationRecord
   def find_url
     "https://www.find-postgraduate-teacher-training.service.gov.uk/course/#{provider.code}/#{code}"
   end
+
+  def application_forms
+    ApplicationForm
+      .includes(:candidate, :application_choices)
+      .joins(application_choices: :course_option)
+      .where(application_choices: { course_options: { course: self } })
+      .distinct
+  end
 end

--- a/app/views/support_interface/courses/show.html.erb
+++ b/app/views/support_interface/courses/show.html.erb
@@ -18,6 +18,14 @@
   'Start on Apply' => govuk_link_to('View on Apply (candidate)', candidate_interface_apply_from_find_path(providerCode: @course.provider.code, courseCode: @course.code)),
 })) %>
 
+<h2 class='govuk-heading-m'>Vacancies</h2>
+
+<%= render(SupportInterface::CourseChoicesTableComponent.new(course_options: @course.course_options)) %>
+
+<h2 class='govuk-heading-m'>Applications</h2>
+
+<%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @course.application_forms) %>
+
 <h2 class='govuk-heading-m'>Settings</h2>
 
 <%= render(SummaryCardComponent.new(rows: {

--- a/spec/system/support_interface/providers_and_courses_spec.rb
+++ b/spec/system/support_interface/providers_and_courses_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'See providers' do
     and_i_click_on_courses
     then_i_see_the_provider_courses
 
-    when_i_click_on_a_course
+    when_i_click_on_a_course_with_applications
     then_i_see_the_course_information
 
     when_i_choose_to_open_the_course_on_apply
@@ -170,12 +170,20 @@ RSpec.feature 'See providers' do
     expect(page).to have_content 'Main site'
   end
 
-  def when_i_click_on_a_course
+  def when_i_click_on_a_course_with_applications
+    course = Course.find_by(code: 'ABC-1')
+    create(:application_choice, course_option: course.course_options.first)
+    create(:application_choice, course_option: course.course_options.first)
     first('table').click_link('ABC-1')
   end
 
   def then_i_see_the_course_information
     expect(page).to have_title 'Primary (ABC-1)'
+    expect(page).to have_content 'Primary (ABC-1) - Full time at Main site Vacancies'
+
+    within '[data-qa="applications"]' do
+      expect(page.all('tbody tr').size).to be(2)
+    end
   end
 
   def when_i_choose_to_open_the_course_on_apply


### PR DESCRIPTION
## Context

This allows access to this information about a course:

- Which course options for a course don't have vacancies 
- Which course options have been removed from Find
- Which applications have applied to the course

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
![image](https://user-images.githubusercontent.com/233676/80593795-b1cc6780-8a19-11ea-81cc-0630aa46b45e.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/fRAKJt36

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
