### PR TITLE
Send Slack message to support when course becomes unavailable

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -154,14 +154,23 @@ private
     not_part_of_an_application = invalid_course_options.where.not(id: chosen_course_option_ids)
     not_part_of_an_application.delete_all
     part_of_an_application = invalid_course_options.where(id: chosen_course_option_ids)
+
     return if part_of_an_application.size.zero?
 
     part_of_an_application.each do |course_option|
-      if course_option.site_still_valid
-        Raven.capture_message(
-          "Course option #{course_option.id}, which is chosen by candidates, is now invalid.",
-        )
+      if !course_option.site_still_valid?
+        # This course option is already marked as invalid,
+        # we don't need to send another message.
+        next
       end
+
+      count = course_option.application_choices.count
+
+      SlackNotificationWorker.perform_async(
+        ":mailbox_with_mail: #{course_option.provider.name}'s course #{course_option.course.name_and_code} is no longer available at location '#{course_option.site.name_and_code}'. #{count} #{count == 1 ? 'candidate has' : 'candidates have'} applied to the course at this location.",
+        Rails.application.routes.url_helpers.support_interface_course_path(course_option.course_id),
+      )
+
       course_option.update!(site_still_valid: false)
     end
   end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -183,7 +183,6 @@ RSpec.describe SyncProviderFromFind do
         expect(CourseOption.exists?(invalid_course_option_one.id)).to eq false
         expect(invalid_course_option_two.reload).not_to be_site_still_valid
         expect(valid_course_option.reload).to be_site_still_valid
-        expect(Raven).to have_received(:capture_message).with(/is now invalid/)
       end
 
       it 'correctly updates subject_codes' do

--- a/spec/support/slack_notifications.rb
+++ b/spec/support/slack_notifications.rb
@@ -4,9 +4,10 @@ RSpec.configure do |config|
       to_return(status: 200, body: '{}')
   end
 
-  def expect_slack_message_with_text(text)
+  def expect_slack_message_with_text(expected_message)
     expect(WebMock).to have_requested(:post, 'https://example.com/slack-webhook').with { |req|
-      JSON.parse(req.body)['text'].match(text)
+      sent_message = JSON.parse(req.body).fetch('text')
+      sent_message.include?(expected_message)
     }
   end
 end

--- a/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
+++ b/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
@@ -15,13 +15,12 @@ RSpec.describe 'Sync from find' do
 
     given_there_is_a_course_on_find_with_multiple_sites
     and_sync_provider_from_find_has_been_called
-    and_raven_can_capture_exceptions
 
     when_find_says_that_a_site_is_no_longer_listed_for_that_course
     and_the_course_option_for_that_site_is_part_of_an_application
     and_sync_provider_from_find_is_called
     then_the_affected_course_option_indicates_that_the_site_is_no_longer_valid
-    and_raven_captures_an_exception
+    and_we_are_notified_so_we_can_contact_the_candidates
   end
 
   def given_there_is_a_course_on_find_with_multiple_sites
@@ -59,16 +58,12 @@ RSpec.describe 'Sync from find' do
     when_sync_provider_from_find_is_called
   end
 
-  def and_raven_can_capture_exceptions
-    allow(Raven).to receive(:capture_message)
-  end
-
   def then_the_affected_course_option_indicates_that_the_site_is_no_longer_valid
     expect(@provider.courses.first.course_options.count).to eq 2
     expect(@course_option.reload.site_still_valid).to eq false
   end
 
-  def and_raven_captures_an_exception
-    expect(Raven).to have_received(:capture_message).with("Course option #{@course_option.id}, which is chosen by candidates, is now invalid.")
+  def and_we_are_notified_so_we_can_contact_the_candidates
+    expect_slack_message_with_text "ABC College's course Primary (X130) is no longer available at location 'Secondary site (Y)'. 1 candidate has applied to the course at this location."
   end
 end


### PR DESCRIPTION
## Context

We currently get a Sentry error in `#twd_apply_tech` when a location is no longer available for a course. We then find out which people are affected and tell support to contact them. This tells the support team directly. Together with https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1974 will make it no longer necessary to involve a developer. 

## Changes proposed in this pull request

Send a Slack message instead of Sentry error.

## Guidance to review

Does the message make sense?

## Link to Trello card

https://trello.com/c/fRAKJt36

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
