### PR TITLE
Return the correct value from request.remote_ip on Azure

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -112,4 +112,32 @@ Rails.application.configure do
   HostingEnvironment.authorised_hosts.each do |host|
     config.hosts << host
   end
+
+  class FixAzureXForwardedForMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      # ActionDispatch::RemoteIp::GetIp does not support IP addresses with
+      # ports included in the CLIENT_IP or X_FORWARDED_FOR headers. Azure includes
+      # ports with these IPs, so they're ignored when remote_ip is calculated.
+      #
+      # In practice this means remote_ip always returns REMOTE_ADDR on Azure,
+      # even though it falls within 172.16.0.0/12 and is therefore known to be
+      # a private IP.
+      #
+      # Rack has solved this issue long ago: https://github.com/rack/rack/issues/1227
+      # so use Rack's own parsing to overwrite this header before it
+      # gets to ActionDispatch::RemoteIp
+      req = Rack::Request.new(env)
+      if(req.forwarded_for.present?)
+        env['HTTP_X_FORWARDED_FOR'] = req.forwarded_for.join(',')
+      end
+
+      @app.call(env)
+    end
+  end
+
+  config.middleware.insert_before ActionDispatch::RemoteIp, FixAzureXForwardedForMiddleware
 end


### PR DESCRIPTION
`request.remote_ip` returns private Azure IPs in production, which means it's useless.

Following investigation https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1588093070402800 we found out that the format Azure uses for IPs in the `X-Forwarded-For` header isn't compatible with the Rails code which tries to parse those IPs and they end up being discarded.

`Rack::Request` does the right thing. Use it to parse and rewrite the `HTTP_X_FORWARDED_FOR` value ahead of time so `ActionDispatch::Request` gets IPs it can deal with.