### PR TITLE
Add UCAS 1st of June recalculation to RecalculateDates worker

### DIFF
--- a/app/workers/recalculate_dates.rb
+++ b/app/workers/recalculate_dates.rb
@@ -18,5 +18,44 @@ class RecalculateDates
         SetDeclineByDefault.new(application_form: application_form).call
       end
     end
+
+    ucas_1st_june_adjustment
+  end
+
+  def ucas_1st_june_adjustment
+    # All code related to the UCAS adjustment can be removed 2020-06-01.
+    #
+    # For the second freeze period, UCAS have introduced a manual adjustment to
+    # how RBDs and DBDs should be recalculated.
+    #
+    adjustment_date = Time.zone.local(2020, 6, 1).end_of_day
+    #
+    #  All applications submitted to a provider before the 7th of March should
+    # have an RBD of the 1st of June.
+    #
+    sent_to_provider_at_cutoff = DateTime.parse('2020-03-07')
+    application_choices_that_need_new_rbd = ApplicationChoice
+      .where(status: :awaiting_provider_decision)
+      .where('sent_to_provider_at <= ?', sent_to_provider_at_cutoff)
+      .where.not(reject_by_default_at: adjustment_date)
+    #
+    # All applications that have received an offer before the 20th of April
+    # should have a DBD of the 1st of June.
+    #
+    offered_at_cutoff = DateTime.parse('2020-04-20')
+    application_choices_that_need_new_dbd = ApplicationChoice
+      .where(status: :offer)
+      .where('offered_at <= ?', offered_at_cutoff)
+      .where.not(decline_by_default_at: adjustment_date)
+
+    Audited.audit_class.as_user('RecalculateDates worker UCAS 1st June adjustment') do
+      application_choices_that_need_new_rbd.find_each do |application_choice|
+        application_choice.update!(reject_by_default_at: adjustment_date)
+      end
+
+      application_choices_that_need_new_dbd.find_each do |application_choice|
+        application_choice.update!(decline_by_default_at: adjustment_date)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Context

To ensure that RBD/DBD dates are consistent with UCAS approach, we need to update our worker temporarily.

All applications that had an RBD or DBD that fell between the 20th of April and 31st of May *before* we made that period a working day freeze should instead be recalculated for the end of the 1st of June.

Based on the fact that RBDs are 40 working days and DBDs are 10 working days, this can be simplified to applications that were `sent_to_provider_at` before the 7th of March for RBDs, and applications that were `offered_at` before the 20th of April for DBDs.

## Changes proposed in this pull request

Add adjustment logic to `RecalculateDates` worker.

## Guidance to review

This makes our worker calculate and writes RBDs and DBDs twice, each time creating a new audit log entry. I can work around this if so desired, but it will lead to more complex logic in the `RecalculateDates worker` block. I think given that we're unlikely to rerun this again before the 1st of June, we don't need to work around this.

Tested this locally pretty thoroughly.

## Link to Trello card

https://trello.com/c/G1yFCFZK/1384-recalculate-rbd-dbd-based-off-ucas-decision

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)