### PR TITLE
Remove notification for unavailable courses

### DIFF
--- a/app/controllers/support_interface/application_forms_controller.rb
+++ b/app/controllers/support_interface/application_forms_controller.rb
@@ -8,7 +8,7 @@ module SupportInterface
       @application_form = application_form
     end
 
-    def action_required
+    def unavailable_choices
       @monitor = SupportInterface::ApplicationMonitor.new
     end
 

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -159,6 +159,7 @@ private
 
     part_of_an_application.each do |course_option|
       next if course_option.site_still_valid == false
+
       course_option.update!(site_still_valid: false)
     end
   end

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -158,19 +158,7 @@ private
     return if part_of_an_application.size.zero?
 
     part_of_an_application.each do |course_option|
-      if !course_option.site_still_valid?
-        # This course option is already marked as invalid,
-        # we don't need to send another message.
-        next
-      end
-
-      count = course_option.application_choices.count
-
-      SlackNotificationWorker.perform_async(
-        ":mailbox_with_mail: #{course_option.provider.name}'s course #{course_option.course.name_and_code} is no longer available at location '#{course_option.site.name_and_code}'. #{count} #{count == 1 ? 'candidate has' : 'candidates have'} applied to the course at this location.",
-        Rails.application.routes.url_helpers.support_interface_course_path(course_option.course_id),
-      )
-
+      next if course_option.site_still_valid == false
       course_option.update!(site_still_valid: false)
     end
   end

--- a/app/views/support_interface/application_forms/unavailable_choices.html.erb
+++ b/app/views/support_interface/application_forms/unavailable_choices.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, 'Applications - action required' %>
+<% content_for :title, 'Applications with unavailable choices' %>
 
 <h2 class='govuk-heading-m'>Applications to courses that no longer are available on Apply</h2>
 

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -5,7 +5,7 @@
 <ul class='govuk-body'>
   <li><%= govuk_link_to 'Performance dashboard', integrations_performance_path %> (public)</li>
   <li><%= govuk_link_to 'Course options without vacancies', support_interface_course_options_path %></li>
-  <li><%= govuk_link_to 'Applications that require action', support_interface_action_required_path %></li>
+  <li><%= govuk_link_to 'Applications with unavailable choices', support_interface_unavailable_choices_path %></li>
   <li><%= govuk_link_to 'Validation errors', support_interface_validation_errors_path %></li>
 </ul>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -472,7 +472,7 @@ Rails.application.routes.draw do
     get '/email-log', to: 'email_log#index', as: :email_log
 
     get '/applications' => 'application_forms#index'
-    get '/applications/action-required' => 'application_forms#action_required', as: :action_required
+    get '/applications/unavailable-choices' => 'application_forms#unavailable_choices', as: :unavailable_choices
     get '/applications/:application_form_id' => 'application_forms#show', as: :application_form
     get '/applications/:application_form_id/audit' => 'application_forms#audit', as: :application_form_audit
     get '/applications/:application_form_id/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment

--- a/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
+++ b/spec/system/sync_provider_from_find/site_is_deleted_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'Sync from find' do
     and_the_course_option_for_that_site_is_part_of_an_application
     and_sync_provider_from_find_is_called
     then_the_affected_course_option_indicates_that_the_site_is_no_longer_valid
-    and_we_are_notified_so_we_can_contact_the_candidates
   end
 
   def given_there_is_a_course_on_find_with_multiple_sites
@@ -61,9 +60,5 @@ RSpec.describe 'Sync from find' do
   def then_the_affected_course_option_indicates_that_the_site_is_no_longer_valid
     expect(@provider.courses.first.course_options.count).to eq 2
     expect(@course_option.reload.site_still_valid).to eq false
-  end
-
-  def and_we_are_notified_so_we_can_contact_the_candidates
-    expect_slack_message_with_text "ABC College's course Primary (X130) is no longer available at location 'Secondary site (Y)'. 1 candidate has applied to the course at this location."
   end
 end


### PR DESCRIPTION
## Context

I was pretty proud of the message introduced in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1975, but this morning I realised we don't actually need it.

https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1588231384012300

## Changes proposed in this pull request

Also updates the "action required" page to make clear no action is required.

## Guidance to review

Does it make sense?

## Link to Trello card

https://trello.com/c/fRAKJt36

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
