### PR TITLE
Candidate can see rejection reasons from Apply1 application

### DIFF
--- a/app/components/candidate_interface/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons_component.html.erb
@@ -1,0 +1,15 @@
+<details class="govuk-details" data-module="govuk-details">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">
+      See feedback from your previous application
+    </span>
+  </summary>
+
+  <div class="govuk-details__text">
+    <% @application_form.application_choices.includes(:course, :provider).rejected.each do |application_choice| %>
+      <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
+        <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>
+      <% end %>
+    <% end %>
+  </div>
+</details>

--- a/app/components/candidate_interface/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons_component.html.erb
@@ -6,7 +6,7 @@
   </summary>
 
   <div class="govuk-details__text">
-    <% @application_form.application_choices.includes(:course, :provider).rejected.each do |application_choice| %>
+    <% @application_form.application_choices.includes(:course, :provider, [:offered_course_option]).rejected.each do |application_choice| %>
       <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
         <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>
       <% end %>

--- a/app/components/candidate_interface/rejection_reasons_component.html.erb
+++ b/app/components/candidate_interface/rejection_reasons_component.html.erb
@@ -5,7 +5,7 @@
     </span>
   </summary>
 
-  <div class="govuk-details__text">
+  <div class="govuk-details__text govuk-!-padding-bottom-0">
     <% @application_form.application_choices.includes(:course, :provider, [:offered_course_option]).rejected.each do |application_choice| %>
       <%= render(SummaryCardComponent.new(rows: application_choice_rows(application_choice))) do %>
         <%= render(SummaryCardHeaderComponent.new(title: application_choice.provider.name)) %>

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -19,7 +19,9 @@ module CandidateInterface
     def course_details_row(application_choice)
       {
         key: 'Course',
-        value: govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code}) <br>".html_safe, application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') + application_choice.course.description
+        value: govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code})",
+                             application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') +
+          content_tag(:p, application_choice.course.description, class: 'govuk-body'),
       }
     end
 

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -19,7 +19,7 @@ module CandidateInterface
     def course_details_row(application_choice)
       {
         key: 'Course',
-        value: govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code})",
+        value: govuk_link_to(application_choice.offered_course.name_and_code,
                              application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') +
           content_tag(:p, application_choice.course.description, class: 'govuk-body'),
       }

--- a/app/components/candidate_interface/rejection_reasons_component.rb
+++ b/app/components/candidate_interface/rejection_reasons_component.rb
@@ -1,0 +1,33 @@
+module CandidateInterface
+  class RejectionReasonsComponent < ViewComponent::Base
+    include ViewHelper
+    validates :application_form, presence: true
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def application_choice_rows(application_choice)
+      [
+        course_details_row(application_choice),
+        rejection_reasons_row(application_choice),
+      ].compact
+    end
+
+  private
+
+    def course_details_row(application_choice)
+      {
+        key: 'Course',
+        value: govuk_link_to("#{application_choice.offered_course.name} (#{application_choice.offered_course.code}) <br>".html_safe, application_choice.offered_course.find_url, target: '_blank', rel: 'noopener') + application_choice.course.description
+      }
+    end
+
+    def rejection_reasons_row(application_choice)
+      {
+        key: 'Reasons for rejection',
+        value: application_choice.rejection_reason,
+      }
+    end
+  end
+end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
       @application_form = current_application
-      @previous_application_form = current_candidate.application_forms.where.not(id: current_application.id).order(id: :desc).last
+      @previous_application_form = ApplicationForm.find(current_application.previous_application_form_id) if current_application.previous_application_form_id.present?
     end
 
     def before_you_start; end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,6 +6,7 @@ module CandidateInterface
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
       @application_form = current_application
+      @apply_1_application_form = current_candidate.application_forms.apply_1.last
     end
 
     def before_you_start; end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,7 +6,7 @@ module CandidateInterface
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
       @application_form = current_application
-      @apply_1_application_form = current_candidate.application_forms.apply_1.last
+      @previous_application_form = current_candidate.application_forms.where.not(id: current_application.id).order(id: :desc).last
     end
 
     def before_you_start; end

--- a/app/services/duplicate_application.rb
+++ b/app/services/duplicate_application.rb
@@ -13,6 +13,7 @@ class DuplicateApplication
       *IGNORED_ATTRIBUTES,
     ).merge(
       phase: 'apply_2',
+      previous_application_form_id: original_application_form.id,
     )
 
     new_application_form = ApplicationForm.create!(attrs)

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,7 +8,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %w[
-    apply_again_rejection_reasons
     candidate_can_cancel_reference
     confirm_conditions
     download_dataset1_from_support_page

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,6 +8,7 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %w[
+    apply_again_rejection_reasons
     candidate_can_cancel_reference
     confirm_conditions
     download_dataset1_from_support_page

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -17,6 +17,10 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
+    <% if FeatureFlag.active?('apply_again_rejection_reasons') && @application_form.apply_2? && @apply_1_application_form.application_choices.rejected.present?  %>
+      <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @apply_1_application_form)) %>
+    <% end %>
+
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">
       <%= t('page_titles.course_choices') %>
     </h2>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -17,8 +17,8 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
-    <% if FeatureFlag.active?('apply_again_rejection_reasons') && @application_form.apply_2? && @apply_1_application_form.application_choices.rejected.present?  %>
-      <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @apply_1_application_form)) %>
+    <% if FeatureFlag.active?('apply_again_rejection_reasons') && @application_form.apply_2? && @previous_application_form.application_choices.rejected.present?  %>
+      <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @previous_application_form)) %>
     <% end %>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -17,7 +17,7 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
-    <% if FeatureFlag.active?('apply_again_rejection_reasons') && @application_form.apply_2? && @previous_application_form.application_choices.rejected.present?  %>
+    <% if FeatureFlag.active?('apply_again') && @application_form.apply_2? && @previous_application_form.application_choices.rejected.present?  %>
       <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @previous_application_form)) %>
     <% end %>
 

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -16,7 +16,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
-
+    
     <% if FeatureFlag.active?('apply_again') && @application_form.apply_2? && @previous_application_form.application_choices.rejected.present?  %>
       <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @previous_application_form)) %>
     <% end %>

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RejectionReasonsComponent do
+  let(:application_form) { create(:completed_application_form) }
+  let(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
+
+  it "renders component with correct values" do
+    application_choice
+    result = render_inline(described_class.new(application_form: application_form))
+
+    expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
+    expect(result.css('.govuk-summary-list__key').text).to include('Course')
+    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_code_and_description)
+    expect(result.css('.govuk-summary-list__key').text).to include('Reasons for rejection')
+    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
+  end
+end

--- a/spec/components/candidate_interface/rejection_reasons_component_spec.rb
+++ b/spec/components/candidate_interface/rejection_reasons_component_spec.rb
@@ -4,13 +4,14 @@ RSpec.describe CandidateInterface::RejectionReasonsComponent do
   let(:application_form) { create(:completed_application_form) }
   let(:application_choice) { create(:application_choice, :with_rejection, application_form: application_form) }
 
-  it "renders component with correct values" do
+  it 'renders component with correct values' do
     application_choice
     result = render_inline(described_class.new(application_form: application_form))
 
     expect(result.css('.app-summary-card__title').text).to include(application_choice.provider.name)
     expect(result.css('.govuk-summary-list__key').text).to include('Course')
-    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_code_and_description)
+    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.name_and_code)
+    expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.course.description)
     expect(result.css('.govuk-summary-list__key').text).to include('Reasons for rejection')
     expect(result.css('.govuk-summary-list__value').to_html).to include(application_choice.rejection_reason)
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -42,6 +42,7 @@ FactoryBot.define do
       work_history_breaks { Faker::Lorem.paragraph_by_chars(number: 400) }
       volunteering_experience { [true, false, nil].sample }
       safeguarding_issues { 'I have a criminal conviction.' }
+      phase { :apply_1 }
 
       # Checkboxes to mark a section as complete
       course_choices_completed { true }
@@ -329,7 +330,7 @@ FactoryBot.define do
 
     trait :with_rejection do
       status { 'rejected' }
-      rejection_reason { 'candidate did not meet minimum course entry requirements' }
+      rejection_reason { Faker::Lorem.paragraph_by_chars(number: 300) }
       rejected_at { Time.zone.now }
     end
 

--- a/spec/services/duplicate_application_spec.rb
+++ b/spec/services/duplicate_application_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe DuplicateApplication do
     expect(duplicate_application_form.updated_at).not_to eq original_application_form.updated_at
   end
 
+  it 'set_the_previous_application_form_id to the original application forms id' do
+    expect(duplicate_application_form.previous_application_form_id).to eq original_application_form.id
+  end
+
   it 'does not copy application choices' do
     expect(original_application_form.application_choices).to be_present
     expect(duplicate_application_form.application_choices).to be_empty

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'Candidate can see their rejection reasons on apply again' do
+  scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
+    given_apply_again_rejection_reasons_is_active
+    and_i_am_signed_in
+    and_i_have_an_apply1_application_with_3_rejections
+    and_i_have_started_my_apply_again_application_form
+
+    when_i_visit_my_apply_again_application_form
+    then_i_can_see_my_previous_rejection_reasons
+  end
+
+  def given_apply_again_rejection_reasons_is_active
+    FeatureFlag.activate('apply_again_rejection_reasons')
+  end
+
+  def and_i_am_signed_in
+    @candidate = create(:candidate)
+    login_as(@candidate)
+  end
+
+  def and_i_have_an_apply1_application_with_3_rejections
+    @application_form = create(:completed_application_form, :with_completed_references, candidate: @candidate)
+    create_list(:application_choice, 3, :with_rejection, application_form: @application_form)
+  end
+
+  def and_i_have_started_my_apply_again_application_form
+    create(:application_form, candidate: @candidate, phase: :apply_2 )
+  end
+
+  def when_i_visit_my_apply_again_application_form
+    visit candidate_interface_application_form_path
+    save_and_open_page
+  end
+
+  def then_i_can_see_my_previous_rejection_reasons
+    expect(page).to have_content(@application_form.application_choices.first.rejection_reason)
+    expect(page).to have_content(@application_form.application_choices.second.rejection_reason)
+    expect(page).to have_content(@application_form.application_choices.third.rejection_reason)
+  end
+end

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -26,12 +26,11 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
   end
 
   def and_i_have_started_my_apply_again_application_form
-    create(:application_form, candidate: @candidate, phase: :apply_2 )
+    create(:application_form, candidate: @candidate, phase: :apply_2)
   end
 
   def when_i_visit_my_apply_again_application_form
     visit candidate_interface_application_form_path
-    save_and_open_page
   end
 
   def then_i_can_see_my_previous_rejection_reasons

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
     given_apply_again_is_active
     and_i_am_signed_in
     and_i_have_an_apply1_application_with_3_rejections
-    and_i_have_started_my_apply_again_application_form
 
-    when_i_visit_my_apply_again_application_form
+    when_i_visit_my_application_complete_page
+    and_i_click_on_apply_again
+    and_i_click_on_start_now
+
     then_i_can_see_my_previous_rejection_reasons
   end
 
@@ -25,12 +27,16 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
     create_list(:application_choice, 3, :with_rejection, application_form: @application_form)
   end
 
-  def and_i_have_started_my_apply_again_application_form
-    create(:application_form, candidate: @candidate, phase: :apply_2)
+  def when_i_visit_my_application_complete_page
+    visit candidate_interface_application_complete_path
   end
 
-  def when_i_visit_my_apply_again_application_form
-    visit candidate_interface_application_form_path
+  def and_i_click_on_apply_again
+    click_link 'Do you want to apply again?'
+  end
+
+  def and_i_click_on_start_now
+    click_button 'Start now'
   end
 
   def then_i_can_see_my_previous_rejection_reasons

--- a/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_can_see_their_rejection_reasons_on_apply_again_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Candidate can see their rejection reasons on apply again' do
   scenario 'when a candidate visits their apply again application form they can see apply1 rejection reasons' do
-    given_apply_again_rejection_reasons_is_active
+    given_apply_again_is_active
     and_i_am_signed_in
     and_i_have_an_apply1_application_with_3_rejections
     and_i_have_started_my_apply_again_application_form
@@ -11,8 +11,8 @@ RSpec.describe 'Candidate can see their rejection reasons on apply again' do
     then_i_can_see_my_previous_rejection_reasons
   end
 
-  def given_apply_again_rejection_reasons_is_active
-    FeatureFlag.activate('apply_again_rejection_reasons')
+  def given_apply_again_is_active
+    FeatureFlag.activate('apply_again')
   end
 
   def and_i_am_signed_in


### PR DESCRIPTION
## Context

As a... candidate
I need to... see why my previous application was rejected
So that... I can make amendments when I Apply again

## Changes proposed in this pull request

- if an application form is apply2 and their appy1 has rejections. Show the reasons

![image](https://user-images.githubusercontent.com/42515961/80795864-a605b000-8b95-11ea-8c11-0fb96d864d9e.png)


## Guidance to review

Should some of the controller logic be pulled down to the model? i.e. 
`@apply_1_application_form = current_candidate.application_forms.apply_1.last`


## Link to Trello card

https://trello.com/c/VQV2ZylK/1392-candidates-can-see-the-reasons-why-their-previous-application-was-rejected-when-they-apply-again

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
