### PR TITLE
Migration for `ApplicationForm#previous_application_form`

### DIFF
--- a/db/migrate/20200501111039_add_application_forms_previous_application_form_id.rb
+++ b/db/migrate/20200501111039_add_application_forms_previous_application_form_id.rb
@@ -1,0 +1,6 @@
+class AddApplicationFormsPreviousApplicationFormId < ActiveRecord::Migration[6.0]
+  def change
+    add_column :application_forms, :previous_application_form_id, :integer
+    add_foreign_key :application_forms, :application_forms, column: :previous_application_form_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_30_225107) do
+ActiveRecord::Schema.define(version: 2020_05_01_111039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -104,6 +104,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_225107) do
     t.text "safeguarding_issues"
     t.jsonb "satisfaction_survey"
     t.string "safeguarding_issues_status", default: "not_answered_yet", null: false
+    t.integer "previous_application_form_id"
     t.index ["candidate_id"], name: "index_application_forms_on_candidate_id"
   end
 
@@ -385,6 +386,7 @@ ActiveRecord::Schema.define(version: 2020_04_30_225107) do
   add_foreign_key "application_choices", "course_options"
   add_foreign_key "application_choices", "course_options", column: "offered_course_option_id"
   add_foreign_key "application_experiences", "application_forms", on_delete: :cascade
+  add_foreign_key "application_forms", "application_forms", column: "previous_application_form_id"
   add_foreign_key "application_forms", "candidates", on_delete: :cascade
   add_foreign_key "application_qualifications", "application_forms", on_delete: :cascade
   add_foreign_key "application_work_history_breaks", "application_forms", on_delete: :cascade


### PR DESCRIPTION
## Context

This is a migration only PR to support an `ApplicationForm#previous_application_form` association. This will allow us to navigate easily from an 'Apply Again' application back to the application it was cloned from

## Changes proposed in this pull request

- [x] Migration to support association

## Guidance to review

- Does the migration work?

## Link to Trello card

https://trello.com/c/mr3GeHAZ/1423-associate-apply-again-applications-with-the-previous-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
