### PR TITLE
Show recent provider note subjects on applications list

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -4,6 +4,10 @@
     <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice) %>
     <div class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
+      <% if most_recent_note %>
+        <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-0"></div>
+        <p class="app-application-card__note"><%= most_recent_note.subject %></p>
+      <% end %>
     <div>
   </h3>
 

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -5,7 +5,6 @@
     <div class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
       <% if most_recent_note %>
-        <div class="govuk-!-margin-top-0 govuk-!-margin-bottom-0"></div>
         <p class="app-application-card__note"><%= most_recent_note.subject %></p>
       <% end %>
     <div>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -13,7 +13,7 @@ module ProviderInterface
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
       @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
-      @most_recent_note = nil
+      @most_recent_note = application_choice.notes.order('created_at DESC').first
     end
   end
 end

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -3,7 +3,8 @@ module ProviderInterface
     include ViewHelper
 
     attr_accessor :accredited_provider, :application_choice, :application_choice_path,
-                  :candidate_name, :course_name_and_code, :course_provider_name, :updated_at
+                  :candidate_name, :course_name_and_code, :course_provider_name, :updated_at,
+                  :most_recent_note
 
     def initialize(application_choice:)
       @accredited_provider = application_choice.accredited_provider
@@ -12,6 +13,7 @@ module ProviderInterface
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
       @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
+      @most_recent_note = nil
     end
   end
 end

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -13,7 +13,9 @@ module ProviderInterface
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
       @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
-      @most_recent_note = application_choice.notes.order('created_at DESC').first
+      if FeatureFlag.active?('notes')
+        @most_recent_note = application_choice.notes.order('created_at DESC').first
+      end
     end
   end
 end

--- a/app/frontend/styles/_notes.scss
+++ b/app/frontend/styles/_notes.scss
@@ -5,7 +5,6 @@
 }
 
 .app-application-card__note {
-  display: inline-block;
   position: relative;
   padding: 1px 0px 1px 15px;
   margin-top: 10px;
@@ -14,7 +13,6 @@
   line-height: 1.25;
   font-weight: 400;
   font-size: 1rem;
-  -webkit-font-smoothing: antialiased;
 
   &:before {
     position: absolute;

--- a/app/frontend/styles/_notes.scss
+++ b/app/frontend/styles/_notes.scss
@@ -1,3 +1,35 @@
+/* for __applications list__ within provider_interface */
+
+.app-application-card__status {
+  text-align: right;
+}
+
+.app-application-card__note {
+  display: inline-block;
+  position: relative;
+  padding: 1px 0px 1px 15px;
+  margin-top: 10px;
+  margin-bottom: 5px;
+  color: $govuk-text-colour;
+  line-height: 1.25;
+  font-weight: 400;
+  font-size: 1rem;
+  -webkit-font-smoothing: antialiased;
+
+  &:before {
+    position: absolute;
+    background: govuk-colour("black");
+    border-radius: 25px;
+    height: 10px;
+    width: 10px;
+    left: 0px;
+    top: 6px;
+    content: " ";
+  }
+}
+
+/* for __single application view__ within provider_interface */
+
 .app-notes {
   border-top: 1px solid #b1b4b6;
 }

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -35,6 +35,15 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
            updated_at: Date.parse('25-03-2020'))
   end
 
+  let(:note) do
+    provider_user = current_provider.provider_users.first
+    Note.new(
+      provider_user: provider_user,
+      subject: 'Needs review',
+      message: 'Please review asap as the deadline is looming.',
+    )
+  end
+
   let(:result) { render_inline described_class.new(application_choice: application_choice) }
 
   let(:card) { result.css('.app-application-card').to_html }
@@ -58,6 +67,11 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
     it 'renders the status of the application' do
       expect(card).to include('Application withdrawn')
+    end
+
+    it 'renders the subject of the most recent note' do
+      application_choice.notes << note
+      expect(card).to include(note.subject)
     end
 
     it 'renders the last updated date' do

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     end
 
     it 'renders the subject of the most recent note' do
+      FeatureFlag.activate('notes')
       application_choice.notes << note
       expect(card).to include(note.subject)
     end


### PR DESCRIPTION
## Context

We need to add this:
![image](https://user-images.githubusercontent.com/107591/80803570-9775c380-8baa-11ea-9d0e-c104527fab7b.png)

## Changes proposed in this pull request

Adding `most_recent_note` to `ProviderInterface::ApplicationCardComponent` and relevant styles.

## Guidance to review

If an application choice has any notes, the most recent one should appear on applications list, just below the status tag.

## Link to Trello card

[Note should appear on the application list page](https://trello.com/c/ai0z23Ma)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
