### PR TITLE
Update sent_to_provider_at field in application choices CSV

### DIFF
--- a/app/services/support_interface/application_choices_export.rb
+++ b/app/services/support_interface/application_choices_export.rb
@@ -10,7 +10,7 @@ module SupportInterface
             choice_status: choice.status,
             provider_code: choice.provider.code,
             course_code: choice.course.code,
-            sent_to_provider_at: sent_to_provider_audit_entry(choice: choice)&.created_at,
+            sent_to_provider_at: choice.sent_to_provider_at,
             reject_by_default_at: choice.reject_by_default_at,
             decline_by_default_at: choice.decline_by_default_at,
             decision: decision_interpretation(choice: choice),
@@ -23,12 +23,6 @@ module SupportInterface
     end
 
   private
-
-    def sent_to_provider_audit_entry(choice:)
-      choice
-        .audits
-        .detect { |entry| entry.audited_changes == { 'status' => %w[application_complete awaiting_provider_decision] } }
-    end
 
     def decision_interpretation(choice:)
       if choice.offered_at.present?


### PR DESCRIPTION
## Context

This predates the existence of this field, which is a more direct way to get the same data.

## Changes proposed in this pull request

Read from `choice.sent_to_provider_at` instead of using audit log entries to infer it.

## Guidance to review

Nothing in particular.

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)