### PR TITLE
Extend system spec for apply again to cover application submission

### DIFF
--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -53,6 +53,18 @@ private
   def submit_application
     application_choices.each do |application_choice|
       SubmitApplicationChoice.new(application_choice).call
+
+      if application_form.apply_again? && enough_references_have_been_provided?
+        ApplicationStateChange.new(application_choice).references_complete!
+      end
     end
+  end
+
+  def enough_references_have_been_provided?
+    application_form
+      .application_references
+      .feedback_provided
+      .uniq
+      .count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
   end
 end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -54,7 +54,7 @@ private
     application_choices.each do |application_choice|
       SubmitApplicationChoice.new(application_choice).call
 
-      if application_form.apply_again? && enough_references_have_been_provided?
+      if FeatureFlag.active?('apply_again') && enough_references_have_been_provided?
         ApplicationStateChange.new(application_choice).references_complete!
       end
     end

--- a/app/views/candidate_interface/application_form/start_apply_again.html.erb
+++ b/app/views/candidate_interface/application_form/start_apply_again.html.erb
@@ -1,4 +1,6 @@
-<h1 class="govuk-heading-xl">Do you want to apply again?</h1>
+<% content_for :title, t('page_titles.start_apply_again') %>
+
+<h1 class="govuk-heading-xl"><%= t('page_titles.start_apply_again') %></h1>
 
 <div class="govuk-grid-row">
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -113,6 +113,7 @@ en:
       respond: Respond to application
       confirm: Confirm offer
     covid_19_guidance: "Coronavirus (COVID-19): deadlines for processing applications extended to 31 May 2020"
+    start_apply_again: Do you want to apply again?
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -61,6 +61,8 @@ RSpec.describe SubmitApplication do
     end
 
     context 'when application is Apply Again' do
+      before { FeatureFlag.activate('apply_again') }
+
       it 'progresses status to `application_complete`' do
         original_application_form = create_application_form
 

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -21,6 +21,11 @@ RSpec.feature 'Candidate with unsuccessful application' do
     and_i_click_on_start_now
 
     then_i_see_a_copy_of_my_application
+
+    when_i_select_a_course
+    and_submit_the_application
+
+    then_application_is_submitted
   end
 
   def given_the_pilot_is_open
@@ -37,7 +42,14 @@ RSpec.feature 'Candidate with unsuccessful application' do
   end
 
   def when_i_have_an_unsuccessful_application
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(
+      :completed_application_form,
+      :with_completed_references,
+      references_count: 2,
+      with_gces: true,
+      candidate: @candidate,
+      safeguarding_issues_status: :no_safeguarding_issues_to_declare,
+    )
     create(:application_choice, status: :rejected, application_form: @application_form)
   end
 
@@ -55,5 +67,27 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def then_i_see_a_copy_of_my_application
     expect(page).to have_content('Your new application is ready for editing')
+  end
+
+  def when_i_select_a_course
+    given_courses_exist
+    and_the_suitability_to_work_with_children_feature_flag_is_on
+
+    click_link 'Course choices'
+    candidate_fills_in_course_choices
+  end
+
+  def and_submit_the_application
+    click_link 'Check and submit your application'
+    click_link 'Continue'
+    choose 'No' # "Is there anything else you would like to tell us?"
+
+    click_button 'Submit application'
+
+    @application = ApplicationForm.last
+  end
+
+  def then_application_is_submitted
+    expect(page).to have_content('Application successfully submitted')
   end
 end

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
     and_submit_the_application
 
     then_application_is_submitted
+    and_application_choices_are_complete
   end
 
   def given_the_pilot_is_open
@@ -83,11 +84,13 @@ RSpec.feature 'Candidate with unsuccessful application' do
     choose 'No' # "Is there anything else you would like to tell us?"
 
     click_button 'Submit application'
-
-    @application = ApplicationForm.last
   end
 
   def then_application_is_submitted
     expect(page).to have_content('Application successfully submitted')
+  end
+
+  def and_application_choices_are_complete
+    expect(ApplicationForm.last.application_choices.first.reload.status).to eq 'application_complete'
   end
 end

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -3,13 +3,6 @@ require 'rails_helper'
 RSpec.feature 'Candidate with unsuccessful application' do
   include CandidateHelper
 
-  around do |example|
-    date_that_avoids_clocks_changing_by_ten_days = Time.zone.local(2020, 1, 13)
-    Timecop.freeze(date_that_avoids_clocks_changing_by_ten_days) do
-      example.run
-    end
-  end
-
   scenario 'Can apply again' do
     given_the_pilot_is_open
     and_apply_again_feature_flag_is_active


### PR DESCRIPTION
## Context

This PR is a follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1970 to improve tests and fix an issue with the Apply Again feature.

## Changes proposed in this pull request

- [x] Extend system spec for starting an Apply Again application to include submission
- [x] Add missing title to template

## Guidance to review

- Does the spec make sense?
- Is the title correct?

## Link to Trello card

https://trello.com/c/uQeHCQJ2/1390-candidates-can-apply-again-which-copies-the-form-with-temporary-interstitial

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
