### PR TITLE
Accept different types of email address input for sign in fallback

### DIFF
--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -18,7 +18,7 @@ module ProviderInterface
     def sign_in_by_email
       raise unless FeatureFlag.active?('dfe_sign_in_fallback')
 
-      provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address).downcase)
+      provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address).downcase.strip)
 
       if provider_user && provider_user.dfe_sign_in_uid.present?
         magic_link_token = MagicLinkToken.new

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -26,7 +26,7 @@ module ProviderInterface
         provider_user.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.zone.now)
 
         SlackNotificationWorker.perform_async(
-          "Provider user #{provider_user.first_name} has requested a fallback signin link",
+          "Provider user #{provider_user.first_name} has requested a fallback sign in link",
           edit_support_interface_provider_user_url(provider_user),
         )
       end

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -18,7 +18,7 @@ module ProviderInterface
     def sign_in_by_email
       raise unless FeatureFlag.active?('dfe_sign_in_fallback')
 
-      provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address))
+      provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address).downcase)
 
       if provider_user && provider_user.dfe_sign_in_uid.present?
         magic_link_token = MagicLinkToken.new

--- a/spec/system/provider_interface/authentication_fallback_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
   end
 
   def when_i_provide_my_email_address
-    fill_in 'Email address', with: 'pRoViDeR@example.com'
+    fill_in 'Email address', with: 'pRoViDeR@example.com '
     click_on 'Continue'
   end
 

--- a/spec/system/provider_interface/authentication_fallback_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
   end
 
   def when_i_provide_my_email_address
-    fill_in 'Email address', with: @email
+    fill_in 'Email address', with: 'pRoViDeR@example.com'
     click_on 'Continue'
   end
 


### PR DESCRIPTION
## Context

This allows users to input their email address with extra spaces and mixed-case.

## Changes proposed in this pull request

See commits.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/t421tPrM/2073-deal-with-may-1st-dfe-signin-outage

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
