### PR TITLE
Apply two thirds width to withdraw offer views

### DIFF
--- a/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_withdraw_offer.html.erb
@@ -10,16 +10,17 @@
     Check and confirm withdrawal
   </h1>
 
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Full name', value: @application_choice.application_form.full_name },
-    { key: 'Course', value: @application_choice.course.name_and_code },
-    { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-    { key: 'Preferred location', value: @application_choice.site.name },
-    { key: 'Reasons for withdrawal', value: @withdraw_offer.offer_withdrawal_reason },
-  ]) %>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      <%= render SummaryListComponent.new(rows: [
+        { key: 'Full name', value: @application_choice.application_form.full_name },
+        { key: 'Course', value: @application_choice.course.name_and_code },
+        { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
+        { key: 'Preferred location', value: @application_choice.site.name },
+        { key: 'Reasons for withdrawal', value: @withdraw_offer.offer_withdrawal_reason },
+      ]) %>
+
       <%= f.hidden_field :offer_withdrawal_reason %>
       <%= f.govuk_submit 'Withdraw offer', warning: true %>
 

--- a/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_withdraw_offer.html.erb
@@ -3,22 +3,22 @@
 
 <%= render(FlashMessageComponent.new(flash: flash)) %>
 
-<%= form_with model: @withdraw_offer, url: provider_interface_application_choice_confirm_withdraw_offer_path(@application_choice.id), method: :post do |f| %>
-  <%= f.govuk_error_summary %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @withdraw_offer, url: provider_interface_application_choice_confirm_withdraw_offer_path(@application_choice.id), method: :post do |f| %>
+      <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl">
-    Withdraw offer
-  </h1>
+      <h1 class="govuk-heading-xl">
+        Withdraw offer
+      </h1>
 
-  <%= render SummaryListComponent.new(rows: [
-    { key: 'Full name', value: @application_choice.application_form.full_name },
-    { key: 'Course', value: @application_choice.course.name_and_code },
-    { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-    { key: 'Preferred location', value: @application_choice.site.name },
-  ]) %>
+      <%= render SummaryListComponent.new(rows: [
+        { key: 'Full name', value: @application_choice.application_form.full_name },
+        { key: 'Course', value: @application_choice.course.name_and_code },
+        { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
+        { key: 'Preferred location', value: @application_choice.site.name },
+      ]) %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Tell us why you’re withdrawing the offer</legend>
         <%= f.govuk_text_area :offer_withdrawal_reason, rows: 5, label: { text: '' }, hint_text: 'We’ll forward your feedback to the candidate' %>
@@ -29,6 +29,6 @@
       <p class="govuk-body">
         <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
       </p>
-    </div>
+    <% end %>
   </div>
-<% end %>
+</div>


### PR DESCRIPTION
## Context

Just a quick fix of content width for withdraw offer views.

## Changes proposed in this pull request

Before:
![image](https://user-images.githubusercontent.com/107591/80948901-ea3dbe00-8dea-11ea-8689-24533334215c.png)

After:

![image](https://user-images.githubusercontent.com/107591/80948862-da25de80-8dea-11ea-89b6-2c35dff09fe8.png)

## Guidance to review

Inspect template changes.

## Link to Trello card

[Defect: width should be 2/3 for withdraw offer](https://trello.com/c/lEHGQQvu)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
