### PR TITLE
Modify max-width of applications list to 960px

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -1,5 +1,5 @@
 <header class="govuk-header <%= classes %>" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-width-container<%= wide ? " app-width-container--wide" : "" %>">
+  <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <%= link_to 'https://gov.uk', class: 'govuk-header__link govuk-header__link--homepage' do %>
         <span class="govuk-header__logotype">

--- a/app/components/header_component.rb
+++ b/app/components/header_component.rb
@@ -1,11 +1,10 @@
 class HeaderComponent < ViewComponent::Base
-  attr_reader :navigation_items, :service_url, :service_name, :classes, :wide
+  attr_reader :navigation_items, :service_url, :service_name, :classes
 
-  def initialize(navigation_items:, service_name:, service_url:, classes: '', wide: false)
+  def initialize(navigation_items:, service_name:, service_url:, classes: '')
     @navigation_items = navigation_items
     @service_name     = service_name
     @service_url      = service_url
     @classes          = classes
-    @wide             = wide
   end
 end

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -1,9 +1,3 @@
-@include govuk-media-query($from: wide) {
-  .app-width-container--wide {
-    max-width: 1220px;
-  }
-}
-
 .moj-action-bar {
   overflow: hidden;
 }

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="govuk-footer govuk-footer--app app-!-print-display-none" role="contentinfo">
-  <div class="govuk-width-container<%= yield(:page_width) == "wide" ? " app-width-container--wide" : "" %>">
+  <div class="govuk-width-container">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <% case try(:current_namespace) %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,32 +3,27 @@
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_candidate_interface(current_candidate, controller),
-                                 wide: yield(:page_width) == "wide")) %>
+                                 navigation_items: NavigationItems.for_candidate_interface(current_candidate, controller))) %>
 <% when 'support_interface' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_support_interface(current_support_user, controller),
-                                 wide: yield(:page_width) == "wide")) %>
+                                 navigation_items: NavigationItems.for_support_interface(current_support_user, controller))) %>
 <% when 'provider_interface' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user),
-                                 wide: yield(:page_width) == "wide")) %>
+                                 navigation_items: NavigationItems.for_provider_interface(current_provider_user))) %>
 <% when 'api_docs' %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
-                                 navigation_items: NavigationItems.for_api_docs(controller),
-                                 wide: yield(:page_width) == "wide")) %>
+                                 navigation_items: NavigationItems.for_api_docs(controller))) %>
 <% else %>
   <% components_url = '/rails/view_components' if request.path.match(/^\/rails\/view_components/) %>
   <% components_name = 'ViewComponent Previews' if request.path.match(/^\/rails\/view_components/) %>
   <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: components_name || try(:service_name),
                                  service_url: components_url || try(:service_url),
-                                 navigation_items: [],
-                                 wide: yield(:page_width) == "wide")) %>
+                                 navigation_items: [])) %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <% content_for :body do %>
-  <div class="govuk-width-container<%= yield(:page_width) == "wide" ? " app-width-container--wide" : "" %>">
+  <div class="govuk-width-container">
     <%= render 'layouts/phase_banner' %>
 
     <%= yield(:before_content) %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for :title, 'Applications' %>
-<% content_for :page_width, 'wide' %>
 
 <% if FeatureFlag.active?('covid_19') %>
   <div class="govuk-grid-row">
@@ -31,26 +30,21 @@
     <% end %>
 
     <div class='moj-filter-layout__content'>
-      <div class='moj-scrollable-pane'>
-        <div class='moj-scrollable-pane__wrapper'>
-        <% if @application_choices.any? %>
-          <div class="app-application-cards">
-            <% @application_choices.each_with_index do |choice, index| %>
-              <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
-            <% end %>
-          </div>
-        <% elsif @page_state.filter_selections.any? %>
-          <p class='govuk-body'>No applications for the selected filters.</p>
-        <% else %>
-          <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
-        <% end %>
+      <% if @application_choices.any? %>
+        <div class="app-application-cards">
+          <% @application_choices.each_with_index do |choice, index| %>
+            <%= render ProviderInterface::ApplicationCardComponent.new(application_choice: choice) %>
+          <% end %>
         </div>
-      </div>
+      <% elsif @page_state.filter_selections.any? %>
+        <p class='govuk-body'>No applications for the selected filters.</p>
+      <% else %>
+        <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
+      <% end %>
     </div>
   </div>
 
   <%= render(PaginatorComponent.new(scope: @application_choices)) %>
-
 
 <% else %>
 


### PR DESCRIPTION
## Context

Aim of this PR is to fix the width of applications index in the provider_interface. This should be 960px rather than 1220px, which is what it's set to currently.

## Changes proposed in this pull request

Adam has pointed out that the root cause for the current width is the inclusion of custom styles, in particular `.app-width-container--wide` and an associated query param `wide` which has crept into various places. Removing all instances of this custom `wide`/`:page_width` logic seems to fix the width of all pages.

## Guidance to review

Should be straightforward. Please inspect all interfaces (candidate, provider and support) when reviewing this code.

## Link to Trello card

[Change application list page width](https://trello.com/c/67mVoJI7)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
