### PR TITLE
Add ping test before slot swap

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -346,7 +346,47 @@ jobs:
               SpecifySlotOrASE: true
               ResourceGroupName: '$(resourceGroupName)'
               Slot: staging
-
+          
+          - task: AzurePowerShell@4
+            displayName: 'GET /check in $(appServiceName)-staging'
+            inputs:
+              azureSubscription: '${{parameters.subscriptionName}}'
+              ScriptType: InlineScript
+              azurePowerShellVersion: LatestVersion
+              Inline: |
+                Param(
+                  [string] $appServiceName = "$(appServiceName)"
+                )
+                # Wait 30 seconds for slot to wake up
+                Start-Sleep -Seconds 30
+                $healthCheckUrl = [string]::Format("https://{0}-staging.azurewebsites.net/check", $appServiceName)
+                $maxAttempts = 5;
+                $statusCode = 0;
+                $attempt=0
+                while($attempt -lt $maxAttempts){
+                  try
+                  {
+                      $response = Invoke-WebRequest -Uri $healthCheckUrl -TimeoutSec 120 -ErrorAction Stop
+                      $statusCode = $response.StatusCode
+                      break;
+                  }
+                  catch
+                  {
+                      $statusCode = $_.Exception.Response.StatusCode.value__
+                      $waitSeconds = ($attempt + 1) * 10
+                      Write-Warning "GET $healthCheckUrl failed; retrying in $waitSeconds seconds"
+                      Start-Sleep -Seconds $waitSeconds
+                  }
+                  $attempt = $attempt + 1
+                }
+                
+                if($statusCode -ne 200){
+                  Write-Warning "GET $healthCheckUrl failed; after $attempt attempts"
+                  Write-Error "GET $healthCheckUrl failed with status code $statusCode"
+                }
+                else{ 
+                  Write-Host "GET $healthCheckUrl succeeded after $attempt attempt(s)"
+                }
 
           - task: AzureAppServiceManage@0
             displayName: 'Swap Slots: $(appServiceName)'


### PR DESCRIPTION
## Context

As per the ticket it is noted that sometimes a slot swap from staging to production can take up an nondeterministic time period (1-7 mins) with the risk of the downtime during that period.

To give us more confidence on the swap process, this step tests if the deployed container image on the staging slot is healthy by pinging the `/check` endpoint and waiting for a `200` status before proceeding with the swap operation.

## Changes proposed in this pull request

Manually ping the `/check` endpoint on staging slot of the app service and check for 200 status to test if the staging slot is warmed up and ready to be swapped to production.

## Guidance to review

Check power shell script.

## Link to Trello card

https://trello.com/c/Clapqcem/1645-investigate-swap-slots-duration-variability

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [-] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
