### PR TITLE
Add qualifications and program type to UCAS export

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -34,6 +34,15 @@ class Course < ApplicationRecord
     full_time_or_part_time: 'B',
   }
 
+  # also copied from Find
+  enum program_type: {
+    higher_education_programme: 'HE',
+    school_direct_training_programme: 'SD',
+    school_direct_salaried_training_programme: 'SS',
+    scitt_programme: 'SC',
+    pg_teaching_apprenticeship: 'TA',
+  }
+
   def name_and_description
     "#{name} #{description}"
   end

--- a/app/services/applications_export_for_ucas.rb
+++ b/app/services/applications_export_for_ucas.rb
@@ -20,6 +20,7 @@ class ApplicationsExportForUCAS
     level: 'Phase', # <- what we call our field: how UCAS refer to it
     funding_type: 'Funding type',
     program_type: 'Programme type',
+    qualifications: 'Qualifications',
     programme_outcome: 'Programme outcome',
     nctl_subject: 'NCTL subject',
     course_name: 'Course name',

--- a/app/services/applications_export_for_ucas.rb
+++ b/app/services/applications_export_for_ucas.rb
@@ -18,7 +18,8 @@ class ApplicationsExportForUCAS
     provider_name: 'Provider name',
     phase: 'Apply stage', # <- what we call our field: how UCAS refer to it
     level: 'Phase', # <- what we call our field: how UCAS refer to it
-    programme_type: 'Programme type',
+    funding_type: 'Funding type',
+    program_type: 'Programme type',
     programme_outcome: 'Programme outcome',
     nctl_subject: 'NCTL subject',
     course_name: 'Course name',
@@ -82,25 +83,23 @@ private
       provider_code: application_choice.provider.code,
       provider_name: application_choice.provider.name,
       phase: form.phase,
-      programme_type: application_choice.course.funding_type,
+      funding_type: application_choice.course.funding_type,
+      program_type: application_choice.course.program_type,
       programme_outcome: application_choice.course.description,
-      nctl_subject: subject_codes(application_choice.course),
+      qualifications: concatenate(application_choice.course.qualifications),
+      nctl_subject: concatenate(application_choice.course.subject_codes),
       course_name: application_choice.course.name,
       course_code: application_choice.course.code,
       sex: form.equality_and_diversity.try(:[], 'sex'),
       disability_status: form.equality_and_diversity.try(:[], 'disability_status'),
-      disabilities: disabilities(form),
+      disabilities: concatenate(form.equality_and_diversity.try(:[], 'disabilities')),
       other_disability: form.equality_and_diversity.try(:[], 'other_disability'),
       ethnic_group: form.equality_and_diversity.try(:[], 'ethnic_group'),
       ethnic_background: form.equality_and_diversity.try(:[], 'ethnic_background'),
     }
   end
 
-  def subject_codes(course)
-    course.subject_codes.to_a.join('|')
-  end
-
-  def disabilities(form)
-    form.equality_and_diversity.try(:[], 'disabilities').to_a.join('|')
+  def concatenate(array)
+    array.to_a.join('|')
   end
 end

--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -130,6 +130,9 @@ private
     course.exposed_in_find = find_course.findable?
     course.subject_codes = find_course.subject_codes
     course.funding_type = find_course.funding_type
+    # these two fields are in the API docs, but not actually in the API yet
+    course.program_type = find_course.try(:program_type)
+    course.qualifications = find_course.try(:qualifications)
     course.age_range = find_course.age_range_in_years&.humanize
   end
 

--- a/spec/services/applications_export_for_ucas_spec.rb
+++ b/spec/services/applications_export_for_ucas_spec.rb
@@ -63,9 +63,11 @@ RSpec.describe ApplicationsExportForUCAS do
       it 'returns the correct details from each choice with the expected names' do
         expect(result.map { |e| e[:provider_code] }.sort).to eq(application.application_choices.map { |e| e.provider.code }.sort)
         expect(result.map { |e| e[:provider_name] }.sort).to eq(application.application_choices.map { |e| e.provider.name }.sort)
-        expect(result.map { |e| e[:programme_type] }.sort).to eq(application.application_choices.map { |e| e.course.funding_type }.sort)
+        expect(result.map { |e| e[:program_type] }.sort).to eq(application.application_choices.map { |e| e.course.program_type }.sort)
+        expect(result.map { |e| e[:funding_type] }.sort).to eq(application.application_choices.map { |e| e.course.funding_type }.sort)
         expect(result.map { |e| e[:programme_outcome] }.sort).to eq(application.application_choices.map { |e| e.course.description }.sort)
         expect(result.map { |e| e[:nctl_subject] }.sort).to eq(application.application_choices.map { |e| e.course.subject_codes.join('|') }.sort)
+        expect(result.map { |e| e[:qualifications] }.sort).to eq(application.application_choices.map { |e| e.course.qualifications.to_a.join('|') }.sort)
         expect(result.map { |e| e[:course_name] }.sort).to eq(application.application_choices.map { |e| e.course.name }.sort)
         expect(result.map { |e| e[:course_code] }.sort).to eq(application.application_choices.map { |e| e.course.code }.sort)
         expect(result.map { |e| e[:application_state] }.sort).to eq(application.application_choices.map(&:status).sort)

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -233,12 +233,14 @@ RSpec.describe SyncProviderFromFind do
           provider_code: 'ABC',
           course_code: '9CBA',
           findable: true,
+          program_type: 'SD',
         )
 
         SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
         course_option = CourseOption.last
 
-        expect(course_option.course.program_type).to eq('SD')
+        # the enum field converts the value from the short code to the expanded value
+        expect(course_option.course.program_type).to eq('school_direct_training_programme')
       end
     end
   end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -197,6 +197,49 @@ RSpec.describe SyncProviderFromFind do
 
         expect(course_option.course.subject_codes).to eq(%w[08])
       end
+
+      # These fields are not present in the Find API yet, but will be soon
+      # Our code should set them to nil at first, then the correct values
+      # once they are populated
+      it 'correctly updates qualifications and program_type when they are not present' do
+        stub_find_api_provider_200(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          findable: true,
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        course_option = CourseOption.last
+
+        expect(course_option.course.qualifications).to be_nil
+        expect(course_option.course.program_type).to be_nil
+      end
+
+      it 'correctly updates qualifications when qualifications are present' do
+        stub_find_api_provider_200_with_qualifications_and_program_type(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          findable: true,
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        course_option = CourseOption.last
+
+        expect(course_option.course.qualifications).to eq(%w[PG PF])
+      end
+
+      it 'correctly updates program_type when program_type is present' do
+        stub_find_api_provider_200_with_qualifications_and_program_type(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          findable: true,
+        )
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        course_option = CourseOption.last
+
+        expect(course_option.course.program_type).to eq('SD')
+      end
     end
   end
 

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -462,6 +462,137 @@ module FindAPIHelper
       "/courses/#{course_code}")
   end
 
+  def stub_find_api_provider_200_with_qualifications_and_program_type(
+    provider_code: 'ABC',
+    provider_name: 'Dummy Provider',
+    course_code: 'X130',
+    site_code: 'X',
+    findable: true,
+    study_mode: 'full_time',
+    description: 'PGCE with QTS full time',
+    start_date: Time.zone.local(2020, 10, 31),
+    course_length: 'OneYear',
+    region_code: 'north_west',
+    site_address_line2: 'C/O The Bruntcliffe Academy',
+    funding_type: 'fee',
+    age_range_in_years: '4 to 8',
+    vac_status: 'full_time_vacancies',
+    qualifications: %w[PG PF],
+    program_type: 'SD'
+  )
+    stub_find_api_provider(provider_code)
+      .to_return(
+        status: 200,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: {
+          'data': {
+            'id': '1',
+            'type': 'providers',
+            'attributes': {
+              'provider_name': provider_name,
+              'provider_code': provider_code,
+              'region_code': region_code,
+            },
+            'relationships': {
+              'sites': {
+                'data': [
+                  { 'id': '1', 'type': 'sites' },
+                ],
+              },
+              'courses': {
+                'data': [
+                  { 'id': '1', 'type': 'courses' },
+                ],
+              },
+            },
+          },
+          'included': [
+            {
+              'id': '1',
+              'type': 'sites',
+              'attributes': {
+                'code': site_code,
+                'location_name': 'Main site',
+                'address1': 'Gorse SCITT ',
+                'address2': site_address_line2,
+                'address3': 'Bruntcliffe Lane',
+                'address4': 'MORLEY, LEEDS',
+                'postcode': 'LS27 0LZ',
+              },
+            },
+            {
+              'id': '1',
+              'type': 'courses',
+              'attributes': {
+                'course_code': course_code,
+                'name': 'Primary',
+                'level': 'primary',
+                'study_mode': study_mode,
+                'description': description,
+                'start_date': start_date,
+                'course_length': course_length,
+                'recruitment_cycle_year': '2020',
+                'findable?': findable,
+                'accrediting_provider': nil,
+                'funding_type': funding_type,
+                'age_range_in_years': age_range_in_years,
+                'program_type': program_type,
+                'qualifications': qualifications,
+              },
+              'relationships': {
+                'sites': {
+                  'data': [
+                    { 'id': '1', 'type': 'sites' },
+                  ],
+                },
+                'subjects': {
+                  'data': [
+                    { 'type': 'subjects', 'id': '11' },
+                  ],
+                },
+                'site_statuses': {
+                  'data': [
+                    { 'id': '222', 'type': 'site_statuses' },
+                  ],
+                },
+              },
+            },
+            {
+              'id': '222',
+              'type': 'site_statuses',
+              'attributes': {
+                'vac_status': vac_status,
+                'publish': 'published',
+                'status': 'running',
+                'has_vacancies?': true,
+              },
+              'relationships': {
+                'site': {
+                  'data': {
+                    'type': 'sites',
+                    'id': '1',
+                  },
+                },
+              },
+            },
+            {
+              'id': '11',
+              'type': 'subjects',
+              'attributes': {
+                'subject_name': 'Business studies',
+                'subject_code': '08',
+                'bursary_amount': '9000',
+                'early_career_payments': nil,
+                'scholarship': nil,
+                'subject_knowledge_enhancement_course_available': false,
+              },
+            },
+          ],
+          'jsonapi': { 'version': '1.0' },
+        }.to_json,
+      )
+  end
+
 private
 
   def stub_find_api_all_providers


### PR DESCRIPTION
## Context
Please note: migrations are included in a separate PR #2008 - please merge that one _first_

As part of ongoing discussions around the data sharing agreement, UCAS have asked for the fields `qualifications` and `program_type` from the Find API to be included in the 'Dataset1' file which we will generate for them each night. These fields are pre-emptively documented in the [Find API Docs](https://api2.publish-teacher-training-courses.service.gov.uk/api-reference.html#schema-courseattributes) but are not yet implemented in the actual API itself.

So we have agreed to add the fields into the export file now, so that they can integrate on the basis that the fields are there, and we will make them blank values until the fields are present in the Find API (ETA: "a few weeks") at which time the values will appear with no further code changes needed.

## Changes proposed in this pull request

1. Populate new fields in `SyncProviderFromFind` 
2. Include fields in `ApplicationsExportForUCAS` service, renaming what was labelled as "Programme Type" back to match our original name "funding_type".
3. Add expectations in the relevant specs for the above


## Guidance to review

Make sure you have some submitted applications in your DB (run `GenerateTestData.new(10).generate` from the console if not)

Then, from the support UI:
1. Enable the `download_dataset1_from_support_page` FeatureFlag
2. Go to /support/performance
3. Click on 'Download Dataset1 (CSV)'
4. View the downloaded file - you should see "Program type" and "Qualifications" fields in the header. All values for those fields should be empty.

## Link to Trello card

[Add program_type and qualifications to the UCAS dataset1 export, (with blank values until Find add them to the API)](https://trello.com/c/igGCClZc/1426-add-programtype-and-qualifications-to-the-ucas-dataset1-export-with-blank-values-until-find-add-them-to-the-api)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
