### PR TITLE
Add missing course information to application show view

### DIFF
--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -4,6 +4,6 @@
   { key: 'Course', value: course_name_and_code },
   { key: 'Cycle', value: cycle },
   { key: 'Preferred location', value: preferred_location },
-  { key: 'Study mode', value: study_mode },
+  { key: 'Full or part time', value: study_mode },
   { key: 'Funding type', value: funding_type },
 ]) %>

--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,0 +1,9 @@
+<%= render SummaryListComponent.new(rows: [
+  { key: 'Provider', value: provider},
+  { key: 'Accredited body', value: accredited_body },
+  { key: 'Course', value: course },
+  { key: 'Cycle', value: cycle },
+  { key: 'Preferred location', value: preferred_location },
+  { key: 'Study mode', value: study_mode },
+]) %>
+

--- a/app/components/provider_interface/course_details_component.html.erb
+++ b/app/components/provider_interface/course_details_component.html.erb
@@ -1,9 +1,9 @@
 <%= render SummaryListComponent.new(rows: [
-  { key: 'Provider', value: provider},
+  { key: 'Provider', value: provider_name_and_code },
   { key: 'Accredited body', value: accredited_body },
-  { key: 'Course', value: course },
+  { key: 'Course', value: course_name_and_code },
   { key: 'Cycle', value: cycle },
   { key: 'Preferred location', value: preferred_location },
   { key: 'Study mode', value: study_mode },
+  { key: 'Funding type', value: funding_type },
 ]) %>
-

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -2,12 +2,15 @@ module ProviderInterface
   class CourseDetailsComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :application_choice, :provider, :course, :cycle, :preferred_location, :study_mode
+    FUNDING_TYPES = { apprenticeship: :apprenticeship, salary: :salaried, fee: :fee_paying }.freeze
+
+    attr_reader :application_choice, :provider_name_and_code, :course_name_and_code,
+                :cycle, :preferred_location, :study_mode
 
     def initialize(application_choice:)
       @application_choice = application_choice
-      @provider = application_choice.provider.name_and_code
-      @course = application_choice.course.name_and_code
+      @provider_name_and_code = application_choice.provider.name_and_code
+      @course_name_and_code = application_choice.course.name_and_code
       @cycle = application_choice.course.recruitment_cycle_year
       @preferred_location = application_choice.site.name_and_code
       @study_mode = application_choice.course_option.study_mode.humanize
@@ -15,7 +18,12 @@ module ProviderInterface
 
     def accredited_body
       accredited_body = @application_choice.course.accredited_provider
-      accredited_body.present? ? accredited_body.name_and_code : provider
+      accredited_body.present? ? accredited_body.name_and_code : provider_name_and_code
+    end
+
+    def funding_type
+      key = @application_choice.course.funding_type.to_sym
+      FUNDING_TYPES[key].to_s.humanize
     end
   end
 end

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -1,0 +1,21 @@
+module ProviderInterface
+  class CourseDetailsComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :application_choice, :provider, :course, :cycle, :preferred_location, :study_mode
+
+    def initialize(application_choice:)
+      @application_choice = application_choice
+      @provider = application_choice.provider.name_and_code
+      @course = application_choice.course.name_and_code
+      @cycle = application_choice.course.recruitment_cycle_year
+      @preferred_location = application_choice.site.name_and_code
+      @study_mode = application_choice.course_option.study_mode.humanize
+    end
+
+    def accredited_body
+      accredited_body = @application_choice.course.accredited_provider
+      accredited_body.present? ? accredited_body.name_and_code : provider
+    end
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -47,13 +47,7 @@
 
     <h2 class="govuk-heading-m govuk-!-margin-top-8" id="course-info">Course</h2>
 
-    <%= render SummaryListComponent.new(rows: [
-      { key: 'Provider', value: @application_choice.provider.name_and_code },
-      { key: 'Course', value: @application_choice.course.name_and_code },
-      { key: 'Cycle', value: @application_choice.course.recruitment_cycle_year },
-      { key: 'Preferred location', value: @application_choice.site.name_and_code },
-      { key: 'Study mode', value: @application_choice.course_option.study_mode.humanize },
-    ]) %>
+    <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice)%>
 
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -15,48 +15,77 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
 
   let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
 
+  def row_text_selector(row_name, render)
+    rows = { provider: 0,
+             accredited_body: 1,
+             course: 2,
+             cycle: 3,
+             location: 4,
+             full_or_part_time: 5,
+             funding_type: 6 }
+
+    render.css('.govuk-summary-list__row')[rows[row_name]].text
+  end
+
   it 'renders the provider name and code' do
-    expect(render.css('.govuk-summary-list__row')[0].text).to include('Provider')
-    expect(render.css('.govuk-summary-list__row')[0].text).to include(application_choice.provider.name_and_code)
+    render_text = row_text_selector(:provider, render)
+
+    expect(render_text).to include('Provider')
+    expect(render_text).to include(application_choice.provider.name_and_code)
   end
 
   context 'when an accredited body is present' do
     it 'renders the accredited body name and code when it is present' do
       render = render_inline(described_class.new(application_choice: application_choice_with_accredited_body))
-      expect(render.css('.govuk-summary-list__row')[1].text).to include('Accredited body')
-      expect(render.css('.govuk-summary-list__row')[1].text).to include(application_choice_with_accredited_body.course.accredited_provider.name)
+
+      render_text = row_text_selector(:accredited_body, render)
+
+      expect(render_text).to include('Accredited body')
+      expect(render_text).to include(application_choice_with_accredited_body.course.accredited_provider.name)
     end
   end
 
   context 'when an accredited body is not present' do
     it 'renders the provider name and code in place of the accredited body name and code' do
-      expect(render.css('.govuk-summary-list__row')[1].text).to include('Accredited body')
-      expect(render.css('.govuk-summary-list__row')[1].text).to include(application_choice.provider.name_and_code)
+      render_text = row_text_selector(:accredited_body, render)
+
+      expect(render_text).to include('Accredited body')
+      expect(render_text).to include(application_choice.provider.name_and_code)
     end
   end
 
   it 'renders the course name and code' do
-    expect(render.css('.govuk-summary-list__row')[2].text).to include('Course')
-    expect(render.css('.govuk-summary-list__row')[2].text).to include(application_choice.course.name_and_code)
+    render_text = row_text_selector(:course, render)
+
+    expect(render_text).to include('Course')
+    expect(render_text).to include(application_choice.course.name_and_code)
   end
 
   it 'renders the recruitment cycle year' do
-    expect(render.css('.govuk-summary-list__row')[3].text).to include('Cycle')
-    expect(render.css('.govuk-summary-list__row')[3].text).to include(application_choice.course.recruitment_cycle_year.to_s)
+    render_text = row_text_selector(:cycle, render)
+
+    expect(render_text).to include('Cycle')
+    expect(render_text).to include(application_choice.course.recruitment_cycle_year.to_s)
   end
 
   it 'renders the preferred location' do
-    expect(render.css('.govuk-summary-list__row')[4].text).to include('Preferred location')
-    expect(render.css('.govuk-summary-list__row')[4].text).to include(application_choice.site.name_and_code)
+    render_text = row_text_selector(:location, render)
+
+    expect(render_text).to include('Preferred location')
+    expect(render_text).to include(application_choice.site.name_and_code)
   end
 
   it 'renders the study mode' do
-    expect(render.css('.govuk-summary-list__row')[5].text).to include('Full or part time')
-    expect(render.css('.govuk-summary-list__row')[5].text).to include(application_choice.course_option.study_mode.humanize)
+    render_text = row_text_selector(:full_or_part_time, render)
+
+    expect(render_text).to include('Full or part time')
+    expect(render_text).to include(application_choice.course_option.study_mode.humanize)
   end
 
   it 'renders financing funding type of a course' do
-    expect(render.css('.govuk-summary-list__row')[6].text).to include('Funding type')
-    expect(render.css('.govuk-summary-list__row')[6].text).to include('Fee paying')
+    render_text = row_text_selector(:funding_type, render)
+
+    expect(render_text).to include('Funding type')
+    expect(render_text).to include('Fee paying')
   end
 end

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
   end
 
   it 'renders the study mode' do
-    expect(render.css('.govuk-summary-list__row')[5].text).to include('Study mode')
+    expect(render.css('.govuk-summary-list__row')[5].text).to include('Full or part time')
     expect(render.css('.govuk-summary-list__row')[5].text).to include(application_choice.course_option.study_mode.humanize)
   end
 

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::CourseDetailsComponent do
+
+  let(:application_choice) { create(:application_choice) }
+  let(:application_choice_with_accredited_body) { create(:application_choice,
+                                                         course: create(:course, :accredited_provider)) }
+
+  let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
+
+  it 'renders the provider name and code' do
+    expect(render.css('.govuk-summary-list__row')[0].text).to include('Provider')
+    expect(render.css('.govuk-summary-list__row')[0].text).to include(application_choice.provider.name_and_code)
+  end
+
+  context 'when an accredited body is present' do
+    it 'renders the accredited body name and code when it is present' do
+      render = render_inline(described_class.new(application_choice: application_choice_with_accredited_body))
+      expect(render.css('.govuk-summary-list__row')[1].text).to include('Accredited body')
+      expect(render.css('.govuk-summary-list__row')[1].text).to include(application_choice_with_accredited_body.course.accredited_provider.name)
+    end
+  end
+
+  context 'when an accredited body is not present' do
+    it 'renders the provider name and code in place of the accredited body name and code' do
+      expect(render.css('.govuk-summary-list__row')[1].text).to include('Accredited body')
+      expect(render.css('.govuk-summary-list__row')[1].text).to include(application_choice.provider.name_and_code)
+    end
+  end
+
+  it 'renders the course name and code' do
+    expect(render.css('.govuk-summary-list__row')[2].text).to include('Course')
+    expect(render.css('.govuk-summary-list__row')[2].text).to include(application_choice.course.name_and_code)
+  end
+
+  it 'renders the recruitment cycle year' do
+    expect(render.css('.govuk-summary-list__row')[3].text).to include('Cycle')
+    expect(render.css('.govuk-summary-list__row')[3].text).to include(application_choice.course.recruitment_cycle_year.to_s)
+  end
+
+  it 'renders the preferred location' do
+    expect(render.css('.govuk-summary-list__row')[4].text).to include('Preferred location')
+    expect(render.css('.govuk-summary-list__row')[4].text).to include(application_choice.site.name_and_code)
+  end
+
+  it 'renders the study mode' do
+    expect(render.css('.govuk-summary-list__row')[5].text).to include('Study mode')
+    expect(render.css('.govuk-summary-list__row')[5].text).to include(application_choice.course_option.study_mode.humanize)
+  end
+
+end

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -6,9 +6,11 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
            course: create(:course, funding_type: 'fee'))
   }
 
+  let(:accredited_provider) { create(:provider) }
+
   let(:application_choice_with_accredited_body) {
     create(:application_choice,
-           course: create(:course, :accredited_provider))
+           course: create(:course, accredited_provider: accredited_provider))
   }
 
   let(:render) { render_inline(described_class.new(application_choice: application_choice)) }

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -1,16 +1,56 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::CourseDetailsComponent do
-  let(:application_choice) {
-    create(:application_choice,
-           course: create(:course, funding_type: 'fee'))
+  let(:course_option) {
+    instance_double(CourseOption,
+                    study_mode: 'Full time')
   }
 
-  let(:accredited_provider) { create(:provider) }
+  let(:site) {
+    instance_double(Site,
+                    name_and_code: 'First Road (F34)')
+  }
+
+  let(:provider) {
+    instance_double(Provider,
+                    name_and_code: 'Best Training (B54)')
+  }
+
+  let(:accredited_provider) {
+    instance_double(Provider,
+                    name_and_code: 'Accredit Now (A78)')
+  }
+
+  let(:course) {
+    instance_double(Course,
+                    name_and_code: 'Geograpghy (H234)',
+                    recruitment_cycle_year: 2020,
+                    accredited_provider: nil,
+                    funding_type: 'fee')
+  }
+
+  let(:course_with_accredited_body) {
+    instance_double(Course,
+                    name_and_code: 'Geograpghy (H234)',
+                    recruitment_cycle_year: 2020,
+                    accredited_provider: accredited_provider,
+                    funding_type: 'fee')
+  }
+
+  let(:application_choice) {
+    instance_double(ApplicationChoice,
+                    course_option: course_option,
+                    provider: provider,
+                    course: course,
+                    site: site)
+  }
 
   let(:application_choice_with_accredited_body) {
-    create(:application_choice,
-           course: create(:course, accredited_provider: accredited_provider))
+    instance_double(ApplicationChoice,
+                    course_option: course_option,
+                    provider: provider,
+                    course: course_with_accredited_body,
+                    site: site)
   }
 
   let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
@@ -31,7 +71,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
     render_text = row_text_selector(:provider, render)
 
     expect(render_text).to include('Provider')
-    expect(render_text).to include(application_choice.provider.name_and_code)
+    expect(render_text).to include('Best Training (B54)')
   end
 
   context 'when an accredited body is present' do
@@ -41,7 +81,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
       render_text = row_text_selector(:accredited_body, render)
 
       expect(render_text).to include('Accredited body')
-      expect(render_text).to include(application_choice_with_accredited_body.course.accredited_provider.name)
+      expect(render_text).to include('Accredit Now (A78)')
     end
   end
 
@@ -50,7 +90,7 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
       render_text = row_text_selector(:accredited_body, render)
 
       expect(render_text).to include('Accredited body')
-      expect(render_text).to include(application_choice.provider.name_and_code)
+      expect(render_text).to include('Best Training (B54)')
     end
   end
 
@@ -58,28 +98,28 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
     render_text = row_text_selector(:course, render)
 
     expect(render_text).to include('Course')
-    expect(render_text).to include(application_choice.course.name_and_code)
+    expect(render_text).to include('Geograpghy (H234)')
   end
 
   it 'renders the recruitment cycle year' do
     render_text = row_text_selector(:cycle, render)
 
     expect(render_text).to include('Cycle')
-    expect(render_text).to include(application_choice.course.recruitment_cycle_year.to_s)
+    expect(render_text).to include('2020')
   end
 
   it 'renders the preferred location' do
     render_text = row_text_selector(:location, render)
 
     expect(render_text).to include('Preferred location')
-    expect(render_text).to include(application_choice.site.name_and_code)
+    expect(render_text).to include('First Road (F34)')
   end
 
   it 'renders the study mode' do
     render_text = row_text_selector(:full_or_part_time, render)
 
     expect(render_text).to include('Full or part time')
-    expect(render_text).to include(application_choice.course_option.study_mode.humanize)
+    expect(render_text).to include('Full time')
   end
 
   it 'renders financing funding type of a course' do

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -1,10 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::CourseDetailsComponent do
+  let(:application_choice) {
+    create(:application_choice,
+           course: create(:course, funding_type: 'fee'))
+  }
 
-  let(:application_choice) { create(:application_choice) }
-  let(:application_choice_with_accredited_body) { create(:application_choice,
-                                                         course: create(:course, :accredited_provider)) }
+  let(:application_choice_with_accredited_body) {
+    create(:application_choice,
+           course: create(:course, :accredited_provider))
+  }
 
   let(:render) { render_inline(described_class.new(application_choice: application_choice)) }
 
@@ -48,4 +53,8 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
     expect(render.css('.govuk-summary-list__row')[5].text).to include(application_choice.course_option.study_mode.humanize)
   end
 
+  it 'renders financing funding type of a course' do
+    expect(render.css('.govuk-summary-list__row')[6].text).to include('Funding type')
+    expect(render.css('.govuk-summary-list__row')[6].text).to include('Fee paying')
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -275,10 +275,6 @@ FactoryBot.define do
     trait :part_time do
       study_mode { :part_time }
     end
-
-    trait :accredited_provider do
-      accredited_provider { provider }
-    end
   end
 
   factory :provider do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -275,6 +275,10 @@ FactoryBot.define do
     trait :part_time do
       study_mode { :part_time }
     end
+
+    trait :accredited_provider do
+      accredited_provider { provider }
+    end
   end
 
   factory :provider do


### PR DESCRIPTION
## Context

Adds more course information (accredited body and funding type) to the course table in the applications show view.

## Changes proposed in this pull request

**Before:**
<img width="629" alt="Screenshot 2020-05-05 at 14 33 29" src="https://user-images.githubusercontent.com/13377553/81072004-67496000-8edd-11ea-9257-0d1905d39c95.png">

**After:**
<img width="621" alt="Screenshot 2020-05-05 at 14 32 29" src="https://user-images.githubusercontent.com/13377553/81071890-41bc5680-8edd-11ea-845f-0c2708935a92.png">


## Guidance to review

- If a course has no `accredited_provider` it is assumed that they are self accrediting and the provider name is rendered as the Accrediting bod (see spec); is this a correct assumption to make?
- Are the details in the right order?
- Is funding type the right thing to show to the user?
- are the names for the funding types correct? Underlying data for funding types is `apprenticeship`, `fee`, and `salary` which are rendered to the user as 'Apprenticeship', 'Fee paying' and 'Salaried' respectively.

## Link to Trello card

https://trello.com/c/Nj7rrX7e/2059-single-application-view-include-missing-information-in-course-section

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
