### PR TITLE
Candidates can't edit old references when they apply again

### DIFF
--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <% @application_form.application_references.includes(:application_form).each do |referee| %>
-  <%= render(SummaryCardComponent.new(rows: referee_rows(referee), editable: @editable)) do %>
+  <%= render(SummaryCardComponent.new(rows: referee_rows(referee), editable: @editable && referee.editable?)) do %>
     <%= render(SummaryCardHeaderComponent.new(title: "#{TextOrdinalizer::ORDINALIZE_MAPPING[referee.ordinal]&.capitalize} referee", heading_level: @heading_level)) do %>
 
       <% if FeatureFlag.active?('candidate_can_cancel_reference') && referee.feedback_requested? %>

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -17,7 +17,7 @@
             <span class="govuk-visually-hidden"> <%= referee.name %></span>
           <% end %>
         </div>
-      <% elsif @editable %>
+      <% elsif @deletable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_referee_path(referee.id), class: 'govuk-link' do %>
             <%= t('application_form.referees.delete') %>

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -17,7 +17,7 @@
             <span class="govuk-visually-hidden"> <%= referee.name %></span>
           <% end %>
         </div>
-      <% elsif @deletable %>
+      <% elsif @editable %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_destroy_referee_path(referee.id), class: 'govuk-link' do %>
             <%= t('application_form.referees.delete') %>

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -2,9 +2,8 @@ module CandidateInterface
   class RefereesReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, deletable: true, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
+    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
       @application_form = application_form
-      @deletable = deletable
       @editable = editable
       @heading_level = heading_level
       @show_incomplete = show_incomplete

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -2,8 +2,9 @@ module CandidateInterface
   class RefereesReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
+    def initialize(application_form:, deletable: true, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
       @application_form = application_form
+      @deletable = deletable
       @editable = editable
       @heading_level = heading_level
       @show_incomplete = show_incomplete

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -61,10 +61,14 @@ module CandidateInterface
     end
 
     def edit
+      head :unprocessable_entity and return # unless @referee.editable?
+
       @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[@referee.ordinal].capitalize} referee"
     end
 
     def update
+      head :unprocessable_entity and return # unless @referee.editable?
+
       if @referee.update(referee_params)
         redirect_to candidate_interface_review_referees_path
       else

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -61,13 +61,13 @@ module CandidateInterface
     end
 
     def edit
-      head :unprocessable_entity and return # unless @referee.editable?
+      head :unprocessable_entity and return unless @referee.editable?
 
       @nth_referee = "#{TextOrdinalizer::ORDINALIZE_MAPPING[@referee.ordinal].capitalize} referee"
     end
 
     def update
-      head :unprocessable_entity and return # unless @referee.editable?
+      head :unprocessable_entity and return unless @referee.editable?
 
       if @referee.update(referee_params)
         redirect_to candidate_interface_review_referees_path

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -79,4 +79,8 @@ class ApplicationReference < ApplicationRecord
 
     replace_referee_at < Time.zone.now
   end
+
+  def editable?
+    feedback_status == 'not_requested_yet'
+  end
 end

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -81,6 +81,6 @@ class ApplicationReference < ApplicationRecord
   end
 
   def editable?
-    feedback_status == 'not_requested_yet'
+    !FeatureFlag.active?('apply_again') || feedback_status == 'not_requested_yet'
   end
 end

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -128,6 +128,15 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form, editable: false))
 
       expect(result.css('.app-summary-list__actions').text).not_to include('Change')
+    end
+  end
+
+  context 'when referees are not deletable' do
+    let(:application_form) { create(:completed_application_form, references_count: 1, with_gces: true) }
+
+    it 'renders component without a delete link' do
+      result = render_inline(described_class.new(application_form: application_form, deletable: false))
+
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.referees.delete'))
     end
   end

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -2,7 +2,14 @@ require 'rails_helper'
 
 RSpec.describe CandidateInterface::RefereesReviewComponent do
   context 'when referees are editable' do
-    let(:application_form) { create(:completed_application_form, references_count: 2, with_gces: true) }
+    let(:application_form) do
+      create(
+        :completed_application_form,
+        references_state: 'unsubmitted',
+        references_count: 2,
+        with_gces: true,
+      )
+    end
 
     it "renders component with correct values for a referee's name" do
       first_referee = application_form.application_references.first
@@ -50,8 +57,8 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       first_referee = application_form.application_references.first
       first_referee.update_columns(
         feedback_status: 'feedback_requested',
-        requested_at: 9.business_days.ago,
-        created_at: 9.business_days.ago,
+        requested_at: 5.days.ago,
+        created_at: 5.days.ago,
       )
       result = render_inline(described_class.new(application_form: application_form))
 

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -136,13 +136,9 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.app-summary-list__actions').text).not_to include('Change')
     end
-  end
-
-  context 'when referees are not deletable' do
-    let(:application_form) { create(:completed_application_form, references_count: 1, with_gces: true) }
 
     it 'renders component without a delete link' do
-      result = render_inline(described_class.new(application_form: application_form, deletable: false))
+      result = render_inline(described_class.new(application_form: application_form, editable: false))
 
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.referees.delete'))
     end

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -139,4 +139,16 @@ RSpec.describe ApplicationReference, type: :model do
       end
     end
   end
+
+  describe '#editable?' do
+    it 'returns true for `not_requested_yet`' do
+      expect(described_class.new(feedback_status: :not_requested_yet).editable?).to be true
+    end
+
+    it 'returns false for all other statuses' do
+      ApplicationReference.feedback_statuses.keys.reject { |s| s == 'not_requested_yet' }.each do |status|
+        expect(described_class.new(feedback_status: status).editable?).to be false
+      end
+    end
+  end
 end

--- a/spec/models/application_reference_spec.rb
+++ b/spec/models/application_reference_spec.rb
@@ -141,13 +141,25 @@ RSpec.describe ApplicationReference, type: :model do
   end
 
   describe '#editable?' do
-    it 'returns true for `not_requested_yet`' do
-      expect(described_class.new(feedback_status: :not_requested_yet).editable?).to be true
+    context 'when `apply_again` feature flag is on' do
+      before { FeatureFlag.activate('apply_again') }
+
+      it 'returns true for `not_requested_yet`' do
+        expect(described_class.new(feedback_status: :not_requested_yet).editable?).to be true
+      end
+
+      it 'returns false for all other statuses' do
+        ApplicationReference.feedback_statuses.keys.reject { |s| s == 'not_requested_yet' }.each do |status|
+          expect(described_class.new(feedback_status: status).editable?).to be false
+        end
+      end
     end
 
-    it 'returns false for all other statuses' do
-      ApplicationReference.feedback_statuses.keys.reject { |s| s == 'not_requested_yet' }.each do |status|
-        expect(described_class.new(feedback_status: status).editable?).to be false
+    context 'when `apply_again` feature flag is off' do
+      it 'returns true for all statuses' do
+        ApplicationReference.feedback_statuses.each_key do |status|
+          expect(described_class.new(feedback_status: status).editable?).to be true
+        end
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -23,6 +23,7 @@ RSpec.feature 'Candidate applying again' do
 
     when_i_add_a_new_referee
     then_i_can_see_i_have_two_referees
+    and_i_can_change_new_referee_details
     and_references_for_original_application_are_not_affected
   end
 
@@ -95,6 +96,11 @@ RSpec.feature 'Candidate applying again' do
   def then_i_can_see_i_have_two_referees
     expect(page).to have_content @completed_references[1].name
     expect(page).to have_content 'Bob Example'
+  end
+
+  def and_i_can_change_new_referee_details
+    expect(page).to have_link('Change name for Bob Example')
+    expect(page).to have_link('Change email address for Bob Example')
   end
 
   def and_references_for_original_application_are_not_affected

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -15,6 +15,9 @@ RSpec.feature 'Candidate applying again' do
 
     then_i_see_a_copy_of_my_application
 
+    when_i_view_referees
+    then_i_cannot_change_referee_details
+
     when_i_delete_a_referee
     then_i_can_see_i_only_have_one_referee
 
@@ -59,8 +62,15 @@ RSpec.feature 'Candidate applying again' do
     expect(page).to have_content('Your new application is ready for editing')
   end
 
-  def when_i_delete_a_referee
+  def when_i_view_referees
     click_on 'Referees'
+  end
+
+  def then_i_cannot_change_referee_details
+    expect(page).not_to have_link('Change')
+  end
+
+  def when_i_delete_a_referee
     click_on "Delete referee #{@completed_references[0].name}"
     click_on I18n.t('application_form.referees.sure_delete_entry')
   end


### PR DESCRIPTION
## Context

In an Apply Again application we will normally have two completed references whereas in normal first-time applications the references are all unsubmitted. We need to stop candidates from editing their old references to prevent them from getting into weird states.

## Changes proposed in this pull request

- [x] Drop the 'Change' links in the `ReviewReferencesComponent` unless the reference is unsubmitted.
- [x] Update system spec.
- [x] Return an invalid operation code if anybody hits the actions that update a references unless it's unsubmitted.
- [x] Look at what needs to be covered by the feature flag.

## Guidance to review

Does the logic around hiding the change links make sense?

## Link to Trello card

https://trello.com/c/pmArg5iR/1397-candidates-cant-edit-old-references-when-they-apply-again

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
