### PR TITLE
Providers with manage users permission can delete users associated with their org

### DIFF
--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -74,6 +74,21 @@ module ProviderInterface
       redirect_to provider_interface_provider_user_path(provider_user)
     end
 
+    def confirm_remove
+      @provider_user = find_provider_user
+    end
+
+    def remove
+      @provider_user = find_provider_user
+      service = RemoveProviderUser.new(
+        current_provider_user: current_provider_user,
+        user_to_remove: @provider_user,
+      )
+
+      flash[:success] = 'User’s account successfully deleted' if service.call!
+      redirect_to provider_interface_provider_users_path
+    end
+
   private
 
     def provider_user_params

--- a/app/services/remove_provider_user.rb
+++ b/app/services/remove_provider_user.rb
@@ -1,0 +1,17 @@
+class RemoveProviderUser
+  attr_reader :current_provider_user, :user_to_remove
+
+  def initialize(current_provider_user:, user_to_remove:)
+    @current_provider_user = current_provider_user
+    @user_to_remove = user_to_remove
+  end
+
+  # Removes associations to providers common to the managing user
+  # and the user we're editing/removing.
+  def call!
+    managed_providers = current_provider_user.provider_permissions.manage_users.includes(:provider).map(&:provider)
+    shared_providers = managed_providers & user_to_remove.providers
+    user_to_remove.providers -= shared_providers
+    user_to_remove.save!
+  end
+end

--- a/app/views/provider_interface/provider_users/confirm_remove.html.erb
+++ b/app/views/provider_interface/provider_users/confirm_remove.html.erb
@@ -1,0 +1,22 @@
+<% content_for :before_content, govuk_back_link_to(provider_interface_provider_users_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @provider_user,
+      url: provider_interface_provider_user_remove_provider_user_path(@provider_user.id),
+      method: :delete do |f| %>
+      <h1 class="govuk-heading-xl">
+        <span class="govuk-caption-xl"><%= @provider_user.full_name %></span>
+        Are you sure you want to delete this user's account?
+      </h1>
+
+      <%= f.submit "Yes I'm sure - delete this account",
+        class: 'govuk-button govuk-button--warning',
+        data: { module: 'govuk-button' } %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Cancel', provider_interface_provider_user_path(@provider_user) %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_users/show.html.erb
+++ b/app/views/provider_interface/provider_users/show.html.erb
@@ -3,3 +3,10 @@
   provider_permissions: @provider_user.provider_permissions,
   possible_permissions: @possible_permissions,
 ) %>
+
+<%= govuk_link_to(
+  'Delete user',
+  provider_interface_provider_user_remove_provider_user_path(@provider_user),
+  class: 'govuk-button govuk-button--warning',
+) %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -451,6 +451,9 @@ Rails.application.routes.draw do
     resources :provider_users, only: %i[index new create show], path: 'provider-users' do
       get 'edit-providers' => 'provider_users#edit_providers', as: :edit_providers
       patch 'update-providers' => 'provider_users#update_providers', as: :update_providers
+
+      get '/remove' => 'provider_users#confirm_remove', as: :confirm_remove_provider_user
+      delete '/remove' => 'provider_users#remove', as: :remove_provider_user
     end
   end
 

--- a/spec/services/remove_provider_user_spec.rb
+++ b/spec/services/remove_provider_user_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe RemoveProviderUser do
+  let(:provider) { create(:provider) }
+  let(:another_provider) { create(:provider) }
+  let(:non_visible_provider) { create(:provider) }
+  let(:current_provider_user) { create(:provider_user, providers: [provider, another_provider]) }
+  let!(:user_to_remove) { create(:provider_user, providers: [provider, another_provider, non_visible_provider]) }
+
+  before { current_provider_user.provider_permissions.update_all(manage_users: true) }
+
+  subject(:service) do
+    described_class.new(current_provider_user: current_provider_user, user_to_remove: user_to_remove)
+  end
+
+  describe 'call!' do
+    it 'dissociates providers common to the managing and managed users' do
+      expect { service.call! }.to change(ProviderPermissions, :count).by(-2)
+
+      expect(user_to_remove.reload.providers).to eq([non_visible_provider])
+    end
+
+    context 'when save! fails' do
+      it 'raises an error' do
+        error = StandardError.new('Ops!')
+        allow(user_to_remove).to receive(:save!).and_raise(error)
+
+        expect { service.call! }.to raise_error(error)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+RSpec.describe 'Removing a provider user' do
+  include DfESignInHelpers
+
+  scenario 'removing a user from all providers' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_add_provider_users_feature_is_enabled
+    and_i_can_manage_applications_for_two_providers
+    and_i_can_manage_users_for_a_provider
+    and_a_provider_user_with_many_providers_exists
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_click_on_the_users_link
+    and_i_click_on_a_user_with_many_providers
+    and_i_click_delete_user
+    and_i_confirm_i_want_to_delete_this_user
+
+    then_the_deleted_user_has_no_visible_provider_permissions
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_the_provider_add_provider_users_feature_is_enabled
+    FeatureFlag.activate('provider_add_provider_users')
+  end
+
+  def and_i_can_manage_applications_for_two_providers
+    provider_user_exists_in_apply_database
+    @managing_user = ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+    @provider = Provider.find_by(code: 'ABC')
+    @another_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_i_can_manage_users_for_a_provider
+    @managing_user.provider_permissions
+      .where(provider: [@provider, @another_provider])
+      .update_all(manage_users: true)
+  end
+
+  def and_a_provider_user_with_many_providers_exists
+    @non_visible_provider = create(:provider)
+    @user_to_remove = create(:provider_user, providers: [@provider, @another_provider, @non_visible_provider])
+  end
+
+  def when_i_click_on_the_users_link
+    click_on('Users')
+  end
+
+  def and_i_click_on_a_user_with_many_providers
+    click_on @user_to_remove.full_name
+  end
+
+  def and_i_click_delete_user
+    click_on 'Delete user'
+  end
+
+  def and_i_confirm_i_want_to_delete_this_user
+    click_on "Yes I'm sure - delete this account"
+  end
+
+  def then_the_deleted_user_has_no_visible_provider_permissions
+    expect(page).to have_content 'User’s account successfully deleted'
+    expect(page).not_to have_content(@user_to_remove.full_name)
+    expect(@user_to_remove.reload.providers).to eq([@non_visible_provider])
+  end
+end


### PR DESCRIPTION
## Context

Provider users with specific permissions can manage other users, we should enable them to remove users from their Provider org(s).
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a way to remove a provider user from provider orgs common to the managing user (the current provider user) and the target user. This effectively deletes them from view. A confirmation step is presented in this journey.

Any associations to provider orgs not common to the managing and editable user are preserved as these are still valid associations.
 
<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/81089810-b949b000-8ef4-11ea-9f25-9c67cc139efe.png)

and confirmation screen

![image](https://user-images.githubusercontent.com/93511/81089929-ea29e500-8ef4-11ea-9a22-b1b53034c1b5.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/pPKOrnfF/2019-build-providers-with-manageusers-permission-can-delete-users-associated-with-their-org
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
