### PR TITLE
Show 404s in provider interface when user not found, feature flag is off

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -121,7 +121,7 @@ module ProviderInterface
   private
 
     def requires_provider_change_response_feature_flag
-      raise unless FeatureFlag.active?('provider_change_response')
+      render_404 unless FeatureFlag.active?('provider_change_response')
     end
 
     def set_application_choice

--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -47,5 +47,9 @@ module ProviderInterface
         redirect_to provider_interface_new_data_sharing_agreement_path
       end
     end
+
+    def render_404
+      render 'errors/not_found', status: :not_found
+    end
   end
 end

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -94,7 +94,7 @@ module ProviderInterface
     end
 
     def requires_provider_add_provider_users_feature_flag
-      raise unless FeatureFlag.active?('provider_add_provider_users')
+      render_404 unless FeatureFlag.active?('provider_add_provider_users')
     end
 
     def redirect_unless_permitted_to_manage_users

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -19,11 +19,6 @@ module ProviderInterface
     end
 
     def new
-      unless current_provider_user.can_manage_users?
-        flash[:warning] = 'You need specific permissions to manage other providers.'
-        return redirect_to provider_interface_provider_users_path
-      end
-
       @form = ProviderUserForm.new(current_provider_user: current_provider_user)
     end
 

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -99,7 +99,7 @@ module ProviderInterface
 
     def redirect_unless_permitted_to_manage_users
       can_manage_users = ProviderPermissions.exists?(provider_user: current_provider_user, manage_users: true)
-      redirect_to root_path, warning: 'You do not have sufficient permissions to manage other users' unless can_manage_users
+      render_404 unless can_manage_users
     end
 
     def find_provider_user

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -8,9 +8,7 @@ module ProviderInterface
     end
 
     def show
-      @provider_user = ProviderUser.visible_to(current_provider_user).find_by(id: params[:id])
-
-      redirect_to(action: :index) and return unless @provider_user
+      @provider_user = find_provider_user
 
       form = ProviderUserForm.new(
         provider_user: @provider_user,
@@ -54,15 +52,14 @@ module ProviderInterface
     end
 
     def edit_providers
-      provider_user = ProviderUser.visible_to(current_provider_user).find_by(id: params[:provider_user_id])
+      provider_user = find_provider_user
+
       @form = ProviderUserForm.from_provider_user(provider_user)
       @form.current_provider_user = current_provider_user
     end
 
     def update_providers
-      provider_user = ProviderUser
-        .visible_to(current_provider_user)
-        .find_by(id: params[:provider_user_id])
+      provider_user = find_provider_user
 
       @form = ProviderUserForm.new(
         provider_user: provider_user,
@@ -103,6 +100,14 @@ module ProviderInterface
     def redirect_unless_permitted_to_manage_users
       can_manage_users = ProviderPermissions.exists?(provider_user: current_provider_user, manage_users: true)
       redirect_to root_path, warning: 'You do not have sufficient permissions to manage other users' unless can_manage_users
+    end
+
+    def find_provider_user
+      ProviderUser
+        .visible_to(current_provider_user)
+        .find(params[:provider_user_id] || params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render_404
     end
   end
 end

--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -16,7 +16,7 @@ module ProviderInterface
     end
 
     def sign_in_by_email
-      raise unless FeatureFlag.active?('dfe_sign_in_fallback')
+      render_404 unless FeatureFlag.active?('dfe_sign_in_fallback')
 
       provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address).downcase.strip)
 

--- a/spec/requests/provider_interface/managing_provider_users_spec.rb
+++ b/spec/requests/provider_interface/managing_provider_users_spec.rb
@@ -22,31 +22,21 @@ RSpec.describe 'ProviderUserController actions' do
     it 'redirects GET requests to index' do
       get provider_interface_provider_users_path
 
-      expect(response).to redirect_to(root_path)
+      expect(response).to be_not_found
     end
 
     it 'redirects GET requests to show' do
       another_user = create(:provider_user, providers: [provider])
       get provider_interface_provider_user_path(another_user)
 
-      expect(response).to redirect_to(root_path)
+      expect(response).to be_not_found
     end
 
     it 'redirects GET requests to edit-providers' do
       another_user = create(:provider_user, providers: [provider])
       get provider_interface_provider_user_edit_providers_path(another_user)
 
-      expect(response).to redirect_to(root_path)
-    end
-  end
-
-  context 'when the user is permitted to manage users' do
-    before { provider_user.provider_permissions.update_all(manage_users: true) }
-
-    it 'GET requests to provider users paths respond successfully' do
-      get provider_interface_provider_users_path
-
-      expect(response).to have_http_status(:success)
+      expect(response).to be_not_found
     end
   end
 


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1931. 

## Changes proposed in this pull request

Shows a 404 when:

- you don't have access to a user
- you don't have access to manage any users
- the feature flag is off 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/BTWwpO0Y

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
