### PR TITLE
Clean up provider user show action

### DIFF
--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -12,12 +12,10 @@ module ProviderInterface
 
       redirect_to(action: :index) and return unless @provider_user
 
-      form = ProviderUserForm.new(
-        provider_user: @provider_user,
+      @possible_permissions = ProviderPermissions.possible_permissions(
         current_provider_user: current_provider_user,
+        provider_user: @provider_user,
       )
-      @possible_permissions = form.possible_permissions
-      @provider_permissions = form.provider_permissions
     end
 
     def new

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -56,22 +56,6 @@ module ProviderInterface
       end
     end
 
-    def possible_permissions
-      provider_ids = current_provider_user
-        .provider_permissions
-        .manage_users
-        .includes(:provider)
-        .order('providers.name')
-        .pluck(:provider_id)
-
-      provider_ids.map do |id|
-        ProviderPermissions.find_or_initialize_by(
-          provider_id: id,
-          provider_user_id: provider_user&.id,
-        )
-      end
-    end
-
     def provider_permissions=(attributes)
       forms = attributes.map { |_, attrs| ProviderPermissionsForm.new(attrs) }.select(&:active)
       @provider_permissions = forms.map do |form|
@@ -104,6 +88,13 @@ module ProviderInterface
       return if provider_permissions_valid?
 
       errors.add(:provider_permissions, 'Insufficient permissions to manage users for this provider')
+    end
+
+    def possible_permissions
+      ProviderPermissions.possible_permissions(
+        current_provider_user: current_provider_user,
+        provider_user: provider_user,
+      )
     end
 
     def provider_permissions_valid?

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -9,4 +9,20 @@ class ProviderPermissions < ActiveRecord::Base
   audited associated_with: :provider_user
 
   scope :manage_users, -> { where(manage_users: true) }
+
+  def self.possible_permissions(current_provider_user:, provider_user:)
+    provider_ids = current_provider_user
+      .provider_permissions
+      .manage_users
+      .includes(:provider)
+      .order('providers.name')
+      .pluck(:provider_id)
+
+    provider_ids.map do |id|
+      find_or_initialize_by(
+        provider_id: id,
+        provider_user_id: provider_user&.id,
+      )
+    end
+  end
 end

--- a/spec/models/provider_interface/provider_user_form_spec.rb
+++ b/spec/models/provider_interface/provider_user_form_spec.rb
@@ -93,23 +93,6 @@ RSpec.describe ProviderInterface::ProviderUserForm do
     end
   end
 
-  describe '#possible_permissions' do
-    let(:providers) do
-      [
-        create(:provider, name: 'ABC'),
-        create(:provider, name: 'AAA'),
-        create(:provider, name: 'ABB'),
-      ]
-    end
-
-    before { current_provider_user.provider_permissions.update_all(manage_users: true) }
-
-    it 'returns a collection of provider permissions the current provider user can assign to other users' do
-      possible_permissions = provider_user_form.possible_permissions.map { |p| p.provider.name }
-      expect(possible_permissions).to eq(%w[AAA ABB ABC])
-    end
-  end
-
   describe '#build' do
     let(:email_address) { 'provider@example.com' }
     let(:form_params) do

--- a/spec/models/provider_permissions_spec.rb
+++ b/spec/models/provider_permissions_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ProviderPermissions do
+  describe '.possible_permissions' do
+    let(:current_provider_user) { create(:provider_user, providers: providers) }
+    let(:provider_user) { create(:provider_user, providers: providers << non_visible_provider) }
+    let(:non_visible_provider) { create(:provider, name: 'ZZZ') }
+    let(:providers) do
+      [
+        create(:provider, name: 'ABC'),
+        create(:provider, name: 'AAA'),
+        create(:provider, name: 'ABB'),
+      ]
+    end
+
+    before { current_provider_user.provider_permissions.update_all(manage_users: true) }
+
+    it 'returns an ordered collection of provider permissions the current user can assign to other users' do
+      expected_provider_names = described_class.possible_permissions(
+        current_provider_user: current_provider_user,
+        provider_user: provider_user,
+      ).map { |p| p.provider.name }
+
+      expect(expected_provider_names).to eq(%w[AAA ABB ABC])
+    end
+  end
+end


### PR DESCRIPTION
## Context

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1931 introduced constraints to which provider organisations were visible to managing provider users.
We decide when reviewing to refactor some parts of the original PR after we merged.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Moves logic to retrieve 'possible' permissions (permissions for providers the managing user can see) to a class method in `ProviderPermissions`. 
- Removes the need to instantiate `ProviderUserForm` in the `provider_users#show` action.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
