### PR TITLE
Cast check icon values to booleans before rendering

### DIFF
--- a/app/components/summary_card_header_component.rb
+++ b/app/components/summary_card_header_component.rb
@@ -1,7 +1,17 @@
 class SummaryCardHeaderComponent < ViewComponent::Base
+  POSSIBLE_CHECK_ICON_VALUES = [true, false, 'true', 'false'].freeze
+
   def initialize(title:, heading_level: 2, check_icon: false)
+    argument_guard(check_icon)
     @title = title
     @heading_level = heading_level
-    @check_icon = check_icon
+    @check_icon = ActiveModel::Type::Boolean.new.cast(check_icon)
+  end
+
+private
+
+  def argument_guard(check_icon)
+    check = POSSIBLE_CHECK_ICON_VALUES.include?(check_icon)
+    raise ArgumentError.new('check_icon must be a boolean, "true" or "false" strings') unless check
   end
 end

--- a/spec/components/summary_card_header_component_spec.rb
+++ b/spec/components/summary_card_header_component_spec.rb
@@ -19,4 +19,31 @@ RSpec.describe SummaryCardHeaderComponent do
     expect(result.css('.app-summary-card__meta').text).to include(t('application_form.review.role_involved_working_with_children'))
     expect(result.css('.app-icon')).to be_present
   end
+
+  it 'does not render a summary card header component with a title and check icon when it is specifically false' do
+    result = render_inline(SummaryCardHeaderComponent.new(title: 'Lando Calrissian', check_icon: false))
+    expect(result.css('.app-summary-card__title').text).to include('Lando Calrissian')
+    expect(result.css('.app-summary-card__meta').text).not_to include(t('application_form.review.role_involved_working_with_children'))
+    expect(result.css('.app-icon')).not_to be_present
+  end
+
+  context 'renders a summary card check_icon when its value is a string literal' do
+    it 'renders the icon when the check_icon when the value is "true"' do
+      result = render_inline(SummaryCardHeaderComponent.new(title: 'Lando Calrissian', check_icon: 'true'))
+      expect(result.css('.app-summary-card__title').text).to include('Lando Calrissian')
+      expect(result.css('.app-summary-card__meta').text).to include(t('application_form.review.role_involved_working_with_children'))
+      expect(result.css('.app-icon')).to be_present
+    end
+
+    it 'does not render the icon when the check_icon when the value is "false"' do
+      result = render_inline(SummaryCardHeaderComponent.new(title: 'Lando Calrissian', check_icon: 'false'))
+      expect(result.css('.app-summary-card__title').text).to include('Lando Calrissian')
+      expect(result.css('.app-summary-card__meta').text).not_to include(t('application_form.review.role_involved_working_with_children'))
+      expect(result.css('.app-icon')).not_to be_present
+    end
+
+    it 'raises an error if check_icon is not true, false, "true", or "false"' do
+      expect { SummaryCardHeaderComponent.new(title: 'Lando Calrissian', check_icon: 'maybe') }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
We were getting false positives when rendering check icons for whether someone had experience of working with children.

PR adds casting to header component so that `check_icon` is rendered when needed.

## Context

Bug identified by user

## Changes proposed in this pull request

N/A in terms of UI design.

## Guidance to review

- is the component level approach correct?

## Link to Trello card

https://trello.com/c/lXwtGC10/2114-bug-this-role-involved-working-with-children-incorrectly-rendering-on-heading-components

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
