### PR TITLE
Improvements to the UI for the reference review page

### DIFF
--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -1,7 +1,7 @@
 <p class="govuk-body">
   <% if @application_form.submitted? %>
     <%= t('application_form.referees.info.after_submission') %>
-  <% else %>
+  <% elsif @application_form.application_references.empty? %>
     <%= t('application_form.referees.info.before_submission') %>
   <% end %>
 </p>

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -8,15 +8,19 @@
 <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: @application_form, editable: true)) %>
 
 <%- if @referees.count < ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
-<p>
-  <% if @referees.any? %>
-    <%= govuk_button_link_to t('application_form.referees.add_second_referee'), candidate_interface_referees_type_path, class: 'govuk-button--secondary' %>
-  <% else %>
-    <%= govuk_button_link_to t('application_form.referees.add_referee'), candidate_interface_referees_type_path, class: 'govuk-button--secondary' %>
-  <% end %>
-</p>
-<%- end %>
+  <p>
+    <% if @referees.any? %>
+      <%= govuk_button_link_to t('application_form.referees.add_second_referee'), candidate_interface_referees_type_path %>
+    <% else %>
+      <%= govuk_button_link_to t('application_form.referees.add_referee'), candidate_interface_referees_type_path %>
+    <% end %>
+  </p>
 
-<p>
-  <%= govuk_button_link_to t('application_form.referees.review.button'), candidate_interface_application_form_path %>
-</p>
+  <p>
+    <%= govuk_link_to t('application_form.referees.add_another_later'), candidate_interface_application_form_path %>
+  </p>
+<%- else %>
+  <p>
+    <%= govuk_button_link_to t('application_form.referees.review.button'), candidate_interface_application_form_path %>
+  </p>
+<%- end %>

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -8,7 +8,7 @@
 <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: @application_form, editable: true)) %>
 
 <%- if @referees.count < ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
-  <p>
+  <p class="govuk-body">
     <% if @referees.any? %>
       <%= govuk_button_link_to t('application_form.referees.add_second_referee'), candidate_interface_referees_type_path %>
     <% else %>
@@ -16,11 +16,15 @@
     <% end %>
   </p>
 
-  <p>
-    <%= govuk_link_to t('application_form.referees.add_another_later'), candidate_interface_application_form_path %>
+  <p class="govuk-body">
+    <% if @referees.any? %>
+      <%= govuk_link_to t('application_form.referees.add_another_later'), candidate_interface_application_form_path %>
+    <% else %>
+      <%= govuk_link_to t('application_form.referees.add_referees_later'), candidate_interface_application_form_path %>
+    <% end %>
   </p>
 <%- else %>
-  <p>
+  <p class="govuk-body">
     <%= govuk_button_link_to t('application_form.referees.review.button'), candidate_interface_application_form_path %>
   </p>
 <%- end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -288,7 +288,8 @@ en:
     referees:
       add_referee: Add referee
       add_second_referee: Add another referee
-      add_another_later: I'll add another referee later
+      add_another_later: I’ll add another referee later
+      add_referees_later: I’ll add referees later
       complete_form_button: Save and continue
       delete: Delete referee
       cancel: Cancel referee
@@ -313,7 +314,8 @@ en:
       chase: Chase this referee and notify the candidate
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:
-        before_submission: We’ll contact your referees after you submit your application. We’ll let you know if they don’t supply a reference.
+        before_submission: You need to add 2 referees.
+        <%# before_submission: We’ll contact your referees after you submit your application. We’ll let you know if they don’t supply a reference. %>
         after_submission: We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.
   activemodel:
     errors:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -315,7 +315,6 @@ en:
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:
         before_submission: You need to add 2 referees.
-        <%# before_submission: We’ll contact your referees after you submit your application. We’ll let you know if they don’t supply a reference. %>
         after_submission: We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.
   activemodel:
     errors:

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -287,7 +287,8 @@ en:
         completed_checkbox: I have completed this section
     referees:
       add_referee: Add referee
-      add_second_referee: Add a second referee
+      add_second_referee: Add another referee
+      add_another_later: I'll add another referee later
       complete_form_button: Save and continue
       delete: Delete referee
       cancel: Cancel referee

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,7 +90,7 @@ en:
     add_volunteering_role: Add role
     edit_volunteering_role: Edit role
     destroy_volunteering_role: Are you sure you want to delete this role?
-    referees: Referees
+    referees: References
     referees_choosing: Choosing your referees
     referee_destroy: Are you sure you want to delete this referee?
     referee_cancel: Are you sure you want to cancel this request for a reference?

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -274,7 +274,7 @@ module CandidateHelper
 
     candidate_fills_in_referee
     click_button 'Save and continue'
-    click_link 'Add a second referee'
+    click_link 'Add another referee'
 
     choose 'Professional'
     click_button 'Continue'

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
       relationship: 'First boss',
     )
     click_button 'Save and continue'
-    click_link 'Add a second referee'
+    click_link 'Add another referee'
 
     choose 'Professional'
     click_button 'Continue'

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'Candidate adding referees' do
   end
 
   def and_i_click_on_add_second_referee
-    click_link 'Add a second referee'
+    click_link 'Add another referee'
   end
 
   def then_i_am_asked_to_specify_the_type_of_my_second_referee

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Candidate applying again' do
   end
 
   def when_i_add_a_new_referee
-    click_on 'Add a second referee'
+    click_link 'Add another referee'
     choose 'Academic'
     click_button 'Continue'
 


### PR DESCRIPTION
## Context

We need to improve some of the call to actions in the references section.

## Changes proposed in this pull request

- [x] Change copy and link styles
- [x] Update specs to fix several regressions

## Guidance to review

The reference review page now looks like this with one referee:

![image](https://user-images.githubusercontent.com/450843/81201111-cd58e480-8fbc-11ea-8085-ecc47a69d92e.png)

and like this when there are none:

![image](https://user-images.githubusercontent.com/450843/81200934-8b2fa300-8fbc-11ea-922e-5013b986bc1c.png)

## Link to Trello card

https://trello.com/c/WKFenLsf/1445-dev-changes-to-the-references-section-for-apply-1-and-apply-2-changing-buttons-link-text-and-surrounding-content-to-make-adding

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
