### PR TITLE
Show the correct number of providers next to each user when a provider is managing users

### DIFF
--- a/app/components/provider_interface/user_list_card_component.rb
+++ b/app/components/provider_interface/user_list_card_component.rb
@@ -12,7 +12,7 @@ module ProviderInterface
     end
 
     def providers_text
-      providers = provider_user.providers & manageable_providers
+      providers = provider_user.providers.where(id: manageable_providers.pluck(:id)).order(:name)
 
       return providers.first.name if providers.size == 1
 

--- a/app/components/provider_interface/user_list_card_component.rb
+++ b/app/components/provider_interface/user_list_card_component.rb
@@ -2,16 +2,18 @@ module ProviderInterface
   class UserListCardComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :provider_user, :full_name, :email_address
+    attr_reader :provider_user, :manageable_providers, :full_name, :email_address
 
-    def initialize(provider_user:)
+    def initialize(provider_user:, manageable_providers:)
       @provider_user = provider_user
+      @manageable_providers = manageable_providers
       @full_name = provider_user.full_name
       @email_address = provider_user.email_address
     end
 
     def providers_text
-      providers = provider_user.providers
+      providers = provider_user.providers & manageable_providers
+
       return providers.first.name if providers.size == 1
 
       "#{providers.first.name} and #{TextCardinalizer.call(providers.size - 1)} more"

--- a/app/components/provider_interface/user_list_card_component.rb
+++ b/app/components/provider_interface/user_list_card_component.rb
@@ -2,18 +2,16 @@ module ProviderInterface
   class UserListCardComponent < ViewComponent::Base
     include ViewHelper
 
-    attr_reader :provider_user, :manageable_providers, :full_name, :email_address
+    attr_reader :provider_user, :providers, :full_name, :email_address
 
-    def initialize(provider_user:, manageable_providers:)
+    def initialize(provider_user:, providers:)
       @provider_user = provider_user
-      @manageable_providers = manageable_providers
+      @providers = providers
       @full_name = provider_user.full_name
       @email_address = provider_user.email_address
     end
 
     def providers_text
-      providers = provider_user.providers.where(id: manageable_providers.pluck(:id)).order(:name)
-
       return providers.first.name if providers.size == 1
 
       "#{providers.first.name} and #{TextCardinalizer.call(providers.size - 1)} more"

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -5,6 +5,7 @@ module ProviderInterface
 
     def index
       @provider_users = ProviderUser.visible_to(current_provider_user)
+      @manageable_providers = Provider.manageable_by(current_provider_user)
     end
 
     def show

--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -4,8 +4,10 @@ module ProviderInterface
     before_action :redirect_unless_permitted_to_manage_users
 
     def index
-      @provider_users = ProviderUser.visible_to(current_provider_user)
-      @manageable_providers = Provider.manageable_by(current_provider_user)
+      users = ProviderUser.includes(:providers).visible_to(current_provider_user)
+      providers = Provider.with_users_manageable_by(current_provider_user).order(:name)
+      @provider_users_with_providers = {}
+      users.each { |u| @provider_users_with_providers[u] = providers & u.providers }
     end
 
     def show

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -27,7 +27,8 @@ class Provider < ApplicationRecord
   audited
 
   scope :manageable_by, ->(provider_user) do
-    where(id: provider_user.provider_permissions.manage_users.select(:provider_id))
+    joins(:provider_permissions)
+      .where(ProviderPermissions.table_name => { provider_user_id: provider_user.id, manage_users: true })
   end
 
   def name_and_code

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -26,7 +26,7 @@ class Provider < ApplicationRecord
 
   audited
 
-  scope :manageable_by, ->(provider_user) do
+  scope :with_users_manageable_by, ->(provider_user) do
     joins(:provider_permissions)
       .where(ProviderPermissions.table_name => { provider_user_id: provider_user.id, manage_users: true })
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -26,6 +26,10 @@ class Provider < ApplicationRecord
 
   audited
 
+  scope :manageable_by, ->(provider_user) do
+    where(id: provider_user.provider_permissions.manage_users.select(:provider_id))
+  end
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -20,10 +20,10 @@
 <% end %>
 
 <div class="govuk-body">
-<% @provider_users.each do |provider_user| %>
+<% @provider_users_with_providers.each do |provider_user, providers| %>
   <%= render ProviderInterface::UserListCardComponent.new(
     provider_user: provider_user,
-    manageable_providers: @manageable_providers,
+    providers: providers,
   ) %>
 <% end %>
 </div>

--- a/app/views/provider_interface/provider_users/index.html.erb
+++ b/app/views/provider_interface/provider_users/index.html.erb
@@ -21,6 +21,9 @@
 
 <div class="govuk-body">
 <% @provider_users.each do |provider_user| %>
-  <%= render ProviderInterface::UserListCardComponent.new(provider_user: provider_user) %>
+  <%= render ProviderInterface::UserListCardComponent.new(
+    provider_user: provider_user,
+    manageable_providers: @manageable_providers,
+  ) %>
 <% end %>
 </div>

--- a/spec/components/provider_interface/user_list_card_component_spec.rb
+++ b/spec/components/provider_interface/user_list_card_component_spec.rb
@@ -12,9 +12,10 @@ RSpec.describe ProviderInterface::UserListCardComponent do
   end
 
   let(:provider_user) { build_stubbed(:provider_user, providers: providers) }
-  let(:instance) { described_class.new(provider_user: provider_user) }
+  let(:instance) { described_class.new(provider_user: provider_user, manageable_providers: manageable_providers) }
   let(:result) { render_inline instance }
   let(:card) { result.css('.app-application-card').to_html }
+  let(:manageable_providers) { providers }
 
   describe 'rendering' do
     it 'renders the name of the provider user' do
@@ -42,6 +43,14 @@ RSpec.describe ProviderInterface::UserListCardComponent do
     context 'when more than one provider exists' do
       it 'renders the name of the first provider and cardinal number for others' do
         expect(instance.providers_text).to eq('Hoth Teacher Training and two more')
+      end
+    end
+
+    context 'when manageable_providers are a subset of user providers' do
+      let(:manageable_providers) { [providers.first, providers.last] }
+
+      it 'renders provider text based on intersection with manageable providers' do
+        expect(instance.providers_text).to eq('Hoth Teacher Training and one more')
       end
     end
   end

--- a/spec/components/provider_interface/user_list_card_component_spec.rb
+++ b/spec/components/provider_interface/user_list_card_component_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe ProviderInterface::UserListCardComponent do
   let(:card) { result.css('.app-application-card').to_html }
   let(:manageable_providers) { providers }
 
+  before do
+    allow(provider_user).to receive(:providers).and_return(
+      ActiveRecordRelationStub.new(ProviderPermissions, providers),
+    )
+  end
+
   describe 'rendering' do
     it 'renders the name of the provider user' do
       expect(card).to include(provider_user.full_name)
@@ -48,6 +54,12 @@ RSpec.describe ProviderInterface::UserListCardComponent do
 
     context 'when manageable_providers are a subset of user providers' do
       let(:manageable_providers) { [providers.first, providers.last] }
+
+      before do
+        allow(provider_user).to receive(:providers).and_return(
+          ActiveRecordRelationStub.new(ProviderPermissions, manageable_providers),
+        )
+      end
 
       it 'renders provider text based on intersection with manageable providers' do
         expect(instance.providers_text).to eq('Hoth Teacher Training and one more')

--- a/spec/components/provider_interface/user_list_card_component_spec.rb
+++ b/spec/components/provider_interface/user_list_card_component_spec.rb
@@ -11,17 +11,10 @@ RSpec.describe ProviderInterface::UserListCardComponent do
     ]
   end
 
-  let(:provider_user) { build_stubbed(:provider_user, providers: providers) }
-  let(:instance) { described_class.new(provider_user: provider_user, manageable_providers: manageable_providers) }
+  let(:provider_user) { build_stubbed(:provider_user, id: 111, providers: providers) }
+  let(:instance) { described_class.new(provider_user: provider_user, providers: providers) }
   let(:result) { render_inline instance }
   let(:card) { result.css('.app-application-card').to_html }
-  let(:manageable_providers) { providers }
-
-  before do
-    allow(provider_user).to receive(:providers).and_return(
-      ActiveRecordRelationStub.new(ProviderPermissions, providers),
-    )
-  end
 
   describe 'rendering' do
     it 'renders the name of the provider user' do
@@ -39,7 +32,7 @@ RSpec.describe ProviderInterface::UserListCardComponent do
 
   describe '#providers_text' do
     context 'when one provider exists' do
-      let(:providers) { [create(:provider)] }
+      let(:providers) { [build_stubbed(:provider)] }
 
       it 'renders the name of the first provider' do
         expect(instance.providers_text).to eq(providers.first.name)
@@ -49,20 +42,6 @@ RSpec.describe ProviderInterface::UserListCardComponent do
     context 'when more than one provider exists' do
       it 'renders the name of the first provider and cardinal number for others' do
         expect(instance.providers_text).to eq('Hoth Teacher Training and two more')
-      end
-    end
-
-    context 'when manageable_providers are a subset of user providers' do
-      let(:manageable_providers) { [providers.first, providers.last] }
-
-      before do
-        allow(provider_user).to receive(:providers).and_return(
-          ActiveRecordRelationStub.new(ProviderPermissions, manageable_providers),
-        )
-      end
-
-      it 'renders provider text based on intersection with manageable providers' do
-        expect(instance.providers_text).to eq('Hoth Teacher Training and one more')
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Provider, type: :model do
-  describe '.manageable_by' do
+  describe '.with_users_manageable_by' do
     it 'scopes results to providers the given user is permitted to manage' do
       provider = create(:provider)
       create(:provider)
       provider_user = create(:provider_user, providers: [provider])
       provider_user.provider_permissions.update_all(manage_users: true)
 
-      expect(described_class.manageable_by(provider_user)).to eq([provider])
+      expect(described_class.with_users_manageable_by(provider_user)).to eq([provider])
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,6 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Provider, type: :model do
+  describe '.manageable_by' do
+    it 'scopes results to providers the given user is permitted to manage' do
+      provider = create(:provider)
+      create(:provider)
+      provider_user = create(:provider_user, providers: [provider])
+      provider_user.provider_permissions.update_all(manage_users: true)
+
+      expect(described_class.manageable_by(provider_user)).to eq([provider])
+    end
+  end
+
   describe '#onboarded?' do
     it 'depends on the presence of a signed Data sharing agreement' do
       provider_with_dsa = create(:provider, :with_signed_agreement)

--- a/spec/support/active_record_relation_stub.rb
+++ b/spec/support/active_record_relation_stub.rb
@@ -6,6 +6,7 @@ class ActiveRecordRelationStub
   # @param records [Array] list of records the association holds
   # @param scopes [Array] list of stubbed scopes
   def initialize(model_klass, records, scopes: [])
+    @model_klass = model_klass
     @records = records
 
     scopes.each do |scope|
@@ -15,6 +16,10 @@ class ActiveRecordRelationStub
         self
       end
     end
+  end
+
+  def where(_hash)
+    self.class.new(@model_klass, records)
   end
 
   def order(_hash)


### PR DESCRIPTION
## Context

We restrict the operations the current provider user can perform based on their provider permissions.
When they view the users index, the provider information for each user should reflect the same constraints on what provider information is visible.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Scope providers to those manageable by current provider user when displaying provider information on the provider users index.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review


<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/dQnskexv/2069-show-the-correct-number-of-providers-next-to-each-user-when-a-provider-is-managing-users
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
