### PR TITLE
set HTTP_CLIENT_IP to HTTP_X_CLIENT_IP 's value

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -136,6 +136,8 @@ Rails.application.configure do
         env['HTTP_X_FORWARDED_FOR'] = req.forwarded_for.join(',')
       end
 
+      # preserves access to sidekiq web
+      # see https://github.com/sinatra/sinatra/blob/master/rack-protection/lib/rack/protection/ip_spoofing.rb#L17
       if env['HTTP_X_CLIENT_IP'].present?
         env['HTTP_CLIENT_IP'] = env['HTTP_X_CLIENT_IP']
       end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -131,8 +131,13 @@ Rails.application.configure do
       # so use Rack's own parsing to overwrite this header before it
       # gets to ActionDispatch::RemoteIp
       req = Rack::Request.new(env)
+      
       if(req.forwarded_for.present?)
         env['HTTP_X_FORWARDED_FOR'] = req.forwarded_for.join(',')
+      end
+
+      if(!env['HTTP_X_CLIENT_IP'].nil?)
+        env['HTTP_CLIENT_IP'] = env['HTTP_X_CLIENT_IP']
       end
 
       @app.call(env)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -132,11 +132,11 @@ Rails.application.configure do
       # gets to ActionDispatch::RemoteIp
       req = Rack::Request.new(env)
       
-      if(req.forwarded_for.present?)
+      if req.forwarded_for.present?
         env['HTTP_X_FORWARDED_FOR'] = req.forwarded_for.join(',')
       end
 
-      if(!env['HTTP_X_CLIENT_IP'].nil?)
+      if env['HTTP_X_CLIENT_IP'].present?
         env['HTTP_CLIENT_IP'] = env['HTTP_X_CLIENT_IP']
       end
 


### PR DESCRIPTION
## Context

`HTTP_CLIENT_IP` header in Azure has port information which is causing issue with Rack::IpSpoofing protection in Sideqik/Web when it compares `HTTP_CLIENT_IP` value with `HTTP_X_FORWARDED_FOR`, from which we have already removed the port information for fetching the correct `remote_ip`.

## Changes proposed in this pull request

We are using `HTTP_X_FORWARDED_FOR` from Rack request which removes the port information,
Change is to strip port information from `HTTP_CLIENT_IP`.
`HTTP_X_CLIENT_IP` header from Azure has only the IP address without the port information.

## Guidance to review
Doesn't cause any impact elsewhere in the system

## Link to Trello card

https://trello.com/c/3YjLFtcn/2105-sidekiq-access-forbidden-on-azure-environments

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
