### PR TITLE
Show pre submission reference guidance under not_requsted_yet status

### DIFF
--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -69,16 +69,18 @@ module CandidateInterface
     end
 
     def feedback_status_row(referee)
-      return nil unless show_status?(referee)
-
-      {
-        key: 'Status',
-        value: feedback_status_label(referee),
-      }
-    end
-
-    def show_status?(referee)
-      referee.application_form.submitted?
+      if referee.not_requested_yet? && !referee.application_form.submitted?
+        {
+          key: 'Status',
+          value: feedback_status_label(referee) +
+            content_tag(:p, t('application_form.referees.info.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2'),
+        }
+      else
+        {
+          key: 'Status',
+          value: feedback_status_label(referee),
+        }
+      end
     end
 
     def feedback_status_label(reference)

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -315,6 +315,7 @@ en:
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:
         before_submission: You need to add 2 referees.
+        not_requested_yet:  We’ll contact your referees after you submit your application.
         after_submission: We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.
   activemodel:
     errors:

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -30,9 +30,13 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
     it 'renders component with correct value for status for unrequested reference' do
       application_form.update_column(:submitted_at, nil)
+      first_referee = application_form.application_references.first
+      first_referee.update(feedback_status: 'not_requested_yet')
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-summary-list__key').text).not_to include('Status')
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Not requested')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.not_requested_yet'))
     end
 
     it 'renders component with correct value for status for given reference' do
@@ -141,16 +145,6 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form, editable: false))
 
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.referees.delete'))
-    end
-  end
-
-  context 'when the application has not been submitted' do
-    it 'renders component with content about what happens with referee details provided' do
-      application_form = build_stubbed(:application_form, submitted_at: nil)
-
-      result = render_inline(described_class.new(application_form: application_form))
-
-      expect(result.text).to include(t('application_form.referees.info.before_submission'))
     end
   end
 

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
 
       expect(result.css('.govuk-summary-list__key').text).to include('Status')
       expect(result.css('.govuk-tag.govuk-tag--green.app-tag').to_html).to include('Reference given')
+      expect(result.css('.govuk-summary-list__value').to_html).not_to include(t('application_form.referees.info.not_requested_yet'))
     end
 
     it 'renders component with correct value for status for declined reference' do
@@ -155,6 +156,16 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.text).to include(t('application_form.referees.info.after_submission'))
+    end
+
+    it 'does not show guidance in the status key for not_requested_yet refereences' do
+      application_form = create(:application_form, submitted_at: Time.zone.now)
+      create(:reference, feedback_status: 'not_requested_yet', application_form: application_form)
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Not requested')
+      expect(result.css('.govuk-summary-list__value').to_html).not_to include(t('application_form.referees.info.not_requested_yet'))
     end
   end
 end


### PR DESCRIPTION
## Context

At the moment, we have static guidance about contacting referees on this page: 

https://bat-design-history.netlify.app/images/apply-for-teacher-training/improving-the-references-user-journey/static-guidance-about-contacting-your-referees-when-you-submit.png

We've changed the design so that guidance appears under the referee status tag instead, appearing only in the 'not requested' state - i.e., when someone has added or replaced a reference:

https://bat-design-history.netlify.app/images/apply-for-teacher-training/improving-the-references-user-journey/showing-guidance-at-the-relevant-point-when-replacing-referees.png

## Changes proposed in this pull request

- Only show the pre-submission guidance when a reference is a  not_requsted_yet state


Before

![image](https://user-images.githubusercontent.com/42515961/81303134-38fd8900-9073-11ea-934b-561895ba5f69.png)


After

![image](https://user-images.githubusercontent.com/42515961/81302911-e7ed9500-9072-11ea-8fd4-7c24c9af281f.png)


Doesn't render post submission

![image](https://user-images.githubusercontent.com/42515961/81302840-ca203000-9072-11ea-92a3-88e875609d66.png)


## Guidance to review

I'll leave a comment about one thing 👍 

## Link to Trello card

https://trello.com/c/el
2X7sKpK/1442-dev-changes-to-references-section-for-apply-1-and-apply-2-turning-static-guidance-into-conditional-guidance-with-slight-change-t

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
