### PR TITLE
Pluralise copy for training provider(s) and course(s) on dashboard

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -21,7 +21,7 @@
   </p>
 <% elsif all_choices_withdrawn? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
-    <%= t('application_complete.dashboard.all_withdrawn', count: choice_count) %>
+    <%= t('application_complete.dashboard.all_withdrawn') %>
   </h2>
 <% elsif all_provider_decisions_made? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
@@ -47,13 +47,16 @@
     If you accept an offer now, your remaining applications will be withdrawn.
   </p>
 <% elsif any_awaiting_provider_decision? %>
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses you’ve applied to</h2>
-
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>
+  </h2>
   <p class="govuk-body">
     <%= t('application_complete.dashboard.providers_respond_by', date: respond_by_date) %>
   </p>
 <% elsif editable? %>
-  <h2 class="govuk-heading-m govuk-!-font-size-27">Courses you’ve applied to</h2>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>
+  </h2>
 
   <div class="govuk-inset-text">
     <p class="govuk-body">

--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -21,11 +21,11 @@
   </p>
 <% elsif all_choices_withdrawn? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
-    <%= t('application_complete.dashboard.all_withdrawn') %>
+    <%= t('application_complete.dashboard.all_withdrawn', count: choice_count) %>
   </h2>
 <% elsif all_provider_decisions_made? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
-    <%= t('application_complete.dashboard.all_provider_decisions_made') %>
+    <%= t('application_complete.dashboard.all_provider_decisions_made', count: choice_count) %>
   </h2>
 
   <% if any_offers? %>

--- a/app/components/candidate_interface/application_complete_content_component.rb
+++ b/app/components/candidate_interface/application_complete_content_component.rb
@@ -31,6 +31,10 @@ module CandidateInterface
       @dates.decline_by_default_at.to_s(:govuk_date)
     end
 
+    def choice_count
+      application_form.application_choices.size
+    end
+
   private
 
     attr_reader :application_form

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -3,10 +3,14 @@ en:
     dashboard:
       edit_link: Edit your application
       some_provider_decisions_made: Some of your training providers haven’t reached a decision yet
-      all_provider_decisions_made: All your training providers have now reached a decision
+      all_provider_decisions_made:
+        one: Your training provider has now reached a decision
+        other: All your training providers have now reached a decision
       providers_respond_by: Training providers must respond by %{date}.
       candidate_respond_by: You have %{remaining_days} days (until %{date}) to respond to any offers.
-      all_withdrawn: You have withdrawn all your choices
+      all_withdrawn:
+        one: You have withdrawn all your choices
+        other: You have withdrawn your choice
       accepted_offer: You have accepted an offer
       recruited: You have met your conditions and are ready to be enrolled
       enrolled: You have been enrolled on your chosen course

--- a/config/locales/application_complete.yml
+++ b/config/locales/application_complete.yml
@@ -8,9 +8,7 @@ en:
         other: All your training providers have now reached a decision
       providers_respond_by: Training providers must respond by %{date}.
       candidate_respond_by: You have %{remaining_days} days (until %{date}) to respond to any offers.
-      all_withdrawn:
-        one: You have withdrawn all your choices
-        other: You have withdrawn your choice
+      all_withdrawn: You have withdrawn all your choices
       accepted_offer: You have accepted an offer
       recruited: You have met your conditions and are ready to be enrolled
       enrolled: You have been enrolled on your chosen course

--- a/spec/components/candidate_interface/application_complete_content_component_spec.rb
+++ b/spec/components/candidate_interface/application_complete_content_component_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class.new(application_form: application_form))
 
-      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made', count: 2))
       expect(render_result.text).to include(t('application_complete.dashboard.candidate_respond_by', remaining_days: '14', date: '5 November 2019'))
     end
 
@@ -78,7 +78,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class.new(application_form: application_form))
 
-      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made', count: 2))
       expect(render_result.text).to include(t('application_complete.dashboard.candidate_respond_by', remaining_days: '14', date: '5 November 2019'))
     end
 
@@ -89,7 +89,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class.new(application_form: application_form))
 
-      expect(render_result.text).to include(t('application_complete.dashboard.all_withdrawn'))
+      expect(render_result.text).to include(t('application_complete.dashboard.all_withdrawn', count: 1))
     end
 
     it 'renders when one offer has been withdrawn and one offered' do
@@ -104,7 +104,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class.new(application_form: application_form))
 
-      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made', count: 2))
     end
 
     it 'renders when the only offer has been rejected' do
@@ -114,7 +114,7 @@ RSpec.describe CandidateInterface::ApplicationCompleteContentComponent do
 
       render_result = render_inline(described_class.new(application_form: application_form))
 
-      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made'))
+      expect(render_result.text).to include(t('application_complete.dashboard.all_provider_decisions_made', count: 1))
     end
   end
 


### PR DESCRIPTION
## Context

As part of the preparation for Apply Again we need to tidy up some of the dashboard copy that assumes there are multiple courses. e.g. “Courses you’ve applied to” 
## Changes proposed in this pull request

- [x] “Courses you’ve applied to” should be singular or plural based on number of choices.
- [x] “All your training providers have now reached a decision” should also be singular/plural based on number of choices

## Guidance to review

This is how things look single application choice applications:

![image](https://user-images.githubusercontent.com/450843/81317206-74ed1a00-9084-11ea-926f-b1ba6d0c49a8.png)

![image](https://user-images.githubusercontent.com/450843/81317852-49b6fa80-9085-11ea-8db2-7fda8e2bb83f.png)

## Link to Trello card

https://trello.com/c/oEMPAxzK/1235-dev-add-logic-to-pluralize-training-providers-on-dashboard

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
