### PR TITLE
Fix access to mailer and component previews

### DIFF
--- a/app/controllers/support_interface/mailer_previews_controller.rb
+++ b/app/controllers/support_interface/mailer_previews_controller.rb
@@ -1,0 +1,8 @@
+module SupportInterface
+  class MailerPreviewsController < SupportInterfaceController
+    def index
+      @previews = ActionMailer::Preview.all
+      @page_title = 'Mailer Previews'
+    end
+  end
+end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -3,7 +3,7 @@ module HostingEnvironment
     if Rails.env.production?
       "https://#{hostname}"
     else
-      'http://localhost:3000'
+      "http://localhost:#{ENV.fetch('PORT', 3000)}"
     end
   end
 

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -16,13 +16,13 @@
 
     <% if Rails.application.config.action_mailer.show_previews %>
     <li class="govuk-footer__inline-list-item">
-      <%= govuk_link_to 'Mail previews', '/rails/mailers' %>
+      <%= govuk_link_to 'Mail previews', '/support/mailers' %>
     </li>
     <% end %>
 
     <% if Rails.application.config.view_component.show_previews %>
     <li class="govuk-footer__inline-list-item">
-      <%= govuk_link_to 'Component previews', '/rails/components' %>
+      <%= govuk_link_to 'Component previews', '/rails/view_components' %>
     </li>
     <% end %>
   </ul>

--- a/app/views/support_interface/mailer_previews/index.html.erb
+++ b/app/views/support_interface/mailer_previews/index.html.erb
@@ -1,0 +1,8 @@
+<% @previews.each do |preview| %>
+<h3><%= preview.preview_name.titleize %></h3>
+<ul>
+<% preview.emails.each do |email| %>
+<li><%= link_to email, url_for(controller: 'rails/mailers', action: 'preview', path: "#{preview.preview_name}/#{email}") %></li>
+<% end %>
+</ul>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,8 @@ Rails.application.configure do
     end
   })
 
+  # for default_url_options, see config/initializers/default_url_options.rb
+
   # Do not buffer STDOUT in Ruby. This behaviour interacts weirdly with the docker-compose
   # log output and causes logs only to be printed when an exception occurs or the process
   # exits.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,8 +44,6 @@ Rails.application.configure do
     end
   })
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-
   # Do not buffer STDOUT in Ruby. This behaviour interacts weirdly with the docker-compose
   # log output and causes logs only to be printed when an exception occurs or the process
   # exits.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,9 +55,6 @@ Rails.application.configure do
   config.action_mailer.notify_settings = {
     api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
   }
-  config.action_mailer.default_url_options = {
-    host: HostingEnvironment.hostname
-  }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,6 +56,8 @@ Rails.application.configure do
     api_key: ENV.fetch('GOVUK_NOTIFY_API_KEY')
   }
 
+  # for default_url_options, see config/initializers/default_url_options.rb
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false

--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,4 +1,9 @@
 uri = URI(HostingEnvironment.application_url)
-Rails.application.routes.default_url_options[:host] = uri.host
-Rails.application.routes.default_url_options[:port] = uri.port
-Rails.application.routes.default_url_options[:protocol] = uri.scheme
+application_config = Rails.application.routes
+mailer_config = ActionMailer::Base
+
+[application_config, mailer_config].each do |config|
+  config.default_url_options[:host] = uri.host
+  config.default_url_options[:port] = uri.port
+  config.default_url_options[:protocol] = uri.scheme
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -564,6 +564,8 @@ Rails.application.routes.draw do
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
 
+    get '/mailers' => 'mailer_previews#index'
+
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes
     require 'sidekiq/web'
     require 'support_user_constraint'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,7 +5,10 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'view_component/test_helpers'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -71,4 +74,6 @@ RSpec.configure do |config|
   config.before { Faker::UniqueGenerator.clear }
 
   config.before { ActionMailer::Base.deliveries.clear }
+
+  config.include ViewComponent::TestHelpers, type: :component
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,10 +5,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
-
 # Add additional requires below this line. Rails is not loaded until this point!
-require 'view_component/test_helpers'
-
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -74,6 +71,4 @@ RSpec.configure do |config|
   config.before { Faker::UniqueGenerator.clear }
 
   config.before { ActionMailer::Base.deliveries.clear }
-
-  config.include ViewComponent::TestHelpers, type: :component
 end


### PR DESCRIPTION
## Context

Recent library upgrades have made mailer and view component previews unavailable.

For component previews, the mounted path changed from `/rails/components` to `/rails/view_components`, so it's just a case of updating our support footer link.

For mailer previews, it's the generation of the preview index that's problematic, as it relies on a `url_for` which errors. The actual email previews seem to work fine, if you know the path.

This is the commit responsible for the use of `url_for`, for (the slightly random reason of) supporting previews in a subdirectory: https://github.com/rails/rails/commit/f5132c19d52c4457aa2e09c647d2f52a73966c68

## Changes proposed in this pull request

This PR updates the support footer links to point to the right paths for mailer and view component previews.

It also brings responsibility for generating the mailer previews index within the app. The code is pretty minimal, should be easy to maintain.

## Guidance to review

Inspect the code changes. Try to access previews through the support interface on various environments and locally.

## Link to Trello card

[Fix mailer previews on QA](https://trello.com/c/vkdrrBy7)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
