### PR TITLE
Extend removing user system spec with re-invitation steps

### DIFF
--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe 'Removing a provider user' do
     and_i_confirm_i_want_to_delete_this_user
 
     then_the_deleted_user_has_no_visible_provider_permissions
+
+    when_i_click_invite_user
+    and_i_reinvite_the_deleted_user
+    then_i_can_see_the_user_and_their_permissions
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -65,5 +69,21 @@ RSpec.describe 'Removing a provider user' do
     expect(page).to have_content 'User’s account successfully deleted'
     expect(page).not_to have_content(@user_to_remove.full_name)
     expect(@user_to_remove.reload.providers).to eq([@non_visible_provider])
+  end
+
+  def when_i_click_invite_user
+    click_on 'Invite user'
+  end
+
+  def and_i_reinvite_the_deleted_user
+    fill_in 'Email address', with: @user_to_remove.email_address
+    check @provider.name_and_code
+    click_on 'Invite user'
+  end
+
+  def then_i_can_see_the_user_and_their_permissions
+    expect(page).to have_content('Provider user invited')
+
+    expect(page).to have_content(@user_to_remove.full_name)
   end
 end


### PR DESCRIPTION
## Context

The trello story to remove a user contains the AC that the removed user can be re-invited.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds to the _Remove provider user_ system spec with steps to re-invite the removed user.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/pPKOrnfF/2019-build-providers-with-manageusers-permission-can-delete-users-associated-with-their-org
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
