### PR TITLE
Pluralize providers on submit success page

### DIFF
--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -67,6 +67,8 @@ module CandidateInterface
     def submit_success
       @support_reference = current_application.support_reference
       @editable_days = TimeLimitConfig.edit_by
+      provider_count = current_application.unique_provider_list.size
+      @pluralized_provider_string = 'provider'.pluralize(provider_count)
     end
 
     def review_submitted

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -121,6 +121,10 @@ class ApplicationForm < ApplicationRecord
     apply_again? && application_choices.present?
   end
 
+  def unique_provider_list
+    application_choices.map(&:provider).uniq
+  end
+
   audited
 
   def ended_without_success?

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -16,8 +16,8 @@
     <p class="govuk-body">You’ll get an email to confirm that your application has been submitted.</p>
 
     <h2 class="govuk-heading-m">References</h2>
-    <p class="govuk-body">We’ll contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training provider(s).</p>
-    <p class="govuk-body">We can’t send your application to your training provider(s) without your references.</p>
+    <p class="govuk-body">We’ll contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training <%= @pluralized_provider_string %>.</p>
+    <p class="govuk-body">We can’t send your application to your training <%= @pluralized_provider_string %> without your references.</p>
     <% unless FeatureFlag.active?('covid_19') %>
       <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
     <% end %>
@@ -32,7 +32,7 @@
     <p class="govuk-body">Your training provider will be in touch with you if they want to arrange an interview.</p>
 
     <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
-    <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your provider(s) when this editing period is over.</p>
+    <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>
     <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
 
     <h2 class="govuk-heading-m">Tell us what you think of this service</h2>

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -187,6 +187,7 @@ RSpec.feature 'Candidate submits the application' do
 
   def then_i_can_see_my_application_has_been_successfully_submitted
     expect(page).to have_content 'Application successfully submitted'
+    expect(page).to have_content 'Your training provider will be in touch with you if they want to arrange an interview.'
   end
 
   def and_i_can_see_my_support_ref


### PR DESCRIPTION
Replace the existing use of 'provider(s)' with a dynamically pluralized
string.

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

### Multiple providers

![Screenshot 2020-05-11 at 10 12 24](https://user-images.githubusercontent.com/519250/81549718-1ae79f80-9377-11ea-8472-2d8c5dc465ae.png)

### Single provider

![Screenshot 2020-05-11 at 10 12 12](https://user-images.githubusercontent.com/519250/81549729-1d49f980-9377-11ea-90a3-af12cd749bcf.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Navigate to /candidate/application/submit-success while signed in as a candidate with a submitted application.

## Link to Trello card
https://trello.com/c/e1YZXfAW
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
