### PR TITLE
Various small frontend fixes for manage

### DIFF
--- a/app/components/provider_interface/reference_with_feedback_component.html.erb
+++ b/app/components/provider_interface/reference_with_feedback_component.html.erb
@@ -1,3 +1,3 @@
 <div data-qa="reference">
-  <%= render SummaryCardComponent.new(rows: rows) %>
+  <%= render SummaryListComponent.new(rows: rows) %>
 </div>

--- a/app/views/provider_interface/offer_changes/confirm_update.html.erb
+++ b/app/views/provider_interface/offer_changes/confirm_update.html.erb
@@ -21,7 +21,9 @@
           <%= f.govuk_submit 'Change offer' %>
         <% end %>
 
-        <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+        <p class="govuk-body">
+          <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+        </p>
       </div>
     </div>
   </div>

--- a/app/views/provider_interface/offer_changes/edit_course.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course.html.erb
@@ -25,6 +25,8 @@
       <%= f.govuk_submit 'Continue' %>
     <% end %>
 
-    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+    </p>
   </div>
 </div>

--- a/app/views/provider_interface/offer_changes/edit_course_option.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_course_option.html.erb
@@ -25,6 +25,8 @@
       <%= f.govuk_submit 'Continue' %>
     <% end %>
 
-    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+    </p>
   </div>
 </div>

--- a/app/views/provider_interface/offer_changes/edit_provider.html.erb
+++ b/app/views/provider_interface/offer_changes/edit_provider.html.erb
@@ -25,6 +25,8 @@
       <%= f.govuk_submit 'Continue' %>
     <% end %>
 
-    <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+    <p class="govuk-body">
+      <%= govuk_link_to 'Cancel', provider_interface_application_choice_path(@application_choice.id), class: 'govuk-link--no-visited-state' %>
+    </p>
   </div>
 </div>


### PR DESCRIPTION
## Context

Small front end changes:
- removing border from references lists
- making the cancel link on certain pages the right size

## Changes proposed in this pull request

**Before:**

References:
![image](https://user-images.githubusercontent.com/13377553/81553212-a57ecd80-937c-11ea-9c8e-0c106d21c63c.png)

Cancel link:
<img width="179" alt="Screenshot 2020-05-11 at 11 48 41" src="https://user-images.githubusercontent.com/13377553/81553647-613ffd00-937d-11ea-9e1b-abd3f3ecedf2.png">



**After:**

References:
<img width="616" alt="Screenshot 2020-05-11 at 11 45 02" src="https://user-images.githubusercontent.com/13377553/81553374-e1b22e00-937c-11ea-8fe2-2059c5b8b220.png">

Cancel link:
<img width="151" alt="Screenshot 2020-05-11 at 11 50 22" src="https://user-images.githubusercontent.com/13377553/81553808-9cdac700-937d-11ea-80f9-8967a68d3571.png">


## Guidance to review

- Note: the trello card has three linked tickets but the "Defect: width should be 2/3 for withdraw offer" one has already been completed.

## Link to Trello card

https://trello.com/c/IxYe6uO4/2058-various-small-frontend-fixes-for-manage

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
