### PR TITLE
Make reference guidance dynamic

### DIFF
--- a/app/components/candidate_interface/referee_guidance_component.html.erb
+++ b/app/components/candidate_interface/referee_guidance_component.html.erb
@@ -1,0 +1,8 @@
+<% if @application_form.application_references.feedback_requested.count == 1 %>
+  <h2 class="govuk-heading-m">Reference</h2>
+  <p class="govuk-body">We’ll contact your referee to ask for your reference. When we receive it, we’ll add it to your application and send it to your training <%= pluralize_provider %>.</p>
+  <p class="govuk-body">We can’t send your application to your training <%= pluralize_provider %> without your reference.</p>
+  <% unless FeatureFlag.active?('covid_19') %>
+    <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
+  <% end %>
+<% end %>

--- a/app/components/candidate_interface/referee_guidance_component.html.erb
+++ b/app/components/candidate_interface/referee_guidance_component.html.erb
@@ -5,4 +5,11 @@
   <% unless FeatureFlag.active?('covid_19') %>
     <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
   <% end %>
+<% else %>
+  <h2 class="govuk-heading-m">References</h2>
+  <p class="govuk-body">We’ll contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training <%= pluralize_provider %>.</p>
+  <p class="govuk-body">We can’t send your application to your training <%= pluralize_provider %> without your references.</p>
+  <% unless FeatureFlag.active?('covid_19') %>
+    <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
+  <% end %>
 <% end %>

--- a/app/components/candidate_interface/referee_guidance_component.html.erb
+++ b/app/components/candidate_interface/referee_guidance_component.html.erb
@@ -2,14 +2,12 @@
   <h2 class="govuk-heading-m">Reference</h2>
   <p class="govuk-body">We’ll contact your referee to ask for your reference. When we receive it, we’ll add it to your application and send it to your training <%= pluralize_provider %>.</p>
   <p class="govuk-body">We can’t send your application to your training <%= pluralize_provider %> without your reference.</p>
-  <% unless FeatureFlag.active?('covid_19') %>
-    <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
-  <% end %>
 <% else %>
   <h2 class="govuk-heading-m">References</h2>
   <p class="govuk-body">We’ll contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training <%= pluralize_provider %>.</p>
   <p class="govuk-body">We can’t send your application to your training <%= pluralize_provider %> without your references.</p>
-  <% unless FeatureFlag.active?('covid_19') %>
-    <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
-  <% end %>
+<% end %>
+
+<% unless FeatureFlag.active?('covid_19') %>
+  <p class="govuk-body">Training providers then have <%= TimeLimitConfig.limits_for(:reject_by_default).first.limit %> working days to respond to your application.</p>
 <% end %>

--- a/app/components/candidate_interface/referee_guidance_component.rb
+++ b/app/components/candidate_interface/referee_guidance_component.rb
@@ -1,0 +1,19 @@
+module CandidateInterface
+  class RefereeGuidanceComponent < ViewComponent::Base
+    attr_reader :application_form
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def pluralize_provider
+      'provider'.pluralize(provider_count)
+    end
+
+  private
+
+    def provider_count
+      @application_form.application_choices.map(&:provider).uniq.count
+    end
+  end
+end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -65,6 +65,7 @@ module CandidateInterface
     end
 
     def submit_success
+      @application_form = current_application
       @support_reference = current_application.support_reference
       @editable_days = TimeLimitConfig.edit_by
       provider_count = current_application.unique_provider_list.size

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -15,11 +15,8 @@
     <h2 class="govuk-heading-m">What happens next</h2>
     <p class="govuk-body">You’ll get an email to confirm that your application has been submitted.</p>
 
-    <h2 class="govuk-heading-m">References</h2>
-    <p class="govuk-body">We’ll contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training <%= @pluralized_provider_string %>.</p>
-    <p class="govuk-body">We can’t send your application to your training <%= @pluralized_provider_string %> without your references.</p>
-    <% unless FeatureFlag.active?('covid_19') %>
-      <p class="govuk-body">Training providers then have 40 working days to respond to your application.</p>
+    <% if @application_form.application_references.feedback_requested.any? %>
+      <%= render CandidateInterface::RefereeGuidanceComponent.new(application_form: @application_form) %>
     <% end %>
 
     <% if FeatureFlag.active?('covid_19') %>

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::RefereeGuidanceComponent do
+  include CourseOptionHelpers
+
+  let(:provider) { create(:provider) }
+
+  context 'when one reference is in the feedback_requested state' do
+    context 'when the candidates courses all have the same provider' do
+      it 'renders the correct singular content for referees, references and providers' do
+        course_option_for_provider(provider: provider)
+        application_form = create(:application_form)
+        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
+        create(:reference, :requested, application_form: application_form)
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-heading-m').text).to eq('Reference')
+        expect(result.css('.govuk-body').text).to include('training provider')
+        expect(result.css('.govuk-body').text).not_to include('training providers')
+      end
+    end
+
+    context 'when the candidates courses have different providers' do
+      it 'renders the correct singular content for referees, references and providers' do
+        provider2 = create(:provider)
+        course_option_for_provider(provider: provider)
+        course_option_for_provider(provider: provider2)
+        application_form = create(:application_form)
+        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
+        create(:application_choice, application_form: application_form, course_option: provider2.courses.first.course_options.first)
+        create(:reference, :requested, application_form: application_form)
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-heading-m').text).to eq('Reference')
+        expect(result.css('.govuk-body').text).to include('training providers')
+      end
+    end
+  end
+end

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -5,14 +5,21 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
 
   let(:provider) { create(:provider) }
 
+  def setup_application
+    course_option_for_provider(provider: provider)
+    @application_form = create(:application_form)
+    create(:application_choice, application_form: @application_form, course_option: provider.courses.first.course_options.first)
+    create(:reference, :requested, application_form: @application_form)
+  end
+
+  before do
+    setup_application
+  end
+
   context 'when one reference is in the feedback_requested state' do
     context 'when the candidates courses all have the same provider' do
-      it 'renders the correct singular content for referees, references and providers' do
-        course_option_for_provider(provider: provider)
-        application_form = create(:application_form)
-        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
-        create(:reference, :requested, application_form: application_form)
-        result = render_inline(described_class.new(application_form: application_form))
+      it 'renders the correct pluralization for referees, references and providerss' do
+        result = render_inline(described_class.new(application_form: @application_form))
 
         expect(result.css('.govuk-heading-m').text).to eq('Reference')
         expect(result.css('.govuk-body').text).to include('training provider')
@@ -21,15 +28,11 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
     end
 
     context 'when the candidates courses have different providers' do
-      it 'renders the correct singular content for referees, references and providers' do
+      it 'renders the correct pluralization for referees, references and providers' do
         provider2 = create(:provider)
-        course_option_for_provider(provider: provider)
         course_option_for_provider(provider: provider2)
-        application_form = create(:application_form)
-        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
-        create(:application_choice, application_form: application_form, course_option: provider2.courses.first.course_options.first)
-        create(:reference, :requested, application_form: application_form)
-        result = render_inline(described_class.new(application_form: application_form))
+        create(:application_choice, application_form: @application_form, course_option: provider2.courses.first.course_options.first)
+        result = render_inline(described_class.new(application_form: @application_form))
 
         expect(result.css('.govuk-heading-m').text).to eq('Reference')
         expect(result.css('.govuk-body').text).to include('training providers')
@@ -39,12 +42,9 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
 
   context 'when two references are in the feedback_requested state' do
     context 'when the candidates courses all have the same provider' do
-      it 'renders the correct singular content for referees, references and providers' do
-        course_option_for_provider(provider: provider)
-        application_form = create(:application_form)
-        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
-        create_list(:reference, 2, :requested, application_form: application_form)
-        result = render_inline(described_class.new(application_form: application_form))
+      it 'renders the correct pluralization for referees, references and providers' do
+        create(:reference, :requested, application_form: @application_form)
+        result = render_inline(described_class.new(application_form: @application_form))
 
         expect(result.css('.govuk-heading-m').text).to eq('References')
         expect(result.css('.govuk-body').text).to include('training provider')
@@ -53,15 +53,12 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
     end
 
     context 'when the candidates courses have different providers' do
-      it 'renders the correct singular content for referees, references and providers' do
+      it 'renders the correct pluralization for referees, references and providers' do
         provider2 = create(:provider)
-        course_option_for_provider(provider: provider)
         course_option_for_provider(provider: provider2)
-        application_form = create(:application_form)
-        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
-        create(:application_choice, application_form: application_form, course_option: provider2.courses.first.course_options.first)
-        create_list(:reference, 2, :requested, application_form: application_form)
-        result = render_inline(described_class.new(application_form: application_form))
+        create(:application_choice, application_form: @application_form, course_option: provider2.courses.first.course_options.first)
+        create(:reference, :requested, application_form: @application_form)
+        result = render_inline(described_class.new(application_form: @application_form))
 
         expect(result.css('.govuk-heading-m').text).to eq('References')
         expect(result.css('.govuk-body').text).to include('training providers')

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -36,4 +36,36 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
       end
     end
   end
+
+  context 'when two references are in the feedback_requested state' do
+    context 'when the candidates courses all have the same provider' do
+      it 'renders the correct singular content for referees, references and providers' do
+        course_option_for_provider(provider: provider)
+        application_form = create(:application_form)
+        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
+        create_list(:reference, 2, :requested, application_form: application_form)
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-heading-m').text).to eq('References')
+        expect(result.css('.govuk-body').text).to include('training provider')
+        expect(result.css('.govuk-body').text).not_to include('training providers')
+      end
+    end
+
+    context 'when the candidates courses have different providers' do
+      it 'renders the correct singular content for referees, references and providers' do
+        provider2 = create(:provider)
+        course_option_for_provider(provider: provider)
+        course_option_for_provider(provider: provider2)
+        application_form = create(:application_form)
+        create(:application_choice, application_form: application_form, course_option: provider.courses.first.course_options.first)
+        create(:application_choice, application_form: application_form, course_option: provider2.courses.first.course_options.first)
+        create_list(:reference, 2, :requested, application_form: application_form)
+        result = render_inline(described_class.new(application_form: application_form))
+
+        expect(result.css('.govuk-heading-m').text).to eq('References')
+        expect(result.css('.govuk-body').text).to include('training providers')
+      end
+    end
+  end
 end

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
 
   context 'when one reference is in the feedback_requested state' do
     context 'when the candidates courses all have the same provider' do
-      it 'renders the correct pluralization for referees, references and providerss' do
+      it 'renders the correct pluralization for referees, references and providers' do
         result = render_inline(described_class.new(application_form: @application_form))
 
         expect(result.css('.govuk-heading-m').text).to eq('Reference')

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -25,6 +25,10 @@ RSpec.feature 'Candidate applying again' do
     then_i_can_see_i_have_two_referees
     and_i_can_change_new_referee_details
     and_references_for_original_application_are_not_affected
+
+    when_i_select_a_course
+    and_i_submit_my_application
+    then_i_am_informed_my_new_referee_will_be_contacted
   end
 
   def given_the_pilot_is_open
@@ -41,7 +45,7 @@ RSpec.feature 'Candidate applying again' do
   end
 
   def when_i_have_an_unsuccessful_application_with_references
-    @application_form = create(:completed_application_form, candidate: @candidate)
+    @application_form = create(:completed_application_form, candidate: @candidate, with_gces: true)
     create(:application_choice, status: :rejected, application_form: @application_form)
     @completed_references = create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @application_form)
     @refused_reference = create(:reference, feedback_status: :feedback_refused, application_form: @application_form)
@@ -110,5 +114,35 @@ RSpec.feature 'Candidate applying again' do
       @completed_references[1].name,
       @refused_reference.name,
     ])
+  end
+
+  def when_i_select_a_course
+    click_link 'Back to application'
+    click_link 'Course choice', exact: true
+    given_courses_exist
+
+    click_link 'Continue'
+    choose 'Yes, I know where I want to apply'
+    click_button 'Continue'
+
+    select 'Gorse SCITT (1N1)'
+    click_button 'Continue'
+
+    choose 'Primary (2XT2)'
+    click_button 'Continue'
+
+    expect(page).to have_link 'Delete choice'
+    expect(page).to have_content 'I have completed this section'
+    expect(page).not_to have_button 'Add another course'
+  end
+
+  def and_i_submit_my_application
+    check t('application_form.courses.complete.completed_checkbox')
+    click_button 'Continue'
+    candidate_submits_application
+  end
+
+  def then_i_am_informed_my_new_referee_will_be_contacted
+    expect(page).to have_content 'We’ll contact your referee to ask for your reference'
   end
 end

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -20,6 +20,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
     when_i_complete_my_application
     then_my_application_is_submitted
+    and_i_do_not_see_referee_related_guidance
   end
 
   def given_the_pilot_is_open
@@ -98,5 +99,9 @@ RSpec.feature 'Candidate with unsuccessful application' do
   def then_my_application_is_submitted
     expect(page).to have_content 'Application successfully submitted'
     expect(ApplicationForm.last.application_choices.first.reload.status).to eq 'application_complete'
+  end
+
+  def and_i_do_not_see_referee_related_guidance
+    expect(page).not_to have_content 'References'
   end
 end


### PR DESCRIPTION
## Context

The guidance for references on the submit successful page should be dynamic.

For referees/references pluralisation

If the candidate is awaiting one reference it should be referee/reference.
If they are awaiting two references. It should be referees/references.
If they have applied again and not updated their references, no guidance should show.

For provider pluralisation

If the candidate's courses are all provided by a single provider it should say, training provider. 
If there are multiple providers, it should say training providers.

## Changes proposed in this pull request

Awaiting one reference and one provider

![image](https://user-images.githubusercontent.com/42515961/81556263-f1804100-9381-11ea-93ae-1c4a6e04e122.png)

Awaiting multiple references and courses which are provided by multiple providers

![image](https://user-images.githubusercontent.com/42515961/81556693-a9ade980-9382-11ea-8f84-840fa003ded6.png)

## Guidance to review

It's probably easiest to just put a submitted application into the correct state via the terminal. Then visit the submit success page.

## Link to Trello card

https://trello.com/c/MrkVzwN6/1443-dev-changes-to-references-section-for-apply-1-and-apply-2-turning-static-guidance-into-conditional-guidance

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
