### PR TITLE
Change 'Preferred location' to 'Training location'

### DIFF
--- a/app/views/provider_interface/conditions/edit.html.erb
+++ b/app/views/provider_interface/conditions/edit.html.erb
@@ -16,7 +16,7 @@
       <%= render SummaryListComponent.new(rows: [
         { key: 'Candidate name', value: @application_choice.application_form.full_name },
         { key: 'Course', value: @application_choice.course.name_and_code },
-        { key: 'Preferred location', value: @application_choice.site.name },
+        { key: 'Training location', value: @application_choice.site.name },
         { key: 'Provider', value: @application_choice.course.provider.name_and_code },
       ]) %>
 


### PR DESCRIPTION

## Context

Change 'Preferred location' to 'Training location' in conditions edit view, which us the wording used elsewhere in the app.

## Changes proposed in this pull request

**Before**
<img width="818" alt="Screenshot 2020-05-11 at 13 50 41" src="https://user-images.githubusercontent.com/13377553/81563634-6bb6c280-938e-11ea-8dc7-a184639ec809.png">

**After**
<img width="594" alt="Screenshot 2020-05-11 at 13 50 59" src="https://user-images.githubusercontent.com/13377553/81563663-75d8c100-938e-11ea-8aa4-23a55ece1813.png">

## Guidance to review

- Is the wording correct?
- To get to this page: Application view > find 'Accepted' application > click 'confirm conditions'. 

## Link to Trello card

https://trello.com/c/zTIou4Id/2119-title-location-title-is-wrong-in-the-confirm-if-the-candidate-has-met-all-conditions-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
