### PR TITLE
Fix title notification for notes dot on application list in wrong place sometimes

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -5,7 +5,7 @@
     <div class="app-application-card__status">
       <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
       <% if most_recent_note %>
-        <p class="app-application-card__note"><%= most_recent_note.subject %></p>
+        <span class="app-application-card__note"><%= most_recent_note.subject %></span>
       <% end %>
     <div>
   </h3>

--- a/app/components/provider_interface/application_status_tag_component.html.erb
+++ b/app/components/provider_interface/application_status_tag_component.html.erb
@@ -1,1 +1,1 @@
-<%= render TagComponent.new(text: text, type: type) %>
+<div><%= render TagComponent.new(text: text, type: type) %></div>


### PR DESCRIPTION
## Context

Dot was in wrong place when note title was approx under 20 chars in length.

## Changes proposed in this pull request

**Before:**
<img width="531" alt="Screenshot 2020-05-11 at 16 27 25" src="https://user-images.githubusercontent.com/13377553/81579659-52207580-93a4-11ea-8e77-99a4260fcd5a.png">


**After:**
<img width="533" alt="Screenshot 2020-05-11 at 16 28 01" src="https://user-images.githubusercontent.com/13377553/81579722-66fd0900-93a4-11ea-88b1-e2b742564539.png">

## Guidance to review

- load provider applications index - make sure it looks right for you.

## Link to Trello card

https://trello.com/c/2gdRmYDC/2115-title-notification-dot-on-application-list-in-wrong-place-sometimes

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
