### PR TITLE
Fix bug on the support interfaces candidate show page

### DIFF
--- a/app/views/support_interface/candidates/show.html.erb
+++ b/app/views/support_interface/candidates/show.html.erb
@@ -16,5 +16,5 @@
 
 <% unless @application_forms.empty? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">Candidate’s applications</h2>
-  <%= render SupportInterface::ApplicationsTableComponent, application_forms: @application_forms %>
+  <%= render SupportInterface::ApplicationsTableComponent.new(application_forms: @application_forms) %>
 <% end %>


### PR DESCRIPTION
## Context

![image](https://user-images.githubusercontent.com/42515961/81579804-8136e700-93a4-11ea-9fbc-32d467a543c4.png)


We're getting the above error. The current way the component is being instantiated is no longer supported.

## Changes proposed in this pull request

Update to use

` SupportInterface::ApplicationsTableComponent.new(application_forms: @application_forms)  `

instead of 

`SupportInterface::ApplicationsTableComponent, application_forms: @application_forms`

## Guidance to review

None

## Link to Trello card

I'll make one quickly

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
