### PR TITLE
Change direct to directly on the accepted offer page

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -8,7 +8,7 @@
   </h2>
 
   <p class="govuk-body">
-    Your training provider will be in touch with you direct to explain what happens next.
+    Your training provider will be in touch with you directly to explain what happens next.
   </p>
 <% elsif any_accepted_offer? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
@@ -17,7 +17,7 @@
 
   <p class="govuk-body">
     We’ve sent you an email to confirm this. Your training provider will be in
-    touch with you direct to explain what happens next.
+    touch with you directly to explain what happens next.
   </p>
 <% elsif all_choices_withdrawn? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">


### PR DESCRIPTION
## Context

We currently tell candidates that their 'training provider will be in touch with you direct to explain what happens next.'

This should say 'directly'.

## Changes proposed in this pull request

Before

![image](https://user-images.githubusercontent.com/42515961/81659330-855d1600-9431-11ea-88e9-6bcb82f16265.png)


After

![image](https://user-images.githubusercontent.com/42515961/81659254-737b7300-9431-11ea-8471-0a1b758a2978.png)

## Link to Trello card

https://trello.com/c/mlevi0Pi/1536-title-spelling-mistake-accepted-offer

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
