### PR TITLE
Build add training location to application card, and course details component.

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -13,7 +13,7 @@
   <dl>
     <div class="app-application-card__primary" >
       <dt class="govuk-visually-hidden">Provider:</dt>
-      <dd class="govuk-body"><%= course_provider_name %></dd>
+      <dd class="govuk-body"><%= course_provider_name %> - <%= site_name_and_code %></dd>
     </div>
 
     <dt class="govuk-visually-hidden">Course:</dt>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -4,7 +4,7 @@ module ProviderInterface
 
     attr_accessor :accredited_provider, :application_choice, :application_choice_path,
                   :candidate_name, :course_name_and_code, :course_provider_name, :updated_at,
-                  :most_recent_note
+                  :most_recent_note, :site_name_and_code
 
     def initialize(application_choice:)
       @accredited_provider = application_choice.accredited_provider
@@ -13,6 +13,7 @@ module ProviderInterface
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
       @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
+      @site_name_and_code = application_choice.site.name_and_code
       if FeatureFlag.active?('notes')
         @most_recent_note = application_choice.notes.order('created_at DESC').first
       end

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -18,7 +18,7 @@ module ProviderInterface
 
     def preferred_location_text
       "#{application_choice.site.name_and_code}\n" \
-      "#{address_formatter}"
+      "#{formatted_address}"
     end
 
     def accredited_body
@@ -32,7 +32,8 @@ module ProviderInterface
     end
 
   private
-    def address_formatter
+
+    def formatted_address
       site = application_choice.site
       "#{site.address_line1}, " \
       "#{site.address_line2}, " \

--- a/app/components/provider_interface/course_details_component.rb
+++ b/app/components/provider_interface/course_details_component.rb
@@ -12,8 +12,13 @@ module ProviderInterface
       @provider_name_and_code = application_choice.provider.name_and_code
       @course_name_and_code = application_choice.course.name_and_code
       @cycle = application_choice.course.recruitment_cycle_year
-      @preferred_location = application_choice.site.name_and_code
+      @preferred_location = preferred_location_text
       @study_mode = application_choice.course_option.study_mode.humanize
+    end
+
+    def preferred_location_text
+      "#{application_choice.site.name_and_code}\n" \
+      "#{address_formatter}"
     end
 
     def accredited_body
@@ -24,6 +29,15 @@ module ProviderInterface
     def funding_type
       key = @application_choice.course.funding_type.to_sym
       FUNDING_TYPES[key].to_s.humanize
+    end
+
+  private
+    def address_formatter
+      site = application_choice.site
+      "#{site.address_line1}, " \
+      "#{site.address_line2}, " \
+      "#{site.address_line3}\n" \
+      "#{site.postcode}"
     end
   end
 end

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -29,9 +29,11 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     create(:application_choice,
            :awaiting_provider_decision,
            course_option: course_option,
-           status: 'withdrawn', application_form: create(:application_form,
-                                                         first_name: 'Jim',
-                                                         last_name: 'James'),
+           status: 'withdrawn',
+           application_form: create(:application_form,
+                                     first_name: 'Jim',
+                                     last_name: 'James'),
+           site: create(:site, code: 'L123', name: 'Skywalker Training'),
            updated_at: Date.parse('25-03-2020'))
   end
 
@@ -77,6 +79,10 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
 
     it 'renders the last updated date' do
       expect(card).to include('25 Mar 2020')
+    end
+
+    it 'renders the location of the course' do
+      expect(card).to include('Skywalker Training (L123)')
     end
 
     context 'when there is no accredited provider' do

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
            course_option: course_option,
            status: 'withdrawn',
            application_form: create(:application_form,
-                                     first_name: 'Jim',
-                                     last_name: 'James'),
+                                    first_name: 'Jim',
+                                    last_name: 'James'),
            site: create(:site, code: 'L123', name: 'Skywalker Training'),
            updated_at: Date.parse('25-03-2020'))
   end

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
 
   let(:site) do
     instance_double(Site,
-                    name_and_code: 'First Road (F34)')
+                    name_and_code: 'First Road (F34)',
+                    address_line1: 'Fountain Street',
+                    address_line2: 'Morley',
+                    address_line3: 'Leeds',
+                    postcode: 'LS27 OPD')
+
   end
 
   let(:provider) do
@@ -113,6 +118,8 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
 
     expect(render_text).to include('Preferred location')
     expect(render_text).to include('First Road (F34)')
+    expect(render_text).to include('Fountain Street, Morley, Leeds')
+    expect(render_text).to include('LS27 OPD')
   end
 
   it 'renders the study mode' do

--- a/spec/components/provider_interface/course_details_component_spec.rb
+++ b/spec/components/provider_interface/course_details_component_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe ProviderInterface::CourseDetailsComponent do
                     address_line2: 'Morley',
                     address_line3: 'Leeds',
                     postcode: 'LS27 OPD')
-
   end
 
   let(:provider) do


### PR DESCRIPTION
## Context

First of 2 PRs to introduce course to locations to provider views and filter (later PR)

This PR adds them to to the application cards for the applications index view and the 'Course Details' section under the application show view.

## Changes proposed in this pull request

**Before:**

Application card in index view:
<img width="538" alt="Screenshot 2020-05-12 at 11 55 08" src="https://user-images.githubusercontent.com/13377553/81676105-708b7d00-9447-11ea-9723-2966f2f4fd60.png">

Course details section of application show view:
<img width="606" alt="Screenshot 2020-05-12 at 11 55 55" src="https://user-images.githubusercontent.com/13377553/81676238-8c8f1e80-9447-11ea-8a11-22f6eddefea5.png">


**After:**
Application card in index view:
<img width="534" alt="Screenshot 2020-05-12 at 11 57 04" src="https://user-images.githubusercontent.com/13377553/81676412-b5afaf00-9447-11ea-9df7-c7e31313da62.png">

Course details section of application show view:
<img width="592" alt="Screenshot 2020-05-12 at 11 56 32" src="https://user-images.githubusercontent.com/13377553/81676351-a466a280-9447-11ea-8201-1c1bc9efbe0b.png">



## Guidance to review

- is the wording correct? (i.e. the location formatting)
- are the tests detailed enough?

## Link to Trello card

https://trello.com/c/kISeiFeX/2099-build-add-training-location-attribute-to-application-view-list-filter

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
