### PR TITLE
Update multiline lambda to class method because Rubocop

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -26,7 +26,7 @@ class Provider < ApplicationRecord
 
   audited
 
-  scope :with_users_manageable_by, ->(provider_user) do
+  def self.with_users_manageable_by(provider_user)
     joins(:provider_permissions)
       .where(ProviderPermissions.table_name => { provider_user_id: provider_user.id, manage_users: true })
   end


### PR DESCRIPTION
## Context

[Rubocop has failed the master build because of a scope defined by a multi-line lambda](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=62312&view=logs&j=21467638-73a8-55d6-0fbd-17df4f78ad18&t=26118ad2-21c0-5f99-88e8-1ea4fd279a1b).
 
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Change the lambda in the scope to a class method.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
