### PR TITLE
Remove feature flags (candidate)

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -54,7 +54,7 @@ module CandidateInterface
     end
 
     def course_change_path(course_choice)
-      if FeatureFlag.active?('edit_course_choices') && has_multiple_courses?(course_choice)
+      if has_multiple_courses?(course_choice)
         candidate_interface_course_choices_course_path(
           course_choice.provider.id,
           course_choice_id: course_choice.id,
@@ -63,7 +63,7 @@ module CandidateInterface
     end
 
     def site_change_path(course_choice)
-      if FeatureFlag.active?('edit_course_choices') && has_multiple_sites?(course_choice)
+      if has_multiple_sites?(course_choice)
         candidate_interface_course_choices_site_path(
           course_choice.provider.id,
           course_choice.course.id,
@@ -106,13 +106,11 @@ module CandidateInterface
     def study_mode_row(course_choice)
       return unless course_choice.course.both_study_modes_available?
 
-      change_path = if FeatureFlag.active?('edit_course_choices')
-                      candidate_interface_course_choices_study_mode_path(
-                        course_choice.provider.id,
-                        course_choice.course.id,
-                        course_choice_id: course_choice.id,
-                      )
-                    end
+      change_path = candidate_interface_course_choices_study_mode_path(
+        course_choice.provider.id,
+        course_choice.course.id,
+        course_choice_id: course_choice.id,
+      )
 
       {
         key: 'Full time or part time',

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -10,7 +10,7 @@
   <%= render(SummaryCardComponent.new(rows: referee_rows(referee), editable: @editable && referee.editable?)) do %>
     <%= render(SummaryCardHeaderComponent.new(title: "#{TextOrdinalizer::ORDINALIZE_MAPPING[referee.ordinal]&.capitalize} referee", heading_level: @heading_level)) do %>
 
-      <% if FeatureFlag.active?('candidate_can_cancel_reference') && referee.feedback_requested? %>
+      <% if referee.feedback_requested? %>
         <div class="app-summary-card__actions">
           <%= link_to candidate_interface_confirm_cancel_referee_path(referee.id), class: 'govuk-link' do %>
             <%= t('application_form.referees.cancel') %>

--- a/app/components/work_history_review_component.rb
+++ b/app/components/work_history_review_component.rb
@@ -49,11 +49,11 @@ class WorkHistoryReviewComponent < ViewComponent::Base
   end
 
   def show_consolidated_work_history_breaks?
-    breaks_in_work_history? && (@application_form.work_history_breaks || !FeatureFlag.active?('work_breaks'))
+    breaks_in_work_history? && @application_form.work_history_breaks
   end
 
   def show_break_placeholders?
-    FeatureFlag.active?('work_breaks') && @application_form.work_history_breaks.blank? && @editable
+    @application_form.work_history_breaks.blank? && @editable
   end
 
 private

--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class EqualityAndDiversityController < CandidateInterfaceController
     before_action :redirect_to_review_unless_ready_to_submit
-    before_action :redirect_to_review_unless_feature_flag_active
 
     def start; end
 
@@ -123,10 +122,6 @@ module CandidateInterface
 
     def redirect_to_review_unless_ready_to_submit
       redirect_to candidate_interface_application_submit_show_path unless ready_to_submit?
-    end
-
-    def redirect_to_review_unless_feature_flag_active
-      redirect_to candidate_interface_application_review_path unless FeatureFlag.active?('equality_and_diversity')
     end
 
     def ready_to_submit?

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class SafeguardingController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
-    before_action :redirect_to_application_form_unless_feature_flag_active
 
     def show; end
 
@@ -24,10 +23,6 @@ module CandidateInterface
     def safeguarding_params
       params.require(:candidate_interface_safeguarding_issues_declaration_form)
         .permit(:share_safeguarding_issues, :safeguarding_issues)
-    end
-
-    def redirect_to_application_form_unless_feature_flag_active
-      redirect_to candidate_interface_application_form_path unless FeatureFlag.active?('suitability_to_work_with_children')
     end
   end
 end

--- a/app/controllers/candidate_interface/work_history/break_controller.rb
+++ b/app/controllers/candidate_interface/work_history/break_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
   class WorkHistory::BreakController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
-    before_action :redirect_to_review_work_history_if_feature_off
 
     def new
       @work_break = if params[:start_date] && params[:end_date]
@@ -74,10 +73,6 @@ module CandidateInterface
           .transform_keys { |key| start_date_field_to_attribute(key) }
           .transform_keys { |key| end_date_field_to_attribute(key) }
           .transform_values(&:strip)
-    end
-
-    def redirect_to_review_work_history_if_feature_off
-      redirect_to candidate_interface_work_history_show_path unless FeatureFlag.active?('work_breaks')
     end
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -23,7 +23,7 @@ module CandidateInterface
         [:training_with_a_disability, training_with_a_disability_completed?],
         [:work_experience, work_experience_completed?],
         [:volunteering, volunteering_completed?],
-        ([:safeguarding, safeguarding_completed?] if FeatureFlag.active?('suitability_to_work_with_children')),
+        [:safeguarding, safeguarding_completed?],
 
         # "Qualifications" section
         [:degrees, degrees_completed?],

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -18,7 +18,6 @@ class FeatureFlag
     provider_change_response
     provider_interface_work_breaks
     provider_view_safeguarding
-    suitability_to_work_with_children
     support_sign_in_confirmation_email
     timeline
     unavailable_course_option_warnings

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -12,7 +12,6 @@ class FeatureFlag
     confirm_conditions
     download_dataset1_from_support_page
     edit_course_choices
-    equality_and_diversity
     notes
     provider_add_provider_users
     provider_application_filters

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -22,7 +22,6 @@ class FeatureFlag
     support_sign_in_confirmation_email
     timeline
     unavailable_course_option_warnings
-    work_breaks
     track_validation_errors
     apply_again
   ].freeze

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -9,7 +9,6 @@ class FeatureFlag
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = %w[
-    candidate_can_cancel_reference
     confirm_conditions
     download_dataset1_from_support_page
     edit_course_choices

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -11,7 +11,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = %w[
     confirm_conditions
     download_dataset1_from_support_page
-    edit_course_choices
     notes
     provider_add_provider_users
     provider_application_filters

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -36,11 +36,9 @@
 
 <%= render(VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
 
-<% if FeatureFlag.active?('suitability_to_work_with_children') %>
-  <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
+<h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
 
-  <%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
-<% end %>
+<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 

--- a/app/views/candidate_interface/application_form/review.html.erb
+++ b/app/views/candidate_interface/application_form/review.html.erb
@@ -28,8 +28,4 @@
 
 <%= render 'review', application_form: @application_form, editable: true %>
 
-<% if FeatureFlag.active?('equality_and_diversity') %>
-  <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>
-<% else %>
-  <%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_application_submit_show_path %>
-<% end %>
+<%= govuk_button_link_to t('review_application.button_continue'), candidate_interface_start_equality_and_diversity_path %>

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -54,11 +54,9 @@
       <li class="app-task-list__item">
         <%= render(TaskListItemComponent.new(text: t('page_titles.training_with_a_disability'), completed: @application_form_presenter.training_with_a_disability_completed?, path: @application_form_presenter.training_with_a_disability_completed? ? candidate_interface_training_with_a_disability_show_path : candidate_interface_training_with_a_disability_edit_path)) %>
       </li>
-      <% if FeatureFlag.active?('suitability_to_work_with_children') %>
-        <li class="app-task-list__item">
-          <%= render(TaskListItemComponent.new(text: t('page_titles.suitability_to_work_with_children'), completed: @application_form_presenter.safeguarding_completed?, path: @application_form_presenter.safeguarding_completed? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path)) %>
-        </li>
-      <% end %>
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent.new(text: t('page_titles.suitability_to_work_with_children'), completed: @application_form_presenter.safeguarding_completed?, path: @application_form_presenter.safeguarding_completed? ? candidate_interface_review_safeguarding_path : candidate_interface_edit_safeguarding_path)) %>
+      </li>
     </ul>
 
     <h2 class="govuk-heading-m govuk-!-font-size-27 govuk-!-margin-bottom-2">

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -32,13 +32,11 @@
   <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
 <% end %>
 
-<% if FeatureFlag.active?('work_breaks') %>
-  <hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
 
-  <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
-    <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>
-    <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, I’ve completed my work history' } %>
-  <% end %>
+<%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
+  <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>
+  <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, I’ve completed my work history' } %>
 <% end %>
 
 <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>

--- a/spec/components/candidate_interface/course_choices_review_component_spec.rb
+++ b/spec/components/candidate_interface/course_choices_review_component_spec.rb
@@ -18,11 +18,10 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include(course_choice.course.start_date.strftime('%B %Y'))
     end
 
-    context 'When multiple courses available at a provider and edit_course_choices feature is active' do
+    context 'When multiple courses available at a provider' do
       let(:course_choice) { application_form.application_choices.first }
 
       before do
-        FeatureFlag.activate('edit_course_choices')
         provider = application_form.application_choices.first.provider
         create(:course, provider: provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
       end
@@ -35,10 +34,8 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'When only one course available at a provider and edit_course_choices feature is active' do
+    context 'When only one course available at a provider' do
       let(:course_choice) { application_form.application_choices.first }
-
-      before { FeatureFlag.activate('edit_course_choices') }
 
       it 'renders the course row without change link' do
         result = render_inline(described_class.new(application_form: application_form))
@@ -52,7 +49,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       let(:result) { render_inline(described_class.new(application_form: application_form)) }
 
       before do
-        FeatureFlag.activate('edit_course_choices')
         course_choice.course.update!(study_mode: 'full_time_or_part_time')
       end
 
@@ -72,7 +68,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       let(:course_choice) { application_form.application_choices.first }
 
       before do
-        FeatureFlag.activate('edit_course_choices')
         course_choice.course.update!(study_mode: %w[full_time part_time].sample)
       end
 
@@ -110,9 +105,7 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'when course choice is single site and edit course choices feature is active' do
-      before { FeatureFlag.activate('edit_course_choices') }
-
+    context 'when course choice is single site' do
       it 'renders without the "Change" location links' do
         result = render_inline(described_class.new(application_form: application_form))
 
@@ -120,10 +113,9 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'when there are multiple site options for course and edit course choices feature is active' do
+    context 'when there are multiple site options for course' do
       before do
         create(:course_option, course: application_form.application_choices.first.course)
-        FeatureFlag.activate('edit_course_choices')
       end
 
       it 'renders the correct text for "Change" location links' do
@@ -135,10 +127,9 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'when other site option is a different study mode for course and edit course choices feature is active' do
+    context 'when other site option is a different study mode for course' do
       before do
         create(:course_option, course: application_form.application_choices.first.course, study_mode: 'part_time')
-        FeatureFlag.activate('edit_course_choices')
       end
 
       it 'renders without the "Change" location links' do
@@ -175,12 +166,11 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       expect(result.css('.app-summary-card__actions').text).not_to include(t('application_form.courses.delete'))
     end
 
-    context 'When multiple courses available at a provider and edit_course_choices feature is active' do
+    context 'When multiple courses available at a provider' do
       let(:application_form) { create_application_form_with_course_choices(statuses: %w[application_complete]) }
       let(:course_choice) { application_form.application_choices.first }
 
       before do
-        FeatureFlag.activate('edit_course_choices')
         provider = application_form.application_choices.first.provider
         create(:course, provider: provider, exposed_in_find: true, open_on_apply: true, study_mode: :full_time)
       end
@@ -192,12 +182,11 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       end
     end
 
-    context 'when there are multiple site options for course and edit course choices feature is active' do
+    context 'when there are multiple site options for course' do
       let(:application_form) { create_application_form_with_course_choices(statuses: %w[application_complete]) }
 
       before do
         create(:course_option, course: application_form.application_choices.first.course)
-        FeatureFlag.activate('edit_course_choices')
       end
 
       it 'renders without a "Change" location links' do
@@ -213,7 +202,6 @@ RSpec.describe CandidateInterface::CourseChoicesReviewComponent do
       let(:result) { render_inline(described_class.new(application_form: application_form, editable: false)) }
 
       before do
-        FeatureFlag.activate('edit_course_choices')
         course_choice.course.update!(study_mode: 'full_time_or_part_time')
       end
 

--- a/spec/components/work_history_review_component_spec.rb
+++ b/spec/components/work_history_review_component_spec.rb
@@ -114,33 +114,12 @@ RSpec.describe WorkHistoryReviewComponent do
       end
     end
 
-    context 'when consolidated work history breaks are editable' do
-      it 'renders summary card for breaks in the work history' do
-        result = render(feature_active: false, explanation: 'WE WERE ON A BREAK!')
-
-        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
-        expect(result.css('.govuk-summary-list__value').to_html).to include('WE WERE ON A BREAK!')
-        expect(result.css('.govuk-summary-list__actions a')[4].attr('href')).to include(
-          Rails.application.routes.url_helpers.candidate_interface_work_history_breaks_path,
-        )
-        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
-      end
-    end
-
-    context 'when consolidated work history breaks are not editable' do
-      it 'renders component without an edit link' do
-        result = render(feature_active: false, explanation: 'I was sleeping.', editable: false)
-
-        expect(result.css('.govuk-summary-list__actions').text).not_to include(t('application_form.work_history.break.change_label'))
-      end
-    end
-
-    context 'when the work breaks feature flag is on, there are existing individual breaks and editable' do
+    context 'There are existing individual breaks and editable' do
       it 'renders component with change and delete links' do
         break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
         breaks = [break1]
 
-        result = render(feature_active: true, breaks: breaks)
+        result = render(breaks: breaks)
 
         expect(result.text).to include('Delete entry for break between February 2019 and April 2019')
         expect(result.text).to include('Change description for break between February 2019 and April 2019')
@@ -148,12 +127,12 @@ RSpec.describe WorkHistoryReviewComponent do
       end
     end
 
-    context 'when the work breaks feature flag is on, there are existing individual breaks and not editable' do
+    context 'There are existing individual breaks and not editable' do
       it 'renders component without change and delete links' do
         break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019)
         breaks = [break1]
 
-        result = render(feature_active: true, breaks: breaks, editable: false)
+        result = render(breaks: breaks, editable: false)
 
         expect(result.text).not_to include('Delete entry for break between February 2019 and April 2019')
         expect(result.text).not_to include('Change description for break between February 2019 and April 2019')
@@ -161,9 +140,9 @@ RSpec.describe WorkHistoryReviewComponent do
       end
     end
 
-    context 'when the work breaks feature flag is on and consolidated work history breaks has a value' do
+    context 'when consolidated work history breaks has a value' do
       it 'renders component with consolidated work breaks and without individual breaks' do
-        result = render(feature_active: true, explanation: 'I was sleeping.')
+        result = render(explanation: 'I was sleeping.')
 
         expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
         expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
@@ -171,39 +150,19 @@ RSpec.describe WorkHistoryReviewComponent do
       end
     end
 
-    context 'when the work breaks feature flag is on and individual breaks are editable' do
+    context 'when individual breaks are editable' do
       it 'renders component without break placeholders' do
-        result = render(feature_active: true, editable: true)
+        result = render(editable: true)
 
         expect(result.css('.app-summary-card__title').text).to include('You have a break in your work history in the last 5 years')
       end
     end
 
-    context 'when the work breaks feature flag is on and individual breaks are not editable' do
+    context 'when individual breaks are not editable' do
       it 'renders component without break placeholders' do
-        result = render(feature_active: true, editable: false)
+        result = render(editable: false)
 
         expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
-      end
-    end
-
-    context 'when the work breaks feature flag is off and there are no breaks' do
-      it 'renders component with consolidated work breaks and without individual breaks' do
-        result = render(feature_active: false)
-
-        expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
-        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
-        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.enter_label'))
-      end
-    end
-
-    context 'when the work breaks feature flag is off and consolidated work history breaks has a value' do
-      it 'renders component with consolidated work breaks and without individual breaks' do
-        result = render(feature_active: false, explanation: 'I was sleeping.')
-
-        expect(result.css('.app-summary-card__title').text).not_to include('You have a break in your work history in the last 5 years')
-        expect(result.css('.govuk-summary-list__key').text).to include(t('application_form.work_history.break.label'))
-        expect(result.css('.govuk-summary-list__actions').text).to include(t('application_form.work_history.break.change_label'))
       end
     end
   end
@@ -235,13 +194,7 @@ RSpec.describe WorkHistoryReviewComponent do
     end
   end
 
-  def render(feature_active: false, explanation: nil, breaks: [], editable: true)
-    if feature_active
-      FeatureFlag.activate('work_breaks')
-    else
-      FeatureFlag.deactivate('work_breaks')
-    end
-
+  def render(explanation: nil, breaks: [], editable: true)
     data[:start_date] = Time.zone.local(2019, 8, 1)
     data[:end_date] = Time.zone.local(2019, 9, 1)
 

--- a/spec/presenters/vendor_api/single_application_presenter_spec.rb
+++ b/spec/presenters/vendor_api/single_application_presenter_spec.rb
@@ -65,9 +65,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
     let(:september2019) { Time.zone.local(2019, 9, 1) }
     let(:december2019) { Time.zone.local(2019, 12, 1) }
 
-    context 'when the work breaks feature flag is on and work history breaks field has a value' do
+    context 'when the work history breaks field has a value' do
       it 'returns the work_history_breaks attribute of an application' do
-        FeatureFlag.activate('work_breaks')
         breaks = []
         application_form = build_stubbed(
           :completed_application_form,
@@ -84,9 +83,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
 
-    context 'when the work breaks feature flag is on and individual breaks have been entered' do
+    context 'when individual breaks have been entered' do
       it 'returns a concatentation of application_work_history_breaks of an application' do
-        FeatureFlag.activate('work_breaks')
         break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019, reason: 'I was watching TV.')
         break2 = build_stubbed(:application_work_history_break, start_date: september2019, end_date: december2019, reason: 'I was playing games.')
         breaks = [break1, break2]
@@ -107,9 +105,8 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
       end
     end
 
-    context 'when the work breaks feature flag is on and no breaks have been entered' do
+    context 'when no breaks have been entered' do
       it 'returns an empty string' do
-        FeatureFlag.activate('work_breaks')
         breaks = []
         application_form = build_stubbed(
           :completed_application_form,
@@ -123,67 +120,6 @@ RSpec.describe VendorAPI::SingleApplicationPresenter do
 
         expect(response.to_json).to be_valid_against_openapi_schema('Application')
         expect(response[:attributes][:work_experience][:work_history_break_explanation]).to eq('')
-      end
-    end
-
-    context 'when the work breaks feature flag is off and no breaks have been entered' do
-      it 'returns an empty string' do
-        FeatureFlag.deactivate('work_breaks')
-        breaks = []
-        application_form = build_stubbed(
-          :completed_application_form,
-          :with_completed_references,
-          work_history_breaks: nil,
-          application_work_history_breaks: breaks,
-        )
-        application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
-
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
-
-        expect(response.to_json).to be_valid_against_openapi_schema('Application')
-        expect(response[:attributes][:work_experience][:work_history_break_explanation]).to eq('')
-      end
-    end
-
-    context 'when the work breaks feature flag is off and work history breaks field has a value' do
-      it 'returns the work_history_breaks attribute of an application' do
-        FeatureFlag.deactivate('work_breaks')
-        breaks = []
-        application_form = build_stubbed(
-          :completed_application_form,
-          :with_completed_references,
-          work_history_breaks: 'I was sleeping.',
-          application_work_history_breaks: breaks,
-        )
-        application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
-
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
-
-        expect(response.to_json).to be_valid_against_openapi_schema('Application')
-        expect(response[:attributes][:work_experience][:work_history_break_explanation]).to eq('I was sleeping.')
-      end
-    end
-
-    context 'when the work breaks feature flag is off and individual breaks have been entered' do
-      it 'returns a concatentation of application_work_history_breaks of an application' do
-        FeatureFlag.deactivate('work_breaks')
-        break1 = build_stubbed(:application_work_history_break, start_date: february2019, end_date: april2019, reason: 'I was watching TV.')
-        break2 = build_stubbed(:application_work_history_break, start_date: september2019, end_date: december2019, reason: 'I was playing games.')
-        breaks = [break1, break2]
-        application_form = build_stubbed(
-          :completed_application_form,
-          :with_completed_references,
-          work_history_breaks: nil,
-          application_work_history_breaks: breaks,
-        )
-        application_choice = build_stubbed(:application_choice, status: 'awaiting_provider_decision', application_form: application_form)
-
-        response = VendorAPI::SingleApplicationPresenter.new(application_choice).as_json
-
-        expect(response.to_json).to be_valid_against_openapi_schema('Application')
-        expect(response[:attributes][:work_experience][:work_history_break_explanation]).to eq(
-          "February 2019 to April 2019: I was watching TV.\n\nSeptember 2019 to December 2019: I was playing games.",
-        )
       end
     end
   end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -23,7 +23,6 @@ module CandidateHelper
 
   def candidate_completes_application_form
     given_courses_exist
-    and_the_suitability_to_work_with_children_feature_flag_is_on
     create_and_sign_in_candidate
     visit candidate_interface_application_form_path
 
@@ -94,10 +93,6 @@ module CandidateHelper
     site = create(:site, name: 'Main site', code: '-', provider: @provider)
     course = create(:course, exposed_in_find: true, open_on_apply: true, name: 'Primary', code: '2XT2', provider: @provider)
     create(:course_option, site: site, course: course)
-  end
-
-  def and_the_suitability_to_work_with_children_feature_flag_is_on
-    FeatureFlag.activate('suitability_to_work_with_children')
   end
 
   def candidate_fills_in_course_choices

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -220,14 +220,10 @@ module CandidateHelper
       fill_in locale.t('details.label'), with: 'I learned a lot about teaching'
 
       choose 'No'
+      choose 'No, I’ve completed my work history'
     end
 
     click_button t('application_form.work_history.complete_form_button')
-
-    click_link t('application_form.work_history.break.enter_label')
-    fill_in 'candidate_interface_work_breaks_form[work_history_breaks]', with: 'I was unwell'
-    click_button t('application_form.work_history.break.button')
-
     check t('application_form.work_history.review.completed_checkbox')
     click_button t('application_form.work_history.review.button')
   end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -81,6 +81,7 @@ module CandidateHelper
   def candidate_submits_application
     click_link 'Check and submit your application'
     click_link 'Continue'
+    click_link 'Continue without completing questionnaire'
     choose 'No' # "Is there anything else you would like to tell us?"
 
     click_button 'Submit application'

--- a/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_in_sandbox_spec.rb
@@ -40,10 +40,11 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
 
     and_i_confirm_my_application
 
-    when_i_choose_not_to_add_further_information
-    and_i_can_submit_the_application
+    when_i_choose_not_to_fill_in_the_equality_and_diversity_survey
+    and_i_choose_not_to_add_further_information
+    and_i_submit_the_application
 
-    i_see_that_the_application_was_sent_to_provider
+    then_i_see_that_the_application_was_sent_to_provider
     and_i_see_that_references_are_given
   end
 
@@ -78,15 +79,19 @@ RSpec.feature 'Candidate adding referees in Sandbox', sandbox: true do
     click_link 'Continue'
   end
 
-  def when_i_choose_not_to_add_further_information
+  def when_i_choose_not_to_fill_in_the_equality_and_diversity_survey
+    click_link 'Continue without completing questionnaire'
+  end
+
+  def and_i_choose_not_to_add_further_information
     choose 'No'
   end
 
-  def and_i_can_submit_the_application
+  def and_i_submit_the_application
     click_button 'Submit application'
   end
 
-  def i_see_that_the_application_was_sent_to_provider
+  def then_i_see_that_the_application_was_sent_to_provider
     visit candidate_interface_application_complete_path
     expect(page).to have_content('Status Pending')
   end

--- a/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
+++ b/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'Cancelling a reference' do
 
   scenario 'candidate cancels a reference request after completing their application' do
     given_i_have_completed_and_submitted_my_application
-    and_the_candidate_can_cancel_reference_flag_is_active
 
     when_i_visit_the_application_complete_page
     and_i_click_delete_on_my_first_reference
@@ -27,10 +26,6 @@ RSpec.describe 'Cancelling a reference' do
   def given_i_have_completed_and_submitted_my_application
     candidate_completes_application_form
     candidate_submits_application
-  end
-
-  def and_the_candidate_can_cancel_reference_flag_is_active
-    FeatureFlag.activate('candidate_can_cancel_reference')
   end
 
   def when_i_visit_the_application_complete_page

--- a/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_course_choices_spec.rb
@@ -5,8 +5,7 @@ RSpec.describe 'Candidate edits course choices' do
   include CourseOptionHelpers
 
   scenario 'Candidate is signed in' do
-    given_that_the_edit_course_choices_feature_flag_is_active
-    and_i_am_signed_in
+    given_i_am_signed_in
     and_there_is_a_course_with_one_course_option
     and_there_is_a_course_with_multiple_course_options
     and_there_is_a_course_with_both_study_modes_but_one_site
@@ -73,11 +72,7 @@ RSpec.describe 'Candidate edits course choices' do
     and_i_should_see_the_updated_study_mode_for_the_third_choice
   end
 
-  def given_that_the_edit_course_choices_feature_flag_is_active
-    FeatureFlag.activate('edit_course_choices')
-  end
-
-  def and_i_am_signed_in
+  def given_i_am_signed_in
     create_and_sign_in_candidate
   end
 

--- a/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
@@ -95,6 +95,7 @@ RSpec.feature 'Candidate deletes their work history' do
     fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
 
     choose 'No'
+    choose 'No, I’ve completed my work history'
 
     click_button t('application_form.work_history.complete_form_button')
   end

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   scenario 'Candidate submits equality and diversity information' do
     given_i_am_signed_in
-    and_the_equality_and_diversity_feature_flag_is_active
     and_i_have_an_application_form_that_is_not_ready_to_submit
     and_i_am_on_the_review_page
 
@@ -93,10 +92,6 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_equality_and_diversity_feature_flag_is_active
-    FeatureFlag.activate('equality_and_diversity')
   end
 
   def and_i_have_an_application_form_that_is_not_ready_to_submit

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -107,6 +107,8 @@ RSpec.feature 'Entering their equality and diversity information' do
 
   def when_i_have_an_application_form_that_is_ready_to_submit
     create :reference, application_form: @application
+    click_link 'Complete section', match: :first
+    candidate_fills_in_safeguarding_issues
   end
 
   def and_i_am_on_the_review_page

--- a/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -5,14 +5,6 @@ RSpec.feature 'Entering their suitability to work with children' do
 
   scenario 'Candidate declares any safeguarding issues' do
     given_i_am_signed_in
-    and_the_suitability_to_work_with_children_feature_flag_is_off
-    when_i_visit_the_site
-    then_i_dont_see_declaring_any_safeguarding_issues
-
-    when_i_visit_the_declaring_any_safeguarding_issues_form
-    then_i_see_the_application_form
-
-    given_the_suitability_to_work_with_children_feature_flag_is_on
     when_i_visit_the_site
     then_i_see_declaring_any_safeguarding_issues
 
@@ -41,26 +33,6 @@ RSpec.feature 'Entering their suitability to work with children' do
 
   def when_i_visit_the_site
     visit candidate_interface_application_form_path
-  end
-
-  def and_the_suitability_to_work_with_children_feature_flag_is_off
-    FeatureFlag.deactivate('suitability_to_work_with_children')
-  end
-
-  def then_i_dont_see_declaring_any_safeguarding_issues
-    expect(page).not_to have_content(t('page_titles.suitability_to_work_with_children'))
-  end
-
-  def when_i_visit_the_declaring_any_safeguarding_issues_form
-    visit candidate_interface_edit_safeguarding_path
-  end
-
-  def then_i_see_the_application_form
-    expect(page).to have_content('Your application')
-  end
-
-  def given_the_suitability_to_work_with_children_feature_flag_is_on
-    FeatureFlag.activate('suitability_to_work_with_children')
   end
 
   def then_i_see_declaring_any_safeguarding_issues

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -11,11 +11,6 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
   scenario 'Candidate enters a reason for a work break' do
     given_i_am_signed_in
-    and_the_work_breaks_feature_flag_is_off
-    when_i_visit_the_new_break_page
-    then_i_am_redirected_to_the_review_work_history_page
-
-    given_the_work_breaks_feature_flag_is_on
     and_i_visit_the_site
 
     when_i_click_on_work_history
@@ -50,22 +45,6 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_work_breaks_feature_flag_is_off
-    FeatureFlag.deactivate('work_breaks')
-  end
-
-  def when_i_visit_the_new_break_page
-    visit candidate_interface_new_work_history_break_path
-  end
-
-  def then_i_am_redirected_to_the_review_work_history_page
-    expect(page).to have_current_path(candidate_interface_work_history_show_path)
-  end
-
-  def given_the_work_breaks_feature_flag_is_on
-    FeatureFlag.activate('work_breaks')
   end
 
   def and_i_visit_the_site

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -31,19 +31,6 @@ RSpec.feature 'Entering their work history' do
     and_i_fill_in_the_job_form # 5/2014 - 1/2019
     then_i_should_see_my_completed_job
 
-    when_i_click_on_add_another_job
-    and_i_fill_in_the_job_form_with_another_job_with_a_break # 3/2019 - current
-    and_i_do_not_fill_in_end_date
-    then_i_should_see_my_second_job
-    and_i_should_be_asked_to_explain_the_break_in_my_work_history
-
-    given_i_am_on_review_work_history_page
-    when_i_click_to_enter_break_explanation
-    then_i_see_the_work_history_break_form
-
-    when_i_fill_in_the_work_history_break_form
-    then_i_see_my_explanation_for_breaks_in_my_work_history
-
     when_i_click_on_change
     and_i_change_the_job_title_to_be_blank
     then_i_should_see_validation_errors
@@ -139,6 +126,7 @@ RSpec.feature 'Entering their work history' do
     fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
 
     choose 'No'
+    choose 'No, I’ve completed my work history'
 
     click_button t('application_form.work_history.complete_form_button')
   end
@@ -164,63 +152,8 @@ RSpec.feature 'Entering their work history' do
     click_link t('application_form.work_history.add_job')
   end
 
-  def when_i_click_on_add_another_job
-    click_link 'Add another job'
-  end
-
   def and_i_fill_in_the_job_form
     when_i_fill_in_the_job_form
-  end
-
-  def and_i_fill_in_the_job_form_with_another_job_with_a_break
-    scope = 'application_form.work_history'
-    fill_in t('role.label', scope: scope), with: 'Chief of Xenomorph Procurement and Research'
-    fill_in t('organisation.label', scope: scope), with: 'Weyland-Yutani'
-
-    choose 'Full-time'
-
-    within('[data-qa="start-date"]') do
-      fill_in 'Month', with: '3'
-      fill_in 'Year', with: '2019'
-    end
-
-    fill_in t('details.label', scope: scope), with: 'Gimme Xenomorphs.'
-
-    choose 'No'
-
-    click_button t('application_form.work_history.complete_form_button')
-  end
-
-  def and_i_do_not_fill_in_end_date; end
-
-  def then_i_should_see_my_second_job
-    expect(page).to have_content('Chief of Xenomorph Procurement and Research')
-  end
-
-  def and_i_should_be_asked_to_explain_the_break_in_my_work_history
-    expect(page).to have_content(t('application_form.work_history.break.label'))
-  end
-
-  def given_i_am_on_review_work_history_page
-    visit candidate_interface_work_history_show_path
-  end
-
-  def when_i_click_to_enter_break_explanation
-    click_link t('application_form.work_history.break.enter_label')
-  end
-
-  def then_i_see_the_work_history_break_form
-    expect(page).to have_content(t('page_titles.work_history_breaks'))
-  end
-
-  def when_i_fill_in_the_work_history_break_form
-    fill_in t('application_form.work_history.break.label'), with: 'WE WERE ON A BREAK!'
-
-    click_button t('application_form.work_history.break.button')
-  end
-
-  def then_i_see_my_explanation_for_breaks_in_my_work_history
-    expect(page).to have_content('WE WERE ON A BREAK!')
   end
 
   def when_i_click_on_change

--- a/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
+++ b/spec/system/candidate_interface/candidate_reviewing_an_incomplete_application_spec.rb
@@ -5,7 +5,6 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   scenario 'sees everything missing from the current state' do
     given_i_am_signed_in
-    and_the_suitability_to_work_with_children_feature_flag_is_on
 
     when_i_visit_the_review_application_page
     then_i_should_be_able_to_click_through_and_complete_each_section_but_science_gcse
@@ -16,10 +15,6 @@ RSpec.feature 'Candidate reviewing an incomplete application' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
-  end
-
-  def and_the_suitability_to_work_with_children_feature_flag_is_on
-    FeatureFlag.activate('suitability_to_work_with_children')
   end
 
   def when_i_visit_the_review_application_page

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -59,10 +59,6 @@ RSpec.feature 'Candidate submits the application' do
     FeatureFlag.activate('covid_19')
   end
 
-  def and_the_suitability_to_work_with_children_feature_flag_is_on
-    FeatureFlag.activate('suitability_to_work_with_children')
-  end
-
   def and_the_covid_19_feature_flag_is_on
     FeatureFlag.activate('covid_19')
   end

--- a/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_submitting_application_spec.rb
@@ -28,7 +28,8 @@ RSpec.feature 'Candidate submits the application' do
 
     and_i_confirm_my_application
 
-    when_i_choose_to_add_further_information_but_omit_adding_details
+    when_i_choose_not_to_fill_in_the_equality_and_diversity_survey
+    and_i_choose_to_add_further_information_but_omit_adding_details
     then_i_should_see_validation_errors
 
     when_i_fill_in_further_information
@@ -168,7 +169,11 @@ RSpec.feature 'Candidate submits the application' do
     click_link 'Continue'
   end
 
-  def when_i_choose_to_add_further_information_but_omit_adding_details
+  def when_i_choose_not_to_fill_in_the_equality_and_diversity_survey
+    click_link 'Continue without completing questionnaire'
+  end
+
+  def and_i_choose_to_add_further_information_but_omit_adding_details
     choose 'Yes'
   end
 

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -199,13 +199,12 @@ RSpec.feature 'Vendor receives the application' do
               description: 'I volunteered.',
             },
           ],
-          work_history_break_explanation: 'I was unwell',
+          work_history_break_explanation: '',
         },
       },
     }
 
     received_attributes = @api_response['data'].first.deep_symbolize_keys
-
     expect(received_attributes.deep_sort).to eq expected_attributes.deep_sort
   end
 end


### PR DESCRIPTION
## Context

These feature flags have all been active on production for quite a while

## Changes proposed in this pull request

The following flags have been removed

- candidate_can_cancel_reference 
- equality_and_diversity
- work_breaks
- suitability_to_work_with_children
- edit_course_choices

## Guidance to review

Review each commit as it's 1 flag per commit.

## Link to Trello card

https://trello.com/c/E26PhwFc/1539-remove-candidate-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
