### PR TITLE
Fix failing test on master

### DIFF
--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Candidate applying again' do
   end
 
   def when_i_have_an_unsuccessful_application_with_references
-    @application_form = create(:completed_application_form, candidate: @candidate, with_gces: true)
+    @application_form = create(:completed_application_form, candidate: @candidate, with_gces: true, safeguarding_issues_status: :no_safeguarding_issues_to_declare)
     create(:application_choice, status: :rejected, application_form: @application_form)
     @completed_references = create_list(:reference, 2, feedback_status: :feedback_provided, application_form: @application_form)
     @refused_reference = create(:reference, feedback_status: :feedback_refused, application_form: @application_form)


### PR DESCRIPTION
## Context

There's currently a failing test on master. Two PRs were merged in, one of which removed a feature flag which affected the other.

## Changes proposed in this pull request

- Add safeguarding concerns to an application form in a failing test.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
