### PR TITLE
Only display synced providers when editing provider permissions in support

### DIFF
--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -51,7 +51,7 @@ module SupportInterface
     end
 
     def possible_permissions
-      Provider.all.pluck(:id).map do |id|
+      Provider.where(sync_courses: true).pluck(:id).map do |id|
         ProviderPermissions.find_or_initialize_by(
           provider_id: id,
           provider_user_id: provider_user.try(:id),

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -1,4 +1,4 @@
-<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Provider' } do %>
+<%= f.govuk_check_boxes_fieldset :provider, legend: { text: 'Provider', tag: 'h2' } do %>
   <div class="app-checkboxes-scroll" %>
     <% f.object.forms_for_possible_permissions.each do |permission_form| %>
       <%= f.fields_for "provider_permissions_forms[]", permission_form do |pf| %>

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -13,7 +13,9 @@ RSpec.feature 'Managing provider users' do
     and_i_click_the_users_link
     and_i_click_the_manange_provider_users_link
     and_i_click_the_add_user_link
-    and_i_enter_an_existing_email
+    then_i_see_synced_providers
+
+    when_i_enter_an_existing_email
     and_i_click_add_user
     then_i_see_an_error
 
@@ -57,8 +59,15 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_providers_exist
-    @provider = create(:provider, name: 'Example provider', code: 'ABC')
-    create(:provider, name: 'Another provider', code: 'DEF')
+    @provider = create(:provider, name: 'Example provider', code: 'ABC', sync_courses: true)
+    create(:provider, name: 'Another provider', code: 'DEF', sync_courses: true)
+    create(:provider, name: 'Not shown provider', code: 'GHI')
+  end
+
+  def then_i_see_synced_providers
+    expect(page).to have_content 'Example provider'
+    expect(page).to have_content 'Another provider'
+    expect(page).not_to have_content 'Not shown provider'
   end
 
   def when_i_visit_the_support_console
@@ -87,7 +96,7 @@ RSpec.feature 'Managing provider users' do
     click_link 'Add provider user'
   end
 
-  def and_i_enter_an_existing_email
+  def when_i_enter_an_existing_email
     create(:provider_user, email_address: 'existing@example.org')
     fill_in 'support_interface_provider_user_form[email_address]', with: 'Existing@example.org'
   end


### PR DESCRIPTION
## Context

This should dramatically reduce the size of the page (currently 3.7MB) and the time it takes to render (42 seconds).

Also update the tag for the legend to be a h2 instead of a h1.

## Changes proposed in this pull request

Only query for synced providers for the `_provider_options` template.

## Guidance to review

Do we need to display unsynced providers in this view?

## Link to Trello card

https://trello.com/c/chVDLTwn/1928-build-speed-up-the-add-a-provider-user-page-in-support

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)