### PR TITLE
Compress HTML and JSON responses

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,7 @@ module ApplyForPostgraduateTeacherTraining
     config.active_job.queue_adapter = :sidekiq
 
     config.middleware.use PDFKit::Middleware, { print_media_type: true }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
+
+    config.middleware.use Rack::Deflater
   end
 end


### PR DESCRIPTION
## Context

Based on https://robots.thoughtbot.com/content-compression-with-rack-deflater

We don't currently use gzip compression for our HTML and JSON responses. This should enable it.

## Changes proposed in this pull request

Enable Rack::Deflater to compress HTML and JSON responses.

## Guidance to review

Check the Heroku review app to see if this was successful.

### Before (note the little ⚠️)

![Screenshot 2020-05-12 at 21 51 50](https://user-images.githubusercontent.com/1650875/81744221-d6edbb00-949a-11ea-827e-f75f4dd81c14.png)

### After

![Screenshot 2020-05-12 at 21 54 24](https://user-images.githubusercontent.com/1650875/81744456-2a600900-949b-11ea-82fb-ec8e143caaab.png)

## Link to Trello card

None.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)