### PR TITLE
Add description and owner properties to feature flags

### DIFF
--- a/app/controllers/integrations/feature_flags_controller.rb
+++ b/app/controllers/integrations/feature_flags_controller.rb
@@ -1,7 +1,7 @@
 module Integrations
   class FeatureFlagsController < IntegrationsController
     def index
-      feature_flags = FeatureFlag::FEATURES.index_with do |feature_name|
+      feature_flags = FeatureFlag::FEATURES.keys.map(&:to_s).index_with do |feature_name|
         {
           name: feature_name.humanize,
           active: FeatureFlag.active?(feature_name),

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,27 +8,27 @@ class FeatureFlag
   end
 
   PERMANENT_SETTINGS = [
-    [:banner_about_problems_with_dfe_sign_in, '', ''],
-    [:banner_for_ucas_downtime, '', ''],
-    [:covid_19, '', ''],
-    [:dfe_sign_in_fallback, '', ''],
-    [:force_ok_computer_to_fail, '', ''],
-    [:pilot_open, 'Enables the Apply for Teacher Training service', 'Theo'],
+    [:banner_about_problems_with_dfe_sign_in, 'Displays a banner to notify users that DfE-Sign is having problems', 'Jake Benilov'],
+    [:banner_for_ucas_downtime, 'Displays a banner to notify users that UCAS is having problems', 'Wen Ting Wang'],
+    [:covid_19, 'Alters deadlines and displays an information banner related to our response to Covid-19', 'Theodor Vararu'],
+    [:dfe_sign_in_fallback, 'Use this when DfE Sign-in is down', 'Tijmen Brommet'],
+    [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
+    [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
-    [:confirm_conditions, '', ''],
-    [:download_dataset1_from_support_page, '', ''],
-    [:notes, '', ''],
-    [:provider_add_provider_users, '', ''],
-    [:provider_application_filters, '', ''],
-    [:provider_change_response, '', ''],
-    [:provider_interface_work_breaks, '', ''],
-    [:provider_view_safeguarding, '', ''],
-    [:support_sign_in_confirmation_email, '', ''],
-    [:timeline, '', ''],
-    [:unavailable_course_option_warnings, '', ''],
-    [:track_validation_errors, '', ''],
+    [:confirm_conditions, 'Allows providers to confirm that conditions related to an offer have been met', 'Michael Nacos'],
+    [:download_dataset1_from_support_page, 'Enables the application CSV download from the support interface', 'Al Davidson'],
+    [:notes, 'Allows providers to add notes to applications', 'Michael Nacos'],
+    [:provider_add_provider_users, 'Allows provider users to invite other provider users', 'Steve Laing'],
+    [:provider_application_filters, 'Allows providers to filter applications returned by the main applications page by status etc.', 'Will McBrien'],
+    [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],
+    [:provider_interface_work_breaks, 'Adds work break information to the provider interface', 'Steve Hook'],
+    [:provider_view_safeguarding, 'Allows providers to see whether a candidate has declared safeguarding issues', 'Will McBrien'],
+    [:support_sign_in_confirmation_email, 'Improves security of support interface with confirmation email to user on first login', 'Tijmen Brommet'],
+    [:timeline, 'Adds a timeline of status change events to the provider interface', 'Steve Hook'],
+    [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
+    [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
   ].freeze
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -1,30 +1,40 @@
 class FeatureFlag
-  PERMANENT_SETTINGS = %w[
-    banner_about_problems_with_dfe_sign_in
-    banner_for_ucas_downtime
-    covid_19
-    dfe_sign_in_fallback
-    force_ok_computer_to_fail
-    pilot_open
+  attr_accessor :name, :description, :owner
+
+  def initialize(name:, description:, owner:)
+    self.name = name
+    self.description = description
+    self.owner = owner
+  end
+
+  PERMANENT_SETTINGS = [
+    [:banner_about_problems_with_dfe_sign_in, '', ''],
+    [:banner_for_ucas_downtime, '', ''],
+    [:covid_19, '', ''],
+    [:dfe_sign_in_fallback, '', ''],
+    [:force_ok_computer_to_fail, '', ''],
+    [:pilot_open, 'Enables the Apply for Teacher Training service', 'Theo'],
   ].freeze
 
-  TEMPORARY_FEATURE_FLAGS = %w[
-    confirm_conditions
-    download_dataset1_from_support_page
-    notes
-    provider_add_provider_users
-    provider_application_filters
-    provider_change_response
-    provider_interface_work_breaks
-    provider_view_safeguarding
-    support_sign_in_confirmation_email
-    timeline
-    unavailable_course_option_warnings
-    track_validation_errors
-    apply_again
+  TEMPORARY_FEATURE_FLAGS = [
+    [:confirm_conditions, '', ''],
+    [:download_dataset1_from_support_page, '', ''],
+    [:notes, '', ''],
+    [:provider_add_provider_users, '', ''],
+    [:provider_application_filters, '', ''],
+    [:provider_change_response, '', ''],
+    [:provider_interface_work_breaks, '', ''],
+    [:provider_view_safeguarding, '', ''],
+    [:support_sign_in_confirmation_email, '', ''],
+    [:timeline, '', ''],
+    [:unavailable_course_option_warnings, '', ''],
+    [:track_validation_errors, '', ''],
+    [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
   ].freeze
 
-  FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).freeze
+  FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|
+    [name, FeatureFlag.new(name: name, description: description, owner: owner)]
+  }.to_h.with_indifferent_access.freeze
 
   def self.activate(feature_name)
     raise unless feature_name.in?(FEATURES)

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -4,7 +4,6 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Feature</th>
-      <th class="govuk-table__header">Owner</th>
       <th class="govuk-table__header">Activated?</th>
       <th class="govuk-table__header">Action</th>
     </tr>
@@ -15,11 +14,8 @@
 
         <td class="govuk-table__cell">
           <h3 class="govuk-!-margin-top-0"><%= feature_name.humanize %></h3>
+          <p>Owner: <%= feature.owner %></p>
           <p><%= feature.description %></p>
-        </td>
-
-        <td class="govuk-table__cell">
-          <%= feature.owner %>
         </td>
 
         <td class="govuk-table__cell">
@@ -32,9 +28,9 @@
 
         <td class="govuk-table__cell">
           <% if FeatureFlag.active?(feature_name) %>
-            <%= button_to "Deactivate ‘#{feature_name.humanize}’", support_interface_deactivate_feature_flag_path(feature_name), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2' %>
+            <%= button_to 'Deactivate', support_interface_deactivate_feature_flag_path(feature_name), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2' %>
           <% else %>
-            <%= button_to "Activate ‘#{feature_name.humanize}’", support_interface_activate_feature_flag_path(feature_name), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2' %>
+            <%= button_to 'Activate', support_interface_activate_feature_flag_path(feature_name), class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-2' %>
           <% end %>
         </td>
       </tr>

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -4,16 +4,22 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th class="govuk-table__header">Feature</th>
+      <th class="govuk-table__header">Owner</th>
       <th class="govuk-table__header">Activated?</th>
       <th class="govuk-table__header">Action</th>
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% FeatureFlag::FEATURES.keys.map(&:to_s).each do |feature_name| %>
+    <% FeatureFlag::FEATURES.each do |feature_name, feature| %>
       <tr class="govuk-table__row">
 
         <td class="govuk-table__cell">
-          <%= feature_name.humanize %>
+          <h3 class="govuk-!-margin-top-0"><%= feature_name.humanize %></h3>
+          <p><%= feature.description %></p>
+        </td>
+
+        <td class="govuk-table__cell">
+          <%= feature.owner %>
         </td>
 
         <td class="govuk-table__cell">

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -9,7 +9,7 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% FeatureFlag::FEATURES.each do |feature_name| %>
+    <% FeatureFlag::FEATURES.keys.map(&:to_s).each do |feature_name| %>
       <tr class="govuk-table__row">
 
         <td class="govuk-table__cell">

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -35,7 +35,7 @@ task copy_feature_flags_from_production: :environment do
 
   puts 'Synchronising feature flags with production...'
 
-  FeatureFlag::FEATURES.each do |f|
+  FeatureFlag::FEATURES.each_key do |f|
     if flags.dig(f, 'active')
       puts "+ #{f}"
       FeatureFlag.activate(f)

--- a/spec/services/feature_flag_spec.rb
+++ b/spec/services/feature_flag_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe FeatureFlag do
+  describe '.activate' do
+    it 'activates a feature' do
+      expect { FeatureFlag.activate('pilot_open') }.to(
+        change { FeatureFlag.active?('pilot_open') }.from(false).to(true),
+      )
+    end
+  end
+
+  describe '.deactivate' do
+    it 'deactivates a feature' do
+      FeatureFlag.activate('pilot_open')
+      expect { FeatureFlag.deactivate('pilot_open') }.to(
+        change { FeatureFlag.active?('pilot_open') }.from(true).to(false),
+      )
+    end
+  end
+end

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -31,30 +31,34 @@ RSpec.feature 'Feature flags' do
 
   def then_i_should_see_the_existing_feature_flags
     expect(page).to have_content(
-      "Pilot open\n#{pilot_open_feature.description}\n#{pilot_open_feature.owner} Inactive",
+      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\nInactive",
     )
   end
 
   def when_i_activate_the_feature
-    click_button 'Activate ‘Pilot open’'
+    within(pilot_open_row) { click_button 'Activate' }
   end
 
   def then_the_feature_is_activated
     expect(page).to have_content(
-      "Pilot open\n#{pilot_open_feature.description}\n#{pilot_open_feature.owner} Active",
+      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\nActive",
     )
     expect(FeatureFlag.active?('pilot_open')).to be true
   end
 
   def when_i_deactivate_the_feature
-    click_button 'Deactivate ‘Pilot open’'
+    within(pilot_open_row) { click_button 'Deactivate' }
   end
 
   def then_the_feature_is_deactivated
     expect(page).to have_content(
-      "Pilot open\n#{pilot_open_feature.description}\n#{pilot_open_feature.owner} Inactive",
+      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\nInactive",
     )
     expect(FeatureFlag.active?('pilot_open')).to be false
+  end
+
+  def pilot_open_row
+    find(:xpath, "//tr[td[contains(.,'Pilot open')]]")
   end
 
   def pilot_open_feature

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -30,7 +30,9 @@ RSpec.feature 'Feature flags' do
   end
 
   def then_i_should_see_the_existing_feature_flags
-    expect(page).to have_content 'Pilot open Inactive'
+    expect(page).to have_content(
+      "Pilot open\n#{pilot_open_feature.description}\n#{pilot_open_feature.owner} Inactive",
+    )
   end
 
   def when_i_activate_the_feature
@@ -38,7 +40,9 @@ RSpec.feature 'Feature flags' do
   end
 
   def then_the_feature_is_activated
-    expect(page).to have_content 'Pilot open Active'
+    expect(page).to have_content(
+      "Pilot open\n#{pilot_open_feature.description}\n#{pilot_open_feature.owner} Active",
+    )
     expect(FeatureFlag.active?('pilot_open')).to be true
   end
 
@@ -47,7 +51,13 @@ RSpec.feature 'Feature flags' do
   end
 
   def then_the_feature_is_deactivated
-    expect(page).to have_content 'Pilot open Inactive'
+    expect(page).to have_content(
+      "Pilot open\n#{pilot_open_feature.description}\n#{pilot_open_feature.owner} Inactive",
+    )
     expect(FeatureFlag.active?('pilot_open')).to be false
+  end
+
+  def pilot_open_feature
+    @pilot_open_feature ||= FeatureFlag::FEATURES[:pilot_open]
   end
 end


### PR DESCRIPTION
## Context

To help support users we want to add a description and owner property to feature flags.

## Changes proposed in this pull request

- [x] Add `FeatureFlags#description` and `owner` and make `FEATURES` a hash of `FeatureFlag` objects rather than an array of strings. Otherwise Feature API remains the same.
- [x] Fill in `description` and `owner` for all the existing feature flags.
- [x] Update support interface to include the new info.

## Guidance to review

- The descriptions and owners that I've added are my best guesses based on code and commit history. Do they make sense?
- How can we improve the layout of the UI? I'd like to change the buttons to just _Active_ and _Deactivate_ rather than _Active thing_ etc. to create a bit more space for the new columns.

![image](https://user-images.githubusercontent.com/450843/81790369-35e41c00-94fd-11ea-808c-d1d9f272c257.png)

## Link to Trello card

https://trello.com/c/PWgn86fL/1439-add-description-and-owner-to-feature-flags

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
