### PR TITLE
Prevent incomplete reference submission

### DIFF
--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -79,13 +79,22 @@ module RefereeInterface
     end
 
     def review
-      @reference = reference
+      @reference_form = ReferenceReviewForm.new(
+        reference: reference,
+      )
     end
 
     def submit_reference
-      SubmitReference.new(reference: reference).save!
+      @reference_form = ReferenceReviewForm.new(
+        reference: reference,
+      )
 
-      redirect_to referee_interface_confirmation_path(token: @token_param)
+      if @reference_form.valid?
+        SubmitReference.new(reference: reference).save!
+        redirect_to referee_interface_confirmation_path(token: @token_param)
+      else
+        render :review
+      end
     end
 
     def submit_questionnaire

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -25,8 +25,10 @@ module RefereeInterface
       @relationship_form.candidate = reference.application_form.full_name
 
       if @relationship_form.save(reference)
-        if reference.safeguarding_concerns.nil?
+        if reference.safeguarding_concerns.blank?
           redirect_to referee_interface_safeguarding_path(token: @token_param)
+        elsif reference.feedback.blank?
+          redirect_to referee_interface_reference_feedback_path(token: @token_param)
         else
           redirect_to referee_interface_reference_review_path(token: @token_param)
         end

--- a/app/models/referee_interface/reference_review_form.rb
+++ b/app/models/referee_interface/reference_review_form.rb
@@ -1,0 +1,19 @@
+module RefereeInterface
+  class ReferenceReviewForm
+    include ActiveModel::Model
+
+    attr_reader :reference
+
+    def initialize(reference:)
+      @reference = reference
+    end
+
+    validate :questions_complete
+
+    def questions_complete
+      if reference.feedback.nil? || reference.safeguarding_concerns.nil? || reference.relationship_correction.nil?
+        errors.add(:base, 'Can\'t submit a reference without answers to all questions')
+      end
+    end
+  end
+end

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -7,14 +7,6 @@ class SubmitReference
   end
 
   def save!
-    # Hacky way of preventing invalid references from being submitted until we
-    # have proper validation on the review page.
-    #
-    # https://trello.com/c/5pEhlYqw/1266-dev-incorrectly-marked-reference-as-received
-    if reference.feedback.nil? || reference.safeguarding_concerns.nil? || reference.relationship_correction.nil?
-      raise 'Can\'t submit a reference without answers to all questions'
-    end
-
     if enough_references_have_been_submitted?
       progress_applications
     else

--- a/app/views/referee_interface/reference/review.html.erb
+++ b/app/views/referee_interface/reference/review.html.erb
@@ -1,13 +1,14 @@
 <% content_for :title, 'Check your answers before submitting your reference' %>
 <% content_for :before_content, govuk_back_link_to(referee_interface_reference_feedback_path(token: @token_param)) %>
 
-<%= form_with url: referee_interface_submit_reference_path(token: @token_param), method: :patch do |f| %>
+<%= form_with model: @reference_form, url: referee_interface_submit_reference_path(token: @token_param), method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
         Check your answers before submitting your reference
       </h1>
-      <%= render(RefereeInterface::ReferenceReviewComponent.new(reference: @reference, token_param: @token_param)) %>
+      <%= render(RefereeInterface::ReferenceReviewComponent.new(reference: @reference_form.reference, token_param: @token_param)) %>
 
       <p class="govuk-body">
         <%= f.govuk_submit t('reference_form.confirm') %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -448,6 +448,8 @@ FactoryBot.define do
           'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => "#{%w[yes no].sample}| ",
         }
       end
+      safeguarding_concerns { '' }
+      relationship_correction { '' }
     end
   end
 

--- a/spec/models/referee_interface/reference_review_form_spec.rb
+++ b/spec/models/referee_interface/reference_review_form_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe RefereeInterface::ReferenceReviewForm do
+  describe 'validations' do
+    let(:review_form) { described_class.new(reference: build_stubbed(:reference, :complete)) }
+
+    it 'is valid when all questions are complete' do
+      expect(review_form).to be_valid
+    end
+
+    context 'when feedback is nil' do
+      before { review_form.reference.feedback = nil }
+
+      it 'is invalid' do
+        expect(review_form).not_to be_valid
+        expect(review_form.errors.full_messages).to eq(
+          ["Can't submit a reference without answers to all questions"],
+        )
+      end
+    end
+
+    context 'when safeguarding_concerns is nil' do
+      before { review_form.reference.safeguarding_concerns = nil }
+
+      it 'is invalid' do
+        expect(review_form).not_to be_valid
+        expect(review_form.errors.full_messages).to eq(
+          ["Can't submit a reference without answers to all questions"],
+        )
+      end
+    end
+
+    context 'when relationship_correction is nil' do
+      before { review_form.reference.relationship_correction = nil }
+
+      it 'is invalid' do
+        expect(review_form).not_to be_valid
+        expect(review_form.errors.full_messages).to eq(
+          ["Can't submit a reference without answers to all questions"],
+        )
+      end
+    end
+  end
+end

--- a/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
+++ b/spec/system/referee_interface/referee_can_submit_a_reference_for_candidate_with_relationship_and_safeguarding_spec.rb
@@ -165,6 +165,7 @@ RSpec.feature 'Referee can submit reference', with_audited: true do
   end
 
   def then_i_can_review_the_amended_relationship
+    click_button 'Continue'
     expect(page).to have_content('Amended by referee to: he is not my friend')
   end
 

--- a/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
+++ b/spec/system/referee_interface/referee_tries_to_submit_incomplete_reference_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Stop submission of incomplete references', with_audited: true do
+  include CandidateHelper
+
+  scenario 'Referee tries to submit incomplete reference' do
+    given_a_candidate_completed_an_application
+    when_the_candidate_submits_the_application
+    then_i_receive_an_email_with_a_magic_link
+
+    when_i_click_on_the_link_within_the_email
+    and_i_confirm_my_relationship_with_the_candidate
+    and_i_manually_skip_ahead_to_the_review_page
+    then_i_cannot_submit_the_reference
+  end
+
+  def given_a_candidate_completed_an_application
+    candidate_completes_application_form
+  end
+
+  def when_the_candidate_submits_the_application
+    candidate_submits_application
+  end
+
+  def then_i_receive_an_email_with_a_magic_link
+    open_email('terri@example.com')
+    matches = current_email.body.match(/(http:\/\/localhost:3000\/reference\?token=[\w-]{20})/)
+    @token = Rack::Utils.parse_query(URI(matches.captures.first).query)['token']
+    @reference_feedback_url = matches.captures.first unless matches.nil?
+  end
+
+  def when_i_click_on_the_link_within_the_email
+    current_email.click_link(@reference_feedback_url)
+  end
+
+  def and_i_confirm_my_relationship_with_the_candidate
+    expect(page).to have_content("Confirm how you know #{@application.full_name}")
+    choose 'Yes'
+    click_button 'Continue'
+  end
+
+  def and_i_manually_skip_ahead_to_the_review_page
+    visit referee_interface_reference_review_path(token: @token)
+  end
+
+  def then_i_cannot_submit_the_reference
+    click_button 'Submit reference'
+    expect(page).to have_content "Can't submit a reference without answers to all questions"
+    expect(ApplicationReference.feedback_provided).to be_empty
+  end
+end


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Providing a reference involves these steps:

1. Confirm relationship
2. Confirm safeguarding concerns
3. Provide feedback
4. Review and submit

This process is currently subject to the following navigation issue:

- A referee completes the relationship and safeguarding steps, stating
  that they have no safeguarding concerns.
- The referee continues to the feedback page but does not complete it.
- The referee later returns by clicking the original email link. This
  takes them to the first step.
- When continuing past the relationship step, safeguarding and feedback
  are skipped and they end up directly on the review page.

This makes it easy for the referee to submit the reference without any
feedback, which results in an error.

## Changes proposed in this pull request

- Fix navigation logic in RefereeInterface::ReferenceController
- Add validation to reference review page
- Remove temporary check on submitted references

(see commits for more detail)

<!-- If there are UI changes, please include Before and After screenshots. -->

### Review page validation

![Screenshot 2020-05-12 at 16 19 20](https://user-images.githubusercontent.com/519250/81789759-58c20080-94fc-11ea-9f66-dc34b59d1b29.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/mpUFgGmd
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
