### PR TITLE
Increase postgres connection and statement timeout

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,9 @@
 default: &default
   adapter: postgresql
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
+  variables:
+    statement_timeout: 10000
+    idle_in_transaction_session_timeout: 10000
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   host: <%= ENV['DB_HOSTNAME'] %>


### PR DESCRIPTION
## Context

Azure seems to be sporadically timing out our postgres queries. The default is 5 seconds. Let's try bumping it to 10 to see if the errors subside.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Bump `timeout` and `statement_timeout` in database.yml.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Does this make sense?

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

None.

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)