### PR TITLE
Remove edit application guidance for apply again

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -53,6 +53,12 @@
   <p class="govuk-body">
     <%= t('application_complete.dashboard.providers_respond_by', date: respond_by_date) %>
   </p>
+
+<% elsif @application_form.apply_again? %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>
+  </h2>
+
 <% elsif editable? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -29,6 +29,8 @@ module CandidateInterface
     end
 
     def edit
+      redirect_to candidate_interface_application_complete_path and return unless current_application.apply_1?
+
       @editable_days = TimeLimitConfig.edit_by
       render :edit_by_support
     end

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -35,7 +35,7 @@
     <% else %>
       <h2 class="govuk-heading-m">Track or withdraw</h2>
       <p class="govuk-body">You can track or withdraw your application from your application dashboard.</p>
-      <p class="govuk-body"><%= govuk_link_to 'To view your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
+      <p class="govuk-body"><%= govuk_link_to 'To view your application, return to your application dashboard', candidate_interface_application_complete_path %>.</p>
     <% end %>
 
     <h2 class="govuk-heading-m">Tell us what you think of this service</h2>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -28,9 +28,15 @@
     <h2 class="govuk-heading-m">Interview</h2>
     <p class="govuk-body">Your training provider will be in touch with you if they want to arrange an interview.</p>
 
-    <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
-    <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>
-    <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
+    <% if @application_form.apply_1? %>
+      <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
+      <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>
+      <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
+    <% else %>
+      <h2 class="govuk-heading-m">Track or withdraw</h2>
+      <p class="govuk-body">You can track or withdraw your application from your application dashboard.</p>
+      <p class="govuk-body"><%= govuk_link_to 'To view your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>
+    <% end %>
 
     <h2 class="govuk-heading-m">Tell us what you think of this service</h2>
     <p class="govuk-body">Your feedback will help us improve.</p>

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -139,7 +139,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
   end
 
   def when_i_click_view_my_application
-    click_link 'To view your application, return to your application dashboard.'
+    click_link 'To view your application, return to your application dashboard'
   end
 
   def then_i_do_not_see_a_link_to_edit_my_application

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -27,6 +27,13 @@ RSpec.feature 'Candidate with unsuccessful application' do
     when_i_complete_my_application
     then_my_application_is_submitted
     and_i_do_not_see_referee_related_guidance
+    and_there_is_no_guidance_on_editing_my_application
+
+    when_i_click_view_my_application
+    then_i_do_not_see_a_link_to_edit_my_application
+
+    when_i_try_and_visit_the_edit_guidance_path
+    then_i_am_redirected_to_my_application_dashboard
   end
 
   def given_the_pilot_is_open
@@ -125,5 +132,25 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def and_i_do_not_see_referee_related_guidance
     expect(page).not_to have_content 'References'
+  end
+
+  def and_there_is_no_guidance_on_editing_my_application
+    expect(page).not_to have_link 'To edit your application, return to your application dashboard'
+  end
+
+  def when_i_click_view_my_application
+    click_link 'To view your application, return to your application dashboard.'
+  end
+
+  def then_i_do_not_see_a_link_to_edit_my_application
+    expect(page).not_to have_link 'Edit your application'
+  end
+
+  def when_i_try_and_visit_the_edit_guidance_path
+    visit candidate_interface_application_edit_path
+  end
+
+  def then_i_am_redirected_to_my_application_dashboard
+    expect(page).to have_current_path(candidate_interface_application_complete_path)
   end
 end


### PR DESCRIPTION
## Context

For apply again applications they should not be given any guidance regarding editing their application.

## Changes proposed in this pull request

- Remove all guidance/links for editing their application

submit success page

before

![image](https://user-images.githubusercontent.com/42515961/81797143-4f3d9600-9506-11ea-9087-057379464742.png)


after

![image](https://user-images.githubusercontent.com/42515961/81797284-7a27ea00-9506-11ea-8922-035d685015e7.png)


complete page

before

![image](https://user-images.githubusercontent.com/42515961/81797106-3f25b680-9506-11ea-8370-c3048e6a5cff.png)


after

![image](https://user-images.githubusercontent.com/42515961/81797748-19e57800-9507-11ea-9c23-186a9f85e7e6.png)

## Guidance to review

Might need a tiny content review on the submit success page

## Link to Trello card

https://trello.com/c/lxNcrkTN/1542-dev-remove-content-referring-to-editing-your-application-on-apply-again

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
