### PR TITLE
Correct flash message on successful provider user invitation

### DIFF
--- a/app/controllers/provider_interface/provider_users_controller.rb
+++ b/app/controllers/provider_interface/provider_users_controller.rb
@@ -43,7 +43,7 @@ module ProviderInterface
 
       render :new and return unless service.call
 
-      flash[:success] = 'Provider user invited'
+      flash[:success] = 'User successfully invited'
       redirect_to provider_interface_provider_users_path
     end
 

--- a/spec/system/provider_interface/provider_invites_user_spec.rb
+++ b/spec/system/provider_interface/provider_invites_user_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Provider invites a new provider user' do
     @new_provider_user = ProviderUser.find_by(email_address: @email_address)
     expect(@new_provider_user).not_to be nil
     expect(@new_provider_user.providers).to include(@provider)
-    expect(page).to have_content('Provider user invited')
+    expect(page).to have_content('User successfully invited')
   end
 
   def and_the_user_should_be_sent_a_welcome_email
@@ -89,7 +89,7 @@ RSpec.feature 'Provider invites a new provider user' do
   end
 
   def then_the_provider_is_assigned_to_the_user
-    expect(page).to have_content('Provider user invited')
+    expect(page).to have_content('User successfully invited')
 
     @existing_provider_user = ProviderUser.find_by(email_address: @email_address)
     expect(@existing_provider_user.providers).to include(@provider)

--- a/spec/system/provider_interface/removing_provider_user_spec.rb
+++ b/spec/system/provider_interface/removing_provider_user_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'Removing a provider user' do
   end
 
   def then_i_can_see_the_user_and_their_permissions
-    expect(page).to have_content('Provider user invited')
+    expect(page).to have_content('User successfully invited')
 
     expect(page).to have_content(@user_to_remove.full_name)
   end


### PR DESCRIPTION
## Context

This wrongly-worded flash message was spotted during last week's bug party.

## Changes proposed in this pull request

Correct the wording

## Link to Trello card

https://trello.com/c/alVKY45K/2120-correct-flash-message-content-after-a-provider-user-is-invited

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
