### PR TITLE
Add view safeguarding information permission for provider users

### DIFF
--- a/app/components/provider_interface/provider_permissions_list_component.html.erb
+++ b/app/components/provider_interface/provider_permissions_list_component.html.erb
@@ -1,17 +1,11 @@
 <% visible_provider_permissions.each do |provider_permission| %>
   <h4><%= provider_permission.provider.name %></h4>
   <ul id="provider-<%= provider_permission.provider.id %>-enabled-permissions">
-    <%
-      humanized_permissions = [].tap do |ary|
-        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
-          ary << permission_name.to_s.humanize if provider_permission.send(permission_name)
-        end
-      end
-    -%>
-    <% humanized_permissions.each do |humanized_permission| %>
-      <li><%= humanized_permission %></li>
+    <% formatted_permissions = humanized_permissions(provider_permission) -%>
+    <% formatted_permissions.each do |formatted_permission| %>
+      <li><%= formatted_permission %></li>
     <% end %>
-    <% if humanized_permissions.empty? %>
+    <% if formatted_permissions.empty? %>
       <li>No permissions</li>
     <% end %>
   </ul>

--- a/app/components/provider_interface/provider_permissions_list_component.html.erb
+++ b/app/components/provider_interface/provider_permissions_list_component.html.erb
@@ -1,14 +1,18 @@
 <% visible_provider_permissions.each do |provider_permission| %>
   <h4><%= provider_permission.provider.name %></h4>
   <ul id="provider-<%= provider_permission.provider.id %>-enabled-permissions">
-    <% ProviderPermissions::VALID_PERMISSIONS.each do |permission_name| %>
-      <li>
-        <% if provider_permission.send(permission_name) %>
-          <%= permission_name.to_s.humanize %>
-        <% else %>
-            No permissions
-        <% end %>
-      </li>
+    <%
+      humanized_permissions = [].tap do |ary|
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+          ary << permission_name.to_s.humanize if provider_permission.send(permission_name)
+        end
+      end
+    -%>
+    <% humanized_permissions.each do |humanized_permission| %>
+      <li><%= humanized_permission %></li>
+    <% end %>
+    <% if humanized_permissions.empty? %>
+      <li>No permissions</li>
     <% end %>
   </ul>
 <% end %>

--- a/app/components/provider_interface/provider_permissions_list_component.rb
+++ b/app/components/provider_interface/provider_permissions_list_component.rb
@@ -11,5 +11,13 @@ module ProviderInterface
     def visible_provider_permissions
       possible_permissions & provider_permissions
     end
+
+    def humanized_permissions(provider_permission)
+      [].tap do |ary|
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+          ary << permission_name.to_s.humanize if provider_permission.send(permission_name)
+        end
+      end
+    end
   end
 end

--- a/app/models/provider_interface/provider_user_form.rb
+++ b/app/models/provider_interface/provider_user_form.rb
@@ -63,7 +63,11 @@ module ProviderInterface
           provider_id: form.provider_permission[:provider_id],
           provider_user_id: provider_user&.id,
         )
-        permission.manage_users = form.provider_permission.fetch(:manage_users, false)
+
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+          permission.send("#{permission_name}=", form.provider_permission.fetch(permission_name, false))
+        end
+
         permission
       end
     end

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -9,6 +9,7 @@ class ProviderPermissions < ActiveRecord::Base
   audited associated_with: :provider_user
 
   scope :manage_users, -> { where(manage_users: true) }
+  scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
 
   def self.possible_permissions(current_provider_user:, provider_user:)
     provider_ids = current_provider_user

--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -1,5 +1,5 @@
 class ProviderPermissions < ActiveRecord::Base
-  VALID_PERMISSIONS = %i[manage_users].freeze
+  VALID_PERMISSIONS = %i[manage_users view_safeguarding_information].freeze
 
   self.table_name = 'provider_users_providers'
 

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -36,6 +36,10 @@ class ProviderUser < ActiveRecord::Base
     end
   end
 
+  def can_view_safeguarding_information_for?(provider)
+    provider_permissions.view_safeguarding_information.exists?(provider: provider)
+  end
+
   def full_name
     "#{first_name} #{last_name}" if first_name.present? && last_name.present?
   end

--- a/app/models/support_interface/provider_user_form.rb
+++ b/app/models/support_interface/provider_user_form.rb
@@ -66,7 +66,11 @@ module SupportInterface
           provider_id: form.provider_permission[:provider_id],
           provider_user_id: provider_user.try(:id),
         )
-        permission.manage_users = form.provider_permission.fetch(:manage_users, false)
+
+        ProviderPermissions::VALID_PERMISSIONS.each do |permission_name|
+          permission.send("#{permission_name}=", form.provider_permission.fetch(permission_name, false))
+        end
+
         permission
       end
     end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -52,7 +52,9 @@
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
     <% if FeatureFlag.active?('provider_view_safeguarding') %>
-      <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
+      <% if current_provider_user.can_view_safeguarding_information_for?(@application_choice.provider) %>
+        <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
+      <% end %>
     <% end %>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-8" id="qualifications">Qualifications</h2>

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -20,6 +20,8 @@
                   <%= ppf.hidden_field :provider_id %>
                   <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
                     <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+                    <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
+                                            label: { text: 'View safeguarding information' } %>
                   <% end %>
                 <% end %>
               <% end %>

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -8,6 +8,8 @@
             <%= ppf.hidden_field :provider_id %>
             <%= ppf.govuk_check_boxes_fieldset :permissions, legend: { text: 'Choose permissions', size: 's' } do %>
               <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
+              <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
+                                      label: { text: 'View safeguarding information' } %>
             <% end %>
           <% end %>
         <% end %>

--- a/spec/components/provider_interface/provider_permissions_list_component_spec.rb
+++ b/spec/components/provider_interface/provider_permissions_list_component_spec.rb
@@ -12,7 +12,13 @@ RSpec.describe ProviderInterface::ProviderPermissionsListComponent do
 
   let(:provider_permissions) do
     [
-      build_stubbed(:provider_permissions, id: 1, manage_users: true, provider: providers[0]),
+      build_stubbed(
+        :provider_permissions,
+        id: 1,
+        manage_users: true,
+        view_safeguarding_information: true,
+        provider: providers[0],
+      ),
       build_stubbed(:provider_permissions, id: 2, provider: providers[1]),
       build_stubbed(:provider_permissions, id: 3, manage_users: true, provider: providers[2]),
       build_stubbed(:provider_permissions, id: 4, manage_users: true, provider: providers[3]),
@@ -33,6 +39,7 @@ RSpec.describe ProviderInterface::ProviderPermissionsListComponent do
 
     expect(result.text).to include(providers[0].name)
     expect(result.css('#provider-10-enabled-permissions').text).to include('Manage users')
+    expect(result.css('#provider-10-enabled-permissions').text).to include('View safeguarding information')
     expect(result.text).to include(providers[1].name)
     expect(result.css('#provider-11-enabled-permissions').text).to include('No permissions')
     expect(result.text).to include(providers[2].name)

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -78,6 +78,26 @@ RSpec.describe ProviderUser, type: :model do
     end
   end
 
+  describe '#can_view_safeguarding_information_for?' do
+    let(:provider_user) { create :provider_user, :with_provider }
+
+    it 'is false without the correct permission' do
+      provider = provider_user.providers.first
+      expect(provider_user.can_view_safeguarding_information_for?(provider)).to be false
+    end
+
+    it 'is false without the correct permission for the given provider' do
+      provider_user.provider_permissions.update_all(view_safeguarding_information: true)
+      expect(provider_user.can_view_safeguarding_information_for?(build_stubbed(:provider))).to be false
+    end
+
+    it 'is true with the correct permission for the given provider' do
+      provider_user.provider_permissions.update_all(view_safeguarding_information: true)
+      provider = provider_user.providers.first
+      expect(provider_user.can_view_safeguarding_information_for?(provider)).to be true
+    end
+  end
+
   describe '.visible_to' do
     it 'returns provider users with access to the same providers as the passed user' do
       provider = create(:provider)

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -16,11 +16,16 @@ RSpec.feature 'Managing provider user permissions' do
 
     then_i_see_providers_and_permissions
     and_i_add_permission_to_manage_users_for_a_provider_user
-    then_i_can_see_the_new_permission_for_the_provider_user
+    then_i_can_see_the_manage_users_permission_for_the_provider_user
     and_i_click_change_providers_and_permissions
 
-    when_i_remove_a_permissions_from_a_provider_user
-    then_i_cant_see_the_permission_for_the_provider_user
+    when_i_remove_manage_users_permissions_from_a_provider_user
+    then_i_cant_see_the_manage_users_permission_for_the_provider_user
+
+    and_i_click_change_providers_and_permissions
+
+    when_i_add_permission_to_view_safeguarding_for_a_provider_user
+    then_i_can_see_the_view_safeguarding_permission_for_the_provider_user
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -71,7 +76,7 @@ RSpec.feature 'Managing provider user permissions' do
     click_on 'Update providers'
   end
 
-  def then_i_can_see_the_new_permission_for_the_provider_user
+  def then_i_can_see_the_manage_users_permission_for_the_provider_user
     expect(page).to have_content 'Providers updated'
 
     within("#provider-#{@provider.id}-enabled-permissions") do
@@ -81,7 +86,7 @@ RSpec.feature 'Managing provider user permissions' do
     expect(@managed_user.provider_permissions.first.manage_users).to be true
   end
 
-  def when_i_remove_a_permissions_from_a_provider_user
+  def when_i_remove_manage_users_permissions_from_a_provider_user
     within(permissions_fields_id_for_provider(@provider)) do
       expect(page).to have_checked_field 'Manage users'
       uncheck 'Manage users'
@@ -90,11 +95,29 @@ RSpec.feature 'Managing provider user permissions' do
     click_on 'Update providers'
   end
 
-  def then_i_cant_see_the_permission_for_the_provider_user
+  def then_i_cant_see_the_manage_users_permission_for_the_provider_user
     expect(page).to have_content 'Providers updated'
     expect(page).not_to have_content 'Manage users'
 
     expect(@managed_user.provider_permissions.first.manage_users).to be false
+  end
+
+  def when_i_add_permission_to_view_safeguarding_for_a_provider_user
+    expect(page).not_to have_checked_field 'View safeguarding information'
+
+    within(permissions_fields_id_for_provider(@provider)) do
+      check 'View safeguarding information'
+    end
+
+    click_on 'Update providers'
+  end
+
+  def then_i_can_see_the_view_safeguarding_permission_for_the_provider_user
+    within("#provider-#{@provider.id}-enabled-permissions") do
+      expect(page).to have_content 'View safeguarding information'
+    end
+
+    expect(@managed_user.provider_permissions.first.view_safeguarding_information).to be true
   end
 
   def permissions_fields_id_for_provider(provider)

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -82,8 +82,6 @@ RSpec.feature 'Managing provider user permissions' do
     within("#provider-#{@provider.id}-enabled-permissions") do
       expect(page).to have_content 'Manage users'
     end
-
-    expect(@managed_user.provider_permissions.first.manage_users).to be true
   end
 
   def when_i_remove_manage_users_permissions_from_a_provider_user
@@ -98,8 +96,6 @@ RSpec.feature 'Managing provider user permissions' do
   def then_i_cant_see_the_manage_users_permission_for_the_provider_user
     expect(page).to have_content 'Providers updated'
     expect(page).not_to have_content 'Manage users'
-
-    expect(@managed_user.provider_permissions.first.manage_users).to be false
   end
 
   def when_i_add_permission_to_view_safeguarding_for_a_provider_user
@@ -116,8 +112,6 @@ RSpec.feature 'Managing provider user permissions' do
     within("#provider-#{@provider.id}-enabled-permissions") do
       expect(page).to have_content 'View safeguarding information'
     end
-
-    expect(@managed_user.provider_permissions.first.view_safeguarding_information).to be true
   end
 
   def permissions_fields_id_for_provider(provider)

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_the_timeline_feature_flag_is_active
     and_my_organisation_has_received_an_application
     and_i_am_permitted_to_see_applications_for_my_provider
+    and_i_am_permitted_to_see_safeguarding_information
     and_i_sign_in_to_the_provider_interface
 
     when_i_visit_that_application_in_the_provider_interface
@@ -42,6 +43,11 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def and_the_safeguarding_declaration_feature_flag_is_active
     FeatureFlag.activate('provider_view_safeguarding')
+  end
+
+  def and_i_am_permitted_to_see_safeguarding_information
+    ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+      .provider_permissions.update_all(view_safeguarding_information: true)
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -180,16 +180,12 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_they_should_be_able_to_manage_users
-    expect(@user.reload.provider_permissions.manage_users.first.provider).to eq(@provider)
-
     within(permissions_fields_id_for_provider(@provider)) do
       expect(page).to have_checked_field('Manage users')
     end
   end
 
   def and_they_should_be_able_to_view_safeguarding_information
-    expect(@user.reload.provider_permissions.view_safeguarding_information.first.provider).to eq(@provider)
-
     within(permissions_fields_id_for_provider(@provider)) do
       expect(page).to have_checked_field('View safeguarding information')
     end
@@ -210,8 +206,6 @@ RSpec.feature 'Managing provider users' do
   end
 
   def then_they_should_not_be_able_to_manage_users
-    expect(@user.reload.provider_permissions.manage_users).to be_empty
-
     within(permissions_fields_id_for_provider(@provider)) do
       expect(page).to have_field('Manage users')
       expect(page).not_to have_checked_field('Manage users')
@@ -219,8 +213,6 @@ RSpec.feature 'Managing provider users' do
   end
 
   def and_they_should_not_have_access_to_the_removed_provider
-    expect(@user.providers).not_to include(@another_provider)
-
     expect(page).to have_checked_field('Example provider (ABC)')
     expect(page).not_to have_checked_field('Another provider (DEF)')
   end

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Managing provider users' do
     and_i_enter_the_users_email_and_name
     and_i_select_a_provider
     and_i_check_permission_to_manage_users
+    and_i_check_permission_to_view_safeguarding_information
     and_i_click_add_user
 
     then_i_should_see_the_list_of_provider_users
@@ -39,6 +40,7 @@ RSpec.feature 'Managing provider users' do
     and_i_reload_the_page
     then_their_email_should_be_editable
     and_they_should_be_able_to_manage_users
+    and_they_should_be_able_to_view_safeguarding_information
 
     when_i_remove_manage_users_permissions
     and_i_remove_access_to_a_provider
@@ -89,6 +91,12 @@ RSpec.feature 'Managing provider users' do
   def and_i_check_permission_to_manage_users
     within(permissions_fields_id_for_provider(@provider)) do
       check 'Manage users'
+    end
+  end
+
+  def and_i_check_permission_to_view_safeguarding_information
+    within(permissions_fields_id_for_provider(@provider)) do
+      check 'View safeguarding information'
     end
   end
 
@@ -176,6 +184,14 @@ RSpec.feature 'Managing provider users' do
 
     within(permissions_fields_id_for_provider(@provider)) do
       expect(page).to have_checked_field('Manage users')
+    end
+  end
+
+  def and_they_should_be_able_to_view_safeguarding_information
+    expect(@user.reload.provider_permissions.view_safeguarding_information.first.provider).to eq(@provider)
+
+    within(permissions_fields_id_for_provider(@provider)) do
+      expect(page).to have_checked_field('View safeguarding information')
     end
   end
 


### PR DESCRIPTION
## Context

As a precursor to delivering permissions at a provider organisation level we need a user level permission which can be used in conjunction with the org level permission.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds `view_safeguarding_information` permission to `ProviderPermissions`
- Adds permission checkbox on existing provider user provider permissions form.
- Adds permission checkbox on existing support interface form for managing provider users.
- Restricts visibility of safeguarding information based on the user-level permission for the relevant provider.

<!-- If there are UI changes, please include Before and After screenshots. -->

![image](https://user-images.githubusercontent.com/93511/81805508-e1e43200-9512-11ea-9316-59d9dc1b8c40.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/bwEGeJa3/2093-build-access-mgmt-safeguarding
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
