### PR TITLE
Do not show the unhelpful default error when a rejection reason is too long

### DIFF
--- a/app/views/provider_interface/decisions/new_reject.html.erb
+++ b/app/views/provider_interface/decisions/new_reject.html.erb
@@ -13,6 +13,7 @@
         <span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>
         <%= f.govuk_text_area :rejection_reason,
           label: { text: 'Tell the candidate why you’re rejecting their application', size: 'xl' },
+          max_chars: 255,
           rows: 5 %>
       </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -201,6 +201,9 @@ en:
           attributes:
             rejection_reason:
               blank: Explain why you’re rejecting the application
+              too_long: |
+                The explanation for why you're rejecting the application must be
+                %{count} characters or fewer
   activerecord:
     attributes:
       application_qualification/qualification_type:


### PR DESCRIPTION
## Context

We noticed the error in the error summary was a nonsensical "too long (must be 255 chars or less)"

## Changes proposed in this pull request

- write a correct error message
- add a hint to the field saying this constraint exists

## Link to Trello card

https://trello.com/c/lahFSqhT/2137-correct-error-message-when-invalid-rejection-details-given

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
