### PR TITLE
Hide subnavigation links in print stylesheet

### DIFF
--- a/app/components/sub_navigation_component.html.erb
+++ b/app/components/sub_navigation_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-tabs app-tabs">
+<div class="govuk-tabs app-tabs govuk-!-display-none-print">
   <ul class="govuk-tabs__list">
     <% items.each do |item| %>
       <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>


### PR DESCRIPTION
## Context

We have useless links in application PDFs since we introduced a subnav at the top of the application.

## Changes proposed in this pull request

Hide the links in the PDFs using `govuk-!-display-none-print`

## Guidance to review

Generate a PDF. See that it has no links at the top.

## Link to Trello card

https://trello.com/c/F5w9TuVh/2139-title-do-we-need-the-links-to-things-on-the-pdf-application-print-outs

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
