### PR TITLE
Prevent 500 on Application PDFs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,7 @@ stages:
         dockerHubImageName: $(imageName)
         railsSecretKeyBase: $(railsSecretKeyBase)
         RAILS_ENV: test
+        RAILS_SERVE_STATIC_FILES: true
         GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
         AUTHORISED_HOSTS: $(authorisedHosts)
         FIND_BASE_URL: $(findBaseUrl)

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,6 @@ module ApplyForPostgraduateTeacherTraining
 
     config.middleware.use PDFKit::Middleware, { print_media_type: true }, disposition: 'attachment', only: [%r[^/provider/applications/\d+]]
 
-    config.middleware.use Rack::Deflater
+    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
   end
 end


### PR DESCRIPTION
PDFs broke in production: https://sentry.io/organizations/dfe-bat/issues/1663167715/?referrer=slack

Move `Rack::Deflater` to the top of the middleware stack as recommended in
https://www.schneems.com/2017/11/08/80-smaller-rails-footprint-with-rack-deflate/

We added the `Rack::Deflater` middleware to compress our responses. This
middleware returns a GZip stream rather than a string.

Unfortunately `PDFKit` ended up next to it in the chain, and tried to
turn the gzip stream into a PDF. This caused an error here:

https://github.com/pdfkit/pdfkit/blob/master/lib/pdfkit/middleware.rb#L23

## Guidance to review

I don't know how to write an automated test for this using our current system test setup (ie `rack-test`). The existing system spec for PDF generation continued to pass while this bug was in evidence. We might be able to repro using a headless browser/cypress.