### PR TITLE
Add confirm completion checkbox for personal details section

### DIFF
--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,0 +1,8 @@
+<%= form_with model: @application_form, url: @path, method: :post do |f| %>
+  <div class='govuk-form-group'>
+    <%= f.hidden_field @field_name, value: false %>
+    <%= f.govuk_check_box @field_name, true, multiple: false, label: { text: t('application_form.completed_checkbox') } %>
+  </div>
+
+  <%= f.govuk_submit t('application_form.continue') %>
+<% end %>

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,0 +1,11 @@
+module CandidateInterface
+  class CompleteSectionComponent < ViewComponent::Base
+    validates :application_form, :path, :field_name, presence: true
+
+    def initialize(application_form:, path:, field_name:)
+      @application_form = application_form
+      @path = path
+      @field_name = field_name
+    end
+  end
+end

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -28,22 +28,9 @@ module CandidateInterface
     end
 
     def complete
-      @application_form = current_application
+      current_application.update!(application_form_params)
 
-      if PersonalDetailsForm.build_from_application(current_application).valid?
-        current_application.update!(application_form_params)
-
-        redirect_to candidate_interface_application_form_path
-      else
-        flash[:warning] = 'You can’t mark this section as complete without adding all your personal details.'
-
-        current_application.personal_details_completed = false
-
-        personal_details_form = PersonalDetailsForm.build_from_application(current_application)
-        @personal_details_review = PersonalDetailsReviewPresenter.new(form: personal_details_form)
-
-        render :show
-      end
+      redirect_to candidate_interface_application_form_path
     end
 
   private

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -1,11 +1,10 @@
 module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    before_action :set_application_form_to_current_application
 
     def edit
-      @personal_details_form = PersonalDetailsForm.build_from_application(
-        current_application,
-      )
+      @personal_details_form = PersonalDetailsForm.build_from_application(@application_form)
     end
 
     def update
@@ -13,6 +12,8 @@ module CandidateInterface
       @personal_details_review = PersonalDetailsReviewPresenter.new(form: @personal_details_form)
 
       if @personal_details_form.save(current_application)
+        @application_form.update!(personal_details_completed: false)
+
         render :show
       else
         track_validation_error(@personal_details_form)
@@ -21,13 +22,32 @@ module CandidateInterface
     end
 
     def show
-      personal_details_form = PersonalDetailsForm.build_from_application(
-        current_application,
-      )
+      personal_details_form = PersonalDetailsForm.build_from_application(@application_form)
       @personal_details_review = PersonalDetailsReviewPresenter.new(form: personal_details_form)
     end
 
+    def complete
+      if PersonalDetailsForm.build_from_application(@application_form).valid?
+        @application_form.update!(application_form_params)
+
+        redirect_to candidate_interface_application_form_path
+      else
+        flash[:warning] = 'You can’t mark this section as complete without adding all your personal details.'
+
+        @application_form.personal_details_completed = false
+
+        personal_details_form = PersonalDetailsForm.build_from_application(@application_form)
+        @personal_details_review = PersonalDetailsReviewPresenter.new(form: personal_details_form)
+
+        render :show
+      end
+    end
+
   private
+
+    def set_application_form_to_current_application
+      @application_form = current_application
+    end
 
     def personal_details_params
       params.require(:candidate_interface_personal_details_form).permit(
@@ -38,6 +58,11 @@ module CandidateInterface
         :english_language_details, :other_language_details
       )
         .transform_keys { |key| dob_field_to_attribute(key) }
+        .transform_values(&:strip)
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(:personal_details_completed)
         .transform_values(&:strip)
     end
 

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -1,18 +1,18 @@
 module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
-    before_action :set_application_form_to_current_application
 
     def edit
-      @personal_details_form = PersonalDetailsForm.build_from_application(@application_form)
+      @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
     end
 
     def update
+      @application_form = current_application
       @personal_details_form = PersonalDetailsForm.new(personal_details_params)
       @personal_details_review = PersonalDetailsReviewPresenter.new(form: @personal_details_form)
 
       if @personal_details_form.save(current_application)
-        @application_form.update!(personal_details_completed: false)
+        current_application.update!(personal_details_completed: false)
 
         render :show
       else
@@ -22,21 +22,24 @@ module CandidateInterface
     end
 
     def show
-      personal_details_form = PersonalDetailsForm.build_from_application(@application_form)
+      @application_form = current_application
+      personal_details_form = PersonalDetailsForm.build_from_application(current_application)
       @personal_details_review = PersonalDetailsReviewPresenter.new(form: personal_details_form)
     end
 
     def complete
-      if PersonalDetailsForm.build_from_application(@application_form).valid?
-        @application_form.update!(application_form_params)
+      @application_form = current_application
+
+      if PersonalDetailsForm.build_from_application(current_application).valid?
+        current_application.update!(application_form_params)
 
         redirect_to candidate_interface_application_form_path
       else
         flash[:warning] = 'You can’t mark this section as complete without adding all your personal details.'
 
-        @application_form.personal_details_completed = false
+        current_application.personal_details_completed = false
 
-        personal_details_form = PersonalDetailsForm.build_from_application(@application_form)
+        personal_details_form = PersonalDetailsForm.build_from_application(current_application)
         @personal_details_review = PersonalDetailsReviewPresenter.new(form: personal_details_form)
 
         render :show
@@ -44,10 +47,6 @@ module CandidateInterface
     end
 
   private
-
-    def set_application_form_to_current_application
-      @application_form = current_application
-    end
 
     def personal_details_params
       params.require(:candidate_interface_personal_details_form).permit(

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -102,7 +102,11 @@ module CandidateInterface
     end
 
     def personal_details_completed?
-      @application_form.personal_details_completed?
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.personal_details_completed?
+      else
+        CandidateInterface::PersonalDetailsForm.build_from_application(@application_form).valid?
+      end
     end
 
     def contact_details_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -102,7 +102,7 @@ module CandidateInterface
     end
 
     def personal_details_completed?
-      CandidateInterface::PersonalDetailsForm.build_from_application(@application_form).valid?
+      @application_form.personal_details_completed?
     end
 
     def contact_details_completed?

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -30,6 +30,8 @@ class FeatureFlag
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
+    [:mark_every_section_complete, 'Each section of the application form should have to be explicitly completed', 'David Gisbey'],
+
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/personal_details/show.html.erb
+++ b/app/views/candidate_interface/personal_details/show.html.erb
@@ -7,11 +7,6 @@
 
 <%= render(SummaryCardComponent.new(rows: @personal_details_review.rows)) %>
 
-<%= form_with model: @application_form, url: candidate_interface_personal_details_complete_path, method: :post do |f| %>
-  <div class='govuk-form-group'>
-    <%= f.hidden_field :personal_details_completed, value: false %>
-    <%= f.govuk_check_box :personal_details_completed, true, multiple: false, label: { text: t('application_form.completed_checkbox') } %>
-  </div>
-
-  <%= f.govuk_submit t('application_form.continue') %>
-<% end %>
+<%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                        path: candidate_interface_personal_details_complete_path,
+                                        field_name: :personal_details_completed)) %>

--- a/app/views/candidate_interface/personal_details/show.html.erb
+++ b/app/views/candidate_interface/personal_details/show.html.erb
@@ -7,4 +7,11 @@
 
 <%= render(SummaryCardComponent.new(rows: @personal_details_review.rows)) %>
 
-<%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<%= form_with model: @application_form, url: candidate_interface_personal_details_complete_path, method: :post do |f| %>
+  <div class='govuk-form-group'>
+    <%= f.hidden_field :personal_details_completed, value: false %>
+    <%= f.govuk_check_box :personal_details_completed, true, multiple: false, label: { text: t('application_form.completed_checkbox') } %>
+  </div>
+
+  <%= f.govuk_submit t('application_form.continue') %>
+<% end %>

--- a/app/views/candidate_interface/personal_details/show.html.erb
+++ b/app/views/candidate_interface/personal_details/show.html.erb
@@ -7,6 +7,10 @@
 
 <%= render(SummaryCardComponent.new(rows: @personal_details_review.rows)) %>
 
-<%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
-                                        path: candidate_interface_personal_details_complete_path,
-                                        field_name: :personal_details_completed)) %>
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                          path: candidate_interface_personal_details_complete_path,
+                                          field_name: :personal_details_completed)) %>
+<% else %>
+  <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% end %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -1,6 +1,8 @@
 en:
   application_form:
     begin_button: Start now
+    completed_checkbox: I have completed this section
+    continue: Continue
     review:
       role_involved_working_with_children: This role involved working with children
     courses:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
 
       scope '/personal-details' do
         get '/' => 'personal_details#edit', as: :personal_details_edit
+        post '/' => 'personal_details#complete', as: :personal_details_complete
         post '/review' => 'personal_details#update', as: :personal_details_update
         get '/review' => 'personal_details#show', as: :personal_details_show
       end

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::CompleteSectionComponent do
+  let(:application_form) { create(:application_form) }
+  let(:path) { Rails.application.routes.url_helpers.candidate_interface_application_form_path }
+  let(:field_name) { 'field_name' }
+
+  it 'renders successfully' do
+    result = render_inline(
+      described_class.new(application_form: application_form,
+                          path: path,
+                          field_name: field_name),
+    )
+
+    expect(result.css('.govuk-form-group').text).to include 'I have completed this section'
+    expect(result.to_html).to include path
+    expect(result.to_html).to include field_name
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -50,6 +50,7 @@ FactoryBot.define do
       other_qualifications_completed { true }
       volunteering_completed { true }
       work_history_completed { true }
+      personal_details_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -132,7 +132,8 @@ module CandidateHelper
     fill_in t('english_main_language.yes_label', scope: scope), with: "I'm great at Galactic Basic so English is a piece of cake", match: :prefer_exact
 
     click_button t('complete_form_button', scope: scope)
-    click_link t('complete_form_button', scope: scope)
+    check t('application_form.completed_checkbox')
+    click_button t('complete_form_button', scope: scope)
   end
 
   def candidate_fills_in_contact_details

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -130,10 +130,13 @@ module CandidateHelper
 
     choose 'Yes'
     fill_in t('english_main_language.yes_label', scope: scope), with: "I'm great at Galactic Basic so English is a piece of cake", match: :prefer_exact
-
     click_button t('complete_form_button', scope: scope)
-    check t('application_form.completed_checkbox')
-    click_button t('complete_form_button', scope: scope)
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('complete_form_button', scope: scope)
+    else
+      click_link 'Continue'
+    end
   end
 
   def candidate_fills_in_contact_details

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -22,7 +22,8 @@ RSpec.feature 'Entering their personal details' do
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
-    when_i_submit_my_details
+    when_i_mark_the_section_as_completed
+    and_i_submit_my_details
     then_i_should_see_the_form
     and_that_the_section_is_completed
 
@@ -100,8 +101,12 @@ RSpec.feature 'Entering their personal details' do
     expect(page).to have_content 'Billy Dee Williams'
   end
 
-  def when_i_submit_my_details
-    click_link 'Continue'
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def and_i_submit_my_details
+    click_button 'Continue'
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_personal_details_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering their personal details' do
 
   scenario 'Candidate submits their personal details' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
     and_i_visit_the_site
 
     when_i_click_on_personal_details
@@ -33,6 +34,10 @@ RSpec.feature 'Entering their personal details' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def and_i_visit_the_site


### PR DESCRIPTION
## Context

First PR is #2051 - Adds a bunch of columns to the application_forms table for the completion of each section.

Currently, the majority of the sections of the application form, do not need to be explicitly marked as complete. This means that many sections are marked as complete by default as they still meet the logic required to do so. 

## Changes proposed in this pull request

- Adds a confirm completion checkbox to the personal details section.

before

![image](https://user-images.githubusercontent.com/42515961/81837668-09e88b00-953d-11ea-8d15-891fdf77f3d9.png)


after


![image](https://user-images.githubusercontent.com/42515961/81837532-e6bddb80-953c-11ea-8d51-5a3715aa32a5.png)


## Guidance to review

## Link to Trello card

https://trello.com/c/2YtoBPNB/1425-explicitly-mark-all-sections-as-complete

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
