### PR TITLE
Remove support_sign_in_confirmation_email feature flag

### DIFF
--- a/app/controllers/dfe_sign_in_controller.rb
+++ b/app/controllers/dfe_sign_in_controller.rb
@@ -31,8 +31,6 @@ class DfESignInController < ActionController::Base
 private
 
   def send_support_sign_in_confirmation_email
-    return unless FeatureFlag.active?('support_sign_in_confirmation_email')
-
     return if cookies.signed[:sign_in_confirmation] == @local_user.id
 
     cookies.signed[:sign_in_confirmation] = {

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -25,7 +25,6 @@ class FeatureFlag
     [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],
     [:provider_interface_work_breaks, 'Adds work break information to the provider interface', 'Steve Hook'],
     [:provider_view_safeguarding, 'Allows providers to see whether a candidate has declared safeguarding issues', 'Will McBrien'],
-    [:support_sign_in_confirmation_email, 'Improves security of support interface with confirmation email to user on first login', 'Tijmen Brommet'],
     [:timeline, 'Adds a timeline of status change events to the provider interface', 'Steve Hook'],
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],

--- a/spec/system/support_interface/authentication_spec.rb
+++ b/spec/system/support_interface/authentication_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe 'A support user authenticates via DfE Sign-in' do
   include DfESignInHelpers
 
   scenario 'signing in successfully' do
-    FeatureFlag.activate('support_sign_in_confirmation_email')
-
     given_i_have_a_dfe_sign_in_account_and_support_authorisation
 
     when_i_visit_the_support_interface_users_path


### PR DESCRIPTION
## Context

We've had this feature on for a bit, we probably won't revert it.

## Changes proposed in this pull request

Remove the flag.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card



## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
