### PR TITLE
Fix position of tag on application page

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -3,7 +3,9 @@
   <h3 class="govuk-heading-m">
     <%= govuk_link_to candidate_name, provider_interface_application_choice_path(application_choice) %>
     <div class="app-application-card__status">
-      <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
+      <div>
+        <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
+      </div>
       <% if most_recent_note %>
         <span class="app-application-card__note"><%= most_recent_note.subject %></span>
       <% end %>

--- a/app/components/provider_interface/application_status_tag_component.html.erb
+++ b/app/components/provider_interface/application_status_tag_component.html.erb
@@ -1,1 +1,1 @@
-<div><%= render TagComponent.new(text: text, type: type) %></div>
+<%= render TagComponent.new(text: text, type: type) %>


### PR DESCRIPTION
## Context

Fix to position of 'status' tag on application card had side effect on application show view. This PR fixes that.

## Changes proposed in this pull request

**Before**
<img width="348" alt="Screenshot 2020-05-14 at 08 56 22" src="https://user-images.githubusercontent.com/13377553/81908183-cc2d4600-95c0-11ea-808f-2e07a355d7ec.png">

**After**
<img width="401" alt="Screenshot 2020-05-14 at 08 56 49" src="https://user-images.githubusercontent.com/13377553/81908231-dcddbc00-95c0-11ea-9fef-9227f15d84ba.png">

## Guidance to review

- Load the app - look at the any application summary.

## Link to Trello card

Was side effect of this: https://trello.com/c/2gdRmYDC/2115-title-notification-dot-on-application-list-in-wrong-place-sometimes

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
