### PR TITLE
Change approach for sharing UI with support interface

### DIFF
--- a/app/views/candidate_interface/application_form/_application_form_specific_data.html.erb
+++ b/app/views/candidate_interface/application_form/_application_form_specific_data.html.erb
@@ -1,0 +1,45 @@
+<h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
+
+<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
+
+<%= render(WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
+
+<%= render(VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
+
+<h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
+
+<%= render(SafeguardingReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
+
+<h3 class="govuk-heading-m">Degree(s)</h3>
+
+<%= render(CandidateInterface::DegreesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
+
+<h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
+
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error)) %>
+
+<h3 class="govuk-heading-m">English GCSE or equivalent</h3>
+
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error)) %>
+
+<% if application_form.science_gcse_needed? %>
+  <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
+
+  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error)) %>
+<% end %>
+
+<h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>
+
+<%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error)) %>
+
+<h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
+
+<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -24,51 +24,7 @@
 
 <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
 
-<h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
-
-<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
-
-<%= render(WorkHistoryReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: !application_form.work_history_completed && editable, missing_error: missing_error)) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Volunteering with children and young people</h2>
-
-<%= render(VolunteeringReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
-
-<h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
-
-<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
-
-<h3 class="govuk-heading-m">Degree(s)</h3>
-
-<%= render(CandidateInterface::DegreesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, show_incomplete: true, missing_error: missing_error)) %>
-
-<h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
-
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error)) %>
-
-<h3 class="govuk-heading-m">English GCSE or equivalent</h3>
-
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error)) %>
-
-<% if @application_form.science_gcse_needed? %>
-  <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
-
-  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error)) %>
-<% end %>
-
-<h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>
-
-<%= render(CandidateInterface::OtherQualificationsReviewComponent.new(application_form: application_form, editable: editable, heading_level: 4, missing_error: missing_error)) %>
-
-<h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
-
-<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
-<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
-<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+<%= render 'application_form_specific_data', application_form: @application_form, editable: editable, missing_error: missing_error %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 

--- a/app/views/provider_interface/application_choices/_application_form_specific_data.html.erb
+++ b/app/views/provider_interface/application_choices/_application_form_specific_data.html.erb
@@ -1,0 +1,37 @@
+<%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: application_form) %>
+
+<% if FeatureFlag.active?('provider_view_safeguarding') %>
+  <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: application_form)%>
+<% end %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
+
+<%= render QualificationsComponent.new(application_form: application_form) %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-8" id="work-history">Work history</h2>
+
+<div data-qa="work-history">
+  <% if FeatureFlag.active?('provider_interface_work_breaks') %>
+    <%= render ProviderInterface::WorkHistoryComponent.new(application_form: application_form) %>
+  <% else %>
+    <%= render WorkHistoryReviewComponent.new(application_form: application_form, editable: false, heading_level: 3) %>
+  <% end %>
+</div>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-8" id="volunteering">Unpaid experience and volunteering</h2>
+
+<div data-qa="volunteering">
+  <% if FeatureFlag.active?('provider_interface_work_breaks') %>
+    <%= render ProviderInterface::VolunteeringHistoryComponent.new(application_form: application_form) %>
+  <% else %>
+    <%= render VolunteeringReviewComponent.new(application_form: application_form, editable: false, heading_level: 3) %>
+  <% end %>
+</div>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-8" id="language-skills">Language skills</h2>
+
+<%= render LanguageSkillsComponent.new(application_form: application_form) %>
+
+<h2 class="govuk-heading-m govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
+
+<%= render PersonalStatementComponent.new(application_form: application_form) %>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -49,45 +49,7 @@
 
     <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice)%>
 
-    <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
-
-    <% if FeatureFlag.active?('provider_view_safeguarding') %>
-      <% if current_provider_user.can_view_safeguarding_information_for?(@application_choice.provider) %>
-        <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
-      <% end %>
-    <% end %>
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
-
-    <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="work-history">Work history</h2>
-
-    <div data-qa="work-history">
-      <% if FeatureFlag.active?('provider_interface_work_breaks') %>
-        <%= render ProviderInterface::WorkHistoryComponent.new(application_form: @application_choice.application_form) %>
-      <% else %>
-        <%= render WorkHistoryReviewComponent.new(application_form: @application_choice.application_form, editable: false, heading_level: 3) %>
-      <% end %>
-    </div>
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="volunteering">Unpaid experience and volunteering</h2>
-
-    <div data-qa="volunteering">
-      <% if FeatureFlag.active?('provider_interface_work_breaks') %>
-        <%= render ProviderInterface::VolunteeringHistoryComponent.new(application_form: @application_choice.application_form) %>
-      <% else %>
-        <%= render VolunteeringReviewComponent.new(application_form: @application_choice.application_form, editable: false, heading_level: 3) %>
-      <% end %>
-    </div>
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="language-skills">Language skills</h2>
-
-    <%= render LanguageSkillsComponent.new(application_form: @application_choice.application_form) %>
-
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
-
-    <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
+    <%= render 'application_form_specific_data', application_form: @application_choice.application_form %>
 
     <% if @application_choice.application_form.application_references.any? %>
       <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -62,25 +62,42 @@
   <% end %>
 <% end %>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
 
-<%= render QualificationsComponent.new(application_form: @application_form) %>
+<h2 class="govuk-heading-l govuk-!-margin-top-8">Application data</h2>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-8">Work history</h2>
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+      <a class="govuk-tabs__tab" href="#what-the-candidate-sees">
+        What the candidate sees
+      </a>
+    </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#what-the-provider-sees">
+        What the provider sees
+      </a>
+    </li>
+  </ul>
 
-<%= render WorkHistoryReviewComponent.new(application_form: @application_form, editable: false, heading_level: 3) %>
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="what-the-candidate-sees">
+    <h2 class="govuk-heading-l">What the candidate sees</h2>
+    <%= render 'candidate_interface/application_form/application_form_specific_data', application_form: @application_form, editable: false, missing_error: false %>
+  </div>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-8">Unpaid experience and volunteering</h2>
-
-<%= render VolunteeringReviewComponent.new(application_form: @application_form, editable: false, heading_level: 3) %>
-
-<h2 class="govuk-heading-l govuk-!-margin-top-8">Language skills</h2>
-
-<%= render LanguageSkillsComponent.new(application_form: @application_form) %>
-
-<h2 class="govuk-heading-l govuk-!-margin-top-8">Personal statement</h2>
-
-<%= render PersonalStatementComponent.new(application_form: @application_form) %>
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="what-the-provider-sees">
+    <h2 class="govuk-heading-l">What the provider sees</h2>
+    <% if @application_form.submitted? %>
+      <%= render 'provider_interface/application_choices/application_form_specific_data', application_form: @application_form %>
+    <% else %>
+      <p class="govuk-body">
+        This application hasn't been submitted yet.
+      </p>
+    <% end %>
+  </div>
+</div>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
 


### PR DESCRIPTION
## Context

This PR intends to solve two sets of related problems all having to do with the sharing of code between candidate, provider and support interfaces.

### Components mixup

* There's a large list of components in app/components that are sometimes used by one namespace, sometimes by two or three. There are also namespace-specific components in app/components/provider_interface, app/components/candidate_interface, etc. This makes it confusing where to put a new component.
* This situation sometimes causes problems with data separation. In https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1121 we introduced a feature the support section that we accidentally displayed to providers (fixed in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1267). We need a more consistent separation to make sure this doesn't happen again.
* Having a lot of components in the root namespace causes difficult situations, where we use namespaced components inside a non-namespaced component.

### Support UI

* The support interface sometimes lags behind provider and candidate interfaces, because they're usually prioritised. It would be better if we don't have to worry about the interfaces getting out of sync. 
* It can be sometimes hard to spot differences in how we display information to candidates and providers.

## Changes proposed in this pull request

Instead of _sharing_ components, explicitly _import_ partials from provider and candidate interface into the support interface, and use them as such. Arguably this is also sharing code between the interfaces, but it's much more preferable to sharing because it's much more explicit. The result is that when we update the provider UI, the support UI is also updated in exactly the same way, and there's no risk of it going wrong.

It has the added benefit of being a lot more explicit and informative to the support users - they can now diagnose issues with the provider interface from support.

Once this is merged, we can move most components that are currently shared between Provider interface and Candidate interface (for example, the `LanguageSkillsComponent`) into the ProviderInterface namespace.

![image](https://user-images.githubusercontent.com/233676/81923970-5e8c1480-95d6-11ea-9356-73ae6db66372.png)

## Guidance to review

Does this make sense?

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
