### PR TITLE
Don't allow users to use DSI Fallback when feature flag is off

### DIFF
--- a/app/controllers/provider_interface/sessions_controller.rb
+++ b/app/controllers/provider_interface/sessions_controller.rb
@@ -16,7 +16,7 @@ module ProviderInterface
     end
 
     def sign_in_by_email
-      render_404 unless FeatureFlag.active?('dfe_sign_in_fallback')
+      render_404 and return unless FeatureFlag.active?('dfe_sign_in_fallback')
 
       provider_user = ProviderUser.find_by(email_address: params.dig(:provider_user, :email_address).downcase.strip)
 
@@ -37,6 +37,8 @@ module ProviderInterface
     def check_your_email; end
 
     def authenticate_with_token
+      redirect_to action: :new and return unless FeatureFlag.active?('dfe_sign_in_fallback')
+
       magic_link_token = MagicLinkToken.from_raw(params.fetch(:token))
       provider_user = ProviderUser.find_by!(magic_link_token: magic_link_token)
 

--- a/spec/system/provider_interface/authentication_fallback_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
     then_i_receive_an_email_with_a_signin_link
     when_i_click_on_the_link_in_my_email
     then_i_am_signed_in
+
+    when_i_sign_out
+    then_i_am_not_signed_in
+
+    given_the_feature_flag_is_switched_off
+    when_i_click_on_the_link_in_my_email
+    then_i_am_not_signed_in
   end
 
   def given_i_am_registered_as_a_provider_user_without_a_dsi_uid
@@ -62,6 +69,20 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
   def then_i_am_signed_in
     within 'header' do
       expect(page).to have_content @email
+    end
+  end
+
+  def when_i_sign_out
+    click_on 'Sign out'
+  end
+
+  def given_the_feature_flag_is_switched_off
+    FeatureFlag.deactivate('dfe_sign_in_fallback')
+  end
+
+  def then_i_am_not_signed_in
+    within 'header' do
+      expect(page).not_to have_content @email
     end
   end
 


### PR DESCRIPTION
## Context

Currently, users who have used the fallback at least once can still click on the links in their emails to sign in, even though the feature flag is switched off. This does not seem intentional.

## Changes proposed in this pull request

Add a `redirect_to and return` in the relevant controller actions.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

Nobody has used this  yet, as we would have received a notification in Slack if so.

## Link to Trello card

None.

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)