### PR TITLE
Support: redirect to application forms from application choice IDs

### DIFF
--- a/app/controllers/support_interface/application_choices_controller.rb
+++ b/app/controllers/support_interface/application_choices_controller.rb
@@ -1,0 +1,8 @@
+module SupportInterface
+  class ApplicationChoicesController < SupportInterfaceController
+    def show
+      choice = ApplicationChoice.find(params[:application_choice_id])
+      redirect_to support_interface_application_form_path(choice.application_form)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -484,6 +484,8 @@ Rails.application.routes.draw do
     get '/applications/:application_form_id/comments/new' => 'application_forms/comments#new', as: :application_form_new_comment
     post '/applications/:application_form_id/comments' => 'application_forms/comments#create', as: :application_form_comments
 
+    get '/application_choices/:application_choice_id' => 'application_choices#show', as: :application_choice
+
     scope '/applications/:application_form_id' do
       get '/change-course' => 'change_course#options', as: :change_course
       post '/change-course' => 'change_course#pick_option'

--- a/spec/requests/support_interface/application_choices_spec.rb
+++ b/spec/requests/support_interface/application_choices_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Support interface - GET application_choice/:application_choice_id', type: :request do
+  def support_user
+    @support_user ||= SupportUser.new(
+      email_address: 'alice@example.com',
+      dfe_sign_in_uid: 'ABC',
+    )
+  end
+
+  def set_support_user_permission
+    allow(SupportUser).to receive(:load_from_session).and_return(support_user)
+  end
+
+  it 'redirects to the parent application form' do
+    set_support_user_permission
+
+    choice = create(:application_choice)
+    form = create(:application_form, application_choices: [choice])
+
+    get(support_interface_application_choice_path(application_choice_id: choice.id))
+
+    expect(response).to redirect_to(support_interface_application_form_path(application_form_id: form.id))
+  end
+end


### PR DESCRIPTION
## Context

It's currently not possible to trace an application choice ID back to its parent application form without looking it up in the database. This means we need to raise PIM requests to find, for example, applications affected by Sentry errors.

## Changes proposed in this pull request

Introduce `/support/application_choices/:application_choice_id` which will
redirect to the parent application form.