### PR TITLE
DSI fallback: expire magic link tokens after an hour

### DIFF
--- a/app/services/provider_interface/magic_link_authentication.rb
+++ b/app/services/provider_interface/magic_link_authentication.rb
@@ -1,5 +1,7 @@
 module ProviderInterface
   module MagicLinkAuthentication
+    TOKEN_DURATION = 1.hour
+
     def self.send_token!(provider_user:)
       magic_link_token = MagicLinkToken.new
       provider_user.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.zone.now)
@@ -8,7 +10,8 @@ module ProviderInterface
 
     def self.get_user_from_token!(token:)
       magic_link_token = MagicLinkToken.from_raw(token)
-      ProviderUser.find_by!(magic_link_token: magic_link_token)
+      ProviderUser.where('magic_link_token_sent_at > ?', TOKEN_DURATION.ago)
+        .find_by!(magic_link_token: magic_link_token)
     end
   end
 end

--- a/app/services/provider_interface/magic_link_authentication.rb
+++ b/app/services/provider_interface/magic_link_authentication.rb
@@ -1,0 +1,14 @@
+module ProviderInterface
+  module MagicLinkAuthentication
+    def self.send_token!(provider_user:)
+      magic_link_token = MagicLinkToken.new
+      provider_user.update!(magic_link_token: magic_link_token.encrypted, magic_link_token_sent_at: Time.zone.now)
+      ProviderMailer.fallback_sign_in_email(provider_user, magic_link_token.raw).deliver_later
+    end
+
+    def self.get_user_from_token!(token:)
+      magic_link_token = MagicLinkToken.from_raw(token)
+      ProviderUser.find_by!(magic_link_token: magic_link_token)
+    end
+  end
+end

--- a/spec/services/provider_interface/magic_link_authentication_spec.rb
+++ b/spec/services/provider_interface/magic_link_authentication_spec.rb
@@ -25,5 +25,19 @@ RSpec.describe ProviderInterface::MagicLinkAuthentication do
 
       expect(returned_user).to eq user
     end
+
+    context 'when the token has expired' do
+      it 'raises an ActiveRecord::RecordNotFound error' do
+        create(:provider_user,
+               magic_link_token: 'known_token',
+               magic_link_token_sent_at: (ProviderInterface::MagicLinkAuthentication::TOKEN_DURATION + 1.second).ago)
+
+        allow(MagicLinkToken).to receive(:from_raw).and_return('known_token')
+
+        expect {
+          ProviderInterface::MagicLinkAuthentication.get_user_from_token!(token: 'known_token')
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
   end
 end

--- a/spec/services/provider_interface/magic_link_authentication_spec.rb
+++ b/spec/services/provider_interface/magic_link_authentication_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::MagicLinkAuthentication do
+  describe '.send_token!' do
+    it 'sets magic_link token and a magic_link_token_sent_at on the provider_user' do
+      user = create(:provider_user)
+
+      Timecop.freeze do
+        expect {
+          ProviderInterface::MagicLinkAuthentication.send_token!(provider_user: user)
+        }.to change { user.magic_link_token }.from(nil).to(String)
+          .and change { user.magic_link_token_sent_at }.from(nil).to(Time.zone.now)
+      end
+    end
+  end
+
+  describe '.get_user_from_token!' do
+    it 'gets the user for the passed token' do
+      user = create(:provider_user,
+                    magic_link_token: 'known_token',
+                    magic_link_token_sent_at: Time.zone.now)
+
+      allow(MagicLinkToken).to receive(:from_raw).and_return('known_token')
+      returned_user = ProviderInterface::MagicLinkAuthentication.get_user_from_token!(token: 'known_token')
+
+      expect(returned_user).to eq user
+    end
+  end
+end


### PR DESCRIPTION
## Context

We don't expire these tokens so they last forever (or until the user regenerates them).

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1989#discussion_r418512600

## Changes proposed in this pull request

Pull the token handling code out of the controller and test it, then add the constraint that tokens must be < 1 hour old.

## Link to Trello card

https://trello.com/c/t421tPrM/2073-deal-with-may-1st-dfe-signin-outage
