### PR TITLE
Test content of Download Application as PDF response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,6 +98,7 @@ group :test do
   gem 'clockwork-test'
   gem 'deepsort'
   gem 'rspec-benchmark'
+  gem 'pdf-reader'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (1.0.3)
     actioncable (6.0.3)
       actionpack (= 6.0.3)
       nio4r (~> 2.0)
@@ -59,6 +60,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     aes_key_wrap (1.0.1)
+    afm (0.2.2)
     ast (2.4.0)
     attr_required (1.0.1)
     audited (4.9.0)
@@ -189,6 +191,7 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.1)
+    hashery (2.1.2)
     hashie (4.1.0)
     holidays (8.2.0)
     http (4.4.1)
@@ -302,6 +305,12 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
+    pdf-reader (2.4.0)
+      Ascii85 (~> 1.0.0)
+      afm (~> 0.2.1)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     pdfkit (0.8.4.2)
     pg (1.2.3)
     pry (0.13.1)
@@ -435,6 +444,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.10.1)
+    ruby-rc4 (0.1.5)
     rubyzip (2.0.0)
     safe_yaml (1.0.5)
     selenium-webdriver (3.142.7)
@@ -469,6 +479,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     timecop (0.9.1)
+    ttfunk (1.6.2.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uk_postcode (2.1.5)
@@ -554,6 +565,7 @@ DEPENDENCIES
   omniauth-rails_csrf_protection
   omniauth_openid_connect
   openapi3_parser (= 0.8.1)
+  pdf-reader
   pdfkit
   pg (~> 1.2.3)
   pry

--- a/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_as_pdf_spec.rb
@@ -55,5 +55,20 @@ RSpec.feature 'Provider sees an application as PDF' do
     expect(page.driver.response.status).to eq(200)
     expect(page.driver.response.content_type).to eq('application/pdf')
     expect(page.driver.response.length).to be > 0
+
+    expect(pdf_text).to include(@application_form.full_name)
+    expect(pdf_text).to include(@application_form.support_reference)
+  end
+
+  def pdf_text
+    @pdf_text ||= begin
+      temp_pdf = Tempfile.new('pdf')
+      temp_pdf << page.source.force_encoding('UTF-8')
+      reader = PDF::Reader.new(temp_pdf)
+      text = reader.pages.map(&:text).join
+      temp_pdf.close
+
+      text
+    end
   end
 end


### PR DESCRIPTION
## Context

Introducing middleware to add compression recently caused PDF downloads to fail.
PDFKit doesn't modify the status of the response if it encounters errors, it probably should but we don't control that.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds a way to read the text from the PDF response and verify the candidate name and support reference are present.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
