### PR TITLE
Remove cool off period for Apply Again applications

### DIFF
--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -51,12 +51,12 @@ private
   end
 
   def submit_application
-    application_choices.each do |application_choice|
-      SubmitApplicationChoice.new(application_choice).call
-
-      if FeatureFlag.active?('apply_again') && enough_references_have_been_provided?
-        ApplicationStateChange.new(application_choice).references_complete!
-      end
+    application_choices.each do |choice|
+      SubmitApplicationChoice.new(
+        choice,
+        apply_again: application_form.apply_again?,
+        enough_references: enough_references_have_been_provided?,
+      ).call
     end
   end
 

--- a/app/services/submit_application_choice.rb
+++ b/app/services/submit_application_choice.rb
@@ -1,11 +1,19 @@
 class SubmitApplicationChoice
-  def initialize(application_choice)
+  def initialize(application_choice, apply_again: false, enough_references: false)
     @application_choice = application_choice
+    @apply_again = apply_again
+    @enough_references = enough_references
   end
 
   def call
-    @application_choice.edit_by = edit_by_time
-    ApplicationStateChange.new(@application_choice).submit!
+    if @apply_again && @enough_references
+      @application_choice.edit_by = Time.zone.now
+      ApplicationStateChange.new(@application_choice).submit!
+      ApplicationStateChange.new(@application_choice).references_complete!
+    else
+      @application_choice.edit_by = edit_by_time
+      ApplicationStateChange.new(@application_choice).submit!
+    end
   end
 
 private

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -38,6 +38,9 @@ private
       reference_feedback_provided!
       application_form.application_choices.awaiting_references.each do |application_choice|
         ApplicationStateChange.new(application_choice).references_complete!
+        if application_form.apply_again?
+          application_choice.update(edit_by: Time.zone.now)
+        end
       end
     end
 

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -1,57 +1,77 @@
 require 'rails_helper'
 
 RSpec.describe SubmitReference do
-  it 'progresses the application choices to the "application complete" status once all references have been received' do
-    application_form = create(:completed_application_form)
-    active_application = create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.from_now)
-    cancelled_application = create(:application_choice, application_form: application_form, status: 'cancelled')
+  describe '#save!' do
+    let(:application_form) { create(:completed_application_form) }
 
-    create(:reference, :complete, application_form: application_form)
-    reference = create(:reference, :unsubmitted, application_form: application_form)
+    context 'minimum required references received' do
+      it 'progresses the application choices to the "application complete" status' do
+        active_application_choice = create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.from_now)
+        cancelled_application_choice = create(:application_choice, application_form: application_form, status: 'cancelled')
 
-    reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+        create(:reference, :complete, application_form: application_form)
+        reference = create(:reference, :unsubmitted, application_form: application_form)
 
-    SubmitReference.new(
-      reference: reference,
-    ).save!
+        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
-    expect(active_application.reload).to be_application_complete
-    expect(cancelled_application.reload).to be_cancelled
-  end
+        SubmitReference.new(
+          reference: reference,
+        ).save!
 
-  it 'progresses the application choices to the "awaiting_provider_decision" status once all references have been received if edit_by has elapsed' do
-    application_form = create(:completed_application_form)
-    create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.ago)
-    create(:reference, :complete, application_form: application_form)
-    reference = create(:reference, :unsubmitted, application_form: application_form)
+        expect(active_application_choice.reload).to be_application_complete
+        expect(cancelled_application_choice.reload).to be_cancelled
+      end
 
-    reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+      it 'progresses the application choices to the "awaiting_provider_decision" if edit_by has elapsed' do
+        create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.ago)
+        create(:reference, :complete, application_form: application_form)
+        reference = create(:reference, :unsubmitted, application_form: application_form)
 
-    SubmitReference.new(
-      reference: reference,
-    ).save!
+        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
-    expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
-  end
+        SubmitReference.new(
+          reference: reference,
+        ).save!
 
-  it 'is okay with a 3rd reference being provided' do
-    application_form = create(:completed_application_form)
-    create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.ago)
-    create(:reference, :complete, application_form: application_form)
-    reference = create(:reference, :unsubmitted, application_form: application_form)
+        expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
+      end
 
-    reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+      it 'sets edit_by to current time if Apply Again application' do
+        application_form.apply_2!
+        create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 2.days.from_now)
+        create(:reference, :complete, application_form: application_form)
+        reference = create(:reference, :unsubmitted, application_form: application_form)
 
-    SubmitReference.new(
-      reference: reference,
-    ).save!
+        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
 
-    another_reference = create(:reference, :unsubmitted, application_form: application_form)
+        Timecop.freeze(Time.utc(2020)) do
+          SubmitReference.new(
+            reference: reference,
+          ).save!
 
-    another_reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+          expect(application_form.application_choices.first.edit_by).to eq Time.utc(2020)
+        end
+      end
 
-    SubmitReference.new(
-      reference: another_reference,
-    ).save!
+      it 'is okay with a 3rd reference being provided' do
+        create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 1.day.ago)
+        create(:reference, :complete, application_form: application_form)
+        reference = create(:reference, :unsubmitted, application_form: application_form)
+
+        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+
+        SubmitReference.new(
+          reference: reference,
+        ).save!
+
+        another_reference = create(:reference, :unsubmitted, application_form: application_form)
+
+        another_reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
+
+        SubmitReference.new(
+          reference: another_reference,
+        ).save!
+      end
+    end
   end
 end

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -29,6 +29,7 @@ RSpec.feature 'Candidate applying again' do
     when_i_select_a_course
     and_i_submit_my_application
     then_i_am_informed_my_new_referee_will_be_contacted
+    and_my_application_is_awaiting_references
   end
 
   def given_the_pilot_is_open
@@ -139,10 +140,15 @@ RSpec.feature 'Candidate applying again' do
   def and_i_submit_my_application
     check t('application_form.courses.complete.completed_checkbox')
     click_button 'Continue'
-    candidate_submits_application
+    @apply_again_application_form = candidate_submits_application
   end
 
   def then_i_am_informed_my_new_referee_will_be_contacted
     expect(page).to have_content 'We’ll contact your referee to ask for your reference'
+  end
+
+  def and_my_application_is_awaiting_references
+    application_choice = @apply_again_application_form.application_choices.first
+    expect(application_choice.status).to eq 'awaiting_references'
   end
 end

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
     when_i_complete_my_application
     then_my_application_is_submitted
+    and_my_application_is_ready_to_send_to_the_provider
     and_i_do_not_see_referee_related_guidance
     and_there_is_no_guidance_on_editing_my_application
 
@@ -127,7 +128,12 @@ RSpec.feature 'Candidate with unsuccessful application' do
 
   def then_my_application_is_submitted
     expect(page).to have_content 'Application successfully submitted'
-    expect(ApplicationForm.last.application_choices.first.reload.status).to eq 'application_complete'
+    @apply_again_choice = ApplicationForm.last.application_choices.first
+    expect(@apply_again_choice.status).to eq 'application_complete'
+  end
+
+  def and_my_application_is_ready_to_send_to_the_provider
+    expect(@apply_again_choice.edit_by.to_date).to eq Time.zone.today
   end
 
   def and_i_do_not_see_referee_related_guidance


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
An Apply Again application may have removed previous references and
added new ones. When the minimum number of required references are
received (currently 2), we want to send the application to the Provider
as soon as possible rather than wait out the cool off period as we do
during a standard application.
## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
- When submitting an application, check to see if it's Apply Again and if enough references have been provided. If so, set its application choice edit_by to the current time (no cool off period) and ensure its status is 'application_complete'.
- For cases where references are required, SubmitReference already progresses the state of application choices when enough references have been received. Add to this logic by checking if the application form is apply_again, and if so set the application_choice edit_by to the current time.
- Restructure the SubmitReference spec for clarity and add an example for the Apply Again logic.
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
- Because of the restructuring in the SubmitReference spec, the file is best reviewed in its full changed state rather than a diff.
 
## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/CUHYQLRj
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
