### PR TITLE
Feature flag audit log and migration to PostgreSQL

### DIFF
--- a/app/components/support_interface/feature_audit_trail_component.html.erb
+++ b/app/components/support_interface/feature_audit_trail_component.html.erb
@@ -1,4 +1,4 @@
-<ul>
+<ul class="govuk-list govuk-list--bullet">
   <% audits.select { |audit| visible?(audit) }.each do |audit| %>
     <li>
       <%= l(audit.created_at.to_date, format: :long) %> <%= l(audit.created_at, format: :time) %> - <%= action_label_for(audit) %> <%= active_value_for(audit) %> by <%= user_label_for(audit) %>

--- a/app/components/support_interface/feature_audit_trail_component.html.erb
+++ b/app/components/support_interface/feature_audit_trail_component.html.erb
@@ -1,0 +1,7 @@
+<ul>
+  <% audits.select { |audit| visible?(audit) }.each do |audit| %>
+    <li>
+      <%= l(audit.created_at.to_date, format: :long) %> <%= l(audit.created_at, format: :time) %> - <%= action_label_for(audit) %> <%= active_value_for(audit) %> by <%= user_label_for(audit) %>
+    </li>
+  <% end %>
+</ul>

--- a/app/components/support_interface/feature_audit_trail_component.html.erb
+++ b/app/components/support_interface/feature_audit_trail_component.html.erb
@@ -1,7 +1,7 @@
 <ul class="govuk-list govuk-list--bullet">
   <% audits.select { |audit| visible?(audit) }.each do |audit| %>
     <li>
-      <%= l(audit.created_at.to_date, format: :long) %> <%= l(audit.created_at, format: :time) %> - <%= action_label_for(audit) %> <%= active_value_for(audit) %> by <%= user_label_for(audit) %>
+      <%= l(audit.created_at.to_date, format: :long) %> <%= l(audit.created_at, format: :time) %> - <%= action_label_for(audit) %> <%= active_value_for(audit) %><%= user_label_for(audit) %>
     </li>
   <% end %>
 </ul>

--- a/app/components/support_interface/feature_audit_trail_component.rb
+++ b/app/components/support_interface/feature_audit_trail_component.rb
@@ -1,0 +1,49 @@
+module SupportInterface
+  class FeatureAuditTrailComponent < ViewComponent::Base
+    include ViewHelper
+
+    validates :feature, presence: true
+
+    ACTIVE_LABEL = 'Active'.freeze
+    INACTIVE_LABEL = 'Inactive'.freeze
+
+    def initialize(feature:)
+      @feature = feature
+    end
+
+    def user_label_for(audit)
+      if audit.user_type == 'SupportUser'
+        audit.user.email_address
+      elsif audit.username.present?
+        audit.username
+      else
+        '(Unknown User)'
+      end
+    end
+
+    def action_label_for(audit)
+      audit.action == 'create' ? 'Created' : 'Changed to'
+    end
+
+    def active_value_for(audit)
+      active_change = audit.audited_changes['active']
+      return INACTIVE_LABEL if active_change.blank?
+
+      is_active =
+        if active_change.is_a?(Array)
+          active_change.second
+        else
+          active_change
+        end
+
+      is_active ? ACTIVE_LABEL : INACTIVE_LABEL
+    end
+
+    def visible?(audit)
+      audit.action == 'create' || !audit.audited_changes['active'].nil?
+    end
+
+    attr_reader :feature
+    delegate :audits, to: :feature
+  end
+end

--- a/app/components/support_interface/feature_audit_trail_component.rb
+++ b/app/components/support_interface/feature_audit_trail_component.rb
@@ -13,11 +13,9 @@ module SupportInterface
 
     def user_label_for(audit)
       if audit.user_type == 'SupportUser'
-        audit.user.email_address
+        " by #{audit.user.email_address}"
       elsif audit.username.present?
-        audit.username
-      else
-        '(Unknown User)'
+        " by #{audit.username}"
       end
     end
 

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -7,6 +7,10 @@ class FeatureFlag
     self.owner = owner
   end
 
+  def feature
+    @feature ||= Feature.find_or_initialize_by(name: name)
+  end
+
   PERMANENT_SETTINGS = [
     [:banner_about_problems_with_dfe_sign_in, 'Displays a banner to notify users that DfE-Sign is having problems', 'Jake Benilov'],
     [:banner_for_ucas_downtime, 'Displays a banner to notify users that UCAS is having problems', 'Theodor Vararu'],
@@ -51,7 +55,7 @@ class FeatureFlag
   def self.active?(feature_name)
     raise unless feature_name.in?(FEATURES)
 
-    Feature.find_or_initialize_by(name: feature_name).active?
+    FEATURES[feature_name].feature.active?
   end
 
   def self.reset!

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -40,24 +40,18 @@ class FeatureFlag
     raise unless feature_name.in?(FEATURES)
 
     sync_with_database(feature_name, true)
-    rollout.activate(feature_name)
   end
 
   def self.deactivate(feature_name)
     raise unless feature_name.in?(FEATURES)
 
     sync_with_database(feature_name, false)
-    rollout.deactivate(feature_name)
   end
 
   def self.active?(feature_name)
     raise unless feature_name.in?(FEATURES)
 
-    rollout.active?(feature_name)
-  end
-
-  def self.rollout
-    @rollout ||= Rollout.new(Redis.current)
+    Feature.find_or_initialize_by(name: feature_name).active?
   end
 
   def self.sync_with_database(feature_name, active)

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -54,6 +54,12 @@ class FeatureFlag
     Feature.find_or_initialize_by(name: feature_name).active?
   end
 
+  def self.reset!
+    return if Rails.env.production?
+
+    Feature.update_all(active: false)
+  end
+
   def self.sync_with_database(feature_name, active)
     feature = Feature.find_or_initialize_by(name: feature_name)
     feature.active = active

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -8,7 +8,7 @@ class FeatureFlag
   end
 
   def feature
-    @feature ||= Feature.find_or_initialize_by(name: name)
+    Feature.find_or_initialize_by(name: name)
   end
 
   PERMANENT_SETTINGS = [

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -9,13 +9,16 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <% FeatureFlag::FEATURES.each do |feature_name, feature| %>
+    <% FeatureFlag::FEATURES.each do |feature_name, feature_flag| %>
       <tr class="govuk-table__row">
 
         <td class="govuk-table__cell">
           <h3 class="govuk-!-margin-top-0"><%= feature_name.humanize %></h3>
-          <p>Owner: <%= feature.owner %></p>
-          <p><%= feature.description %></p>
+          <p>Owner: <%= feature_flag.owner %></p>
+          <p><%= feature_flag.description %></p>
+          <p>
+            <%= render SupportInterface::FeatureAuditTrailComponent.new(feature: feature_flag.feature) %>
+          </p>
         </td>
 
         <td class="govuk-table__cell">

--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,8 @@ development:
 test:
   <<: *default
   database: 'bat_apply_test'
+  variables:
+    idle_in_transaction_session_timeout: 0
 
 production:
   <<: *default

--- a/spec/components/previews/support_interface/feature_audit_trail_component_preview.rb
+++ b/spec/components/previews/support_interface/feature_audit_trail_component_preview.rb
@@ -1,0 +1,9 @@
+module SupportInterface
+  class FeatureAuditTrailComponentPreview < ViewComponent::Preview
+    def pilot_open
+      render SupportInterface::FeatureAuditTrailComponent.new(
+        feature: Feature.find_by(name: 'pilot_open'),
+      )
+    end
+  end
+end

--- a/spec/components/support_interface/feature_audit_trail_component_spec.rb
+++ b/spec/components/support_interface/feature_audit_trail_component_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true do
+  subject { described_class.new(feature: feature) }
+
+  def bob_support_user
+    @bob ||= create :support_user, email_address: 'bob@example.com'
+  end
+
+  def alice_support_user
+    @alice ||= create :support_user, email_address: 'alice@example.com'
+  end
+
+  def render_result
+    render_inline(subject)
+  end
+
+  context 'with a feature that was created with a false value' do
+    def feature
+      @feature ||= begin
+        Timecop.freeze(Time.zone.local(2020, 5, 1, 12, 0, 0)) do
+          Audited.audit_class.as_user(bob_support_user) do
+            create(:feature)
+          end
+        end
+      end
+    end
+
+    it 'renders the create audit entry' do
+      expect(render_result.text).to include('1 May 2020 12:00 - Created Inactive by bob@example.com')
+    end
+  end
+
+  context 'with a feature that was created with a true value and updated to false' do
+    def feature
+      @feature ||= begin
+        Timecop.freeze(Time.zone.local(2020, 5, 1, 12, 0, 0)) do
+          Audited.audit_class.as_user(bob_support_user) do
+            create(:feature, active: true)
+          end
+        end
+      end
+      Timecop.freeze(Time.zone.local(2020, 5, 3, 15, 30, 0)) do
+        Audited.audit_class.as_user(alice_support_user) do
+          @feature.update!(active: false)
+        end
+      end
+      @feature
+    end
+
+    it 'renders the create audit entry' do
+      expect(render_result.text).to include('1 May 2020 12:00 - Created Active by bob@example.com')
+    end
+
+    it 'renders the update audit entry' do
+      expect(render_result.text).to include('3 May 2020 15:30 - Changed to Inactive by alice@example.com')
+    end
+  end
+end

--- a/spec/components/support_interface/feature_audit_trail_component_spec.rb
+++ b/spec/components/support_interface/feature_audit_trail_component_spec.rb
@@ -35,9 +35,7 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
     def feature
       @feature ||= begin
         Timecop.freeze(Time.zone.local(2020, 5, 1, 12, 0, 0)) do
-          Audited.audit_class.as_user(bob_support_user) do
-            create(:feature, active: true)
-          end
+          create(:feature, active: true)
         end
       end
       Timecop.freeze(Time.zone.local(2020, 5, 3, 15, 30, 0)) do
@@ -49,11 +47,11 @@ RSpec.describe SupportInterface::FeatureAuditTrailComponent, with_audited: true 
     end
 
     it 'renders the create audit entry' do
-      expect(render_result.text).to include('1 May 2020 12:00 - Created Active by bob@example.com')
+      expect(render_result.text).to include("1 May 2020 12:00 - Created Active\n")
     end
 
     it 'renders the update audit entry' do
-      expect(render_result.text).to include('3 May 2020 15:30 - Changed to Inactive by alice@example.com')
+      expect(render_result.text).to include("3 May 2020 15:30 - Changed to Inactive by alice@example.com\n")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,4 +71,6 @@ RSpec.configure do |config|
   config.before { Faker::UniqueGenerator.clear }
 
   config.before { ActionMailer::Base.deliveries.clear }
+
+  config.before { FeatureFlag.reset! }
 end

--- a/spec/system/support_interface/feature_flags_spec.rb
+++ b/spec/system/support_interface/feature_flags_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature 'Feature flags' do
+RSpec.feature 'Feature flags', with_audited: true do
   include DfESignInHelpers
 
   scenario 'Manage features' do
@@ -12,9 +12,11 @@ RSpec.feature 'Feature flags' do
 
     when_i_activate_the_feature
     then_the_feature_is_activated
+    and_i_can_see_the_activation_in_the_audit_trail
 
     when_i_deactivate_the_feature
     then_the_feature_is_deactivated
+    and_i_can_see_the_deactivation_in_the_audit_trail
   end
 
   def given_i_am_a_support_user
@@ -31,7 +33,7 @@ RSpec.feature 'Feature flags' do
 
   def then_i_should_see_the_existing_feature_flags
     expect(page).to have_content(
-      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\nInactive",
+      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}",
     )
   end
 
@@ -41,9 +43,15 @@ RSpec.feature 'Feature flags' do
 
   def then_the_feature_is_activated
     expect(page).to have_content(
-      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\nActive",
+      /Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\n.*\nActive/,
     )
     expect(FeatureFlag.active?('pilot_open')).to be true
+  end
+
+  def and_i_can_see_the_activation_in_the_audit_trail
+    expect(page).to have_content(
+      'Changed to Active by user@apply-support.com',
+    )
   end
 
   def when_i_deactivate_the_feature
@@ -52,9 +60,15 @@ RSpec.feature 'Feature flags' do
 
   def then_the_feature_is_deactivated
     expect(page).to have_content(
-      "Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\nInactive",
+      /Pilot open\nOwner: #{pilot_open_feature.owner}\n#{pilot_open_feature.description}\n.*\nInactive/,
     )
     expect(FeatureFlag.active?('pilot_open')).to be false
+  end
+
+  def and_i_can_see_the_deactivation_in_the_audit_trail
+    expect(page).to have_content(
+      'Changed to Inactive by user@apply-support.com',
+    )
   end
 
   def pilot_open_row


### PR DESCRIPTION
## Context

Support staff need to be able see when a particular feature was activated or deactivated and by whom. This is  PR #3 for this card that switches reading of the feature flags from Redis to the `features` table in PostgreSQL. It will need to be deployed separately to and after https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2081

## Changes proposed in this pull request

- [x] Switch `FeatureFlag.active?` etc. over to using PostgreSQL. API stays the same.
- [x] Auditing is already configured https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2081 and should start happening when we set up
- [x] Display the audit log for feature flags in the support interface.
- [x] Change base to `master` and rebased when upstream branch merged.
- [x] Update system specs for support interface

## Guidance to review

- We need to deploy this after the code change that migrates data from Redis to PostgreSQL. Ideally it would be two deploys in quick succession. Is there a better way to roll this out?
- There are not too many changes in areas of the code base that are dependent on the `FeatureFlag` API. Have I missed anything?
- We can drop the `rollout` gem if we remove the migrator class in future to keep our dependencies lean.

![image](https://user-images.githubusercontent.com/450843/82238571-71347f80-992f-11ea-83c2-add345cbcc4f.png)

## Link to Trello card
 
https://trello.com/c/hkzUvtMz/1440-%F0%9F%8F%88-audit-log-of-when-features-were-enabled

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
