### PR TITLE
Add completed checkbox to 5 sections of the application form

### DIFF
--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -12,6 +12,8 @@ module CandidateInterface
       @contact_details_form = ContactDetailsForm.new(contact_details_params)
 
       if @contact_details_form.save_address(current_application)
+        current_application.update!(contact_details_completed: false)
+
         redirect_to candidate_interface_contact_details_review_path
       else
         track_validation_error(@contact_details_form)

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -17,6 +17,8 @@ module CandidateInterface
         )
 
         if updated_contact_details_form.valid?(:address)
+          current_application.update!(contact_details_completed: false)
+
           redirect_to candidate_interface_contact_details_review_path
         else
           redirect_to candidate_interface_contact_details_edit_address_path

--- a/app/controllers/candidate_interface/contact_details/review_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/review_controller.rb
@@ -5,5 +5,18 @@ module CandidateInterface
     def show
       @application_form = current_application
     end
+
+    def complete
+      current_application.update!(application_form_params)
+
+      redirect_to candidate_interface_application_form_path
+    end
+
+  private
+
+    def application_form_params
+      params.require(:application_form).permit(:contact_details_completed)
+        .transform_values(&:strip)
+    end
   end
 end

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -27,5 +27,10 @@ module CandidateInterface
         current_application.qualification_in_subject(:gcse, subject_param),
       )
     end
+
+    def update_gcse_completed(value)
+      attribute_to_update = "#{@subject}_gcse_completed"
+      current_application.update!("#{attribute_to_update}": value)
+    end
   end
 end

--- a/app/controllers/candidate_interface/gcse/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class Gcse::GradeController < Gcse::DetailsController
     before_action :redirect_to_dashboard_if_submitted
+    before_action :set_subject
 
     def update
       @qualification_type = details_form.qualification.qualification_type
@@ -10,6 +11,7 @@ module CandidateInterface
       @application_qualification = details_form.save_grade
 
       if @application_qualification
+        update_gcse_completed(false)
         redirect_to next_gcse_path
       else
         @application_qualification = details_form

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -1,7 +1,6 @@
 module CandidateInterface
-  class Gcse::ReviewController < CandidateInterfaceController
+  class Gcse::ReviewController < Gcse::DetailsController
     before_action :redirect_to_dashboard_if_submitted
-
     before_action :set_subject
 
     def show
@@ -10,22 +9,9 @@ module CandidateInterface
     end
 
     def complete
-      attribute_to_update = "#{@subject}_gcse_completed"
-      value = params.dig('application_form', 'gcse_completed')
-
-      current_application.update!("#{attribute_to_update}": value)
+      update_gcse_completed(params.dig('application_form', 'gcse_completed'))
 
       redirect_to candidate_interface_application_form_path
-    end
-
-  private
-
-    def set_subject
-      @subject = subject_param
-    end
-
-    def subject_param
-      params.require(:subject)
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -5,7 +5,17 @@ module CandidateInterface
     before_action :set_subject
 
     def show
+      @application_form = current_application
       @application_qualification = current_application.qualification_in_subject(:gcse, subject_param)
+    end
+
+    def complete
+      attribute_to_update = "#{@subject}_gcse_completed"
+      value = params.dig('application_form', 'gcse_completed')
+
+      current_application.update!("#{attribute_to_update}": value)
+
+      redirect_to candidate_interface_application_form_path
     end
 
   private

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -1,5 +1,5 @@
 module CandidateInterface
-  class Gcse::TypeController < CandidateInterfaceController
+  class Gcse::TypeController < Gcse::DetailsController
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
 
@@ -14,6 +14,8 @@ module CandidateInterface
       @application_qualification.set_attributes(qualification_params)
 
       if @application_qualification.save_base(current_candidate.current_application)
+        update_gcse_completed(false)
+
         redirect_to next_gcse_path
       else
         track_validation_error(@application_qualification)

--- a/app/controllers/candidate_interface/gcse/year_controller.rb
+++ b/app/controllers/candidate_interface/gcse/year_controller.rb
@@ -10,6 +10,8 @@ module CandidateInterface
       @application_qualification = details_form.save_year
 
       if @application_qualification
+        update_gcse_completed(false)
+
         redirect_to candidate_interface_gcse_review_path
       else
         @application_qualification = details_form

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -2,7 +2,9 @@ module CandidateInterface
   class SafeguardingController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
 
-    def show; end
+    def show
+      @application_form = current_application
+    end
 
     def edit
       @safeguarding = SafeguardingIssuesDeclarationForm.build_from_application(current_application)
@@ -12,10 +14,18 @@ module CandidateInterface
       @safeguarding = SafeguardingIssuesDeclarationForm.new(safeguarding_params)
 
       if @safeguarding.save(current_application)
+        current_application.update!(safeguarding_issues_completed: false)
+
         redirect_to candidate_interface_review_safeguarding_path
       else
         render :edit
       end
+    end
+
+    def complete
+      current_application.update!(application_form_params)
+
+      redirect_to candidate_interface_application_form_path
     end
 
   private
@@ -23,6 +33,11 @@ module CandidateInterface
     def safeguarding_params
       params.require(:candidate_interface_safeguarding_issues_declaration_form)
         .permit(:share_safeguarding_issues, :safeguarding_issues)
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(:safeguarding_issues_completed)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -13,6 +13,8 @@ module CandidateInterface
 
       if @training_with_a_disability_form.save(current_application)
         @application_form = current_application
+        current_application.update!(training_with_a_disability_completed: false)
+
         redirect_to candidate_interface_training_with_a_disability_show_path
       else
         track_validation_error(@training_with_a_disability_form)
@@ -27,12 +29,23 @@ module CandidateInterface
       )
     end
 
+    def complete
+      current_application.update!(application_form_params)
+
+      redirect_to candidate_interface_application_form_path
+    end
+
   private
 
     def training_with_a_disability_params
       params.require(:candidate_interface_training_with_a_disability_form).permit(
         :disclose_disability, :disability_disclosure
       )
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(:training_with_a_disability_completed)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -164,15 +164,27 @@ module CandidateInterface
     end
 
     def maths_gcse_completed?
-      gcse_completed?(@application_form.maths_gcse)
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.maths_gcse_completed
+      else
+        gcse_completed?(@application_form.maths_gcse)
+      end
     end
 
     def english_gcse_completed?
-      gcse_completed?(@application_form.english_gcse)
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.english_gcse_completed
+      else
+        gcse_completed?(@application_form.english_gcse)
+      end
     end
 
     def science_gcse_completed?
-      gcse_completed?(@application_form.science_gcse)
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.science_gcse_completed
+      else
+        gcse_completed?(@application_form.science_gcse)
+      end
     end
 
     def other_qualifications_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -208,9 +208,13 @@ module CandidateInterface
     end
 
     def training_with_a_disability_completed?
-      @application_form.disclose_disability == false || \
-        (@application_form.disclose_disability == true && \
-          @application_form.disability_disclosure.present?)
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.training_with_a_disability_completed
+      else
+        @application_form.disclose_disability == false || \
+          (@application_form.disclose_disability == true && \
+            @application_form.disability_disclosure.present?)
+      end
     end
 
     def course_choices_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -234,8 +234,12 @@ module CandidateInterface
     end
 
     def safeguarding_completed?
-      @application_form.no_safeguarding_issues_to_declare? ||
-        @application_form.has_safeguarding_issues_to_declare?
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.safeguarding_issues_completed
+      else
+        @application_form.no_safeguarding_issues_to_declare? ||
+          @application_form.has_safeguarding_issues_to_declare?
+      end
     end
 
   private

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -110,9 +110,13 @@ module CandidateInterface
     end
 
     def contact_details_completed?
-      contact_details = CandidateInterface::ContactDetailsForm.build_from_application(@application_form)
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.contact_details_completed
+      else
+        contact_details = CandidateInterface::ContactDetailsForm.build_from_application(@application_form)
 
-      contact_details.valid?(:base) && contact_details.valid?(:address)
+        contact_details.valid?(:base) && contact_details.valid?(:address)
+      end
     end
 
     def work_experience_completed?

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -7,4 +7,11 @@
 
 <%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to t('application_form.contact_details.review.button'), candidate_interface_application_form_path %>
+
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                          path: candidate_interface_contact_details_complete_path,
+                                          field_name: :contact_details_completed)) %>
+<% else %>
+  <%= govuk_button_link_to t('application_form.contact_details.review.button'), candidate_interface_application_form_path %>
+<% end %>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -5,4 +5,10 @@
 
 <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_qualification, subject: @subject)) %>
 
-<%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+ <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                         path: candidate_interface_gcse_complete_path,
+                                         field_name: :gcse_completed)) %>
+<% else %>
+  <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% end %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -7,6 +7,10 @@
 
 <%= render(SafeguardingReviewComponent.new(application_form: @current_application)) %>
 
-<p class="govuk-body">
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                          path: candidate_interface_complete_safeguarding_path,
+                                          field_name: :safeguarding_issues_completed)) %>
+<% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
-</p>
+<% end %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -7,4 +7,10 @@
 
 <%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to t('application_form.training_with_a_disability.review.button'), candidate_interface_application_form_path %>
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                          path: candidate_interface_training_with_a_disability_complete_path,
+                                          field_name: :training_with_a_disability_completed)) %>
+<% else %>
+  <%= govuk_button_link_to t('application_form.training_with_a_disability.review.button'), candidate_interface_application_form_path %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -320,6 +320,7 @@ Rails.application.routes.draw do
         get '/' => 'safeguarding#edit', as: :edit_safeguarding
         post '/' => 'safeguarding#update'
         get '/review' => 'safeguarding#show', as: :review_safeguarding
+        post '/complete' => 'safeguarding#complete', as: :complete_safeguarding
       end
 
       scope '/satisfaction-survey' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,7 @@ Rails.application.routes.draw do
         patch '/year' => 'gcse/year#update', as: :gcse_details_update_year
 
         get '/review' => 'gcse/review#show', as: :gcse_review
+        post '/complete' => 'gcse/review#complete', as: :gcse_complete
       end
 
       scope '/work-history' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
         get '/' => 'training_with_a_disability#edit', as: :training_with_a_disability_edit
         post '/review' => 'training_with_a_disability#update', as: :training_with_a_disability_update
         get '/review' => 'training_with_a_disability#show', as: :training_with_a_disability_show
+        post '/complete' => 'training_with_a_disability#complete', as: :training_with_a_disability_complete
       end
 
       scope '/contact-details' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,7 @@ Rails.application.routes.draw do
         post '/address' => 'contact_details/address#update', as: :contact_details_update_address
 
         get '/review' => 'contact_details/review#show', as: :contact_details_review
+        post '/complete' => 'contact_details/review#complete', as: :contact_details_complete
       end
 
       scope '/gcse/:subject', constraints: { subject: /(maths|english|science)/ } do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -55,6 +55,7 @@ FactoryBot.define do
       english_gcse_completed { true }
       maths_gcse_completed { true }
       science_gcse_completed { true }
+      training_with_a_disability_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -52,6 +52,9 @@ FactoryBot.define do
       work_history_completed { true }
       personal_details_completed { true }
       contact_details_completed { true }
+      english_gcse_completed { true }
+      maths_gcse_completed { true }
+      science_gcse_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -51,6 +51,7 @@ FactoryBot.define do
       volunteering_completed { true }
       work_history_completed { true }
       personal_details_completed { true }
+      contact_details_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,6 +56,7 @@ FactoryBot.define do
       maths_gcse_completed { true }
       science_gcse_completed { true }
       training_with_a_disability_completed { true }
+      safeguarding_issues_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -1,32 +1,35 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::ApplicationFormPresenter do
+  before do
+    FeatureFlag.activate('mark_every_section_complete')
+  end
+
   describe '#personal_details_completed?' do
     it 'returns true if personal details section is completed' do
-      application_form = FactoryBot.build(:completed_application_form)
+      application_form = FactoryBot.build(:application_form, personal_details_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_personal_details_completed
     end
 
     it 'returns false if personal details section is incomplete' do
-      application_form = FactoryBot.build(:application_form)
+      application_form = FactoryBot.build(:application_form, personal_details_completed: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
-
       expect(presenter).not_to be_personal_details_completed
     end
   end
 
   describe '#contact_details_completed?' do
     it 'returns true if contact details section is completed' do
-      application_form = FactoryBot.build(:completed_application_form)
+      application_form = FactoryBot.build(:application_form, contact_details_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_contact_details_completed
     end
 
     it 'returns false if contact details section is incomplete' do
-      application_form = FactoryBot.build(:application_form)
+      application_form = FactoryBot.build(:application_form, contact_details_completed: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).not_to be_contact_details_completed

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -177,53 +177,18 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#training_with_a_disability_completed?' do
-    let(:application_form) do
-      FactoryBot.build(:completed_application_form)
-    end
-    let(:presenter) do
-      CandidateInterface::ApplicationFormPresenter.new(application_form)
-    end
+    it 'returns true if training with a disabilitty section is completed' do
+      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-    context 'when the candidate has not selected Yes or No to the disclosure question' do
-      before do
-        application_form.disclose_disability = nil
-      end
-
-      it 'returns false' do
-        expect(presenter.training_with_a_disability_completed?).to eq(false)
-      end
+      expect(presenter).to be_training_with_a_disability_completed
     end
 
-    context 'when the candidate says Yes to disclosure but has not filled in the text field' do
-      before do
-        application_form.disclose_disability = true
-        application_form.disability_disclosure = ''
-      end
+    it 'returns false if maths training with a disabilitty section is incomplete' do
+      application_form = FactoryBot.build(:application_form, training_with_a_disability_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-      it 'returns false' do
-        expect(presenter.training_with_a_disability_completed?).to eq(false)
-      end
-    end
-
-    context 'when the candidate says Yes to disclosure and has filled in the text field' do
-      before do
-        application_form.disclose_disability = true
-        application_form.disability_disclosure = 'I have difficulty climbing stairs'
-      end
-
-      it 'returns true' do
-        expect(presenter.training_with_a_disability_completed?).to eq(true)
-      end
-    end
-
-    context 'when the candidate has selected No to the disclosure question' do
-      before do
-        application_form.disclose_disability = false
-      end
-
-      it 'returns true' do
-        expect(presenter.training_with_a_disability_completed?).to eq(true)
-      end
+      expect(presenter).not_to be_training_with_a_disability_completed
     end
   end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -36,6 +36,54 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
     end
   end
 
+  describe '#maths_gcse_completed?' do
+    it 'returns true if maths gcse section is completed' do
+      application_form = FactoryBot.build(:application_form, maths_gcse_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_maths_gcse_completed
+    end
+
+    it 'returns false if maths gcse section is incomplete' do
+      application_form = FactoryBot.build(:application_form, maths_gcse_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_maths_gcse_completed
+    end
+  end
+
+  describe '#english_gcse_completed?' do
+    it 'returns true if english gcse section is completed' do
+      application_form = FactoryBot.build(:application_form, english_gcse_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_english_gcse_completed
+    end
+
+    it 'returns false if english gcse section is incomplete' do
+      application_form = FactoryBot.build(:application_form, english_gcse_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_english_gcse_completed
+    end
+  end
+
+  describe '#science_gcse_completed?' do
+    it 'returns true if science gcse section is completed' do
+      application_form = FactoryBot.build(:application_form, science_gcse_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_science_gcse_completed
+    end
+
+    it 'returns false if science gcse section is incomplete' do
+      application_form = FactoryBot.build(:application_form, science_gcse_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_science_gcse_completed
+    end
+  end
+
   describe '#degrees_completed?' do
     it 'returns true if degrees section is completed' do
       application_form = FactoryBot.build(:application_form, degrees_completed: true)

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -274,52 +274,18 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#safeguarding_completed?' do
-    it 'returns false if safeguarding issues is not answered yet' do
-      application_form = build_stubbed(
-        :application_form,
-        safeguarding_issues: nil,
-        safeguarding_issues_status: :not_answered_yet,
-      )
-
+    it 'returns true if the safeguarding section is completed' do
+      application_form = FactoryBot.build(:application_form, safeguarding_issues_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-      expect(presenter.safeguarding_completed?).to eq(false)
+      expect(presenter).to be_safeguarding_completed
     end
 
-    it 'returns false if safeguarding issues question was not asked' do
-      application_form = build_stubbed(
-        :application_form,
-        safeguarding_issues: nil,
-        safeguarding_issues_status: :never_asked,
-      )
-
+    it 'returns false if safeguarding section is incomplete' do
+      application_form = FactoryBot.build(:application_form, safeguarding_issues_completed: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-      expect(presenter.safeguarding_completed?).to eq(false)
-    end
-
-    it 'returns true if safeguarding issues are declared' do
-      application_form = build_stubbed(
-        :application_form,
-        safeguarding_issues: 'I have a criminal conviction',
-        safeguarding_issues_status: :has_safeguarding_issues_to_declare,
-      )
-
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
-
-      expect(presenter.safeguarding_completed?).to eq(true)
-    end
-
-    it 'returns true if safeguarding issues are denied' do
-      application_form = build_stubbed(
-        :application_form,
-        safeguarding_issues: nil,
-        safeguarding_issues_status: :no_safeguarding_issues_to_declare,
-      )
-
-      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
-
-      expect(presenter.safeguarding_completed?).to eq(true)
+      expect(presenter).not_to be_safeguarding_completed
     end
   end
 

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -147,7 +147,13 @@ module CandidateHelper
     fill_in t('application_form.contact_details.address_line3.label'), with: 'London'
     fill_in t('application_form.contact_details.postcode.label'), with: 'SW1P 3BT'
     click_button t('application_form.contact_details.address.button')
-    click_link t('application_form.contact_details.review.button')
+
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    else
+      click_link t('application_form.contact_details.review.button')
+    end
   end
 
   def candidate_fills_in_their_degree

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -295,7 +295,13 @@ module CandidateHelper
     click_button 'Save and continue'
     fill_in 'Enter year', with: '1990'
     click_button 'Save and continue'
-    click_link 'Back to application'
+
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    else
+      click_link 'Back to application'
+    end
   end
 
   def candidate_explains_a_missing_gcse

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -203,8 +203,12 @@ module CandidateHelper
     fill_in 'Give any relevant information', with: 'I have a criminal conviction.'
 
     click_button 'Continue'
-
-    click_link 'Continue'
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    else
+      click_link 'Continue'
+    end
   end
 
   def candidate_fills_in_work_experience

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -44,8 +44,6 @@ module CandidateHelper
 
     click_link t('page_titles.training_with_a_disability')
     candidate_fills_in_disability_info
-    click_button t('application_form.training_with_a_disability.complete_form_button')
-    click_link t('application_form.training_with_a_disability.review.button')
 
     click_link t('page_titles.suitability_to_work_with_children')
     candidate_fills_in_safeguarding_issues
@@ -190,6 +188,14 @@ module CandidateHelper
   def candidate_fills_in_disability_info
     choose t('application_form.training_with_a_disability.disclose_disability.yes')
     fill_in t('application_form.training_with_a_disability.disability_disclosure.label'), with: 'I have difficulty climbing stairs'
+    click_button t('application_form.training_with_a_disability.complete_form_button')
+
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    else
+      click_link t('application_form.training_with_a_disability.review.button')
+    end
   end
 
   def candidate_fills_in_safeguarding_issues

--- a/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_contact_details_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering their contact details' do
 
   scenario 'Candidate submits their contact details' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
     and_i_visit_the_site
     and_the_track_validation_errors_feature_is_on
 
@@ -37,7 +38,8 @@ RSpec.feature 'Entering their contact details' do
     and_i_submit_my_address
     then_i_can_check_my_revised_address
 
-    when_i_submit_my_details
+    when_i_mark_the_section_as_completed
+    and_i_submit_my_details
     then_i_should_see_the_form
     and_that_the_section_is_completed
 
@@ -47,6 +49,10 @@ RSpec.feature 'Entering their contact details' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def and_i_visit_the_site
@@ -148,8 +154,12 @@ RSpec.feature 'Entering their contact details' do
     expect(page).to have_content 'Problems Street'
   end
 
-  def when_i_submit_my_details
-    click_link t('application_form.contact_details.review.button')
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def and_i_submit_my_details
+    click_button t('application_form.contact_details.review.button')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/candidate_entering_disability_info_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_disability_info_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering their disability information' do
 
   scenario 'Candidate submits their disability information' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
     and_i_visit_the_site
 
     when_i_click_on_check_your_answers
@@ -24,7 +25,8 @@ RSpec.feature 'Entering their disability information' do
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
-    when_i_submit_my_details
+    when_i_mark_the_section_as_completed
+    and_i_submit_my_details
     then_i_should_see_the_form
     and_that_the_section_is_completed
 
@@ -34,6 +36,10 @@ RSpec.feature 'Entering their disability information' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def and_i_visit_the_site
@@ -105,8 +111,12 @@ RSpec.feature 'Entering their disability information' do
     expect(page).not_to have_content 'I have difficulty climbing stairs'
   end
 
-  def when_i_submit_my_details
-    click_link 'Continue'
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def and_i_submit_my_details
+    click_button 'Continue'
   end
 
   def then_i_should_see_the_form
@@ -114,6 +124,6 @@ RSpec.feature 'Entering their disability information' do
   end
 
   def and_that_the_section_is_completed
-    expect(page).to have_css('#training-with-a-disability-badge-id', text: 'Completed')
+    expect(page).to have_css('#asking-for-support-if-you-have-a-disability-or-other-needs-badge-id', text: 'Completed')
   end
 end

--- a/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_gcse_spec.rb
@@ -5,6 +5,8 @@ RSpec.feature 'Candidate entering GCSE details' do
 
   scenario 'Candidate submits their maths GCSE details and then update them' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
+
     when_i_visit_the_candidate_application_page
     and_i_click_on_the_maths_gcse_link
     then_i_see_the_add_gcse_maths_page
@@ -53,12 +55,17 @@ RSpec.feature 'Candidate entering GCSE details' do
     and_i_click_save_and_continue
     then_i_see_the_review_page_with_updated_year
 
-    when_i_visit_the_candidate_application_page
-    i_see_the_maths_gcse_is_completed
+    when_i_mark_the_section_as_completed
+    and_click_continue
+    then_i_see_the_maths_gcse_is_completed
   end
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def given_i_am_not_signed_in; end
@@ -173,8 +180,16 @@ RSpec.feature 'Candidate entering GCSE details' do
     fill_in 'Enter year', with: '2000'
   end
 
-  def i_see_the_maths_gcse_is_completed
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def then_i_see_the_maths_gcse_is_completed
     expect(page).to have_css('#maths-gcse-or-equivalent-badge-id', text: 'Completed')
+  end
+
+  def and_click_continue
+    click_button t('application_form.continue')
   end
 
   def when_i_click_on_the_maths_gcse_link

--- a/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_suitability_to_work_with_children_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering their suitability to work with children' do
 
   scenario 'Candidate declares any safeguarding issues' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
     when_i_visit_the_site
     then_i_see_declaring_any_safeguarding_issues
 
@@ -23,12 +24,17 @@ RSpec.feature 'Entering their suitability to work with children' do
     and_i_click_on_continue
     then_i_see_my_updated_answer
 
-    when_i_click_on_continue
+    when_i_mark_the_section_as_completed
+    and_i_click_on_continue
     then_i_see_the_section_is_completed
   end
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def when_i_visit_the_site
@@ -75,6 +81,10 @@ RSpec.feature 'Entering their suitability to work with children' do
   def then_i_see_my_updated_answer
     expect(page).to have_content(t('page_titles.suitability_to_work_with_children'))
     expect(page).to have_content('No')
+  end
+
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
   end
 
   def when_i_click_on_continue


### PR DESCRIPTION
## Context

First PR is #2051 - Adds a bunch of columns to the application_forms table for the completion of each section.

Second PR is #2063 - Adds the implementation for personal details

Currently, the majority of the sections of the application form, do not need to be explicitly marked as complete. This means that many sections are marked as complete by default as they still meet the logic required to do so. 

The following sections still need to be added.

- [x] contact details
- [x] English GCSE
- [x] Maths GCSE 
- [x] Science GCSE
- [x] Training with a disability
- [x] safeguarding issues

## Changes proposed in this pull request

For each of the above:

- Adds a route
- Adds a checkbox
- The course presenter uses the attribute_completed value for section completion
- If a section is complete and they edit the section it sets the value to false (incomplete)

## Guidance to review

This should be a lot easier to review than it looks if you review by commit. Most are very similar.

The GCSE sections definitely needs some work. I'm wondering if i should rename details controller to base controller? Or just have the logic in each controller than having them inherit from the details controller.

Any thoughts?

A further PR to backfill data will need to be raised.
## Link to Trello card

https://trello.com/c/2YtoBPNB/1425-explicitly-mark-all-sections-as-complete

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
