### PR TITLE
Add last completed checkboxes for each application form section

### DIFF
--- a/app/components/candidate_interface/complete_section_component.html.erb
+++ b/app/components/candidate_interface/complete_section_component.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @application_form, url: @path, method: :post do |f| %>
+<%= form_with model: @application_form, url: @path, method: @request_method do |f| %>
   <div class='govuk-form-group'>
     <%= f.hidden_field @field_name, value: false %>
     <%= f.govuk_check_box @field_name, true, multiple: false, label: { text: t('application_form.completed_checkbox') } %>

--- a/app/components/candidate_interface/complete_section_component.rb
+++ b/app/components/candidate_interface/complete_section_component.rb
@@ -1,10 +1,11 @@
 module CandidateInterface
   class CompleteSectionComponent < ViewComponent::Base
-    validates :application_form, :path, :field_name, presence: true
+    validates :application_form, :path, :request_method, :field_name, presence: true
 
-    def initialize(application_form:, path:, field_name:)
+    def initialize(application_form:, path:, request_method:, field_name:)
       @application_form = application_form
       @path = path
+      @request_method = request_method
       @field_name = field_name
     end
   end

--- a/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
@@ -12,7 +12,9 @@ module CandidateInterface
       @becoming_a_teacher_form = BecomingATeacherForm.new(becoming_a_teacher_params)
 
       if @becoming_a_teacher_form.save(current_application)
-        render :show
+        current_application.update!(becoming_a_teacher_completed: false)
+
+        redirect_to candidate_interface_becoming_a_teacher_show_path
       else
         track_validation_error(@becoming_a_teacher_form)
         render :edit
@@ -20,7 +22,13 @@ module CandidateInterface
     end
 
     def show
-      @becoming_a_teacher_form = current_application
+      @application_form = current_application
+    end
+
+    def complete
+      current_application.update!(application_form_params)
+
+      redirect_to candidate_interface_application_form_path
     end
 
   private
@@ -29,6 +37,11 @@ module CandidateInterface
       params.require(:candidate_interface_becoming_a_teacher_form).permit(
         :becoming_a_teacher,
       )
+        .transform_values(&:strip)
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(:becoming_a_teacher_completed)
         .transform_values(&:strip)
     end
   end

--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -12,6 +12,8 @@ module CandidateInterface
       @interview_preferences_form = InterviewPreferencesForm.new(interview_preferences_params)
 
       if @interview_preferences_form.save(current_application)
+        current_application.update!(interview_preferences_completed: false)
+
         redirect_to candidate_interface_interview_preferences_show_path
       else
         track_validation_error(@interview_preferences_form)
@@ -20,7 +22,13 @@ module CandidateInterface
     end
 
     def show
-      @interview_preferences_form = current_application
+      @application_form = current_application
+    end
+
+    def complete
+      current_application.update!(application_form_params)
+
+      redirect_to candidate_interface_application_form_path
     end
 
   private
@@ -29,6 +37,11 @@ module CandidateInterface
       params.require(:candidate_interface_interview_preferences_form).permit(
         :any_preferences, :interview_preferences
       )
+        .transform_values(&:strip)
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(:interview_preferences_completed)
         .transform_values(&:strip)
     end
   end

--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -13,7 +13,9 @@ module CandidateInterface
       @subject_knowledge_form = SubjectKnowledgeForm.new(subject_knowledge_params)
 
       if @subject_knowledge_form.save(current_application)
-        render :show
+        current_application.update!(subject_knowledge_completed: false)
+
+        redirect_to candidate_interface_subject_knowledge_show_path
       else
         track_validation_error(@subject_knowledge_form)
         @course_names = chosen_course_names
@@ -22,7 +24,13 @@ module CandidateInterface
     end
 
     def show
-      @subject_knowledge_form = current_application
+      @application_form = current_application
+    end
+
+    def complete
+      current_application.update!(application_form_params)
+
+      redirect_to candidate_interface_application_form_path
     end
 
   private
@@ -36,6 +44,11 @@ module CandidateInterface
 
     def chosen_course_names
       current_application.application_choices.map(&:course).map(&:name_and_code)
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(:subject_knowledge_completed)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -120,7 +120,7 @@ module CandidateInterface
 
         redirect_to candidate_interface_application_form_path
       else
-        flash[:warning] = 'You can’t mark this section complete without adding two referees.'
+        flash[:warning] = "You can’t mark this section complete without adding #{ApplicationForm::MINIMUM_COMPLETE_REFERENCES} referees."
         current_application.references_completed = false
         @application_form = current_candidate.current_application
 

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -212,7 +212,11 @@ module CandidateInterface
     end
 
     def interview_preferences_completed?
-      CandidateInterface::InterviewPreferencesForm.build_from_application(@application_form).valid?
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.interview_preferences_completed
+      else
+        CandidateInterface::InterviewPreferencesForm.build_from_application(@application_form).valid?
+      end
     end
 
     def training_with_a_disability_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -204,7 +204,11 @@ module CandidateInterface
     end
 
     def subject_knowledge_completed?
-      CandidateInterface::SubjectKnowledgeForm.build_from_application(@application_form).valid?
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.subject_knowledge_completed
+      else
+        CandidateInterface::SubjectKnowledgeForm.build_from_application(@application_form).valid?
+      end
     end
 
     def interview_preferences_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -242,7 +242,11 @@ module CandidateInterface
     end
 
     def all_referees_provided_by_candidate?
-      @application_form.application_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.references_completed
+      else
+        @application_form.application_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
+      end
     end
 
     def safeguarding_completed?

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -196,7 +196,11 @@ module CandidateInterface
     end
 
     def becoming_a_teacher_completed?
-      CandidateInterface::BecomingATeacherForm.build_from_application(@application_form).valid?
+      if FeatureFlag.active?('mark_every_section_complete')
+        @application_form.becoming_a_teacher_completed
+      else
+        CandidateInterface::BecomingATeacherForm.build_from_application(@application_form).valid?
+      end
     end
 
     def subject_knowledge_completed?

--- a/app/views/candidate_interface/contact_details/review/show.html.erb
+++ b/app/views/candidate_interface/contact_details/review/show.html.erb
@@ -11,6 +11,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
   <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                           path: candidate_interface_contact_details_complete_path,
+                                          request_method: :post,
                                           field_name: :contact_details_completed)) %>
 <% else %>
   <%= govuk_button_link_to t('application_form.contact_details.review.button'), candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -8,6 +8,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                          path: candidate_interface_gcse_complete_path,
+                                         request_method: :post,
                                          field_name: :gcse_completed)) %>
 <% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/personal_details/show.html.erb
+++ b/app/views/candidate_interface/personal_details/show.html.erb
@@ -10,6 +10,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
   <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                           path: candidate_interface_personal_details_complete_path,
+                                          request_method: :post,
                                           field_name: :personal_details_completed)) %>
 <% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/show.html.erb
@@ -18,6 +18,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
   <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                           path: candidate_interface_becoming_a_teacher_complete_path,
+                                          request_method: :post,
                                           field_name: :becoming_a_teacher_completed)) %>
 <% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/show.html.erb
@@ -13,6 +13,12 @@
 </ul>
 <p class="govuk-body govuk-!-font-weight-bold">You’ll be able to review it again before you submit your application.</p>
 
-<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @becoming_a_teacher_form)) %>
+<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                          path: candidate_interface_becoming_a_teacher_complete_path,
+                                          field_name: :becoming_a_teacher_completed)) %>
+<% else %>
+  <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% end %>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/show.html.erb
@@ -5,6 +5,12 @@
   <%= t('page_titles.interview_preferences') %>
 </h1>
 
-<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @interview_preferences_form)) %>
+<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                          path: candidate_interface_interview_preferences_complete_path,
+                                          field_name: :interview_preferences_completed)) %>
+<% else %>
+  <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% end %>

--- a/app/views/candidate_interface/personal_statement/interview_preferences/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/interview_preferences/show.html.erb
@@ -10,6 +10,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
   <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                           path: candidate_interface_interview_preferences_complete_path,
+                                          request_method: :post,
                                           field_name: :interview_preferences_completed)) %>
 <% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/show.html.erb
@@ -5,6 +5,12 @@
   <%= t('page_titles.subject_knowledge') %>
 </h1>
 
-<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @subject_knowledge_form)) %>
+<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: @application_form)) %>
 
-<%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% if FeatureFlag.active?('mark_every_section_complete') %>
+  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                          path: candidate_interface_subject_knowledge_complete_path,
+                                          field_name: :subject_knowledge_completed)) %>
+<% else %>
+  <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
+<% end %>

--- a/app/views/candidate_interface/personal_statement/subject_knowledge/show.html.erb
+++ b/app/views/candidate_interface/personal_statement/subject_knowledge/show.html.erb
@@ -10,6 +10,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
   <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                           path: candidate_interface_subject_knowledge_complete_path,
+                                          request_method: :post,
                                           field_name: :subject_knowledge_completed)) %>
 <% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -23,8 +23,16 @@
       <%= govuk_link_to t('application_form.referees.add_referees_later'), candidate_interface_application_form_path %>
     <% end %>
   </p>
-<%- else %>
-  <p class="govuk-body">
-    <%= govuk_button_link_to t('application_form.referees.review.button'), candidate_interface_application_form_path %>
-  </p>
-<%- end %>
+<% else %>
+<p class="govuk-body">
+
+  <% if FeatureFlag.active?('mark_every_section_complete') %>
+    <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
+                                            path: candidate_interface_complete_referees_path,
+                                            request_method: :patch,
+                                            field_name: :references_completed)) %>
+  <% else %>
+      <%= govuk_button_link_to t('application_form.referees.review.button'), candidate_interface_application_form_path %>
+    </p>
+  <% end %>
+<% end %>

--- a/app/views/candidate_interface/safeguarding/show.html.erb
+++ b/app/views/candidate_interface/safeguarding/show.html.erb
@@ -10,6 +10,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
   <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                           path: candidate_interface_complete_safeguarding_path,
+                                          request_method: :post,
                                           field_name: :safeguarding_issues_completed)) %>
 <% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>

--- a/app/views/candidate_interface/training_with_a_disability/show.html.erb
+++ b/app/views/candidate_interface/training_with_a_disability/show.html.erb
@@ -10,6 +10,7 @@
 <% if FeatureFlag.active?('mark_every_section_complete') %>
   <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                           path: candidate_interface_training_with_a_disability_complete_path,
+                                          request_method: :post,
                                           field_name: :training_with_a_disability_completed)) %>
 <% else %>
   <%= govuk_button_link_to t('application_form.training_with_a_disability.review.button'), candidate_interface_application_form_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,7 @@ Rails.application.routes.draw do
         get '/interview-preferences' => 'personal_statement/interview_preferences#edit', as: :interview_preferences_edit
         post '/interview-preferences/review' => 'personal_statement/interview_preferences#update', as: :interview_preferences_update
         get '/interview-preferences/review' => 'personal_statement/interview_preferences#show', as: :interview_preferences_show
+        post '/interview-preferences/complete' => 'personal_statement/interview_preferences#complete', as: :interview_preferences_complete
       end
 
       scope '/training-with-a-disability' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
         get '/subject-knowledge' => 'personal_statement/subject_knowledge#edit', as: :subject_knowledge_edit
         post '/subject-knowledge/review' => 'personal_statement/subject_knowledge#update', as: :subject_knowledge_update
         get '/subject-knowledge/review' => 'personal_statement/subject_knowledge#show', as: :subject_knowledge_show
+        post '/subject-knowledge/complete' => 'personal_statement/subject_knowledge#complete', as: :subject_knowledge_complete
 
         get '/interview-preferences' => 'personal_statement/interview_preferences#edit', as: :interview_preferences_edit
         post '/interview-preferences/review' => 'personal_statement/interview_preferences#update', as: :interview_preferences_update

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -273,7 +273,7 @@ Rails.application.routes.draw do
         post '/(:type)' => 'referees#create'
 
         get '/review' => 'referees#review', as: :review_referees
-        patch '/review' => 'referees#complete', as: :complete_referees
+        patch '/complete' => 'referees#complete', as: :complete_referees
 
         get '/edit/:id' => 'referees#edit', as: :edit_referee
         patch '/update/:id' => 'referees#update', as: :update_referee

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
         get '/becoming-a-teacher' => 'personal_statement/becoming_a_teacher#edit', as: :becoming_a_teacher_edit
         post '/becoming-a-teacher/review' => 'personal_statement/becoming_a_teacher#update', as: :becoming_a_teacher_update
         get '/becoming-a-teacher/review' => 'personal_statement/becoming_a_teacher#show', as: :becoming_a_teacher_show
+        post '/becoming-a-teacher/complete' => 'personal_statement/becoming_a_teacher#complete', as: :becoming_a_teacher_complete
 
         get '/subject-knowledge' => 'personal_statement/subject_knowledge#edit', as: :subject_knowledge_edit
         post '/subject-knowledge/review' => 'personal_statement/subject_knowledge#update', as: :subject_knowledge_update

--- a/spec/components/candidate_interface/complete_section_component_spec.rb
+++ b/spec/components/candidate_interface/complete_section_component_spec.rb
@@ -4,16 +4,19 @@ RSpec.describe CandidateInterface::CompleteSectionComponent do
   let(:application_form) { create(:application_form) }
   let(:path) { Rails.application.routes.url_helpers.candidate_interface_application_form_path }
   let(:field_name) { 'field_name' }
+  let(:request_method) { 'post' }
 
   it 'renders successfully' do
     result = render_inline(
       described_class.new(application_form: application_form,
                           path: path,
+                          request_method: request_method,
                           field_name: field_name),
     )
 
     expect(result.css('.govuk-form-group').text).to include 'I have completed this section'
     expect(result.to_html).to include path
+    expect(result.to_html).to include request_method
     expect(result.to_html).to include field_name
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -57,6 +57,7 @@ FactoryBot.define do
       science_gcse_completed { true }
       training_with_a_disability_completed { true }
       safeguarding_issues_completed { true }
+      becoming_a_teacher_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -58,6 +58,7 @@ FactoryBot.define do
       training_with_a_disability_completed { true }
       safeguarding_issues_completed { true }
       becoming_a_teacher_completed { true }
+      subject_knowledge_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -59,6 +59,7 @@ FactoryBot.define do
       safeguarding_issues_completed { true }
       becoming_a_teacher_completed { true }
       subject_knowledge_completed { true }
+      interview_preferences_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -60,6 +60,7 @@ FactoryBot.define do
       becoming_a_teacher_completed { true }
       subject_knowledge_completed { true }
       interview_preferences_completed { true }
+      references_completed { true }
 
       transient do
         application_choices_count { 0 }

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -225,51 +225,18 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#all_referees_provided_by_candidate?' do
-    let(:application_form) do
-      FactoryBot.create(:application_form)
-    end
-    let(:presenter) do
-      CandidateInterface::ApplicationFormPresenter.new(application_form)
-    end
+    it 'returns true if the referees section has been completed' do
+      application_form = build(:application_form, references_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-    context 'when there are no referees' do
-      before do
-        application_form.application_references.delete_all
-      end
-
-      it 'returns false' do
-        expect(presenter.all_referees_provided_by_candidate?).to eq(false)
-      end
+      expect(presenter).to be_all_referees_provided_by_candidate
     end
 
-    context 'when there is one referee' do
-      before do
-        create(:reference, application_form: application_form)
-      end
+    it 'returns false if the referees section is incomplete' do
+      application_form = build(:application_form, references_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
-      it 'returns false' do
-        expect(presenter.all_referees_provided_by_candidate?).to eq(false)
-      end
-    end
-
-    context 'when there are two referees' do
-      before do
-        create_list(:reference, 2, application_form: application_form)
-      end
-
-      it 'returns true' do
-        expect(presenter.all_referees_provided_by_candidate?).to eq(true)
-      end
-    end
-
-    context 'when there are 3 referees' do
-      before do
-        create_list(:reference, 3, application_form: application_form)
-      end
-
-      it 'returns true' do
-        expect(presenter.all_referees_provided_by_candidate?).to eq(true)
-      end
+      expect(presenter).not_to be_all_referees_provided_by_candidate
     end
   end
 

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -465,14 +465,14 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#becoming_a_teacher_completed?' do
-    it 'returns true if becoming a teacher section is completed' do
+    it 'returns true if the becoming a teacher section is completed' do
       application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_becoming_a_teacher_completed
     end
 
-    it 'returns false if becoming a teacher section is incomplete' do
+    it 'returns false if the becoming a teacher section is incomplete' do
       application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
@@ -481,18 +481,34 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
   end
 
   describe '#subject_knowledge_completed?' do
-    it 'returns true if subject knowledge section is completed' do
+    it 'returns true if the interview prefrences section is completed' do
       application_form = FactoryBot.build(:application_form, subject_knowledge_completed: true)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).to be_subject_knowledge_completed
     end
 
-    it 'returns false if subject knowledge section is incomplete' do
+    it 'returns false if the subject knowledge section is incomplete' do
       application_form = FactoryBot.build(:application_form, subject_knowledge_completed: false)
       presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
 
       expect(presenter).not_to be_subject_knowledge_completed
+    end
+  end
+
+  describe '#intervew_preferences_completed?' do
+    it 'returns true if the interview prefrences section is completed' do
+      application_form = FactoryBot.build(:application_form, interview_preferences_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_interview_preferences_completed
+    end
+
+    it 'returns false if the interview prefrences section is incomplete' do
+      application_form = FactoryBot.build(:application_form, interview_preferences_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_interview_preferences_completed
     end
   end
 end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -463,4 +463,20 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       end
     end
   end
+
+  describe '#becoming_a_teacher_completed?' do
+    it 'returns true if becoming a teacher section is completed' do
+      application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_becoming_a_teacher_completed
+    end
+
+    it 'returns false if becoming a teacher section is incomplete' do
+      application_form = FactoryBot.build(:application_form, becoming_a_teacher_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_becoming_a_teacher_completed
+    end
+  end
 end

--- a/spec/presenters/candidate_interface/application_form_presenter_spec.rb
+++ b/spec/presenters/candidate_interface/application_form_presenter_spec.rb
@@ -479,4 +479,20 @@ RSpec.describe CandidateInterface::ApplicationFormPresenter do
       expect(presenter).not_to be_becoming_a_teacher_completed
     end
   end
+
+  describe '#subject_knowledge_completed?' do
+    it 'returns true if subject knowledge section is completed' do
+      application_form = FactoryBot.build(:application_form, subject_knowledge_completed: true)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).to be_subject_knowledge_completed
+    end
+
+    it 'returns false if subject knowledge section is incomplete' do
+      application_form = FactoryBot.build(:application_form, subject_knowledge_completed: false)
+      presenter = CandidateInterface::ApplicationFormPresenter.new(application_form)
+
+      expect(presenter).not_to be_subject_knowledge_completed
+    end
+  end
 end

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -325,7 +325,12 @@ module CandidateHelper
     fill_in t('application_form.personal_statement.becoming_a_teacher.label'), with: 'I believe I would be a first-rate teacher'
     click_button t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
     # Confirmation page
-    click_link t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    else
+      click_link t('application_form.personal_statement.becoming_a_teacher.complete_form_button')
+    end
   end
 
   def candidate_fills_in_subject_knowledge

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -350,7 +350,12 @@ module CandidateHelper
     fill_in t('application_form.personal_statement.interview_preferences.yes_label'), with: 'Not on a Wednesday'
     click_button t('application_form.personal_statement.interview_preferences.complete_form_button')
     # Confirmation page
-    click_link 'Continue'
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    else
+      click_link 'Continue'
+    end
   end
 
   def current_candidate

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -337,7 +337,12 @@ module CandidateHelper
     fill_in t('application_form.personal_statement.subject_knowledge.label'), with: 'Everything'
     click_button t('application_form.personal_statement.subject_knowledge.complete_form_button')
     # Confirmation page
-    click_link t('application_form.personal_statement.subject_knowledge.complete_form_button')
+    if FeatureFlag.active?('mark_every_section_complete')
+      check t('application_form.completed_checkbox')
+      click_button t('application_form.continue')
+    else
+      click_link t('application_form.personal_statement.subject_knowledge.complete_form_button')
+    end
   end
 
   def candidate_fills_in_interview_preferences

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Candidate adding referees' do
 
   scenario 'Candidate adds references' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
     and_i_visit_the_application_form
 
     given_i_have_no_existing_references_on_the_form
@@ -54,12 +55,17 @@ RSpec.feature 'Candidate adding referees' do
     and_i_click_continue
     then_i_see_the_updated_reference_type
 
-    when_i_click_continue
+    when_i_mark_the_section_as_completed
+    and_i_click_continue
     then_i_see_referees_is_complete
   end
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def given_i_have_no_existing_references_on_the_form
@@ -203,5 +209,9 @@ RSpec.feature 'Candidate adding referees' do
     expect(page).to have_content('lumbergh@example.com')
     expect(page).to have_content('School-based')
     expect(page).to have_content('manager for several years')
+  end
+
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
   end
 end

--- a/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
+++ b/spec/system/candidate_interface/candidate_becoming_a_teacher_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
 
   scenario 'Candidate submits why they want to be a teacher' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
     and_i_visit_the_site
     and_the_track_validation_errors_feature_is_on
 
@@ -22,7 +23,8 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
-    when_i_submit_my_details
+    when_i_mark_the_section_as_completed
+    and_i_submit_the_form
     then_i_should_see_the_form
     and_that_the_section_is_completed
 
@@ -32,6 +34,10 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def and_the_track_validation_errors_feature_is_on
@@ -91,8 +97,8 @@ RSpec.feature 'Entering "Why do you want to be a teacher?"' do
     expect(page).to have_content 'Hello world again'
   end
 
-  def when_i_submit_my_details
-    click_link 'Continue'
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_interview_preferences_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering interview preferences' do
 
   scenario 'Candidate submits their interview preferences' do
     given_i_am_signed_in
+    and_the_mark_every_section_as_complete_flag_is_active
     and_i_visit_the_site
 
     when_i_click_on_interview_preferences
@@ -20,7 +21,8 @@ RSpec.feature 'Entering interview preferences' do
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
-    when_i_submit_my_interview_preferences
+    when_i_mark_the_section_as_completed
+    and_i_submit_my_interview_preferences
     then_i_should_see_the_form
     and_that_the_section_is_completed
 
@@ -30,6 +32,10 @@ RSpec.feature 'Entering interview preferences' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def and_i_visit_the_site
@@ -73,8 +79,12 @@ RSpec.feature 'Entering interview preferences' do
     expect(page).to have_content t('application_form.personal_statement.interview_preferences.no_value')
   end
 
-  def when_i_submit_my_interview_preferences
-    click_link 'Continue'
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def and_i_submit_my_interview_preferences
+    click_button 'Continue'
   end
 
   def then_i_should_see_the_form

--- a/spec/system/candidate_interface/candidate_entering_subject_knowledge_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_subject_knowledge_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature 'Entering subject knowledge' do
 
   scenario 'Candidate submits their subject knowledge' do
     given_courses_exist
+    and_the_mark_every_section_as_complete_flag_is_active
 
     given_i_am_signed_in
     and_i_visit_the_site
@@ -24,7 +25,8 @@ RSpec.feature 'Entering subject knowledge' do
     and_i_submit_the_form
     then_i_can_check_my_revised_answers
 
-    when_i_submit_my_subject_knowledge
+    when_i_mark_the_section_as_completed
+    and_i_submit_my_subject_knowledge
     then_i_should_see_the_form
     and_that_the_section_is_completed
 
@@ -34,6 +36,10 @@ RSpec.feature 'Entering subject knowledge' do
 
   def given_i_am_signed_in
     create_and_sign_in_candidate
+  end
+
+  def and_the_mark_every_section_as_complete_flag_is_active
+    FeatureFlag.activate('mark_every_section_complete')
   end
 
   def and_i_visit_the_site
@@ -85,8 +91,12 @@ RSpec.feature 'Entering subject knowledge' do
     expect(page).to have_content 'Hello world again'
   end
 
-  def when_i_submit_my_subject_knowledge
-    click_link 'Continue'
+  def when_i_mark_the_section_as_completed
+    check t('application_form.completed_checkbox')
+  end
+
+  def and_i_submit_my_subject_knowledge
+    click_button 'Continue'
   end
 
   def then_i_should_see_the_form


### PR DESCRIPTION
## Context

First PR is #2051 - Adds a bunch of columns to the application_forms table for the completion of each section.

Second PR is #2063 - Adds the implementation for personal details

Third PR is #2086 - Adds a completed checkbox for the first 5 sections

Currently, the majority of the sections of the application form, do not need to be explicitly marked as complete. This means that many sections are marked as complete by default as they still meet the logic required to do so. 

The following sections still need to be added.

- [x] personal statement 
- [x] subject knowledge
- [x] interview needs
- [x] references

## Changes proposed in this pull request

For each of the above:

- Adds a route
- Adds a checkbox
- The course presenter uses the attribute_completed value for section completion
- If a section is complete and they edit the section it sets the value to false (incomplete)

## Guidance to review

This should be a lot easier to review than it looks if you review by commit. Most are very similar.

A further PR to backfill data will need to be raised.

## Link to Trello card

https://trello.com/c/2YtoBPNB/1425-explicitly-mark-all-sections-as-complete

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
