### PR TITLE
Deal with errors from find sync

### DIFF
--- a/app/lib/find_sync_check.rb
+++ b/app/lib/find_sync_check.rb
@@ -1,0 +1,29 @@
+class FindSyncCheck < OkComputer::Check
+  LAST_SUCCESSFUL_SYNC = 'last-successful-sync-with-find'.freeze
+
+  def self.set_last_sync(date)
+    Redis.current.set(LAST_SUCCESSFUL_SYNC, date)
+  end
+
+  def self.clear_last_sync
+    Redis.current.del(LAST_SUCCESSFUL_SYNC)
+  end
+
+  def self.last_sync
+    Redis.current.get(LAST_SUCCESSFUL_SYNC)
+  end
+
+  def check
+    last_date = self.class.last_sync
+
+    if last_date.nil?
+      mark_failure
+      mark_message 'Problem finding the time when the Find sync last succeeded'
+    elsif Time.zone.parse(last_date) < (Time.zone.now - 1.hour)
+      mark_failure
+      mark_message 'The sync with Find hasn\'t succeeded in an hour'
+    else
+      mark_message 'The sync with Find has succeeded in the last hour'
+    end
+  end
+end

--- a/app/services/sync_all_providers_from_find.rb
+++ b/app/services/sync_all_providers_from_find.rb
@@ -7,6 +7,8 @@ class SyncAllProvidersFromFind
     find_providers = FindAPI::Provider.current_cycle.all
 
     sync_providers(find_providers)
+  rescue JsonApiClient::Errors::ConnectionError
+    raise SyncFindApiError
   end
 
   def self.sync_providers(find_providers)
@@ -19,4 +21,6 @@ class SyncAllProvidersFromFind
   end
 
   private_class_method :sync_providers
+
+  class SyncFindApiError < StandardError; end
 end

--- a/app/services/sync_all_providers_from_find.rb
+++ b/app/services/sync_all_providers_from_find.rb
@@ -7,6 +7,8 @@ class SyncAllProvidersFromFind
     find_providers = FindAPI::Provider.current_cycle.all
 
     sync_providers(find_providers)
+
+    FindSyncCheck.set_last_sync(Time.zone.now)
   rescue JsonApiClient::Errors::ConnectionError
     raise SyncFindApiError
   end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -30,3 +30,4 @@ OkComputer::Registry.register 'sidekiq_default_queue', OkComputer::SidekiqLatenc
 OkComputer::Registry.register 'sidekiq_mailers_queue', OkComputer::SidekiqLatencyCheck.new(queue: 'mailers', threshold: 100) # threshold in seconds
 OkComputer::Registry.register 'sidekiq_retries_count', SidekiqRetriesCheck.new
 OkComputer::Registry.register 'simulated_failure', SimulatedFailureCheck.new
+OkComputer::Registry.register 'find_sync', FindSyncCheck.new

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -7,5 +7,6 @@ Raven.configure do |config|
     'ActionController::UnknownHttpMethod',
     'ActionDispatch::Http::Parameters::ParseError',
     'Redis::CannotConnectError',
+    'SyncAllProvidersFromFind::SyncFindApiError',
   ]
 end

--- a/spec/lib/find_sync_check_spec.rb
+++ b/spec/lib/find_sync_check_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe FindSyncCheck do
+  describe '#check' do
+    it 'succeeds if the sync has happened in the last hour' do
+      FindSyncCheck.set_last_sync(Time.zone.now)
+
+      expect(FindSyncCheck.new.check).to eql('The sync with Find has succeeded in the last hour')
+    end
+
+    it 'fails if the sync has never happened' do
+      FindSyncCheck.clear_last_sync
+
+      expect(FindSyncCheck.new.check).to eql('Problem finding the time when the Find sync last succeeded')
+    end
+
+    it 'fails if the sync hasn\'t happened recently' do
+      FindSyncCheck.set_last_sync(Time.zone.now - 10.days)
+
+      expect(FindSyncCheck.new.check).to eql('The sync with Find hasn\'t succeeded in an hour')
+    end
+  end
+end

--- a/spec/services/sync_all_providers_from_find_spec.rb
+++ b/spec/services/sync_all_providers_from_find_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe SyncAllProvidersFromFind do
       expect { SyncAllProvidersFromFind.call }.to change { Provider.count }.by(2)
     end
 
+    it 'sets the last updated timestamp' do
+      FindSyncCheck.clear_last_sync
+
+      stub_find_api_all_providers_200([
+        {
+          provider_code: 'ABC',
+          name: 'ABC College',
+        },
+      ])
+
+      SyncAllProvidersFromFind.call
+
+      expect(FindSyncCheck.last_sync).not_to be_blank
+    end
+
     it 'creates only missing providers when the database contains some of the providers already' do
       create :provider, code: 'DEF', name: 'DEF College'
 


### PR DESCRIPTION
## Context

Calls to Find sometimes fail, which is expected. The problem is that it generates Sentry errors that aren't actionable.

## Changes proposed in this pull request

- Ignore errors when making requests to Find in the sync
- Keep track of the last time the sync succeeded
- Sound the alarm when it hasn't happened successfully in an hour 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/VG5mhgFw

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
