### PR TITLE
Bug fix for empty qualification values on review submitted page

### DIFF
--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -27,7 +27,7 @@ module CandidateInterface
     def qualification_row
       {
         key: t('application_form.degree.qualification.label'),
-        value: gcse_qualification_types[application_qualification.qualification_type.to_sym],
+        value: gcse_qualification_types[application_qualification.qualification_type.to_sym.downcase],
         action: "qualification for #{gcse_qualification_types[application_qualification.qualification_type.to_sym]}, #{subject}",
         change_path: candidate_interface_gcse_details_edit_type_path(subject: subject),
       }

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -61,12 +61,9 @@ module CandidateInterface
     end
 
     def gcse_qualification_types
-      {
-        gcse: 'GCSE',
-        gce_o_level: 'GCE O Level',
-        scottish_national_5: 'Scottish National 5',
+      t('application_form.gcse.qualification_types').merge(
         other_uk: application_qualification.other_uk_qualification_type,
-      }
+      )
     end
   end
 end

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -1,22 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
-  context 'when the subject is maths' do
-    it 'displays award year, qualification type and grade' do
-      application_form = build :application_form
-      @qualification = application_qualification = build(
-        :application_qualification,
-        application_form: application_form,
-        qualification_type: 'GCSE',
-        level: 'gcse',
-      )
-      result = render_inline(
-        described_class.new(application_qualification: application_qualification, subject: 'maths'),
-      )
+  it 'displays award year, qualification type and grade' do
+    application_form = build :application_form
+    @qualification = application_qualification = build(
+      :application_qualification,
+      application_form: application_form,
+      qualification_type: 'GCSE',
+      level: 'gcse',
+      grade: 'c',
+    )
+    result = render_inline(
+      described_class.new(application_qualification: application_qualification, subject: 'maths'),
+    )
 
-      expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
-      expect(result.text).to match(/Grade\s+#{@qualification.grade}/)
-      expect(result.text).to match(/Qualification\s+GCSE/)
-    end
+    expect(result.text).to match(/Qualification\s+GCSE/)
+    expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
+    expect(result.text).to match(/Grade\s+#{@qualification.grade.upcase}/)
   end
 end

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
+  context 'when the subject is maths' do
+    it 'displays award year, qualification type and grade' do
+      application_form = build :application_form
+      @qualification = application_qualification = build(
+        :application_qualification,
+        application_form: application_form,
+        qualification_type: 'GCSE',
+        level: 'gcse',
+      )
+      result = render_inline(
+        described_class.new(application_qualification: application_qualification, subject: 'maths'),
+      )
+
+      expect(result.text).to match(/Year awarded\s+#{@qualification.award_year}/)
+      expect(result.text).to match(/Grade\s+#{@qualification.grade}/)
+      expect(result.text).to match(/Qualification\s+GCSE/)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -183,7 +183,7 @@ FactoryBot.define do
 
   factory :application_qualification do
     level { %w[degree gcse other].sample }
-    qualification_type { %w[BA Masters A-Level GCSE].sample }
+    qualification_type { %w[BA Masters A-Level gcse].sample }
     subject { Faker::Educator.subject }
     grade { %w[first upper_second A B].sample }
     predicted_grade { %w[true false].sample }
@@ -195,7 +195,7 @@ FactoryBot.define do
 
     factory :gcse_qualification do
       level { 'gcse' }
-      qualification_type { 'GCSE' }
+      qualification_type { 'gcse' }
       subject { %w[maths english science].sample }
       grade { %w[A B C].sample }
       awarding_body { Faker::Educator.secondary_school }


### PR DESCRIPTION
## Context

The `CandidateInterface::GcseQualificationReviewComponent` on the review submitted page shows blank values for valid values for qualification type.

## Changes proposed in this pull request

- [x] Add spec to reproduce bug
- [x] Fix lookup by downcasing value and using the same I18n key as the input form
- [x] Investigate whether there are other values in production DB that could be a problem

On production:
```
irb(main):006:0> ApplicationQualification.where(level: 'gcse').pluck(:qualification_type).uniq
=> ["gcse", "scottish_national_5", "gce_o_level", "other_uk", "missing"]
```

## Guidance to review

- Originally `qualification_type` was output as a blank value unless there is a valid key in `gcse_qualification_types`. There should only be 5 values and this is certainly the case on production. However it's possible to get other values if you use factories so I guess the test data may well be off.

![image](https://user-images.githubusercontent.com/450843/82324654-e6589100-99d1-11ea-91ca-2858ad222c17.png)

## Link to Trello card

https://trello.com/c/1Xp6qLxE/1559-bug-shows-nil-for-qualification-type-on-maths-english-gcse-section-on-the-review-submitted-page

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
