### PR TITLE
Grant the view safeguarding permission to all test users

### DIFF
--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -11,7 +11,8 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
   end
   SupportUser.find_or_create_by!(dfe_sign_in_uid: 'dev-support', email_address: 'support@example.com')
 
-  ProviderPermissions.update_all(manage_users: true) if FeatureFlag.active?('provider_add_provider_users')
+  ProviderPermissions.update_all(manage_users: true)
+  ProviderPermissions.update_all(view_safeguarding_information: true)
 end
 
 desc 'Sync some pilot-enabled providers and open all their courses'


### PR DESCRIPTION
## Context

Missed in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2057

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds the `view_safeguarding_information` permission for all test users.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/bwEGeJa3/2093-build-access-mgmt-safeguarding
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
