### PR TITLE
Prevent adding third reference via back button etc.

### DIFF
--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -18,8 +18,10 @@ module CandidateInterface
         set_referee_id
 
         @reference_type_form = Reference::RefereeTypeForm.build_from_reference(@referee)
-      else
+      elsif current_application.can_add_reference?
         @reference_type_form = Reference::RefereeTypeForm.new
+      else
+        redirect_to candidate_interface_review_referees_path
       end
     end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -130,4 +130,8 @@ class ApplicationForm < ApplicationRecord
   def ended_without_success?
     application_choices.map(&:status).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }
   end
+
+  def can_add_reference?
+    submitted? || apply_again? || application_references.size < MINIMUM_COMPLETE_REFERENCES
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -123,4 +123,44 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#can_add_reference?' do
+    it 'returns true if there are fewer than 2 references' do
+      application_reference = build :reference
+      application_form = build :application_form, application_references: [application_reference]
+      expect(application_form.can_add_reference?).to be true
+    end
+
+    it 'returns false if there are already 2 references' do
+      application_reference1 = build :reference
+      application_reference2 = build :reference
+      application_form = build(
+        :application_form,
+        application_references: [application_reference1, application_reference2],
+      )
+      expect(application_form.can_add_reference?).to be false
+    end
+
+    it 'returns true if there are already 2 references but the form is submitted' do
+      application_reference1 = build :reference
+      application_reference2 = build :reference
+      application_form = build(
+        :application_form,
+        application_references: [application_reference1, application_reference2],
+        submitted_at: 3.days.ago,
+      )
+      expect(application_form.can_add_reference?).to be true
+    end
+
+    it 'returns true if there are already 2 references but its an Apply Again form' do
+      application_reference1 = build :reference
+      application_reference2 = build :reference
+      application_form = build(
+        :application_form,
+        application_references: [application_reference1, application_reference2],
+        phase: 'apply_2',
+      )
+      expect(application_form.can_add_reference?).to be true
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_adding_referees_spec.rb
+++ b/spec/system/candidate_interface/candidate_adding_referees_spec.rb
@@ -58,6 +58,9 @@ RSpec.feature 'Candidate adding referees' do
     when_i_mark_the_section_as_completed
     and_i_click_continue
     then_i_see_referees_is_complete
+
+    when_i_navigate_to_the_add_referees_page
+    then_i_am_redirected_to_the_referees_review_page
   end
 
   def given_i_am_signed_in
@@ -213,5 +216,13 @@ RSpec.feature 'Candidate adding referees' do
 
   def when_i_mark_the_section_as_completed
     check t('application_form.completed_checkbox')
+  end
+
+  def when_i_navigate_to_the_add_referees_page
+    visit candidate_interface_referees_type_path
+  end
+
+  def then_i_am_redirected_to_the_referees_review_page
+    expect(page).to have_current_path(candidate_interface_review_referees_path)
   end
 end


### PR DESCRIPTION
## Context

It is possible to add a third referee before submission by using the back button or navigating directly to the relevant URL.

## Changes proposed in this pull request

- [x] Add guard to controller that redirects to the reference review page if you've already hit the maximum number
- [x] Update system spec

## Guidance to review

- I'm not certain about the business rules for this. I've assumed that we allow adding more than two referees if the form has already been submitted (e.g. to add a replacement) or the application is an 'Apply Again'.
- Do we need validation at the model level? (or maybe a service class)
- Are there any other ways you can kick the add new referee process off?
- Is the referee review page the right place to redirect to?

## Link to Trello card

https://trello.com/c/fP6OTkQv/1557-bug-pre-submission-third-referee

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
