### PR TITLE
Remove notes feature flag

### DIFF
--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -14,9 +14,7 @@ module ProviderInterface
       @course_provider_name = application_choice.offered_course.provider.name
       @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
       @site_name_and_code = application_choice.site.name_and_code
-      if FeatureFlag.active?('notes')
-        @most_recent_note = application_choice.notes.order('created_at DESC').first
-      end
+      @most_recent_note = application_choice.notes.order('created_at DESC').first
     end
   end
 end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -1,7 +1,6 @@
 module ProviderInterface
   class ApplicationChoicesController < ProviderInterfaceController
     before_action :set_application_choice_and_sub_navigation_items, except: %i[index]
-    before_action :require_notes_feature, only: %i[notes new_note create_note]
 
     def index
       @page_state = ProviderApplicationsPageState.new(
@@ -63,10 +62,6 @@ module ProviderInterface
       current_provider_user.providers
     end
 
-    def require_notes_feature
-      redirect_to(action: :show) unless FeatureFlag.active?('notes')
-    end
-
     def set_application_choice_and_sub_navigation_items
       @application_choice = get_application_choice
       @sub_navigation_items = get_sub_navigation_items
@@ -83,11 +78,9 @@ module ProviderInterface
         { name: 'Application', url: provider_interface_application_choice_path(@application_choice) },
       ]
 
-      if FeatureFlag.active?('notes')
-        sub_navigation_items.push(
-          { name: 'Notes', url: provider_interface_application_choice_notes_path(@application_choice) },
-        )
-      end
+      sub_navigation_items.push(
+        { name: 'Notes', url: provider_interface_application_choice_notes_path(@application_choice) },
+      )
 
       if FeatureFlag.active?('timeline')
         sub_navigation_items.push(

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -23,7 +23,6 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [:confirm_conditions, 'Allows providers to confirm that conditions related to an offer have been met', 'Michael Nacos'],
     [:download_dataset1_from_support_page, 'Enables the application CSV download from the support interface', 'Al Davidson'],
-    [:notes, 'Allows providers to add notes to applications', 'Michael Nacos'],
     [:provider_add_provider_users, 'Allows provider users to invite other provider users', 'Steve Laing'],
     [:provider_application_filters, 'Allows providers to filter applications returned by the main applications page by status etc.', 'Will McBrien'],
     [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
     end
 
     it 'renders the subject of the most recent note' do
-      FeatureFlag.activate('notes')
       application_choice.notes << note
       expect(card).to include(note.subject)
     end

--- a/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_adds_note_to_application_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   scenario 'adds a note' do
     given_i_am_a_provider_user_with_dfe_sign_in
-    and_the_notes_feature_flag_is_active
     and_the_timeline_feature_flag_is_active
     and_my_organisation_has_received_an_application
     and_i_sign_in_to_the_provider_interface
@@ -32,10 +31,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     provider_user = create(:provider_user, dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
     provider_user.providers << @provider
     user_exists_in_dfe_sign_in
-  end
-
-  def and_the_notes_feature_flag_is_active
-    FeatureFlag.activate('notes')
   end
 
   def and_the_timeline_feature_flag_is_active


### PR DESCRIPTION
## Context

This feature is enabled in prod and providers are using (and liking!) it

## Changes proposed in this pull request

Remove the flag

## Guidance to review

Did I miss anything?

## Link to Trello card

https://trello.com/c/nQuDewpQ/2190-dev-feature-flag-embargo

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
