### PR TITLE
Backfill ApplicationForm#edit_by

### DIFF
--- a/db/migrate/20200520104405_migrate_edit_by_value_to_application_form.rb
+++ b/db/migrate/20200520104405_migrate_edit_by_value_to_application_form.rb
@@ -1,0 +1,10 @@
+class MigrateEditByValueToApplicationForm < ActiveRecord::Migration[6.0]
+  def change
+    application_forms = ApplicationForm.includes(:application_choices).where.not(submitted_at: nil)
+
+    application_forms.each do |application_form|
+      edit_by = application_form.application_choices.first&.edit_by
+      application_form.update(edit_by: edit_by)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_093014) do
+ActiveRecord::Schema.define(version: 2020_05_20_104405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"


### PR DESCRIPTION
## Context

**Needs to be merged after #2099** 

We need to backfill edit_by dates on the application forms before deploying the rest of the changes to the code out.

## Changes proposed in this pull request

- for submitted applications use the first application choices edit_by to populate its edit_by column

## Guidance to review

A further PR to drop the edit_by column from the application choices column will follow.

## Link to Trello card

https://trello.com/b/aRIgjf0y/candidate-team-board

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
