### PR TITLE
Bring Provider application page closer to the prototype

### DIFF
--- a/app/components/interview_preferences_component.html.erb
+++ b/app/components/interview_preferences_component.html.erb
@@ -1,0 +1,1 @@
+<%= simple_format interview_preferences, class: 'govuk-body' %>

--- a/app/components/interview_preferences_component.rb
+++ b/app/components/interview_preferences_component.rb
@@ -1,0 +1,11 @@
+class InterviewPreferencesComponent < ViewComponent::Base
+  delegate :interview_preferences, to: :application_form
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+private
+
+  attr_reader :application_form
+end

--- a/app/components/personal_statement_component.html.erb
+++ b/app/components/personal_statement_component.html.erb
@@ -1,1 +1,9 @@
-<%= render SummaryListComponent.new(rows: rows) %>
+<h3 class="govuk-heading-s govuk-!-margin-bottom-0">Vocation</h3>
+<p class="govuk-hint govuk-!-margin-top-0">Question to candidate: “Why do you want to be a teacher?”</p>
+<%= simple_format becoming_a_teacher, class: 'govuk-body' %></p>
+<h3 class="govuk-heading-s govuk-!-margin-bottom-0">Subject knowledge</h3>
+<p class="govuk-hint govuk-!-margin-top-0">Question to candidate: “Your knowledge about the subject you want to teach”</p>
+<%= simple_format subject_knowledge, class: 'govuk-body' %></p>
+<h3 class="govuk-heading-s govuk-!-margin-bottom-0">Further information</h3>
+<p class="govuk-hint govuk-!-margin-top-0">Question to candidate: “Is there anything else you would like to tell us about your application?”</p>
+<%= simple_format further_information, class: 'govuk-body' %></p>

--- a/app/components/personal_statement_component.rb
+++ b/app/components/personal_statement_component.rb
@@ -3,33 +3,11 @@ class PersonalStatementComponent < ViewComponent::Base
 
   delegate :becoming_a_teacher,
            :subject_knowledge,
-           :interview_preferences,
            :further_information,
            to: :application_form
 
   def initialize(application_form:)
     @application_form = application_form
-  end
-
-  def rows
-    [
-      {
-        key: t('application_form.personal_statement.becoming_a_teacher.label'),
-        value: becoming_a_teacher,
-      },
-      {
-        key: 'Subject knowledge',
-        value: subject_knowledge,
-      },
-      {
-        key: t('application_form.personal_statement.interview_preferences.label'),
-        value: interview_preferences.presence || 'No preference given',
-      },
-      {
-        key: 'Further information',
-        value: further_information.presence || 'No further information given',
-      },
-    ]
   end
 
 private

--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -40,7 +40,7 @@ module ProviderInterface
     def email_address_row
       {
         key: 'Email address',
-        value: email_address,
+        value: mail_to(email_address),
       }
     end
 

--- a/app/components/provider_interface/safeguarding_declaration_component.html.erb
+++ b/app/components/provider_interface/safeguarding_declaration_component.html.erb
@@ -1,3 +1,1 @@
-<h2 class="govuk-heading-m govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
-
 <p class="govuk-body"><%= message %></p>

--- a/app/components/provider_interface/training_with_disability_component.html.erb
+++ b/app/components/provider_interface/training_with_disability_component.html.erb
@@ -1,2 +1,1 @@
-<h2 class="govuk-heading-m govuk-!-margin-top-8" id="disabilities">Disability and other needs</h2>
 <p class="govuk-body"><%= disability_disclosure %></p>

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -57,7 +57,11 @@
       <% end %>
     <% end %>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Interview</h2>
+
+    <%= render InterviewPreferencesComponent.new(application_form: @application_choice.application_form) %>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="qualifications">Qualifications</h2>
 
     <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>
 

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -45,14 +45,17 @@
       </div>
     <% end %>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="course-info">Course</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="course-info">Course details</h2>
 
     <%= render ProviderInterface::CourseDetailsComponent.new(application_choice: @application_choice)%>
+
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="disabilities">Disability, access and other needs</h2>
 
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
     <% if FeatureFlag.active?('provider_view_safeguarding') %>
       <% if current_provider_user.can_view_safeguarding_information_for?(@application_choice.provider) %>
+        <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
         <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
       <% end %>
     <% end %>
@@ -65,7 +68,7 @@
 
     <%= render QualificationsComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="work-history">Work history</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="work-history">Work history</h2>
 
     <div data-qa="work-history">
       <% if FeatureFlag.active?('provider_interface_work_breaks') %>
@@ -75,7 +78,7 @@
       <% end %>
     </div>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="volunteering">Unpaid experience and volunteering</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="volunteering">Unpaid experience and volunteering</h2>
 
     <div data-qa="volunteering">
       <% if FeatureFlag.active?('provider_interface_work_breaks') %>
@@ -85,15 +88,17 @@
       <% end %>
     </div>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="language-skills">Language skills</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="language-skills">Language skills</h2>
 
     <%= render LanguageSkillsComponent.new(application_form: @application_choice.application_form) %>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
+    <h2 class="govuk-heading-l govuk-!-margin-top-8" id="personal-statement">Personal statement</h2>
 
     <%= render PersonalStatementComponent.new(application_form: @application_choice.application_form) %>
 
     <% if @application_choice.application_form.application_references.any? %>
+      <h2 class="govuk-heading-l govuk-!-margin-top-8" id="personal-statement">References</h2>
+
       <% @application_choice.application_form.application_references.each_with_index do |reference, i| %>
         <h2 class="govuk-heading-m govuk-!-margin-top-8"><%= "#{TextOrdinalizer.call((i + 1)).capitalize} referee" %></h2>
         <%= render ProviderInterface::ReferenceWithFeedbackComponent.new(reference: reference) %>

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -82,6 +82,10 @@
 
 <%= render PersonalStatementComponent.new(application_form: @application_form) %>
 
+<h2 class="govuk-heading-l govuk-!-margin-top-8">Interview</h2>
+
+<%= render InterviewPreferencesComponent.new(application_form: @application_form) %>
+
 <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
 
 <%= render SupportInterface::SafeguardingIssuesComponent.new(application_form: @application_form) %>

--- a/spec/components/provider_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/reference_with_feedback_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
     it 'contains an email address row' do
       row = component.rows.second
       expect(row[:key]).to eq('Email address')
-      expect(row[:value]).to eq(reference.email_address)
+      expect(row[:value]).to include(reference.email_address)
     end
 
     it 'contains a relationship row' do

--- a/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
+++ b/spec/components/provider_interface/safeguarding_declaration_component_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
-  let(:heading) { 'Criminal convictions and professional misconduct' }
-
   context 'when the candidate was never asked the safeguarding question' do
     it 'displays the correct text' do
       application_form = build_stubbed(
@@ -12,7 +10,6 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
       )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(heading)
       expect(result.text).to include('Never asked.')
     end
   end
@@ -26,7 +23,6 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
       )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(heading)
       expect(result.text).to include('The candidate has shared information related to safeguarding. Please contact them directly for more details.')
     end
   end
@@ -40,7 +36,6 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
       )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(heading)
       expect(result.text).to include('No information shared.')
     end
   end
@@ -54,7 +49,6 @@ RSpec.describe ProviderInterface::SafeguardingDeclarationComponent do
       )
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.text).to include(heading)
       expect(result.text).to include('Not answered yet')
     end
   end

--- a/spec/components/provider_interface/training_with_disability_component_spec.rb
+++ b/spec/components/provider_interface/training_with_disability_component_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe ProviderInterface::TrainingWithDisabilityComponent do
       disability_disclosure: 'I am hard of hearing',
     )
     result = render_inline(described_class.new(application_form: application_form))
-    expect(result.text).to include('Disability and other needs')
     expect(result.text).to include('I am hard of hearing')
   end
 end


### PR DESCRIPTION
## Context

During the bug bash we noticed the provider UI application page wasn't up to date.

## Changes proposed in this pull request

- Make the titles bigger, which is consistent with the prototype. Some components had the title inside. Make them leave the title outside, which is consistent with the majority of components.
- Display the personal statement in a column, not a table
- As part of that, the "Interview" section is removed in the prototype, so pull that out in the Provider and Support UI
- Make email addresses in referee details clickable as in the prototype

This PR doesn't change the layout for references, though we need to do that.

#### Old personal statement

![Screenshot 2020-05-20 at 13 50 26](https://user-images.githubusercontent.com/642279/82451487-f6da3b80-9aa5-11ea-9f0a-00bd3991039e.png)

#### New personal statement — note larger title
![Screenshot 2020-05-20 at 14 22 48](https://user-images.githubusercontent.com/642279/82451522-00fc3a00-9aa6-11ea-968e-48ef034942bd.png)

## Guidance to review

Does it look right?

## Link to Trello card

https://trello.com/c/cHPLYYLe/2135-personal-statement-layout-is-wrong

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
