### PR TITLE
Remove .uniq from site factory

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -227,8 +227,8 @@ FactoryBot.define do
   factory :site do
     provider
 
-    code { Faker::Alphanumeric.unique.alphanumeric(number: 1).upcase }
-    name { Faker::Educator.unique.secondary_school }
+    code { Faker::Alphanumeric.alphanumeric(number: 1).upcase }
+    name { Faker::Educator.secondary_school }
     address_line1 { Faker::Address.street_address }
     address_line2 { Faker::Address.city }
     address_line3 { Faker::Address.county }


### PR DESCRIPTION
While it is true, that there is a constraint in the Find system that
stops providers from creating sites past an upper limit because
otherwise the characters would overlap, it doesn't seem necessary to
replicate this in our factories.

Names don't need to be unique as far as I know.


## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)