### PR TITLE
Check user and organisation level permissions for safeguarding

### DIFF
--- a/app/models/provider_interface/accredited_body_permissions.rb
+++ b/app/models/provider_interface/accredited_body_permissions.rb
@@ -1,0 +1,4 @@
+module ProviderInterface
+  class AccreditedBodyPermissions < ProviderRelationshipPermissions
+  end
+end

--- a/app/models/provider_interface/provider_relationship_permissions.rb
+++ b/app/models/provider_interface/provider_relationship_permissions.rb
@@ -1,0 +1,8 @@
+module ProviderInterface
+  class ProviderRelationshipPermissions < ApplicationRecord
+    belongs_to :ratifying_provider, class_name: 'Provider'
+    belongs_to :training_provider, class_name: 'Provider'
+
+    scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
+  end
+end

--- a/app/models/provider_interface/training_provider_permissions.rb
+++ b/app/models/provider_interface/training_provider_permissions.rb
@@ -1,0 +1,4 @@
+module ProviderInterface
+  class TrainingProviderPermissions < ProviderRelationshipPermissions
+  end
+end

--- a/app/views/provider_interface/application_choices/show.html.erb
+++ b/app/views/provider_interface/application_choices/show.html.erb
@@ -54,7 +54,7 @@
     <%= render ProviderInterface::TrainingWithDisabilityComponent.new(application_form: @application_choice.application_form) %>
 
     <% if FeatureFlag.active?('provider_view_safeguarding') %>
-      <% if current_provider_user.can_view_safeguarding_information_for?(@application_choice.provider) %>
+      <% if ProviderAuthorisation.new(actor: current_provider_user).can_view_safeguarding_information?(course: @application_choice.course) %>
         <h2 class="govuk-heading-l govuk-!-margin-top-8">Criminal convictions and professional misconduct</h2>
         <%= render ProviderInterface::SafeguardingDeclarationComponent.new(application_form: @application_choice.application_form)%>
       <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -312,6 +312,20 @@ FactoryBot.define do
     end
   end
 
+  factory :accredited_body_permissions,
+          class: 'ProviderInterface::AccreditedBodyPermissions' do
+    type { 'ProviderInterface::AccreditedBodyPermissions' }
+    ratifying_provider { provider }
+    training_provider { provider }
+  end
+
+  factory :training_provider_permissions,
+          class: 'ProviderInterface::TrainingProviderPermissions' do
+    type { 'ProviderInterface::TrainingProviderPermissions' }
+    ratifying_provider { provider }
+    training_provider { provider }
+  end
+
   factory :application_choice do
     application_form
     course_option

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -56,6 +56,13 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   def when_i_am_permitted_to_see_safeguarding_information
     ProviderUser.find_by(dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
       .provider_permissions.update_all(view_safeguarding_information: true)
+
+    create(
+      :training_provider_permissions,
+      ratifying_provider: create(:provider),
+      training_provider: @application_choice.course.provider,
+      view_safeguarding_information: true,
+    )
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in


### PR DESCRIPTION
## Context

Organisational level permissions need to be applied in conjunction with user level permissions in order to afford the granularity needed in our planned access controls feature.
<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds `ProviderRelationshipPermissions` model and STI subclasses `AccreditedBodyPermissions` and `TrainingProviderPermissions` to denote the types of relationship permissions apply to.
- Adds a convenience method on `ProviderAuthorisation` service to check user and organisation permissions.
- Uses the service method to check that the provider user has been granted individual and organisational permissions to view safeguarding information.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/F6QCZXqx/2169-provider-to-provider-permissions-affect-what-users-can-do-in-the-system
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
