### PR TITLE
Allow ratifying provider to be null

### DIFF
--- a/db/migrate/20200520143639_allow_nulls_for_ratifying_providers_in_provider_relationship_permissions.rb
+++ b/db/migrate/20200520143639_allow_nulls_for_ratifying_providers_in_provider_relationship_permissions.rb
@@ -1,0 +1,5 @@
+class AllowNullsForRatifyingProvidersInProviderRelationshipPermissions < ActiveRecord::Migration[6.0]
+  def change
+    change_column(:provider_relationship_permissions, :ratifying_provider_id, :integer, null: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_102317) do
+ActiveRecord::Schema.define(version: 2020_05_20_143639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -281,7 +281,7 @@ ActiveRecord::Schema.define(version: 2020_05_19_102317) do
   create_table "provider_relationship_permissions", force: :cascade do |t|
     t.string "type", null: false
     t.integer "training_provider_id", null: false
-    t.integer "ratifying_provider_id", null: false
+    t.integer "ratifying_provider_id"
     t.boolean "view_safeguarding_information", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false


### PR DESCRIPTION
## Context

This migration PR https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2094/files#diff-211254c6b60fe3ebd7ebb745c0f3486fR6 introduced the `provider_relationship_permissions` table, but added not-null constraints on the `ratifying_provider_id` column.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Self-ratifying training providers won't need to populate this field so allow null here.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/F6QCZXqx/2169-provider-to-provider-permissions-affect-what-users-can-do-in-the-system
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
