### PR TITLE
Display errors in the add note form in order

### DIFF
--- a/app/models/provider_interface/new_note_form.rb
+++ b/app/models/provider_interface/new_note_form.rb
@@ -3,9 +3,9 @@ module ProviderInterface
     include ActiveModel::Model
     attr_accessor :application_choice, :subject, :message, :provider_user
 
-    validates :application_choice, :subject, :message, :provider_user, presence: true
-    validates :subject, length: { maximum: 40 }
-    validates :message, length: { maximum: 500 }
+    validates :application_choice, :provider_user, presence: true
+    validates :subject, length: { maximum: 40 }, presence: true
+    validates :message, length: { maximum: 500 }, presence: true
 
     def save
       if valid?


### PR DESCRIPTION
## Context

During the Bug Bash we noticed errors appearing out of order.

## Changes proposed in this pull request

Help Rails put them in the right order 🍰 

## Link to Trello card

https://trello.com/c/tiLiEGT2/2130-errors-in-wrong-order-when-causing-errors-in-the-add-a-note-form

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
