### PR TITLE
Don’t show "Awaiting decision" if flash is present

### DIFF
--- a/app/views/provider_interface/application_choices/_application_choice_header.html.erb
+++ b/app/views/provider_interface/application_choices/_application_choice_header.html.erb
@@ -1,4 +1,4 @@
-<% if @application_choice.status == 'awaiting_provider_decision' -%>
+<% if @application_choice.status == 'awaiting_provider_decision' && flash.empty? -%>
   <div class="app-banner">
     <div class="app-banner__message">
       <h2 class="govuk-heading-m govuk-!-margin-bottom-0">


### PR DESCRIPTION
## Context

Spotted in the bug bash

## Changes proposed in this pull request

Hide the "Awaiting decision" banner unless the flash is empty

## Guidance to review

No test! 🤠 

## Link to Trello card

https://trello.com/c/C5XZPFvU/2134-when-i-add-a-note-to-a-new-application-there-are-2-alert-boxes

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
