### PR TITLE
run deploy QA stage in parallel to test stages

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -258,7 +258,7 @@ jobs:
                 Param(
                   [string] $resourceGroupName = "$(resourceGroupName)",
                   [string] $appServiceName = "$(appServiceName)",
-                  [string] $containerImageReference = "${{parameters.dockerHubUsername}}/${{parameters.containerImageReference}}",
+                  [string] $containerImageReference = "${{parameters.containerImageReference}}",
                   [array] $containers = @("clock", "worker")
                 )
                 $output = az webapp config container set --resource-group $resourceGroupName --name $appServiceName --slot staging --docker-custom-image-name $containerImageReference

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -337,8 +337,8 @@ stages:
 
 - stage: deploy_qa
   displayName: 'Deploy - QA'
-  dependsOn: test_release
-  condition: and(succeeded('test_release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+  dependsOn: build_release
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
   variables:
   - group: APPLY - ENV - QA
   jobs:
@@ -352,7 +352,7 @@ stages:
       serviceName: 'apply'
       redisCacheSKU: 'Premium'
       redisCacheFamily: 'P'
-      containerImageReference: '$(imageName):$(build.buildNumber)'
+      containerImageReference: '$(dockerHubUsername)/$(imageName):$(build.buildNumber)'
       keyVaultName: 's106d01-shared-kv-01'
       keyVaultResourceGroup: 's106d01-shared-rg'
       customHostName: '$(govukHostname)'
@@ -393,9 +393,9 @@ stages:
 
 
 - stage: deploy_devops
+  dependsOn: build_release
   displayName: 'Deploy - DevOps'
-  dependsOn: test_release
-  condition: and(succeeded('test_release'), eq(variables['Build.SourceBranchName'], variables.devDeployBranchNameOverride))
+  condition: eq(variables['Build.SourceBranchName'], variables.devDeployBranchNameOverride)
   variables:
   - group: APPLY - ENV - DevOps
   jobs:
@@ -408,9 +408,9 @@ stages:
       resourceEnvironmentName: 'd02'
       serviceName: 'apply'
       ${{ if eq(variables['deployOnly'], true) }}:
-        containerImageReference: '$(imageName):latest'
+        containerImageReference: '$(dockerHubUsername)/$(imageName):latest'
       ${{ if eq(variables['deployOnly'], false) }}:
-        containerImageReference: '$(imageName):$(build.buildNumber)'
+        containerImageReference: '$(dockerHubUsername)/$(imageName):$(build.buildNumber)'
       keyVaultName: 's106d01-shared-kv-01'
       keyVaultResourceGroup: 's106d01-shared-rg'
       databaseName: 'apply'

--- a/azure/containers.json
+++ b/azure/containers.json
@@ -103,8 +103,7 @@
         }
     },
     "variables": {
-        "containerImageName": "[concat(parameters('dockerHubUsername'), '/', parameters('containerImageReference'))]",
-        "appServiceRuntimeStack": "[concat('DOCKER|', parameters('dockerHubUsername'), '/', parameters('containerImageReference'))]",
+        "appServiceRuntimeStack": "[concat('DOCKER|', parameters('containerImageReference'))]",
         "rubyAuthHosts": "[if(greater(length(parameters('customHostName')), 0), concat(parameters('authorisedHosts'), ',', parameters('customHostName')), parameters('authorisedHosts'))]",
         "environmentVariablesWeb": "[concat(parameters('appEnvironmentVariables'), array(json('{\"name\": \"SERVICE_TYPE\", \"value\": \"web\"}')))]",
         "environmentVariablesClk": "[concat(parameters('appEnvironmentVariables'), array(json('{\"name\": \"SERVICE_TYPE\", \"value\": \"clock\"}')))]",
@@ -170,7 +169,7 @@
                         "value": "[concat(parameters('containerInstanceNamePrefix'), '-wkr')]"
                     },
                     "imageName": {
-                        "value": "[variables('containerImageName')]"
+                        "value": "[parameters('containerImageReference')]"
                     },
                     "numberCpuCores": {
                         "value": "[parameters('ciWorkerCpus')]"
@@ -208,7 +207,7 @@
                         "value": "[concat(parameters('containerInstanceNamePrefix'), '-clk')]"
                     },
                     "imageName": {
-                        "value": "[variables('containerImageName')]"
+                        "value": "[parameters('containerImageReference')]"
                     },
                     "numberCpuCores": {
                         "value": "[parameters('ciClockCpus')]"


### PR DESCRIPTION
Run the deploy to QA and DevOps environment stage in parallel to the
test stages.
Pass in fully qualified container image name to the ARM templates.

## Context

We want to eagerly deploy to QA. And have sufficient confidence in the build so as to be deployed to QA as it would have passed test runs in github actions.

## Changes proposed in this pull request

Run the deploy to QA and DevOps stages in parallel after the build & publish image stage and in parallel to the test stages.

## Guidance to review


## Link to Trello card

https://trello.com/c/bXdXiYG0/2204-run-deploy-to-qa-stage-in-parallel-to-the-test-jobs

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
