### PR TITLE
Catch more errors in Find sync

### DIFF
--- a/app/services/sync_all_providers_from_find.rb
+++ b/app/services/sync_all_providers_from_find.rb
@@ -9,7 +9,7 @@ class SyncAllProvidersFromFind
     sync_providers(find_providers)
 
     FindSyncCheck.set_last_sync(Time.zone.now)
-  rescue JsonApiClient::Errors::ConnectionError
+  rescue JsonApiClient::Errors::ApiError
     raise SyncFindApiError
   end
 

--- a/spec/services/sync_all_providers_from_find_spec.rb
+++ b/spec/services/sync_all_providers_from_find_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe SyncAllProvidersFromFind do
       expect(FindSyncCheck.last_sync).not_to be_blank
     end
 
+    it 'does not set the last updated timestamp when encountering an error' do
+      FindSyncCheck.clear_last_sync
+
+      stub_find_api_all_providers_503
+
+      expect { SyncAllProvidersFromFind.call }.to raise_error(SyncAllProvidersFromFind::SyncFindApiError)
+
+      expect(FindSyncCheck.last_sync).to be_blank
+    end
+
     it 'creates only missing providers when the database contains some of the providers already' do
       create :provider, code: 'DEF', name: 'DEF College'
 

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -420,6 +420,18 @@ module FindAPIHelper
       )
   end
 
+  def stub_find_api_all_providers_503
+    stub_find_api_all_providers
+      .to_return(
+        status: 503,
+        headers: { 'Content-Type': 'application/vnd.api+json' },
+        body: {
+          data: {},
+          jsonapi: { version: '1.0' },
+        }.to_json,
+      )
+  end
+
   def stub_find_api_course_200(provider_code, course_code, course_name)
     stub_find_api_course(provider_code, course_code)
       .to_return(


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2095.

## Changes proposed in this pull request

Catch all errors raised by the JSON Api Client. Also adds a test as suggested by @vigneshmsft in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2095#discussion_r427225426.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/VG5mhgFw

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
