### PR TITLE
Add provider locations filters to provider interface

### DIFF
--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -56,7 +56,7 @@
 
                         <div class="govuk-checkboxes__item">
                           <input class="govuk-checkboxes__input" id="<%= filter[:name] %>-<%= option[:value] %>" name="<%= filter[:name] %>[]" type="checkbox" <%= "checked" if option[:checked] %> value="<%= option[:value] %>">
-                          <label class="govuk-label govuk-checkboxes__label" for=<%= option[:name] %>>
+                          <label class="govuk-label govuk-checkboxes__label" for="<%= filter[:name] %>-<%= option[:value] %>">
                             <%= option[:label] %>
                           </label>
 

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -97,6 +97,7 @@ module ProviderInterface
     end
 
     def provider_locations_filters
+      return [] if applied_filters[:provider].nil?
       providers = ProviderOptionsService.new(provider_user).providers_with_sites
 
       providers.map do |p|

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -80,7 +80,11 @@ module ProviderInterface
     end
 
     def accredited_provider_filter
-      accredited_providers_options = ProviderOptionsService.new(provider_user).accredited_providers.map do |accredited_provider|
+      accredited_providers = ProviderOptionsService.new(provider_user).accredited_providers
+
+      return nil if accredited_providers.empty?
+
+      accredited_providers_options = accredited_providers.map do |accredited_provider|
         {
           value: accredited_provider.id,
           label: accredited_provider.name,

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -8,7 +8,7 @@ module ProviderInterface
     end
 
     def filters
-      ([] << search_filter << status_filter << provider_filter << accredited_provider_filter).compact
+      ([] << search_filter << status_filter << provider_filter << accredited_provider_filter).concat(provider_locations_filters).compact
     end
 
     def filtered?
@@ -94,6 +94,25 @@ module ProviderInterface
         name: 'accredited_provider',
         options: accredited_providers_options,
       }
+    end
+
+    def provider_locations_filters
+      providers = ProviderOptionsService.new(provider_user).providers
+
+      providers.map do |p|
+        {
+          type: :checkboxes,
+          heading: "Locations for #{p.name}",
+          name: 'provider_locations',
+          options: p.sites.map do |s|
+            {
+              value: s.id,
+              label: s.name,
+              checked: false,
+            }
+          end
+        }
+      end
     end
   end
 end

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -16,7 +16,7 @@ module ProviderInterface
     end
 
     def applied_filters
-      @params.permit(:candidate_name, provider: [], status: [], accredited_provider: []).to_h
+      @params.permit(:candidate_name, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
     end
 
   private
@@ -103,14 +103,14 @@ module ProviderInterface
         {
           type: :checkboxes,
           heading: "Locations for #{p.name}",
-          name: 'provider_locations',
+          name: 'provider_location',
           options: p.sites.map do |s|
             {
               value: s.id,
               label: s.name,
-              checked: false,
+              checked: applied_filters[:provider_location]&.include?(s.id.to_s),
             }
-          end
+          end,
         }
       end
     end

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -102,6 +102,8 @@ module ProviderInterface
       providers = ProviderOptionsService.new(provider_user).providers_with_sites(provider_ids: applied_filters[:provider])
 
       providers.map do |p|
+        next unless p.sites.count > 1
+
         {
           type: :checkboxes,
           heading: "Locations for #{p.name}",

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -98,7 +98,8 @@ module ProviderInterface
 
     def provider_locations_filters
       return [] if applied_filters[:provider].nil?
-      providers = ProviderOptionsService.new(provider_user).providers_with_sites
+
+      providers = ProviderOptionsService.new(provider_user).providers_with_sites(provider_ids: applied_filters[:provider])
 
       providers.map do |p|
         {

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -97,7 +97,7 @@ module ProviderInterface
     end
 
     def provider_locations_filters
-      providers = ProviderOptionsService.new(provider_user).providers
+      providers = ProviderOptionsService.new(provider_user).providers_with_sites
 
       providers.map do |p|
         {

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -32,11 +32,18 @@ class FilterApplicationChoicesForProviders
       application_choices.where('courses.accredited_provider_id' => accredited_providers)
     end
 
+    def provider_location(application_choices, provider_location)
+      return application_choices if provider_location.blank?
+
+      application_choices.where('sites.id' => provider_location)
+    end
+
     def create_filter_query(application_choices, filters)
       filtered_application_choices = search(application_choices, filters[:candidate_name])
       filtered_application_choices = provider(filtered_application_choices, filters[:provider])
       filtered_application_choices = accredited_provider(filtered_application_choices, filters[:accredited_provider])
       filtered_application_choices = status(filtered_application_choices, filters[:status])
+      filtered_application_choices = provider_location(filtered_application_choices, filters[:provider_location])
       filtered_application_choices
     end
   end

--- a/app/services/provider_interface/provider_options_service.rb
+++ b/app/services/provider_interface/provider_options_service.rb
@@ -31,13 +31,15 @@ module ProviderInterface
     end
 
     # TODO: Write test from this in provider_options_service_spec
-    def providers_with_sites
+    def providers_with_sites(provider_ids:)
       Provider
         .joins(:courses)
+        .where(id: provider_ids)
         .where(courses: { accredited_provider: provider_user.providers })
         .or(
           Provider
             .joins(:courses)
+            .where(id: provider_ids)
             .where(courses: { provider: provider_user.providers }),
         )
         .includes([:sites]).distinct

--- a/app/services/provider_interface/provider_options_service.rb
+++ b/app/services/provider_interface/provider_options_service.rb
@@ -30,7 +30,6 @@ module ProviderInterface
         .distinct
     end
 
-    # TODO: Write test from this in provider_options_service_spec
     def providers_with_sites(provider_ids:)
       Provider
         .joins(:courses)

--- a/app/services/provider_interface/provider_options_service.rb
+++ b/app/services/provider_interface/provider_options_service.rb
@@ -30,6 +30,19 @@ module ProviderInterface
         .distinct
     end
 
+    # TODO: Write test from this in provider_options_service_spec
+    def providers_with_sites
+      Provider
+        .joins(:courses)
+        .where(courses: { accredited_provider: provider_user.providers })
+        .or(
+          Provider
+            .joins(:courses)
+            .where(courses: { provider: provider_user.providers }),
+        )
+        .includes([:sites]).distinct
+    end
+
     def providers_with_manageable_users
       Provider
         .joins(provider_permissions: :provider_user)

--- a/spec/components/previews/provider_interface/filter_component_preview.rb
+++ b/spec/components/previews/provider_interface/filter_component_preview.rb
@@ -1,6 +1,6 @@
 module ProviderInterface
   class FilterComponentPreview < ViewComponent::Preview
-    def defualt_view
+    def default_view
       render_component_for(page_state: page_state_mock(filters: with_name_status_provider_and_accredited_provider))
     end
 

--- a/spec/components/previews/provider_interface/filter_component_preview.rb
+++ b/spec/components/previews/provider_interface/filter_component_preview.rb
@@ -1,7 +1,11 @@
 module ProviderInterface
   class FilterComponentPreview < ViewComponent::Preview
-    def fully_selected
+    def defualt_view
       render_component_for(page_state: page_state_mock(filters: with_name_status_provider_and_accredited_provider))
+    end
+
+    def with_locations_view
+      render_component_for(page_state: page_state_mock(filters: with_name_status_provider_accredited_provider_and_locations))
     end
 
   private
@@ -38,6 +42,35 @@ module ProviderInterface
          heading: 'Accredited provider',
          name: 'accredited_provider',
          options: [{ value: 5, label: 'Coventry University', checked: nil }] }]
+    end
+
+    def with_name_status_provider_accredited_provider_and_locations
+      [{ type: :search, heading: 'Candidate’s name', value: '', name: 'candidate_name' },
+       { type: :checkboxes,
+         heading: 'Status',
+         name: 'status',
+         options: [{ value: 'awaiting_provider_decision', label: 'New', checked: false },
+                   { value: 'offer', label: 'Offered', checked: false },
+                   { value: 'pending_conditions', label: 'Accepted', checked: false },
+                   { value: 'recruited', label: 'Conditions met', checked: false },
+                   { value: 'enrolled', label: 'Enrolled', checked: false },
+                   { value: 'rejected', label: 'Rejected', checked: false },
+                   { value: 'declined', label: 'Declined', checked: true },
+                   { value: 'withdrawn', label: 'Application withdrawn', checked: true },
+                   { value: 'conditions_not_met', label: 'Conditions not met', checked: false },
+                   { value: 'offer_withdrawn', label: 'Withdrawn by us', checked: false }] },
+       { type: :checkboxes,
+         heading: 'Provider',
+         name: 'provider',
+         options: [{ value: 1, label: 'Gorse SCITT', checked: false }] },
+       { type: :checkboxes,
+         heading: 'Accredited provider',
+         name: 'accredited_provider',
+         options: [{ value: 5, label: 'Coventry University', checked: nil }] },
+       { type: :checkboxes,
+         heading: 'Locations for Gorse SCITT',
+         name: 'location',
+         options: [{ value: 1, label: 'Humbledown School', checked: false }, { value: 2, label: 'Twinswale Place', checked: false }] }]
     end
   end
 end

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -62,9 +62,6 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
   end
 
-  xit 'will not renturn locations unless the provider filter is active' do
-  end
-
   describe '#applied_filters' do
     let(:params) do
       ActionController::Parameters.new({ 'status' => %w[

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
       expect(headings).to include("Locations for #{provider1.name}")
 
-      # TODO: think if more specific test that tests multiple provider_locations
       relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
       relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
 

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -51,11 +51,14 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       expect(headings).to include("Locations for #{provider1.name}")
 
       # TODO: think if more specific test that tests multiple provider_locations
-      expect(page_state.filters[3][:options][0][:value]).to eq(provider1.sites.first.id)
-      expect(page_state.filters[3][:options][1][:value]).to eq(provider1.sites.last.id)
+      relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
+      relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
 
-      expect(page_state.filters[3][:options][0][:label]).to eq(provider1.sites.first.name)
-      expect(page_state.filters[3][:options][1][:label]).to eq(provider1.sites.last.name)
+      expect(relevant_provider_ids).to include(page_state.filters[3][:options][0][:value])
+      expect(relevant_provider_ids).to include(page_state.filters[3][:options][1][:value])
+
+      expect(relevant_provider_names).to include(page_state.filters[3][:options][0][:label])
+      expect(relevant_provider_names).to include(page_state.filters[3][:options][1][:label])
     end
   end
 

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
   let(:course2) { create(:course) }
   let(:course3) { create(:course) }
 
-  let(:provider1) { create(:provider, courses: [course1]) }
+  let(:site1) { create(:site) }
+  let(:site2) { create(:site) }
+
+  let(:provider1) { create(:provider, courses: [course1], sites: [site1, site2]) }
   let(:provider2) { create(:provider, courses: [course2]) }
   let(:provider3) { create(:provider, courses: [course3]) }
 
@@ -17,7 +20,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(params: ActionController::Parameters.new,
                                        provider_user: provider_user)
 
-      expected_number_of_filters = 4
+      expected_number_of_filters = 7
       providers_array_index = 2
       number_of_courses = 3
 
@@ -30,13 +33,32 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(params: ActionController::Parameters.new,
                                        provider_user: another_provider_user)
 
-      expected_number_of_filters = 3
+      expected_number_of_filters = 4
 
       headings = page_state.filters.map { |filter| filter[:heading] }
 
       expect(page_state.filters.size).to be(expected_number_of_filters)
       expect(headings).not_to include('Provider')
     end
+
+    it 'can return filter config for a list of provider locations' do
+      page_state = described_class.new(params: ActionController::Parameters.new,
+                                       provider_user: another_provider_user)
+
+      headings = page_state.filters.map { |filter| filter[:heading] }
+
+      expect(headings).to include("Locations for #{provider1.name}")
+
+      #TODO: think if more specific test that tests multiple provider_locations
+      expect(page_state.filters[3][:options][0][:value]).to eq(provider1.sites.first.id)
+      expect(page_state.filters[3][:options][1][:value]).to eq(provider1.sites.last.id)
+
+      expect(page_state.filters[3][:options][0][:label]).to eq(provider1.sites.first.name)
+      expect(page_state.filters[3][:options][1][:label]).to eq(provider1.sites.last.name)
+    end
+  end
+
+  xit 'will not renturn locations unless the provider filter is active' do
   end
 
   describe '#applied_filters' do

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(params: ActionController::Parameters.new,
                                        provider_user: provider_user)
 
-      expected_number_of_filters = 7
+      expected_number_of_filters = 4
       providers_array_index = 2
       number_of_courses = 3
 
@@ -33,7 +33,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(params: ActionController::Parameters.new,
                                        provider_user: another_provider_user)
 
-      expected_number_of_filters = 4
+      expected_number_of_filters = 3
 
       headings = page_state.filters.map { |filter| filter[:heading] }
 
@@ -42,7 +42,8 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
     end
 
     it 'can return filter config for a list of provider locations' do
-      page_state = described_class.new(params: ActionController::Parameters.new,
+      page_state = described_class.new(params: ActionController::Parameters.new({ provider: [provider1.id] }),
+
                                        provider_user: another_provider_user)
 
       headings = page_state.filters.map { |filter| filter[:heading] }

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
 
       expect(headings).to include("Locations for #{provider1.name}")
 
-      #TODO: think if more specific test that tests multiple provider_locations
+      # TODO: think if more specific test that tests multiple provider_locations
       expect(page_state.filters[3][:options][0][:value]).to eq(provider1.sites.first.id)
       expect(page_state.filters[3][:options][1][:value]).to eq(provider1.sites.last.id)
 

--- a/spec/models/provider_interface/provider_applications_page_state_spec.rb
+++ b/spec/models/provider_interface/provider_applications_page_state_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(params: ActionController::Parameters.new,
                                        provider_user: provider_user)
 
-      expected_number_of_filters = 4
+      expected_number_of_filters = 3
       providers_array_index = 2
       number_of_courses = 3
 
@@ -33,7 +33,7 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       page_state = described_class.new(params: ActionController::Parameters.new,
                                        provider_user: another_provider_user)
 
-      expected_number_of_filters = 3
+      expected_number_of_filters = 2
 
       headings = page_state.filters.map { |filter| filter[:heading] }
 
@@ -53,11 +53,11 @@ RSpec.describe ProviderInterface::ProviderApplicationsPageState do
       relevant_provider_ids = [provider1.sites.first.id, provider1.sites.last.id]
       relevant_provider_names = [provider1.sites.first.name, provider1.sites.last.name]
 
-      expect(relevant_provider_ids).to include(page_state.filters[3][:options][0][:value])
-      expect(relevant_provider_ids).to include(page_state.filters[3][:options][1][:value])
+      expect(relevant_provider_ids).to include(page_state.filters[2][:options][0][:value])
+      expect(relevant_provider_ids).to include(page_state.filters[2][:options][1][:value])
 
-      expect(relevant_provider_names).to include(page_state.filters[3][:options][0][:label])
-      expect(relevant_provider_names).to include(page_state.filters[3][:options][1][:label])
+      expect(relevant_provider_names).to include(page_state.filters[2][:options][0][:label])
+      expect(relevant_provider_names).to include(page_state.filters[2][:options][1][:label])
     end
   end
 

--- a/spec/services/provider_interface/provider_options_service_spec.rb
+++ b/spec/services/provider_interface/provider_options_service_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ProviderInterface::ProviderOptionsService do
   before do
+    @sites = [create(:site), create(:site)]
     @providers = create_list :provider, 5
     @accredited_providers = create_list :provider, 5
     @provider_user = create :provider_user, providers: [@providers[0], @providers[1]]
@@ -63,6 +64,17 @@ RSpec.describe ProviderInterface::ProviderOptionsService do
 
     it 'returns providers with users manageable by the provider user' do
       expect(described_class.new(provider_user).providers_with_manageable_users).to eq([@providers.last])
+    end
+  end
+
+  describe '#providers_with_sites' do
+    it 'returns providers with sites' do
+      @provider_user.providers.first.update(sites: @sites)
+
+      providers = described_class.new(@provider_user).providers_with_sites(provider_ids: @provider_user.providers.first.id)
+
+      expect(providers.first.association(:sites).loaded?).to eq(true)
+      expect(providers.first.sites).to match_array(@sites)
     end
   end
 end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -71,6 +71,50 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible_again
+    and_i_click_the_sign_out_button
+  end
+
+  scenario 'filter should not have accredited providers heading if none are available' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_from_multiple_providers
+    and_my_organisation_has_courses_with_applications_without_accredited_providers
+    and_i_sign_in_to_the_provider_interface
+
+    and_accept_the_data_sharing_agreement
+
+    when_i_visit_the_provider_page
+    then_i_do_not_expect_to_see_the_accredited_providers_filter_heading
+    and_i_click_the_sign_out_button
+  end
+
+  def and_i_click_the_sign_out_button
+    click_link 'Sign out'
+  end
+
+  def and_accept_the_data_sharing_agreement
+    find(:css, '#provider-agreement-accept-agreement-true-field').set(true)
+    click_button('Continue')
+  end
+
+  def and_my_organisation_has_courses_with_applications_without_accredited_providers
+    course_option_one = course_option_for_provider(provider: current_provider,
+                                                   site: site,
+                                                   course: create(:course,
+                                                                  name: 'Alchemy',
+                                                                  provider: current_provider))
+
+    course_option_two = course_option_for_provider(provider: second_provider, course: create(:course, name: 'Science', provider: second_provider))
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
+           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 5.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           create(:application_form, first_name: 'Greg', last_name: 'Taft'), updated_at: 4.days.ago)
+  end
+
+  def then_i_do_not_expect_to_see_the_accredited_providers_filter_heading
+    expect(page).to have_content('Filter')
+    expect(page).not_to have_content('Accredited provider')
   end
 
   def then_i_should_see_locations_that_belong_to_all_of_the_selected_providers_that_have_more_than_one_site

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     when_i_clear_the_filters
     when_i_filter_by_a_specific_provider
-    then_i_should_only_see_locations_that_belog_to_that_provider
+    then_i_should_only_see_locations_that_belong_to_that_provider
 
     when_i_filter_by_provider_location
     then_i_only_see_applications_for_that_provider_location
@@ -79,7 +79,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).not_to have_content('Locations for University of Arrakis')
   end
 
-  def then_i_should_only_see_locations_that_belog_to_that_provider
+  def then_i_should_only_see_locations_that_belong_to_that_provider
     expect(page).not_to have_content('Locations for Caladan University')
   end
 

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -4,7 +4,8 @@ RSpec.feature 'Providers should be able to filter applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  let(:current_provider) { create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training') }
+  let(:site) { create(:site, name: 'Test site name') }
+  let(:current_provider) { create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training', sites: [site]) }
   let(:second_provider) { create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University') }
   let(:third_provider) { create(:provider, :with_signed_agreement, code: 'GHI', name: 'University of Arrakis') }
   let(:accredited_provider1) { create(:provider, code: 'JKL', name: 'College of Dumbervale') }
@@ -47,9 +48,29 @@ RSpec.feature 'Providers should be able to filter applications' do
     and_i_filter_by_accredited_provider
     then_i_only_see_applications_for_a_given_accredited_provider
     then_i_expect_the_relevant_accredited_provider_tags_to_be_visible
-
     when_i_click_to_remove_an_accredited_provider_tag
+
+    when_i_filter_by_provider_location
+    then_i_only_see_applications_for_that_provider_location
+    and_i_expect_the_relevant_provider_location_tags_to_be_visible
+
+    when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible_again
+  end
+
+  def then_i_only_see_applications_for_that_provider_location
+    expect(page).not_to have_content('Adam Jones')
+    expect(page).not_to have_content('Tom Jones')
+    expect(page).to have_content('Jim James')
+  end
+
+  def when_i_filter_by_provider_location
+    find(:css, "#provider_location-#{site.id}").set(true)
+    click_button('Apply filters')
+  end
+
+  def and_i_expect_the_relevant_provider_location_tags_to_be_visible
+    expect(page).to have_css('.moj-filter-tags', text: site.name)
   end
 
   def when_i_visit_the_provider_page
@@ -65,7 +86,13 @@ RSpec.feature 'Providers should be able to filter applications' do
   end
 
   def and_my_organisation_has_courses_with_applications
-    course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider, accredited_provider: accredited_provider1))
+    course_option_one = course_option_for_provider(provider: current_provider,
+                                                   site: site,
+                                                   course: create(:course,
+                                                                  name: 'Alchemy',
+                                                                  provider: current_provider,
+                                                                  accredited_provider: accredited_provider1))
+
     course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider, accredited_provider: accredited_provider2))
     course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
 

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -21,6 +21,8 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     then_i_expect_to_see_the_filter_dialogue
 
+    then_i_location_filters_should_not_be_visible
+
     when_i_filter_for_rejected_applications
     then_only_rejected_applications_should_be_visible
     and_a_rejected_tag_should_be_visible
@@ -37,6 +39,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_expect_all_applications_to_be_visible
 
     when_i_filter_by_provider
+    then_i_location_filters_should_be_visible
     then_i_only_see_applications_for_a_given_provider
     then_i_expect_the_relevant_provider_tags_to_be_visible
 
@@ -50,12 +53,23 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_expect_the_relevant_accredited_provider_tags_to_be_visible
     when_i_click_to_remove_an_accredited_provider_tag
 
+    when_i_filter_by_provider
     when_i_filter_by_provider_location
     then_i_only_see_applications_for_that_provider_location
     and_i_expect_the_relevant_provider_location_tags_to_be_visible
 
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible_again
+  end
+
+
+  def then_i_location_filters_should_be_visible
+    expect(page).to have_content('Locations for')
+  end
+
+
+  def then_i_location_filters_should_not_be_visible
+    expect(page).not_to have_content('Locations for')
   end
 
   def then_i_only_see_applications_for_that_provider_location

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -6,10 +6,13 @@ RSpec.feature 'Providers should be able to filter applications' do
 
   let(:site) { create(:site, name: 'Test site name') }
   let(:site2) { create(:site, name: 'Second test site') }
+  let(:site3) { create(:site, name: 'Second test site') }
+  let(:site4) { create(:site, name: 'Second test site') }
+  let(:site5) { create(:site, name: 'Second test site') }
 
-  let(:current_provider) { create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training', sites: [site]) }
-  let(:second_provider) { create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University', sites: [site2]) }
-  let(:third_provider) { create(:provider, :with_signed_agreement, code: 'GHI', name: 'University of Arrakis') }
+  let(:current_provider) { create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training', sites: [site, site2]) }
+  let(:second_provider) { create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University', sites: [site3, site4]) }
+  let(:third_provider) { create(:provider, :with_signed_agreement, code: 'GHI', name: 'University of Arrakis', sites: [site5]) }
   let(:accredited_provider1) { create(:provider, code: 'JKL', name: 'College of Dumbervale') }
   let(:accredited_provider2) { create(:provider, code: 'MNO', name: 'Wimleydown University') }
 
@@ -56,7 +59,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     when_i_click_to_remove_an_accredited_provider_tag
 
     when_i_filter_by_providers
-    then_i_should_see_locations_that_belong_to_all_of_the_selected_providers
+    then_i_should_see_locations_that_belong_to_all_of_the_selected_providers_that_have_more_than_one_site
 
     when_i_clear_the_filters
     when_i_filter_by_a_specific_provider
@@ -70,9 +73,10 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_expect_all_applications_to_be_visible_again
   end
 
-  def then_i_should_see_locations_that_belong_to_all_of_the_selected_providers
+  def then_i_should_see_locations_that_belong_to_all_of_the_selected_providers_that_have_more_than_one_site
     expect(page).to have_content('Locations for Hoth Teacher Training')
     expect(page).to have_content('Locations for Caladan University')
+    expect(page).not_to have_content('Locations for University of Arrakis')
   end
 
   def then_i_should_only_see_locations_that_belog_to_that_provider

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -5,8 +5,10 @@ RSpec.feature 'Providers should be able to filter applications' do
   include DfESignInHelpers
 
   let(:site) { create(:site, name: 'Test site name') }
+  let(:site2) { create(:site, name: 'Second test site') }
+
   let(:current_provider) { create(:provider, :with_signed_agreement, code: 'ABC', name: 'Hoth Teacher Training', sites: [site]) }
-  let(:second_provider) { create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University') }
+  let(:second_provider) { create(:provider, :with_signed_agreement, code: 'DEF', name: 'Caladan University', sites: [site2]) }
   let(:third_provider) { create(:provider, :with_signed_agreement, code: 'GHI', name: 'University of Arrakis') }
   let(:accredited_provider1) { create(:provider, code: 'JKL', name: 'College of Dumbervale') }
   let(:accredited_provider2) { create(:provider, code: 'MNO', name: 'Wimleydown University') }
@@ -38,8 +40,8 @@ RSpec.feature 'Providers should be able to filter applications' do
     when_i_clear_the_filters
     then_i_expect_all_applications_to_be_visible
 
-    when_i_filter_by_provider
-    then_i_location_filters_should_be_visible
+    when_i_filter_by_providers
+    then_location_filters_should_be_visible
     then_i_only_see_applications_for_a_given_provider
     then_i_expect_the_relevant_provider_tags_to_be_visible
 
@@ -53,7 +55,13 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_expect_the_relevant_accredited_provider_tags_to_be_visible
     when_i_click_to_remove_an_accredited_provider_tag
 
-    when_i_filter_by_provider
+    when_i_filter_by_providers
+    then_i_should_see_locations_that_belong_to_all_of_the_selected_providers
+
+    when_i_clear_the_filters
+    when_i_filter_by_a_specific_provider
+    then_i_should_only_see_locations_that_belog_to_that_provider
+
     when_i_filter_by_provider_location
     then_i_only_see_applications_for_that_provider_location
     and_i_expect_the_relevant_provider_location_tags_to_be_visible
@@ -62,11 +70,18 @@ RSpec.feature 'Providers should be able to filter applications' do
     then_i_expect_all_applications_to_be_visible_again
   end
 
-
-  def then_i_location_filters_should_be_visible
-    expect(page).to have_content('Locations for')
+  def then_i_should_see_locations_that_belong_to_all_of_the_selected_providers
+    expect(page).to have_content('Locations for Hoth Teacher Training')
+    expect(page).to have_content('Locations for Caladan University')
   end
 
+  def then_i_should_only_see_locations_that_belog_to_that_provider
+    expect(page).not_to have_content('Locations for Caladan University')
+  end
+
+  def then_location_filters_should_be_visible
+    expect(page).to have_content('Locations for')
+  end
 
   def then_i_location_filters_should_not_be_visible
     expect(page).not_to have_content('Locations for')
@@ -197,9 +212,14 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).to have_css('.app-application-cards', text: 'Declined')
   end
 
-  def when_i_filter_by_provider
+  def when_i_filter_by_providers
     find(:css, "#provider-#{current_provider.id}").set(true)
     find(:css, "#provider-#{second_provider.id}").set(true)
+    click_button('Apply filters')
+  end
+
+  def when_i_filter_by_a_specific_provider
+    find(:css, "#provider-#{current_provider.id}").set(true)
     click_button('Apply filters')
   end
 


### PR DESCRIPTION
## Context

Allows users to filter applications by provider's locations on the provider user interface.

## Changes proposed in this pull request

**Before**
<img width="339" alt="Screenshot 2020-05-22 at 14 52 48" src="https://user-images.githubusercontent.com/13377553/82674935-ebb91400-9c3b-11ea-8aa1-f8394e284779.png">


**After**
<img width="348" alt="Screenshot 2020-05-22 at 14 51 55" src="https://user-images.githubusercontent.com/13377553/82674835-cc21eb80-9c3b-11ea-9566-b8ce3ea2b600.png">

## Guidance to review

- are the tests specific enough?
- to the names make sense to you?
- can you find any bugs in the way that the filter operates, try different combinations etc.
- location filters shouldn't show on the page before a provider is filtered for.
- filters for locations should only appear if their provider organisation is filtered for.

## Link to Trello card

https://trello.com/c/kISeiFeX/2099-build-add-training-location-attribute-to-application-view-list-filter

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)

