### PR TITLE
Completed sections - Fix error links

### DIFF
--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -2,13 +2,14 @@ module CandidateInterface
   class BecomingATeacherReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false)
+    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
       @application_form = application_form
       @becoming_a_teacher_form = CandidateInterface::BecomingATeacherForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
+      @submit_application_attempt = submit_application_attempt
     end
 
     def becoming_a_teacher_form_rows
@@ -16,7 +17,11 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      !@becoming_a_teacher_form.valid? && @editable
+      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+        !@application_form.becoming_a_teacher_completed && @editable
+      else
+        !@becoming_a_teacher_form.valid? && @editable
+      end
     end
 
   private

--- a/app/components/candidate_interface/becoming_a_teacher_review_component.rb
+++ b/app/components/candidate_interface/becoming_a_teacher_review_component.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class BecomingATeacherReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @becoming_a_teacher_form = CandidateInterface::BecomingATeacherForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
-      @submit_application_attempt = submit_application_attempt
+      @submitting_application = submitting_application
     end
 
     def becoming_a_teacher_form_rows
@@ -17,7 +17,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+      if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.becoming_a_teacher_completed && @editable
       else
         !@becoming_a_teacher_form.valid? && @editable

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class ContactDetailsReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false, submit_show: false)
+    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
       @application_form = application_form
       @contact_details_form = CandidateInterface::ContactDetailsForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
-      @submit_show = submit_show
+      @submit_application_attempt = submit_application_attempt
     end
 
     def contact_details_form_rows
@@ -17,7 +17,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.contact_details_completed && @editable
       else
         !@contact_details_form.valid?(:base) && !@contact_details_form.valid?(:address) && @editable

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -2,13 +2,14 @@ module CandidateInterface
   class ContactDetailsReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false)
+    def initialize(application_form:, editable: true, missing_error: false, submit_show: false)
       @application_form = application_form
       @contact_details_form = CandidateInterface::ContactDetailsForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
+      @submit_show = submit_show
     end
 
     def contact_details_form_rows
@@ -16,7 +17,11 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      !@contact_details_form.valid?(:base) && !@contact_details_form.valid?(:address) && @editable
+      if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+        !@application_form.contact_details_completed && @editable
+      else
+        !@contact_details_form.valid?(:base) && !@contact_details_form.valid?(:address) && @editable
+      end
     end
 
   private

--- a/app/components/candidate_interface/contact_details_review_component.rb
+++ b/app/components/candidate_interface/contact_details_review_component.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class ContactDetailsReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @contact_details_form = CandidateInterface::ContactDetailsForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
-      @submit_application_attempt = submit_application_attempt
+      @submitting_application = submitting_application
     end
 
     def contact_details_form_rows
@@ -17,7 +17,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+      if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.contact_details_completed && @editable
       else
         !@contact_details_form.valid?(:base) && !@contact_details_form.valid?(:address) && @editable

--- a/app/components/candidate_interface/gcse_qualification_review_component.html.erb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.html.erb
@@ -1,4 +1,6 @@
-<% if @application_qualification %>
+<% if show_missing_banner? %>
+  <%= render(SectionMissingBannerComponent.new(section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), error: @missing_error)) %>
+<% elsif @application_qualification %>
   <%= render(SummaryCardComponent.new(rows: gcse_qualification_rows, editable: @editable)) do %>
     <% title = if @application_qualification.missing_qualification?
                  t('application_form.gcse.qualification_types.missing')
@@ -7,8 +9,6 @@
                end %>
     <%= render(SummaryCardHeaderComponent.new(title: title, heading_level: @heading_level)) %>
   <% end %>
-<% elsif @editable %>
-  <%= render(SectionMissingBannerComponent.new(section: "#{subject}_gcse", section_path: candidate_interface_gcse_details_edit_type_path(subject: subject.to_sym), error: @missing_error)) %>
 <% else %>
   <p class="govuk-body">No GCSE entered.</p>
 <% end %>

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -1,13 +1,13 @@
 module CandidateInterface
   class GcseQualificationReviewComponent < ViewComponent::Base
-    def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submit_application_attempt: false)
+    def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submitting_application: false)
       @application_form = application_form
       @application_qualification = application_qualification
       @subject = subject
       @editable = editable
       @heading_level = heading_level
       @missing_error = missing_error
-      @submit_application_attempt = submit_application_attempt
+      @submitting_application = submitting_application
     end
 
     def gcse_qualification_rows
@@ -24,7 +24,7 @@ module CandidateInterface
 
     def show_missing_banner?
       gcse_completed = "#{@subject}_gcse_completed"
-      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+      if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.send(gcse_completed) && @editable
       else
         @editable && !@application_qualification

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -1,13 +1,13 @@
 module CandidateInterface
   class GcseQualificationReviewComponent < ViewComponent::Base
-    def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submit_show: false)
+    def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submit_application_attempt: false)
       @application_form = application_form
       @application_qualification = application_qualification
       @subject = subject
       @editable = editable
       @heading_level = heading_level
       @missing_error = missing_error
-      @submit_show = submit_show
+      @submit_application_attempt = submit_application_attempt
     end
 
     def gcse_qualification_rows
@@ -24,7 +24,7 @@ module CandidateInterface
 
     def show_missing_banner?
       gcse_completed = "#{@subject}_gcse_completed"
-      if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.send(gcse_completed) && @editable
       else
         @editable && !@application_qualification

--- a/app/components/candidate_interface/gcse_qualification_review_component.rb
+++ b/app/components/candidate_interface/gcse_qualification_review_component.rb
@@ -1,11 +1,13 @@
 module CandidateInterface
   class GcseQualificationReviewComponent < ViewComponent::Base
-    def initialize(application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false)
+    def initialize(application_form:, application_qualification:, subject:, editable: true, heading_level: 2, missing_error: false, submit_show: false)
+      @application_form = application_form
       @application_qualification = application_qualification
       @subject = subject
       @editable = editable
       @heading_level = heading_level
       @missing_error = missing_error
+      @submit_show = submit_show
     end
 
     def gcse_qualification_rows
@@ -17,6 +19,15 @@ module CandidateInterface
           award_year_row,
           grade_row,
         ]
+      end
+    end
+
+    def show_missing_banner?
+      gcse_completed = "#{@subject}_gcse_completed"
+      if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+        !@application_form.send(gcse_completed) && @editable
+      else
+        @editable && !@application_qualification
       end
     end
 

--- a/app/components/candidate_interface/interview_preferences_review_component.rb
+++ b/app/components/candidate_interface/interview_preferences_review_component.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class InterviewPreferencesReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @interview_preferences_form = CandidateInterface::InterviewPreferencesForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
-      @submit_application_attempt = submit_application_attempt
+      @submitting_application = submitting_application
     end
 
     def interview_preferences_form_rows
@@ -17,7 +17,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+      if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.interview_preferences_completed && @editable
       else
         !@interview_preferences_form.valid? && @editable

--- a/app/components/candidate_interface/interview_preferences_review_component.rb
+++ b/app/components/candidate_interface/interview_preferences_review_component.rb
@@ -2,13 +2,14 @@ module CandidateInterface
   class InterviewPreferencesReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false)
+    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
       @application_form = application_form
       @interview_preferences_form = CandidateInterface::InterviewPreferencesForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
+      @submit_application_attempt = submit_application_attempt
     end
 
     def interview_preferences_form_rows
@@ -16,7 +17,11 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      !@interview_preferences_form.valid? && @editable
+      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+        !@application_form.interview_preferences_completed && @editable
+      else
+        !@interview_preferences_form.valid? && @editable
+      end
     end
 
   private

--- a/app/components/candidate_interface/other_information.html.erb
+++ b/app/components/candidate_interface/other_information.html.erb
@@ -1,0 +1,6 @@
+<%= render 'survey_page',
+  title: t('page_titles.other_information'),
+  url: candidate_interface_satisfaction_survey_submit_other_information_path,
+  previous_url: candidate_interface_satisfaction_survey_improvements_path,
+  five_radio_buttons: false,
+  text_area: true %>

--- a/app/components/candidate_interface/personal_details_review_component.html.erb
+++ b/app/components/candidate_interface/personal_details_review_component.html.erb
@@ -1,7 +1,5 @@
-<% if @personal_details_form.valid? %>
-  <%= render(SummaryCardComponent.new(rows: rows, editable: @editable)) %>
-<% elsif @editable %>
+<% if show_missing_banner? %>
   <%= render(SectionMissingBannerComponent.new(section: :personal_details, section_path: candidate_interface_personal_details_edit_path, error: @missing_error)) %>
 <% else %>
-  <p class="govuk-body">No personal details entered.</p>
+  <%= render(SummaryCardComponent.new(rows: rows, editable: @editable)) %>
 <% end %>

--- a/app/components/candidate_interface/personal_details_review_component.rb
+++ b/app/components/candidate_interface/personal_details_review_component.rb
@@ -17,6 +17,14 @@ module CandidateInterface
         .rows
     end
 
+    def show_missing_banner?
+      if FeatureFlag.active?('mark_every_section_complete')
+        @editable && !@application_form.personal_details_completed
+      else
+        !@personal_details_form.valid?
+      end
+    end
+
   private
 
     attr_reader :application_form

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -2,13 +2,13 @@ module CandidateInterface
   class RefereesReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, submit_application_attempt: false)
+    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, submitting_application: false)
       @application_form = application_form
       @editable = editable
       @heading_level = heading_level
       @show_incomplete = show_incomplete
       @missing_error = missing_error
-      @submit_application_attempt = submit_application_attempt
+      @submitting_application = submitting_application
     end
 
     def referee_rows(referee)
@@ -26,7 +26,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+      if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.references_completed && @editable
       else
         @show_incomplete && @application_form.application_references.count < minimum_references && @editable

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -2,12 +2,13 @@ module CandidateInterface
   class RefereesReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
+    def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false, submit_application_attempt: false)
       @application_form = application_form
       @editable = editable
       @heading_level = heading_level
       @show_incomplete = show_incomplete
       @missing_error = missing_error
+      @submit_application_attempt = submit_application_attempt
     end
 
     def referee_rows(referee)
@@ -25,7 +26,11 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      @show_incomplete && @application_form.application_references.count < minimum_references && @editable
+      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+        !@application_form.references_completed && @editable
+      else
+        @show_incomplete && @application_form.application_references.count < minimum_references && @editable
+      end
     end
 
   private

--- a/app/components/candidate_interface/subject_knowledge_review_component.rb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.rb
@@ -2,13 +2,14 @@ module CandidateInterface
   class SubjectKnowledgeReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false)
+    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
       @application_form = application_form
       @subject_knowledge_form = CandidateInterface::SubjectKnowledgeForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
+      @submit_application_attempt = submit_application_attempt
     end
 
     def subject_knowledge_form_rows
@@ -16,7 +17,11 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      !@subject_knowledge_form.valid? && @editable
+      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+        !@application_form.subject_knowledge_completed && @editable
+      else
+        !@subject_knowledge_form.valid? && @editable
+      end
     end
 
   private

--- a/app/components/candidate_interface/subject_knowledge_review_component.rb
+++ b/app/components/candidate_interface/subject_knowledge_review_component.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class SubjectKnowledgeReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @subject_knowledge_form = CandidateInterface::SubjectKnowledgeForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
-      @submit_application_attempt = submit_application_attempt
+      @submitting_application = submitting_application
     end
 
     def subject_knowledge_form_rows
@@ -17,7 +17,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+      if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.subject_knowledge_completed && @editable
       else
         !@subject_knowledge_form.valid? && @editable

--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class TrainingWithADisabilityReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
+    def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
       @application_form = application_form
       @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
-      @submit_application_attempt = submit_application_attempt
+      @submitting_application = submitting_application
     end
 
     def training_with_a_disability_form_rows
@@ -20,7 +20,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+      if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.training_with_a_disability_completed && @editable
       else
         !@training_with_a_disability_form.valid? && @editable

--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -2,13 +2,14 @@ module CandidateInterface
   class TrainingWithADisabilityReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false)
+    def initialize(application_form:, editable: true, missing_error: false, submit_show: false)
       @application_form = application_form
       @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
+      @submit_show = submit_show
     end
 
     def training_with_a_disability_form_rows
@@ -19,7 +20,11 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      !@training_with_a_disability_form.valid? && @editable
+      if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+        !@application_form.training_with_a_disability_completed && @editable
+      else
+        !@training_with_a_disability_form.valid? && @editable
+      end
     end
 
   private

--- a/app/components/candidate_interface/training_with_a_disability_review_component.rb
+++ b/app/components/candidate_interface/training_with_a_disability_review_component.rb
@@ -2,14 +2,14 @@ module CandidateInterface
   class TrainingWithADisabilityReviewComponent < ViewComponent::Base
     validates :application_form, presence: true
 
-    def initialize(application_form:, editable: true, missing_error: false, submit_show: false)
+    def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
       @application_form = application_form
       @training_with_a_disability_form = CandidateInterface::TrainingWithADisabilityForm.build_from_application(
         @application_form,
       )
       @editable = editable
       @missing_error = missing_error
-      @submit_show = submit_show
+      @submit_application_attempt = submit_application_attempt
     end
 
     def training_with_a_disability_form_rows
@@ -20,7 +20,7 @@ module CandidateInterface
     end
 
     def show_missing_banner?
-      if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+      if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
         !@application_form.training_with_a_disability_completed && @editable
       else
         !@training_with_a_disability_form.valid? && @editable

--- a/app/components/safeguarding_review_component.rb
+++ b/app/components/safeguarding_review_component.rb
@@ -1,10 +1,10 @@
 class SafeguardingReviewComponent < ViewComponent::Base
-  def initialize(application_form:, editable: true, missing_error: false, submit_show: false)
+  def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
     @application_form = application_form
     @safeguarding = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
     @editable = editable
     @missing_error = missing_error
-    @submit_show = submit_show
+    @submit_application_attempt = submit_application_attempt
   end
 
   def safeguarding_rows
@@ -12,7 +12,7 @@ class SafeguardingReviewComponent < ViewComponent::Base
   end
 
   def show_missing_banner?
-    if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+    if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
       !@application_form.safeguarding_issues_completed && @editable
     else
       !@safeguarding.valid? && @editable

--- a/app/components/safeguarding_review_component.rb
+++ b/app/components/safeguarding_review_component.rb
@@ -1,10 +1,10 @@
 class SafeguardingReviewComponent < ViewComponent::Base
-  def initialize(application_form:, editable: true, missing_error: false, submit_application_attempt: false)
+  def initialize(application_form:, editable: true, missing_error: false, submitting_application: false)
     @application_form = application_form
     @safeguarding = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
     @editable = editable
     @missing_error = missing_error
-    @submit_application_attempt = submit_application_attempt
+    @submitting_application = submitting_application
   end
 
   def safeguarding_rows
@@ -12,7 +12,7 @@ class SafeguardingReviewComponent < ViewComponent::Base
   end
 
   def show_missing_banner?
-    if @submit_application_attempt && FeatureFlag.active?('mark_every_section_complete')
+    if @submitting_application && FeatureFlag.active?('mark_every_section_complete')
       !@application_form.safeguarding_issues_completed && @editable
     else
       !@safeguarding.valid? && @editable

--- a/app/components/safeguarding_review_component.rb
+++ b/app/components/safeguarding_review_component.rb
@@ -1,8 +1,10 @@
 class SafeguardingReviewComponent < ViewComponent::Base
-  def initialize(application_form:, editable: true, missing_error: false)
+  def initialize(application_form:, editable: true, missing_error: false, submit_show: false)
+    @application_form = application_form
     @safeguarding = CandidateInterface::SafeguardingIssuesDeclarationForm.build_from_application(application_form)
     @editable = editable
     @missing_error = missing_error
+    @submit_show = submit_show
   end
 
   def safeguarding_rows
@@ -10,7 +12,11 @@ class SafeguardingReviewComponent < ViewComponent::Base
   end
 
   def show_missing_banner?
-    !@safeguarding.valid? && @editable
+    if @submit_show && FeatureFlag.active?('mark_every_section_complete')
+      !@application_form.safeguarding_issues_completed && @editable
+    else
+      !@safeguarding.valid? && @editable
+    end
   end
 
 private

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -26,7 +26,7 @@
 
 <h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
 
-<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_show: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -67,7 +67,7 @@
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
 
 <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
-<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
 <%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -38,7 +38,7 @@
 
 <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
 
-<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_show: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -22,7 +22,7 @@
 
 <h3 class="govuk-heading-m">Contact details</h3>
 
-<%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_show: true)) %>
 
 <h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -22,11 +22,11 @@
 
 <h3 class="govuk-heading-m">Contact details</h3>
 
-<%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
+<%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
 <h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
 
-<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
+<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 
@@ -38,7 +38,7 @@
 
 <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
 
-<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
+<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
@@ -48,16 +48,16 @@
 
 <h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error, submit_application_attempt: true)) %>
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
 <h3 class="govuk-heading-m">English GCSE or equivalent</h3>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submit_application_attempt: true)) %>
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 
 <% if @application_form.science_gcse_needed? %>
   <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
 
-  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submit_application_attempt: true)) %>
+  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submitting_application: true)) %>
 <% end %>
 
 <h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>
@@ -66,10 +66,10 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
 
-<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
-<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
-<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
+<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
+<%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
+<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submitting_application: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 
-<%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error, submit_application_attempt: true)) %>
+<%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error, submitting_application: true)) %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -72,4 +72,4 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 
-<%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error)) %>
+<%= render(CandidateInterface::RefereesReviewComponent.new(application_form: application_form, editable: editable, heading_level: 3, show_incomplete: true, missing_error: missing_error, submit_application_attempt: true)) %>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -48,16 +48,16 @@
 
 <h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error)) %>
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error, submit_show: true)) %>
 
 <h3 class="govuk-heading-m">English GCSE or equivalent</h3>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error)) %>
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submit_show: true)) %>
 
 <% if @application_form.science_gcse_needed? %>
   <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
 
-  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error)) %>
+  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submit_show: true)) %>
 <% end %>
 
 <h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -66,7 +66,7 @@
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Personal statement and interview</h2>
 
-<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
 <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
 <%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
 

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -22,11 +22,11 @@
 
 <h3 class="govuk-heading-m">Contact details</h3>
 
-<%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_show: true)) %>
+<%= render(CandidateInterface::ContactDetailsReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
 
 <h3 class="govuk-heading-m">Asking for support if you have a disability</h3>
 
-<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_show: true)) %>
+<%= render(CandidateInterface::TrainingWithADisabilityReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Work history</h2>
 
@@ -38,7 +38,7 @@
 
 <h3 class="govuk-heading-m"><%= t('page_titles.suitability_to_work_with_children') %></h3>
 
-<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_show: true)) %>
+<%= render(SafeguardingReviewComponent.new(application_form: @application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">Qualifications</h2>
 
@@ -48,16 +48,16 @@
 
 <h3 class="govuk-heading-m">Maths GCSE or equivalent</h3>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error, submit_show: true)) %>
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.maths_gcse, subject: 'maths', editable: editable, heading_level: 4, missing_error: missing_error, submit_application_attempt: true)) %>
 
 <h3 class="govuk-heading-m">English GCSE or equivalent</h3>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submit_show: true)) %>
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.english_gcse, subject: 'english', editable: editable, heading_level: 4, missing_error: missing_error, submit_application_attempt: true)) %>
 
 <% if @application_form.science_gcse_needed? %>
   <h3 class="govuk-heading-m">Science GCSE or equivalent</h3>
 
-  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submit_show: true)) %>
+  <%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_form.science_gcse, subject: 'science', editable: editable, heading_level: 4, missing_error: missing_error, submit_application_attempt: true)) %>
 <% end %>
 
 <h3 class="govuk-heading-m">Academic and other relevant qualifications</h3>

--- a/app/views/candidate_interface/application_form/_review.html.erb
+++ b/app/views/candidate_interface/application_form/_review.html.erb
@@ -68,7 +68,7 @@
 
 <%= render(CandidateInterface::BecomingATeacherReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
 <%= render(CandidateInterface::SubjectKnowledgeReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
-<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error)) %>
+<%= render(CandidateInterface::InterviewPreferencesReviewComponent.new(application_form: application_form, editable: editable, missing_error: missing_error, submit_application_attempt: true)) %>
 
 <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
 

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -3,7 +3,7 @@
 
 <h1 class="govuk-heading-xl"><%= t("gcse_summary.page_titles.#{@subject}") %></h1>
 
-<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_qualification: @application_qualification, subject: @subject)) %>
+<%= render(CandidateInterface::GcseQualificationReviewComponent.new(application_form: @application_form, application_qualification: @application_qualification, subject: @subject, )) %>
 
 <% if FeatureFlag.active?('mark_every_section_complete') %>
  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,

--- a/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
+++ b/spec/components/candidate_interface/gcse_qualification_review_component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CandidateInterface::GcseQualificationReviewComponent do
       grade: 'c',
     )
     result = render_inline(
-      described_class.new(application_qualification: application_qualification, subject: 'maths'),
+      described_class.new(application_form: application_form, application_qualification: application_qualification, subject: 'maths'),
     )
 
     expect(result.text).to match(/Qualification\s+GCSE/)


### PR DESCRIPTION
## Context

Currently, when you go on the submit show page and try and submit an incomplete application you receive errors asking you to complete the section.

When you click on the link it should direct you to that section of the page so you can click on complete the section. 

This is not working

## Changes proposed in this pull request

- If the feature flag is active and the relevant component is called from the submit_show page. Use the application_form_presenter complete logic for the link.
- If the component is called in any other context. Use the previous section completed validations. e.g. for contact details check the number and address are valid/completed.

## Guidance to review

- Create a new application, try and submit it with the flag on and off. Do the links work?

## Link to Trello card

https://trello.com/c/2YtoBPNB/1425-explicitly-mark-all-sections-as-complete

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
