### PR TITLE
Complete sections - fix checkbox related behaviour 

### DIFF
--- a/app/controllers/candidate_interface/gcse/review_controller.rb
+++ b/app/controllers/candidate_interface/gcse/review_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class Gcse::ReviewController < Gcse::DetailsController
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
+    before_action :set_field_name
 
     def show
       @application_form = current_application
@@ -9,9 +10,20 @@ module CandidateInterface
     end
 
     def complete
-      update_gcse_completed(params.dig('application_form', 'gcse_completed'))
+      current_application.update!(application_form_params)
 
       redirect_to candidate_interface_application_form_path
+    end
+
+  private
+
+    def set_field_name
+      @field_name = "#{@subject}_gcse_completed"
+    end
+
+    def application_form_params
+      params.require(:application_form).permit(@field_name)
+        .transform_values(&:strip)
     end
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -45,6 +45,7 @@ class TestApplications
         volunteering_experiences_count: 1,
         references_count: 2,
         with_gces: true,
+        with_degree: true,
         submitted_at: nil,
         candidate: candidate,
         first_name: first_name,

--- a/app/views/candidate_interface/gcse/review/show.html.erb
+++ b/app/views/candidate_interface/gcse/review/show.html.erb
@@ -9,7 +9,7 @@
  <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
                                          path: candidate_interface_gcse_complete_path,
                                          request_method: :post,
-                                         field_name: :gcse_completed)) %>
+                                         field_name: @field_name)) %>
 <% else %>
   <%= govuk_button_link_to 'Continue', candidate_interface_application_form_path %>
 <% end %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -70,6 +70,7 @@ FactoryBot.define do
         references_state { :requested }
         with_gces { false }
         full_work_history { false }
+        with_degree { false }
       end
 
       trait :with_completed_references do
@@ -119,6 +120,10 @@ FactoryBot.define do
           create(:gcse_qualification, application_form: application_form, subject: 'maths')
           create(:gcse_qualification, application_form: application_form, subject: 'english')
           create(:gcse_qualification, application_form: application_form, subject: 'science')
+        end
+
+        if evaluator.with_degree
+          create(:degree_qualification, application_form: application_form)
         end
 
         edit_by = if application_form.submitted_at.nil?


### PR DESCRIPTION
## Context

There are two bugs fixed in this PR.

The first can be seen in the clip in the comment in the trello card. It was actually a pre-existing bug. A test application has the degree section completed by default, but an actual application_qualification is not created. This means if you click on the degree section and try and continue/submit the completed form checkbox you hit a validation, checking for the presence of a degree.

This is actually desirable behaviour so i think the easiest fix is just to create a degree as part of a test application. 

The second bug is that the GCSE sections do not default to being checked when they have previously been completed. 

## Changes proposed in this pull request

- When a test application is generated, create a degree and associate it with the application form
- Check the complete section checkbox if the section is marked as complete

## Link to Trello card

https://trello.com/c/2YtoBPNB/1425-explicitly-mark-all-sections-as-complete

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
