### PR TITLE
Ensure completed section booleans are updated with the flag off

### DIFF
--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -1,8 +1,5 @@
 module CandidateInterface
   class ContactDetails::AddressController < ContactDetails::BaseController
-    before_action :redirect_to_dashboard_if_submitted
-    after_action :complete_section, only: %i[update]
-
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
         current_application,

--- a/app/controllers/candidate_interface/contact_details/address_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/address_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
-  class ContactDetails::AddressController < CandidateInterfaceController
+  class ContactDetails::AddressController < ContactDetails::BaseController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(

--- a/app/controllers/candidate_interface/contact_details/base_controller.rb
+++ b/app/controllers/candidate_interface/contact_details/base_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class ContactDetails::BaseController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def edit
       @contact_details_form = ContactDetailsForm.build_from_application(
@@ -34,6 +35,14 @@ module CandidateInterface
     def contact_details_params
       params.require(:candidate_interface_contact_details_form).permit(:phone_number)
         .transform_values(&:strip)
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.contact_details_completed? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(contact_details_completed: true)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -32,5 +32,13 @@ module CandidateInterface
       attribute_to_update = "#{@subject}_gcse_completed"
       current_application.update!("#{attribute_to_update}": value)
     end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.gcse_completed(current_application.send("#{@subject}_gcse")) && !FeatureFlag.active?('mark_every_section_complete')
+        update_gcse_completed(true)
+      end
+    end
   end
 end

--- a/app/controllers/candidate_interface/gcse/details_controller.rb
+++ b/app/controllers/candidate_interface/gcse/details_controller.rb
@@ -36,7 +36,7 @@ module CandidateInterface
     def complete_section
       presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
 
-      if presenter.gcse_completed(current_application.send("#{@subject}_gcse")) && !FeatureFlag.active?('mark_every_section_complete')
+      if presenter.send("#{@subject}_gcse_completed?") && !FeatureFlag.active?('mark_every_section_complete')
         update_gcse_completed(true)
       end
     end

--- a/app/controllers/candidate_interface/gcse/grade_controller.rb
+++ b/app/controllers/candidate_interface/gcse/grade_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class Gcse::GradeController < Gcse::DetailsController
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
+    after_action :complete_section, only: %i[update]
 
     def update
       @qualification_type = details_form.qualification.qualification_type

--- a/app/controllers/candidate_interface/gcse/type_controller.rb
+++ b/app/controllers/candidate_interface/gcse/type_controller.rb
@@ -2,6 +2,7 @@ module CandidateInterface
   class Gcse::TypeController < Gcse::DetailsController
     before_action :redirect_to_dashboard_if_submitted
     before_action :set_subject
+    after_action :complete_section, only: %i[update]
 
     # 1st step - Edit qualification type
     def edit

--- a/app/controllers/candidate_interface/gcse/year_controller.rb
+++ b/app/controllers/candidate_interface/gcse/year_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class Gcse::YearController < Gcse::DetailsController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def update
       @qualification_type = details_form.qualification.qualification_type

--- a/app/controllers/candidate_interface/personal_details_controller.rb
+++ b/app/controllers/candidate_interface/personal_details_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class PersonalDetailsController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def edit
       @personal_details_form = PersonalDetailsForm.build_from_application(current_application)
@@ -58,6 +59,14 @@ module CandidateInterface
       when 'date_of_birth(2i)' then 'month'
       when 'date_of_birth(1i)' then 'year'
       else key
+      end
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.personal_details_completed? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(personal_details_completed: true)
       end
     end
   end

--- a/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/becoming_a_teacher_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class PersonalStatement::BecomingATeacherController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def edit
       @becoming_a_teacher_form = BecomingATeacherForm.build_from_application(
@@ -43,6 +44,14 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:becoming_a_teacher_completed)
         .transform_values(&:strip)
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.becoming_a_teacher_completed? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(becoming_a_teacher_completed: true)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/interview_preferences_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class PersonalStatement::InterviewPreferencesController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def edit
       @interview_preferences_form = InterviewPreferencesForm.build_from_application(
@@ -43,6 +44,14 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:interview_preferences_completed)
         .transform_values(&:strip)
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.interview_preferences_completed? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(interview_preferences_completed: true)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
+++ b/app/controllers/candidate_interface/personal_statement/subject_knowledge_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class PersonalStatement::SubjectKnowledgeController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def edit
       @subject_knowledge_form = SubjectKnowledgeForm.build_from_application(
@@ -49,6 +50,14 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:subject_knowledge_completed)
         .transform_values(&:strip)
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.subject_knowledge_completed? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(subject_knowledge_completed: true)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -174,7 +174,7 @@ module CandidateInterface
         .transform_values(&:strip)
     end
 
-    def complete_section
+    def set_section_to_complete_or_incomplete
       presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
 
       if presenter.all_referees_provided_by_candidate? && !FeatureFlag.active?('mark_every_section_complete')

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -4,6 +4,7 @@ module CandidateInterface
     before_action :set_referee, only: %i[edit update confirm_destroy destroy confirm_cancel cancel]
     before_action :set_referees, only: %i[type update_type new create index review]
     before_action :set_nth_referee, only: %i[type new]
+    after_action :set_section_to_complete_or_incomplete, only: %i[update_type create update destroy]
 
     def index
       if @referees.empty?
@@ -171,6 +172,16 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:references_completed)
         .transform_values(&:strip)
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.all_referees_provided_by_candidate? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(references_completed: true)
+      elsif !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(references_completed: false)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/safeguarding_controller.rb
+++ b/app/controllers/candidate_interface/safeguarding_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class SafeguardingController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def show
       @application_form = current_application
@@ -38,6 +39,14 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:safeguarding_issues_completed)
         .transform_values(&:strip)
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.safeguarding_completed? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(safeguarding_issues_completed: true)
+      end
     end
   end
 end

--- a/app/controllers/candidate_interface/training_with_a_disability_controller.rb
+++ b/app/controllers/candidate_interface/training_with_a_disability_controller.rb
@@ -1,6 +1,7 @@
 module CandidateInterface
   class TrainingWithADisabilityController < CandidateInterfaceController
     before_action :redirect_to_dashboard_if_submitted
+    after_action :complete_section, only: %i[update]
 
     def edit
       @training_with_a_disability_form = TrainingWithADisabilityForm.build_from_application(
@@ -46,6 +47,14 @@ module CandidateInterface
     def application_form_params
       params.require(:application_form).permit(:training_with_a_disability_completed)
         .transform_values(&:strip)
+    end
+
+    def complete_section
+      presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
+
+      if presenter.training_with_a_disability_completed? && !FeatureFlag.active?('mark_every_section_complete')
+        current_application.update!(training_with_a_disability_completed: true)
+      end
     end
   end
 end

--- a/spec/system/candidate_interface/candidate_completes_application_with_mark_every_section_complete_flag_off_spec.rb
+++ b/spec/system/candidate_interface/candidate_completes_application_with_mark_every_section_complete_flag_off_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'candidate fills in application' do
+  include CandidateHelper
+
+  scenario 'with mark_every_section_complete flag on it updates the relevant section completed booleans' do
+    given_i_am_signed_in
+    and_i_have_completed_my_application
+    then_the_section_completed_booleans_for_each_section_are_set_to_true
+  end
+
+  def given_i_am_signed_in
+    create_and_sign_in_candidate
+  end
+
+  def when_i_visit_the_application_page
+    visit candidate_interface_application_form_path
+  end
+
+  def and_i_have_completed_my_application
+    candidate_completes_application_form
+  end
+
+  def then_the_section_completed_booleans_for_each_section_are_set_to_true
+    application_form = ApplicationForm.first
+    expect(application_form.personal_details_completed).to be_truthy
+    expect(application_form.contact_details_completed).to be_truthy
+    expect(application_form.maths_gcse_completed).to be_truthy
+    expect(application_form.english_gcse_completed).to be_truthy
+    expect(application_form.science_gcse_completed).to be_truthy
+    expect(application_form.training_with_a_disability_completed).to be_truthy
+    expect(application_form.safeguarding_issues_completed).to be_truthy
+    expect(application_form.becoming_a_teacher_completed).to be_truthy
+    expect(application_form.subject_knowledge_completed).to be_truthy
+    expect(application_form.interview_preferences_completed).to be_truthy
+    expect(application_form.references_completed).to be_truthy
+  end
+end


### PR DESCRIPTION
## Context

When the `mark_section_as_complete` feature flag is off, the section completed booleans should still be updated.

## Changes proposed in this pull request

- Change the `completed_section_component` to always update the section to true when a user clicks continue without being presented with a checkbox.

## Guidance to review

None really 

## Link to Trello card

https://trello.com/c/2YtoBPNB/1425-explicitly-mark-all-sections-as-complete

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
