### PR TITLE
reapply Gemfile.lock updates with correct rack version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     benchmark-malloc (0.2.0)
     benchmark-perf (0.6.0)
     benchmark-trend (0.4.0)
-    bindata (2.4.4)
+    bindata (2.4.7)
     bindex (0.8.1)
     brakeman (4.8.2)
     builder (3.2.4)
@@ -281,14 +281,14 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
-    omniauth_openid_connect (0.3.3)
+    omniauth_openid_connect (0.3.4)
       addressable (~> 2.5)
       omniauth (~> 1.9)
       openid_connect (~> 1.1)
     openapi3_parser (0.8.1)
       commonmarker (~> 0.17)
       psych (~> 3.1)
-    openid_connect (1.1.8)
+    openid_connect (1.2.0)
       activemodel
       attr_required (>= 1.0.0)
       json-jwt (>= 1.5.0)
@@ -317,12 +317,12 @@ GEM
     puma (4.3.4)
       nio4r (~> 2.0)
     rack (2.2.2)
-    rack-oauth2 (1.10.0)
+    rack-oauth2 (1.14.0)
       activesupport
       attr_required
       httpclient
-      json-jwt (>= 1.9.0)
-      rack
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
     rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
@@ -462,7 +462,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    swd (1.1.2)
+    swd (1.2.0)
       activesupport (>= 3)
       attr_required (>= 0.0.5)
       httpclient (>= 2.4)
@@ -480,7 +480,7 @@ GEM
     validate_email (0.1.6)
       activemodel (>= 3.0)
       mail (>= 2.2.5)
-    validate_url (1.0.8)
+    validate_url (1.0.11)
       activemodel (>= 3.0.0)
       public_suffix
     view_component (2.7.0)


### PR DESCRIPTION
PR 2127 has applied a wrong verion of rack because of dependency on
rack-ouaut2.
Set correct version for rack and reapply other changes in the above PR.

## Context
#2127 was reverted as it broke the application.

## Changes proposed in this pull request

Reapply changes in 2127 and set correct rack version

## Guidance to review


## Link to Trello card


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
