### PR TITLE
Send application to provider immediately when applying again

### DIFF
--- a/spec/services/submit_application_choice_spec.rb
+++ b/spec/services/submit_application_choice_spec.rb
@@ -47,19 +47,16 @@ RSpec.describe SubmitApplicationChoice do
     end
   end
 
-  describe 'Submit an Apply Again application choice' do
+  describe 'Submit an application choice to the provider immediately' do
     let(:submit_application_choice) do
       SubmitApplicationChoice.new(
         application_choice,
-        apply_again: apply_again,
-        enough_references: enough_references,
+        send_to_provider_immediately: send_to_provider_immediately,
       ).call
     end
 
-    let(:apply_again) { true }
-
     context 'and enough references have been provided' do
-      let(:enough_references) { true }
+      let(:send_to_provider_immediately) { true }
 
       it 'sets the edit_by timestamp to now' do
         submit_application_choice
@@ -70,12 +67,12 @@ RSpec.describe SubmitApplicationChoice do
       it 'updates the application choice state to Application Complete' do
         submit_application_choice
 
-        expect(application_choice).to be_application_complete
+        expect(application_choice).to be_awaiting_provider_decision
       end
     end
 
     context 'and not enough references have been provided' do
-      let(:enough_references) { false }
+      let(:send_to_provider_immediately) { false }
 
       it 'updates the application choice to Awaiting References' do
         submit_application_choice

--- a/spec/services/submit_application_spec.rb
+++ b/spec/services/submit_application_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe SubmitApplication do
     context 'when application is Apply Again' do
       before { FeatureFlag.activate('apply_again') }
 
-      it 'progresses status to `application_complete`' do
+      it 'progresses status to `awaiting_provider_decision`' do
         original_application_form = create_application_form
 
         original_application_form.application_references << build(:reference, email_address: 'bob@example.com', feedback_status: :feedback_provided)
@@ -79,7 +79,7 @@ RSpec.describe SubmitApplication do
         SubmitApplication.new(application_form).call
 
         application_form.application_choices.reload
-        expect(application_form.application_choices[0]).to be_application_complete
+        expect(application_form.application_choices[0]).to be_awaiting_provider_decision
       end
     end
   end

--- a/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_with_unsuccessful_application_applies_again_spec.rb
@@ -25,8 +25,8 @@ RSpec.feature 'Candidate with unsuccessful application' do
     and_i_can_indeed_only_select_one_course
 
     when_i_complete_my_application
-    then_my_application_is_submitted
-    and_my_application_is_ready_to_send_to_the_provider
+    then_my_application_is_submitted_and_sent_to_the_provider
+    and_i_receive_an_email_that_my_application_has_been_sent
     and_i_do_not_see_referee_related_guidance
     and_there_is_no_guidance_on_editing_my_application
 
@@ -126,14 +126,16 @@ RSpec.feature 'Candidate with unsuccessful application' do
     candidate_submits_application
   end
 
-  def then_my_application_is_submitted
+  def then_my_application_is_submitted_and_sent_to_the_provider
     expect(page).to have_content 'Application successfully submitted'
     @apply_again_choice = ApplicationForm.last.application_choices.first
-    expect(@apply_again_choice.status).to eq 'application_complete'
+    expect(@apply_again_choice.status).to eq 'awaiting_provider_decision'
+    expect(@apply_again_choice.edit_by.to_date).to eq Time.zone.today
   end
 
-  def and_my_application_is_ready_to_send_to_the_provider
-    expect(@apply_again_choice.edit_by.to_date).to eq Time.zone.today
+  def and_i_receive_an_email_that_my_application_has_been_sent
+    open_email(@candidate.email_address)
+    expect(current_email.subject).to have_content t('candidate_mailer.application_sent_to_provider.subject')
   end
 
   def and_i_do_not_see_referee_related_guidance


### PR DESCRIPTION
## Context

We need to send applications off to providers as soon as they are submitted when users apply again.

## Changes proposed in this pull request

Add an option to the SubmitApplicationChoice service that allows us to immediately send off an application choice.

## Guidance to review

Does this make sense? I will reuse this in another PR about allowing support users to add applications to forms that are in the "awaiting provider decision" state.

## Link to Trello card

https://trello.com/c/azfEJqBy/1593-dev-send-apply-again-application-straight-away-mvp

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)