### PR TITLE
Allow support users to add courses when awaiting_provider_decision

### DIFF
--- a/app/models/support_interface/add_course_to_application_form.rb
+++ b/app/models/support_interface/add_course_to_application_form.rb
@@ -49,7 +49,7 @@ module SupportInterface
     def application_form_in_correct_state
       return if awaiting_references? || awaiting_provider_decision?
 
-      errors[:base] << 'You can only add a course to an application that has at least 1 other application choice in the "awaiting references" state.'
+      errors[:base] << 'You can only add a course to an application that has at least 1 other application choice in the "awaiting references" or "awaiting_provider_decision" state.'
     end
   end
 end

--- a/app/models/support_interface/add_course_to_application_form.rb
+++ b/app/models/support_interface/add_course_to_application_form.rb
@@ -15,7 +15,10 @@ module SupportInterface
         status: 'unsubmitted',
       )
 
-      SubmitApplicationChoice.new(application_choice).call
+      SubmitApplicationChoice.new(
+        application_choice,
+        send_to_provider_immediately: awaiting_provider_decision?,
+      ).call
     end
 
   private
@@ -32,11 +35,19 @@ module SupportInterface
       errors[:base] << "There's no course option with ID #{course_option_id}"
     end
 
+    def awaiting_references?
+      application_form.application_choices.any?(&:awaiting_references?)
+    end
+
+    def awaiting_provider_decision?
+      application_form.application_choices.any?(&:awaiting_provider_decision?)
+    end
+
     # For simplicity we only support adding applications to forms that are in
-    # "Awaiting references" state, because we need to add the choices in the
-    # same state as other applications.
+    # "Awaiting references" or "Awaiting provider decision" state, because we
+    # need to add the choices in the same state as other applications.
     def application_form_in_correct_state
-      return if application_form.application_choices.any?(&:awaiting_references?)
+      return if awaiting_references? || awaiting_provider_decision?
 
       errors[:base] << 'You can only add a course to an application that has at least 1 other application choice in the "awaiting references" state.'
     end

--- a/app/views/support_interface/application_forms/show.html.erb
+++ b/app/views/support_interface/application_forms/show.html.erb
@@ -40,7 +40,7 @@
   <% end %>
 <% end %>
 
-<% if @application_form.application_choices.any?(&:awaiting_references?) %>
+<% if @application_form.application_choices.any?(&:awaiting_references?) || @application_form.application_choices.any?(&:awaiting_provider_decision?) %>
 <div class='govuk-body'>
   <%= govuk_button_link_to 'Add or withdraw course choices', support_interface_change_course_path(@application_form) %>
 </div>

--- a/spec/system/support_interface/change_courses/add_another_course_spec.rb
+++ b/spec/system/support_interface/change_courses/add_another_course_spec.rb
@@ -14,6 +14,15 @@ RSpec.feature 'Add another course to application' do
 
     then_the_new_course_is_added_to_the_application
     and_i_can_no_longer_add_a_course_because_3_is_the_max
+
+    when_there_is_a_candidate_who_wants_a_course_added_in_awaiting_provider_decision
+
+    when_i_visit_the_application_form
+    and_click_on_the_button_to_change_courses
+    and_i_select_the_option_to_add_a_course
+    and_i_fill_in_the_course_option_id_for_the_desired_course
+
+    then_another_new_course_is_added_to_the_application
   end
 
   def given_i_am_a_support_user
@@ -60,5 +69,18 @@ RSpec.feature 'Add another course to application' do
 
     expect(page).not_to have_content I18n.t!('support_interface.change_course.add_course')
     expect(page).to have_content 'This application already has 3 courses'
+  end
+
+  def when_there_is_a_candidate_who_wants_a_course_added_in_awaiting_provider_decision
+    @application_form = create(:completed_application_form)
+
+    create(:application_choice, status: 'awaiting_provider_decision', application_form: @application_form)
+    create(:application_choice, status: 'awaiting_provider_decision', application_form: @application_form)
+
+    @new_course_option = create(:course_option, course: create(:course, name: 'Another new course'))
+  end
+
+  def then_another_new_course_is_added_to_the_application
+    expect(page).to have_content 'Another new course'
   end
 end


### PR DESCRIPTION
## Context

Merge https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2134 first.

We have to add a course to a candidate's application because the provider is not replying. We have a form to do this in support, but it only works if the choices are in the `awaiting_references`.

## Changes proposed in this pull request

Make the support form work when the application is in the `awaiting_provider_decision` state.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/fiJcy82l/1586-manually-add-course-to-candidates-application

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
