### PR TITLE
Fix some mailer previews

### DIFF
--- a/app/views/support_interface/mailer_previews/index.html.erb
+++ b/app/views/support_interface/mailer_previews/index.html.erb
@@ -1,8 +1,8 @@
 <% @previews.each do |preview| %>
-<h3><%= preview.preview_name.titleize %></h3>
-<ul>
+<h3 class="govuk-heading-m"><%= preview.preview_name.titleize %></h3>
+<ul class="govuk-list govuk-list--bullet">
 <% preview.emails.each do |email| %>
-<li><%= link_to email, url_for(controller: 'rails/mailers', action: 'preview', path: "#{preview.preview_name}/#{email}") %></li>
+<li><%= govuk_link_to email, url_for(controller: 'rails/mailers', action: 'preview', path: "#{preview.preview_name}/#{email}") %></li>
 <% end %>
 </ul>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,11 +35,13 @@ module ApplyForPostgraduateTeacherTraining
 
     config.exceptions_app = self.routes
 
+    show_previews = Rails.env.development? || HostingEnvironment.qa? || HostingEnvironment.review?
+
     config.action_mailer.preview_path = Rails.root.join('spec/mailers/previews')
-    config.action_mailer.show_previews = Rails.env.development? || HostingEnvironment.qa? || HostingEnvironment.review?
+    config.action_mailer.show_previews = show_previews
 
     config.view_component.preview_path = Rails.root.join('spec/components/previews')
-    config.view_component.show_previews = Rails.env.development? || HostingEnvironment.qa? || HostingEnvironment.review?
+    config.view_component.show_previews = show_previews
 
     config.time_zone = 'London'
 

--- a/spec/mailers/mailer_previews_spec.rb
+++ b/spec/mailers/mailer_previews_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+BROKEN_PREVIEWS = {
+  'CandidateMailerPreview' => %w[new_referee_request chase_candidate_decision_with_one_offer new_offer_decisions_pending new_offer_single_offer chase_candidate_decision_with_multiple_offers new_offer_multiple_offers decline_last_application_choice new_referee_request_with_email_bounced chase_references_again withdraw_last_application_choice new_referee_request_with_refused],
+  'RefereeMailerPreview' => %w[reference_request_email],
+}.freeze
+
+RSpec.describe 'Mailer previews' do
+  ActionMailer::Preview.all.each do |preview|
+    describe preview do
+      preview.emails.each do |email|
+        it email do
+          pending 'currently broken' if BROKEN_PREVIEWS.fetch(preview.to_s, []).include?(email)
+          expect { preview.call(email) }.not_to raise_error
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Context

Mailer previews are broken due to a variety of reasons.

## Changes proposed in this pull request

Un-break them and add tests so hopefully they stay un-broken.

- Stub the `.update!` method on the `build_stubbed` candidate that is passed into the emails that create magic links; prevents errors which warn that "you can't call ActiveRecord methods on a build_stubbed object"
- Reuse the same `site` so that we don't hit the `.uniq` limit for the codes and school addresses which is a bit of a rabbit hole
- Add request specs to test if mailers return 200; I set the tests that are currently failing to be `pending`

The same tweaks can be used to fix almost all the other emails, but I will do that in a follow-up PR.

## Guidance to review

Commit by commit if you like.

I made some small tweaks to the preview page so it looks prettier too.

### Before

![Screenshot 2020-05-21 at 14 58 03](https://user-images.githubusercontent.com/1650875/82693284-31d0a080-9c59-11ea-8307-9e8eaf9d23cd.png)

### After

![Screenshot 2020-05-21 at 14 58 10](https://user-images.githubusercontent.com/1650875/82693293-34cb9100-9c59-11ea-88e2-735566ce80e8.png)

### Tests

![Screenshot 2020-05-27 at 13 56 11](https://user-images.githubusercontent.com/1650875/83021434-e5eb7600-a021-11ea-91c1-4050c6524dc9.png)

## Link to Trello card

https://trello.com/c/Rulh9wiA/1582-fix-broken-mailer-previews

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
