### PR TITLE
revert omniauth_openid_connect to 0.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,7 +281,7 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
-    omniauth_openid_connect (0.3.4)
+    omniauth_openid_connect (0.3.3)
       addressable (~> 2.5)
       omniauth (~> 1.9)
       openid_connect (~> 1.1)


### PR DESCRIPTION
0.3.4 is causing issues with login, reverting back to 0.3.3 whilst issue
is being fixed in omniauth_openid_connect
https://github.com/m0n9oose/omniauth_openid_connect/commit/6398ad13dcc7a7543fed17da493dc5b5ad2bb64d

## Context

Current version (0.3.4) is breaking logging into the service in QA.

## Changes proposed in this pull request

revert gem omniauth_openid_connect to 0.3.3

## Guidance to review

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
