### PR TITLE
Add provider relationships when syncing courses

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -84,6 +84,8 @@ private
 
     course.save!
 
+    add_provider_relationships(course)
+
     site_statuses = find_course.site_statuses
     find_course.sites.each do |find_site|
       site = provider.sites.find_or_create_by(code: find_site.code)
@@ -144,6 +146,19 @@ private
 
       course.accredited_provider = accredited_provider
     end
+  end
+
+  def add_provider_relationships(course)
+    return if course.accredited_provider.blank?
+
+    ProviderInterface::TrainingProviderPermissions.find_or_create_by!(
+      ratifying_provider: course.accredited_provider,
+      training_provider: provider,
+    )
+    ProviderInterface::AccreditedBodyPermissions.find_or_create_by!(
+      ratifying_provider: course.accredited_provider,
+      training_provider: provider,
+    )
   end
 
   def handle_course_options_with_invalid_sites(course, find_course)


### PR DESCRIPTION
## Context

We set the accredited body for a course when we sync data from Find. This forms the basis of a relationship between the training provider and the provider who ratifies the course. We need to set organisation-wide permissions at this level so we need to create the relationship in the database. 

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Adds ratifying and training provider permissions records when syncing courses from Find.

This only happens where the training provider is **not** self-ratifying and existing
relationships are also ignored. 
Permissions on these relationships are switched off by default.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/3fUMow3P/2209-update-sync-from-find-to-populate-provider-relationship-records

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
