### PR TITLE
Add previous / subsequent applications to support

### DIFF
--- a/app/components/support_interface/application_summary_component.rb
+++ b/app/components/support_interface/application_summary_component.rb
@@ -18,6 +18,8 @@ module SupportInterface
         submitted_row,
         last_updated_row,
         state_row,
+        previous_application_row,
+        subsequent_application_row,
       ].compact
     end
 
@@ -52,6 +54,24 @@ module SupportInterface
       {
         key: 'State',
         value: formatted_status,
+      }
+    end
+
+    def previous_application_row
+      return unless application_form.previous_application_form
+
+      {
+        key: 'Previous application',
+        value: govuk_link_to(application_form.previous_application_form.support_reference, support_interface_application_form_path(application_form.previous_application_form)),
+      }
+    end
+
+    def subsequent_application_row
+      return unless application_form.subsequent_application_form
+
+      {
+        key: 'Subsequent application',
+        value: govuk_link_to(application_form.subsequent_application_form.support_reference, support_interface_application_form_path(application_form.subsequent_application_form)),
       }
     end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -13,6 +13,9 @@ class ApplicationForm < ApplicationRecord
   has_many :application_references, -> { order('id ASC') }
   has_many :application_work_history_breaks
 
+  belongs_to :previous_application_form, class_name: 'ApplicationForm', optional: true, inverse_of: 'subsequent_application_form'
+  has_one :subsequent_application_form, class_name: 'ApplicationForm', foreign_key: 'previous_application_form_id', inverse_of: 'previous_application_form'
+
   MINIMUM_COMPLETE_REFERENCES = 2
   MAXIMUM_REFERENCES = 10
   DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe ApplicationForm do
     expect(application_form.support_reference).to be_present
   end
 
+  describe '#previous_application_form' do
+    it 'refers to the previous application' do
+      previous_application_form = create(:application_form)
+      application_form = create(:application_form, previous_application_form_id: previous_application_form.id)
+
+      expect(application_form.previous_application_form).to eql(previous_application_form)
+      expect(application_form.previous_application_form.subsequent_application_form).to eql(application_form)
+    end
+  end
+
   describe 'auditing', with_audited: true do
     it 'records an audit entry when creating a new ApplicationForm' do
       application_form = create :application_form


### PR DESCRIPTION
## Context

We've now introduced te ability to apply again. This adds some things to the support UI. 

## Changes proposed in this pull request

Given we have a candidate with 2 applications:

![image](https://user-images.githubusercontent.com/233676/82918539-c9d9cd00-9f6c-11ea-8d12-0d6bb62924fd.png)

The first application will have a link to the "subsequent" application:

![image](https://user-images.githubusercontent.com/233676/82918611-e37b1480-9f6c-11ea-87fe-55e6d9fa73ed.png)

And the second a link back:

![image](https://user-images.githubusercontent.com/233676/82918641-eb3ab900-9f6c-11ea-9e8b-cce5c5bde9cc.png)

FYI the associations on ApplicationForm will be used in a future PR for some refactoring.

## Guidance to review

Is "subsequent" the right word? 

## Link to Trello card

https://trello.com/c/6aEZkNZi

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
