### PR TITLE
Post a slack message every 5 signups

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -3,6 +3,8 @@ class StateChangeNotifier
     helpers = Rails.application.routes.url_helpers
     candidate_number = Candidate.where(hide_in_reporting: false).count
 
+    return unless (candidate_number % 5).zero?
+
     candidate_number_is_significant = (candidate_number % 1000).zero?
     text = if candidate_number_is_significant
              ":ultrafastparrot: The #{candidate_number.ordinalize} candidate just signed up @channel"

--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -5,9 +5,9 @@ class StateChangeNotifier
 
     return unless (candidate_number % 5).zero?
 
-    candidate_number_is_significant = (candidate_number % 1000).zero?
+    candidate_number_is_significant = (candidate_number % 100).zero?
     text = if candidate_number_is_significant
-             ":ultrafastparrot: The #{candidate_number.ordinalize} candidate just signed up @channel"
+             ":ultrafastparrot: The #{candidate_number.ordinalize} candidate just signed up"
            else
              ":sparkles: The #{candidate_number.ordinalize} candidate just signed up"
            end

--- a/spec/services/magic_link_sign_up_spec.rb
+++ b/spec/services/magic_link_sign_up_spec.rb
@@ -2,11 +2,16 @@ require 'rails_helper'
 
 RSpec.describe MagicLinkSignUp do
   describe 'Candidate signs up' do
-    let(:candidate) { create(:candidate) }
-
-    it 'sends a Slack notification' do
+    it 'sends a Slack notification every 5 signups' do
       allow(SlackNotificationWorker).to receive(:perform_async)
-      MagicLinkSignUp.call(candidate: candidate)
+
+      create_list(:candidate, 3)
+      MagicLinkSignUp.call(candidate: create(:candidate))
+
+      expect(SlackNotificationWorker).not_to have_received(:perform_async)
+
+      MagicLinkSignUp.call(candidate: create(:candidate))
+
       expect(SlackNotificationWorker).to have_received(:perform_async)
     end
   end

--- a/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
+++ b/spec/system/candidate_interface/candidate_signs_up_using_magic_link_with_an_invalid_token_spec.rb
@@ -11,7 +11,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
     and_i_fill_in_the_eligiblity_form_with_yes
     and_i_submit_my_email_address
     then_i_receive_an_email_inviting_me_to_sign_up
-    and_a_slack_message_is_sent
 
     when_the_magic_link_token_is_overwritten
     and_i_click_on_the_link_in_my_email
@@ -69,10 +68,6 @@ RSpec.feature 'Candidate tries to sign up using magic link with an invalid token
   def then_i_receive_an_email_inviting_me_to_sign_up
     open_email(@email)
     expect(current_email.subject).to have_content t('authentication.sign_up.email.subject')
-  end
-
-  def and_a_slack_message_is_sent
-    expect_slack_message_with_text ':sparkles: The 1st candidate just signed up'
   end
 
   def when_the_magic_link_token_is_overwritten


### PR DESCRIPTION
## Context

We're getting quite a few signups now, which clutters the support Slack channel.

## Changes proposed in this pull request

This only posts every 5th slack message. I've removed the integration test because it's starting to become tricky, and I don't want to do a lot of setup specificially for testing this message. The unit test covers the code fine.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
