### PR TITLE
Refactor and simplify conditionals for "Apply Again"

### DIFF
--- a/app/components/candidate_interface/application_complete_content_component.html.erb
+++ b/app/components/candidate_interface/application_complete_content_component.html.erb
@@ -54,11 +54,6 @@
     <%= t('application_complete.dashboard.providers_respond_by', date: respond_by_date) %>
   </p>
 
-<% elsif @application_form.apply_again? %>
-  <h2 class="govuk-heading-m govuk-!-font-size-27">
-    <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>
-  </h2>
-
 <% elsif editable? %>
   <h2 class="govuk-heading-m govuk-!-font-size-27">
     <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>
@@ -74,4 +69,8 @@
 
     <%= govuk_link_to t('application_complete.dashboard.edit_link'), candidate_interface_application_edit_path %>
   </div>
+<% else %>
+  <h2 class="govuk-heading-m govuk-!-font-size-27">
+    <%= "#{'Course'.pluralize(choice_count)} you’ve applied to" %>
+  </h2>
 <% end %>

--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -4,11 +4,8 @@ module CandidateInterface
 
     def index
       @course_choices = current_candidate.current_application.application_choices
-      if @course_choices.count < 1
-        render :index, locals: {
-          apply_again: @current_application.apply_again?,
-        }
-      else
+
+      if @course_choices.any?
         redirect_to candidate_interface_course_choices_review_path
       end
     end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -6,7 +6,6 @@ module CandidateInterface
     def show
       @application_form_presenter = CandidateInterface::ApplicationFormPresenter.new(current_application)
       @application_form = current_application
-      @previous_application_form = ApplicationForm.find(current_application.previous_application_form_id) if current_application.previous_application_form_id.present?
     end
 
     def before_you_start; end

--- a/app/controllers/candidate_interface/application_form_controller.rb
+++ b/app/controllers/candidate_interface/application_form_controller.rb
@@ -28,7 +28,7 @@ module CandidateInterface
     end
 
     def edit
-      redirect_to candidate_interface_application_complete_path and return unless current_application.apply_1?
+      redirect_to candidate_interface_application_complete_path and return unless current_application.can_edit_after_submission?
 
       @editable_days = TimeLimitConfig.edit_by
       render :edit_by_support

--- a/app/controllers/candidate_interface/candidate_interface_controller.rb
+++ b/app/controllers/candidate_interface/candidate_interface_controller.rb
@@ -62,6 +62,8 @@ module CandidateInterface
       @current_application ||= current_candidate.current_application
     end
 
+    helper_method :current_application
+
     def render_404
       render 'errors/not_found', status: :not_found
     end

--- a/app/controllers/candidate_interface/course_choices/add_another_course_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/add_another_course_controller.rb
@@ -2,12 +2,10 @@ module CandidateInterface
   module CourseChoices
     class AddAnotherCourseController < BaseController
       def ask
-        @additional_courses_allowed = 3 - current_candidate.current_application.application_choices.count
         @add_another_course = AddAnotherCourseForm.new
       end
 
       def decide
-        @additional_courses_allowed = 3 - current_candidate.current_application.application_choices.count
         @add_another_course = AddAnotherCourseForm.new(add_another_course_params)
         return render :add_another_course unless @add_another_course.valid?
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -151,6 +151,6 @@ class ApplicationForm < ApplicationRecord
   end
 
   def can_add_reference?
-    submitted? || candidate_has_previously_applied? || application_references.size < MINIMUM_COMPLETE_REFERENCES
+    application_references.size < MINIMUM_COMPLETE_REFERENCES
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -120,6 +120,10 @@ class ApplicationForm < ApplicationRecord
     apply_2?
   end
 
+  def candidate_has_previously_applied?
+    previous_application_form_id.present?
+  end
+
   def apply_again_course_chosen?
     apply_again? && application_choices.present?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -118,10 +118,6 @@ class ApplicationForm < ApplicationRecord
     updated_at == created_at
   end
 
-  def apply_again?
-    apply_2?
-  end
-
   def candidate_has_previously_applied?
     previous_application_form_id.present?
   end
@@ -151,6 +147,6 @@ class ApplicationForm < ApplicationRecord
   end
 
   def can_add_reference?
-    submitted? || apply_again? || application_references.size < MINIMUM_COMPLETE_REFERENCES
+    submitted? || candidate_has_previously_applied? || application_references.size < MINIMUM_COMPLETE_REFERENCES
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -124,6 +124,10 @@ class ApplicationForm < ApplicationRecord
     previous_application_form_id.present?
   end
 
+  def candidate_can_choose_single_course?
+    apply_2?
+  end
+
   def apply_again_course_chosen?
     apply_again? && application_choices.present?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -138,6 +138,10 @@ class ApplicationForm < ApplicationRecord
     choices_left_to_make.positive?
   end
 
+  def can_edit_after_submission?
+    apply_1?
+  end
+
   def unique_provider_list
     application_choices.map(&:provider).uniq
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -130,6 +130,18 @@ class ApplicationForm < ApplicationRecord
     apply_2?
   end
 
+  def choices_left_to_make
+    number_of_choices_candidate_can_make - application_choices.size
+  end
+
+  def number_of_choices_candidate_can_make
+    candidate_can_choose_single_course? ? 1 : 3
+  end
+
+  def can_add_more_choices?
+    choices_left_to_make.positive?
+  end
+
   def apply_again_course_chosen?
     apply_again? && application_choices.present?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -142,10 +142,6 @@ class ApplicationForm < ApplicationRecord
     choices_left_to_make.positive?
   end
 
-  def apply_again_course_chosen?
-    apply_again? && application_choices.present?
-  end
-
   def unique_provider_list
     application_choices.map(&:provider).uniq
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -1,6 +1,8 @@
 # The Application Form is filled in and submitted by the Candidate. Candidates
 # can initially apply to 3 different courses, represented by an Application Choice.
 class ApplicationForm < ApplicationRecord
+  audited
+
   include Chased
 
   belongs_to :candidate
@@ -135,8 +137,6 @@ class ApplicationForm < ApplicationRecord
   def unique_provider_list
     application_choices.map(&:provider).uniq
   end
-
-  audited
 
   def ended_without_success?
     application_choices.map(&:status).all? { |status| ApplicationStateChange::UNSUCCESSFUL_END_STATES.include?(status) }

--- a/app/models/candidate_interface/pick_site_form.rb
+++ b/app/models/candidate_interface/pick_site_form.rb
@@ -4,8 +4,7 @@ module CandidateInterface
 
     attr_accessor :application_form, :provider_id, :course_id, :study_mode, :course_option_id
     validates :course_option_id, presence: true
-    validate :candidate_can_only_apply_to_3_courses, on: :save
-    validate :only_1_apply_again_course_allowed, on: :save
+    validate :number_of_choices, on: :save
 
     def available_sites
       relation = CourseOption.selectable.includes(:site).where(course_id: course.id)
@@ -41,19 +40,16 @@ module CandidateInterface
       @provider ||= Provider.find(provider_id)
     end
 
-    def candidate_can_only_apply_to_3_courses
-      return if application_form.application_choices.count <= 2
+    def number_of_choices
+      return if application_form.can_add_more_choices?
 
-      errors[:base] << I18n.t('errors.messages.too_many_course_choices', course_name_and_code: course_option.course.name_and_code)
-    end
+      error_key = if application_form.candidate_can_choose_single_course?
+                    'errors.messages.apply_again_course_already_chosen'
+                  else
+                    'errors.messages.too_many_course_choices'
+                  end
 
-    def only_1_apply_again_course_allowed
-      if application_form.apply_again_course_chosen?
-        errors[:base] << I18n.t!(
-          'errors.application_choices.apply_again_course_already_chosen',
-          course_name_and_code: course_option.course.name_and_code,
-        )
-      end
+      errors[:base] << I18n.t!(error_key, course_name_and_code: course_option.course.name_and_code)
     end
   end
 end

--- a/app/presenters/candidate_interface/application_form_presenter.rb
+++ b/app/presenters/candidate_interface/application_form_presenter.rb
@@ -8,10 +8,6 @@ module CandidateInterface
       "Last saved on #{@application_form.updated_at.to_s(:govuk_date_and_time)}"
     end
 
-    def apply_again?
-      @application_form.apply_again?
-    end
-
     def sections_with_completion
       [
         # "Courses" section

--- a/app/services/candidate_interface/pick_course_option.rb
+++ b/app/services/candidate_interface/pick_course_option.rb
@@ -31,7 +31,7 @@ module CandidateInterface
         course_choices = application_form.application_choices
         flash[:success] = "You’ve added #{course_choices.last.course.name_and_code} to your application"
 
-        if current_application.can_add_more_choices?
+        if application_form.can_add_more_choices?
           redirect_to candidate_interface_course_choices_add_another_course_path
         else
           redirect_to candidate_interface_course_choices_index_path

--- a/app/services/candidate_interface/pick_course_option.rb
+++ b/app/services/candidate_interface/pick_course_option.rb
@@ -31,7 +31,7 @@ module CandidateInterface
         course_choices = application_form.application_choices
         flash[:success] = "You’ve added #{course_choices.last.course.name_and_code} to your application"
 
-        if course_choices.count.between?(1, 2) && !application_form.apply_again?
+        if current_application.can_add_more_choices?
           redirect_to candidate_interface_course_choices_add_another_course_path
         else
           redirect_to candidate_interface_course_choices_index_path

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -65,7 +65,7 @@ private
   end
 
   def send_to_provider_immediately?
-    application_form.apply_again? && enough_references_have_been_provided?
+    application_form.candidate_has_previously_applied? && enough_references_have_been_provided?
   end
 
   def enough_references_have_been_provided?

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -65,7 +65,7 @@ private
   end
 
   def send_to_provider_immediately?
-    application_form.candidate_has_previously_applied? && enough_references_have_been_provided?
+    !application_form.can_edit_after_submission? && enough_references_have_been_provided?
   end
 
   def enough_references_have_been_provided?

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -10,11 +10,7 @@ class SubmitApplication
 
   def call
     ActiveRecord::Base.transaction do
-      if application_form.apply_again? && enough_references_have_been_provided?
-        application_form.update!(submitted_at: Time.zone.now, edit_by: Time.zone.now)
-      else
-        application_form.update!(submitted_at: Time.zone.now, edit_by: edit_by_time)
-      end
+      application_form.update!(submitted_at: Time.zone.now, edit_by: edit_by_time)
       submit_application
     end
 

--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -38,10 +38,17 @@ private
       reference_feedback_provided!
       application_form.application_choices.awaiting_references.each do |application_choice|
         ApplicationStateChange.new(application_choice).references_complete!
-        if application_form.apply_again?
-          application_choice.update!(edit_by: Time.zone.now)
-          application_form.update!(edit_by: Time.zone.now)
-        end
+
+        next unless application_form.candidate_has_previously_applied?
+
+        # If the candidate has previously applied, they have less of a need to
+        # edit the application. Hence, we clear out the usual 7-day edit window
+        # by resetting the `edit_by` time.
+        application_form.update!(edit_by: Time.zone.now)
+
+        # Temporarily here until we've transitioned `ApplicationChoice#edit_by`
+        # to `ApplicationForm#edit_by` - https://trello.com/c/IbvLIdCn.
+        application_choice.update!(edit_by: Time.zone.now)
       end
     end
 

--- a/app/views/candidate_interface/application_choices/index.html.erb
+++ b/app/views/candidate_interface/application_choices/index.html.erb
@@ -6,7 +6,7 @@
     <h1 class="govuk-heading-xl">
       <%= t('page_titles.choosing_courses') %>
     </h1>
-    <% if apply_again %>
+    <% if @current_application.candidate_can_choose_single_course? %>
       <%= render 'guidance_apply_again' %>
     <% else %>
       <%= render 'guidance' %>

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -2,10 +2,10 @@
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path, 'Back to application') %>
 
 <h1 class="govuk-heading-xl">
-  <% if @application_form.apply_again? %>
+  <% if @application_form.candidate_can_choose_single_course? %>
     <%= t('page_titles.course_choice') %>
   <% else %>
-  <%= t('page_titles.course_choices') %>
+    <%= t('page_titles.course_choices') %>
   <% end %>
 </h1>
 

--- a/app/views/candidate_interface/application_choices/review.html.erb
+++ b/app/views/candidate_interface/application_choices/review.html.erb
@@ -17,9 +17,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <% if @course_choices.present? %>
-        <% if @application_form.apply_again? %>
-          <% # noop  %>
-        <% elsif @course_choices.count < 3 %>
+        <% if @application_form.can_add_more_choices? %>
           <%= link_to 'Add another course', candidate_interface_course_choices_choose_path, class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-9' %>
         <% end %>
 

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -16,11 +16,11 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
-    <% if FeatureFlag.active?('apply_again') && @application_form.apply_2? && @previous_application_form.application_choices.rejected.any?  %>
-      <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @previous_application_form)) %>
-    <% end %>
+    <% if FeatureFlag.active?('apply_again') && @application_form.candidate_has_previously_applied? %>
+      <% if @application_form.previous_application_form.application_choices.rejected.any?  %>
+        <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
+      <% end %>
 
-    <% if @application_form_presenter.apply_again? %>
       <%= render(
         CandidateInterface::ApplicationFormApplyAgainCourseChoiceComponent.new(
           completed: @application_form_presenter.course_choices_completed?,
@@ -111,7 +111,7 @@
   <div class="govuk-grid-column-one-third">
     <%= render partial: '/candidate_interface/shared/need_help', locals: { support_reference: @application_form.support_reference } %>
 
-    <% if FeatureFlag.active?('apply_again') && @previous_application_form.present? %>
+    <% if FeatureFlag.active?('apply_again') && @application_form.candidate_has_previously_applied? %>
       <h2 class="govuk-heading-s">Previous applications</h2>
       <%= render(CandidateInterface::LinksToPreviousApplicationsComponent.new(application_form: @application_form)) %>
     <% end %>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -28,7 +28,7 @@
     <h2 class="govuk-heading-m">Interview</h2>
     <p class="govuk-body">Your training provider will be in touch with you if they want to arrange an interview.</p>
 
-    <% if @application_form.apply_1? %>
+    <% if @application_form.can_edit_after_submission? %>
       <h2 class="govuk-heading-m">Track, edit or withdraw</h2>
       <p class="govuk-body">You have <%= @editable_days %> to edit your application. We'll only send your application to your <%= @pluralized_provider_string %> when this editing period is over.</p>
       <p class="govuk-body"><%= govuk_link_to 'To edit your application, return to your application dashboard.', candidate_interface_application_complete_path %></p>

--- a/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
@@ -1,4 +1,4 @@
-<% title = "You can choose #{@additional_courses_allowed} more #{'course'.pluralize(@additional_courses_allowed)}" %>
+<% title = "You can choose #{current_application.choices_left_to_make} more #{'course'.pluralize(current_application.choices_left_to_make)}" %>
 <% content_for :title, title_with_error_prefix(title, @add_another_course.errors.any?) %>
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_form_path) %>
 

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -7,7 +7,7 @@
 
 <%= render(CandidateInterface::RefereesReviewComponent.new(application_form: @application_form, editable: true)) %>
 
-<%- if @referees.count < ApplicationForm::MINIMUM_COMPLETE_REFERENCES %>
+<% if @application_form.can_add_reference? %>
   <p class="govuk-body">
     <% if @referees.any? %>
       <%= govuk_button_link_to t('application_form.referees.add_second_referee'), candidate_interface_referees_type_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -264,13 +264,13 @@ en:
     messages:
       too_many_words: Must be %{count} words or fewer
       too_many_course_choices: You cannot have more than 3 course choices. You must delete a choice if you want to apply to #{course_name_and_code}.
+      apply_again_course_already_chosen: You cannot choose more than 1 course when you apply again. You must delete your existing choice if you want to apply to %{course_name_and_code}
     application_choices:
       course_not_available: You cannot apply to '%{descriptor}' because it is not running
       course_full: You cannot apply to '%{descriptor}' because it has no vacancies
       chosen_site_full: Your chosen site for '%{descriptor}' has no vacancies
       course_closed_on_apply: "'%{course_name_and_code}' at %{provider_name} is not available on Apply for teacher training anymore"
       already_added: You have already added %{course_name_and_code}
-      apply_again_course_already_chosen: You cannot choose more than 1 course when you apply again. You must delete your existing choice if you want to apply to %{course_name_and_code}
   date:
     formats:
       long: "%e %B %Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,7 +270,7 @@ en:
       chosen_site_full: Your chosen site for '%{descriptor}' has no vacancies
       course_closed_on_apply: "'%{course_name_and_code}' at %{provider_name} is not available on Apply for teacher training anymore"
       already_added: You have already added %{course_name_and_code}
-      apply_again_course_already_chosen: You cannot choose more than 1 course when you Apply Again. You must delete your existing choice if you want to apply to %{course_name_and_code}
+      apply_again_course_already_chosen: You cannot choose more than 1 course when you apply again. You must delete your existing choice if you want to apply to %{course_name_and_code}
   date:
     formats:
       long: "%e %B %Y"

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -16,6 +16,36 @@ RSpec.describe ApplicationForm do
     end
   end
 
+  describe '#choices_left_to_make' do
+    it 'returns the number of choices that an candidate can make in the first instance' do
+      application_form = create(:application_form)
+
+      expect(application_form.reload.choices_left_to_make).to be(3)
+
+      create(:application_choice, application_form: application_form)
+
+      expect(application_form.reload.choices_left_to_make).to be(2)
+
+      create(:application_choice, application_form: application_form)
+
+      expect(application_form.reload.choices_left_to_make).to be(1)
+
+      create(:application_choice, application_form: application_form)
+
+      expect(application_form.reload.choices_left_to_make).to be(0)
+    end
+
+    it 'returns the number of choices that an candidate can make in "Apply 2"' do
+      application_form = create(:application_form, phase: 'apply_2')
+
+      expect(application_form.reload.choices_left_to_make).to be(1)
+
+      create(:application_choice, application_form: application_form)
+
+      expect(application_form.reload.choices_left_to_make).to be(0)
+    end
+  end
+
   describe 'auditing', with_audited: true do
     it 'records an audit entry when creating a new ApplicationForm' do
       application_form = create :application_form

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -180,27 +180,5 @@ RSpec.describe ApplicationForm do
       )
       expect(application_form.can_add_reference?).to be false
     end
-
-    it 'returns true if there are already 2 references but the form is submitted' do
-      application_reference1 = build :reference
-      application_reference2 = build :reference
-      application_form = build(
-        :application_form,
-        application_references: [application_reference1, application_reference2],
-        submitted_at: 3.days.ago,
-      )
-      expect(application_form.can_add_reference?).to be true
-    end
-
-    it 'returns true if there are already 2 references but its an Apply Again form' do
-      application_reference1 = build :reference
-      application_reference2 = build :reference
-      application_form = build(
-        :application_form,
-        application_references: [application_reference1, application_reference2],
-        phase: 'apply_2',
-      )
-      expect(application_form.can_add_reference?).to be true
-    end
   end
 end

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SubmitReference do
       end
 
       it 'sets edit_by to current time if Apply Again application' do
-        application_form.apply_2!
+        application_form.update! previous_application_form: create(:application_form)
         create(:application_choice, application_form: application_form, status: 'awaiting_references', edit_by: 2.days.from_now)
         create(:reference, :complete, application_form: application_form)
         reference = create(:reference, :unsubmitted, application_form: application_form)
@@ -114,7 +114,7 @@ RSpec.describe SubmitReference do
       end
 
       it 'sets edit_by to current time if Apply Again application' do
-        application_form = create(:completed_application_form, phase: :apply_2, edit_by: 2.days.from_now)
+        application_form = create(:completed_application_form, previous_application_form: create(:application_form), edit_by: 2.days.from_now)
         application_choice = create(:application_choice, application_form: application_form, status: 'awaiting_references')
         create(:reference, :complete, application_form: application_form)
         reference = create(:reference, :unsubmitted, application_form: application_form)


### PR DESCRIPTION
## Context

We've introduced the feature to allow candidates to apply again recently. This means we've introduced a bunch of conditionals in the code where we check whether or not the user is in the "apply 2" phase. This could make it harder to understand the codebase. 

It's also not always clear _why_ a certain thing is different in the different phases. In https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1588250617304800 we decided to decouple the act of "applying again" from the 1-course choice restriction, but we haven't implemented that. 

## Changes proposed in this pull request

- Replace `apply_again?` by different conditionals for `candidate_has_previously_applied?` and `candidate_can_choose_single_course?`. This will make it possible to allow candidates who have applied in a previous cycle to apply to 3 courses, by changing the `phase` for these applications.
- Use descriptive conditionals that explain what we're after, like `candidate_has_previously_applied?` or `can_edit_after_submission?`.
- Remove conditionals if they're not necessary
- Fixup some other duplicated code like the check how many choices the candidate can add

## Guidance to review

Review this *per commit* - it wouldn't make sense otherwise.

## Link to Trello card

https://trello.com/c/6aEZkNZi

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
