### PR TITLE
Add enforce_provider_to_provider_permissions feature flag

### DIFF
--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,6 +26,7 @@ class FeatureFlag
     [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],
     [:provider_interface_work_breaks, 'Adds work break information to the provider interface', 'Steve Hook'],
     [:provider_view_safeguarding, 'Allows providers to see whether a candidate has declared safeguarding issues', 'Will McBrien'],
+    [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -25,11 +25,16 @@ class ProviderAuthorisation
   end
 
   def can_view_safeguarding_information?(course:)
-    @actor.provider_permissions.view_safeguarding_information
-      .exists?(provider: [course.provider, course.accredited_provider].compact) &&
-      (course.accredited_provider.blank? ||
-        ratifying_provider_can_view_safeguarding_information?(course: course) ||
-          training_provider_can_view_safeguarding_information?(course: course))
+    if FeatureFlag.active?(:enforce_provider_to_provider_permissions)
+      @actor.provider_permissions.view_safeguarding_information
+        .exists?(provider: [course.provider, course.accredited_provider].compact) &&
+        (course.accredited_provider.blank? ||
+          ratifying_provider_can_view_safeguarding_information?(course: course) ||
+            training_provider_can_view_safeguarding_information?(course: course))
+    else
+      @actor.provider_permissions.view_safeguarding_information
+        .exists?(provider: [course.provider, course.accredited_provider].compact)
+    end
   end
 
   # automatically generates assert_can...! methods e.g. #assert_can_make_offer! for #can_make_offer?

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -119,6 +119,10 @@ RSpec.describe ProviderAuthorisation do
       )
     end
 
+    before do
+      FeatureFlag.activate(:enforce_provider_to_provider_permissions)
+    end
+
     subject(:can_view_safeguarding_information) do
       described_class.new(actor: provider_user)
         .can_view_safeguarding_information?(course: course)

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
   scenario 'the application data is visible' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_safeguarding_declaration_feature_flag_is_active
+    and_the_enforce_provider_to_provider_permissions_feature_flag_is_active
     and_my_organisation_has_received_an_application
     and_i_am_permitted_to_see_applications_for_my_provider
     and_i_sign_in_to_the_provider_interface
@@ -51,6 +52,10 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def and_the_safeguarding_declaration_feature_flag_is_active
     FeatureFlag.activate('provider_view_safeguarding')
+  end
+
+  def and_the_enforce_provider_to_provider_permissions_feature_flag_is_active
+    FeatureFlag.activate('enforce_provider_to_provider_permissions')
   end
 
   def when_i_am_permitted_to_see_safeguarding_information


### PR DESCRIPTION
## Context

Until providers have a chance to set these permissions they'll start to see bits of functionality cut off with no way to get them back. For example, if we allowed them to assign "See safeguarding information" then the user might _not_ be able to see safeguarding information owing to a provider-provider relationship that can't be configured.

## Changes proposed in this pull request

Add a feature flag `enforce_provider_to_provider_permissions`.

## Guidance to review

Does it make sense?

## Link to Trello card

Part of https://trello.com/c/N14wup32/2089-epic-provider-users-can-set-up-org-org-permissions

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)