### PR TITLE
Allow downloading provider users CSV from support/users/provider

### DIFF
--- a/app/views/support_interface/provider_users/index.html.erb
+++ b/app/views/support_interface/provider_users/index.html.erb
@@ -20,4 +20,6 @@
   ]) %>
 <% end %>
 
+<%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path, class: 'govuk-button' %>
+
 <%= render(SupportInterface::ProviderUsersTableComponent.new(provider_users: @provider_users)) %>

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -12,7 +12,9 @@ RSpec.feature 'Managing provider users' do
     when_i_visit_the_support_console
     and_i_click_the_users_link
     and_i_click_the_manange_provider_users_link
-    and_i_click_the_add_user_link
+    then_i_should_see_a_csv_export_button
+
+    when_i_click_the_add_user_link
     then_i_see_synced_providers
 
     when_i_enter_an_existing_email
@@ -84,6 +86,10 @@ RSpec.feature 'Managing provider users' do
     click_link 'Provider users'
   end
 
+  def then_i_should_see_a_csv_export_button
+    expect(page).to have_link('Download active provider users (CSV)')
+  end
+
   def and_i_select_a_provider
     check 'Example provider (ABC)'
   end
@@ -100,7 +106,7 @@ RSpec.feature 'Managing provider users' do
     end
   end
 
-  def and_i_click_the_add_user_link
+  def when_i_click_the_add_user_link
     click_link 'Add provider user'
   end
 


### PR DESCRIPTION
## Context

We wasted 5 minutes looking for this button earlier and eventually found it on the "Performance" page of all places. That might make sense for usage analysis—and I've left it there—but this page is a logical place for it to live if e.g. you need to get a list of emails for a mailout.

## Changes proposed in this pull request

![Screenshot 2020-05-27 at 11 28 31](https://user-images.githubusercontent.com/642279/83008959-ec6ff280-a00d-11ea-974f-3aa1ec13f50d.png)

## Guidance to review

Does this make sense?

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
