### PR TITLE
Remove remnant of edit application feature

### DIFF
--- a/app/controllers/candidate_interface/application_choices_controller.rb
+++ b/app/controllers/candidate_interface/application_choices_controller.rb
@@ -35,10 +35,6 @@ module CandidateInterface
 
       render :index if @application_form.application_choices.count.zero?
 
-      if @application_form.submitted?
-        @application_form.application_choices.filter(&:unsubmitted?).each { |choice| SubmitApplicationChoice.new(choice).call }
-      end
-
       if @application_form.update(application_form_params)
         redirect_to candidate_interface_application_form_path
       else


### PR DESCRIPTION
## Context

This code path will never be called because if the application is submitted, this controller can't be visited. It's a remnant of the feature that allowed people to edit their application (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1508).

## Changes proposed in this pull request

Remove it.

## Guidance to review

Ok?

## Link to Trello card

https://trello.com/c/6aEZkNZi

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
