### PR TITLE
Use DFE-Digital's fork of audited

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'omniauth_openid_connect'
 gem 'omniauth-rails_csrf_protection'
 
 gem 'workflow'
-gem 'audited'
+gem 'audited', git: 'https://github.com/DFE-Digital/audited'
 gem 'discard'
 
 gem 'json-schema'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/DFE-Digital/audited
+  revision: 9b3c366573712801ae43b04e80f827c78397192e
+  specs:
+    audited (4.9.0)
+      activerecord (>= 4.2, < 6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -61,8 +68,6 @@ GEM
     aes_key_wrap (1.0.1)
     ast (2.4.0)
     attr_required (1.0.1)
-    audited (4.9.0)
-      activerecord (>= 4.2, < 6.1)
     backports (3.15.0)
     bcrypt (3.1.13)
     benchmark-malloc (0.2.0)
@@ -517,7 +522,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  audited
+  audited!
   brakeman
   bullet
   business_time


### PR DESCRIPTION
For various reasons that I don't understand fully, applying some Rails best practices(TM) to Audited's autoloading code makes mailer previews work with `mail-notify` again. I raised a PR on audited but they haven't looked at it in 2 weeks, so here's a fork with the fix in the meantime.