### PR TITLE
Allow providers to change study_mode when modifying offers

### DIFF
--- a/app/components/provider_interface/change_offer/change_course_component.rb
+++ b/app/components/provider_interface/change_offer/change_course_component.rb
@@ -18,14 +18,8 @@ module ProviderInterface
         Course.where(
           open_on_apply: true,
           provider_id: change_offer_form.provider_id,
-          study_mode: relevant_study_modes,
           recruitment_cycle_year: recruitment_cycle_year,
         ).order(:name)
-      end
-
-      def relevant_study_modes
-        current = change_offer_form.study_mode || application_choice.offered_option.study_mode
-        [current, 'full_time_or_part_time']
       end
 
       def recruitment_cycle_year

--- a/app/components/provider_interface/change_offer/change_course_component.rb
+++ b/app/components/provider_interface/change_offer/change_course_component.rb
@@ -18,13 +18,18 @@ module ProviderInterface
         Course.where(
           open_on_apply: true,
           provider_id: change_offer_form.provider_id,
-          study_mode: study_mode_for_courses,
+          study_mode: relevant_study_modes,
+          recruitment_cycle_year: recruitment_cycle_year,
         ).order(:name)
       end
 
-      def study_mode_for_courses
-        current_study_mode = application_choice.offered_option.study_mode
-        [current_study_mode, :full_time_or_part_time]
+      def relevant_study_modes
+        current = change_offer_form.study_mode || application_choice.offered_option.study_mode
+        [current, 'full_time_or_part_time']
+      end
+
+      def recruitment_cycle_year
+        application_choice.offered_course.recruitment_cycle_year # same year as application
       end
 
       def page_title

--- a/app/components/provider_interface/change_offer/change_location_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_location_component.html.erb
@@ -8,6 +8,7 @@
       <%= f.hidden_field :entry %>
       <%= f.hidden_field :provider_id %>
       <%= f.hidden_field :course_id %>
+      <%= f.hidden_field :study_mode %>
       <%= f.govuk_radio_buttons_fieldset :course_option_id do %>
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">

--- a/app/components/provider_interface/change_offer/change_location_component.rb
+++ b/app/components/provider_interface/change_offer/change_location_component.rb
@@ -12,6 +12,8 @@ module ProviderInterface
         if @change_offer_form.valid?
           @change_offer_form.step = @change_offer_form.next_step
         end
+
+        preselect_same_site_if_available
       end
 
       def course_options
@@ -20,6 +22,14 @@ module ProviderInterface
           study_mode: change_offer_form.study_mode,
           # TODO: check vacancy_status, e.g. 'B'
         ).includes(:site).order('sites.name')
+      end
+
+      def preselect_same_site_if_available
+        if change_offer_form.course_option_id
+          previous_option = CourseOption.find(change_offer_form.course_option_id)
+          new_option = course_options.find_by(site_id: previous_option.site.id)
+          change_offer_form.course_option_id = new_option.id if new_option
+        end
       end
 
       def page_title

--- a/app/components/provider_interface/change_offer/change_provider_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_provider_component.html.erb
@@ -8,6 +8,7 @@
       <%= f.hidden_field :step %>
       <%= f.hidden_field :entry %>
       <%= f.hidden_field :course_id %>
+      <%= f.hidden_field :study_mode %>
       <%= f.hidden_field :course_option_id %>
       <%= f.govuk_radio_buttons_fieldset :provider_id do %>
 

--- a/app/components/provider_interface/change_offer/change_study_mode_component.html.erb
+++ b/app/components/provider_interface/change_offer/change_study_mode_component.html.erb
@@ -7,7 +7,7 @@
       <%= f.hidden_field :step %>
       <%= f.hidden_field :entry %>
       <%= f.hidden_field :provider_id %>
-      <%= f.hidden_field :study_mode %>
+      <%= f.hidden_field :course_id %>
       <%= f.hidden_field :course_option_id %>
       <%= f.govuk_radio_buttons_fieldset :course_id do %>
 
@@ -18,8 +18,8 @@
           </h1>
         </legend>
 
-        <% courses.each do |course| %>
-          <%= f.govuk_radio_button :course_id, course.id, label: { text: course.name_and_code }, hint_text: course.description %>
+        <% study_modes.each do |study_mode| %>
+          <%= f.govuk_radio_button :study_mode, study_mode, label: { text: study_mode.to_s.humanize }, hint_text: course.name_and_code %>
         <% end %>
       <% end %>
 

--- a/app/components/provider_interface/change_offer/change_study_mode_component.rb
+++ b/app/components/provider_interface/change_offer/change_study_mode_component.rb
@@ -1,32 +1,33 @@
 module ProviderInterface
   module ChangeOffer
-    class ChangeLocationComponent < ViewComponent::Base
+    class ChangeStudyModeComponent < ViewComponent::Base
       include ViewHelper
 
-      attr_reader :change_offer_form, :application_choice
+      attr_reader :change_offer_form, :application_choice, :providers
 
       def initialize(change_offer_form:)
         @change_offer_form = change_offer_form
         @application_choice = change_offer_form.application_choice
+        @providers = providers
 
         if @change_offer_form.valid?
           @change_offer_form.step = @change_offer_form.next_step
         end
       end
 
-      def course_options
-        CourseOption.where(
-          course_id: change_offer_form.course_id,
-          study_mode: change_offer_form.study_mode,
-          # TODO: check vacancy_status, e.g. 'B'
-        ).includes(:site).order('sites.name')
+      def study_modes
+        %w[full_time part_time]
+      end
+
+      def course
+        Course.find change_offer_form.course_id
       end
 
       def page_title
-        if application_choice.offer? && change_offer_form.entry == :course_option
-          'Change location'
+        if application_choice.offer? && change_offer_form.entry == :study_mode
+          'Change to full time or part time'
         else
-          'Select location'
+          'Select full time or part time'
         end
       end
 

--- a/app/components/provider_interface/change_offer/confirm_component.html.erb
+++ b/app/components/provider_interface/change_offer/confirm_component.html.erb
@@ -16,6 +16,7 @@
           <%= f.hidden_field :step %>
           <%= f.hidden_field :provider_id %>
           <%= f.hidden_field :course_id %>
+          <%= f.hidden_field :study_mode %>
           <%= f.hidden_field :course_option_id %>
           <%= f.govuk_submit 'Change offer' %>
         <% end %>

--- a/app/components/provider_interface/change_offer/confirm_component.rb
+++ b/app/components/provider_interface/change_offer/confirm_component.rb
@@ -26,7 +26,7 @@ module ProviderInterface
       end
 
       def study_modes
-        Course.find(change_offer_form.course_id).course_options.pluck(:study_mode).uniq
+        Course.find(change_offer_form.course_id).study_modes_present
       end
 
       def change_path_options

--- a/app/components/provider_interface/change_offer/confirm_component.rb
+++ b/app/components/provider_interface/change_offer/confirm_component.rb
@@ -26,7 +26,7 @@ module ProviderInterface
       end
 
       def study_modes
-        Course.find(change_offer_form.course_id).study_modes_present
+        Course.find(change_offer_form.course_id).available_study_modes_from_options
       end
 
       def change_path_options

--- a/app/components/provider_interface/change_offer/confirm_component.rb
+++ b/app/components/provider_interface/change_offer/confirm_component.rb
@@ -25,11 +25,16 @@ module ProviderInterface
         end
       end
 
+      def study_modes
+        Course.find(change_offer_form.course_id).course_options.pluck(:study_mode).uniq
+      end
+
       def change_path_options
         entry = change_offer_form.entry
         {
           change_provider_path: (params_for_step(:provider) if entry == 'provider'),
           change_course_path: (params_for_step(:course) if %w[provider course].include? entry),
+          change_study_mode_path: (params_for_step(:study_mode) if study_modes.count > 1),
           change_course_option_path: params_for_step(:course_option),
         }
       end
@@ -38,6 +43,7 @@ module ProviderInterface
         new_form_hash = {
           provider_id: change_offer_form.provider_id,
           course_id: change_offer_form.course_id,
+          study_mode: change_offer_form.study_mode,
           course_option_id: change_offer_form.course_option_id,
           entry: change_offer_form.entry,
           step: step_symbol,

--- a/app/components/provider_interface/change_offer_component.rb
+++ b/app/components/provider_interface/change_offer_component.rb
@@ -29,6 +29,10 @@ module ProviderInterface
         ProviderInterface::ChangeOffer::ChangeLocationComponent.new(
           change_offer_form: change_offer_form,
         )
+      when :study_mode
+        ProviderInterface::ChangeOffer::ChangeStudyModeComponent.new(
+          change_offer_form: change_offer_form,
+        )
       when :course
         ProviderInterface::ChangeOffer::ChangeCourseComponent.new(
           change_offer_form: change_offer_form,

--- a/app/components/provider_interface/change_offer_component.rb
+++ b/app/components/provider_interface/change_offer_component.rb
@@ -30,9 +30,18 @@ module ProviderInterface
           change_offer_form: change_offer_form,
         )
       when :study_mode
-        ProviderInterface::ChangeOffer::ChangeStudyModeComponent.new(
-          change_offer_form: change_offer_form,
-        )
+        study_modes = Course.find(change_offer_form.course_id).study_modes_present
+        if study_modes.count > 1
+          ProviderInterface::ChangeOffer::ChangeStudyModeComponent.new(
+            change_offer_form: change_offer_form,
+          )
+        else # skip to location
+          change_offer_form.study_mode = study_modes.first
+          change_offer_form.step = :course_option
+          ProviderInterface::ChangeOffer::ChangeLocationComponent.new(
+            change_offer_form: change_offer_form,
+          )
+        end
       when :course
         ProviderInterface::ChangeOffer::ChangeCourseComponent.new(
           change_offer_form: change_offer_form,

--- a/app/components/provider_interface/change_offer_component.rb
+++ b/app/components/provider_interface/change_offer_component.rb
@@ -30,17 +30,15 @@ module ProviderInterface
           change_offer_form: change_offer_form,
         )
       when :study_mode
-        study_modes = Course.find(change_offer_form.course_id).study_modes_present
+        study_modes = Course.find(change_offer_form.course_id).available_study_modes_from_options
         if study_modes.count > 1
           ProviderInterface::ChangeOffer::ChangeStudyModeComponent.new(
             change_offer_form: change_offer_form,
           )
-        else # skip to location
+        else # skip to next step
           change_offer_form.study_mode = study_modes.first
-          change_offer_form.step = :course_option
-          ProviderInterface::ChangeOffer::ChangeLocationComponent.new(
-            change_offer_form: change_offer_form,
-          )
+          change_offer_form.step = change_offer_form.next_step
+          sub_component
         end
       when :course
         ProviderInterface::ChangeOffer::ChangeCourseComponent.new(

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -34,7 +34,7 @@ module ProviderInterface
         when 'Course'
           row.merge(change_path: @change_course_path, action: 'course')
         when 'Study mode'
-          row.merge(change_path: @change_study_mode_path, action: 'study mode')
+          row.merge(change_path: @change_study_mode_path, action: 'to full time or part time')
         when 'Location'
           row.merge(change_path: @change_course_option_path, action: 'location')
         else

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -11,6 +11,7 @@ module ProviderInterface
       @header = header
       @change_provider_path = options[:change_provider_path]
       @change_course_path = options[:change_course_path]
+      @change_study_mode_path = options[:change_study_mode_path]
       @change_course_option_path = options[:change_course_option_path]
     end
 
@@ -32,6 +33,8 @@ module ProviderInterface
           row.merge(change_path: @change_provider_path, action: 'training provider')
         when 'Course'
           row.merge(change_path: @change_course_path, action: 'course')
+        when 'Study mode'
+          row.merge(change_path: @change_study_mode_path, action: 'study mode')
         when 'Location'
           row.merge(change_path: @change_course_option_path, action: 'location')
         else

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -33,7 +33,7 @@ module ProviderInterface
           row.merge(change_path: @change_provider_path, action: 'training provider')
         when 'Course'
           row.merge(change_path: @change_course_path, action: 'course')
-        when 'Full time/part time'
+        when 'Full time or part time'
           row.merge(change_path: @change_study_mode_path, action: 'to full time or part time')
         when 'Location'
           row.merge(change_path: @change_course_option_path, action: 'location')

--- a/app/components/provider_interface/offer_summary_list_component.rb
+++ b/app/components/provider_interface/offer_summary_list_component.rb
@@ -33,7 +33,7 @@ module ProviderInterface
           row.merge(change_path: @change_provider_path, action: 'training provider')
         when 'Course'
           row.merge(change_path: @change_course_path, action: 'course')
-        when 'Study mode'
+        when 'Full time/part time'
           row.merge(change_path: @change_study_mode_path, action: 'to full time or part time')
         when 'Location'
           row.merge(change_path: @change_course_option_path, action: 'location')

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -13,7 +13,7 @@ module ProviderInterface
           },
           {
             key: 'Study mode',
-            value: course_option.full_time? ? 'Full time' : 'Part time',
+            value: course_option.study_mode.humanize,
           },
           {
             key: 'Location',

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -12,7 +12,7 @@ module ProviderInterface
             value: course_option.course.name_and_code,
           },
           {
-            key: 'Full time/part time',
+            key: 'Full time or part time',
             value: course_option.study_mode.humanize,
           },
           {

--- a/app/components/provider_interface/status_box_components/course_rows.rb
+++ b/app/components/provider_interface/status_box_components/course_rows.rb
@@ -12,7 +12,7 @@ module ProviderInterface
             value: course_option.course.name_and_code,
           },
           {
-            key: 'Study mode',
+            key: 'Full time/part time',
             value: course_option.study_mode.humanize,
           },
           {

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -36,7 +36,7 @@ module ProviderInterface
             row.merge(change_path: change_path(:provider), action: 'training provider')
           when 'Course'
             row.merge(change_path: change_path(:course), action: 'course')
-          when 'Full time/part time'
+          when 'Full time or part time'
             row.merge(change_path: change_path(:study_mode), action: 'to full time or part time')
           when 'Location'
             row.merge(change_path: change_path(:course_option), action: 'location')

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -5,12 +5,13 @@ module ProviderInterface
       include StatusBoxComponents::CourseRows
 
       attr_reader :application_choice
-      attr_reader :available_providers, :available_courses, :available_course_options
+      attr_reader :available_providers, :available_courses, :available_study_modes, :available_course_options
 
       def initialize(application_choice:, options: {})
         @application_choice = application_choice
         @available_providers = options[:available_providers]
         @available_courses = options[:available_courses]
+        @available_study_modes = options[:available_study_modes]
         @available_course_options = options[:available_course_options]
       end
 
@@ -35,6 +36,8 @@ module ProviderInterface
             row.merge(change_path: change_path(:provider), action: 'training provider')
           when 'Course'
             row.merge(change_path: change_path(:course), action: 'course')
+          when 'Study mode'
+            row.merge(change_path: change_path(:study_mode), action: 'study mode')
           when 'Location'
             row.merge(change_path: change_path(:course_option), action: 'location')
           else
@@ -64,6 +67,7 @@ module ProviderInterface
         collection = case target
                      when :provider then available_providers
                      when :course then available_courses
+                     when :study_mode then available_study_modes
                      when :course_option then available_course_options
                      end
         collection.count > 1 if collection

--- a/app/components/provider_interface/status_box_components/offer_component.rb
+++ b/app/components/provider_interface/status_box_components/offer_component.rb
@@ -36,8 +36,8 @@ module ProviderInterface
             row.merge(change_path: change_path(:provider), action: 'training provider')
           when 'Course'
             row.merge(change_path: change_path(:course), action: 'course')
-          when 'Study mode'
-            row.merge(change_path: change_path(:study_mode), action: 'study mode')
+          when 'Full time/part time'
+            row.merge(change_path: change_path(:study_mode), action: 'to full time or part time')
           when 'Location'
             row.merge(change_path: change_path(:course_option), action: 'location')
           else

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -5,11 +5,7 @@ module ProviderInterface
 
     def respond
       @pick_response_form = PickResponseForm.new
-
-      if @application_choice.course.study_modes_present.count > 1
-        current_study_mode = @application_choice.offered_option.study_mode
-        @other_study_mode = current_study_mode == 'full_time' ? 'part time' : 'full time'
-      end
+      @alternative_study_mode = @application_choice.offered_option.alternative_study_mode
     end
 
     def submit_response

--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -5,6 +5,11 @@ module ProviderInterface
 
     def respond
       @pick_response_form = PickResponseForm.new
+
+      if @application_choice.course.study_modes_present.count > 1
+        current_study_mode = @application_choice.offered_option.study_mode
+        @other_study_mode = current_study_mode == 'full_time' ? 'part time' : 'full time'
+      end
     end
 
     def submit_response

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -9,6 +9,7 @@ module ProviderInterface
             application_choice: @application_choice,
             provider_id: @application_choice.offered_option.provider.id,
             course_id: @application_choice.offered_course.id,
+            study_mode: @application_choice.offered_option.study_mode,
             course_option_id: @application_choice.offered_option.id,
             step: params[:step]&.to_sym,
           )
@@ -63,6 +64,7 @@ module ProviderInterface
         application_choice: @application_choice,
         provider_id: change_offer_params[:provider_id]&.to_i,
         course_id: change_offer_params[:course_id]&.to_i,
+        study_mode: change_offer_params[:study_mode],
         course_option_id: change_offer_params[:course_option_id]&.to_i,
         entry: change_offer_params[:entry],
         step: params[:step]&.to_sym,
@@ -70,7 +72,7 @@ module ProviderInterface
     end
 
     def change_offer_params
-      params.require(:provider_interface_change_offer_form).permit(:provider_id, :course_id, :course_option_id, :entry)
+      params.require(:provider_interface_change_offer_form).permit(:provider_id, :course_id, :study_mode, :course_option_id, :entry)
     rescue ActionController::ParameterMissing
       {}
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,7 +83,11 @@ class Course < ApplicationRecord
     study_mode == 'full_time_or_part_time'
   end
 
-  def study_modes_present
+  def supports_study_mode?(mode)
+    both_study_modes_available? || study_mode == mode
+  end
+
+  def available_study_modes_from_options
     course_options.pluck(:study_mode).uniq
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -83,6 +83,10 @@ class Course < ApplicationRecord
     study_mode == 'full_time_or_part_time'
   end
 
+  def study_modes_present
+    course_options.pluck(:study_mode).uniq
+  end
+
   def full?
     course_options.all?(&:no_vacancies?)
   end

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -40,4 +40,8 @@ class CourseOption < ApplicationRecord
   def course_full?
     course.course_options.vacancies.blank?
   end
+
+  def alternative_study_mode
+    (course.available_study_modes_from_options - [study_mode]).first
+  end
 end

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -1,14 +1,14 @@
 module ProviderInterface
   class ChangeOfferForm
     include ActiveModel::Model
-    attr_accessor :application_choice, :step, :provider_id, :course_id, :course_option_id, :entry
+    attr_accessor :application_choice, :step, :provider_id, :course_id, :study_mode, :course_option_id, :entry
 
     validates :application_choice, presence: true
 
     # This is a form for a multi-step process, in which each step depends on the previous ones.
     # Validation needs to take this into account, e.g. it is fine for course_id to be blank if step == :provider
     #
-    STEPS = %i[provider course course_option confirm update].freeze
+    STEPS = %i[provider course study_mode course_option confirm update].freeze
     validates :step, presence: true, inclusion: { in: STEPS, message: '%{value} is not a valid step' }
 
     def step_after?(step_symbol)
@@ -44,6 +44,17 @@ module ProviderInterface
       end
     end
 
+    VALID_STUDY_MODES = %w[full_time part_time].freeze
+
+    validates_each :study_mode do |record, attr, value|
+      if record.step_after?(:study_mode)
+        record.errors.add attr, :blank if value.blank?
+        record.errors.add attr, :unsupported if value.present? && !VALID_STUDY_MODES.include?(value)
+        record.errors.add attr, :unavailable_for_course if value.present? && !study_mode_valid_for_course?(record)
+        record.errors.add attr, :no_course_options if value.present? && !study_mode_with_options?(record)
+      end
+    end
+
     validates_each :course_option_id do |record, attr, value|
       if record.step_after?(:course_option)
         record.errors.add attr, :blank if value.blank? || !course_option_matches_course?(record)
@@ -62,6 +73,15 @@ module ProviderInterface
 
     def self.course_option_matches_course?(record)
       record.course_option_id && CourseOption.find(record.course_option_id).course.id == record.course_id
+    end
+
+    def self.study_mode_valid_for_course?(record)
+      course = Course.find(record.course_id) if record.course_id
+      course && (course.both_study_modes_available? || course.study_mode == record.study_mode)
+    end
+
+    def self.study_mode_with_options?(record)
+      CourseOption.where(course_id: record.course_id, study_mode: record.study_mode).present?
     end
 
     def new_offer?

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -76,8 +76,10 @@ module ProviderInterface
     end
 
     def self.study_mode_valid_for_course?(record)
-      course = Course.find(record.course_id) if record.course_id
-      course && (course.both_study_modes_available? || course.study_mode == record.study_mode)
+      if record.course_id
+        course = Course.find(record.course_id)
+        course.supports_study_mode? record.study_mode
+      end
     end
 
     def self.study_mode_with_options?(record)

--- a/app/models/provider_interface/pick_response_form.rb
+++ b/app/models/provider_interface/pick_response_form.rb
@@ -2,7 +2,7 @@ module ProviderInterface
   class PickResponseForm
     include ActiveModel::Model
 
-    VALID_CHANGE_DECISIONS = %w[edit_course edit_course_option edit_provider].freeze
+    VALID_CHANGE_DECISIONS = %w[edit_course edit_study_mode edit_course_option edit_provider].freeze
     VALID_DECISIONS = (%w[new_offer new_reject] + VALID_CHANGE_DECISIONS).freeze
 
     attr_accessor :decision

--- a/app/services/get_all_change_options_from_offered_option.rb
+++ b/app/services/get_all_change_options_from_offered_option.rb
@@ -1,32 +1,36 @@
 class GetAllChangeOptionsFromOfferedOption
   attr_accessor :application_choice, :available_providers
-  attr_accessor :available_courses, :available_course_options
+  attr_accessor :available_courses, :available_study_modes, :available_course_options
 
   def initialize(application_choice:, available_providers: nil)
     @application_choice = application_choice
 
     @available_providers = available_providers || [application_choice.offered_course.provider]
 
-    @available_courses = \
-      Course.where(
-        open_on_apply: true,
-        provider: application_choice.offered_course.provider,
-        study_mode: study_mode_for_other_courses,
-        recruitment_cycle_year: application_choice.offered_course.recruitment_cycle_year,
-      ).order(:name)
+    @available_courses = Course.where(
+      open_on_apply: true,
+      provider: application_choice.offered_course.provider,
+      study_mode: study_mode_for_other_courses,
+      recruitment_cycle_year: application_choice.offered_course.recruitment_cycle_year,
+    ).order(:name)
 
-    @available_course_options = \
-      CourseOption.where(
-        course: application_choice.offered_course,
-        study_mode: application_choice.offered_option.study_mode, # preserving study_mode, for now
-        # TODO: check vacancy_status, e.g. 'B'
-      ).includes(:site).order('sites.name')
+    @available_study_modes = CourseOption.where(
+      course: application_choice.offered_course,
+      # TODO: check vacancy_status, e.g. 'B'
+    ).pluck(:study_mode).uniq
+
+    @available_course_options = CourseOption.where(
+      course: application_choice.offered_course,
+      study_mode: application_choice.offered_option.study_mode, # preserving study_mode
+      # TODO: check vacancy_status, e.g. 'B'
+    ).includes(:site).order('sites.name')
   end
 
   def call
     {
       available_providers: available_providers,
       available_courses: available_courses,
+      available_study_modes: available_study_modes,
       available_course_options: available_course_options,
     }
   end

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -28,7 +28,7 @@
       <%= render SummaryListComponent.new(rows: [
         { key: 'Provider', value: @application_choice.offered_option.provider.name_and_code },
         { key: 'Course', value: @application_choice.offered_course.name_and_code },
-        { key: 'Full time/part time', value: @application_choice.offered_option.study_mode.humanize },
+        { key: 'Full time or part time', value: @application_choice.offered_option.study_mode.humanize },
         { key: 'Location', value: @application_choice.offered_site.name },
         { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
         { key: 'Conditions', value: conditions },

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -26,9 +26,11 @@
       <%= f.govuk_error_summary %>
 
       <%= render SummaryListComponent.new(rows: [
+        { key: 'Provider', value: @application_choice.offered_option.provider.name_and_code },
         { key: 'Course', value: @application_choice.offered_course.name_and_code },
+        { key: 'Full time/part time', value: @application_choice.offered_option.study_mode.humanize },
+        { key: 'Location', value: @application_choice.offered_site.name },
         { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
-        { key: 'Preferred location', value: @application_choice.offered_site.name },
         { key: 'Conditions', value: conditions },
       ]) %>
 

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -21,8 +21,8 @@
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
         <% if FeatureFlag.active?('provider_change_response') -%>
           <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>
-          <% if @other_study_mode %>
-            <%= f.govuk_radio_button :decision, 'edit_study_mode', label: { text: "#{offer_text} but change to #{@other_study_mode}" }, link_errors: true %>
+          <% if @alternative_study_mode %>
+            <%= f.govuk_radio_button :decision, 'edit_study_mode', label: { text: "#{offer_text} but change to #{@alternative_study_mode.humanize.downcase}" }, link_errors: true %>
           <% end %>
           <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" }, link_errors: true %>
           <% if current_provider_user.providers.size > 1 %>

--- a/app/views/provider_interface/decisions/respond.html.erb
+++ b/app/views/provider_interface/decisions/respond.html.erb
@@ -21,6 +21,9 @@
         <%= f.govuk_radio_button :decision, 'new_offer', label: { text: offer_text }, link_errors: true %>
         <% if FeatureFlag.active?('provider_change_response') -%>
           <%= f.govuk_radio_button :decision, 'edit_course', label: { text: "#{offer_text} but change course" }, link_errors: true %>
+          <% if @other_study_mode %>
+            <%= f.govuk_radio_button :decision, 'edit_study_mode', label: { text: "#{offer_text} but change to #{@other_study_mode}" }, link_errors: true %>
+          <% end %>
           <%= f.govuk_radio_button :decision, 'edit_course_option', label: { text: "#{offer_text} but change location" }, link_errors: true %>
           <% if current_provider_user.providers.size > 1 %>
             <%= f.govuk_radio_button :decision, 'edit_provider', label: { text: "#{offer_text} but change training provider" }, link_errors: true %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -161,6 +161,11 @@ en:
             course_id:
               blank: You have not chosen a new course
               not_open_on_apply: Course not open on Apply
+            study_mode:
+              blank: Select full time or part time
+              unsupported: Please specify a valid study mode
+              unavailable_for_course: Unavailable for this course
+              no_course_options: No relevant course options available
             course_option_id:
               blank: You have not chosen a new location
         provider_interface/confirm_conditions_form:

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -19,7 +19,7 @@ desc 'Sync some pilot-enabled providers and open all their courses'
 task sync_dev_providers_and_open_courses: :environment do
   puts 'Syncing data from Find...'
 
-  provider_codes = HostingEnvironment.review? ? %w[1N1] : %w[1N1 2LR C58 C85]
+  provider_codes = HostingEnvironment.review? ? %w[C85] : %w[1N1 2LR C58 C85]
   provider_codes.each do |code|
     SyncProviderFromFind.call(provider_code: code, sync_courses: true)
   end

--- a/spec/components/previews/provider_interface/change_offer_preview.rb
+++ b/spec/components/previews/provider_interface/change_offer_preview.rb
@@ -16,7 +16,15 @@ module ProviderInterface
       render_with form
     end
 
-    def existing_offer_start_at_3_location(provider_interface_change_offer_form: nil)
+    def existing_offer_start_at_3_study_mode(provider_interface_change_offer_form: nil)
+      initial_step :study_mode
+      set_application_choice application_choice_with_offer
+
+      form = submitted_form(provider_interface_change_offer_form) || new_form
+      render_with form
+    end
+
+    def existing_offer_start_at_4_location(provider_interface_change_offer_form: nil)
       initial_step :course_option
       set_application_choice application_choice_with_offer
 
@@ -49,7 +57,15 @@ module ProviderInterface
       render_with form
     end
 
-    def new_offer_start_at_3_location(provider_interface_change_offer_form: nil)
+    def new_offer_start_at_3_study_mode(provider_interface_change_offer_form: nil)
+      initial_step :study_mode
+      set_application_choice application_choice_awaiting_decision
+
+      form = submitted_form(provider_interface_change_offer_form) || new_form
+      render_with form
+    end
+
+    def new_offer_start_at_4_location(provider_interface_change_offer_form: nil)
       initial_step :course_option
       set_application_choice application_choice_awaiting_decision
 
@@ -112,10 +128,12 @@ module ProviderInterface
       if new_course_option
         provider_id = new_course_option.provider.id
         course_id = new_course_option.course.id
+        study_mode = new_course_option.study_mode
         course_option_id = new_course_option.id
       else
         provider_id = application_choice.offered_course.provider.id
         course_id = application_choice.offered_course.id
+        study_mode = application_choice.offered_option.study_mode
         course_option_id = application_choice.offered_option.id
       end
       ProviderInterface::ChangeOfferForm.new(
@@ -123,6 +141,7 @@ module ProviderInterface
         step: @step,
         provider_id: provider_id,
         course_id: course_id,
+        study_mode: study_mode,
         course_option_id: course_option_id,
       )
     end

--- a/spec/components/provider_interface/status_box_components/course_rows_spec.rb
+++ b/spec/components/provider_interface/status_box_components/course_rows_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe ProviderInterface::StatusBoxComponents::CourseRows do
   it 'displays information about the offered course' do
     rows = helper.course_rows(course_option: create(:course_option))
 
-    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Full time/part time']
+    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Full time or part time']
   end
 
   it 'includes the accredited_provider if present' do
     course = create(:course, accredited_provider: create(:provider))
     rows = helper.course_rows(course_option: create(:course_option, course: course))
 
-    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Full time/part time', 'Accredited body']
+    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Full time or part time', 'Accredited body']
   end
 end

--- a/spec/components/provider_interface/status_box_components/course_rows_spec.rb
+++ b/spec/components/provider_interface/status_box_components/course_rows_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe ProviderInterface::StatusBoxComponents::CourseRows do
   it 'displays information about the offered course' do
     rows = helper.course_rows(course_option: create(:course_option))
 
-    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Study mode']
+    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Full time/part time']
   end
 
   it 'includes the accredited_provider if present' do
     course = create(:course, accredited_provider: create(:provider))
     rows = helper.course_rows(course_option: create(:course_option, course: course))
 
-    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Study mode', 'Accredited body']
+    expect(rows.map { |r| r[:key] }).to match_array ['Course', 'Location', 'Provider', 'Full time/part time', 'Accredited body']
   end
 end

--- a/spec/models/provider_interface/change_offer_form_spec.rb
+++ b/spec/models/provider_interface/change_offer_form_spec.rb
@@ -4,14 +4,17 @@ RSpec.describe ProviderInterface::ChangeOfferForm do
   include CourseOptionHelpers
   let(:provider_user) { create(:provider_user, :with_provider) }
   let(:provider) { provider_user.providers.first }
-  let(:course) { create(:course, :open_on_apply, provider: provider) }
+  let(:course) { create(:course, :open_on_apply, :with_both_study_modes, provider: provider) }
+  let(:study_mode) { course_option.study_mode }
   let(:course_option) { course_option_for_provider(provider: provider, course: course) }
+
   let(:application_choice) { create(:application_choice, :with_modified_offer, course_option: course_option) }
   let(:form_with_application_choice) { described_class.new(application_choice: application_choice, step: step) }
 
   def invalid_for_missing(attribute)
     form_with_application_choice.provider_id = course_option.course.provider.id
     form_with_application_choice.course_id = course_option.course.id
+    form_with_application_choice.study_mode = study_mode
     form_with_application_choice.course_option_id = course_option.id
     form_with_application_choice.send("#{attribute}=".to_sym, nil)
     expect(form_with_application_choice).to be_invalid
@@ -45,6 +48,17 @@ RSpec.describe ProviderInterface::ChangeOfferForm do
     end
   end
 
+  describe 'step: :study_mode' do
+    let(:step) { :study_mode }
+    let(:subject) { form_with_application_choice }
+
+    %w[provider_id course_id].each do |attribute|
+      it "is invalid when :#{attribute} is missing" do
+        invalid_for_missing attribute
+      end
+    end
+  end
+
   describe 'step: :course_option' do
     let(:step) { :course_option }
     let(:subject) { form_with_application_choice }
@@ -52,19 +66,57 @@ RSpec.describe ProviderInterface::ChangeOfferForm do
     it 'is valid when provider_id and course_id are set and related' do
       form_with_application_choice.provider_id = course.provider.id
       form_with_application_choice.course_id = course.id
+      form_with_application_choice.study_mode = study_mode
       expect(form_with_application_choice).to be_valid
-    end
-
-    %w[provider_id course_id].each do |attribute|
-      it "is invalid when :#{attribute} is missing" do
-        invalid_for_missing attribute
-      end
     end
 
     it 'is invalid when provider_id and course_id are set but not related' do
       form_with_application_choice.provider_id = 458
       form_with_application_choice.course_id = course.id
       expect(form_with_application_choice).to be_invalid
+    end
+
+    it 'is valid when course supports the selected study_mode and relevant options exist' do
+      course_option_for_provider(provider: provider, course: course, study_mode: 'part_time')
+      form_with_application_choice.provider_id = provider.id
+      form_with_application_choice.course_id = course.id
+      form_with_application_choice.study_mode = 'part_time'
+      expect(form_with_application_choice).to be_valid
+    end
+
+    it 'is invalid when course does not support the selected study_mode' do
+      full_time_course = create(
+        :course,
+        :open_on_apply,
+        :full_time,
+        provider: provider,
+      )
+      course_option_for_provider(provider: provider, course: full_time_course)
+      form_with_application_choice.provider_id = provider.id
+      form_with_application_choice.course_id = full_time_course.id
+      form_with_application_choice.study_mode = 'part_time'
+      expect(form_with_application_choice).to be_invalid
+    end
+
+    it 'is invalid when no course_options are available for this study_mode' do
+      form_with_application_choice.provider_id = provider.id
+      other_course = create(:course, :open_on_apply, :full_time, provider: provider)
+      form_with_application_choice.course_id = other_course.id
+      form_with_application_choice.study_mode = 'full_time'
+      expect(form_with_application_choice).to be_invalid
+    end
+
+    it 'is invalid for unrecognised study modes' do
+      form_with_application_choice.provider_id = course.provider.id
+      form_with_application_choice.course_id = course.id
+      form_with_application_choice.study_mode = 'arbitrary_mode'
+      expect(form_with_application_choice).to be_invalid
+    end
+
+    %w[provider_id course_id study_mode].each do |attribute|
+      it "is invalid when :#{attribute} is missing" do
+        invalid_for_missing attribute
+      end
     end
   end
 
@@ -75,21 +127,23 @@ RSpec.describe ProviderInterface::ChangeOfferForm do
     it 'is valid when provider_id, course_id and course_option_id are all set and related' do
       form_with_application_choice.provider_id = course_option.course.provider.id
       form_with_application_choice.course_id = course_option.course.id
+      form_with_application_choice.study_mode = study_mode
       form_with_application_choice.course_option_id = course_option.id
       expect(form_with_application_choice).to be_valid
+    end
+
+    it 'is invalid when provider_id, course_id, course_option_id are set but not related' do
+      form_with_application_choice.provider_id = course_option.course.provider.id
+      form_with_application_choice.course_id = course_option.course.id
+      form_with_application_choice.study_mode = study_mode
+      form_with_application_choice.course_option_id = create(:course_option).id
+      expect(form_with_application_choice).to be_invalid
     end
 
     %w[provider_id course_id course_option_id].each do |attribute|
       it "is invalid when :#{attribute} is missing" do
         invalid_for_missing attribute
       end
-    end
-
-    it 'is invalid when provider_id, course_id, course_option_id are set but not related' do
-      form_with_application_choice.provider_id = course_option.course.provider.id
-      form_with_application_choice.course_id = course_option.course.id
-      form_with_application_choice.course_option_id = create(:course_option).id
-      expect(form_with_application_choice).to be_invalid
     end
   end
 
@@ -100,6 +154,7 @@ RSpec.describe ProviderInterface::ChangeOfferForm do
     it 'is valid when provider_id, course_id and course_option_id are all set and related' do
       form_with_application_choice.provider_id = course_option.course.provider.id
       form_with_application_choice.course_id = course_option.course.id
+      form_with_application_choice.study_mode = study_mode
       form_with_application_choice.course_option_id = course_option.id
       expect(form_with_application_choice).to be_valid
     end

--- a/spec/services/get_all_change_options_from_offered_option_spec.rb
+++ b/spec/services/get_all_change_options_from_offered_option_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe GetAllChangeOptionsFromOfferedOption do
   describe '#call' do
     let(:returned_hash) { service.call }
 
-    it 'returns a hash of available providers, courses and course_options' do
+    it 'returns a hash of available providers, courses, study_modes and course_options' do
       expect(returned_hash.keys).to \
-        eq %i[available_providers available_courses available_course_options]
+        eq %i[available_providers available_courses available_study_modes available_course_options]
     end
 
     it 'includes all providers associated with the user' do
@@ -42,6 +42,13 @@ RSpec.describe GetAllChangeOptionsFromOfferedOption do
       expect(returned_hash[:available_courses]).not_to include(not_open)
       expect(returned_hash[:available_courses]).not_to include(wrong_year)
       expect(returned_hash[:available_courses]).not_to include(part_time_only)
+    end
+
+    it 'includes all study modes available for the course' do
+      course = course_option.course
+      create(:course_option, :part_time, course: course)
+
+      expect(returned_hash[:available_study_modes]).to eq(%w[full_time part_time])
     end
 
     it 'includes all course options for current course (subject to study_mode)' do

--- a/spec/system/provider_interface/provider_changes_an_offer_spec.rb
+++ b/spec/system/provider_interface/provider_changes_an_offer_spec.rb
@@ -8,8 +8,7 @@ RSpec.feature 'Provider changes an offer' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_two_providers
     and_an_offered_application_choice_exists_for_one_of_my_providers
-    and_another_relevant_course_exists_for_this_provider
-    and_a_part_time_only_course_exists_for_this_provider
+    and_other_full_time_and_part_time_courses_exist_for_this_provider
     and_an_older_course_exists_for_this_provider
     and_i_sign_in_to_the_provider_interface
     and_i_view_an_offered_application
@@ -44,18 +43,19 @@ RSpec.feature 'Provider changes an offer' do
   end
 
   def and_an_offered_application_choice_exists_for_one_of_my_providers
+    # Course @course_option_one belongs to is exclusively full-time
     @course_option_one = course_option_for_provider(provider: @provider, study_mode: 'full_time')
     @application_offered = create(:application_choice, :with_offer, course_option: @course_option_one)
   end
 
-  def and_another_relevant_course_exists_for_this_provider
-    @other_course = create(:course, :open_on_apply, :with_both_study_modes, provider: @provider)
-    @course_option_two = create(:course_option, :full_time, course: @other_course)
-    @course_option_three = create(:course_option, :part_time, course: @other_course)
-  end
-
-  def and_a_part_time_only_course_exists_for_this_provider
+  def and_other_full_time_and_part_time_courses_exist_for_this_provider
+    # Course with both study modes and associated course options
+    @both_modes_course = create(:course, :open_on_apply, :with_both_study_modes, provider: @provider)
+    @course_option_two = create(:course_option, :full_time, course: @both_modes_course)
+    @course_option_three = create(:course_option, :part_time, course: @both_modes_course)
+    # Exclusively part-time course with associated course option
     @part_time_course = create(:course, :open_on_apply, :part_time, provider: @provider)
+    @course_option_four = create(:course_option, :part_time, course: @part_time_course)
   end
 
   def and_an_older_course_exists_for_this_provider
@@ -99,14 +99,14 @@ RSpec.feature 'Provider changes an offer' do
   end
 
   def then_i_see_all_courses_for_this_provider_year_and_study_mode
-    expect(page).not_to have_content @part_time_course.name_and_code
     expect(page).not_to have_content @old_course.name_and_code
     expect(page).to have_content @course_option_one.course.name_and_code
-    expect(page).to have_content @other_course.name_and_code
+    expect(page).to have_content @part_time_course.name_and_code
+    expect(page).to have_content @both_modes_course.name_and_code
   end
 
   def and_i_can_change_the_course
-    choose @other_course.name_and_code
+    choose @both_modes_course.name_and_code
     click_on 'Continue'
   end
 
@@ -116,9 +116,10 @@ RSpec.feature 'Provider changes an offer' do
   end
 
   def and_i_see_all_available_locations_for_this_study_mode
-    expect(page).not_to have_content @course_option_one.site.name
-    expect(page).not_to have_content @course_option_two.site.name
+    expect(page).not_to have_content @course_option_one.site.name # wrong everything
+    expect(page).not_to have_content @course_option_two.site.name # wrong study_mode
     expect(page).to have_content @course_option_three.site.name
+    expect(page).not_to have_content @course_option_four.site.name # wrong course
   end
 
   def and_i_can_change_the_location

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -27,7 +27,6 @@ RSpec.feature 'Provider makes changes before making an offer' do
     and_i_can_change_training_provider
     and_i_see_all_courses_for_this_provider
     and_i_can_change_the_course
-    and_i_can_select_the_study_mode
     and_i_see_all_available_locations_for_this_course
     and_i_can_change_the_location
 
@@ -117,11 +116,6 @@ RSpec.feature 'Provider makes changes before making an offer' do
 
   def and_i_can_change_the_course
     choose @course_option_two.course.name_and_code
-    click_on 'Continue'
-  end
-
-  def and_i_can_select_the_study_mode
-    choose 'Full time'
     click_on 'Continue'
   end
 

--- a/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
+++ b/spec/system/provider_interface/provider_makes_changes_before_offer_spec.rb
@@ -27,6 +27,7 @@ RSpec.feature 'Provider makes changes before making an offer' do
     and_i_can_change_training_provider
     and_i_see_all_courses_for_this_provider
     and_i_can_change_the_course
+    and_i_can_select_the_study_mode
     and_i_see_all_available_locations_for_this_course
     and_i_can_change_the_location
 
@@ -116,6 +117,11 @@ RSpec.feature 'Provider makes changes before making an offer' do
 
   def and_i_can_change_the_course
     choose @course_option_two.course.name_and_code
+    click_on 'Continue'
+  end
+
+  def and_i_can_select_the_study_mode
+    choose 'Full time'
     click_on 'Continue'
   end
 


### PR DESCRIPTION
## Context

As a provider user, when making an initial offer, I want to be able to change the offer `study_mode` to full time or part time, subject to the available course options.

As a provider user, when changing an existing offer, I want to be able to change the offer `study_mode` to full time or part time, subject to the available course options.

## Changes proposed in this pull request

This PR adds `study_mode` as a step within `ChangeOfferForm` and related validations (study_mode must not be blank, be either 'full_time' or 'part_time', the course must support the selected `study_mode` and options of that `study_mode` must be available).

It also introduces the relevant `ChangeStudyModeComponent` to the family of change offer components and updates the controllers to pass `study_mode` information to the form supplied to `ChangeOfferComponent`.

## Guidance to review

When using the review app, interact with Coventry University related applications, as their courses support both full time and part time options. (e.g. https://apply-for-te-1995-chang-y7o4yn.herokuapp.com/provider/applications/24) Gorse SCITT courses tend to be full time only.

Here are some screenshots. Display is often conditional, see notes.

### ### Responding to an application:
![image](https://user-images.githubusercontent.com/107591/83161212-0db10b80-a100-11ea-887e-6ae0d7240544.png)
Note: The option to make an offer but change the `study_mode` is new. This option will appear only if options of the other type are available for the chosen course.

---------------------------------------

### ### Confirming a new offer:
![image](https://user-images.githubusercontent.com/107591/83161400-4ea92000-a100-11ea-86a7-36ff2ede751f.png)
Note: Provider name and code, study_mode information are new additions.

---------------------------------------

### ### Looking at an existing offer:
![image](https://user-images.githubusercontent.com/107591/83161561-831cdc00-a100-11ea-88ca-174819161afd.png)
Note: 'Change' link for study_mode is new.

---------------------------------------

### ### Changing the study_mode:
![image](https://user-images.githubusercontent.com/107591/83161651-9b8cf680-a100-11ea-81ec-014dddc14d85.png)
Note: This is a brand new step. This step is skipped if no other study modes are available for the chosen course.

---------------------------------------

### ### Confirming changes to an existing offer:
![image](https://user-images.githubusercontent.com/107591/83161710-b0698a00-a100-11ea-9f09-f9c7bd60c83a.png)
Note: Change links at the bottom are conditional to whether other study modes are available, as well as to `entry`-related concerns (as before).

---------------------------------------

### Other considerations

- The logic that determines if other study modes are available for a course does not take into account `recruitment_cycle_year`.
- The form will check whether a course is 'open on Apply' but not the `vacancies` status of the course.

## Link to Trello card

https://trello.com/c/0u3Z8WLc

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
