### PR TITLE
cancel build if there are new commits to a branch

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -80,9 +80,13 @@ jobs:
       runOnce:
         deploy:
           steps:
+          - template: cancel-build-if-not-latest-template.yml
+            parameters:
+              sourceBranchName: $(Build.SourceBranchName)
+
           - task: AzurePowerShell@4
             displayName: 'Azure PowerShell Script - Set Deployment Type for Resource Group $(resourceGroupName)'
-            condition: succeeded()
+            condition: and(succeeded(), eq(variables['buildCancelled'], false))
             env:
               SYSTEM_ACCESSTOKEN: $(system.accesstoken)
               COMMIT_HASH: $(build.sourceVersion)
@@ -179,7 +183,7 @@ jobs:
 
           - task: AzureResourceGroupDeployment@2
             displayName: 'ARM Deployment - Create Or Update Resource Group action on $(resourceGroupName)'
-            condition: and(succeeded(), eq(variables['fullDeployment'], true))
+            condition: and(eq(variables['buildCancelled'], false), eq(variables['fullDeployment'], true))
             inputs:
               azureSubscription: '${{parameters.subscriptionName}}'
               resourceGroupName: '$(resourceGroupName)'
@@ -249,7 +253,7 @@ jobs:
 
           - task: AzureCLI@2
             displayName: 'Azure CLI - Update Container Images in Resource Group $(resourceGroupName)'
-            condition: and(succeeded(), eq(variables['fullDeployment'], false))
+            condition: and(eq(variables['buildCancelled'], false), eq(variables['fullDeployment'], false))
             inputs:
               azureSubscription: '${{parameters.subscriptionName}}'
               ScriptType: ps
@@ -314,7 +318,7 @@ jobs:
 
           - task: AzurePowerShell@4
             displayName: 'Azure PowerShell Script - Tag resource group: $(resourceGroupName)'
-            condition: succeeded()
+            condition: and(succeeded(), eq(variables['buildCancelled'], false))
             inputs:
               azureSubscription: '${{parameters.subscriptionName}}'
               ScriptType: InlineScript
@@ -335,8 +339,14 @@ jobs:
 
                 Set-AzResourceGroup -Name $resourceGroupName -Tag $tags
 
-          - template: swap-staging-production-template.yml
+          - template: cancel-build-if-not-latest-template.yml
             parameters:
-              azureSubscription: ${{parameters.subscriptionName}}
-              resourceGroup: $(resourceGroupName)
-              appService: $(appServiceName)
+              sourceBranchName: $(Build.SourceBranchName)
+              runStep: ${{ eq(variables['fullDeployment'], false) }}
+
+          - ${{ if eq(variables['buildCancelled'], false) }}:
+            - template: swap-staging-production-template.yml
+              parameters:
+                azureSubscription: ${{parameters.subscriptionName}}
+                resourceGroup: $(resourceGroupName)
+                appService: $(appServiceName)

--- a/azure-pipelines-release.yml
+++ b/azure-pipelines-release.yml
@@ -9,6 +9,8 @@ variables:
   value: 'apply-for-postgraduate-teacher-training'
 - name: debug
   value: true
+- name: buildCancelled
+  value: false
 
 stages:
 - stage: publish_arm_template

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ variables:
   value: true
 - name: deployOnly
   value: false
+- name: buildCancelled
+  value: false
 
 stages:
 - stage: build_release
@@ -43,10 +45,15 @@ stages:
         echo "##vso[task.setvariable variable=docker_path;]$docker_path"
         mkdir $(pipelineDockerCachePath)
       displayName: 'Configure build environment'
+    
+    - template: cancel-build-if-not-latest-template.yml
+      parameters:
+        sourceBranchName: $(Build.SourceBranchName)
 
     - script: |
          make build
       displayName: 'Build Docker image'
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
       env:
         DOCKER_BUILDKIT: $(dockerBuildkitState)
         COMPOSE_DOCKER_CLI_BUILD: $(dockerBuildkitState)
@@ -66,30 +73,36 @@ stages:
         docker save $(docker history -q $(dockerHubUsername)/$(imageName) | grep -v "<missing>") | gzip > $(System.DefaultWorkingDirectory)/docker_images/$(imageName).tar.gz
         docker images $(dockerHubUsername)/$(imageName) | sed 1d | awk '{print $1 " " $2 " " $3}' > $(System.DefaultWorkingDirectory)/docker_images/images_manifest.txt
       displayName: 'Export Docker image pipeline artifact'
-      condition: succeeded()
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Docker image artifact'
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
       inputs:
         path: '$(System.DefaultWorkingDirectory)/docker_images/'
         artifactName: 'docker_artifacts'
     
     - task: PublishPipelineArtifact@1
       displayName: 'Publish ARM template artifacts'
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
       inputs:
         path: '$(System.DefaultWorkingDirectory)/azure/'
         artifactName: 'arm_template'
-    
+
+    - template: cancel-build-if-not-latest-template.yml
+      parameters:
+        sourceBranchName: $(Build.SourceBranchName)
+
     - task: Docker@2
       displayName: Login to DockerHub
-      condition: and(succeeded(), eq(variables['deployOnly'], false))
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
       inputs:
         containerRegistry: 'DfE Docker Hub'
         command: 'login'
 
     - task: Docker@2
       displayName: Push image to DockerHub
-      condition: and(succeeded(), eq(variables['deployOnly'], false))
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
       inputs:
         containerRegistry: 'DfE Docker Hub'
         repository: '$(dockerHubUsername)/$(imageName)'
@@ -100,12 +113,12 @@ stages:
     - script: |
         docker tag $(dockerHubUsername)/$(imageName):$(Build.BuildNumber) $(dockerHubUsername)/$(imageName):latest
         docker rmi $(dockerHubUsername)/$(imageName):$(Build.BuildNumber)
-      displayName: Tage image as latest (if master)
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+      displayName: Tag image as latest (if master)
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')))
 
     - task: Docker@2
       displayName: Push image (latest) to DockerHub
-      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')))
       inputs:
         containerRegistry: 'DfE Docker Hub'
         repository: '$(dockerHubUsername)/$(imageName)'
@@ -142,6 +155,10 @@ stages:
         echo '##vso[task.setvariable variable=COMPOSE_FILE]docker-compose.yml:docker-compose.azure.yml'
       displayName: 'Configure environment'
 
+    - template: cancel-build-if-not-latest-template.yml
+      parameters:
+        sourceBranchName: $(Build.SourceBranchName)
+
     - script: |
         docker pull $(dockerHubUsername)/$(imageName):$(Build.BuildNumber)
         make az_setup
@@ -159,6 +176,10 @@ stages:
         FIND_BASE_URL: $(findBaseUrl)
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
         SANDBOX: $(sandbox)
+
+    - template: cancel-build-if-not-latest-template.yml
+      parameters:
+        sourceBranchName: $(Build.SourceBranchName)
 
     - script: make ci.lint-ruby
       name: ci_lint_ruby
@@ -271,6 +292,10 @@ stages:
         echo '##vso[task.setvariable variable=COMPOSE_FILE]docker-compose.yml:docker-compose.azure.yml'
       displayName: 'Configure environment'
 
+    - template: cancel-build-if-not-latest-template.yml
+      parameters:
+        sourceBranchName: $(Build.SourceBranchName)
+
     - script: |
         docker pull $(dockerHubUsername)/$(imageName):$(Build.BuildNumber)
         make az_setup
@@ -289,6 +314,10 @@ stages:
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
         SANDBOX: $(sandbox)
     
+    - template: cancel-build-if-not-latest-template.yml
+      parameters:
+        sourceBranchName: $(Build.SourceBranchName)
+
     - script: |
         make ci.test
         test_result=$?
@@ -338,7 +367,7 @@ stages:
 - stage: deploy_qa
   displayName: 'Deploy - QA'
   dependsOn: build_release
-  condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   variables:
   - group: APPLY - ENV - QA
   jobs:
@@ -395,7 +424,7 @@ stages:
 - stage: deploy_devops
   dependsOn: build_release
   displayName: 'Deploy - DevOps'
-  condition: eq(variables['Build.SourceBranchName'], variables.devDeployBranchNameOverride)
+  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], variables.devDeployBranchNameOverride))
   variables:
   - group: APPLY - ENV - DevOps
   jobs:

--- a/cancel-build-if-not-latest-template.yml
+++ b/cancel-build-if-not-latest-template.yml
@@ -1,0 +1,75 @@
+parameters:
+  - name: sourceBranchName
+    displayName: Name of the branch trigerring the build
+    type: string
+  - name: runStep
+    displayName: Boolean value indicating if to run the step, default true.
+    type: boolean
+    default: true
+
+steps:
+  - powershell: |
+      if($env:DEBUG){
+        $DebugPreference = "Continue"
+       }
+      $azureDevOpsAuthorizationHeader = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+      $gitHubApiHeader = @{ Accept = "application/vnd.github.v3+json" }
+      $azurePipelinesBuildApi = "$($env:COLLECTION_URL)$env:PROJECT_ID/_apis/build/builds/$($env:BUILD_ID)?api-version=5.1"
+      $gitHubGetCurrentCommitApi = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/git/commits/$($env:COMMIT_ID)"
+      $gitHubGetNewCommitsToMasterApi = "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/commits?sha=$($env:SOURCE_BRANCH)"
+      
+      Write-Debug "azurePipelinesBuildApi is $azurePipelinesBuildApi"
+      Write-Debug "gitHubGetCurrentCommitApi is $gitHubGetCurrentCommitApi"
+      Write-Debug "SOURCE_BRANCH IS $env:SOURCE_BRANCH"
+      Write-Debug "BUILD_NUMBER IS $env:BUILD_NUMBER"
+      Write-Debug "AccessToken is $env:SYSTEM_ACCESSTOKEN"
+      Write-Debug "ORGANISATION_ID is $env:ORGANISATION_ID"
+      Write-Debug "COLLECTION_URL is $env:COLLECTION_URL"
+      Write-Debug "COMMIT_ID is $($env:COMMIT_ID)"
+      Write-Debug "BUILD_ID is $env:BUILD_ID"
+      Write-Debug "PROJECT_ID is $env:PROJECT_ID"
+      Write-Debug "PROJECT_NAME is $env:PROJECT_NAME"
+
+      $currentCommit = Invoke-RestMethod -Uri $gitHubGetCurrentCommitApi -Headers $gitHubApiHeader -Method Get -ErrorAction SilentlyContinue -ErrorVariable $gitHubApiError
+      $currentCommitSha = $currentCommit.sha
+      $currentCommitTimestamp = $currentCommit.committer.date | Get-Date -UFormat '+%Y-%m-%dT%H:%M:%S.000Z'
+      Write-Debug "currentCommitTimestamp is $($currentCommitTimestamp)"
+      $gitHubGetNewCommitsToMasterApi = $gitHubGetNewCommitsToMasterApi + "&since=$($currentCommitTimestamp)"
+      Write-Debug "gitHubGetNewCommitsToMasterApi is $gitHubGetNewCommitsToMasterApi"
+
+      $commitsSinceCurrentCommit = Invoke-RestMethod -Uri $gitHubGetNewCommitsToMasterApi -Headers $gitHubApiHeader -Method Get
+      if($commitsSinceCurrentCommit){
+        Write-Host "Current Commit to $($env:SOURCE_BRANCH) : $($currentCommitSha)"
+        Write-Host "Latest  Commit to $($env:SOURCE_BRANCH) : $($commitsSinceCurrentCommit[0].sha)"
+      }
+      
+      if($commitsSinceCurrentCommit[0].sha -and $currentCommitSha -ne $commitsSinceCurrentCommit[0].sha){
+        Write-Warning "There are new commits to $($env:SOURCE_BRANCH) since this commit, cancelling current build..."
+        Write-Host "##vso[task.logissue type=warning;]There are new commits to master since this commit, Cancelling this build..."
+
+        $currentBuild = Invoke-RestMethod -Uri $azurePipelinesBuildApi -Headers $azureDevOpsAuthorizationHeader -Method Get -ErrorAction Stop -ErrorVariable $errorVariable
+        Write-Debug $currentBuild | ConvertTo-Json
+        $currentBuild.status = "cancelling"
+        $requestBody = @{
+          buildNumber = $currentBuild.buildNumber
+          id = $currentBuild.id
+          status = "cancelling"
+        } | ConvertTo-Json
+        Write-Host "requestBody => is $requestBody"
+        Write-Host "##vso[task.setvariable variable=buildCancelled]$true"
+        $cancelPipeline = Invoke-RestMethod -Uri $azurePipelinesBuildApi -Headers $azureDevOpsAuthorizationHeader -Method Patch -Body $requestBody -ContentType "application/json" -ErrorAction SilentlyContinue -ErrorVariable errorVariable
+      }
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      ORGANISATION_ID: $(System.CollectionId)
+      COLLECTION_URL: $(System.TeamFoundationCollectionUri)
+      COMMIT_ID: $(Build.SourceVersion)
+      SOURCE_BRANCH: ${{ parameters.sourceBranchName }}
+      BUILD_ID: $(Build.BuildId)
+      BUILD_NUMBER: $(Build.BuildNumber)
+      PROJECT_ID: $(System.TeamProjectId)
+      PROJECT_NAME: $(System.TeamProject)
+      DEBUG: $(System.Debug)
+    displayName: Check for new commits to ${{ parameters.sourceBranchName }}
+    condition: and(succeeded(), and(${{parameters.runStep}}, or(eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['Build.Reason'], 'BatchedCI'))))
+    continueOnError: true


### PR DESCRIPTION
check if there are new commits to a branch since triggering commit,
and cancel current build if triggering commit is not the most recent
commit to that branch.

## Context

Currently a build runs to completion even if there are new commits queued for a new build thereby making the deployment out of date as soon as it completes. 
We can save time by cancelling builds if there are new commits to a branch since the build has been triggered. 

## Changes proposed in this pull request
New scripts to check for new commits to a branch since a commit triggering the build.
Run this check at few checkpoints across the build proces after/before long running tasks.
I have tested these changes in the main `apply-for-teacher-training` and also by creating a new pipeline for testing purpose.

## Guidance to review

## Link to Trello card

https://trello.com/c/LvGTz4b6/2206-check-if-batched-triggers-are-enabled-in-the-pipeline

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
