### PR TITLE
Do not fail a build if there are warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -255,6 +255,12 @@ stages:
         testRunner: JUnit
         testResultsFiles: 'results/*.xml'
 
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Cucumber Results XML'
+      inputs:
+        path: '$(System.DefaultWorkingDirectory)/results/'
+        artifactName: 'cucumberResults'
+
 
   - job: test_docker_image_batch_2
     displayName: 'Test Docker Image - RSpec'
@@ -304,7 +310,6 @@ stages:
             if [ $(grep "^<testsuite name=\"rspec\"" results/rspec-results.xml | cut -d' ' -f4 | cut -d'"' -f2) -gt 0 ]
             then
               echo "##vso[task.logissue type=warning]One or more rspec tests were skipped"
-              exit 1
             fi
           else
             echo "##vso[task.logissue type=error]rspec-results file not found."
@@ -333,6 +338,12 @@ stages:
       inputs:
         testRunner: JUnit
         testResultsFiles: 'results/*.xml'
+
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish RSpec Results'
+      inputs:
+        path: '$(System.DefaultWorkingDirectory)/results/'
+        artifactName: 'rspecResults'
 
 
 - stage: deploy_qa


### PR DESCRIPTION
do not fail a build run if there are warnings in test runs.
Also publish the test results as build artifacts.

## Context

Current build fails, if there are warnings in the test runs.
Warnings might be intentional and we do not want to fail the build unless there are errors. 

## Changes proposed in this pull request

Do not fail rspec test task in case of warnings.
Example build with warnings: https://dev.azure.com/dfe-ssp/Become-A-Teacher/_build/results?buildId=65745&view=results

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)