### PR TITLE
Remove setting edit_by when submitting references

### DIFF
--- a/app/services/submit_reference.rb
+++ b/app/services/submit_reference.rb
@@ -38,13 +38,6 @@ private
       reference_feedback_provided!
       application_form.application_choices.awaiting_references.each do |application_choice|
         ApplicationStateChange.new(application_choice).references_complete!
-
-        next unless application_form.candidate_has_previously_applied?
-
-        # If the candidate has previously applied, they have less of a need to
-        # edit the application. Hence, we clear out the usual 7-day edit window
-        # by resetting the `edit_by` time.
-        application_form.update!(edit_by: Time.zone.now)
       end
     end
 

--- a/spec/services/submit_reference_spec.rb
+++ b/spec/services/submit_reference_spec.rb
@@ -38,23 +38,6 @@ RSpec.describe SubmitReference do
         expect(application_form.reload.application_choices).to all(be_awaiting_provider_decision)
       end
 
-      it 'sets edit_by to current time if the candidate is applying again' do
-        application_form = create(:completed_application_form, previous_application_form: create(:application_form), edit_by: 2.days.from_now)
-        create(:application_choice, application_form: application_form, status: 'awaiting_references')
-        create(:reference, :complete, application_form: application_form)
-        reference = create(:reference, :unsubmitted, application_form: application_form)
-
-        reference.update!(feedback: 'Trustworthy', relationship_correction: '', safeguarding_concerns: '')
-
-        Timecop.freeze(Time.utc(2020)) do
-          SubmitReference.new(
-            reference: reference,
-          ).save!
-
-          expect(application_form.edit_by).to eq Time.utc(2020)
-        end
-      end
-
       it 'is okay with a 3rd reference being provided' do
         application_form = create(:completed_application_form, edit_by: 1.day.ago)
 


### PR DESCRIPTION
## Context

This was introduced in https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/commit/e129c5be147f4bfe158546cf5c166034ced8edd6, but I think it's not needed anymore. The `edit_by` date is already set when the application is submitted:

https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/blob/b607578b5536756e5a2e3b7da2a931a64dbacdd3/app/services/submit_application.rb#L13-L14

## Changes proposed in this pull request

Remove the code.

## Guidance to review

Is this right? @malcolmbaig to confirm.

## Link to Trello card

https://trello.com/c/6aEZkNZi

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
