### PR TITLE
Remove custom support/mailer_previews controller

### DIFF
--- a/app/controllers/support_interface/mailer_previews_controller.rb
+++ b/app/controllers/support_interface/mailer_previews_controller.rb
@@ -1,8 +1,0 @@
-module SupportInterface
-  class MailerPreviewsController < SupportInterfaceController
-    def index
-      @previews = ActionMailer::Preview.all
-      @page_title = 'Mailer Previews'
-    end
-  end
-end

--- a/app/views/layouts/_footer_meta_support.html.erb
+++ b/app/views/layouts/_footer_meta_support.html.erb
@@ -16,7 +16,7 @@
 
     <% if Rails.application.config.action_mailer.show_previews %>
     <li class="govuk-footer__inline-list-item">
-      <%= govuk_link_to 'Mail previews', '/support/mailers' %>
+      <%= govuk_link_to 'Mail previews', '/rails/mailers' %>
     </li>
     <% end %>
 

--- a/app/views/support_interface/mailer_previews/index.html.erb
+++ b/app/views/support_interface/mailer_previews/index.html.erb
@@ -1,8 +1,0 @@
-<% @previews.each do |preview| %>
-<h3><%= preview.preview_name.titleize %></h3>
-<ul>
-<% preview.emails.each do |email| %>
-<li><%= link_to email, url_for(controller: 'rails/mailers', action: 'preview', path: "#{preview.preview_name}/#{email}") %></li>
-<% end %>
-</ul>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -565,8 +565,6 @@ Rails.application.routes.draw do
     get '/sign-in' => 'sessions#new'
     get '/sign-out' => 'sessions#destroy'
 
-    get '/mailers' => 'mailer_previews#index'
-
     # https://github.com/mperham/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes
     require 'sidekiq/web'
     require 'support_user_constraint'


### PR DESCRIPTION
## Context

As part of #2029 we moved previews from `rails/mailers` to `support/mailers`.

Now that we have #2153, Mailer previews work again, so we don't need the workaround.

## Changes proposed in this pull request

Remove the controller, route and view for our ersatz mailer preview index, and update the links in the view.

## Guidance to review

All gone?

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
