### PR TITLE
Don’t equate "No" with completion on work experience form

### DIFF
--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -36,7 +36,7 @@
 
 <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
   <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>
-  <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, I’ve completed my work history' } %>
+  <%= f.govuk_radio_button :add_another_job, false, label: { text: 'No, not at the moment' } %>
 <% end %>
 
 <%= f.govuk_submit t('application_form.work_history.complete_form_button') %>

--- a/app/views/candidate_interface/work_history/edit/_form.html.erb
+++ b/app/views/candidate_interface/work_history/edit/_form.html.erb
@@ -32,7 +32,7 @@
   <%= f.govuk_radio_button :working_with_children, false, label: { text: 'No' } %>
 <% end %>
 
-<hr class="govuk-section-break govuk-section-break--visible govuk-!-margin-bottom-5">
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
 <%= f.govuk_radio_buttons_fieldset :add_another_job, legend: { text: 'Do you want to add another job?', tag: 'span' } do %>
   <%= f.govuk_radio_button :add_another_job, true, label: { text: 'Yes, I want to add another job' } %>

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -235,7 +235,7 @@ module CandidateHelper
       fill_in locale.t('details.label'), with: 'I learned a lot about teaching'
 
       choose 'No'
-      choose 'No, I’ve completed my work history'
+      choose 'No, not at the moment'
     end
 
     click_button t('application_form.work_history.complete_form_button')

--- a/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
+++ b/spec/system/candidate_interface/candidate_edits_work_history_after_completing_the_section_spec.rb
@@ -95,7 +95,7 @@ RSpec.feature 'Candidate deletes their work history' do
     fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
 
     choose 'No'
-    choose 'No, I’ve completed my work history'
+    choose 'No, not at the moment'
 
     click_button t('application_form.work_history.complete_form_button')
   end

--- a/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_breaks_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature 'Entering reasons for their work history breaks' do
 
     choose 'No'
 
-    choose 'No, I’ve completed my work history'
+    choose 'No, not at the moment'
 
     click_button t('application_form.work_history.complete_form_button')
   end

--- a/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_work_history_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature 'Entering their work history' do
     fill_in t('details.label', scope: scope), with: 'I gained exposure to breakthrough technologies and questionable business ethics'
 
     choose 'No'
-    choose 'No, I’ve completed my work history'
+    choose 'No, not at the moment'
 
     click_button t('application_form.work_history.complete_form_button')
   end


### PR DESCRIPTION
## Context

One of the most common errors we are seeing is from users who end up on the "Add role" page, but submit without filling anything in – triggering an error for each field.

Some users may not be selecting "No" because we've equated that with completion. For example, a user may not be adding any further jobs because they don’t have all employment details on hand, rather than because they have added all jobs.

https://trello.com/c/Uk4kquQH/1604-design-prevent-users-from-submitting-an-empty-add-role-work-experience-form