### PR TITLE
More upbeat Slack emoji for offer acceptances in Support channel

### DIFF
--- a/app/lib/state_change_notifier.rb
+++ b/app/lib/state_change_notifier.rb
@@ -47,7 +47,7 @@ class StateChangeNotifier
       text = "#{applicant}'s application has just been rejected by default"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :offer_accepted
-      text = ":ok: #{applicant} has accepted #{provider_name}'s offer"
+      text = ":handshake: #{applicant} has accepted #{provider_name}'s offer"
       url = helpers.support_interface_application_form_url(application_form_id)
     when :offer_declined
       text = ":no_good: #{applicant} has declined #{provider_name}'s offer"


### PR DESCRIPTION
## Context

The 🆗 for offer acceptances always bugs me in Slack.

## Changes proposed in this pull request

:ok: ➡️ 🤝 

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
