### PR TITLE
Adding PR trigger to build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,10 @@ trigger:
     include:
       - "*"
 
-pr: none
+pr:
+  branches:
+    include:
+      - master
 
 variables:
 - group: Docker Shared variables


### PR DESCRIPTION
Currently only the source branch CI is built as part of a PR check,
this change will build the merged commit as PR validation check.

## Context

Currently a build on master could fail after a PR has been merged because the merged commit is not validated as part of the PR checks.

## Changes proposed in this pull request

When a PR is opened GitHub creates a new merged ref of the source and target branch.
Add a PR trigger for the build, to build the merged commit ref as a PR validation check.

## Guidance to review

## Link to Trello card

https://trello.com/c/xs1HKv0v/2214-pr-build-improvements-do-a-merge-build-before-merging-a-pr

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
