### PR TITLE
Consistent labels when asking to add another

### DIFF
--- a/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
+++ b/app/views/candidate_interface/course_choices/add_another_course/ask.html.erb
@@ -7,7 +7,7 @@
     <div class="govuk-grid-column-two-thirds">
       <%= f.govuk_error_summary %>
 
-      <h1 class="govuk-heading-xl "><%= title %></h1>
+      <h1 class="govuk-heading-xl"><%= title %></h1>
       <p class="govuk-body">After you submit your application you can’t apply for more courses through this service.</p>
 
       <%= f.govuk_radio_buttons_fieldset :add_another_course, legend: { tag: 'h2', size: 'm', text: 'Do you want to add another course?' } do %>

--- a/app/views/candidate_interface/other_qualifications/details/new.html.erb
+++ b/app/views/candidate_interface/other_qualifications/details/new.html.erb
@@ -34,7 +34,7 @@
           <%= f.govuk_radio_button :choice, 'same_type', label: { text: "Yes, add another qualification" } %>
         <% end %>
         <%= f.govuk_radio_button :choice, 'different_type', label: { text: 'Yes, add a different qualification' } %>
-        <%= f.govuk_radio_button :choice, 'no', label: { text: 'No, not right  now' } %>
+        <%= f.govuk_radio_button :choice, 'no', label: { text: 'No, not at the moment' } %>
       <% end %>
 
       <%= f.govuk_submit t('application_form.other_qualification.base.button') %>

--- a/spec/support/test_helpers/candidate_helper.rb
+++ b/spec/support/test_helpers/candidate_helper.rb
@@ -179,7 +179,7 @@ module CandidateHelper
     fill_in t('application_form.other_qualification.institution_name.label'), with: 'Yugi College'
     fill_in t('application_form.other_qualification.grade.label'), with: 'A'
     fill_in t('application_form.other_qualification.award_year.label'), with: '2015'
-    choose 'No, not right now'
+    choose 'No, not at the moment'
     click_button t('application_form.other_qualification.base.button')
     check t('application_form.other_qualification.review.completed_checkbox')
     click_button t('application_form.other_qualification.review.button')

--- a/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_other_qualification_spec.rb
@@ -167,7 +167,7 @@ RSpec.feature 'Entering their other qualifications' do
   end
 
   def and_i_choose_not_to_add_additional_qualifications
-    choose 'No, not right now'
+    choose 'No, not at the moment'
   end
 
   def then_i_see_the_other_qualification_review_page


### PR DESCRIPTION
## Context

For courses and work history, when asking if you want to add another, the option to decline is worded as ‘No, not at the moment’. For other qualifications, we say ‘No, not right now’. We should be consistent with how we label things.

## Changes proposed in this pull request

Updated label in other qualifications to say ‘No, not right now’.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
