### PR TITLE
Change wording on providers' "Change permissions" button

### DIFF
--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -30,7 +30,7 @@
         </div>
       <% end %>
 
-      <%= f.govuk_submit 'Update providers' %>
+      <%= f.govuk_submit 'Save' %>
     <% end %>
   </div>
 </div>

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature 'Managing provider user permissions' do
       check 'Manage users'
     end
 
-    click_on 'Update providers'
+    click_on 'Save'
   end
 
   def then_i_can_see_the_manage_users_permission_for_the_provider_user
@@ -90,7 +90,7 @@ RSpec.feature 'Managing provider user permissions' do
       uncheck 'Manage users'
     end
 
-    click_on 'Update providers'
+    click_on 'Save'
   end
 
   def then_i_cant_see_the_manage_users_permission_for_the_provider_user
@@ -105,7 +105,7 @@ RSpec.feature 'Managing provider user permissions' do
       check 'View safeguarding information'
     end
 
-    click_on 'Update providers'
+    click_on 'Save'
   end
 
   def then_i_can_see_the_view_safeguarding_permission_for_the_provider_user


### PR DESCRIPTION
## Context

We noticed this was inconsistent during the bug bash: the page is called "Change permissions" and the button said "Update providers".

## Changes proposed in this pull request

Change the button text to "Save"

## Link to Trello card

https://trello.com/c/7N9bCvzi/2129-title-labelling-of-provider-permissions-form-inconsistent

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
