### PR TITLE
Fix all mailer previews

### DIFF
--- a/spec/mailers/mailer_previews_spec.rb
+++ b/spec/mailers/mailer_previews_spec.rb
@@ -1,15 +1,10 @@
 require 'rails_helper'
 
-BROKEN_PREVIEWS = {
-  'RefereeMailerPreview' => %w[reference_request_email],
-}.freeze
-
 RSpec.describe 'Mailer previews' do
   ActionMailer::Preview.all.each do |preview|
     describe preview do
       preview.emails.each do |email|
         it email do
-          pending 'currently broken' if BROKEN_PREVIEWS.fetch(preview.to_s, []).include?(email)
           expect { preview.call(email) }.not_to raise_error
         end
       end

--- a/spec/mailers/mailer_previews_spec.rb
+++ b/spec/mailers/mailer_previews_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 BROKEN_PREVIEWS = {
-  'CandidateMailerPreview' => %w[new_referee_request chase_candidate_decision_with_one_offer new_offer_decisions_pending new_offer_single_offer chase_candidate_decision_with_multiple_offers new_offer_multiple_offers decline_last_application_choice new_referee_request_with_email_bounced chase_references_again withdraw_last_application_choice new_referee_request_with_refused],
   'RefereeMailerPreview' => %w[reference_request_email],
 }.freeze
 

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -20,7 +20,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def changed_offer
-    application_choice = FactoryBot.build(:submitted_application_choice, :with_modified_offer)
+    application_choice = FactoryBot.build_stubbed(:submitted_application_choice, course_option: course_option, application_form: application_form, offered_course_option: course_option)
 
     CandidateMailer.changed_offer(application_choice)
   end
@@ -84,7 +84,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def new_offer_multiple_offers
-    course_option = FactoryBot.build_stubbed(:course_option)
+    course_option = FactoryBot.build_stubbed(:course_option, site: site)
     application_choice = application_form.application_choices.build(
       course_option: course_option,
       status: :offer,
@@ -93,7 +93,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       offered_course_option: course_option,
       decline_by_default_at: 10.business_days.from_now,
     )
-    other_course_option = FactoryBot.build_stubbed(:course_option)
+    other_course_option = FactoryBot.build_stubbed(:course_option, site: site)
     application_form.application_choices.build(
       course_option: other_course_option,
       status: :offer,
@@ -176,9 +176,9 @@ class CandidateMailerPreview < ActionMailer::Preview
       :application_form,
       first_name: 'Harry',
       application_choices: [
-        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
-        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
-        FactoryBot.build_stubbed(:application_choice, status: 'awaiting_provider_decision', declined_by_default: false),
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true, course_option: course_option),
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true, course_option: course_option),
+        FactoryBot.build_stubbed(:application_choice, status: 'awaiting_provider_decision', declined_by_default: false, course_option: course_option),
       ],
     )
 
@@ -190,8 +190,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       :application_form,
       first_name: 'Harry',
       application_choices: [
-        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
-        FactoryBot.build_stubbed(:application_choice, status: 'awaiting_provider_decision', declined_by_default: false),
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true, course_option: course_option),
+        FactoryBot.build_stubbed(:application_choice, status: 'awaiting_provider_decision', declined_by_default: false, course_option: course_option),
       ],
     )
 
@@ -203,8 +203,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       :application_form,
       first_name: 'Harry',
       application_choices: [
-        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
-        FactoryBot.build_stubbed(:application_choice, status: 'rejected', declined_by_default: false),
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true, course_option: course_option),
+        FactoryBot.build_stubbed(:application_choice, status: 'rejected', declined_by_default: false, course_option: course_option),
       ],
     )
 
@@ -216,8 +216,8 @@ class CandidateMailerPreview < ActionMailer::Preview
       :application_form,
       first_name: 'Harry',
       application_choices: [
-        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
-        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true),
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true, course_option: course_option),
+        FactoryBot.build_stubbed(:application_choice, status: 'declined', declined_by_default: true, course_option: course_option),
       ],
     )
 
@@ -307,9 +307,6 @@ private
   end
 
   def application_choice_with_offer
-    course = FactoryBot.build_stubbed(:course)
-    course_option = FactoryBot.build_stubbed(:course_option, course: course)
-
     FactoryBot.build_stubbed(:application_choice, :with_offer,
                              course_option: course_option,
                              decline_by_default_at: Time.zone.now)

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -30,7 +30,7 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def chase_references_again
-    CandidateMailer.chase_references_again(reference)
+    CandidateMailer.chase_references_again(reference.application_form)
   end
 
   def survey_email
@@ -231,6 +231,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       application_choices: [
         FactoryBot.build_stubbed(:application_choice, status: 'declined'),
       ],
+      candidate: candidate,
     )
 
     CandidateMailer.decline_last_application_choice(application_form.application_choices.first)
@@ -243,6 +244,7 @@ class CandidateMailerPreview < ActionMailer::Preview
       application_choices: [
         FactoryBot.build_stubbed(:application_choice, status: 'withdrawn'),
       ],
+      candidate: candidate,
     )
 
     CandidateMailer.withdraw_last_application_choice(application_form)
@@ -271,7 +273,7 @@ private
   end
 
   def application_form
-    @application_form ||= FactoryBot.build_stubbed(:application_form, first_name: 'Gemma')
+    @application_form ||= FactoryBot.build_stubbed(:application_form, first_name: 'Gemma', candidate: candidate)
   end
 
   def reference
@@ -284,6 +286,7 @@ private
       first_name: 'Tyrell',
       last_name: 'Wellick',
       application_choices: course_choices,
+      candidate: candidate,
     )
   end
 

--- a/spec/mailers/previews/referee_mailer_preview.rb
+++ b/spec/mailers/previews/referee_mailer_preview.rb
@@ -25,6 +25,12 @@ private
   end
 
   def reference
-    FactoryBot.build_stubbed(:reference, application_form: application_form)
+    reference = FactoryBot.build_stubbed(:reference, application_form: application_form)
+
+    def reference.refresh_feedback_token!(*)
+      123456
+    end
+
+    reference
   end
 end


### PR DESCRIPTION
## Context

Our mailer previews are currently broken for a few of the templates.

## Changes proposed in this pull request

Stub out `candidate` object in more candidate mailer previews.

... Monkey patch a `build_stubbed` reference object so that the `refresh_feedback_token!` does not hit the database anymore, which fails because it's looking for an `ApplicationReference` that has an ID from a `build_stubbed` reference, which doesn't exist in our database.

## Guidance to review

Please ignore the monkey patch and :shipit:?

Review commit by commit.

<img width="824" alt="Screenshot 2020-05-29 at 16 27 33" src="https://user-images.githubusercontent.com/1650875/83277142-8cbe4680-a1c9-11ea-9b6b-5cb799b166d6.png">

## Link to Trello card

https://trello.com/c/Rulh9wiA/1582-fix-broken-mailer-previews

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)