### PR TITLE
Email candidates with unsuccessful applications before apply again

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -212,6 +212,13 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def apply_again_call_to_action(application_form)
+    email_for_candidate(
+      application_form,
+      subject: I18n.t!('candidate_mailer.apply_again_call_to_action.subject'),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/services/send_apply_again_call_to_action.rb
+++ b/app/services/send_apply_again_call_to_action.rb
@@ -13,10 +13,12 @@ private
   def unsuccessful_application_forms
     ApplicationForm
       .joins(:application_choices)
+      .joins("LEFT OUTER JOIN emails ON emails.application_form_id = application_forms.id AND emails.mailer = 'candidate_mailer' AND emails.mail_template = 'apply_again_call_to_action'")
       .where
       .not(application_choices: {
         status: ApplicationStateChange.valid_states - ApplicationStateChange::UNSUCCESSFUL_END_STATES.map(&:to_sym),
       })
+      .where(emails: { id: nil })
       .distinct
   end
 end

--- a/app/services/send_apply_again_call_to_action.rb
+++ b/app/services/send_apply_again_call_to_action.rb
@@ -14,11 +14,12 @@ private
     ApplicationForm
       .joins(:application_choices)
       .joins("LEFT OUTER JOIN emails ON emails.application_form_id = application_forms.id AND emails.mailer = 'candidate_mailer' AND emails.mail_template = 'apply_again_call_to_action'")
-      .where
-      .not(application_choices: {
+      .joins('LEFT OUTER JOIN application_forms AS subsequent_application_form ON application_forms.id = subsequent_application_form.previous_application_form_id')
+      .where.not(application_choices: {
         status: ApplicationStateChange.valid_states - ApplicationStateChange::UNSUCCESSFUL_END_STATES.map(&:to_sym),
       })
       .where(emails: { id: nil })
+      .where(subsequent_application_form: { id: nil })
       .distinct
   end
 end

--- a/app/services/send_apply_again_call_to_action.rb
+++ b/app/services/send_apply_again_call_to_action.rb
@@ -1,0 +1,22 @@
+# This worker will be as a one-off task to inform previously unsuccessful candidates about apply again
+class SendApplyAgainCallToAction
+  include Sidekiq::Worker
+
+  def perform
+    unsuccessful_application_forms.find_each do |application_form|
+      CandidateMailer.apply_again_call_to_action(application_form).deliver
+    end
+  end
+
+private
+
+  def unsuccessful_application_forms
+    ApplicationForm
+      .joins(:application_choices)
+      .where
+      .not(application_choices: {
+        status: ApplicationStateChange.valid_states - ApplicationStateChange::UNSUCCESSFUL_END_STATES.map(&:to_sym),
+      })
+      .distinct
+  end
+end

--- a/app/views/candidate_mailer/apply_again_call_to_action.text.erb
+++ b/app/views/candidate_mailer/apply_again_call_to_action.text.erb
@@ -12,7 +12,7 @@ We’ve saved your last application, so all you have to do is:
 
 Sign in to apply again:
 
-<%= @candidate_magic_link %>
+<%= candidate_magic_link(@application_form.candidate) %>
 
 # Get help
 
@@ -20,4 +20,4 @@ Call Get Into Teaching for free on 0800 389 2500 or chat to an adviser online:
 
 https://getintoteaching.education.gov.uk/contact
 
-For any technical issues using Apply for teacher training, contact us at becomingateacher@digital.education.gov.uk
+For any technical issues using Apply for teacher training, contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/app/views/candidate_mailer/apply_again_call_to_action.text.erb
+++ b/app/views/candidate_mailer/apply_again_call_to_action.text.erb
@@ -1,0 +1,23 @@
+Dear <%= @application_form.first_name %>,
+
+# You can still apply for teacher training
+
+You can apply for teacher training again if you have not got a place yet.
+
+We’ve saved your last application, so all you have to do is:
+
+- choose a course
+- make any changes
+- submit
+
+Sign in to apply again:
+
+<%= @candidate_magic_link %>
+
+# Get help
+
+Call Get Into Teaching for free on 0800 389 2500 or chat to an adviser online:
+
+https://getintoteaching.education.gov.uk/contact
+
+For any technical issues using Apply for teacher training, contact us at becomingateacher@digital.education.gov.uk

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -56,3 +56,5 @@ en:
       subject: "You have not met your conditions for %{course_name}: next steps"
     changed_offer:
       subject: "%{provider_name} changed the details of your offer"
+    apply_again_call_to_action:
+      subject: You can still apply for teacher training

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -381,4 +381,37 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect(email).to have_content 'declined your offer to study'
     end
   end
+
+  describe '#apply_again_call_to_action' do
+    it 'has the correct subject and content' do
+      application_form = build_stubbed(
+        :application_form,
+        first_name: 'Fred',
+        candidate: @candidate,
+        application_choices: [
+          build_stubbed(
+            :application_choice,
+            status: 'rejected',
+            course_option: build_stubbed(
+              :course_option,
+              course: build_stubbed(
+                :course,
+                name: 'Mathematics',
+                code: 'M101',
+                provider: build_stubbed(
+                  :provider,
+                  name: 'Cholbury College',
+                ),
+              ),
+            ),
+          ),
+        ],
+      )
+      email = described_class.apply_again_call_to_action(application_form)
+
+      expect(email.subject).to eq 'You can still apply for teacher training'
+      expect(email.body).to include('Dear Fred,')
+      expect(email.body).to include('You can apply for teacher training again if you have not got a place yet')
+    end
+  end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -256,6 +256,19 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.conditions_not_met(application_choice_with_offer)
   end
 
+  def apply_again_call_to_action
+    application_form = FactoryBot.build_stubbed(
+      :application_form,
+      first_name: 'Bob',
+      candidate: candidate,
+      application_choices: [
+        FactoryBot.build_stubbed(:application_choice, status: 'rejected'),
+      ],
+    )
+
+    CandidateMailer.apply_again_call_to_action(application_form)
+  end
+
 private
 
   def candidate

--- a/spec/services/send_apply_again_call_to_action_spec.rb
+++ b/spec/services/send_apply_again_call_to_action_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe SendApplyAgainCallToAction do
+  describe '#perform' do
+    it 'sends a call to action email to the candidate with the unsuccessful application' do
+      successful_application_form = FactoryBot.create(:completed_application_form)
+      unsuccessful_application_form = FactoryBot.create(:completed_application_form)
+      FactoryBot.create(
+        :application_choice,
+        status: :offer,
+        application_form: successful_application_form,
+      )
+      FactoryBot.create(
+        :application_choice,
+        status: :rejected,
+        application_form: unsuccessful_application_form,
+      )
+
+      expect { described_class.new.perform }.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect(ActionMailer::Base.deliveries.first.to).to eq [unsuccessful_application_form.candidate.email_address]
+      expect(ActionMailer::Base.deliveries.first.subject).to match(/You can still apply for teacher training/)
+    end
+  end
+end

--- a/spec/services/send_apply_again_call_to_action_spec.rb
+++ b/spec/services/send_apply_again_call_to_action_spec.rb
@@ -20,5 +20,24 @@ RSpec.describe SendApplyAgainCallToAction do
       expect(ActionMailer::Base.deliveries.first.to).to eq [unsuccessful_application_form.candidate.email_address]
       expect(ActionMailer::Base.deliveries.first.subject).to match(/You can still apply for teacher training/)
     end
+
+    it 'does NOT send a call to action email to the candidate with the unsuccessful application' do
+      unsuccessful_application_form = FactoryBot.create(:completed_application_form)
+      FactoryBot.create(
+        :application_choice,
+        status: :rejected,
+        application_form: unsuccessful_application_form,
+      )
+      Email.create!(
+        application_form_id: unsuccessful_application_form.id,
+        to: unsuccessful_application_form.candidate.email_address,
+        subject: 'You can still apply',
+        body: 'some text',
+        mailer: 'candidate_mailer',
+        mail_template: 'apply_again_call_to_action',
+      )
+
+      expect { described_class.new.perform }.not_to(change { ActionMailer::Base.deliveries.count })
+    end
   end
 end

--- a/spec/services/send_apply_again_call_to_action_spec.rb
+++ b/spec/services/send_apply_again_call_to_action_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe SendApplyAgainCallToAction do
       expect(ActionMailer::Base.deliveries.first.subject).to match(/You can still apply for teacher training/)
     end
 
-    it 'does NOT send a call to action email to the candidate with the unsuccessful application' do
+    it 'does not send a call to action email to a candidate that already received the email' do
       unsuccessful_application_form = FactoryBot.create(:completed_application_form)
       FactoryBot.create(
         :application_choice,
@@ -31,11 +31,23 @@ RSpec.describe SendApplyAgainCallToAction do
       Email.create!(
         application_form_id: unsuccessful_application_form.id,
         to: unsuccessful_application_form.candidate.email_address,
-        subject: 'You can still apply',
+        subject: 'you can still apply',
         body: 'some text',
         mailer: 'candidate_mailer',
         mail_template: 'apply_again_call_to_action',
       )
+
+      expect { described_class.new.perform }.not_to(change { ActionMailer::Base.deliveries.count })
+    end
+
+    it 'does not send a call to action email to a candidate that already started apply again' do
+      unsuccessful_application_form = FactoryBot.create(:completed_application_form)
+      FactoryBot.create(
+        :application_choice,
+        status: :rejected,
+        application_form: unsuccessful_application_form,
+      )
+      DuplicateApplication.new(unsuccessful_application_form).duplicate
 
       expect { described_class.new.perform }.not_to(change { ActionMailer::Base.deliveries.count })
     end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -34,6 +34,7 @@ RSpec.feature 'Docs' do
       provider_mailer-account_created
       referee_mailer-reference_cancelled_email
       provider_mailer-fallback_sign_in_email
+      candidate_mailer-apply_again_call_to_action
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"


### PR DESCRIPTION
## Context

We want to send a call to action email to all candidates whose applications ended unsuccessfully before we released apply again.

## Changes proposed in this pull request

- [x] `CandidateMailer#apply_again_call_to_action` email
- [x] Mailer preview for the above
- [x] `SendApplyAgainCallToAction` service class to email all unsuccessful candidates

## Guidance to review

![image](https://user-images.githubusercontent.com/450843/83311483-4c7db900-a207-11ea-96e8-889304c6175f.png)

- I didn't want to over-engineer this as it's a one-off mailshot but do we need a way to ensure that we don't send these emails twice to the same person? e.g. a field in the database.
- Do we need a rake task to trigger the service class?
- Do we need to parameterise the service class (and rake task) with a datetime for the time that we released the apply again feature or is it ok to assume this will be run soon enough after that happens?

## Link to Trello card

https://trello.com/c/yyvDNpCO/1607-dev-build-email-for-candidates-who-were-unsuccessful-when-we-didnt-have-apply-again

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
