### PR TITLE
Do not side-effect in WithdrawApplication transaction

### DIFF
--- a/app/services/withdraw_application.rb
+++ b/app/services/withdraw_application.rb
@@ -8,10 +8,10 @@ class WithdrawApplication
       ApplicationStateChange.new(application_choice).withdraw!
       application_choice.update!(withdrawn_at: Time.zone.now)
       SetDeclineByDefault.new(application_form: application_choice.application_form).call
+    end
 
-      if @application_choice.application_form.ended_without_success? && FeatureFlag.active?('apply_again')
-        CandidateMailer.withdraw_last_application_choice(@application_choice.application_form).deliver_later
-      end
+    if @application_choice.application_form.ended_without_success? && FeatureFlag.active?('apply_again')
+      CandidateMailer.withdraw_last_application_choice(@application_choice.application_form).deliver_later
     end
 
     StateChangeNotifier.call(:withdraw, application_choice: application_choice)


### PR DESCRIPTION
## Context

There's a side effect (sending an email) inside an ActiveRecord::Transaction block.

This isn't good because if the transaction fails for any reason then the emails will be sent even though the database change has been rolled back. This is unlikely when the emails are sent after all the other updates, but it still could happen because of e.g. a network issue or if we added code after the email call.

## Changes proposed in this pull request

Push the side effect down, out of the block.

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
