### PR TITLE
Providers see sorting information in the applications view

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -32,7 +32,7 @@
       <div class="app-application-card__secondary">
         <div class="app-application-card__date">
           <dt class="govuk-visually-hidden">Date:</dt>
-          <dd class="govuk-body">Updated on <%= updated_at %></dd>
+          <dd class="govuk-body">Changed <%= changed_at %></dd>
         </div>
       </div>
     </div>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ViewHelper
 
     attr_accessor :accredited_provider, :application_choice, :application_choice_path,
-                  :candidate_name, :course_name_and_code, :course_provider_name, :updated_at,
+                  :candidate_name, :course_name_and_code, :course_provider_name, :changed_at,
                   :most_recent_note, :site_name_and_code
 
     def initialize(application_choice:)
@@ -12,7 +12,7 @@ module ProviderInterface
       @candidate_name = application_choice.application_form.full_name
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
-      @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
+      @changed_at = application_choice.updated_at.to_s(:govuk_date_and_time)
       @site_name_and_code = application_choice.site.name_and_code
       @most_recent_note = application_choice.notes.order('created_at DESC').first
     end

--- a/app/components/provider_interface/header_component.html.erb
+++ b/app/components/provider_interface/header_component.html.erb
@@ -1,0 +1,34 @@
+<header class="govuk-header <%= classes %>" role="banner" data-module="govuk-header">
+  <div class="govuk-header__container govuk-width-container">
+    <div class="govuk-header__logo">
+      <%= link_to 'https://gov.uk', class: 'govuk-header__link govuk-header__link--homepage' do %>
+        <span class="govuk-header__logotype">
+          <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="30" width="36">
+            <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
+            <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+          </svg>
+          <span class="govuk-header__logotype-text">
+            GOV.UK
+          </span>
+        </span>
+      <% end %>
+    </div>
+    <div class="govuk-header__content">
+      <%= link_to service_name, service_url, class: 'govuk-header__link govuk-header__link--service-name' %>
+      <% if navigation_items.any? %>
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-!-print-display-none" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+        <ul id="navigation" class="govuk-header__navigation app-!-print-display-none" aria-label="Top Level Navigation">
+          <% navigation_items.each do |nav_item| %>
+            <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
+              <% if nav_item.href %>
+                <%= link_to nav_item.text, nav_item.href, class: 'govuk-header__link' %>
+              <% else %>
+                <strong><%= nav_item.text %></strong>
+              <% end %>
+            <% end %>
+          </li>
+        </ul>
+      <% end %>
+    </div>
+  </div>
+</header>

--- a/app/components/provider_interface/header_component.rb
+++ b/app/components/provider_interface/header_component.rb
@@ -1,0 +1,10 @@
+class ProviderInterface::HeaderComponent < ViewComponent::Base
+  attr_reader :navigation_items, :service_url, :service_name, :classes
+
+  def initialize(navigation_items:, service_name:, service_url:, classes: '')
+    @navigation_items = navigation_items
+    @service_name     = service_name
+    @service_url      = service_url
+    @classes          = classes
+  end
+end

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -1,3 +1,7 @@
 .moj-action-bar {
   overflow: hidden;
 }
+
+.applications-sorted-by-explanation {
+  text-align: right;
+}

--- a/app/frontend/styles/_provider_header.scss
+++ b/app/frontend/styles/_provider_header.scss
@@ -1,0 +1,11 @@
+// .govuk-header__logo {
+//   @include govuk-media-query($from: tablet) {
+//     width: 60%;
+//   }
+// }
+
+// .govuk-header__content {
+//   @include govuk-media-query($from: tablet) {
+//     width: 40%;
+//   }
+// }

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -10,7 +10,7 @@
                                  service_url: service_link,
                                  navigation_items: NavigationItems.for_support_interface(current_support_user, controller))) %>
 <% when 'provider_interface' %>
-  <%= render(HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
+  <%= render(ProviderInterface::HeaderComponent.new(classes: "app-header--#{HostingEnvironment.environment_name}",
                                  service_name: service_name,
                                  service_url: service_link,
                                  navigation_items: NavigationItems.for_provider_interface(current_provider_user))) %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -24,6 +24,7 @@
     page_state: @page_state,
   ) %>
   <div class='moj-filter-layout__content'>
+    <p class='govuk-body applications-sorted-by-explanation'>Sorted by: last changed</p>
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -58,8 +58,8 @@ en:
     withdrawn: Withdrawn
     conditions_not_met: Conditions not met
   provider_application_states:
-    application_complete: New
-    awaiting_provider_decision: New
+    application_complete: Submitted
+    awaiting_provider_decision: Submitted
     awaiting_references: Awaiting references
     cancelled: Cancelled
     declined: Declined

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       expect(card).to include(note.subject)
     end
 
-    it 'renders the last updated date' do
-      expect(card).to include('25 Mar 2020')
+    it 'renders the last "changed at" date in the correct format' do
+      expect(card).to include('Changed 25 March 2020 at 12:00am')
     end
 
     it 'renders the location of the course' do

--- a/spec/components/provider_interface/header_component_spec.rb
+++ b/spec/components/provider_interface/header_component_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe ProviderInterface::HeaderComponent do
+  let(:navigation_items) { [] }
+
+  subject(:rendered_component) do
+    render_inline(described_class.new(navigation_items: navigation_items, service_name: '', service_url: '#'))
+  end
+
+  describe 'rendering NavigationItems' do
+    context 'when they are links' do
+      let(:navigation_items) do
+        [
+          NavigationItems::NavigationItem.new(
+            'I am a link',
+            'http://my.url',
+            false,
+          ),
+        ]
+      end
+
+      it 'renders them correctly' do
+        expect(rendered_component.text).to include 'I am a link'
+        expect(rendered_component.xpath(".//li/a[@href='http://my.url']")).to be_present
+      end
+    end
+
+    context 'when they are not links' do
+      let(:navigation_items) do
+        [
+          NavigationItems::NavigationItem.new(
+            'I am not a link',
+            nil,
+            false,
+          ),
+        ]
+      end
+
+      it 'does not try to render them as links' do
+        expect(rendered_component.xpath('.//li/a')).not_to be_present
+      end
+    end
+
+    context 'when they are active' do
+      let(:navigation_items) do
+        [
+          NavigationItems::NavigationItem.new(
+            'I am not a link',
+            nil,
+            true,
+          ),
+        ]
+      end
+
+      it 'assigns the --active class' do
+        expect(rendered_component.to_s).to include 'govuk-header__navigation-item--active'
+      end
+    end
+  end
+end

--- a/spec/models/provider_emails_for_application_choices_spec.rb
+++ b/spec/models/provider_emails_for_application_choices_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ProviderEmailsForApplicationChoices do
       result = ProviderEmailsForApplicationChoices.new([application_choice.id]).as_csv
 
       expect(result).to include "email address,name,affected applications\n"
-      expect(result).to include 'pamela@example.com,Pamela Provider,* Ciara Candidate (ABC123) (New)'
+      expect(result).to include 'pamela@example.com,Pamela Provider,* Ciara Candidate (ABC123) (Submitted)'
       expect(result).to include "https://www.apply-for-teacher-training.education.gov.uk/provider/applications/#{application_choice.id}\n"
     end
   end

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.feature 'Providers should be able to sort applications' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'by column headings' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_my_organisation_has_courses_with_applications
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_page
+    then_i_should_see_the_applications_in_descending_date_order
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_my_organisation_has_courses_with_applications
+    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+
+    course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
+    course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
+    course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
+           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           create(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           create(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
+           create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+  end
+
+  def when_i_visit_the_provider_page
+    visit provider_interface_path
+  end
+
+  def then_i_should_see_the_applications_in_descending_date_order
+    expect('Jim James').to appear_before('Tom Jones')
+    expect('Tom Jones').to appear_before('Bill Bones')
+  end
+end

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -12,6 +12,11 @@ RSpec.feature 'Providers should be able to sort applications' do
 
     when_i_visit_the_provider_page
     then_i_should_see_the_applications_in_descending_date_order
+    and_the_sorted_by_explanation_line_should_be_present
+  end
+
+  def and_the_sorted_by_explanation_line_should_be_present
+    expect(page).to have_content('Sorted by: last changed')
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Providers should be able to sort applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
+  # rubocop:disable RSpec/ExpectActual
+
   scenario 'by column headings' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
@@ -55,4 +57,6 @@ RSpec.feature 'Providers should be able to sort applications' do
     expect('Jim James').to appear_before('Tom Jones')
     expect('Tom Jones').to appear_before('Bill Bones')
   end
+
+  # rubocop:enable RSpec/ExpectActual
 end

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Provider responds to application' do
 
   def then_i_can_see_its_status(application)
     if application.status == 'awaiting_provider_decision'
-      expect(page).to have_content 'New'
+      expect(page).to have_content 'Submitted'
     elsif application.status == 'rejected'
       expect(page).to have_content 'Rejected'
     end


### PR DESCRIPTION
## Context

Adds the 'Sorted by: last changed' info to the top of the application index view in the provider interface.

Changed status tag for 'New' applications to 'Submitted'.

Also updates the application cards' dates to the following format:

"Changed 1 June 2020 at 11:28am" (obvs the date and times will vary)

## Changes proposed in this pull request

**Before:**
<img width="898" alt="Screenshot 2020-06-01 at 11 29 34" src="https://user-images.githubusercontent.com/13377553/83400683-2e78aa00-a3fb-11ea-9c51-5da324bfe856.png">

**After:**
<img width="907" alt="Screenshot 2020-06-01 at 11 31 08" src="https://user-images.githubusercontent.com/13377553/83400801-667fed00-a3fb-11ea-8d45-da35637a6b3d.png">


## Guidance to review

- I have added some tests and amended some to accommodate these changes, do you agree to the specificity of these tests? 
- are the formats correct for the info line and the dates?

## Link to Trello card

https://trello.com/c/2F0Hwaif/2208-providers-see-sorting-information-in-the-applications-view

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
