### PR TITLE
Providers see sorting information in the applications view

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -32,7 +32,7 @@
       <div class="app-application-card__secondary">
         <div class="app-application-card__date">
           <dt class="govuk-visually-hidden">Date:</dt>
-          <dd class="govuk-body">Updated on <%= updated_at %></dd>
+          <dd class="govuk-body">Changed <%= changed_at %></dd>
         </div>
       </div>
     </div>

--- a/app/components/provider_interface/application_card_component.rb
+++ b/app/components/provider_interface/application_card_component.rb
@@ -3,7 +3,7 @@ module ProviderInterface
     include ViewHelper
 
     attr_accessor :accredited_provider, :application_choice, :application_choice_path,
-                  :candidate_name, :course_name_and_code, :course_provider_name, :updated_at,
+                  :candidate_name, :course_name_and_code, :course_provider_name, :changed_at,
                   :most_recent_note, :site_name_and_code
 
     def initialize(application_choice:)
@@ -12,7 +12,7 @@ module ProviderInterface
       @candidate_name = application_choice.application_form.full_name
       @course_name_and_code = application_choice.offered_course.name_and_code
       @course_provider_name = application_choice.offered_course.provider.name
-      @updated_at = application_choice.updated_at.to_s(:govuk_date_short_month)
+      @changed_at = application_choice.updated_at.to_s(:govuk_date_and_time)
       @site_name_and_code = application_choice.site.name_and_code
       @most_recent_note = application_choice.notes.order('created_at DESC').first
     end

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -1,3 +1,7 @@
 .moj-action-bar {
   overflow: hidden;
 }
+
+.applications-sorted-by-explanation {
+  text-align: right;
+}

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -24,6 +24,7 @@
     page_state: @page_state,
   ) %>
   <div class='moj-filter-layout__content'>
+    <p class='govuk-body applications-sorted-by-explanation'>Sorted by: last changed</p>
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -58,8 +58,8 @@ en:
     withdrawn: Withdrawn
     conditions_not_met: Conditions not met
   provider_application_states:
-    application_complete: New
-    awaiting_provider_decision: New
+    application_complete: Submitted
+    awaiting_provider_decision: Submitted
     awaiting_references: Awaiting references
     cancelled: Cancelled
     declined: Declined

--- a/spec/components/provider_interface/application_card_component_spec.rb
+++ b/spec/components/provider_interface/application_card_component_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe ProviderInterface::ApplicationCardComponent do
       expect(card).to include(note.subject)
     end
 
-    it 'renders the last updated date' do
-      expect(card).to include('25 Mar 2020')
+    it 'renders the last "changed at" date in the correct format' do
+      expect(card).to include('Changed 25 March 2020 at 12:00am')
     end
 
     it 'renders the location of the course' do

--- a/spec/models/provider_emails_for_application_choices_spec.rb
+++ b/spec/models/provider_emails_for_application_choices_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ProviderEmailsForApplicationChoices do
       result = ProviderEmailsForApplicationChoices.new([application_choice.id]).as_csv
 
       expect(result).to include "email address,name,affected applications\n"
-      expect(result).to include 'pamela@example.com,Pamela Provider,* Ciara Candidate (ABC123) (New)'
+      expect(result).to include 'pamela@example.com,Pamela Provider,* Ciara Candidate (ABC123) (Submitted)'
       expect(result).to include "https://www.apply-for-teacher-training.education.gov.uk/provider/applications/#{application_choice.id}\n"
     end
   end

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -4,8 +4,6 @@ RSpec.feature 'Providers should be able to sort applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
-  # rubocop:disable RSpec/ExpectActual
-
   scenario 'by column headings' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
@@ -53,10 +51,10 @@ RSpec.feature 'Providers should be able to sort applications' do
     visit provider_interface_path
   end
 
+  # rubocop:disable RSpec/ExpectActual
   def then_i_should_see_the_applications_in_descending_date_order
     expect('Jim James').to appear_before('Tom Jones')
     expect('Tom Jones').to appear_before('Bill Bones')
   end
-
   # rubocop:enable RSpec/ExpectActual
 end

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.feature 'Providers should be able to sort applications' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'by column headings' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_my_organisation_has_courses_with_applications
+    and_i_sign_in_to_the_provider_interface
+
+    when_i_visit_the_provider_page
+    then_i_should_see_the_applications_in_descending_date_order
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_my_organisation_has_courses_with_applications
+    current_provider = create(:provider, :with_signed_agreement, code: 'ABC')
+
+    course_option_one = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Alchemy', provider: current_provider))
+    course_option_two = course_option_for_provider(provider: current_provider, course: create(:course, name: 'Divination', provider: current_provider))
+    course_option_three = course_option_for_provider(provider: current_provider, course: create(:course, name: 'English', provider: current_provider))
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_one, status: 'withdrawn', application_form:
+           create(:application_form, first_name: 'Jim', last_name: 'James'), updated_at: 1.day.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           create(:application_form, first_name: 'Adam', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'offer', application_form:
+           create(:application_form, first_name: 'Tom', last_name: 'Jones'), updated_at: 2.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_three, status: 'declined', application_form:
+           create(:application_form, first_name: 'Bill', last_name: 'Bones'), updated_at: 3.days.ago)
+  end
+
+  def when_i_visit_the_provider_page
+    visit provider_interface_path
+  end
+
+  def then_i_should_see_the_applications_in_descending_date_order
+    expect('Jim James').to appear_before('Tom Jones')
+    expect('Tom Jones').to appear_before('Bill Bones')
+  end
+end

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -12,6 +12,11 @@ RSpec.feature 'Providers should be able to sort applications' do
 
     when_i_visit_the_provider_page
     then_i_should_see_the_applications_in_descending_date_order
+    and_the_sorted_by_explanation_line_should_be_present
+  end
+
+  def and_the_sorted_by_explanation_line_should_be_present
+    expect(page).to have_content('Sorted by: last changed')
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in

--- a/spec/system/provider_interface/provider_applications_sort_spec.rb
+++ b/spec/system/provider_interface/provider_applications_sort_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature 'Providers should be able to sort applications' do
   include CourseOptionHelpers
   include DfESignInHelpers
 
+  # rubocop:disable RSpec/ExpectActual
+
   scenario 'by column headings' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_i_am_permitted_to_see_applications_for_my_provider
@@ -55,4 +57,6 @@ RSpec.feature 'Providers should be able to sort applications' do
     expect('Jim James').to appear_before('Tom Jones')
     expect('Tom Jones').to appear_before('Bill Bones')
   end
+
+  # rubocop:enable RSpec/ExpectActual
 end

--- a/spec/system/provider_interface/provider_responds_to_application_spec.rb
+++ b/spec/system/provider_interface/provider_responds_to_application_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature 'Provider responds to application' do
 
   def then_i_can_see_its_status(application)
     if application.status == 'awaiting_provider_decision'
-      expect(page).to have_content 'New'
+      expect(page).to have_content 'Submitted'
     elsif application.status == 'rejected'
       expect(page).to have_content 'Rejected'
     end


### PR DESCRIPTION
## Context

Adds the 'Sorted by: last changed' info to the top of the application index view in the provider interface.

Changed status tag for 'New' applications to 'Submitted'.

Also updates the application cards' dates to the following format:

"Changed 1 June 2020 at 11:28am" (obvs the date and times will vary)

## Changes proposed in this pull request

**Before:**
<img width="898" alt="Screenshot 2020-06-01 at 11 29 34" src="https://user-images.githubusercontent.com/13377553/83400683-2e78aa00-a3fb-11ea-9c51-5da324bfe856.png">

**After:**
<img width="907" alt="Screenshot 2020-06-01 at 11 31 08" src="https://user-images.githubusercontent.com/13377553/83400801-667fed00-a3fb-11ea-8d45-da35637a6b3d.png">


## Guidance to review

- I have added some tests and amended some to accommodate these changes, do you agree to the specificity of these tests? 
- are the formats correct for the info line and the dates?

## Link to Trello card

https://trello.com/c/2F0Hwaif/2208-providers-see-sorting-information-in-the-applications-view

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
