### PR TITLE
Add health check test post deployment

### DIFF
--- a/health-check-template.yml
+++ b/health-check-template.yml
@@ -1,0 +1,46 @@
+parameters:
+  - name: url
+    type: string
+    displayName: The health check URL
+  - name: waitBeforeFirstPing
+    type: boolean
+    displayName: Boolean value indicating if script should wait for 10 seconds before the first attempt
+    default: true
+
+steps:
+  - powershell: |
+      $waitBeforeFirstPing = ${{ parameters.waitBeforeFirstPing }}
+      if($waitBeforeFirstPing -eq $true){
+        # Wait 30 seconds for slot to wake up
+        Start-Sleep -Seconds 10
+      }
+      $healthCheckUrl = "${{ parameters.url }}"
+      $maxAttempts = 5;
+      $statusCode = 0;
+      $attempt=0
+      while($attempt -lt $maxAttempts){
+        $attempt = $attempt + 1
+        try
+        {
+            $response = Invoke-WebRequest -Uri $healthCheckUrl -TimeoutSec 120 -ErrorAction Stop
+            $statusCode = $response.StatusCode
+            break;
+        }
+        catch
+        {
+            $statusCode = $_.Exception.Response.StatusCode.value__
+            $waitSeconds = $attempt * 10
+            Write-Warning "Retrying GET $healthCheckUrl in $waitSeconds seconds..."
+            Start-Sleep -Seconds $waitSeconds
+        }
+      }
+
+      if($statusCode -ne 200){
+        Write-Warning "GET $healthCheckUrl failed with status code $statusCode; after $attempt attempts"
+        Write-Host "##vso[task.logissue type=error;]GET $healthCheckUrl failed with status code $statusCode"
+        exit 1
+      }
+      else{ 
+        Write-Host "GET $healthCheckUrl succeeded after $attempt attempt(s)"
+      }
+    displayName: Health check - GET ${{ parameters.url }}

--- a/health-check-template.yml
+++ b/health-check-template.yml
@@ -42,5 +42,6 @@ steps:
       }
       else{ 
         Write-Host "GET $healthCheckUrl succeeded after $attempt attempt(s)"
+        exit 0
       }
     displayName: Health check - GET ${{ parameters.url }}

--- a/swap-staging-production-template.yml
+++ b/swap-staging-production-template.yml
@@ -11,7 +11,7 @@ parameters:
 
 steps:
   - task: AzureAppServiceManage@0
-    condition: eq(variables.buildCancelled, false)
+    condition: and(succeeded(), eq(variables.buildCancelled, false))
     displayName: Start Staging slot in ${{ parameters.appService }}
     inputs:
       azureSubscription: '${{ parameters.azureSubscription }}'
@@ -20,57 +20,28 @@ steps:
       SpecifySlotOrASE: true
       ResourceGroupName: '${{ parameters.resourceGroup }}'
       Slot: 'staging'
-
-  - task: PowerShell@2
-    condition: eq(variables.buildCancelled, false)
-    displayName: 'GET /check in ${{ parameters.appService }}-staging'
-    inputs:
-      targetType: 'inline'
-      script: |
-        $appServiceName = "${{ parameters.appService }}"
-        # Wait 30 seconds for slot to wake up
-        Start-Sleep -Seconds 30
-        $healthCheckUrl = [string]::Format("https://{0}-staging.azurewebsites.net/check", $appServiceName)
-        $maxAttempts = 5;
-        $statusCode = 0;
-        $attempt=0
-        while($attempt -lt $maxAttempts){
-          $attempt = $attempt + 1
-          try
-          {
-              $response = Invoke-WebRequest -Uri $healthCheckUrl -TimeoutSec 120 -ErrorAction Stop
-              $statusCode = $response.StatusCode
-              break;
-          }
-          catch
-          {
-              $statusCode = $_.Exception.Response.StatusCode.value__
-              $waitSeconds = $attempt * 10
-              Write-Warning "Retrying GET $healthCheckUrl in $waitSeconds seconds..."
-              Start-Sleep -Seconds $waitSeconds
-          }
-        }
-        
-        if($statusCode -ne 200){
-          Write-Warning "GET $healthCheckUrl failed; after $attempt attempts"
-          Write-Error "GET $healthCheckUrl failed with status code $statusCode"
-        }
-        else{ 
-          Write-Host "GET $healthCheckUrl succeeded after $attempt attempt(s)"
-        }          
+  
+  - template: health-check-template.yml
+    parameters:
+      url: ${{ format('https://{0}-staging.azurewebsites.net/check', parameters.appService) }}
 
   - task: AzureAppServiceManage@0
-    condition: eq(variables.buildCancelled, false)
+    condition: and(succeeded(), eq(variables.buildCancelled, false))
     displayName: Swap Staging slot to Production
     inputs:
       azureSubscription: '${{ parameters.azureSubscription }}'
       Action: 'Swap Slots'
       WebAppName: '${{ parameters.appService }}'
       ResourceGroupName: '${{ parameters.resourceGroup }}'
-      SourceSlot: 'staging'          
+      SourceSlot: 'staging'
+  
+  - template: health-check-template.yml
+    parameters:
+      url: ${{ format('https://{0}.azurewebsites.net/check', parameters.appService) }}
+      waitBeforeFirstPing: false
 
   - task: AzureAppServiceManage@0
-    condition: eq(variables.buildCancelled, false)
+    condition: and(succeeded(), eq(variables.buildCancelled, false))
     displayName: Stop Staging slot in ${{ parameters.appService }}
     inputs:
       azureSubscription: '${{ parameters.azureSubscription }}'


### PR DESCRIPTION
Adds a health check step post deployment, this will help determine if
application is running successfully after a deployment.

## Context

Currently there is a manual step to check if the site is started and running after a deployment has been completed. This proposes to add a health check and check for 200 status to determine if the site is up and running post deployment.

## Changes proposed in this pull request

Move the current staging health check to a common template.
Reuse the step to do a health check on the production slot after the swap operation has been completed.

## Guidance to review


## Link to Trello card

https://trello.com/c/edgyqppq/285-add-healthcheck-to-the-end-of-the-devops-deployment-pipeline-making-sure-container-instances-are-running

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
