### PR TITLE
Update content on accept/decline/withdraw pages

### DIFF
--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -53,8 +53,13 @@ module CandidateInterface
   private
 
     def set_application_choice
-      @application_choice = current_candidate.current_application.application_choices.find(params[:id])
+      @application_choice = @current_application.application_choices.find(params[:id])
     end
+
+    def single_application_choice?
+      @current_application.application_choices.size == 1
+    end
+    helper_method :single_application_choice?
 
     def check_that_candidate_can_decline
       unless ApplicationStateChange.new(@application_choice).can_decline?

--- a/app/controllers/candidate_interface/decisions_controller.rb
+++ b/app/controllers/candidate_interface/decisions_controller.rb
@@ -82,5 +82,23 @@ module CandidateInterface
     def check_that_candidate_has_an_offer
       render_404 unless @application_choice.offer?
     end
+
+    def course_choice_rows
+      [
+        {
+          key: 'Provider',
+          value: @application_choice.offered_course.provider.name,
+        },
+        {
+          key: 'Course',
+          value: @application_choice.offered_course.name_and_code,
+        },
+        {
+          key: 'Location',
+          value: @application_choice.offered_option.site.name,
+        },
+      ]
+    end
+    helper_method :course_choice_rows
   end
 end

--- a/app/views/candidate_interface/decisions/accept.html.erb
+++ b/app/views/candidate_interface/decisions/accept.html.erb
@@ -9,12 +9,17 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render(CandidateInterface::OfferReviewComponent.new(course_choice: @application_choice)) %>
 
-    <p class="govuk-body">By accepting this offer, you confirm that:</p>
-
-    <ul class="govuk-list govuk-list--bullet">
-      <li>you understand any other applications made through Apply for teacher training will be automatically withdrawn</li>
-      <li>you have not accepted any other offers of teacher training places (for example through UCAS Teacher Training)</li>
-    </ul>
+    <% if single_application_choice? %>
+      <p class="govuk-body">
+        By accepting this offer you confirm that you have not accepted any other offers of teacher training places (for example through UCAS Teacher Training).
+      </p>
+    <% else %>
+      <p class="govuk-body">By accepting this offer, you confirm that:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>you understand any other applications made through Apply for teacher training will be automatically withdrawn</li>
+        <li>you have not accepted any other offers of teacher training places (for example through UCAS Teacher Training)</li>
+      </ul>
+    <% end %>
 
     <%= form_with model: @respond_to_offer, url: candidate_interface_accept_offer_path(@application_choice) do |f| %>
       <%= f.govuk_submit 'Accept offer' %>

--- a/app/views/candidate_interface/decisions/decline.html.erb
+++ b/app/views/candidate_interface/decisions/decline.html.erb
@@ -15,9 +15,15 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render(CandidateInterface::OfferReviewComponent.new(course_choice: @application_choice)) %>
 
-    <p class="govuk-body">
-      If you decline this offer (and all other offers on current applications) you can still apply for more courses this year through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %>.
-    </p>
+    <% if single_application_choice? %>
+      <p class="govuk-body">
+        If you decline this offer you can still apply for more courses this year.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+          If you decline this offer (and all other other offers on current applications) you can still apply for more courses this year.
+      </p>
+    <% end %>
 
     <%= form_with model: @respond_to_offer, url: candidate_interface_decline_offer_path(@application_choice) do |f| %>
       <%= f.submit 'Yes I’m sure - decline this offer', class: 'govuk-button govuk-button--warning' %>

--- a/app/views/candidate_interface/decisions/withdraw.html.erb
+++ b/app/views/candidate_interface/decisions/withdraw.html.erb
@@ -2,13 +2,23 @@
 <% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path, 'Back to application dashboard') %>
 
 <h1 class="govuk-heading-xl govuk-heading-xl">
-  <%= t('page_titles.withdraw_course_choice') %>
+  Are you sure you want to withdraw this course choice?
 </h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Confirm you would like to withdraw your application to study:</p>
-    <p class="govuk-body"><strong><%= @application_choice.course.name_and_code %> at <%= @application_choice.provider.name %></strong></p>
-    <%= button_to 'Withdraw my application', candidate_interface_withdraw_path, class: 'govuk-button govuk-button--warning' %>
+    <%= render(SummaryListComponent.new(rows: course_choice_rows)) %>
+
+    <% if single_application_choice? %>
+      <p class="govuk-body">
+        If you withdraw this course choice you can still apply for more courses this year.
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        If you withdraw this course choice (and all your other course choices) you can still apply for more courses this year.
+      </p>
+    <% end %>
+
+    <%= button_to "Yes I’m sure - withdraw this course choice", candidate_interface_withdraw_path, class: 'govuk-button govuk-button--warning' %>
   </div>
 </div>

--- a/spec/system/candidate_interface/candidate_withdraws_spec.rb
+++ b/spec/system/candidate_interface/candidate_withdraws_spec.rb
@@ -76,11 +76,11 @@ RSpec.feature 'A candidate withdraws her application' do
   end
 
   def then_i_see_a_confirmation_page
-    expect(page).to have_content('Confirm')
+    expect(page).to have_content('Are you sure you want to withdraw this course choice?')
   end
 
   def when_i_click_to_confirm_withdrawal
-    click_button 'Withdraw my application'
+    click_button 'Yes I’m sure - withdraw this course choice'
   end
 
   def then_my_application_should_be_withdrawn


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
We have to make some content amends to the pages that the user sees when they accept or decline and offer or withdraw an application choice in apply again. The current copy doesn't gracefully handle applications with only one choice.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->
- Update copy on accept/decline pages.
- Rework the withdraw page, which the designs assume is a bit more developed than the one that currently exists.

Regarding the latter bullet, the designs contain details of the 'conditions' of the course choice. This doesn't really apply to the withdraw page, because you can only withdraw a choice when the state is one of `awaiting_provider_decision`, `pending_conditions`, or `recruited`. I've therefore just added the course details. 

Example:

![withdraw](https://user-images.githubusercontent.com/519250/83418574-bcfd2380-a41b-11ea-93a7-bb328ac7037b.png)

## Guidance to review

Checking the six variants is a bit onerous, but the easiest way is probably pulling the branch down locally rather than a review app.

- accept/decline pages - find an app that's `awaiting_candidate_decision` in the support console (the dev data rake task should create one) and check URLS of the form `http://localhost:3000/candidate/application/choice/:id/offer/decline` and `http://localhost:3000/candidate/application/choice/:id/offer/decline`
- withdraw page - find an app that's `awaiting_provider_decision` and view `http://localhost:3000/candidate/application/complete`. Click `Withdraw` on one of the choices.
- delete/add choices via the console as needed to see the single/multiple variants.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card
https://trello.com/c/cTz3SfpR
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
