### PR TITLE
Fix font size and spacing on applications appearing in provider application index

### DIFF
--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -7,7 +7,7 @@
         <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
       </div>
       <% if most_recent_note %>
-        <span class="app-application-card__note"><span class='note-bullet-point'> </span><%= most_recent_note.subject %></span>
+        <span class="app-application-card__note"><span aria-hidden='true' class='note-bullet-point'> </span><%= most_recent_note.subject %></span>
       <% end %>
     <div>
   </h3>

--- a/app/components/provider_interface/application_card_component.html.erb
+++ b/app/components/provider_interface/application_card_component.html.erb
@@ -7,7 +7,7 @@
         <%= render ProviderInterface::ApplicationStatusTagComponent.new(application_choice: application_choice) %>
       </div>
       <% if most_recent_note %>
-        <span class="app-application-card__note"><%= most_recent_note.subject %></span>
+        <span class="app-application-card__note"><span class='note-bullet-point'> </span><%= most_recent_note.subject %></span>
       <% end %>
     <div>
   </h3>

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -6,8 +6,17 @@
 .app-application-card {
   border-bottom: 1px solid govuk-colour('mid-grey');
   margin-bottom: govuk-spacing(3);
+  
+  h3 {
+    margin-bottom: 0;
+  }
+
+  dl {
+    margin-top: govuk-spacing(1);
+  }
   dd {
     @include govuk-font($size: 19);
+    margin: 0;
   }
 
   &__footer {
@@ -48,10 +57,6 @@
 
   &__status {
     float: right;
-  }
-
-  dd {
-    margin: 0;
   }
 }
 

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -30,6 +30,7 @@
   }
 
   &__primary {
+    padding-top: govuk-spacing(2);
     dd {
       @include govuk-font($size: 16);
     }

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -6,6 +6,9 @@
 .app-application-card {
   border-bottom: 1px solid govuk-colour('mid-grey');
   margin-bottom: govuk-spacing(3);
+  dd {
+    @include govuk-font($size: 24);
+  }
 
   &__footer {
     @include govuk-media-query($from: tablet) {
@@ -19,7 +22,7 @@
     width: 100%;
 
     dd, dt {
-      @include govuk-font($size: 14);
+      @include govuk-font($size: 16);
       color: govuk-colour('dark-grey');
       display: inline;
     }
@@ -28,7 +31,7 @@
 
   &__primary {
     dd {
-      @include govuk-font($size: 14);
+      @include govuk-font($size: 16);
     }
   }
 

--- a/app/frontend/styles/_application-card.scss
+++ b/app/frontend/styles/_application-card.scss
@@ -7,7 +7,7 @@
   border-bottom: 1px solid govuk-colour('mid-grey');
   margin-bottom: govuk-spacing(3);
   dd {
-    @include govuk-font($size: 24);
+    @include govuk-font($size: 19);
   }
 
   &__footer {

--- a/app/frontend/styles/_notes.scss
+++ b/app/frontend/styles/_notes.scss
@@ -16,19 +16,18 @@
 
   display: inline-block;
   word-break: normal; 
-  max-width: 150px;
-  text-align: left;
+  width: fit-content(20em);
+  max-width: 220px;
+  text-align: right;
+}
 
-  &:before {
-    position: absolute;
-    background: govuk-colour("black");
-    border-radius: 25px;
-    height: 10px;
-    width: 10px;
-    left: 0px;
-    top: 6px;
-    content: " ";
-  }
+.note-bullet-point {
+  display: inline-block;
+  margin-right: 5px;
+  background: govuk-colour("black");
+  border-radius: 50%;
+  height: 10px;
+  width: 10px;
 }
 
 /* for __single application view__ within provider_interface */

--- a/app/frontend/styles/_notes.scss
+++ b/app/frontend/styles/_notes.scss
@@ -14,6 +14,11 @@
   font-weight: 400;
   font-size: 1rem;
 
+  display: inline-block;
+  word-break: normal; 
+  max-width: 150px;
+  text-align: left;
+
   &:before {
     position: absolute;
     background: govuk-colour("black");

--- a/app/frontend/styles/_notes.scss
+++ b/app/frontend/styles/_notes.scss
@@ -15,7 +15,6 @@
   font-size: 1rem;
 
   display: inline-block;
-  word-break: normal; 
   max-width: 240px;
   text-align: right;
 }

--- a/app/frontend/styles/_notes.scss
+++ b/app/frontend/styles/_notes.scss
@@ -16,8 +16,7 @@
 
   display: inline-block;
   word-break: normal; 
-  width: fit-content(20em);
-  max-width: 220px;
+  max-width: 240px;
   text-align: right;
 }
 


### PR DESCRIPTION
## Context

Fixes font sizes and spacing of note messages on application cards on the provider interface application index view.

## Changes proposed in this pull request

**Before:**
<img width="540" alt="Screenshot 2020-06-01 at 16 15 12" src="https://user-images.githubusercontent.com/13377553/83423582-161c8580-a423-11ea-94ca-93927d1a60f1.png">

**After:**
<img width="537" alt="Screenshot 2020-06-01 at 16 14 23" src="https://user-images.githubusercontent.com/13377553/83423505-f9804d80-a422-11ea-901b-53d203ad59cc.png">

## Guidance to review

- Does it look like it matches the design to you?

## Link to Trello card

https://trello.com/c/d1WgjClI/2218-wrong-font-size-and-spacing-on-applications-appearing-in-the-list

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
