### PR TITLE
Do not return dupes from GetApplicationChoicesReadyToSendToProvider

### DIFF
--- a/app/services/get_application_forms_ready_to_send_to_providers.rb
+++ b/app/services/get_application_forms_ready_to_send_to_providers.rb
@@ -4,6 +4,7 @@ class GetApplicationFormsReadyToSendToProviders
       .joins(:application_choices)
       .where('"application_choices"."status" = ?', 'application_complete')
       .where('"application_forms"."edit_by" < ?', Time.zone.now)
+      .group(:id)
 
     forms.select do |f|
       f.application_choices.all? { |application_choice| application_choice.status == 'application_complete' }

--- a/spec/services/get_application_forms_ready_to_send_to_providers_spec.rb
+++ b/spec/services/get_application_forms_ready_to_send_to_providers_spec.rb
@@ -55,4 +55,15 @@ RSpec.describe GetApplicationFormsReadyToSendToProviders do
       expect(returned_application_forms).to be_empty
     end
   end
+
+  context 'when there are multiple application choices' do
+    before do
+      create(:application_choice, application_form: application_form, status: :application_complete)
+      create(:application_choice, application_form: application_form, status: :application_complete)
+    end
+
+    it 'returns only one form' do
+      expect(returned_application_forms.count).to eq 1
+    end
+  end
 end

--- a/spec/services/send_application_to_provider_spec.rb
+++ b/spec/services/send_application_to_provider_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe SendApplicationToProvider do
     expect(application_choice.reload.sent_to_provider_at).not_to be_nil
   end
 
-  it 'does nothing if the status is not `application_complete`' do
-    SendApplicationToProvider.new(application_choice: application_choice(status: 'awaiting_references')).call
-
-    expect(application_choice.reload.status).to eq 'awaiting_references'
-  end
-
   it 'sets the `reject_by_default_at` date and `reject_by_default_days`' do
     reject_by_default_at = 20.business_days.from_now.end_of_day
     time_limit_calculator = instance_double(TimeLimitCalculator, call: { days: 20, time_in_future: reject_by_default_at })
@@ -60,5 +54,25 @@ RSpec.describe SendApplicationToProvider do
     }.to change { ActionMailer::Base.deliveries.count }.by(1)
 
     expect(ActionMailer::Base.deliveries.first.to.first).to eq(user.email_address)
+  end
+
+  describe 'dependency on application status' do
+    it 'works if the status is application_complete' do
+      SendApplicationToProvider.new(application_choice: application_choice(status: 'application_complete')).call
+
+      expect(application_choice.reload.status).to eq 'awaiting_provider_decision'
+    end
+
+    it 'works if the status is unsubmitted' do
+      SendApplicationToProvider.new(application_choice: application_choice(status: 'unsubmitted')).call
+
+      expect(application_choice.reload.status).to eq 'awaiting_provider_decision'
+    end
+
+    it 'does not work for another status' do
+      SendApplicationToProvider.new(application_choice: application_choice(status: 'awaiting_references')).call
+
+      expect(application_choice.reload.status).to eq 'awaiting_references'
+    end
   end
 end


### PR DESCRIPTION
## Context

We saw the same email being delivered 3 times in production from SendApplicationsToProvidersWorker.

## Changes proposed in this pull request

When getting forms to send emails for, return each form once, not `n` times, where `n` is the number of choices. This was happening because we `JOIN`ed without `GROUP BY`.

## Guidance to review

Any unintended consequences?

## Link to Trello card

https://trello.com/c/ik9C3Nit/2223-investigate-too-many-emails-being-sent-to-provider-users

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
