### PR TITLE
Split RSpec Unit & Integration Test runs to be run in parallel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -285,97 +285,15 @@ stages:
         path: '$(System.DefaultWorkingDirectory)/results/'
         artifactName: 'cucumberResults'
 
-
-  - job: test_docker_image_batch_2
-    displayName: 'Test Docker Image - RSpec'
-    condition: and(succeeded(), eq(variables['deployOnly'], false))
-    pool:
-      vmImage: 'Ubuntu-16.04'
-
-    variables:
-    - name: system.debug
-      value: $(debug)
-
-    steps:
-    - script: |
-        echo '##vso[task.setvariable variable=COMPOSE_FILE]docker-compose.yml:docker-compose.azure.yml'
-      displayName: 'Configure environment'
-
-    - template: cancel-build-if-not-latest-template.yml
-      parameters:
-        sourceBranchName: $(Build.SourceBranchName)
-
-    - script: |
-        docker pull $(dockerHubUsername)/$(imageName):$(Build.BuildNumber)
-        make az_setup
-      displayName: 'Load Docker image & setup container'
-      env:
-        DOCKER_BUILDKIT: $(dockerBuildkitState)
-        COMPOSE_DOCKER_CLI_BUILD: $(dockerBuildkitState)
-        dockerHubUsername: $(dockerHubUsername)
-        dockerHubImageName: $(imageName)
-        dockerHubImageTag: $(Build.BuildNumber)
-        railsSecretKeyBase: $(railsSecretKeyBase)
-        RAILS_ENV: test
-        GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
-        AUTHORISED_HOSTS: $(authorisedHosts)
-        FIND_BASE_URL: $(findBaseUrl)
-        GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
-        SANDBOX: $(sandbox)
-    
-    - template: cancel-build-if-not-latest-template.yml
-      parameters:
-        sourceBranchName: $(Build.SourceBranchName)
-
-    - script: |
-        make ci.test
-        test_result=$?
-        if [ "$test_result" == "0" ]
-        then
-          if [ -f results/rspec-results.xml ]
-          then
-            if [ $(grep "^<testsuite name=\"rspec\"" results/rspec-results.xml | cut -d' ' -f5 | cut -d'"' -f2) -gt 0 ]
-            then
-              echo "##vso[task.logissue type=error]One or more rspec tests failed"
-              exit 1
-            fi
-            if [ $(grep "^<testsuite name=\"rspec\"" results/rspec-results.xml | cut -d' ' -f4 | cut -d'"' -f2) -gt 0 ]
-            then
-              echo "##vso[task.logissue type=warning]One or more rspec tests were skipped"
-            fi
-          else
-            echo "##vso[task.logissue type=error]rspec-results file not found."
-            exit 1
-          fi
-          exit 0
-        else
-          echo "##vso[task.logissue type=error]Rspec test task exited abnormally."
-          exit 1
-        fi
-      name: ci_test
-      displayName: 'Execute tests'
-      env:
-        dockerHubUsername: $(dockerHubUsername)
-        dockerHubImageName: $(imageName)
-        dockerHubImageTag: $(Build.BuildNumber)
-        RAILS_ENV: test
-        GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
-        AUTHORISED_HOSTS: $(authorisedHosts)
-        FIND_BASE_URL: $(findBaseUrl)
-        GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
-        SANDBOX: $(sandbox)
-
-    - task: PublishTestResults@2
-      displayName: 'Publish test results'
-      inputs:
-        testRunner: JUnit
-        testResultsFiles: 'results/*.xml'
-
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish RSpec Results'
-      inputs:
-        path: '$(System.DefaultWorkingDirectory)/results/'
-        artifactName: 'rspecResults'
+  - template: rspec-job-template.yml
+    parameters:
+      testCommand: 'integration-tests'
+      displayName: 'Integration Tests'
+        
+  - template: rspec-job-template.yml
+    parameters:
+      testCommand: 'unit-tests'
+      displayName: 'Unit Tests'
 
 
 - stage: deploy_qa

--- a/rspec-job-template.yml
+++ b/rspec-job-template.yml
@@ -1,0 +1,63 @@
+parameters:
+  - name: testCommand
+    type: string
+  - name: displayName
+    type: string
+
+jobs:
+- job:
+  displayName: 'RSpec - ${{ parameters.displayName }}'
+  condition: and(succeeded(), eq(variables['deployOnly'], false))
+  pool:
+    vmImage: 'Ubuntu-16.04'
+  variables:
+  - name: system.debug
+    value: $(debug)
+
+  steps:
+  - script: |
+      echo '##vso[task.setvariable variable=COMPOSE_FILE]docker-compose.yml:docker-compose.azure.yml'
+    displayName: 'Configure environment'
+
+  - template: cancel-build-if-not-latest-template.yml
+    parameters:
+      sourceBranchName: $(Build.SourceBranchName)
+
+  - script: |
+      docker pull $(dockerHubUsername)/$(imageName):$(Build.BuildNumber)
+      make az_setup
+    displayName: 'Load Docker image & setup container'
+    env:
+      DOCKER_BUILDKIT: $(dockerBuildkitState)
+      COMPOSE_DOCKER_CLI_BUILD: $(dockerBuildkitState)
+      dockerHubUsername: $(dockerHubUsername)
+      dockerHubImageName: $(imageName)
+      dockerHubImageTag: $(Build.BuildNumber)
+      railsSecretKeyBase: $(railsSecretKeyBase)
+      RAILS_ENV: test
+      GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
+      AUTHORISED_HOSTS: $(authorisedHosts)
+      FIND_BASE_URL: $(findBaseUrl)
+      GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+      SANDBOX: $(sandbox)
+  
+  - template: cancel-build-if-not-latest-template.yml
+    parameters:
+      sourceBranchName: $(Build.SourceBranchName)
+ 
+  - template: run-rspec-test-template.yml
+    parameters:
+      testCommand: ${{ format('ci.{0}', parameters.testCommand) }}
+      testResultsFile: ${{ format('results/rspec-{0}-results.xml', parameters.testCommand) }}
+
+  - task: PublishTestResults@2
+    displayName: 'Publish test results'
+    inputs:
+      testRunner: JUnit
+      testResultsFiles: 'results/*.xml'
+
+  - task: PublishPipelineArtifact@1
+    displayName: 'Publish RSpec Results'
+    inputs:
+      path: '$(System.DefaultWorkingDirectory)/results/'
+      artifactName: ${{ format('rspec-{0}', parameters.testCommand) }}

--- a/run-rspec-test-template.yml
+++ b/run-rspec-test-template.yml
@@ -1,0 +1,44 @@
+parameters:
+  - name: testCommand
+    type: string
+  - name: testResultsFile
+    type: string
+
+steps:
+  - script: |
+      make ${{ parameters.testCommand }}
+        test_result=$?
+        if [ "$test_result" == "0" ]
+        then
+          if [ -f $testResultFile ]
+          then
+            if [ $(grep "^<testsuite name=\"rspec\"" $testResultFile | cut -d' ' -f5 | cut -d'"' -f2) -gt 0 ]
+            then
+              echo "##vso[task.logissue type=error]One or more rspec tests failed"
+              exit 1
+            fi
+            if [ $(grep "^<testsuite name=\"rspec\"" $testResultFile | cut -d' ' -f4 | cut -d'"' -f2) -gt 0 ]
+            then
+              echo "##vso[task.logissue type=warning]One or more rspec tests were skipped"
+            fi
+          else
+            echo "##vso[task.logissue type=error]rspec-results file not found."
+            exit 1
+          fi
+          exit 0
+        else
+          echo "##vso[task.logissue type=error]Rspec test task exited abnormally."
+          exit 1
+        fi
+    displayName: 'Execute ${{ parameters.testCommand }}'
+    env:
+      testResultFile: ${{ parameters.testResultsFile }}
+      dockerHubUsername: $(dockerHubUsername)
+      dockerHubImageName: $(imageName)
+      dockerHubImageTag: $(Build.BuildNumber)
+      RAILS_ENV: test
+      GOVUK_NOTIFY_API_KEY: $(govukNotifyAPIKey)
+      AUTHORISED_HOSTS: $(authorisedHosts)
+      FIND_BASE_URL: $(findBaseUrl)
+      GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
+      SANDBOX: $(sandbox)


### PR DESCRIPTION
Run RSpec unit and integration tests tasks as parallel jobs in the
pipeline. This will save the total time spent running the test stage in
the pipeline.

## Context
We currently have a single job defined in the pipeline to run Rspec. 
This takes about 5-6 mins to run in the pipeline. 
We can save some time by splitting the run into parallel `unit` & `integration` runs.

## Changes proposed in this pull request

Split the RSpec job into templates which can be reused.
Reuse the template to run `unit-test` and `integration-test` make targets.

## Guidance to review


## Link to Trello card

https://trello.com/c/EM24MnZe/260-run-acceptance-tests-in-parallel-in-build-pipeline

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
