### PR TITLE
Add new email for when candidate submits an Apply again application

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,5 +1,7 @@
 class CandidateMailer < ApplicationMailer
   def application_submitted(application_form)
+    @candidate_magic_link = candidate_magic_link(application_form.candidate)
+
     email_for_candidate(
       application_form,
     )

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -7,6 +7,14 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def application_submitted_apply_again(application_form)
+    @application_choice = application_form.application_choices.first
+
+    email_for_candidate(
+      application_form,
+    )
+  end
+
   def application_sent_to_provider(application_form)
     email_for_candidate(
       application_form,

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -25,7 +25,11 @@ class SubmitApplication
         ApplicationStateChange.new(application_choice).submit!
       end
 
-      CandidateMailer.application_submitted(application_form).deliver_later
+      if application_form.apply_2?
+        CandidateMailer.application_submitted_apply_again(application_form).deliver_later
+      else
+        CandidateMailer.application_submitted(application_form).deliver_later
+      end
       send_reference_request_email_to_referees(application_form)
       StateChangeNotifier.call(:submit_application, application_form: application_form)
       auto_approve_references_in_sandbox(application_form)

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -12,7 +12,7 @@ Your application reference is <%= @application_form.support_reference %>.
 
 You can track the progress of your <%= 'application'.pluralize(@application_form.application_choices.count) %> here:
 
-<%= candidate_magic_link(@candidate) %>
+<%= @candidate_magic_link %>
 
 # Making changes to your application
 
@@ -30,7 +30,7 @@ You can withdraw your application to your <%= 'course'.pluralize(@application_fo
 
 Sign in to your account and click ‘withdraw’ next to the course(s) you want to withdraw:
 
-<%= candidate_magic_link(@candidate) %>
+<%= @candidate_magic_link %>
 
 # References
 

--- a/app/views/candidate_mailer/application_submitted_apply_again.text.erb
+++ b/app/views/candidate_mailer/application_submitted_apply_again.text.erb
@@ -1,0 +1,19 @@
+Dear <%= @application_form.first_name %>,
+
+# Application submitted
+
+You’ve submitted an application for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
+
+Your application reference is <%= @application_form.support_reference %>.
+
+You can track the progress of your application on your dashboard:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+# What’s next?
+
+If your training provider decides to progress your application, they’ll contact you to organise an interview.
+
+# Need help?
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk).

--- a/config/locales/application_states.yml
+++ b/config/locales/application_states.yml
@@ -40,7 +40,7 @@ en:
       name: Ended without success
       description: All of the candidate’s applications have been withdrawn, rejected or declined.
     unknown_state:
-      name: 'Unknown!'
+      name: "Unknown!"
       description: This application is in a state that we don’t recognise. Please report this to a developer.
   candidate_application_states:
     application_complete: Submitted
@@ -181,6 +181,7 @@ en:
       description: The candidate can submit the form once all required fields are completed.
       emails:
         - candidate_mailer-application_submitted
+        - candidate_mailer-application_submitted_apply_again
         - referee_mailer-reference_request_email
 
     unsubmitted-send_to_provider:
@@ -245,7 +246,7 @@ en:
     awaiting_provider_decision-reject:
       name: Provider rejects
       by: provider
-      description:  |
+      description: |
         The provider rejects the candidate.
 
         An email is sent to the candidate, the content of which depends
@@ -360,87 +361,87 @@ en:
     not_signed_up-sign_up:
       name: Sign up
       by: candidate
-      description: ''
+      description: ""
 
     never_signed_in-sign_in:
       name: Sign in
       by: candidate
-      description: ''
+      description: ""
 
     unsubmitted_not_started_form-edit_form:
       name: Edit form
       by: candidate
-      description: ''
+      description: ""
 
     unsubmitted_in_progress-submit:
       name: Submit
       by: candidate
-      description: ''
+      description: ""
 
     awaiting_references-all_withdrawn:
       name: Withdraw
       by: candidate
-      description: ''
+      description: ""
 
     waiting_to_be_sent-send_to_provider:
       name: Send to provider
       by: candidate
-      description: ''
+      description: ""
 
     waiting_to_be_sent-all_withdrawn:
       name: Withdraw
       by: candidate
-      description: ''
+      description: ""
 
     awaiting_provider_decisions-at_least_one_offer:
       name: At least one offer
       by: provider
-      description: ''
+      description: ""
 
     awaiting_references-references_complete:
       name: All references completed
       by: system
-      description: ''
+      description: ""
 
     awaiting_provider_decisions-no_offers:
       name: No offers
       by: provider
-      description: ''
+      description: ""
 
     awaiting_provider_decisions-all_rejected:
       name: All rejected
       by: provider
-      description: ''
+      description: ""
 
     awaiting_provider_decisions-all_withdrawn:
       name: Withdraw
       by: candidate
-      description: ''
+      description: ""
 
     awaiting_candidate_response-offer_accepted:
       name: Offer accepted
       by: candidate
-      description: ''
+      description: ""
 
     awaiting_candidate_response-all_offers_declined:
       name: All offers declined
       by: candidate
-      description: ''
+      description: ""
 
     pending_conditions-conditions_met:
       name: Conditions are met
       by: provider
-      description: ''
+      description: ""
 
     pending_conditions-conditions_not_met:
       name: Conditions not met
       by: provider
-      description: ''
+      description: ""
 
     recruited-enrol:
       name: Enrol
       by: provider
-      description: ''
+      description: ""
 
     ended_without_success-start_apply_again:
       name: Start in Apply again (not built)

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -5,9 +5,11 @@ en:
     survey_chaser_email:
       subject: We’d love to hear from you about your teacher training application
     reference_received:
-      subject: 'You have a reference for your teacher training application'
+      subject: "You have a reference for your teacher training application"
     application_submitted:
-      subject: 'You’ve submitted your teacher training application'
+      subject: "You’ve submitted your teacher training application"
+    application_submitted_apply_again:
+      subject: "You’ve submitted your teacher training application"
     application_sent_to_provider:
       subject: Your application is being considered
     chase_reference:

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -3,10 +3,21 @@ class CandidateMailerPreview < ActionMailer::Preview
     application_form = FactoryBot.build_stubbed(
       :completed_application_form,
       candidate: candidate,
-      support_reference: 'ABC-DEF',
+      support_reference: 'ABCDEF',
     )
 
     CandidateMailer.application_submitted(application_form)
+  end
+
+  def application_submitted_apply_again
+    application_form = FactoryBot.build_stubbed(
+      :completed_application_form,
+      candidate: candidate,
+      support_reference: 'ABCDEF',
+      application_choices: [FactoryBot.build_stubbed(:application_choice, :awaiting_provider_decision, course_option: course_option)],
+    )
+
+    CandidateMailer.application_submitted_apply_again(application_form)
   end
 
   def application_sent_to_provider


### PR DESCRIPTION
## Context

We need a different version of the 'application submitted' email for candidates who apply again. The email will not mention references as most people will keep their references from Apply 1.

## Changes proposed in this pull request

Add email that is sent to candidates when they submit their apply again application.

## Guidance to review

Does this make sense?

## Link to Trello card

https://trello.com/c/5J7sX8iQ

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)