### PR TITLE
Content changes to speed up the reference process

### DIFF
--- a/app/components/candidate_interface/additional_referees_start_component.html.erb
+++ b/app/components/candidate_interface/additional_referees_start_component.html.erb
@@ -5,17 +5,30 @@
 <p class="govuk-body">
   <% if reference_status.references_that_needed_to_be_replaced.count == 1 %>
     <%= reason_for_replacement(references_that_need_replacement.first) %>.
+    <p class="govuk-body">Add a new referee as soon as possible. Courses can become full at any time and providers do not consider applications without 2 references.</p>
+
+    <% if overdue_references.any? %>
+      <p class="govuk-body">Adding a new referee will not prevent <%= overdue_references.first.name %> from giving a reference. You can keep chasing <%= overdue_references.first.name %> if you know they’re planning on giving a reference.</p>
+    <% end %>
+
   <% else %>
     Your referees have not given us a reference:
     <ul class="govuk-list govuk-list--bullet">
       <% references_that_need_replacement.each do |ref| %>
-        <li class="govuk-body"><%= reason_for_replacement(ref) %></li>
+        <li class="govuk-body"><%= reason_for_replacement(ref) %>. Add a new referee as soon as possible.</li>
       <% end %>
     </ul>
+
+    <p class="govuk-body">Courses can become full at any time and providers do not consider applications without 2 references.</p>
+
+    <% if overdue_references.count == 1 %>
+      <p class="govuk-body">Adding a new referee will not prevent <%= overdue_references.first.name %> from giving a reference. You can keep chasing <%= overdue_references.first.name %> if you know they’re planning on giving a reference.</p>
+    <% elsif  overdue_references.count == 2 %>
+      <p class="govuk-body">Adding a new referee will not prevent <%= overdue_references.first.name %> and <%= overdue_references.second.name %> from giving a reference. You can keep chasing your referees if you know they’re planning on giving a reference.</p>
+    <% end %>
+
   <% end %>
 </p>
-
-<p class="govuk-body">We can’t send your application to your teacher training providers without 2 complete references.</p>
 
 <% if reference_status.number_of_references_that_currently_need_replacing == 1 %>
   <p> <%= govuk_button_link_to 'Add a new referee', candidate_interface_additional_referee_type_path %></p>

--- a/app/components/candidate_interface/additional_referees_start_component.rb
+++ b/app/components/candidate_interface/additional_referees_start_component.rb
@@ -39,6 +39,10 @@ module CandidateInterface
       @reference_status.references_that_needed_to_be_replaced
     end
 
+    def overdue_references
+      references_that_need_replacement.select(&:feedback_overdue?)
+    end
+
     attr_reader :application_form
   end
 end

--- a/app/components/candidate_interface/referee_guidance_component.html.erb
+++ b/app/components/candidate_interface/referee_guidance_component.html.erb
@@ -1,11 +1,13 @@
 <% if @application_form.application_references.feedback_requested.count == 1 %>
   <h2 class="govuk-heading-m">Reference</h2>
-  <p class="govuk-body">We’ll contact your referee to ask for your reference. When we receive it, we’ll add it to your application and send it to your training <%= pluralize_provider %>.</p>
-  <p class="govuk-body">We can’t send your application to your training <%= pluralize_provider %> without your reference.</p>
+  <p class="govuk-body">We’ve sent an email to your referee and will send them a reminder in <%= @editable_days %>.</p>
+  <p class="govuk-body">When we get your reference, we’ll add it to your application and send it to your training <%= pluralize_provider %>.</p>
+  <p class="govuk-body">Courses can become full at any time. Keep in touch with your referee to ensure they’re planning on giving a reference as soon as possible.</p>
 <% else %>
   <h2 class="govuk-heading-m">References</h2>
-  <p class="govuk-body">We’ll contact your referees to ask for your references. When we receive them, we’ll add them to your application and send it to your training <%= pluralize_provider %>.</p>
-  <p class="govuk-body">We can’t send your application to your training <%= pluralize_provider %> without your references.</p>
+  <p class="govuk-body">We’ve sent an email to your referees and will send them a reminder in <%= @editable_days %>.</p>
+  <p class="govuk-body">When we get your references, we’ll add them to your application and send it to your training <%= pluralize_provider %>.</p>
+  <p class="govuk-body">Courses can become full at any time. Keep in touch with your referees to ensure they’re planning on giving a reference as soon as possible.</p>
 <% end %>
 
 <% unless FeatureFlag.active?('covid_19') %>

--- a/app/components/candidate_interface/referee_guidance_component.rb
+++ b/app/components/candidate_interface/referee_guidance_component.rb
@@ -2,8 +2,9 @@ module CandidateInterface
   class RefereeGuidanceComponent < ViewComponent::Base
     attr_reader :application_form
 
-    def initialize(application_form:)
+    def initialize(application_form:, editable_days:)
       @application_form = application_form
+      @editable_days = editable_days
     end
 
     def pluralize_provider

--- a/app/components/candidate_interface/referees_review_component.html.erb
+++ b/app/components/candidate_interface/referees_review_component.html.erb
@@ -1,7 +1,5 @@
 <p class="govuk-body">
-  <% if @application_form.submitted? %>
-    <%= t('application_form.referees.info.after_submission') %>
-  <% elsif @application_form.application_references.empty? %>
+  <% if @application_form.application_references.empty? %>
     <%= t('application_form.referees.info.before_submission') %>
   <% end %>
 </p>

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -74,48 +74,12 @@ module CandidateInterface
     end
 
     def feedback_status_row(referee)
-      if referee.not_requested_yet? && !referee.application_form.submitted?
-        {
-          key: 'Status',
-          value: feedback_status_label(referee) +
-            content_tag(:p, t('application_form.referees.info.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2'),
-        }
-      elsif referee.feedback_refused?
-        {
-          key: 'Status',
-          value: feedback_status_label(referee) +
-            content_tag(:p, t('application_form.referees.info.declined'), class: 'govuk-body govuk-!-margin-top-2'),
-        }
-      elsif referee.feedback_overdue?
-        {
-          key: 'Status',
-          value: feedback_status_label(referee) +
-            content_tag(:p, t('application_form.referees.info.feedback_overdue'), class: 'govuk-body govuk-!-margin-top-2'),
-        }
-      elsif referee.feedback_requested? && referee.requested_at > Time.zone.now - 5.days
-        {
-          key: 'Status',
-          value: feedback_status_label(referee) +
-            content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_less_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2'),
-        }
-      elsif referee.feedback_requested?
-        {
-          key: 'Status',
-          value: feedback_status_label(referee) +
-            content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2'),
-        }
-      elsif referee.cancelled?
-        {
-          key: 'Status',
-          value: feedback_status_label(referee) +
-            content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2'),
-        }
-      else
-        {
-          key: 'Status',
-          value: feedback_status_label(referee),
-        }
-      end
+      value = feedback_status_label(referee) + feedback_status_content(referee)
+
+      {
+        key: 'Status',
+        value: value,
+      }
     end
 
     def feedback_status_label(reference)
@@ -131,6 +95,22 @@ module CandidateInterface
       return t('candidate_reference_status.feedback_overdue') if reference.feedback_overdue?
 
       t("candidate_reference_status.#{reference.feedback_status}")
+    end
+
+    def feedback_status_content(referee)
+      if referee.not_requested_yet? && !referee.application_form.submitted?
+        content_tag(:p, t('application_form.referees.info.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2')
+      elsif referee.feedback_refused?
+        content_tag(:p, t('application_form.referees.info.declined'), class: 'govuk-body govuk-!-margin-top-2')
+      elsif referee.feedback_overdue?
+        content_tag(:p, t('application_form.referees.info.feedback_overdue'), class: 'govuk-body govuk-!-margin-top-2')
+      elsif referee.feedback_requested? && referee.requested_at > Time.zone.now - 5.days
+        content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_less_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
+      elsif referee.feedback_requested?
+        content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
+      elsif referee.cancelled?
+        content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
+      end
     end
 
     def feedback_status_colour(reference)

--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -80,6 +80,36 @@ module CandidateInterface
           value: feedback_status_label(referee) +
             content_tag(:p, t('application_form.referees.info.not_requested_yet'), class: 'govuk-body govuk-!-margin-top-2'),
         }
+      elsif referee.feedback_refused?
+        {
+          key: 'Status',
+          value: feedback_status_label(referee) +
+            content_tag(:p, t('application_form.referees.info.declined'), class: 'govuk-body govuk-!-margin-top-2'),
+        }
+      elsif referee.feedback_overdue?
+        {
+          key: 'Status',
+          value: feedback_status_label(referee) +
+            content_tag(:p, t('application_form.referees.info.feedback_overdue'), class: 'govuk-body govuk-!-margin-top-2'),
+        }
+      elsif referee.feedback_requested? && referee.requested_at > Time.zone.now - 5.days
+        {
+          key: 'Status',
+          value: feedback_status_label(referee) +
+            content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_less_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2'),
+        }
+      elsif referee.feedback_requested?
+        {
+          key: 'Status',
+          value: feedback_status_label(referee) +
+            content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2'),
+        }
+      elsif referee.cancelled?
+        {
+          key: 'Status',
+          value: feedback_status_label(referee) +
+            content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2'),
+        }
       else
         {
           key: 'Status',

--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -88,6 +88,8 @@ module CandidateInterface
 
     def confirm_cancel
       if @referee.feedback_requested?
+        provider_count = current_application.application_choices.map(&:provider).uniq.count
+        @pluralize_provider = 'provider'.pluralize(provider_count)
         @application_form = current_application
       else
         redirect_to candidate_interface_review_referees_path

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -22,11 +22,7 @@ class TimeLimitConfig
   Rule = Struct.new(:from_date, :to_date, :limit)
 
   def self.edit_by
-    if FeatureFlag.active?('covid_19')
-      Days.new(count: 7, type: :calendar)
-    else
-      Days.new(count: 5, type: :working)
-    end
+    Days.new(count: 5, type: :working)
   end
 
   def self.chase_referee_by

--- a/app/views/candidate_interface/application_form/edit_by_support.html.erb
+++ b/app/views/candidate_interface/application_form/edit_by_support.html.erb
@@ -7,16 +7,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have <%= @editable_days %> after submission to edit most sections of your application.</p>
-    <p class="govuk-body">To edit, you’ll need to email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>, explaining which changes you’d like to make.</p>
-    <p class="govuk-body">We can only edit your application once.</p>
-    <h2 class="govuk-heading-m">Course choice</h2>
-    <p class="govuk-body">We can change your choice of training provider, course or location within the <%= @editable_days %> editing period.</p>
-    <p class="govuk-body">We can also delete a course choice.</p>
-    <p class="govuk-body">After this, you can email us asking to withdraw your application completely.</p>
-    <h2 class="govuk-heading-m">References</h2>
-    <p class="govuk-body">We can’t edit your choice of referees unless they refuse to give a reference. We’ll email you if this happens, so you can put forward a replacement referee.</p>
-    <h2 class="govuk-heading-m">Contact details</h2>
-    <p class="govuk-body">You can update your contact details at any point during the application process. To do this, email us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+    <p class="govuk-body">You have <%= @editable_days %> to edit your application.</p>
+    <p class="govuk-body">Tell us what changes you need to make by emailing us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
+    <p class="govuk-body">We can only make changes once.</p>
+    <h2 class="govuk-heading-m">Changing your references</h2>
+    <p class="govuk-body"><%= govuk_link_to 'You can edit your references from your application dashboard.', candidate_interface_application_complete_path %></p>
+    <h2 class="govuk-heading-m">Changing your contact details</h2>
+    <p class="govuk-body">You can ask us to change your contact details at any time by emailing us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
   </div>
 </div>

--- a/app/views/candidate_interface/application_form/submit_success.html.erb
+++ b/app/views/candidate_interface/application_form/submit_success.html.erb
@@ -16,7 +16,7 @@
     <p class="govuk-body">You’ll get an email to confirm that your application has been submitted.</p>
 
     <% if @application_form.application_references.feedback_requested.any? %>
-      <%= render CandidateInterface::RefereeGuidanceComponent.new(application_form: @application_form) %>
+      <%= render CandidateInterface::RefereeGuidanceComponent.new(application_form: @application_form, editable_days: TimeLimitConfig.edit_by) %>
     <% end %>
 
     <% if FeatureFlag.active?('covid_19') %>

--- a/app/views/candidate_interface/referees/confirm_cancel.html.erb
+++ b/app/views/candidate_interface/referees/confirm_cancel.html.erb
@@ -9,16 +9,16 @@
         <%= t('page_titles.referee_cancel') %>
       </h1>
 
-      <p class='govuk-body'>You will need to give details of a new referee.</p>
+      <p class='govuk-body'>We’ll tell <%= @referee.name %> that they do not need to give a reference.</p>
 
-      <p class='govuk-body'>We cannot send your application to your provider(s) without 2 references.</p>
+      <p class='govuk-body'>We cannot send your application to your <%= @pluralize_provider %> without 2 references.</p>
 
-      <p class='govuk-body'> We’ll tell <%= @referee.name %> that they do not need to give a reference.</p>
+      <p class='govuk-body'><%= govuk_link_to 'You can check the progress of your reference requests on your dashboard.', candidate_interface_application_complete_path %></p>
 
       <%= f.submit t('application_form.referees.sure_cancel_entry'), class: 'govuk-button govuk-button--warning', data: { module: 'govuk-button' } %>
 
       <p class="govuk-body">
-        <%= govuk_link_to 'Cancel', candidate_interface_review_referees_path %>
+        <%= govuk_link_to 'No - I’ve changed my mind', candidate_interface_review_referees_path %>
       </p>
     <% end %>
   </div>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -318,7 +318,11 @@ en:
       info:
         before_submission: You need to add 2 referees.
         not_requested_yet:  We’ll contact your referees after you submit your application.
-        after_submission: We’ve contacted the referees you provided below. We’ll let you know if they don’t supply a reference.
+        declined: Your referee chose not to give a reference.
+        awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
+        awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.
+        cancelled: You cancelled your reference request.
+        feedback_overdue: Your referee has not responded yet. Keep chasing the referee or cancel the request in favour of another referee.
   activemodel:
     errors:
       models:

--- a/spec/components/candidate_interface/additional_referees_start_component_spec.rb
+++ b/spec/components/candidate_interface/additional_referees_start_component_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe CandidateInterface::AdditionalRefereesStartComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.govuk-body').text).to include("#{late_referee.name} did not respond to our request.")
+      expect(result.css('.govuk-body').text).to include("Adding a new referee will not prevent #{late_referee.name} from giving a reference.")
     end
   end
 
@@ -88,6 +89,23 @@ RSpec.describe CandidateInterface::AdditionalRefereesStartComponent do
       expect(result.css('.govuk-body').text).to include("Our email requesting a reference didn’t reach #{first_referee.name}")
       expect(result.css('.govuk-body').text).to include("#{second_referee.name} said they won’t give a reference")
       expect(result.css('.govuk-body').text).not_to include(third_referee.name.to_s)
+    end
+  end
+
+  context 'when mulitple references are overdue' do
+    let(:late_referee) { build_stubbed(:reference, :requested, application_form: application_form) }
+    let(:late_referee2) { build_stubbed(:reference, :requested, application_form: application_form) }
+
+    let(:references) { [late_referee, late_referee2] }
+
+    it 'gives a reason that feedback is overdue' do
+      allow(late_referee).to receive(:requested_at).and_return(Time.zone.now - 30.days)
+      allow(late_referee2).to receive(:requested_at).and_return(Time.zone.now - 30.days)
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-body').text).to include("#{late_referee.name} did not respond to our request. Add a new referee as soon as possible.")
+      expect(result.css('.govuk-body').text).to include("#{late_referee2.name} did not respond to our request. Add a new referee as soon as possible.")
+      expect(result.css('.govuk-body').text).to include("Adding a new referee will not prevent #{late_referee.name} and #{late_referee2.name} from giving a reference.")
     end
   end
 end

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
   context 'when one reference is in the feedback_requested state' do
     context 'when the candidates courses all have the same provider' do
       it 'renders the correct pluralization for referees, references and providers' do
-        result = render_inline(described_class.new(application_form: @application_form))
+        result = render_inline(described_class.new(application_form: @application_form, editable_days: 5))
 
         expect(result.css('.govuk-heading-m').text).to eq('Reference')
         expect(result.css('.govuk-body').text).to include('training provider')
@@ -45,7 +45,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
         provider2 = create(:provider)
         course_option_for_provider(provider: provider2)
         create(:application_choice, application_form: @application_form, course_option: provider2.courses.first.course_options.first)
-        result = render_inline(described_class.new(application_form: @application_form))
+        result = render_inline(described_class.new(application_form: @application_form, editable_days: 5))
 
         expect(result.css('.govuk-heading-m').text).to eq('Reference')
         expect(result.css('.govuk-body').text).to include('training providers')
@@ -57,7 +57,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
     context 'when the candidates courses all have the same provider' do
       it 'renders the correct pluralization for referees, references and providers' do
         create(:reference, :requested, application_form: @application_form)
-        result = render_inline(described_class.new(application_form: @application_form))
+        result = render_inline(described_class.new(application_form: @application_form, editable_days: 5))
 
         expect(result.css('.govuk-heading-m').text).to eq('References')
         expect(result.css('.govuk-body').text).to include('training provider')
@@ -71,7 +71,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
         course_option_for_provider(provider: provider2)
         create(:application_choice, application_form: @application_form, course_option: provider2.courses.first.course_options.first)
         create(:reference, :requested, application_form: @application_form)
-        result = render_inline(described_class.new(application_form: @application_form))
+        result = render_inline(described_class.new(application_form: @application_form, editable_days: 5))
 
         expect(result.css('.govuk-heading-m').text).to eq('References')
         expect(result.css('.govuk-body').text).to include('training providers')

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
       end
 
       it 'renders the correct rejection by default time limit' do
-        result = render_inline(described_class.new(application_form: @application_form))
+        result = render_inline(described_class.new(application_form: @application_form, editable_days: 5))
         expect(result.css('.govuk-body').text).to include(
           'Training providers then have 40 working days to respond to your application',
         )

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -20,44 +20,23 @@ RSpec.describe TimeLimitConfig do
   end
 
   describe '.edit_by' do
-    context 'when the COVID-19 feature flag is on' do
-      before { FeatureFlag.activate('covid_19') }
 
-      it 'returns 7 days' do
-        expect(TimeLimitConfig.edit_by.count).to eq(7)
-      end
+    before { FeatureFlag.deactivate('covid_19') }
 
-      it 'returns type as calendar' do
-        expect(TimeLimitConfig.edit_by.type).to eq(:calendar)
-      end
-
-      it 'displays "7 calendar days"' do
-        expect(TimeLimitConfig.edit_by.to_s).to eq('7 calendar days')
-      end
-
-      it 'returns days as ActiveSupport:Duration object' do
-        expect(TimeLimitConfig.edit_by.to_days).to be_a_kind_of(ActiveSupport::Duration)
-      end
+    it 'returns 5 days' do
+      expect(TimeLimitConfig.edit_by.count).to eq(5)
     end
 
-    context 'when the COVID-19 feature flag is off' do
-      before { FeatureFlag.deactivate('covid_19') }
+    it 'returns type as working' do
+      expect(TimeLimitConfig.edit_by.type).to eq(:working)
+    end
 
-      it 'returns 5 days' do
-        expect(TimeLimitConfig.edit_by.count).to eq(5)
-      end
+    it 'displays "5 calendar days"' do
+      expect(TimeLimitConfig.edit_by.to_s).to eq('5 working days')
+    end
 
-      it 'returns type as working' do
-        expect(TimeLimitConfig.edit_by.type).to eq(:working)
-      end
-
-      it 'displays "5 calendar days"' do
-        expect(TimeLimitConfig.edit_by.to_s).to eq('5 working days')
-      end
-
-      it 'returns days as BusinessTime::BusinessDays object' do
-        expect(TimeLimitConfig.edit_by.to_days).to be_a_kind_of(BusinessTime::BusinessDays)
-      end
+    it 'returns days as BusinessTime::BusinessDays object' do
+      expect(TimeLimitConfig.edit_by.to_days).to be_a_kind_of(BusinessTime::BusinessDays)
     end
   end
 end

--- a/spec/lib/time_limit_config_spec.rb
+++ b/spec/lib/time_limit_config_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe TimeLimitConfig do
   end
 
   describe '.edit_by' do
-
     before { FeatureFlag.deactivate('covid_19') }
 
     it 'returns 5 days' do

--- a/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
+++ b/spec/system/candidate_interface/candidate_cancels_a_reference_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Cancelling a reference' do
 
   def given_that_i_have_10_references
     create_list(:reference, 7, application_form: @reference.application_form, feedback_status: 'cancelled')
-    create(:reference, application_form: @reference.application_form, feedback_status: 'feedback_requested')
+    create(:reference, application_form: @reference.application_form, feedback_status: 'feedback_requested', requested_at: 1.day.ago)
   end
 
   def when_i_visit_the_application_complete_page

--- a/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
+++ b/spec/system/candidate_interface/candidate_replaces_reference_after_applying_again_spec.rb
@@ -144,7 +144,7 @@ RSpec.feature 'Candidate applying again' do
   end
 
   def then_i_am_informed_my_new_referee_will_be_contacted
-    expect(page).to have_content 'We’ll contact your referee to ask for your reference'
+    expect(page).to have_content 'We’ve sent an email to your referee'
   end
 
   def and_my_application_is_awaiting_references


### PR DESCRIPTION
## Context

There is loads of content that needs tweaking on referee related content. 

This PR covers 5 separate changes.

1. Updating the edit after submission guidance
2. Updating the post submission referee guidance
3. Updating the guidance on the cancel referee page
4. Updating the content on the referee interstitial page 
5. The referee review component displays guidance for each referee state

## Changes proposed in this pull request

Edit page

Before 

![image](https://user-images.githubusercontent.com/42515961/83633390-c9f35180-a598-11ea-8a3a-c29104e5747c.png)


After

![image](https://user-images.githubusercontent.com/42515961/83633424-d5467d00-a598-11ea-8958-f1849130f970.png)


Application submit success page

Before

![image](https://user-images.githubusercontent.com/42515961/83633556-0b83fc80-a599-11ea-9198-790deef32789.png)


After

![image](https://user-images.githubusercontent.com/42515961/83633504-fa3af000-a598-11ea-954a-3e3ec721ed4d.png)

Cancel referee page

Before 

![image](https://user-images.githubusercontent.com/42515961/83633656-33736000-a599-11ea-917e-9ca4fc7da4fa.png)


After

![image](https://user-images.githubusercontent.com/42515961/83633686-438b3f80-a599-11ea-9236-a2c2ab297c84.png)

Referee interstitial page

Before 

![image](https://user-images.githubusercontent.com/42515961/83633857-80573680-a599-11ea-834b-6682e55b5d43.png)


After

![image](https://user-images.githubusercontent.com/42515961/83633816-72091a80-a599-11ea-8745-2283e2a04e44.png)

Referee review component - complete page

Before

![image](https://user-images.githubusercontent.com/42515961/83633970-a977c700-a599-11ea-921a-c0c873b24ea3.png)


After 

Response overdue 

![image](https://user-images.githubusercontent.com/42515961/83634135-efcd2600-a599-11ea-8aea-5ccae564be7d.png)

Cancelled 

![image](https://user-images.githubusercontent.com/42515961/83634204-0bd0c780-a59a-11ea-87d6-01aaa464339d.png)

Declined

![image](https://user-images.githubusercontent.com/42515961/83634407-6bc76e00-a59a-11ea-9ed6-e013dd43f148.png)

Awaiting feedback (requested less than 5 days ago)

![image](https://user-images.githubusercontent.com/42515961/83634922-46872f80-a59b-11ea-8f1c-ba0cf01e1933.png)


Awaiting feedback (requested more than 5 days ago)

![image](https://user-images.githubusercontent.com/42515961/83635028-6e769300-a59b-11ea-9387-c3ac3bbe3d2a.png)


## Guidance to review

Review by commit.

Content for 1st commits changes - https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.dk8jrqyzbd8s

Content for 2nd commits changes -
https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.j1wrtwyyu4nr

Content for 3rd commits changes -
https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.3zqb2xsapxb

Content for 4th commits changes -
https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.9y1bmz78oy1t

Content for 5th commits changes -
https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.ctg0n2pmgwm0

## Link to Trello card

https://trello.com/c/8LCXhKhv/1645-dev-design-tweaks-to-make-references-go-faster

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
