### PR TITLE
Refactor reference safeguarding attributes

### DIFF
--- a/app/components/provider_interface/reference_with_feedback_component.rb
+++ b/app/components/provider_interface/reference_with_feedback_component.rb
@@ -9,6 +9,7 @@ module ProviderInterface
              :relationship_confirmation,
              :relationship_correction,
              :safeguarding_concerns,
+             :safeguarding_concerns_status,
              to: :reference
 
     def initialize(reference:)
@@ -70,12 +71,12 @@ module ProviderInterface
     def safeguarding_row
       {
         key: 'Does the referee know of any reason why this candidate should not work with children?',
-        value: safeguarding_concerns.present? ? 'Yes' : 'No',
+        value: reference.has_safeguarding_concerns_to_declare? ? 'Yes' : 'No',
       }
     end
 
     def safeguarding_concerns_row
-      return nil if safeguarding_concerns.blank?
+      return nil unless reference.has_safeguarding_concerns_to_declare?
 
       {
         key: 'Reason(s) given by referee why this candidate should not work with children',

--- a/app/components/referee_interface/reference_review_component.rb
+++ b/app/components/referee_interface/reference_review_component.rb
@@ -22,9 +22,9 @@ module RefereeInterface
     end
 
     def safeguarding_concerns
-      concerns = if @reference.safeguarding_concerns.nil?
+      concerns = if @reference.not_answered_yet? || @reference.never_asked?
                    'Not answered'
-                 elsif @reference.safeguarding_concerns.blank?
+                 elsif @reference.no_safeguarding_concerns_to_declare?
                    'No'
                  else
                    @reference.safeguarding_concerns

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -25,7 +25,7 @@ module RefereeInterface
       @relationship_form.candidate = reference.application_form.full_name
 
       if @relationship_form.save(reference)
-        if reference.safeguarding_concerns.blank?
+        if reference.safeguarding_concerns.blank? || reference.never_asked?
           redirect_to referee_interface_safeguarding_path(token: @token_param)
         elsif reference.feedback.blank?
           redirect_to referee_interface_reference_feedback_path(token: @token_param)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -87,6 +87,7 @@ class TestApplications
         @application_form.application_references.each do |reference|
           reference.relationship_correction = ['', Faker::Lorem.sentence].sample
           reference.safeguarding_concerns = ['', Faker::Lorem.sentence].sample
+          reference.safeguarding_concerns_status = reference.safeguarding_concerns.blank? ? :no_safeguarding_concerns_to_declare : :has_safeguarding_concerns_to_declare
 
           reference.update!(feedback: 'You are awesome')
 

--- a/app/models/application_reference.rb
+++ b/app/models/application_reference.rb
@@ -33,6 +33,13 @@ class ApplicationReference < ApplicationRecord
     character: 'character',
   }
 
+  enum safeguarding_concerns_status: {
+    not_answered_yet: 'not_answered_yet',
+    no_safeguarding_concerns_to_declare: 'no_safeguarding_concerns_to_declare',
+    has_safeguarding_concerns_to_declare: 'has_safeguarding_concerns_to_declare',
+    never_asked: 'never_asked',
+  }
+
   def ordinal
     application_form.application_references.find_index(self).to_i + 1
   end

--- a/app/models/referee_interface/reference_safeguarding_form.rb
+++ b/app/models/referee_interface/reference_safeguarding_form.rb
@@ -16,8 +16,10 @@ module RefereeInterface
     def save(application_reference)
       return false unless valid?
 
-      concerns = any_safeguarding_concerns == 'no' ? '' : safeguarding_concerns
-      application_reference.update!(safeguarding_concerns: concerns)
+      application_reference.update!(
+        safeguarding_concerns: safeguarding_concerns,
+        safeguarding_concerns_status: any_safeguarding_concerns == 'yes' ? :has_safeguarding_concerns_to_declare : :no_safeguarding_concerns_to_declare,
+      )
     end
 
   private

--- a/app/models/referee_interface/reference_safeguarding_form.rb
+++ b/app/models/referee_interface/reference_safeguarding_form.rb
@@ -17,7 +17,7 @@ module RefereeInterface
       return false unless valid?
 
       application_reference.update!(
-        safeguarding_concerns: safeguarding_concerns,
+        safeguarding_concerns: any_safeguarding_concerns == 'yes' ? safeguarding_concerns : '',
         safeguarding_concerns_status: any_safeguarding_concerns == 'yes' ? :has_safeguarding_concerns_to_declare : :no_safeguarding_concerns_to_declare,
       )
     end

--- a/app/services/submit_application.rb
+++ b/app/services/submit_application.rb
@@ -54,6 +54,7 @@ private
     reference.update!(
       relationship_correction: '',
       safeguarding_concerns: '',
+      safeguarding_concerns_status: :no_safeguarding_concerns_to_declare,
       feedback: I18n.t('new_referee_request.auto_approve_feedback'),
     )
 

--- a/db/migrate/20200527170532_backfill_application_references_safeguarding_concerns_status.rb
+++ b/db/migrate/20200527170532_backfill_application_references_safeguarding_concerns_status.rb
@@ -1,0 +1,11 @@
+class BackfillApplicationReferencesSafeguardingConcernsStatus < ActiveRecord::Migration[6.0]
+  def up
+    execute "UPDATE \"references\" SET safeguarding_concerns_status = 'never_asked' WHERE feedback_status IN ('feedback_provided', 'feedback_refused') AND (safeguarding_concerns IS NULL)"
+    execute "UPDATE \"references\" SET safeguarding_concerns_status = 'no_safeguarding_concerns_to_declare' WHERE safeguarding_concerns = ''"
+    execute "UPDATE \"references\" SET safeguarding_concerns_status = 'has_safeguarding_concerns_to_declare' WHERE NOT safeguarding_concerns = '' AND safeguarding_concerns IS NOT NULL"
+  end
+
+  def down
+    execute "UPDATE \"references\" SET safeguarding_concerns_status = 'not_answered_yet'"
+  end
+end

--- a/features/step_definitions/application_steps.rb
+++ b/features/step_definitions/application_steps.rb
@@ -71,6 +71,7 @@ When('{string} provides a reference') do |referee_email|
     feedback: Faker::Lorem.sentence(word_count: 20),
     relationship_correction: '',
     safeguarding_concerns: '',
+    safeguarding_concerns_status: :no_safeguarding_concerns_to_declare,
   )
 
   SubmitReference.new(

--- a/spec/components/provider_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/provider_interface/reference_with_feedback_component_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe ProviderInterface::ReferenceWithFeedbackComponent do
 
       it 'contains safeguarding concerns where present' do
         reference.safeguarding_concerns = 'Is a big bad wolf, has posed as elderly grandparent.'
+        reference.safeguarding_concerns_status = :has_safeguarding_concerns_to_declare
         expect(safeguarding_row[:value]).to eq('Yes')
 
         expect(safeguarding_concerns_row[:key]).to eq(

--- a/spec/components/referee_interface/reference_review_component_spec.rb
+++ b/spec/components/referee_interface/reference_review_component_spec.rb
@@ -35,7 +35,13 @@ RSpec.describe RefereeInterface::ReferenceReviewComponent do
   end
 
   context 'when there are safeguarding concerns' do
-    let(:reference) { build_stubbed(:reference, safeguarding_concerns: 'very very concerned') }
+    let(:reference) do
+      build_stubbed(
+        :reference,
+        safeguarding_concerns: 'very very concerned',
+        safeguarding_concerns_status: :has_safeguarding_concerns_to_declare,
+      )
+    end
 
     it 'displays the safeguarding concerns' do
       result = render_inline(described_class.new(reference: reference))


### PR DESCRIPTION
## Context

This refactoring makes the data model for reference safeguarding concerns more explicit with a new `ApplicationReference#safeguarding_concerns_status` attribute.  This tracks the status of a referees answer to the safeguarding concerns question.

## Changes proposed in this pull request

Note that the migration to add the `safeguarding_concerns_status` column was merged a while ago. https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/1852

- [x] Migrate existing 'magic' values for `safeguarding_concerns` and backfill the `safeguarding_concerns_status` column.
- [x] Enum for `ApplicationReference#safeguarding_concerns_status`
- [x] Update references to `ApplicationReference#safeguarding_concerns` that assume or save any special values.

## Guidance to review

- Note that there is a backfill migration in this PR together with code changes that work with that data. There is a chance that code could be deployed before the data is updated however splitting this work into separate deploys would probably be worse.
- Is there anything I've missed? Any ways that `safeguarding_concerns` could get out of step with `safeguarding_concerns_status` in the future? (I've tested referees filling out the reference form and what gets saved in the DB - not sure whether that covers it).

## Link to Trello card

https://trello.com/c/yVWTeArd/1523-dev-refactor-applicationreference-safeguarding-attributes

## Things to check

- [?] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
