### PR TITLE
Remove enrolment section from offer_accepted email

### DIFF
--- a/app/views/provider_mailer/offer_accepted.text.erb
+++ b/app/views/provider_mailer/offer_accepted.text.erb
@@ -10,12 +10,6 @@ Sign in to Manage teacher training applications to update the application status
 
 <%= provider_interface_application_choice_url(@application_choice) %>
 
-# Tell us when the candidate has enrolled
-
-Sign in to Manage teacher training applications to update the application status when they’ve enrolled:
-
-<%= provider_interface_application_choice_url(@application_choice) %>
-
 # Update the database of teacher training providers
 
 Enter the candidate’s details into the database of teacher training providers (DTTP) when they’ve started the course.


### PR DESCRIPTION
## Context

Enrolment is not currently possible or necessary, but we mention it in the email.

## Changes proposed in this pull request

Take it out of the email.

### Before
![Screenshot 2020-06-03 at 11 08 34](https://user-images.githubusercontent.com/642279/83624903-251e4780-a58b-11ea-8d12-3d79cc9179e1.png)

### After

![Screenshot 2020-06-03 at 11 08 23](https://user-images.githubusercontent.com/642279/83624912-264f7480-a58b-11ea-8a83-28601942d274.png)

## Link to Trello card

https://trello.com/c/ZUAIrGKC/2222-offer-accepted-email-should-not-contain-enrollment-section

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
