### PR TITLE
Adding a note updates the ApplicationChoice's updated_at

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,4 @@
 class Note < ApplicationRecord
-  belongs_to :application_choice
+  belongs_to :application_choice, touch: true
   belongs_to :provider_user
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Note do
+  it 'changes updated_at on the associated ApplicationChoice' do
+    choice = create(:application_choice)
+
+    expect {
+      create(:note, application_choice: choice)
+    }.to(change { choice.updated_at })
+  end
+end


### PR DESCRIPTION
## Context

Adding a note does not currently push an Application higher up the provider application list, which is sorted by last changed.

## Changes proposed in this pull request

Add `touch: true` to the association so a change to a note updates the `ApplicationChoice`.

## Guidance to review

As a provider, choose an application halfway down the applications list. Add a note. See it is now at the top of the list.

## Link to Trello card

https://trello.com/c/DcnYnJln/2221-applicationchoice-updatedat-not-updated-when-note-added-to-application

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
