### PR TITLE
Remove provider user email from banner

### DIFF
--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -39,7 +39,7 @@ class NavigationItems
     def for_provider_interface(current_provider_user)
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
-      items = [NavigationItem.new(current_provider_user.email_address, nil, false)]
+      items = [NavigationItem.new('Applications', provider_interface_applications_path, false)]
 
       if FeatureFlag.active?('provider_add_provider_users') && current_provider_user.can_manage_users?
         items << NavigationItem.new('Users', provider_interface_provider_users_path, false)

--- a/spec/system/provider_interface/authentication_fallback_spec.rb
+++ b/spec/system/provider_interface/authentication_fallback_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'A provider authenticates via the fallback mechanism' do
 
   def then_i_am_signed_in
     within 'header' do
-      expect(page).to have_content @email
+      expect(page).to have_content 'Sign out'
     end
   end
 

--- a/spec/system/provider_interface/authentication_spec.rb
+++ b/spec/system/provider_interface/authentication_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
     and_i_sign_in_via_dfe_sign_in
 
     then_i_am_redirected_to_the_provider_interface_applications_path
-    and_i_should_see_my_email_address
+    and_i_should_see_the_link_to_sign_out
     and_the_timestamp_of_this_sign_in_is_recorded
     and_my_profile_details_are_refreshed
 
@@ -50,11 +50,9 @@ RSpec.describe 'A provider authenticates via DfE Sign-in' do
     expect(page).to have_current_path(provider_interface_applications_path(some_key: 'some_value'))
   end
 
-  def and_i_should_see_my_email_address
-    expect(page).to have_content('provider@example.com')
+  def and_i_should_see_the_link_to_sign_out
+    expect(page).to have_content('Sign out')
   end
-
-  alias_method :then_i_should_see_my_email_address, :and_i_should_see_my_email_address
 
   def when_i_click_sign_out
     click_link 'Sign out'


### PR DESCRIPTION
This is not a nav item in the design, and causes a nav item overflow
issue with long email addresses due to the new slimmer banner.

Provider user email is replaced with a link to the provider applications
view as per the prototype design.

## Context

With the new banner long emails cause a mis-alignment of nav items, which was identified on QA in product review. 

The default Dev email is not long enough for this to have been an issue.

Emails are not part of the header designs on the prototype so given this they are removed in this PR.

## Changes proposed in this pull request

Before:
<img width="883" alt="Screenshot 2020-06-03 at 11 55 11" src="https://user-images.githubusercontent.com/13377553/83628875-1b97de00-a591-11ea-8cec-d5547efec0a4.png">

After:
<img width="909" alt="Screenshot 2020-06-03 at 11 55 50" src="https://user-images.githubusercontent.com/13377553/83628945-31a59e80-a591-11ea-9186-99218341a1ba.png">


## Guidance to review

- is there a reason we shouldn't do this? 

## Link to Trello card

- follow up to: https://trello.com/c/st1Mq1h6/2005-build-implement-the-new-header-for-manage-applications

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
