### PR TITLE
Show a useful error when API clients try to make offers to a closed course

### DIFF
--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -18,7 +18,11 @@ module VendorAPI
           site_code: course_data[:site_code],
         ).call
 
-        (render_cannot_find_course_option and return) unless course_option && course_option.course.open_on_apply
+        if !course_option
+          render_cannot_find_course_option and return
+        elsif course_option.course_closed_on_apply?
+          render_course_not_open and return
+        end
       else
         course_option = nil
       end
@@ -110,6 +114,17 @@ module VendorAPI
           {
             error: 'CourseOptionError',
             message: 'Cannot find an appropriate course option for these codes',
+          },
+        ],
+      }
+    end
+
+    def render_course_not_open
+      render status: :unprocessable_entity, json: {
+        errors: [
+          {
+            error: 'CourseOptionError',
+            message: 'This course is not open for applications via the Apply service',
           },
         ],
       }


### PR DESCRIPTION
## Context

Current behaviour when an API client tries to offer on a course that is not open on apply is to return the error "Cannot find an appropriate course option for these codes". This isn't helpful. 

## Changes proposed in this pull request

For this case, introduce a new error message: `This course is not open for applications via the Apply service`.

## Link to Trello card

https://trello.com/c/pvFqo8AX/2219-api-bugs-reported-by-ucb

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
