### PR TITLE
Add organisations index and details pages

### DIFF
--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -1,6 +1,7 @@
 module ProviderInterface
   class OrganisationsController < ProviderInterfaceController
     before_action :render_403_unless_organisation_valid_for_user, only: :show
+    before_action :render_403_unless_user_can_manage_organisations
 
     def index; end
 
@@ -19,6 +20,10 @@ module ProviderInterface
 
     def render_403_unless_organisation_valid_for_user
       render_403 unless current_provider_user.providers.include?(provider)
+    end
+
+    def render_403_unless_user_can_manage_organisations
+      render_403 unless current_provider_user.can_manage_organisations?
     end
 
     def provider

--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -1,0 +1,28 @@
+module ProviderInterface
+  class OrganisationsController < ProviderInterfaceController
+    before_action :render_403_unless_organisation_valid_for_user, only: :show
+
+    def index; end
+
+    def show
+      @ratifying_permissions = ProviderRelationshipPermissions
+        .includes(:training_provider, :ratifying_provider)
+        .where(ratifying_provider: provider)
+        .group_by(&:training_provider_id)
+      @training_permissions = ProviderRelationshipPermissions
+        .includes(:training_provider, :ratifying_provider)
+        .where(training_provider: provider)
+        .group_by(&:ratifying_provider_id)
+    end
+
+  private
+
+    def render_403_unless_organisation_valid_for_user
+      render_403 unless current_provider_user.providers.include?(provider)
+    end
+
+    def provider
+      @provider ||= Provider.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/provider_interface/organisations_controller.rb
+++ b/app/controllers/provider_interface/organisations_controller.rb
@@ -1,9 +1,10 @@
 module ProviderInterface
   class OrganisationsController < ProviderInterfaceController
     before_action :render_403_unless_organisation_valid_for_user, only: :show
-    before_action :render_403_unless_user_can_manage_organisations
 
-    def index; end
+    def index
+      @manageable_providers = Provider.with_permissions_visible_to(current_provider_user)
+    end
 
     def show
       @ratifying_permissions = ProviderRelationshipPermissions
@@ -19,11 +20,7 @@ module ProviderInterface
   private
 
     def render_403_unless_organisation_valid_for_user
-      render_403 unless current_provider_user.providers.include?(provider)
-    end
-
-    def render_403_unless_user_can_manage_organisations
-      render_403 unless current_provider_user.can_manage_organisations?
+      render_403 unless Provider.with_permissions_visible_to(current_provider_user).include?(provider)
     end
 
     def provider

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -49,7 +49,7 @@ module ProviderInterface
 
     def provider_relationship_permissions_form_params
       permissions_attrs = %i[view_safeguarding_information]
-      params.require(:provider_interface_provider_relationship_permissions_form)
+      params.fetch(:provider_interface_provider_relationship_permissions_form, {})
         .permit(
           accredited_body_permissions: permissions_attrs,
           training_provider_permissions: permissions_attrs,

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -39,10 +39,11 @@ class NavigationItems
     def for_provider_interface(current_provider_user)
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
-      items = [
-        NavigationItem.new('Applications', provider_interface_applications_path, false),
-        NavigationItem.new('Organisations', provider_interface_organisations_path, false),
-      ]
+      items = [NavigationItem.new('Applications', provider_interface_applications_path, false)]
+
+      if current_provider_user.can_manage_organisations?
+        items << NavigationItem.new('Organisations', provider_interface_organisations_path, false)
+      end
 
       if FeatureFlag.active?('provider_add_provider_users') && current_provider_user.can_manage_users?
         items << NavigationItem.new('Users', provider_interface_provider_users_path, false)

--- a/app/models/navigation_items.rb
+++ b/app/models/navigation_items.rb
@@ -39,7 +39,10 @@ class NavigationItems
     def for_provider_interface(current_provider_user)
       return [NavigationItem.new('Sign in', provider_interface_sign_in_path, false)] unless current_provider_user
 
-      items = [NavigationItem.new('Applications', provider_interface_applications_path, false)]
+      items = [
+        NavigationItem.new('Applications', provider_interface_applications_path, false),
+        NavigationItem.new('Organisations', provider_interface_organisations_path, false),
+      ]
 
       if FeatureFlag.active?('provider_add_provider_users') && current_provider_user.can_manage_users?
         items << NavigationItem.new('Users', provider_interface_provider_users_path, false)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -31,6 +31,19 @@ class Provider < ApplicationRecord
       .where(ProviderPermissions.table_name => { provider_user_id: provider_user.id, manage_users: true })
   end
 
+  def self.with_permissions_visible_to(provider_user)
+    provider_ids = ProviderInterface::ProviderRelationshipPermissions
+      .where(training_provider: provider_user.providers)
+      .or(
+        ProviderInterface::ProviderRelationshipPermissions.where(
+          ratifying_provider_id: provider_user.providers,
+        ),
+      )
+      .pluck(:ratifying_provider_id, :training_provider_id).flatten
+
+    where(id: provider_ids).order(:name)
+  end
+
   def name_and_code
     "#{name} (#{code})"
   end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -48,6 +48,10 @@ class ProviderUser < ActiveRecord::Base
     provider_permissions.exists?(manage_users: true)
   end
 
+  def can_manage_organisations?
+    ProviderInterface::ProviderRelationshipPermissions.exists?(training_provider: providers)
+  end
+
 private
 
   def downcase_email_address

--- a/app/views/provider_interface/organisations/_check_icon.html.erb
+++ b/app/views/provider_interface/organisations/_check_icon.html.erb
@@ -1,0 +1,3 @@
+<svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+   <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+</svg>

--- a/app/views/provider_interface/organisations/_permissions_list.html.erb
+++ b/app/views/provider_interface/organisations/_permissions_list.html.erb
@@ -1,0 +1,12 @@
+<ul class="govuk-list">
+  <% if permission.view_safeguarding_information %>
+    <li>
+      <%= render 'check_icon' %>
+      access safeguarding information
+    </li>
+  <% end %>
+  <li>
+    <%= render 'check_icon' %>
+    view applications
+  </li>
+</ul>

--- a/app/views/provider_interface/organisations/index.html.erb
+++ b/app/views/provider_interface/organisations/index.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-grid">
   <div class="govuk-grid-column-two-third">
     <h1 class="govuk-heading-xl">Organisations</h1>
-    <% current_provider_user.providers.each do |provider| %>
+    <% @manageable_providers.each do |provider| %>
       <div class="app-application-card">
         <div>
-          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+          <h2 class="govuk-heading-m">
             <%= govuk_link_to provider.name, provider_interface_organisation_path(provider) %>
           </h2>
         </div>

--- a/app/views/provider_interface/organisations/index.html.erb
+++ b/app/views/provider_interface/organisations/index.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid">
+  <div class="govuk-grid-column-two-third">
+    <h1 class="govuk-heading-xl">Organisations</h1>
+    <% current_provider_user.providers.each do |provider| %>
+      <div class="app-application-card">
+        <div>
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-0">
+            <%= govuk_link_to provider.name, provider_interface_organisation_path(provider) %>
+          </h2>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -32,6 +32,13 @@
 
       <p class="govuk-!-margin-bottom-1 govuk-body"><%= ratifying_permission.ratifying_provider.name %> can:</p>
       <%= render 'permissions_list', permission: ratifying_permission %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to 'Change', provider_interface_edit_provider_relationship_permissions_path(
+          training_provider_id: training_permission.training_provider.id,
+          ratifying_provider_id: training_permission.ratifying_provider.id,
+        ) if current_provider_user.can_manage_organisations? %>
+      </p>
     <% end %>
   </div>
 </div>

--- a/app/views/provider_interface/organisations/show.html.erb
+++ b/app/views/provider_interface/organisations/show.html.erb
@@ -1,0 +1,37 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= @provider.name %></h1>
+    <% @ratifying_permissions.each do |_id, permissions| %>
+      <% ratifying_permission, training_permission = permissions %>
+      <h2 class="govuk-heading-m">
+        For courses ratified by <%= ratifying_permission.ratifying_provider.name %> and run by <%= ratifying_permission.training_provider.name %>
+      </h2>
+      <div class="app-banner govuk-!-margin-bottom-4">
+        <div class="app-banner__message">
+          Contact <%= ratifying_permission.training_provider.name %> to change permissions.
+        </div>
+      </div>
+
+      <h2 class="govuk-heading-m">
+        For courses ratified by <%= ratifying_permission.ratifying_provider.name %> and run by <%= ratifying_permission.training_provider.name %>
+      </h2>
+      <p class="govuk-!-margin-bottom-1 govuk-body"><%= ratifying_permission.ratifying_provider.name %> can:</p>
+      <%= render 'permissions_list', permission: ratifying_permission %>
+
+      <p class="govuk-!-margin-bottom-1 govuk-body"><%= ratifying_permission.training_provider.name %> can:</p>
+      <%= render 'permissions_list', permission: training_permission %>
+    <% end %>
+
+    <% @training_permissions.each do |_id, permissions| %>
+      <% ratifying_permission, training_permission = permissions %>
+      <h2 class="govuk-heading-m">
+        For courses run by <%= training_permission.training_provider.name %> and ratified by <%= training_permission.ratifying_provider.name %>
+      </h2>
+      <p class="govuk-!-margin-bottom-1 govuk-body"><%= training_permission.training_provider.name %> can:</p>
+      <%= render 'permissions_list', permission: training_permission %>
+
+      <p class="govuk-!-margin-bottom-1 govuk-body"><%= ratifying_permission.ratifying_provider.name %> can:</p>
+      <%= render 'permissions_list', permission: ratifying_permission %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/provider_interface/provider_relationship_permissions/success.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/success.html.erb
@@ -17,9 +17,11 @@
       Inviting users
     </h2>
 
-    <p class="govuk-body">
-      Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
-    </p>
+    <% if current_provider_user.can_manage_users? %>
+      <p class="govuk-body">
+        Select <%= govuk_link_to 'Users', provider_interface_provider_users_path %> (at the top of every page) to add users and manage their permissions.
+      </p>
+    <% end %>
     <h2 class="govuk-heading-m">
       Manage your applications
     </h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -455,6 +455,8 @@ Rails.application.routes.draw do
       delete '/remove' => 'provider_users#remove', as: :remove_provider_user
     end
 
+    resources :organisations, only: %i[index show], path: 'organisations'
+
     get '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id/success' => 'provider_relationship_permissions#success',
         as: :provider_relationship_permissions_success
     get '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id/edit' => 'provider_relationship_permissions#edit',

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -2,13 +2,37 @@ require 'rails_helper'
 
 RSpec.describe Provider, type: :model do
   describe '.with_users_manageable_by' do
-    it 'scopes results to providers the given user is permitted to manage' do
+    it 'scopes results to providers where the user is permitted to manage other users' do
       provider = create(:provider)
       create(:provider)
       provider_user = create(:provider_user, providers: [provider])
       provider_user.provider_permissions.update_all(manage_users: true)
 
       expect(described_class.with_users_manageable_by(provider_user)).to eq([provider])
+    end
+  end
+
+  describe '.with_permissions_visible_to' do
+    it 'scopes results to providers the given user can manage permissions for' do
+      a_provider = create(:provider)
+      training_provider = create(:provider, name: 'ZZZ')
+      ratifying_provider = create(:provider, name: 'AAA')
+
+      provider_user = create(:provider_user, providers: [training_provider, ratifying_provider, a_provider])
+      create(
+        :accredited_body_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: training_provider,
+      )
+      create(
+        :training_provider_permissions,
+        ratifying_provider: ratifying_provider,
+        training_provider: training_provider,
+      )
+
+      expect(described_class.with_permissions_visible_to(provider_user)).to eq(
+        [ratifying_provider, training_provider],
+      )
     end
   end
 

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -98,6 +98,19 @@ RSpec.describe ProviderUser, type: :model do
     end
   end
 
+  describe '#can_manage_organisations?' do
+    let(:provider_user) { create :provider_user, :with_provider }
+
+    it 'is false when no provider relationship permissions exist for associated providers' do
+      expect(provider_user.can_manage_organisations?).to be(false)
+    end
+
+    it 'is true when provider relationship permissions exist for associated providers' do
+      create(:training_provider_permissions, training_provider: provider_user.providers.first)
+      expect(provider_user.can_manage_organisations?).to be(true)
+    end
+  end
+
   describe '.visible_to' do
     it 'returns provider users with access to the same providers as the passed user' do
       provider = create(:provider)

--- a/spec/requests/provider_interface/see_organisations_pages_spec.rb
+++ b/spec/requests/provider_interface/see_organisations_pages_spec.rb
@@ -16,34 +16,38 @@ RSpec.describe 'Organisations', type: :request do
       )
   end
 
-  context 'when the user cannot manage organisations' do
-    before { allow(provider_user).to receive(:can_manage_organisations?).and_return(false) }
-
-    describe 'GET index' do
-      it 'responds with 403' do
-        get provider_interface_organisations_path
-
-        expect(response.status).to eq(403)
-      end
-    end
-
+  context 'when the provider is not associated with the current user' do
     describe 'GET show' do
       it 'responds with 403' do
-        get provider_interface_organisation_path(provider)
+        get provider_interface_organisation_path(create(:provider))
 
         expect(response.status).to eq(403)
       end
     end
   end
 
-  context 'when the provider is not associated with the current user' do
-    before { allow(provider_user).to receive(:can_manage_organisations?).and_return(true) }
-
+  context 'when the provider is a ratifies courses for a provider associated with the current user' do
     describe 'GET show' do
-      it 'responds with 403' do
-        get provider_interface_organisation_path(create(:provider))
+      let(:ratifying_provider) { create(:provider, :with_signed_agreement) }
 
-        expect(response.status).to eq(403)
+      before do
+        create(
+          :accredited_body_permissions,
+          ratifying_provider: ratifying_provider,
+          training_provider: provider,
+        )
+
+        create(
+          :training_provider_permissions,
+          ratifying_provider: ratifying_provider,
+          training_provider: provider,
+        )
+      end
+
+      it 'responds successfully' do
+        get provider_interface_organisation_path(ratifying_provider)
+
+        expect(response.status).to eq(200)
       end
     end
   end

--- a/spec/requests/provider_interface/see_organisations_pages_spec.rb
+++ b/spec/requests/provider_interface/see_organisations_pages_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe 'Organisations', type: :request do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  context 'when the user cannot manage organisations' do
+    before { allow(provider_user).to receive(:can_manage_organisations?).and_return(false) }
+
+    describe 'GET index' do
+      it 'responds with 403' do
+        get provider_interface_organisations_path
+
+        expect(response.status).to eq(403)
+      end
+    end
+
+    describe 'GET show' do
+      it 'responds with 403' do
+        get provider_interface_organisation_path(provider)
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+
+  context 'when the provider is not associated with the current user' do
+    before { allow(provider_user).to receive(:can_manage_organisations?).and_return(true) }
+
+    describe 'GET show' do
+      it 'responds with 403' do
+        get provider_interface_organisation_path(create(:provider))
+
+        expect(response.status).to eq(403)
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -34,6 +34,8 @@ RSpec.feature 'See organisation permissions' do
     @provider_user = ProviderUser.last
     @training_provider = Provider.find_by(code: 'ABC')
     @ratifying_provider = Provider.find_by(code: 'DEF')
+    @unmanageable_provider = create(:provider, :with_signed_agreement)
+    @provider_user.providers << @unmanageable_provider
   end
 
   def and_the_provider_has_courses_ratified_by_another_provider
@@ -58,6 +60,7 @@ RSpec.feature 'See organisation permissions' do
   def then_i_can_see_provider_organisations_i_belong_to
     expect(page).to have_link(@training_provider.name)
     expect(page).to have_link(@ratifying_provider.name)
+    expect(page).not_to have_link(@unmanageable_provider.name)
   end
 
   def when_i_click_on_a_ratifying_provider_organisation

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -83,6 +83,10 @@ RSpec.feature 'See organisation permissions' do
   def then_i_can_see_permissions_for_the_training_provider
     expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
     expect(page).to have_content("#{@training_provider.name} can:\nview applications")
+
+    expect(page).to have_link('Change', href: provider_interface_edit_provider_relationship_permissions_path(
+      ratifying_provider_id: @ratifying_provider.id, training_provider_id: @training_provider.id,
+    ))
   end
 
   def and_i_can_see_permissions_for_the_ratifying_provider

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -6,9 +6,9 @@ RSpec.feature 'See organisation permissions' do
   scenario 'A provider user views the organisations they belong to' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_provider_permissions_feature_is_enabled
-    and_i_sign_in_to_the_provider_interface
     and_i_can_manage_organisations_for_a_provider
     and_the_provider_has_courses_ratified_by_another_provider
+    and_i_sign_in_to_the_provider_interface
 
     when_i_visit_the_provider_organisations_page
     then_i_can_see_provider_organisations_i_belong_to

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature 'See organisation permissions' do
   end
 
   def when_i_visit_the_provider_organisations_page
-    visit provider_interface_organisations_path
+    click_on 'Organisations'
   end
 
   def then_i_can_see_provider_organisations_i_belong_to

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.feature 'See organisation permissions' do
+  include DfESignInHelpers
+
+  scenario 'A provider user views the organisations they belong to' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_permissions_feature_is_enabled
+    and_i_sign_in_to_the_provider_interface
+    and_i_can_manage_organisations_for_a_provider
+    and_the_provider_has_courses_ratified_by_another_provider
+
+    when_i_visit_the_provider_organisations_page
+    then_i_can_see_provider_organisations_i_belong_to
+
+    when_i_click_on_a_ratifying_provider_organisation
+    then_i_can_see_permissions_for_the_ratifying_provider
+
+    when_i_visit_the_provider_organisations_page
+    and_i_click_on_a_training_provider_organisation
+    then_i_can_see_permissions_for_the_training_provider
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def and_the_provider_permissions_feature_is_enabled
+    FeatureFlag.activate('enforce_provider_to_provider_permissions')
+  end
+
+  def and_i_can_manage_organisations_for_a_provider
+    @provider_user = ProviderUser.last
+    @training_provider = Provider.find_by(code: 'ABC')
+    @ratifying_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_the_provider_has_courses_ratified_by_another_provider
+    create(
+      :accredited_body_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @training_provider,
+      view_safeguarding_information: true,
+    )
+
+    create(
+      :training_provider_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @training_provider,
+    )
+  end
+
+  def when_i_visit_the_provider_organisations_page
+    visit provider_interface_organisations_path
+  end
+
+  def then_i_can_see_provider_organisations_i_belong_to
+    expect(page).to have_link(@training_provider.name)
+    expect(page).to have_link(@ratifying_provider.name)
+  end
+
+  def when_i_click_on_a_ratifying_provider_organisation
+    click_on @ratifying_provider.name
+  end
+
+  def then_i_can_see_permissions_for_the_ratifying_provider
+    expect(page).to have_content("For courses ratified by #{@ratifying_provider.name} and run by #{@training_provider.name}")
+    expect(page).to have_content("#{@ratifying_provider.name} can:\naccess safeguarding information")
+  end
+
+  def and_i_can_see_permissions_for_the_training_provider
+    expect(page).to have_content("#{@training_provider.name} can:\nview applications")
+  end
+
+  def and_i_click_on_a_training_provider_organisation
+    click_on @training_provider.name
+  end
+
+  def then_i_can_see_permissions_for_the_training_provider
+    expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
+    expect(page).to have_content("#{@training_provider.name} can:\nview applications")
+  end
+
+  def and_i_can_see_permissions_for_the_ratifying_provider
+    expect(page).to have_content("#{@training_provider.name} can:\naccess safeguarding information")
+  end
+end


### PR DESCRIPTION
## Context

Part of the provider relationship permissions journey relies on an organisations page for a provider user. This page links pages per organisation which display the permissions for that org.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds `/provider/organisations` index page
- Adds a page displaying permissions for a single organisation relative to their relationship to various other ratifying and training providers.
- Adds a navigation link for organisations index page

#### Organisations index

![image](https://user-images.githubusercontent.com/93511/83647688-15175f80-a5ad-11ea-841c-0591197ddfdb.png)

#### Organisations permissions details
![image](https://user-images.githubusercontent.com/93511/83646785-0da38680-a5ac-11ea-9d19-4ec3c47beff7.png)

 
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

I haven't placed any of these pages behind feature flags as there are no links to actions to manage permissions etc. This might not be the right approach.

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/RDYz6s69/2251-build-provider-organisations-pages
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
