### PR TITLE
Lower RBD time limit to 20 days after 1st July 2020

### DIFF
--- a/app/components/candidate_interface/referee_guidance_component.html.erb
+++ b/app/components/candidate_interface/referee_guidance_component.html.erb
@@ -9,5 +9,5 @@
 <% end %>
 
 <% unless FeatureFlag.active?('covid_19') %>
-  <p class="govuk-body">Training providers then have <%= TimeLimitConfig.limits_for(:reject_by_default).first.limit %> working days to respond to your application.</p>
+  <p class="govuk-body">Training providers then have <%= reject_by_default_days %> working days to respond to your application.</p>
 <% end %>

--- a/app/components/candidate_interface/referee_guidance_component.rb
+++ b/app/components/candidate_interface/referee_guidance_component.rb
@@ -10,6 +10,13 @@ module CandidateInterface
       'provider'.pluralize(provider_count)
     end
 
+    def reject_by_default_days
+      @reject_by_default_days ||= TimeLimitCalculator.new(
+        rule: :reject_by_default,
+        effective_date: @application_form&.application_choices&.first&.sent_to_provider_at || Time.zone.now,
+      ).call[:days]
+    end
+
   private
 
     def provider_count

--- a/app/components/candidate_interface/referee_guidance_component.rb
+++ b/app/components/candidate_interface/referee_guidance_component.rb
@@ -13,7 +13,7 @@ module CandidateInterface
     def reject_by_default_days
       @reject_by_default_days ||= TimeLimitCalculator.new(
         rule: :reject_by_default,
-        effective_date: @application_form&.application_choices&.first&.sent_to_provider_at || Time.zone.now,
+        effective_date: @application_form.application_choices.first&.sent_to_provider_at || Time.zone.now,
       ).call[:days]
     end
 

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -51,6 +51,7 @@ class TimeLimitConfig
     ],
     chase_provider_before_rbd: [
       Rule.new(nil, nil, 20),
+      Rule.new(Time.zone.local(2020, 7, 1), nil, 10),
     ],
     chase_candidate_before_dbd: [
       Rule.new(nil, nil, 5),

--- a/app/lib/time_limit_config.rb
+++ b/app/lib/time_limit_config.rb
@@ -44,6 +44,7 @@ class TimeLimitConfig
   RULES = {
     reject_by_default: [
       Rule.new(nil, nil, 40),
+      Rule.new(Time.zone.local(2020, 7, 1), nil, 20),
     ],
     decline_by_default: [
       Rule.new(nil, nil, 10),

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -1,6 +1,10 @@
 class CandidateMailer < ApplicationMailer
   def application_submitted(application_form)
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
+    @respond_within_days = TimeLimitCalculator.new(
+      rule: :reject_by_default,
+      effective_date: application_form.application_choices.first.sent_to_provider_at || Time.zone.now,
+    ).call[:days]
 
     email_for_candidate(
       application_form,

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -3,7 +3,7 @@ class CandidateMailer < ApplicationMailer
     @candidate_magic_link = candidate_magic_link(application_form.candidate)
     @respond_within_days = TimeLimitCalculator.new(
       rule: :reject_by_default,
-      effective_date: application_form.application_choices.first.sent_to_provider_at || Time.zone.now,
+      effective_date: application_form.application_choices.first&.sent_to_provider_at || Time.zone.now,
     ).call[:days]
 
     email_for_candidate(

--- a/app/mailers/provider_mailer.rb
+++ b/app/mailers/provider_mailer.rb
@@ -30,6 +30,7 @@ class ProviderMailer < ApplicationMailer
 
   def chase_provider_decision(provider_user, application_choice)
     @application = map_application_choice_params(application_choice)
+    @working_days_left = Time.zone.now.to_date.business_days_until(application_choice.reject_by_default_at.to_date)
 
     email_for_provider(
       provider_user,

--- a/app/views/candidate_mailer/application_submitted.text.erb
+++ b/app/views/candidate_mailer/application_submitted.text.erb
@@ -45,7 +45,7 @@ If your training provider decides to progress your application, they’ll contac
 <% if FeatureFlag.active?('covid_19') %>
 Due to the impact of coronavirus, it might take some time for providers to get back to you.
 <% else %>
-They should make a decision on whether to make an offer within <%= TimeLimitConfig.limits_for(:reject_by_default).first.limit %> working days of receiving your application.
+They should make a decision on whether to make an offer within <%= @respond_within_days %> working days of receiving your application.
 <% end %>
 
 # Need help?

--- a/app/views/provider_mailer/chase_provider_decision.text.erb
+++ b/app/views/provider_mailer/chase_provider_decision.text.erb
@@ -6,7 +6,7 @@ Dear <%= @provider_user_name || 'colleague' %>
 
 <% else %>
 
-# Only <%= TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit %> working days left to respond
+# Only <%= @working_days_left %> working days left to respond
 
 <% end %>
 
@@ -18,7 +18,7 @@ Log in to Manage teacher training applications to respond:
 
 <% else %>
 
-Log in to Manage teacher training applications to respond within <%= TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit %> working days:
+Log in to Manage teacher training applications to respond within <%= @working_days_left %> working days:
 
 <% end %>
 

--- a/spec/components/candidate_interface/referee_guidance_component_spec.rb
+++ b/spec/components/candidate_interface/referee_guidance_component_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
     create(:reference, :requested, application_form: @application_form)
   end
 
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 3, 1, 12, 0, 0)) do
+      example.run
+    end
+  end
+
   before do
     setup_application
   end
@@ -24,6 +30,13 @@ RSpec.describe CandidateInterface::RefereeGuidanceComponent do
         expect(result.css('.govuk-heading-m').text).to eq('Reference')
         expect(result.css('.govuk-body').text).to include('training provider')
         expect(result.css('.govuk-body').text).not_to include('training providers')
+      end
+
+      it 'renders the correct rejection by default time limit' do
+        result = render_inline(described_class.new(application_form: @application_form))
+        expect(result.css('.govuk-body').text).to include(
+          'Training providers then have 40 working days to respond to your application',
+        )
       end
     end
 

--- a/spec/mailers/provider_mailer_spec.rb
+++ b/spec/mailers/provider_mailer_spec.rb
@@ -98,6 +98,10 @@ RSpec.describe ProviderMailer, type: :mailer do
   end
 
   describe 'Send provider decision chaser email' do
+    before do
+      @application_choice.update(reject_by_default_at: 20.business_days.from_now)
+    end
+
     context 'with the covid_19 feature flag off' do
       it_behaves_like('a provider mail with subject and content', :chase_provider_decision,
                       I18n.t!('provider_application_waiting_for_decision.email.subject',
@@ -105,9 +109,9 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'provider name' => 'Dear Johny English',
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
-                      'time to respond' => "Only #{TimeLimitConfig.limits_for(:chase_provider_before_rbd).first.limit} working days left to respond",
+                      'time to respond' => 'Only 20 working days left to respond',
                       'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
-                      'reject by default at' => (Time.zone.now + 40.days).to_s(:govuk_date).strip,
+                      'reject by default at' => 20.business_days.from_now.to_s(:govuk_date).strip,
                       'link to the application' => 'http://localhost:3000/provider/applications/')
     end
 
@@ -121,7 +125,7 @@ RSpec.describe ProviderMailer, type: :mailer do
                       'candidate name' => 'Harry Potter',
                       'course name and code' => 'Computer Science (6IND)',
                       'submission date' => (Time.zone.now - 5.days).to_s(:govuk_date).strip,
-                      'reject by default at' => (Time.zone.now + 40.days).to_s(:govuk_date).strip,
+                      'reject by default at' => 20.business_days.from_now.to_s(:govuk_date).strip,
                       'link to the application' => 'http://localhost:3000/provider/applications/')
     end
   end

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -92,16 +92,10 @@ RSpec.describe TimeLimitCalculator do
 
   describe 'configured reject_by_default limits' do
     context 'before 2020-07-01' do
-      around do |example|
-        Timecop.freeze(Time.zone.local(2020, 6, 15)) do
-          example.run
-        end
-      end
-
       it 'applies the 40 day rule' do
         calculator = TimeLimitCalculator.new(
           rule: :reject_by_default,
-          effective_date: Time.zone.today,
+          effective_date: Time.zone.local(2020, 6, 15),
         )
         expect(calculator.call).to eq(
           days: 40,
@@ -112,21 +106,45 @@ RSpec.describe TimeLimitCalculator do
     end
 
     context 'after 2020-07-01' do
-      around do |example|
-        Timecop.freeze(Time.zone.local(2020, 7, 6)) do
-          example.run
-        end
-      end
-
       it 'applies the 20 day rule' do
         calculator = TimeLimitCalculator.new(
           rule: :reject_by_default,
-          effective_date: Time.zone.today,
+          effective_date: Time.zone.local(2020, 7, 6),
         )
         expect(calculator.call).to eq(
           days: 20,
           time_in_future: Time.zone.local(2020, 8, 3).end_of_day,
           time_in_past: Time.zone.local(2020, 6, 8).end_of_day,
+        )
+      end
+    end
+  end
+
+  describe 'configured chase_provider_before_rbd limits' do
+    context 'before 2020-07-01' do
+      it 'applies the 40 day rule' do
+        calculator = TimeLimitCalculator.new(
+          rule: :chase_provider_before_rbd,
+          effective_date: Time.zone.local(2020, 6, 15),
+        )
+        expect(calculator.call).to eq(
+          days: 20,
+          time_in_future: Time.zone.local(2020, 7, 13).end_of_day,
+          time_in_past: Time.zone.local(2020, 3, 10).end_of_day,
+        )
+      end
+    end
+
+    context 'after 2020-07-01' do
+      it 'applies the 20 day rule' do
+        calculator = TimeLimitCalculator.new(
+          rule: :chase_provider_before_rbd,
+          effective_date: Time.zone.local(2020, 7, 6),
+        )
+        expect(calculator.call).to eq(
+          days: 10,
+          time_in_future: Time.zone.local(2020, 7, 20).end_of_day,
+          time_in_past: Time.zone.local(2020, 6, 22).end_of_day,
         )
       end
     end

--- a/spec/services/time_limit_calculator_spec.rb
+++ b/spec/services/time_limit_calculator_spec.rb
@@ -89,4 +89,46 @@ RSpec.describe TimeLimitCalculator do
       days: nil, time_in_future: nil, time_in_past: nil,
     )
   end
+
+  describe 'configured reject_by_default limits' do
+    context 'before 2020-07-01' do
+      around do |example|
+        Timecop.freeze(Time.zone.local(2020, 6, 15)) do
+          example.run
+        end
+      end
+
+      it 'applies the 40 day rule' do
+        calculator = TimeLimitCalculator.new(
+          rule: :reject_by_default,
+          effective_date: Time.zone.today,
+        )
+        expect(calculator.call).to eq(
+          days: 40,
+          time_in_future: Time.zone.local(2020, 8, 10).end_of_day,
+          time_in_past: Time.zone.local(2020, 2, 11).end_of_day,
+        )
+      end
+    end
+
+    context 'after 2020-07-01' do
+      around do |example|
+        Timecop.freeze(Time.zone.local(2020, 7, 6)) do
+          example.run
+        end
+      end
+
+      it 'applies the 20 day rule' do
+        calculator = TimeLimitCalculator.new(
+          rule: :reject_by_default,
+          effective_date: Time.zone.today,
+        )
+        expect(calculator.call).to eq(
+          days: 20,
+          time_in_future: Time.zone.local(2020, 8, 3).end_of_day,
+          time_in_past: Time.zone.local(2020, 6, 8).end_of_day,
+        )
+      end
+    end
+  end
 end

--- a/spec/support/test_helpers/mailer_setup_helper.rb
+++ b/spec/support/test_helpers/mailer_setup_helper.rb
@@ -19,6 +19,7 @@ module TestHelpers
         offer: { conditions: ['DBS check', 'Pass exams'] },
         offered_course_option: course_option,
         decline_by_default_at: 10.business_days.from_now,
+        sent_to_provider_at: 10.business_days.ago,
         reject_by_default_days: 10,
       )
     end

--- a/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
+++ b/spec/system/provider_interface/provider_receives_email_when_an_application_is_getting_close_to_the_reject_by_default_date_spec.rb
@@ -4,6 +4,12 @@ RSpec.feature 'An application is waiting for decision for 20 working days' do
   include CourseOptionHelpers
   include CandidateHelper
 
+  around do |example|
+    Timecop.freeze(Time.zone.local(2020, 1, 1)) do
+      example.run
+    end
+  end
+
   scenario 'the provider receives a chaser email' do
     given_a_candidate_has_submitted_an_application_form
     and_an_application_was_sent_to_provider


### PR DESCRIPTION
## Context

UCAS have confirmed that the RBD date should be lowered to 20 (business) days from 1st July.

## Changes proposed in this pull request

- [x] Add new configuration rule with a start date of 1/7/2020 that applies the new limit after that date.
- [x] Add a spec that tests the `TimeLimitCalculator` together with the new config (not stubbed).

## Guidance to review

- Nothing in particular

## Link to Trello card

https://trello.com/c/iawQmftw/1566-dev-lower-rbd-to-20-days-from-1st-july

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
