### PR TITLE
Show existing equality and diversity answers if present

### DIFF
--- a/app/controllers/candidate_interface/equality_and_diversity_controller.rb
+++ b/app/controllers/candidate_interface/equality_and_diversity_controller.rb
@@ -2,7 +2,16 @@ module CandidateInterface
   class EqualityAndDiversityController < CandidateInterfaceController
     before_action :redirect_to_review_unless_ready_to_submit
 
-    def start; end
+    def start
+      entrypoint_path =
+        if current_application.equality_and_diversity_answers_provided?
+          candidate_interface_review_equality_and_diversity_path
+        else
+          candidate_interface_edit_equality_and_diversity_sex_path
+        end
+
+      render :start, locals: { entrypoint_path: entrypoint_path }
+    end
 
     def edit_sex
       @sex = EqualityAndDiversity::SexForm.build_from_application(current_application)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -21,6 +21,12 @@ class ApplicationForm < ApplicationRecord
   MINIMUM_COMPLETE_REFERENCES = 2
   MAXIMUM_REFERENCES = 10
   DECISION_PENDING_STATUSES = %w[awaiting_references application_complete awaiting_provider_decision].freeze
+  EQUALITY_AND_DIVERSITY_MINIMAL_ATTR = %w[sex disabilities ethnic_group].freeze
+
+  def equality_and_diversity_answers_provided?
+    answered_questions = Hash(equality_and_diversity).keys
+    EQUALITY_AND_DIVERSITY_MINIMAL_ATTR.all? { |attr| attr.in? answered_questions }
+  end
 
   enum phase: {
     apply_1: 'apply_1',

--- a/app/views/candidate_interface/equality_and_diversity/start.html.erb
+++ b/app/views/candidate_interface/equality_and_diversity/start.html.erb
@@ -12,7 +12,7 @@
     <p class="govuk-body">We collect this data to reduce discrimination on the basis of sex, disability and ethnicity.</p>
     <p class="govuk-body">Your data will only be shared with training providers when you are enrolled on a course.</p>
 
-    <%= govuk_button_link_to 'Continue', candidate_interface_edit_equality_and_diversity_sex_path %>
+    <%= govuk_button_link_to 'Continue', entrypoint_path %>
 
     <p class="govuk-body">
       <%= govuk_link_to 'Continue without completing questionnaire', candidate_interface_application_submit_show_path %>

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -181,4 +181,31 @@ RSpec.describe ApplicationForm do
       expect(application_form.can_add_reference?).to be false
     end
   end
+
+  describe '#equality_and_diversity_answers_provided?' do
+    context 'when minimal expected attributes are present' do
+      it 'is true' do
+        application_form = build(:completed_application_form, :with_equality_and_diversity_data)
+        expect(application_form.equality_and_diversity_answers_provided?).to be true
+      end
+    end
+
+    context 'when minimal expected attributes are not present' do
+      it 'is false' do
+        application_form = build(:completed_application_form)
+        application_form.equality_and_diversity = { 'sex' => 'male' }
+
+        expect(application_form.equality_and_diversity_answers_provided?).to be false
+      end
+    end
+
+    context 'when no attributes are present' do
+      it 'is false' do
+        application_form = build(:completed_application_form)
+        application_form.equality_and_diversity = nil
+
+        expect(application_form.equality_and_diversity_answers_provided?).to be false
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
+++ b/spec/system/candidate_interface/candidate_entering_equality_and_diversity_information_spec.rb
@@ -88,6 +88,9 @@ RSpec.feature 'Entering their equality and diversity information' do
     and_i_describe_my_other_ethnic_background
     and_i_click_on_continue
     then_i_can_review_my_updated_ethnicity
+
+    when_i_manually_restart_the_questionnaire
+    then_i_go_straight_to_the_review_page
   end
 
   def given_i_am_signed_in
@@ -304,5 +307,14 @@ RSpec.feature 'Entering their equality and diversity information' do
   def then_i_can_review_my_updated_ethnicity
     expect(page).to have_content('Check your answers')
     expect(page).to have_content('White (I am Hungarian)')
+  end
+
+  def when_i_manually_restart_the_questionnaire
+    visit candidate_interface_start_equality_and_diversity_path
+    click_link 'Continue'
+  end
+
+  def then_i_go_straight_to_the_review_page
+    expect(page).to have_current_path candidate_interface_review_equality_and_diversity_path
   end
 end


### PR DESCRIPTION


## Context

<!-- Why are you making this change? What might surprise someone about it? -->
If a candidate goes through Apply Again, we duplicate their original
application form. This includes any equality and diversity information
they might have provided the first time round. For a better user
experience, we want to allow these candidates to edit their answers to
these questionnaires rather than go through the questionnaire from the
beginning.

## Changes proposed in this pull request

Change the questionnaire navigation behaviour so that if the minimal
expected set of answers have been provided, clicking continue from the
start page takes them straight to the review page.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->
https://trello.com/c/NLsIXHjF
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
