### PR TITLE
Allow users to grant make_decisions permission

### DIFF
--- a/app/models/provider_permissions.rb
+++ b/app/models/provider_permissions.rb
@@ -3,6 +3,7 @@ class ProviderPermissions < ActiveRecord::Base
     manage_users
     manage_organisations
     view_safeguarding_information
+    make_decisions
   ].freeze
 
   self.table_name = 'provider_users_providers'
@@ -14,6 +15,7 @@ class ProviderPermissions < ActiveRecord::Base
 
   scope :manage_users, -> { where(manage_users: true) }
   scope :view_safeguarding_information, -> { where(view_safeguarding_information: true) }
+  scope :make_decisions, -> { where(make_decisions: true) }
 
   def self.possible_permissions(current_provider_user:, provider_user:)
     provider_ids = current_provider_user

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -26,6 +26,7 @@ class FeatureFlag
     [:provider_change_response, 'Allows providers to change the course that they are offering to a candidate', 'Michael Nacos'],
     [:provider_interface_work_breaks, 'Adds work break information to the provider interface', 'Steve Hook'],
     [:provider_view_safeguarding, 'Allows providers to see whether a candidate has declared safeguarding issues', 'Will McBrien'],
+    [:provider_make_decisions_restriction, 'Restricts ability to respond to users with make_decision permission', 'Michael Nacos'],
     [:enforce_provider_to_provider_permissions, 'Provider-to-provider permissions affect what provider users can see and do', 'Duncan Brown'],
     [:unavailable_course_option_warnings, 'Warns candidates at submission time if a course has become unavailable since they originally chose it', 'Malcolm Baig'],
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],

--- a/app/views/provider_interface/provider_users/edit_providers.html.erb
+++ b/app/views/provider_interface/provider_users/edit_providers.html.erb
@@ -22,6 +22,10 @@
                     <%= ppf.govuk_check_box :manage_users, true, multiple: false, label: { text: 'Manage users' } %>
                     <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
                                             label: { text: 'View safeguarding information' } %>
+                    <% if FeatureFlag.active?('provider_make_decisions_restriction') %>
+                    <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
+                                            label: { text: 'Make decisions' } %>
+                    <% end %>
                   <% end %>
                 <% end %>
               <% end %>

--- a/app/views/support_interface/provider_users/_provider_options.html.erb
+++ b/app/views/support_interface/provider_users/_provider_options.html.erb
@@ -12,6 +12,8 @@
                                       label: { text: 'Manage organisations' } %>
               <%= ppf.govuk_check_box :view_safeguarding_information, true, multiple: false,
                                       label: { text: 'View safeguarding information' } %>
+              <%= ppf.govuk_check_box :make_decisions, true, multiple: false,
+                                      label: { text: 'Make decisions' } %>
             <% end %>
           <% end %>
         <% end %>

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -13,6 +13,7 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
 
   ProviderPermissions.update_all(manage_users: true)
   ProviderPermissions.update_all(view_safeguarding_information: true)
+  ProviderPermissions.update_all(make_decisions: true)
 end
 
 desc 'Sync some pilot-enabled providers and open all their courses'

--- a/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_user_permissions_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature 'Managing provider user permissions' do
   scenario 'Provider manages permissions for users' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_provider_add_provider_users_feature_is_enabled
+    and_the_make_decisions_restriction_feature_flag_is_active
     and_i_can_manage_applications_for_two_providers
     and_i_can_manage_users_for_a_provider
     and_i_sign_in_to_the_provider_interface
@@ -26,6 +27,11 @@ RSpec.feature 'Managing provider user permissions' do
 
     when_i_add_permission_to_view_safeguarding_for_a_provider_user
     then_i_can_see_the_view_safeguarding_permission_for_the_provider_user
+
+    and_i_click_change_providers_and_permissions
+
+    and_i_add_permission_to_make_decisions_for_a_provider_user
+    then_i_can_see_the_make_decisions_permission_for_the_provider_user
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -111,6 +117,26 @@ RSpec.feature 'Managing provider user permissions' do
   def then_i_can_see_the_view_safeguarding_permission_for_the_provider_user
     within("#provider-#{@provider.id}-enabled-permissions") do
       expect(page).to have_content 'View safeguarding information'
+    end
+  end
+
+  def and_the_make_decisions_restriction_feature_flag_is_active
+    FeatureFlag.activate('provider_make_decisions_restriction')
+  end
+
+  def and_i_add_permission_to_make_decisions_for_a_provider_user
+    expect(page).not_to have_checked_field 'Make decisions'
+
+    within(permissions_fields_id_for_provider(@provider)) do
+      check 'Make decisions'
+    end
+
+    click_on 'Save'
+  end
+
+  def then_i_can_see_the_make_decisions_permission_for_the_provider_user
+    within("#provider-#{@provider.id}-enabled-permissions") do
+      expect(page).to have_content 'Make decisions'
     end
   end
 

--- a/spec/system/support_interface/managing_provider_users_spec.rb
+++ b/spec/system/support_interface/managing_provider_users_spec.rb
@@ -26,6 +26,7 @@ RSpec.feature 'Managing provider users' do
     and_i_check_permission_to_manage_users
     and_i_check_permission_to_manage_organisations
     and_i_check_permission_to_view_safeguarding_information
+    and_i_check_permission_to_make_decisions
     and_i_click_add_user
 
     then_i_should_see_the_list_of_provider_users
@@ -45,6 +46,7 @@ RSpec.feature 'Managing provider users' do
     and_they_should_be_able_to_manage_users
     and_they_should_be_able_to_manage_organisations
     and_they_should_be_able_to_view_safeguarding_information
+    and_they_should_be_able_to_make_decisions
 
     when_i_remove_manage_users_permissions
     and_i_remove_manage_organisations_permissions
@@ -113,6 +115,12 @@ RSpec.feature 'Managing provider users' do
   def and_i_check_permission_to_view_safeguarding_information
     within(permissions_fields_id_for_provider(@provider)) do
       check 'View safeguarding information'
+    end
+  end
+
+  def and_i_check_permission_to_make_decisions
+    within(permissions_fields_id_for_provider(@provider)) do
+      check 'Make decisions'
     end
   end
 
@@ -210,6 +218,12 @@ RSpec.feature 'Managing provider users' do
   def and_they_should_be_able_to_view_safeguarding_information
     within(permissions_fields_id_for_provider(@provider)) do
       expect(page).to have_checked_field('View safeguarding information')
+    end
+  end
+
+  def and_they_should_be_able_to_make_decisions
+    within(permissions_fields_id_for_provider(@provider)) do
+      expect(page).to have_checked_field('Make decisions')
     end
   end
 


### PR DESCRIPTION
## Context

A previous PR introduced the `make_decisions` column for provider users. This PR adds the relevant UI checkboxes for provider and support users to grant or remove this permission to/from provider users. 

## Changes proposed in this pull request

This PR introduces the `:provider_make_decisions_restriction` flag, which is intended to remove the 'make decisions' ability from all provider users, unless they have the `make_decisions` user-level permission. Currently, activating this feature flag has no impact on any users other than showing/hiding the 'Make decisions' checkboxes when managing users: if the feature is off, these checkboxes are hidden.

The logic of enforcing `make_decisions` will be tackled in a separate PR.

#### Support interface

![image](https://user-images.githubusercontent.com/107591/83774507-ad7d1500-a67d-11ea-912e-99d5ad49fc92.png)

#### Provider interface

![image](https://user-images.githubusercontent.com/107591/83774544-b968d700-a67d-11ea-99fa-b0c05e36e7f9.png)

## Guidance to review

'Make decisions' checkboxes are shown within the support interface regardless of the feature flag. This is for allowing support users to inspect the status of `make_decisions` before we turn on the feature in production.

## Link to Trello card

[Provider users have to have make_decisions permission before they can make decision](https://trello.com/c/CwAkdmkP)

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
