### PR TITLE
Create test applications in Apply again state

### DIFF
--- a/app/workers/generate_test_applications.rb
+++ b/app/workers/generate_test_applications.rb
@@ -20,5 +20,6 @@ class GenerateTestApplications
     test_applications.create_application states: [:conditions_not_met]
     test_applications.create_application states: [:enrolled]
     test_applications.create_application states: [:withdrawn]
+    test_applications.create_application states: [:awaiting_provider_decision], apply_again: true
   end
 end

--- a/spec/workers/generate_test_applications_spec.rb
+++ b/spec/workers/generate_test_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GenerateTestApplications do
   it 'generates 15 test candidates with applications in various states' do
     GenerateTestApplications.new.perform
 
-    expect(Candidate.count).to be 15
+    expect(Candidate.count).to be 16
     expect(ApplicationChoice.pluck(:status)).to include(
       'awaiting_provider_decision',
       'awaiting_references',


### PR DESCRIPTION
## Context

We need an easy way to see and test applications from users in the Apply again state.

## Changes proposed in this pull request

Modify the `create_application` method to now allow creating an application in the `apply_2` state.

## Guidance to review

My idea is to run `create_application` recursively first, to create a `rejected` application, and then `Candidate.last` to grab the last user and create another application for them. Does this make sense?

Tested it locally, seems to work.

## Link to Trello card

No card.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)