### PR TITLE
Update referee content for email bounced and reference refused emails

### DIFF
--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -1,11 +1,23 @@
 Dear <%= @application_form.first_name %>,
 
+<% if @reason == :email_bounced ||  @reason == :refused %>
+# Give a new referee as soon as possible
+<% else %>
 # Give details of a new referee
+<% end %>
 
-<%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name, referee_email: @reference.email_address) %>
+<%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name) %>
 
-Please add a new referee:
+<% if @reason == :email_bounced %>
+Give a new referee or add <%= @reference.name %>’s details again if they were not correct.
+<% else %>
+Give a new referee:
+<% end %>
 
 <%= candidate_magic_link(@candidate) %>
 
-We can’t send your application to your teacher training providers without 2 complete references.
+We cannot send applications to teacher training providers without 2 references. Courses can become full at any time - get your reference as soon as possible.
+
+# Need help?
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -22,15 +22,13 @@ en:
         explanation: |-
           We haven’t had a reference from %{referee_name}.
       refused:
-        subject: "%{referee_name} won’t give a reference"
+        subject: "Give new referee as soon as possible: %{referee_name} won’t give a reference"
         explanation: |-
           %{referee_name} said they won’t give a reference.
       email_bounced:
-        subject: "Our email didn’t reach %{referee_name}"
+        subject: "Give new referee as soon as possible. Our email didn’t reach %{referee_name}"
         explanation: |-
           Our email requesting a reference didn’t reach %{referee_name}.
-
-          We emailed the referee using this address: %{referee_email}
     application_rejected:
       all_rejected:
         subject: "%{provider_name} has responded: next steps"

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a new reference request mail with subject and content', :email_bounced,
         I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
         'heading' => 'Dear Tyrell',
-        'explanation' => "Our email requesting a reference didn’t reach Scott Knowles.\r\n\r\nWe emailed the referee using this address: ting@canpaint.com"
+        'explanation' => 'Our email requesting a reference didn’t reach Scott Knowles.'
       )
     end
   end


### PR DESCRIPTION
## Context

Another PR related to speeding up the reference process. 

This one covers the emails sent to a candidate when their reference request bounces or the referee declines to give one.

## Changes proposed in this pull request

Bounced
Before

![image](https://user-images.githubusercontent.com/42515961/83779431-d43e4a00-a683-11ea-9242-d9037a37a06f.png)


After

![image](https://user-images.githubusercontent.com/42515961/83779385-c5579780-a683-11ea-8453-3805fc790b11.png)



Declined to give feedback
Before

![image](https://user-images.githubusercontent.com/42515961/83779470-e02a0c00-a683-11ea-89bb-f017ec25d817.png)


After

![image](https://user-images.githubusercontent.com/42515961/83779504-eddf9180-a683-11ea-9193-67a52d4c26bd.png)


## Guidance to review

bounced content 

https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.ne4o1cbio6tb

refused content

https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.t3jelbsv0ri

## Link to Trello card

https://trello.com/c/8LCXhKhv/1645-dev-design-tweaks-to-make-references-go-faster?menu=filter&filter=label:Dev

https://trello.com/c/Yzx4U7br/930-speeding-up-the-references-process-replace-the-content-on-the-reference-request-email-bounced-email

https://trello.com/c/j3WNtGEs/931-speeding-up-the-references-process-replace-the-content-on-the-referee-declined-email


## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
