### PR TITLE
Allow support users to reinstate a reference

### DIFF
--- a/app/components/support_interface/reference_with_feedback_component.html.erb
+++ b/app/components/support_interface/reference_with_feedback_component.html.erb
@@ -1,7 +1,13 @@
 <div data-qa="reference">
   <%= render SummaryCardComponent.new(rows: rows) do %>
     <%= render(SummaryCardHeaderComponent.new(title: title)) do %>
-      <% unless cancelled? %>
+      <% if cancelled? %>
+        <div class='app-summary-card__actions'>
+          <%= link_to support_interface_reinstate_reference_path(@reference), class: 'govuk-link' do %>
+          Reinstate reference<span class="govuk-visually-hidden"> for <%= @reference.name %></span>
+          <% end %>
+        </div>
+      <% elsif feedback_requested? %>
         <div class='app-summary-card__actions'>
           <%= link_to support_interface_cancel_reference_path(@reference), class: 'govuk-link' do %>
             Cancel reference<span class="govuk-visually-hidden"> for <%= @reference.name %></span>

--- a/app/components/support_interface/reference_with_feedback_component.rb
+++ b/app/components/support_interface/reference_with_feedback_component.rb
@@ -10,6 +10,7 @@ module SupportInterface
              :feedback_status,
              :consent_to_be_contacted,
              :cancelled?,
+             :feedback_requested?,
              to: :reference
 
     def initialize(reference:, reference_number:)

--- a/app/controllers/support_interface/references_controller.rb
+++ b/app/controllers/support_interface/references_controller.rb
@@ -10,5 +10,16 @@ module SupportInterface
       flash[:success] = 'Reference was cancelled'
       redirect_to support_interface_application_form_path(reference.application_form)
     end
+
+    def reinstate
+      @reference = ApplicationReference.find(params[:reference_id])
+    end
+
+    def confirm_reinstate
+      reference = ApplicationReference.find(params[:reference_id])
+      reference.update!(feedback_status: 'feedback_requested')
+      flash[:success] = 'Reference was reinstated'
+      redirect_to support_interface_application_form_path(reference.application_form)
+    end
   end
 end

--- a/app/views/support_interface/references/reinstate.html.erb
+++ b/app/views/support_interface/references/reinstate.html.erb
@@ -1,0 +1,38 @@
+<% content_for :browser_title, 'Reinstate reference' %>
+<% content_for :before_content, govuk_back_link_to(support_interface_application_form_path(@reference.application_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Are you sure you want to reinstate this reference?
+    </h1>
+
+    <p class="govuk-body">
+      Reinstating a reference will:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>allow this referee to provide a reference</li>
+      <li>prevent the candidate from providing a replacement referee</li>
+    </ul>
+
+    <p class="govuk-body">
+      Reinstating a reference does <strong>not send email notifications</strong>.
+    </p>
+
+    <%= render(SummaryCardComponent.new(rows: [
+    {
+      key: 'Reference name',
+      value: @reference.name,
+    },
+    {
+      key: 'Reference email address',
+      value: @reference.email_address,
+    },
+    ])) %>
+
+    <%= form_with model: @reference, url: support_interface_reinstate_reference_path(@reference), method: :post do |f| %>
+      <%= f.govuk_submit 'Reinstate reference' %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -515,6 +515,9 @@ Rails.application.routes.draw do
     get '/references/:reference_id/cancel' => 'references#cancel', as: :cancel_reference
     post '/references/:reference_id/cancel' => 'references#confirm_cancel'
 
+    get '/references/:reference_id/reinstate' => 'references#reinstate', as: :reinstate_reference
+    post '/references/:reference_id/reinstate' => 'references#confirm_reinstate'
+
     get '/tokens' => 'api_tokens#index', as: :api_tokens
     post '/tokens' => 'api_tokens#create'
 

--- a/spec/components/support_interface/reference_with_feedback_component_spec.rb
+++ b/spec/components/support_interface/reference_with_feedback_component_spec.rb
@@ -1,20 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe SupportInterface::ReferenceWithFeedbackComponent do
-  describe 'Cancel link' do
-    it 'is included when the reference is not cancelled' do
+  describe 'Cancel and reinstate links' do
+    it 'Cancel link is present when the reference is feedback_requested' do
       reference = build_stubbed(:reference, feedback_status: 'feedback_requested')
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
       expect(rendered_component).to include('Cancel reference')
+      expect(rendered_component).not_to include('Reinstate reference')
     end
 
-    it 'is not included when the reference is cancelled' do
+    it 'Reinstate link is present when the reference is cancelled' do
       reference = build_stubbed(:reference, feedback_status: 'cancelled')
 
       render_inline(SupportInterface::ReferenceWithFeedbackComponent.new(reference: reference, reference_number: 1))
 
+      expect(rendered_component).to include('Reinstate reference')
       expect(rendered_component).not_to include('Cancel reference')
     end
   end

--- a/spec/system/support_interface/cancel_reference_spec.rb
+++ b/spec/system/support_interface/cancel_reference_spec.rb
@@ -11,6 +11,10 @@ RSpec.feature 'Cancelling references' do
     when_i_click_to_cancel_the_reference
     and_i_confirm_i_really_want_to_cancel_the_reference
     then_the_reference_is_cancelled
+
+    when_i_click_to_reinstate_the_reference
+    and_i_confirm_i_really_want_to_reinstate_the_reference
+    then_the_reference_is_reinstated
   end
 
   def given_i_am_a_support_user
@@ -37,5 +41,18 @@ RSpec.feature 'Cancelling references' do
   def then_the_reference_is_cancelled
     expect(page).to have_content 'Reference was cancelled'
     expect(page).to have_content 'Cancelled'
+  end
+
+  def when_i_click_to_reinstate_the_reference
+    click_on 'Reinstate reference for Harry'
+  end
+
+  def and_i_confirm_i_really_want_to_reinstate_the_reference
+    click_on 'Reinstate reference'
+  end
+
+  def then_the_reference_is_reinstated
+    expect(page).to have_content 'Reference was reinstated'
+    expect(page).to have_content 'Requested'
   end
 end


### PR DESCRIPTION
## Context

If a reference is cancelled by accident, we want an easy way to reverse this.

## Changes proposed in this pull request

Basically `s/cancel/reinstate/`.

Also, sneakily prevent cancelling a referee that isn't in the `feedback_requested` state. This allows me to predictably know what `reinstate` should do, without having to crawl the audit log.

## Guidance to review

<img width="1003" alt="Screenshot 2020-06-04 at 16 57 33" src="https://user-images.githubusercontent.com/1650875/83780188-bf15eb00-a684-11ea-8233-59f98eee3c3c.png">
<img width="758" alt="Screenshot 2020-06-04 at 16 57 38" src="https://user-images.githubusercontent.com/1650875/83780199-c2a97200-a684-11ea-9f19-bc298dd99305.png">
<img width="1020" alt="Screenshot 2020-06-04 at 16 57 42" src="https://user-images.githubusercontent.com/1650875/83780202-c3da9f00-a684-11ea-978d-24fb583bbd9f.png">


## Link to Trello card

Nope.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)