### PR TITLE
Update candidate chaser email

### DIFF
--- a/app/views/candidate_mailer/chase_reference.text.erb
+++ b/app/views/candidate_mailer/chase_reference.text.erb
@@ -1,15 +1,23 @@
 Dear <%= @application_form.first_name %>,
 
-# Get in contact with <%= @reference.name %>
+# Get in contact with <%= @reference.name %> as soon as possible
 
-We haven’t heard back from your referee yet.
+<%= @reference.name %> has not given you a reference yet.
 
-Ask the referee to check their email and give a reference as soon as possible.
+Ask them to check their inbox including their junk or spam emails and give a reference as soon as possible.
 
-You gave us this address for the referee: <%= @reference.email_address %>
+# Check you’ve given the right details
 
-We need to hear from <%= @reference.name %> within 5 working days.
+You gave us this email address:
 
-If this email address is wrong please get in touch with us with us at:
+<%= @reference.email_address %>
 
-[becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)
+If this is not correct, cancel the reference request and add in the referee details again:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+We cannot send applications to teacher training providers without 2 references. Courses can become full at any time - get your reference as soon as possible.
+
+# Need help?
+
+Contact us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk)

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -13,7 +13,7 @@ en:
     application_sent_to_provider:
       subject: Your application is being considered
     chase_reference:
-      subject: "%{referee_name} hasn’t given a reference yet"
+      subject: "Chase %{referee_name}: they have not given a reference yet"
     chase_references_again:
       subject: Get your references as soon as possible
     new_referee_request:

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a new reference request mail with subject and content', :email_bounced,
         I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
         'heading' => 'Dear Tyrell',
-        'explanation' => "Our email requesting a reference didn’t reach Scott Knowles.\r\n\r\nWe emailed the referee using this address: ting@canpaint.com"
+        'explanation' => 'Our email requesting a reference didn’t reach Scott Knowles.'
       )
     end
   end

--- a/spec/system/referee_interface/referee_does_not_respond_spec.rb
+++ b/spec/system/referee_interface/referee_does_not_respond_spec.rb
@@ -41,7 +41,7 @@ RSpec.feature 'Referee does not respond in time' do
   def and_an_email_is_sent_to_the_candidate
     open_email(@application.candidate.email_address)
 
-    expect(current_email.subject).to end_with('Anne Other hasn’t given a reference yet')
+    expect(current_email.subject).to end_with('Chase Anne Other: they have not given a reference yet')
   end
 
   def when_the_candidate_does_not_respond_within_14_days


### PR DESCRIPTION
## Context

Another PR changing referee related content. 

This time in the candidate chaser email which I sent if a referee doesn't respond.

## Changes proposed in this pull request

Before 

![image](https://user-images.githubusercontent.com/42515961/83781429-719a7d80-a686-11ea-80c2-0dabef944f5f.png)


After

![image](https://user-images.githubusercontent.com/42515961/83781393-63e4f800-a686-11ea-9649-f6b107fef264.png)

## Guidance to review

Content 

https://docs.google.com/document/d/1o2bCTF1_DzpVe8XXaRxfNJ6fdW-iL72WYnkpyhC9vkI/edit#heading=h.mbuhvokcce9l

## Link to Trello card

https://trello.com/c/8LCXhKhv/1645-dev-design-tweaks-to-make-references-go-faster?menu=filter&filter=label:Dev

https://trello.com/c/CaBw0CQw/932-speeding-up-the-references-process-replace-the-content-on-the-referee-has-not-replied-after-5-working-days-email
## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
