### PR TITLE
Filters on small screens

### DIFF
--- a/app/components/provider_interface/filter_component.html.erb
+++ b/app/components/provider_interface/filter_component.html.erb
@@ -5,6 +5,7 @@
         <h2 class="govuk-heading-m">Filter</h2>
       </div>
       <div class="moj-filter__header-action">
+        <%= link_to("Close", provider_interface_applications_path(toggle_filter_off_params),class:"moj-filter__close", type:"button") %>
       </div>
     </div>
 

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -23,7 +23,7 @@ module ProviderInterface
     end
 
     def toggle_filter_off_params
-      toggle = { filter_visible: [@page_state.filter_visible?] }
+      toggle = { filters_visible: [@page_state.filters_visible?] }
       @page_state.applied_filters.merge(toggle)
     end
 

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -23,7 +23,7 @@ module ProviderInterface
     end
 
     def toggle_filter_off_params
-      toggle = { filters_visible: [@page_state.filters_visible?] }
+      toggle = { filters_visible: [!@page_state.filters_visible?] }
       @page_state.applied_filters.merge(toggle)
     end
 

--- a/app/components/provider_interface/filter_component.rb
+++ b/app/components/provider_interface/filter_component.rb
@@ -22,6 +22,11 @@ module ProviderInterface
       end
     end
 
+    def toggle_filter_off_params
+      toggle = { filter_visible: [@page_state.filter_visible?] }
+      @page_state.applied_filters.merge(toggle)
+    end
+
     def remove_checkbox_tag_link(name, value)
       params = filters_to_params(filters)
       params[name].reject! { |val| val == value }

--- a/app/components/provider_interface/filter_toggle_component.html.erb
+++ b/app/components/provider_interface/filter_toggle_component.html.erb
@@ -1,6 +1,6 @@
 <div class="moj-action-bar">
   <div class="moj-action-bar__filter">
       <%= link_to toggle_button_text, provider_interface_applications_path(toggle_params),
-      class: "govuk-button govuk-button--secondary", type: "button" %>
+      class: "filter-toggle govuk-button govuk-button--secondary", type: "button" %>
   </div>
 </div>

--- a/app/components/provider_interface/filter_toggle_component.html.erb
+++ b/app/components/provider_interface/filter_toggle_component.html.erb
@@ -1,6 +1,6 @@
 <div class="moj-action-bar">
   <div class="moj-action-bar__filter">
-    <%= link_to toggle_button_text, url_for(params_for_current_state)),
+      <%= link_to toggle_button_text, provider_interface_applications_path(toggle_params),
       class: "govuk-button govuk-button--secondary", type: "button" %>
   </div>
 </div>

--- a/app/components/provider_interface/filter_toggle_component.rb
+++ b/app/components/provider_interface/filter_toggle_component.rb
@@ -23,6 +23,5 @@ module ProviderInterface
     def toggle_control
       @page_state.filter_visible?
     end
-
   end
 end

--- a/app/components/provider_interface/filter_toggle_component.rb
+++ b/app/components/provider_interface/filter_toggle_component.rb
@@ -14,7 +14,7 @@ module ProviderInterface
     end
 
     def toggle_params
-      toggle = { filters_visible: [toggle_control] }
+      toggle = { filters_visible: [!toggle_control] }
       @page_state.applied_filters.merge(toggle)
     end
 

--- a/app/components/provider_interface/filter_toggle_component.rb
+++ b/app/components/provider_interface/filter_toggle_component.rb
@@ -10,18 +10,18 @@ module ProviderInterface
     end
 
     def toggle_button_text
-      toggle_control ? 'Hide filter' : 'Show filter'
+      toggle_control ? 'Hide filters' : 'Show filters'
     end
 
     def toggle_params
-      toggle = { filter_visible: [toggle_control] }
+      toggle = { filters_visible: [toggle_control] }
       @page_state.applied_filters.merge(toggle)
     end
 
   private
 
     def toggle_control
-      @page_state.filter_visible?
+      @page_state.filters_visible?
     end
   end
 end

--- a/app/components/provider_interface/filter_toggle_component.rb
+++ b/app/components/provider_interface/filter_toggle_component.rb
@@ -1,0 +1,28 @@
+module ProviderInterface
+  class FilterToggleComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :page_state
+    delegate :filters, to: :page_state
+
+    def initialize(page_state:)
+      @page_state = page_state
+    end
+
+    def toggle_button_text
+      toggle_control ? 'Hide filter' : 'Show filter'
+    end
+
+    def toggle_params
+      toggle = { filter_visible: [toggle_control] }
+      @page_state.applied_filters.merge(toggle)
+    end
+
+  private
+
+    def toggle_control
+      @page_state.filter_visible?
+    end
+
+  end
+end

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -26,13 +26,21 @@
   padding-bottom: govuk-spacing(5);
 }
 
+.filter-toggle {
+  max-width: 112.16px;
+  float: right;
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+.moj-filter__header-action {
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
 .moj-filter__options {
   box-shadow: none;
 }
 
-.app-filter {
-  display: none;
-  @include govuk-media-query($from: large) {
-    display: block;
-  }
-}

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -28,6 +28,7 @@
 
 .filter-toggle {
   max-width: 112.16px;
+  font-size: 1rem;
   float: right;
   @include govuk-media-query($from: desktop) {
     display: none;

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -4,4 +4,5 @@
 
 .applications-sorted-by-explanation {
   text-align: right;
+
 }

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -5,4 +5,7 @@
 .applications-sorted-by-explanation {
   text-align: right;
 
+  @include govuk-media-query($until: desktop) {
+    text-align: left;
+  }
 }

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -11,12 +11,20 @@ module ProviderInterface
       ([] << search_filter << status_filter << provider_filter << accredited_provider_filter).concat(provider_locations_filters).compact
     end
 
+    def filter_visible?
+      if applied_filters[:filter_visible]
+        applied_filters[:filter_visible].first.eql?('true') ? false : true
+      else
+        true
+      end
+    end
+
     def filtered?
       applied_filters.values.any?
     end
 
     def applied_filters
-      @params.permit(:candidate_name, provider: [], status: [], accredited_provider: [], provider_location: []).to_h
+      @params.permit(:candidate_name, provider: [], status: [], accredited_provider: [], provider_location: [], filter_visible: []).to_h
     end
 
   private

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -11,9 +11,9 @@ module ProviderInterface
       ([] << search_filter << status_filter << provider_filter << accredited_provider_filter).concat(provider_locations_filters).compact
     end
 
-    def filter_visible?
-      if applied_filters[:filter_visible]
-        applied_filters[:filter_visible].first.eql?('true') ? false : true
+    def filters_visible?
+      if applied_filters[:filters_visible]
+        applied_filters[:filters_visible].first.eql?('true') ? false : true
       else
         true
       end
@@ -24,7 +24,7 @@ module ProviderInterface
     end
 
     def applied_filters
-      @params.permit(:candidate_name, provider: [], status: [], accredited_provider: [], provider_location: [], filter_visible: []).to_h
+      @params.permit(:candidate_name, provider: [], status: [], accredited_provider: [], provider_location: [], filters_visible: []).to_h
     end
 
   private

--- a/app/models/provider_interface/provider_applications_page_state.rb
+++ b/app/models/provider_interface/provider_applications_page_state.rb
@@ -13,7 +13,7 @@ module ProviderInterface
 
     def filters_visible?
       if applied_filters[:filters_visible]
-        applied_filters[:filters_visible].first.eql?('true') ? false : true
+        applied_filters[:filters_visible].first.eql?('true') ? true : false
       else
         true
       end

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -20,7 +20,7 @@
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <div class='moj-filter-layout'>
-  <% if @page_state.filter_visible? %>
+  <% if @page_state.filters_visible? %>
     <%= render ProviderInterface::FilterComponent.new(
       page_state: @page_state,
     ) %>

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -20,11 +20,14 @@
 <h1 class='govuk-heading-xl'>Applications</h1>
 
 <div class='moj-filter-layout'>
-  <%= render ProviderInterface::FilterComponent.new(
-    page_state: @page_state,
-  ) %>
+  <% if @page_state.filter_visible? %>
+    <%= render ProviderInterface::FilterComponent.new(
+      page_state: @page_state,
+    ) %>
+  <% end %>
   <div class='moj-filter-layout__content'>
     <p class='govuk-body applications-sorted-by-explanation'>Sorted by: last changed</p>
+    <%= render ProviderInterface::FilterToggleComponent.new(page_state: @page_state) %>
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>


### PR DESCRIPTION
## Context

The filter was not appearing on small screens due to it being hidden.

This PR makes the filter render on small screens and also adds functionality to show and hide the filter in line with the designs.

NOTE: we use Rack for system tests, this is unable to resize the window so it was agreed by the dev team to leave this piece of functionality untested and add a tech debt ticket to look at how this sort of thing can be tested in the round.

I would be grateful for any suggestions on this front though as it would be better to have some form of tests for this if we can.

## Changes proposed in this pull request

**Before:**
<img width="655" alt="Screenshot 2020-06-05 at 10 57 48" src="https://user-images.githubusercontent.com/13377553/83863575-69405200-a71b-11ea-831b-9a8ab56ad926.png">


**After:**

When filter is open:
<img width="655" alt="Screenshot 2020-06-05 at 10 57 11" src="https://user-images.githubusercontent.com/13377553/83863501-53cb2800-a71b-11ea-9602-58d9999a30b9.png">

When filter is closed:
<img width="656" alt="Screenshot 2020-06-05 at 10 58 49" src="https://user-images.githubusercontent.com/13377553/83863664-8d9c2e80-a71b-11ea-9a6a-ba41709f2afd.png">

## Guidance to review

- Check out the prototype and set it to a small screen view with dev tools. Does this match what you see when you do the same to the app running locally?

## Link to Trello card

https://trello.com/c/uIR5I9M4/2122-title-filters-not-working-at-all-on-small-screens

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
