### PR TITLE
Consistent capitalisation for Get Into Teaching

### DIFF
--- a/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
+++ b/app/views/candidate_interface/apply_from_find/apply_on_ucas_only.html.erb
@@ -9,7 +9,7 @@
       <span class="govuk-caption-xl"><%= @course.name_and_code %></span>
       <%= t('apply_from_find.heading') %>
     </h1>
-    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit Get into Teaching for <a class="govuk-link" target="_blank" href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training">guidance on applying for teacher training</a>.</p>
+    <p class="govuk-body">You must apply for this course on UCAS. You’ll need to register with UCAS before you can apply. Visit Get Into Teaching for <a class="govuk-link" target="_blank" href="https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training">guidance on applying for teacher training</a>.</p>
 
     <p class="govuk-body">When you apply you’ll need these codes for the Choices section of your application form:</p>
 

--- a/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/no_courses.html.erb
@@ -18,7 +18,7 @@
       <li>still submit your current application to other providers</li>
     </ul>
 
-    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get into Teaching guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training' %></p>
+    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training' %></p>
 
     <p class="govuk-body govuk-!-margin-bottom-0">
       <%= govuk_button_link_to t('apply_from_find.ucas_apply_button'), UCAS.apply_url %>

--- a/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
+++ b/app/views/candidate_interface/course_choices/ucas/with_course.html.erb
@@ -18,7 +18,7 @@
       <li>still submit your current application with other course choices</li>
     </ul>
 
-    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get into Teaching guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training' %></p>
+    <p class="govuk-body govuk-!-margin-bottom-6">For more information, see our <%= govuk_link_to 'Get Into Teaching guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply-for-teacher-training' %></p>
 
     <h2 class=govuk-heading-m>Make a note of your choice</h2>
     <p class="govuk-body">When you apply through UCAS, you’ll need these details for the course choices section of your application:</p>

--- a/app/views/candidate_interface/decisions/offer.html.erb
+++ b/app/views/candidate_interface/decisions/offer.html.erb
@@ -24,7 +24,7 @@
       <ul class="govuk-list govuk-list--bullet">
         <li>you can only accept one offer, across both Apply for teacher training and UCAS teacher training</li>
         <li>if you fail to respond, or you decline all your offers, you can still apply to other courses this year through <%= govuk_link_to 'UCAS Teacher Training', UCAS.apply_url %></li>
-        <li>you can register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk' %> to get help from a teacher training advisor</li>
+        <li>you can register with <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk' %> to get help from a teacher training advisor</li>
       </ul>
 
       <%= f.govuk_radio_buttons_fieldset :response, legend: { size: 'm', text: 'How do you want to respond to this offer?', tag: 'span' } do %>

--- a/app/views/candidate_interface/gcse/type/edit.html.erb
+++ b/app/views/candidate_interface/gcse/type/edit.html.erb
@@ -22,7 +22,7 @@
           <% elsif option.id == :missing %>
             <%= f.govuk_radio_button :qualification_type, option.id, label: { text: option.label }, link_errors: i.zero? do %>
               <p class="govuk-hint">You can still apply for teacher training if you are missing this qualification or its equivalent. However, it will need to be in place by the start of your course.</p>
-              <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to 'Get into teaching', 'https://getintoteaching.education.gov.uk/get-help-and-support/' %>.</p>
+              <p class="govuk-hint">For advice, contact your chosen training provider or <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/get-help-and-support/' %>.</p>
               <%= f.govuk_text_area :missing_explanation, label: { text: t('application_form.gcse.missing_explanation.label'), size: 's' }, rows: 12, max_words: 200 do %>
               <% end %>
             <% end %>

--- a/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
+++ b/app/views/candidate_interface/personal_statement/becoming_a_teacher/edit.html.erb
@@ -12,7 +12,7 @@
 
       <p class="govuk-body">Use this section to showcase your motivation, commitment and teaching potential, backing up your answer with specific examples.</p>
       <p class="govuk-body">Give providers an insight into your personality by writing honestly and thoughtfully. Avoid cliché and write in clear, correct, concise English.</p>
-      <p class="govuk-body">To get help with personal statements from a teacher training adviser, register with <%= govuk_link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/' %>.</p>
+      <p class="govuk-body">To get help with personal statements from a teacher training adviser, register with <%= govuk_link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/' %>.</p>
 
       <p class="govuk-body govuk-!-font-weight-bold">You do not have to cover everything in this list, but suggested topics include:</p>
       <ul class="govuk-list govuk-list--bullet">

--- a/app/views/candidate_mailer/application_rejected_all_rejected.erb
+++ b/app/views/candidate_mailer/application_rejected_all_rejected.erb
@@ -4,7 +4,7 @@
 
 You can still apply to more courses this year through UCAS.
 
-Get into Teaching can help you with this. Call them for free on 0800 389 2500 or chat to an adviser online:
+Get Into Teaching can help you with this. Call them for free on 0800 389 2500 or chat to an adviser online:
 
 https://getintoteaching.education.gov.uk
 


### PR DESCRIPTION
## Context

Get Into Teaching capitalise each part of the their name (whether they should or not, is another matter). We currently refer to this service as:

* Get Into Teaching
* Get into Teaching
* Get into teaching

We should be consistent.