### PR TITLE
Use content_status to populate the withdrawn boolean on course

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -136,6 +136,7 @@ private
     course.program_type = find_course.try(:program_type)
     course.qualifications = find_course.try(:qualifications)
     course.age_range = find_course.age_range_in_years&.humanize
+    course.withdrawn = find_course.content_status == 'withdrawn'
   end
 
   def add_accredited_provider(course, find_accredited_provider)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -268,6 +268,7 @@ FactoryBot.define do
     course_length { 'OneYear' }
     start_date { Faker::Date.between(from: 1.month.from_now, to: 1.year.from_now) }
     age_range { '4 to 8' }
+    withdrawn { false }
 
     subject_codes { [Faker::Alphanumeric.alphanumeric(number: 2, min_alpha: 1).upcase] }
     funding_type { %w[fee salary apprenticeship].sample }

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -99,6 +99,20 @@ RSpec.describe SyncProviderFromFind do
         expect(CourseOption.first.vacancy_status).to eq 'vacancies'
       end
 
+      it 'correctly updates withdrawn attribute for an existing course' do
+        stub_find_api_provider_200(
+          provider_code: 'ABC',
+          course_code: '9CBA',
+          content_status: 'withdrawn',
+        )
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        expect(CourseOption.count).to eq 1
+        Course.first.update!(withdrawn: false)
+
+        SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
+        expect(Course.first.withdrawn).to eq true
+      end
+
       it 'correctly handles accredited providers' do
         stub_find_api_provider_200_with_accredited_provider(
           provider_code: 'ABC',

--- a/spec/support/test_helpers/find_api_helper.rb
+++ b/spec/support/test_helpers/find_api_helper.rb
@@ -13,7 +13,8 @@ module FindAPIHelper
     site_address_line2: 'C/O The Bruntcliffe Academy',
     funding_type: 'fee',
     age_range_in_years: '4 to 8',
-    vac_status: 'full_time_vacancies'
+    vac_status: 'full_time_vacancies',
+    content_status: 'published'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -71,6 +72,7 @@ module FindAPIHelper
                 'accrediting_provider': nil,
                 'funding_type': funding_type,
                 'age_range_in_years': age_range_in_years,
+                'content_status': content_status,
               },
               'relationships': {
                 'sites': {
@@ -139,7 +141,8 @@ module FindAPIHelper
     start_date: Time.zone.local(2020, 10, 31),
     course_length: 'OneYear',
     region_code: 'north_west',
-    age_range_in_years: '4 to 8'
+    age_range_in_years: '4 to 8',
+    content_status: 'published'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -194,6 +197,7 @@ module FindAPIHelper
                 'course_length': course_length,
                 'recruitment_cycle_year': '2020',
                 'findable?': findable,
+                'content_status': content_status,
                 'accrediting_provider': {
                   'provider_name': accredited_provider_name,
                   'provider_code': accredited_provider_code,
@@ -253,7 +257,8 @@ module FindAPIHelper
     start_date: Time.zone.local(2020, 10, 31),
     course_length: 'OneYear',
     region_code: 'north_west',
-    age_range_in_years: '4 to 8'
+    age_range_in_years: '4 to 8',
+    content_status: 'published'
 
   )
     response_hash = {
@@ -325,6 +330,7 @@ module FindAPIHelper
               'accrediting_provider': nil,
               'funding_type': 'fee',
               'age_range_in_years': age_range_in_years,
+              'content_status': content_status,
             },
             'relationships': {
               'sites': {
@@ -490,7 +496,8 @@ module FindAPIHelper
     age_range_in_years: '4 to 8',
     vac_status: 'full_time_vacancies',
     qualifications: %w[PG PF],
-    program_type: 'SD'
+    program_type: 'SD',
+    content_status: 'published'
   )
     stub_find_api_provider(provider_code)
       .to_return(
@@ -550,6 +557,7 @@ module FindAPIHelper
                 'age_range_in_years': age_range_in_years,
                 'program_type': program_type,
                 'qualifications': qualifications,
+                'content_status': content_status,
               },
               'relationships': {
                 'sites': {


### PR DESCRIPTION
## Context

In order to implement the designs for the new replace application choice flow. We need to know if a course option was withdrawn (the whole course is discontinued) or simply became full.

We can find this out by using FIND's API as the content status attribute is 'withdrawn' if a course has been withdrawn. 

## Changes proposed in this pull request

- Populate the withdrawn boolean on courses via the FIND V3 API.

## Link to Trello card

https://trello.com/c/kUjDNNbH/1646-dev-update-course-choices-if-course-becomes-full-while-waiting-for-references

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
