### PR TITLE
Fix Withdrawn by us and Rejected filters

### DIFF
--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -31,6 +31,8 @@ class ApplicationChoice < ApplicationRecord
     conditions_not_met: 'conditions_not_met',
   }
 
+  scope :offer_withdrawn, -> { where(status: 'rejected').where.not(offer_withdrawn_at: nil) }
+
   def offer_withdrawn?
     rejected? && !offer_withdrawn_at.nil?
   end

--- a/app/services/filter_application_choices_for_providers.rb
+++ b/app/services/filter_application_choices_for_providers.rb
@@ -17,7 +17,15 @@ class FilterApplicationChoicesForProviders
     def status(application_choices, statuses)
       return application_choices if statuses.blank?
 
-      application_choices.where(status: statuses)
+      filtered_application_choices = application_choices.where(status: statuses)
+
+      if statuses.include?('offer_withdrawn')
+        filtered_application_choices = filtered_application_choices.or(application_choices.offer_withdrawn)
+      elsif statuses.include?('rejected')
+        filtered_application_choices = filtered_application_choices.where(offer_withdrawn_at: nil)
+      end
+
+      filtered_application_choices
     end
 
     def provider(application_choices, providers)

--- a/spec/models/application_choice_spec.rb
+++ b/spec/models/application_choice_spec.rb
@@ -130,4 +130,13 @@ RSpec.describe ApplicationChoice, type: :model do
       end
     end
   end
+
+  describe 'offer_withdrawn scope' do
+    it 'returns offer withdrawn application choices' do
+      create(:application_choice, status: 'rejected', offer_withdrawn_at: nil)
+      offer_withdraw_application_choice = create(:application_choice, status: 'rejected', offer_withdrawn_at: 2.days.ago)
+      expect(described_class.offer_withdrawn.count).to eq 1
+      expect(described_class.offer_withdrawn).to eq [offer_withdraw_application_choice]
+    end
+  end
 end

--- a/spec/services/provider_interface/filter_application_choices_for_providers_spec.rb
+++ b/spec/services/provider_interface/filter_application_choices_for_providers_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe FilterApplicationChoicesForProviders do
+  include CourseOptionHelpers
+
+  describe '#call' do
+    let(:submitted_application_choice) { create(:application_choice, :awaiting_provider_decision, status: 'awaiting_provider_decision') }
+    let(:offered_application_choice) { create(:application_choice, :with_offer, status: 'offer') }
+    let(:accepted_application_choice) { create(:application_choice, :with_accepted_offer, status: 'pending_conditions') }
+    let(:conditions_met_application_choice) { create(:application_choice, :awaiting_provider_decision, status: 'recruited') }
+    let(:enrolled_application_choice) { create(:application_choice, status: 'enrolled') }
+    let(:rejected_application_choice) { create(:application_choice, :with_rejection, status: 'rejected') }
+    let(:declined_application_choice) { create(:application_choice, :with_declined_offer, status: 'declined') }
+    let(:application_withdrawn_application_choice) { create(:application_choice, status: 'withdrawn') }
+    let(:conditions_not_met_application_choice) { create(:application_choice, status: 'conditions_not_met') }
+    let(:withdrawn_by_us_application_choice) { create(:application_choice, status: 'rejected', offer_withdrawn_at: 2.days.ago) }
+
+    context 'when filtering by status' do
+      let(:application_choices) { ApplicationChoice.all }
+
+      test_data =
+        [
+          { filter: 'Submitted', filter_status: 'awaiting_provider_decision' },
+          { filter: 'Offered', filter_status: 'offer' },
+          { filter: 'Accepted', filter_status: 'pending_conditions' },
+          { filter: 'Conditions met', filter_status: 'recruited' },
+          { filter: 'Enrolled', filter_status: 'enrolled' },
+          { filter: 'Rejected', filter_status: 'rejected' },
+          { filter: 'Declined', filter_status: 'declined' },
+          { filter: 'Application withdrawn', filter_status: 'withdrawn' },
+          { filter: 'Conditions not met', filter_status: 'conditions_not_met' },
+          { filter: 'Withdrawn by us', filter_status: 'offer_withdrawn' },
+        ]
+
+      test_data.each_with_index do |example, index|
+        it "single #{example[:filter]} filter returns only #{example[:filter].downcase} application choices" do
+          returned_application_choices = described_class.call(
+            application_choices: application_choices,
+            filters: { status: [example[:filter_status]] },
+          )
+          ordered_expected_application_choices = [submitted_application_choice, offered_application_choice,
+                                                  accepted_application_choice, conditions_met_application_choice,
+                                                  enrolled_application_choice, rejected_application_choice,
+                                                  declined_application_choice, application_withdrawn_application_choice,
+                                                  conditions_not_met_application_choice, withdrawn_by_us_application_choice]
+
+          expect(returned_application_choices).to eq([ordered_expected_application_choices[index]])
+        end
+      end
+
+      it 'combined Submitted and Rejected filters return submitted and withdrawn by us application choices' do
+        filters = { status: %w[awaiting_provider_decision rejected] }
+        returned_application_choices = described_class.call(
+          application_choices: application_choices,
+          filters: filters,
+        )
+        expect(returned_application_choices).to match_array([submitted_application_choice, rejected_application_choice])
+      end
+
+      it 'combined Submitted and Withdrawn by us filters return submitted and withdrawn by us application choices' do
+        filters = { status: %w[awaiting_provider_decision offer_withdrawn] }
+        returned_application_choices = described_class.call(
+          application_choices: application_choices,
+          filters: filters,
+        )
+        expect(returned_application_choices).to match_array([submitted_application_choice, withdrawn_by_us_application_choice])
+      end
+    end
+  end
+end

--- a/spec/system/provider_interface/provider_applications_filter_spec.rb
+++ b/spec/system/provider_interface/provider_applications_filter_spec.rb
@@ -202,6 +202,9 @@ RSpec.feature 'Providers should be able to filter applications' do
 
     create(:application_choice, :awaiting_provider_decision, course_option: course_option_seven, status: 'declined', application_form:
            create(:application_form, first_name: 'Luke', last_name: 'Smith'), updated_at: 7.days.ago)
+
+    create(:application_choice, :awaiting_provider_decision, course_option: course_option_two, status: 'rejected', offer_withdrawn_at: 2.days.ago, application_form:
+           create(:application_form, first_name: 'John', last_name: 'Smith'), updated_at: 8.days.ago)
   end
 
   def then_i_expect_to_see_the_filter_dialogue
@@ -218,6 +221,7 @@ RSpec.feature 'Providers should be able to filter applications' do
     expect(page).not_to have_css('.app-application-cards', text: 'Offer')
     expect(page).not_to have_css('.app-application-cards', text: 'Application withdrawn')
     expect(page).not_to have_css('.app-application-cards', text: 'Declined')
+    expect(page).not_to have_css('.app-application-cards', text: 'Withdrawn by us')
   end
 
   def and_the_rejected_tickbox_should_still_be_checked


### PR DESCRIPTION
## Context

'Withdrawn by us' filter was showing no results and 'Rejected' filter included
both rejected and withdrawn by us applications. This was caused by the fact
that the status filter was running WHERE status query. However
`offer_withdrawn` does not exist in the database; those applications have
`rejected` status in the database.

## Changes proposed in this pull request

- separately add offer withdrawn application choices when 'Withdrawn by us' filter is selected
- when the 'Rejected' filter is selected, exclude 'Withdrawn by us' applications from the results

| Before  | After |
| ------------- | ------------- |
| <img width="972" alt="Screenshot 2020-06-08 at 14 46 13" src="https://user-images.githubusercontent.com/38078064/84037885-1d014600-a997-11ea-9c5b-b56300dea493.png"> |<img width="984" alt="Screenshot 2020-06-08 at 14 40 05" src="https://user-images.githubusercontent.com/38078064/84037959-34d8ca00-a997-11ea-8b9a-bf410e665ef4.png">|
|<img width="977" alt="Screenshot 2020-06-08 at 14 39 48" src="https://user-images.githubusercontent.com/38078064/84037992-3d310500-a997-11ea-98f7-8330d1f6dbea.png">|<img width="987" alt="Screenshot 2020-06-08 at 14 38 45" src="https://user-images.githubusercontent.com/38078064/84038019-4326e600-a997-11ea-82d1-ee16942e9430.png">|

## Guidance to review
- go to http://localhost:3000/provider/applications
- try different filters such as:
  - 'Withdrawn by us' only
  - 'Rejected' only
  - 'Withdrawn by us' & 'Rejected' 
  - 'Withdrawn by us' & some other filters
  - 'Rejected' & some other filters

_Note:_ In the service spec I explicitly specified the status to highlight it even though it's sometimes done by the factory - happy to change it.

## Link to Trello card

https://trello.com/c/U0OeofIp/2116-title-provider-interface-application-filter-by-status-wrong

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
