### PR TITLE
Provider user needing to set organisation permissions sets them on first login

### DIFF
--- a/app/controllers/provider_interface/provider_interface_controller.rb
+++ b/app/controllers/provider_interface/provider_interface_controller.rb
@@ -69,8 +69,8 @@ module ProviderInterface
 
     def check_provider_relationship_permissions
       return unless FeatureFlag.active?('enforce_provider_to_provider_permissions')
-      return if request.path == provider_interface_provider_relationship_permissions_setup_path
       return unless current_provider_user
+      return if performing_provider_organisation_setup?
 
       if provider_permissions_need_setup?
         redirect_to provider_interface_provider_relationship_permissions_setup_path
@@ -88,6 +88,13 @@ module ProviderInterface
       ProviderAuthorisation.new(actor: current_provider_user).can_manage_organisation?(
         provider: permissions.training_provider,
       )
+    end
+
+    def performing_provider_organisation_setup?
+      [
+        ProviderInterface::ProviderAgreementsController,
+        ProviderInterface::ProviderRelationshipPermissionsController,
+      ].include?(request.controller_class)
     end
 
     def render_404

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -7,7 +7,7 @@ module ProviderInterface
       @training_provider_permissions = TrainingProviderPermissions.where(
         setup_at: nil,
         training_provider: current_provider_user.providers,
-      )
+      ).includes(%i[training_provider ratifying_provider]).order(:created_at)
     end
 
     def success; end

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -3,6 +3,13 @@ module ProviderInterface
     before_action :render_404_unless_permissions_found
     before_action :render_403_unless_access_permitted
 
+    def setup
+      @training_provider_permissions = TrainingProviderPermissions.where(
+        setup_at: nil,
+        training_provider: current_provider_user.providers,
+      )
+    end
+
     def success; end
 
     def edit
@@ -62,9 +69,10 @@ module ProviderInterface
     end
 
     def render_403_unless_access_permitted
-      render_403 unless current_provider_user.providers.include?(
-        training_provider_permissions.training_provider,
-      )
+      render_403 unless current_provider_user.can_manage_organisations? &&
+        current_provider_user.providers.include?(
+          training_provider_permissions.training_provider,
+        )
     end
   end
 end

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -68,10 +68,10 @@ module ProviderInterface
     end
 
     def render_403_unless_access_permitted
-      render_403 unless current_provider_user.can_manage_organisations? &&
-        current_provider_user.providers.include?(
-          training_provider_permissions.training_provider,
-        )
+      training_provider = training_provider_permissions.training_provider
+
+      render_403 unless ProviderAuthorisation.new(actor: current_provider_user)
+        .can_manage_organisation?(provider: training_provider)
     end
   end
 end

--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -23,9 +23,8 @@ module ProviderInterface
 
     def update
       initialize_form
-      @form.assign_permissions_attributes(provider_relationship_permissions_form_params)
 
-      if @form.save!
+      if @form.update!(provider_relationship_permissions_form_params)
         redirect_to provider_interface_provider_relationship_permissions_success_path
       else
         flash[:warning] = 'Unable to save permissions, please try again. If problems persist please contact support.'

--- a/app/forms/provider_interface/provider_relationship_permissions_form.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_form.rb
@@ -8,10 +8,12 @@ module ProviderInterface
       @training_provider_permissions.assign_attributes(training_provider_permissions_from_params(params))
     end
 
-    def save!
-      @accredited_body_permissions.setup_at = Time.current
-      @training_provider_permissions.setup_at = Time.current
-      @accredited_body_permissions.save! && @training_provider_permissions.save!
+    def update!(params)
+      @accredited_body_permissions.update!(
+        accredited_body_permissions_from_params(params).merge(setup_at: Time.current),
+      ) && @training_provider_permissions.update!(
+        training_provider_permissions_from_params(params).merge(setup_at: Time.current),
+      )
     end
 
   private

--- a/app/forms/provider_interface/provider_relationship_permissions_form.rb
+++ b/app/forms/provider_interface/provider_relationship_permissions_form.rb
@@ -9,6 +9,8 @@ module ProviderInterface
     end
 
     def save!
+      @accredited_body_permissions.setup_at = Time.current
+      @training_provider_permissions.setup_at = Time.current
       @accredited_body_permissions.save! && @training_provider_permissions.save!
     end
 

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -36,10 +36,6 @@ class ProviderUser < ActiveRecord::Base
     end
   end
 
-  def can_view_safeguarding_information_for?(provider)
-    provider_permissions.view_safeguarding_information.exists?(provider: provider)
-  end
-
   def full_name
     "#{first_name} #{last_name}" if first_name.present? && last_name.present?
   end

--- a/app/models/provider_user.rb
+++ b/app/models/provider_user.rb
@@ -49,7 +49,7 @@ class ProviderUser < ActiveRecord::Base
   end
 
   def can_manage_organisations?
-    ProviderInterface::ProviderRelationshipPermissions.exists?(training_provider: providers)
+    provider_permissions.exists?(manage_organisations: true)
   end
 
 private

--- a/app/services/provider_authorisation.rb
+++ b/app/services/provider_authorisation.rb
@@ -48,6 +48,12 @@ class ProviderAuthorisation
     end
   end
 
+  def can_manage_organisation?(provider:)
+    return true if @actor.is_a?(SupportUser)
+
+    @actor.provider_permissions.exists?(provider: provider, manage_organisations: true)
+  end
+
   # automatically generates assert_can...! methods e.g. #assert_can_make_offer! for #can_make_offer?
   instance_methods.select { |m| m.match PERMISSION_METHOD_REGEXP }.each do |method|
     permission_name = method.to_s.scan(PERMISSION_METHOD_REGEXP).last.first

--- a/app/views/provider_interface/provider_relationship_permissions/setup.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/setup.html.erb
@@ -1,0 +1,39 @@
+<div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+		<h1 class="govuk-heading-xl">
+			Set up permissions for your organisation
+		</h1>
+	</div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body">
+    <p>You can control who has access to sensitive information, and who can make decisions about applications.</p>
+    <p>We’ll ask you to set up the permissions between you and the organisations that ratify your courses.</p>
+    <p>You’ll then be able to choose permissions for any individual users you add to your organisation.</p>
+    <p>You can change these settings at any time.</p>
+    <h2 class="govuk-heading-m">Your organisations that need setting up</h2>
+
+    <% @training_provider_permissions.each do |permission| %>
+      <div class="app-application-card govuk-!-margin-bottom-7">
+        <div>
+          <h2 class="govuk-heading-s govuk-!-margin-bottom-0"><%= permission.training_provider.name %></h2>
+          <p class="govuk-!-margin-top-1 govuk-!-margin-bottom-1">Organisations that ratify your courses:</p>
+          <ul class="govuk-list govuk-list--bullet">
+            <li><%= permission.ratifying_provider.name %></li>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+    <%= govuk_link_to(
+      'Continue',
+      provider_interface_edit_provider_relationship_permissions_path(
+        ratifying_provider_id: @training_provider_permissions.first.ratifying_provider.id,
+        training_provider_id: @training_provider_permissions.first.training_provider.id,
+      ),
+      class: "govuk-button",
+    ) %>
+
+  </div>
+</div>

--- a/app/views/provider_interface/provider_relationship_permissions/success.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/success.html.erb
@@ -29,9 +29,7 @@
       Continue to your applications.
     </p>
     <p>
-      <a href="/" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-        Continue
-      </a>
+      <%= govuk_link_to 'Continue', provider_interface_applications_path, class: 'govuk-button' %>
     </p>
   </div>
 </div>

--- a/app/views/provider_interface/provider_relationship_permissions/success.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/success.html.erb
@@ -11,7 +11,7 @@
     </h2>
 
     <p class="govuk-body">
-      Select <a href="<%= provider_interface_organisations_path %>">Organisations</a> (at the top of every page) to update your permissions.
+      Select <%= govuk_link_to 'Organisations', provider_interface_organisations_path %> (at the top of every page) to update your permissions.
     </p>
     <h2 class="govuk-heading-m">
       Inviting users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -480,6 +480,8 @@ Rails.application.routes.draw do
 
     resources :organisations, only: %i[index show], path: 'organisations'
 
+    get '/provider-relationship-permissions/setup' => 'provider_relationship_permissions#setup',
+        as: :provider_relationship_permissions_setup
     get '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id/success' => 'provider_relationship_permissions#success',
         as: :provider_relationship_permissions_success
     get '/provider-relationship-permissions/:training_provider_id/:ratifying_provider_id/edit' => 'provider_relationship_permissions#edit',

--- a/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
@@ -26,14 +26,28 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsForm do
   end
 
   describe '#save!' do
-    it 'saves accredited and training provider permissions models' do
+    before do
       allow(accredited_body_permissions).to receive(:save!).and_return(true)
       allow(training_provider_permissions).to receive(:save!).and_return(true)
+    end
 
+    it 'saves accredited and training provider permissions models' do
       form.save!
 
       expect(accredited_body_permissions).to have_received(:save!)
       expect(training_provider_permissions).to have_received(:save!)
+    end
+
+    it 'assigns current time to setup_at attribute' do
+      the_time = Time.current
+      allow(accredited_body_permissions).to receive(:setup_at=)
+      allow(training_provider_permissions).to receive(:setup_at=)
+      allow(Time).to receive(:current).and_return(the_time)
+
+      form.save!
+
+      expect(accredited_body_permissions).to have_received(:setup_at=).with(the_time)
+      expect(training_provider_permissions).to have_received(:setup_at=).with(the_time)
     end
   end
 end

--- a/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsForm do
       form.update!(permissions_attrs)
 
       expect(accredited_body_permissions).to have_received(:update!)
-        .with({ view_safeguarding_information: false, setup_at: the_time })
+        .with({ make_decisions: false, view_safeguarding_information: false, setup_at: the_time })
       expect(training_provider_permissions).to have_received(:update!)
-        .with({ view_safeguarding_information: true, setup_at: the_time })
+        .with({ make_decisions: false, view_safeguarding_information: true, setup_at: the_time })
     end
   end
 end

--- a/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
+++ b/spec/forms/provider_interface/provider_relationship_permissions_form_spec.rb
@@ -25,29 +25,25 @@ RSpec.describe ProviderInterface::ProviderRelationshipPermissionsForm do
     end
   end
 
-  describe '#save!' do
+  describe '#update!' do
+    let(:permissions_attrs) do
+      { training_provider_permissions: { view_safeguarding_information: 'true' } }
+    end
+    let(:the_time) { Time.current }
+
     before do
-      allow(accredited_body_permissions).to receive(:save!).and_return(true)
-      allow(training_provider_permissions).to receive(:save!).and_return(true)
-    end
-
-    it 'saves accredited and training provider permissions models' do
-      form.save!
-
-      expect(accredited_body_permissions).to have_received(:save!)
-      expect(training_provider_permissions).to have_received(:save!)
-    end
-
-    it 'assigns current time to setup_at attribute' do
-      the_time = Time.current
-      allow(accredited_body_permissions).to receive(:setup_at=)
-      allow(training_provider_permissions).to receive(:setup_at=)
+      allow(accredited_body_permissions).to receive(:update!).and_return(true)
+      allow(training_provider_permissions).to receive(:update!).and_return(true)
       allow(Time).to receive(:current).and_return(the_time)
+    end
 
-      form.save!
+    it 'updates accredited and training provider permissions models' do
+      form.update!(permissions_attrs)
 
-      expect(accredited_body_permissions).to have_received(:setup_at=).with(the_time)
-      expect(training_provider_permissions).to have_received(:setup_at=).with(the_time)
+      expect(accredited_body_permissions).to have_received(:update!)
+        .with({ view_safeguarding_information: false, setup_at: the_time })
+      expect(training_provider_permissions).to have_received(:update!)
+        .with({ view_safeguarding_information: true, setup_at: the_time })
     end
   end
 end

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -92,41 +92,6 @@ RSpec.describe ProviderUser, type: :model do
     end
   end
 
-
-
-  describe '#can_view_safeguarding_information_for?' do
-    let(:provider_user) { create :provider_user, :with_provider }
-
-    it 'is false without the correct permission' do
-      provider = provider_user.providers.first
-      expect(provider_user.can_view_safeguarding_information_for?(provider)).to be false
-    end
-
-    it 'is false without the correct permission for the given provider' do
-      provider_user.provider_permissions.update_all(view_safeguarding_information: true)
-      expect(provider_user.can_view_safeguarding_information_for?(build_stubbed(:provider))).to be false
-    end
-
-    it 'is true with the correct permission for the given provider' do
-      provider_user.provider_permissions.update_all(view_safeguarding_information: true)
-      provider = provider_user.providers.first
-      expect(provider_user.can_view_safeguarding_information_for?(provider)).to be true
-    end
-  end
-
-  describe '#can_manage_organisations?' do
-    let(:provider_user) { create :provider_user, :with_provider }
-
-    it 'is false when no provider relationship permissions exist for associated providers' do
-      expect(provider_user.can_manage_organisations?).to be(false)
-    end
-
-    it 'is true when provider relationship permissions exist for associated providers' do
-      create(:training_provider_permissions, training_provider: provider_user.providers.first)
-      expect(provider_user.can_manage_organisations?).to be(true)
-    end
-  end
-
   describe '.visible_to' do
     it 'returns provider users with access to the same providers as the passed user' do
       provider = create(:provider)

--- a/spec/models/provider_user_spec.rb
+++ b/spec/models/provider_user_spec.rb
@@ -78,6 +78,22 @@ RSpec.describe ProviderUser, type: :model do
     end
   end
 
+  describe 'can_manage_organisations?' do
+    let(:provider_user) { create :provider_user, :with_provider }
+
+    it 'is false for users without the manage organisations permission' do
+      expect(provider_user.can_manage_organisations?).to be false
+    end
+
+    it 'is true for users with the manage organisations permission' do
+      provider_user.provider_permissions.first.update(manage_organisations: true)
+
+      expect(provider_user.can_manage_organisations?).to be true
+    end
+  end
+
+
+
   describe '#can_view_safeguarding_information_for?' do
     let(:provider_user) { create :provider_user, :with_provider }
 

--- a/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_request_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe 'ProviderRelationshipPermissions', type: :request do
         ratifying_provider: ratifying_provider,
         training_provider: training_provider,
       )
+      provider_user.provider_permissions.update_all(manage_organisations: true)
     end
 
     context 'GET edit' do

--- a/spec/requests/provider_interface/provider_relationship_permissions_setup_spec.rb
+++ b/spec/requests/provider_interface/provider_relationship_permissions_setup_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe 'ProviderRelationshipPermissions setup', type: :request do
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:provider_user) { create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID') }
+
+  before do
+    FeatureFlag.activate('enforce_provider_to_provider_permissions')
+
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  describe 'redirecting when permissions need setup' do
+    context 'when the user has permissions to manage the provider' do
+      before do
+        create(:training_provider_permissions, training_provider: provider, setup_at: nil)
+        provider_user.provider_permissions.find_by(provider: provider).update(manage_organisations: true)
+      end
+
+      it 'redirects to setup' do
+        get provider_interface_applications_path
+
+        expect(response.status).to eq(302)
+        expect(response.redirect_url).to eq(provider_interface_provider_relationship_permissions_setup_url)
+      end
+    end
+
+    context 'when the user does not have  permissions to manage the provider' do
+      before do
+        create(:training_provider_permissions, ratifying_provider: provider, setup_at: nil)
+        provider_user.provider_permissions.find_by(provider: provider).update(manage_organisations: true)
+      end
+
+      it 'does not redirect to setup' do
+        get provider_interface_applications_path
+
+        expect(response.status).to eq(200)
+      end
+    end
+  end
+
+  describe 'when no relevant permissions need setup' do
+    before do
+      create(:training_provider_permissions, ratifying_provider: provider, setup_at: Time.current)
+      provider_user.provider_permissions.find_by(provider: provider).update(manage_organisations: true)
+    end
+
+    it 'does not redirect' do
+      get provider_interface_applications_path
+
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/services/provider_authorisation_spec.rb
+++ b/spec/services/provider_authorisation_spec.rb
@@ -270,4 +270,42 @@ RSpec.describe ProviderAuthorisation do
       it { is_expected.to be false }
     end
   end
+
+  describe 'can_manage_organisation?' do
+    context 'for a support user' do
+      let(:support_user) { create(:support_user) }
+
+      subject(:auth_context) { ProviderAuthorisation.new(actor: support_user) }
+
+      it 'is true' do
+        expect(auth_context.can_manage_organisation?(provider: create(:provider))).to be true
+      end
+    end
+
+    context 'for a provider user with permission to manage an organisation' do
+      let(:provider_user) { create(:provider_user, :with_provider) }
+
+      subject(:auth_context) { ProviderAuthorisation.new(actor: provider_user) }
+
+      it 'is true' do
+        provider = provider_user.providers.first
+        provider_user.provider_permissions.find_by(provider: provider).update(manage_organisations: true)
+
+        expect(auth_context.can_manage_organisation?(provider: provider)).to be true
+      end
+    end
+
+    context 'for a provider user without permission to manage an organisation' do
+      let(:provider_user) { create(:provider_user, :with_provider) }
+
+      subject(:auth_context) { ProviderAuthorisation.new(actor: provider_user) }
+
+      it 'is false' do
+        provider = provider_user.providers.first
+        provider_user.provider_permissions.find_by(provider: provider).update(manage_organisations: true)
+
+        expect(auth_context.can_manage_organisation?(provider: create(:provider))).to be false
+      end
+    end
+  end
 end

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.feature 'Managing provider user permissions' do
+RSpec.feature 'Managing provider to provider relationship permissions' do
   include DfESignInHelpers
 
-  scenario 'Provider manages permissions for users' do
+  scenario 'Provider manages permissions for their organisation' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_provider_permissions_feature_is_enabled
     and_the_safeguarding_declaration_feature_flag_is_active
@@ -49,8 +49,8 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def and_i_can_manage_organisations_for_a_provider
-    # This relies on the 'manage_organisations' permission, yet to be implemented.
     @provider_user = ProviderUser.last
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
     @training_provider = Provider.find_by(code: 'ABC')
     @ratifying_provider = Provider.find_by(code: 'DEF')
   end

--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
       ratifying_provider: create(:provider),
       training_provider: @application_choice.course.provider,
       view_safeguarding_information: true,
+      setup_at: Time.current,
     )
   end
 

--- a/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
+++ b/spec/system/provider_interface/see_organisations_and_permissions_spec.rb
@@ -36,6 +36,7 @@ RSpec.feature 'See organisation permissions' do
     @ratifying_provider = Provider.find_by(code: 'DEF')
     @unmanageable_provider = create(:provider, :with_signed_agreement)
     @provider_user.providers << @unmanageable_provider
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
   end
 
   def and_the_provider_has_courses_ratified_by_another_provider
@@ -44,12 +45,14 @@ RSpec.feature 'See organisation permissions' do
       ratifying_provider: @ratifying_provider,
       training_provider: @training_provider,
       view_safeguarding_information: true,
+      setup_at: Time.current,
     )
 
     create(
       :training_provider_permissions,
       ratifying_provider: @ratifying_provider,
       training_provider: @training_provider,
+      setup_at: Time.current,
     )
   end
 

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -40,13 +40,13 @@ RSpec.feature 'Setting up provider relationship permissions' do
 
   def and_i_can_manage_organisations
     @provider_user = ProviderUser.last
-    @provider_user.provider_permissions.update_all(manage_organisations: true)
     @training_provider = Provider.find_by(code: 'ABC')
     @ratifying_provider = Provider.find_by(code: 'DEF')
 
     @another_training_provider = create(:provider, :with_signed_agreement)
     @another_ratifying_provider = create(:provider, :with_signed_agreement)
     @provider_user.providers << @another_training_provider
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
   end
 
   def and_my_organisations_have_not_had_permissions_setup

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Setting up provider relationship permissions' do
+  include DfESignInHelpers
+
+  scenario 'Provider user sets up permissions for their organisation' do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_the_provider_permissions_feature_is_enabled
+    and_i_can_manage_organisations
+    and_my_organisation_has_not_had_permissions_setup
+
+    when_i_sign_in_to_the_provider_interface
+    then_i_should_see_the_permissions_setup_page
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+    provider_user_exists_in_apply_database
+  end
+
+  def and_the_provider_permissions_feature_is_enabled
+    FeatureFlag.activate('enforce_provider_to_provider_permissions')
+  end
+
+  def and_i_can_manage_organisations
+    @provider_user = ProviderUser.last
+    @provider_user.provider_permissions.update_all(manage_organisations: true)
+    @training_provider = Provider.find_by(code: 'ABC')
+    @ratifying_provider = Provider.find_by(code: 'DEF')
+  end
+
+  def and_my_organisation_has_not_had_permissions_setup
+    create(
+      :accredited_body_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @training_provider,
+    )
+
+    create(
+      :training_provider_permissions,
+      ratifying_provider: @ratifying_provider,
+      training_provider: @training_provider,
+    )
+  end
+
+  alias_method :when_i_sign_in_to_the_provider_interface, :and_i_sign_in_to_the_provider_interface
+
+  def then_i_should_see_the_permissions_setup_page
+    expect(page).to have_content('Set up permissions for your organisation')
+  end
+end

--- a/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/setup_provider_relationship_permissions_spec.rb
@@ -7,10 +7,26 @@ RSpec.feature 'Setting up provider relationship permissions' do
     given_i_am_a_provider_user_with_dfe_sign_in
     and_the_provider_permissions_feature_is_enabled
     and_i_can_manage_organisations
-    and_my_organisation_has_not_had_permissions_setup
+    and_my_organisations_have_not_had_permissions_setup
 
     when_i_sign_in_to_the_provider_interface
-    then_i_should_see_the_permissions_setup_page
+    then_i_can_see_the_permissions_setup_page
+
+    when_i_click_continue
+    and_i_choose_permissions_for_the_provider_relationship
+    and_i_confirm_my_choices
+    then_i_see_permissions_were_successfully_saved
+
+    when_i_click_continue
+    then_i_can_see_the_permissions_setup_page
+
+    when_i_click_continue
+    and_i_choose_permissions_for_another_provider_relationship
+    and_i_confirm_my_choices_again
+    then_i_see_permissions_were_successfully_saved
+
+    when_i_click_continue
+    then_i_can_see_candidate_applications
   end
 
   def given_i_am_a_provider_user_with_dfe_sign_in
@@ -27,9 +43,13 @@ RSpec.feature 'Setting up provider relationship permissions' do
     @provider_user.provider_permissions.update_all(manage_organisations: true)
     @training_provider = Provider.find_by(code: 'ABC')
     @ratifying_provider = Provider.find_by(code: 'DEF')
+
+    @another_training_provider = create(:provider, :with_signed_agreement)
+    @another_ratifying_provider = create(:provider, :with_signed_agreement)
+    @provider_user.providers << @another_training_provider
   end
 
-  def and_my_organisation_has_not_had_permissions_setup
+  def and_my_organisations_have_not_had_permissions_setup
     create(
       :accredited_body_permissions,
       ratifying_provider: @ratifying_provider,
@@ -41,11 +61,69 @@ RSpec.feature 'Setting up provider relationship permissions' do
       ratifying_provider: @ratifying_provider,
       training_provider: @training_provider,
     )
+
+    create(
+      :accredited_body_permissions,
+      ratifying_provider: @another_ratifying_provider,
+      training_provider: @another_training_provider,
+    )
+
+    create(
+      :training_provider_permissions,
+      ratifying_provider: @another_ratifying_provider,
+      training_provider: @another_training_provider,
+    )
   end
 
   alias_method :when_i_sign_in_to_the_provider_interface, :and_i_sign_in_to_the_provider_interface
 
-  def then_i_should_see_the_permissions_setup_page
+  def then_i_can_see_the_permissions_setup_page
     expect(page).to have_content('Set up permissions for your organisation')
+  end
+
+  def when_i_click_continue
+    click_on 'Continue'
+  end
+
+  def and_i_choose_permissions_for_the_provider_relationship
+    expect(page).to have_content("For courses run by #{@training_provider.name} and ratified by #{@ratifying_provider.name}")
+
+    within(find('.govuk-checkboxes__item', match: :first)) do
+      check 'They have access to safeguarding information'
+    end
+
+    click_on 'Continue'
+  end
+
+  def and_i_confirm_my_choices
+    expect(page).to have_content("#{@training_provider.name} can:\nsee safeguarding information view applications")
+    expect(page).to have_content("#{@ratifying_provider.name} can:\nview applications")
+
+    click_on 'Save permissions'
+  end
+
+  def then_i_see_permissions_were_successfully_saved
+    expect(page).to have_content('Permissions successfully set up')
+  end
+
+  def and_i_choose_permissions_for_another_provider_relationship
+    expect(page).to have_content("For courses run by #{@another_training_provider.name} and ratified by #{@another_ratifying_provider.name}")
+
+    within(find('.govuk-checkboxes__item', match: :first)) do
+      check 'They have access to safeguarding information'
+    end
+
+    click_on 'Continue'
+  end
+
+  def and_i_confirm_my_choices_again
+    expect(page).to have_content("#{@another_training_provider.name} can:\nsee safeguarding information view applications")
+    expect(page).to have_content("#{@another_ratifying_provider.name} can:\nview applications")
+
+    click_on 'Save permissions'
+  end
+
+  def then_i_can_see_candidate_applications
+    expect(page).to have_css('h1.govuk-heading-xl', text: 'Applications')
   end
 end


### PR DESCRIPTION
## Context

Users with the `manage_organisations` permissions can assign provider relationship permissions for their training provider and the ratifying provider for relevant courses.
These relationships between providers are defined and populated from data in Find.
The relationships are treated as 'set up' once the designated user has set permissions and confirmed them.

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

- Adds a filter in `ProviderInterfaceController` to redirect the relevant user to set up organisation permissions.
- This takes the user into a set of steps which detail what the permissions mean and allows them to select the appropriate permissions for training and ratifying providers.
- Saves a timestamp on each `ProviderRelationshipPermissions` record confirmed by the user.
- The user exits these steps once all associated provider relationship permissions have been set up and confirmed.

<!-- If there are UI changes, please include Before and After screenshots. -->

#### 1. Setup step

![image](https://user-images.githubusercontent.com/93511/84135343-c56be480-aa41-11ea-877e-8df34f20a510.png)

#### 2. Assign permissions step

![image](https://user-images.githubusercontent.com/93511/84135520-fea45480-aa41-11ea-8a2c-c1a691217307.png)

#### 3. Confirmation

![image](https://user-images.githubusercontent.com/93511/84135601-18de3280-aa42-11ea-8de7-cf8c62537503.png)

#### 4. Success

![image](https://user-images.githubusercontent.com/93511/84135682-2f848980-aa42-11ea-95eb-7f5a569a5a2b.png)


## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/hX3bkcvr/2236-%F0%9F%8F%88-a-provider-user-needing-to-set-organisation-permissions-sets-them-on-first-login
<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
