### PR TITLE
Add application reference to Vendor API responses

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -10,6 +10,7 @@ module VendorAPI
         id: application_choice.id.to_s,
         type: 'application',
         attributes: {
+          application_reference: application_form.support_reference,
           status: application_choice.status,
           phase: application_form.phase,
           updated_at: application_choice.updated_at.iso8601,

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 9th June 2020
+
+New attributes:
+
+- `ApplicationAttributes` now has an `application_reference` attribute of type string.
+
 ### 20th May 2020
 
 Corrections to documentation

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -337,6 +337,7 @@ components:
       type: object
       additionalProperties: false
       required:
+      - application_reference
       - candidate
       - phase
       - contact_details
@@ -355,6 +356,11 @@ components:
       - further_information
       - work_experience
       properties:
+        application_reference:
+          type: string
+          description: The candidate's reference number for their application in the Apply system
+          maxLength: 10
+          example: AB1234
         status:
           type: string
           description: |

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -13,6 +13,7 @@ FactoryBot.define do
     candidate
 
     factory :completed_application_form do
+      support_reference { GenerateSupportRef.call }
       first_name { Faker::Name.first_name }
       last_name { Faker::Name.last_name }
       date_of_birth { Faker::Date.birthday }

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -71,6 +71,7 @@ RSpec.feature 'Vendor receives the application' do
       id: @provider.application_choices.first.id.to_s,
       type: 'application',
       attributes: {
+        application_reference: @provider.application_forms.first.support_reference,
         personal_statement: "Why do you want to become a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
         interview_preferences: 'Not on a Wednesday',
         offer: nil,


### PR DESCRIPTION
## Context

One of the vendors pointed out that it would be useful to have
application_reference since it’s displayed to the candidates and providers in
the UI. Application reference is often used when candidates contact providers.
Adding it to the API will allow provider's system to display this information
and therefore to identify candidates/application by the reference.

## Changes proposed in this pull request

 Return application_reference in the response. 

## Guidance to review

- GET /applications/{application_id} returns application_reference
- API docs are updated:
  - http://localhost:3000/api-docs/reference#get-applications-application_id HTTP 200 example
  - http://localhost:3000/api-docs/reference#applicationattributes-object

## Link to Trello card

https://trello.com/c/ObzwukFU/2246-add-application-reference-to-vendor-api-responses

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
