### PR TITLE
Update incorrect content in referee review component

### DIFF
--- a/app/components/candidate_interface/referees_review_component.rb
+++ b/app/components/candidate_interface/referees_review_component.rb
@@ -109,7 +109,7 @@ module CandidateInterface
       elsif referee.feedback_requested?
         content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
       elsif referee.cancelled?
-        content_tag(:p, t('application_form.referees.info.awaiting_reference_sent_more_than_5_days_ago'), class: 'govuk-body govuk-!-margin-top-2')
+        content_tag(:p, t('application_form.referees.info.cancelled'), class: 'govuk-body govuk-!-margin-top-2')
       end
     end
 

--- a/spec/components/candidate_interface/referees_review_component_spec.rb
+++ b/spec/components/candidate_interface/referees_review_component_spec.rb
@@ -100,6 +100,18 @@ RSpec.describe CandidateInterface::RefereesReviewComponent do
       expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.feedback_overdue'))
     end
 
+    it 'renders component with correct value for status for cancelled reference request' do
+      first_referee = application_form.application_references.first
+      first_referee.update_columns(
+        feedback_status: 'cancelled',
+      )
+      result = render_inline(described_class.new(application_form: application_form))
+
+      expect(result.css('.govuk-summary-list__key').text).to include('Status')
+      expect(result.css('.govuk-tag.govuk-tag--red.app-tag').to_html).to include('Cancelled')
+      expect(result.css('.govuk-summary-list__value').to_html).to include(t('application_form.referees.info.cancelled'))
+    end
+
     it 'renders component along with a delete link for each referee' do
       referee_id = application_form.application_references.first.id
       result = render_inline(described_class.new(application_form: application_form))


### PR DESCRIPTION
## Context

Some incorrect content slipped into the referee review component for the cancelled state. I've added a test and fixed it.

## Changes proposed in this pull request

- Fix the content and add a test

Before 

![image](https://user-images.githubusercontent.com/42515961/84130153-c9483880-aa3a-11ea-9519-3d26933ac89b.png)

After 

![image](https://user-images.githubusercontent.com/42515961/84130097-ba618600-aa3a-11ea-9f38-b2caa453a7a2.png)

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

https://trello.com/c/8LCXhKhv/1645-dev-design-tweaks-to-make-references-go-faster

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
