### PR TITLE
Add replace course choice banner

### DIFF
--- a/app/components/candidate_interface/new_course_choice_needed_banner_component.html.erb
+++ b/app/components/candidate_interface/new_course_choice_needed_banner_component.html.erb
@@ -1,0 +1,13 @@
+<div class="app-banner app-banner--info" aria-labelledby="info-message">
+  <div class="app-banner__message">
+    <h2 class="govuk-heading-m" id="info-message">
+      <% if @application_form.course_choices_that_need_replacing.count == 1 %>
+          One of your choices is not available anymore.
+      <% else %>
+        Some of your choices are not available anymore.
+      <% end %>
+      <br>
+    <%= govuk_link_to 'Update your course choice now', '#' %>.
+    </h2>
+  </div>
+</div>

--- a/app/components/candidate_interface/new_course_choice_needed_banner_component.html.erb
+++ b/app/components/candidate_interface/new_course_choice_needed_banner_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-banner app-banner--info" aria-labelledby="info-message">
   <div class="app-banner__message">
-    <h2 class="govuk-heading-m" id="info-message">
+    <h2 class="govuk-heading-m" id="replace-course-choice-info">
       <% if @application_form.course_choices_that_need_replacing.count == 1 %>
           One of your choices is not available anymore.
       <% else %>

--- a/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
+++ b/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
@@ -1,0 +1,15 @@
+module CandidateInterface
+  class NewCourseChoiceNeededBannerComponent < ViewComponent::Base
+    include ViewHelper
+
+    validates :application_form, presence: true
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def render?
+      @application_form.course_choices_that_need_replacing.any?
+    end
+  end
+end

--- a/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
+++ b/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
@@ -9,7 +9,9 @@ module CandidateInterface
     end
 
     def render?
-      @application_form.course_choices_that_need_replacing.any? && @application_form.application_choices.first.awaiting_references?
+      FeatureFlag.active?('replace_full_or_withdrawn_application_choices') &&
+        @application_form.course_choices_that_need_replacing.any? &&
+        @application_form.application_choices.first.awaiting_references?
     end
   end
 end

--- a/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
+++ b/app/components/candidate_interface/new_course_choice_needed_banner_component.rb
@@ -9,7 +9,7 @@ module CandidateInterface
     end
 
     def render?
-      @application_form.course_choices_that_need_replacing.any?
+      @application_form.course_choices_that_need_replacing.any? && @application_form.application_choices.first.awaiting_references?
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -175,7 +175,7 @@ private
   end
 
   def withdrawn_course_choices
-    application_choices.map(&:course_option).select(&:course_withdrawn?).map(&:application_choices)
+    application_choices.includes(%i[course_option course]).map(&:course_option).select(&:course_withdrawn?).map(&:application_choices)
   end
 
   def full_course_choices

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -164,9 +164,21 @@ class ApplicationForm < ApplicationRecord
     !can_edit_after_submission? && enough_references_have_been_provided?
   end
 
+  def course_choices_that_need_replacing
+    (withdrawn_course_choices + full_course_choices).flatten.uniq
+  end
+
 private
 
   def enough_references_have_been_provided?
     application_references.feedback_provided.count >= MINIMUM_COMPLETE_REFERENCES
+  end
+
+  def withdrawn_course_choices
+    application_choices.map(&:course_option).select(&:course_withdrawn?).map(&:application_choices)
+  end
+
+  def full_course_choices
+    application_choices.map(&:course_option).select(&:no_vacancies?).map(&:application_choices)
   end
 end

--- a/app/models/course_option.rb
+++ b/app/models/course_option.rb
@@ -41,6 +41,10 @@ class CourseOption < ApplicationRecord
     course.course_options.vacancies.blank?
   end
 
+  def course_withdrawn?
+    course.withdrawn
+  end
+
   def alternative_study_mode
     (course.available_study_modes_from_options - [study_mode]).first
   end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -32,7 +32,7 @@ class FeatureFlag
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
     [:mark_every_section_complete, 'Each section of the application form should have to be explicitly completed', 'David Gisbey'],
-    [:replace_full_or_withdrawn_application_choices, 'Candidates need to be given the option to replace full or withdrawn application choices', 'David Gisbey'],
+    [:replace_full_or_withdrawn_application_choices, 'Allows candidates to replace full or withdrawn application choices post-submission', 'David Gisbey'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -32,6 +32,7 @@ class FeatureFlag
     [:track_validation_errors, 'Captures validation errors triggered by candidates so that they can be reviewed by support staff', 'Steve Hook'],
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
     [:mark_every_section_complete, 'Each section of the application form should have to be explicitly completed', 'David Gisbey'],
+    [:replace_full_or_withdrawn_application_choices, 'Candidates need to be given the option to replace full or withdrawn application choices', 'David Gisbey'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -4,7 +4,7 @@
 <% new_application_choice_needed_component = CandidateInterface::NewCourseChoiceNeededBannerComponent.new(application_form: @application_form) %>
 <% if new_references_needed_component.render? %>
   <%= render new_references_needed_component %>
-<% elsif FeatureFlag.active?('replace_full_or_withdrawn_application_choices') && new_application_choice_needed_component.render? %>
+<% elsif new_application_choice_needed_component.render? %>
   <%= render new_application_choice_needed_component %>
 <% elsif flash.empty? %>
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>

--- a/app/views/candidate_interface/application_form/complete.html.erb
+++ b/app/views/candidate_interface/application_form/complete.html.erb
@@ -1,8 +1,11 @@
 <% content_for :title, t('page_titles.application_dashboard') %>
 
 <% new_references_needed_component = CandidateInterface::NewReferencesNeededComponent.new(application_form: @application_form) %>
+<% new_application_choice_needed_component = CandidateInterface::NewCourseChoiceNeededBannerComponent.new(application_form: @application_form) %>
 <% if new_references_needed_component.render? %>
   <%= render new_references_needed_component %>
+<% elsif FeatureFlag.active?('replace_full_or_withdrawn_application_choices') && new_application_choice_needed_component.render? %>
+  <%= render new_application_choice_needed_component %>
 <% elsif flash.empty? %>
   <%= render CandidateInterface::Covid19DashboardBannerComponent.new(application_form: @application_form) %>
 <% end %>

--- a/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
+++ b/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
@@ -4,13 +4,23 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
   describe '#render?' do
     let(:application_form) { create(:application_form) }
 
-    context 'when a course has been withdrawn' do
+    context 'when a course has been withdrawn and the candidate is awaiting their references' do
       it 'renders the component' do
         course = create(:course, withdrawn: true)
         course_option = create(:course_option, course: course)
-        create(:application_choice, application_form: application_form, course_option: course_option)
+        create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
         expect(described_class.new(application_form: application_form).render?).to be_truthy
+      end
+    end
+
+    context 'when a course has been withdrawn and the candidates application is complete' do
+      it 'does not render the componen' do
+        course = create(:course, withdrawn: true)
+        course_option = create(:course_option, course: course)
+        create(:application_choice, application_form: application_form, course_option: course_option, status: 'application_complete')
+
+        expect(described_class.new(application_form: application_form).render?).to be_falsey
       end
     end
 
@@ -18,7 +28,7 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
       it 'does not render the component' do
         course = create(:course, withdrawn: false)
         course_option = create(:course_option, course: course)
-        create(:application_choice, application_form: application_form, course_option: course_option)
+        create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
         expect(described_class.new(application_form: application_form).render?).to be_falsey
       end
@@ -27,7 +37,7 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
     context 'when a course choice has become full' do
       it 'renders the component' do
         course_option = build(:course_option, vacancy_status: 'no_vacancies')
-        create(:application_choice, application_form: application_form, course_option: course_option)
+        create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
         expect(described_class.new(application_form: application_form).render?).to be_truthy
       end
@@ -36,7 +46,7 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
     context 'when a course choice still has vacancies' do
       it 'does not render the component' do
         course_option = build(:course_option, vacancy_status: 'vacancies')
-        create(:application_choice, application_form: application_form, course_option: course_option)
+        create(:application_choice, application_form: application_form, course_option: course_option, status: 'awaiting_references')
 
         expect(described_class.new(application_form: application_form).render?).to be_falsey
       end

--- a/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
+++ b/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
+  describe '#render?' do
+    let(:application_form) { create(:application_form) }
+
+    context 'when a course has been withdrawn' do
+      it 'renders the component' do
+        course = create(:course, withdrawn: true)
+        course_option = create(:course_option, course: course)
+        create(:application_choice, application_form: application_form, course_option: course_option)
+
+        expect(described_class.new(application_form: application_form).render?).to be_truthy
+      end
+    end
+
+    context 'when a course has not been withdrawn' do
+      it 'does not render the component' do
+        course = create(:course, withdrawn: false)
+        course_option = create(:course_option, course: course)
+        create(:application_choice, application_form: application_form, course_option: course_option)
+
+        expect(described_class.new(application_form: application_form).render?).to be_falsey
+      end
+    end
+
+    context 'when a course choice has become full' do
+      it 'renders the component' do
+        course_option = build(:course_option, vacancy_status: 'no_vacancies')
+        create(:application_choice, application_form: application_form, course_option: course_option)
+
+        expect(described_class.new(application_form: application_form).render?).to be_truthy
+      end
+    end
+
+    context 'when a course choice still has vacancies' do
+      it 'does not render the component' do
+        course_option = build(:course_option, vacancy_status: 'vacancies')
+        create(:application_choice, application_form: application_form, course_option: course_option)
+
+        expect(described_class.new(application_form: application_form).render?).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
+++ b/spec/components/candidate_interface/new_course_choice_needed_banner_component_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe CandidateInterface::NewCourseChoiceNeededBannerComponent do
   describe '#render?' do
     let(:application_form) { create(:application_form) }
 
+    before { FeatureFlag.activate('replace_full_or_withdrawn_application_choices') }
+
     context 'when a course has been withdrawn and the candidate is awaiting their references' do
       it 'renders the component' do
         course = create(:course, withdrawn: true)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -208,4 +208,23 @@ RSpec.describe ApplicationForm do
       end
     end
   end
+
+  describe '#course_choices_that_need_replacing' do
+    it 'returns course_choices whose courses have been withdrawn or course_option has become full' do
+      application_form = create(:application_form)
+      course1 = create(:course, withdrawn: true)
+      course2 = create(:course, withdrawn: false)
+      course3 = create(:course, withdrawn: false)
+
+      course_option1 = create(:course_option, course: course1, vacancy_status: 'no_vacancies')
+      course_option2 = create(:course_option, course: course2, vacancy_status: 'no_vacancies')
+      course_option3 = create(:course_option, course: course3, vacancy_status: 'vacancies')
+
+      application_choice1 = create(:application_choice, application_form: application_form, course_option: course_option1)
+      application_choice2 = create(:application_choice, application_form: application_form, course_option: course_option2)
+      create(:application_choice, application_form: application_form, course_option: course_option3)
+
+      expect(application_form.course_choices_that_need_replacing).to eq [application_choice1, application_choice2]
+    end
+  end
 end

--- a/spec/models/course_option_spec.rb
+++ b/spec/models/course_option_spec.rb
@@ -102,4 +102,24 @@ RSpec.describe CourseOption, type: :model do
       end
     end
   end
+
+  describe '#course_withdrawn?' do
+    context 'when a course options course has been withdrawn' do
+      it 'returns true' do
+        course = create(:course, withdrawn: true)
+        course_option = create(:course_option, course: course)
+
+        expect(course_option.course_withdrawn?).to be true
+      end
+    end
+
+    context 'when a course options course has not been withdrawn' do
+      it 'returns false' do
+        course = create(:course, withdrawn: false)
+        course_option = create(:course_option, course: course)
+
+        expect(course_option.course_withdrawn?).to be false
+      end
+    end
+  end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   end
 
   def given_i_have_two_full_course_choices
-    application_choice = create(:application_choice, application_form: @application)
+    application_choice = create(:application_choice, application_form: @application, status: 'awaiting_references')
     application_choice.course_option.no_vacancies!
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe 'A course option selected by a candidate has become full or been withdrawn' do
+  include CandidateHelper
+  include CourseOptionHelpers
+
+  scenario 'when a candidate arrives at the dashboard they can follow the replace course flow' do
+    given_the_replace_full_or_withdrawn_application_choices_is_active
+    and_i_have_submitted_my_application
+    and_one_of_my_application_choices_has_become_full
+    and_another_course_exists
+
+    when_i_arrive_at_my_application_dashboard
+    then_i_see_that_one_of_my_choices_in_not_available
+
+    given_i_have_two_full_course_choices
+
+    when_i_arrive_at_my_application_dashboard
+    then_i_see_that_multiple_choices_are_not_available
+  end
+
+  def given_the_replace_full_or_withdrawn_application_choices_is_active
+    FeatureFlag.activate('replace_full_or_withdrawn_application_choices')
+  end
+
+  def and_i_have_submitted_my_application
+    candidate_completes_application_form
+    candidate_submits_application
+  end
+
+  def and_one_of_my_application_choices_has_become_full
+    @course_option = @application.application_choices.first.course_option
+    @course_option.no_vacancies!
+  end
+
+  def and_another_course_exists
+    course_option_for_provider_code(provider_code: '1N1')
+  end
+
+  def when_i_arrive_at_my_application_dashboard
+    visit candidate_interface_application_complete_path
+  end
+
+  def then_i_see_that_one_of_my_choices_in_not_available
+    expect(page).to have_content 'One of your choices is not available anymore.'
+  end
+
+  def given_i_have_two_full_course_choices
+    application_choice = create(:application_choice, application_form: @application)
+    application_choice.course_option.no_vacancies!
+  end
+
+  def then_i_see_that_multiple_choices_are_not_available
+    expect(page).to have_content 'Some of your choices are not available anymore.'
+  end
+end


### PR DESCRIPTION
## Context

If a candidates course choice becomes full while they are awaiting their references, they should be able to replace a course choice. 

This PR adds a banner on the application dashboard if the following is true:

1. A course option associated with one of their course choices becomes full
2. A course is withdrawn that is associated with one of their course choices
3. They are currently awaiting references
4. The `replace_full_or_withdrawn_application_choices` is toggled on

## Changes proposed in this pull request

- Add logic into the ApplicationForm and CourseOption models that allows for the return of all course choices that meet the number 1 and 2 criteria above.
- Creates a component for the banner which is slightly different based on the number of course choices that need to be replaced.

One 

![image](https://user-images.githubusercontent.com/42515961/84146113-0ddfce00-aa53-11ea-8928-92caf86aa8f8.png)


Multiple 

![image](https://user-images.githubusercontent.com/42515961/84146422-99595f00-aa53-11ea-93c7-cd787842546e.png)


## Guidance to review

Designs 

https://docs.google.com/document/d/1FwPaGSYzSViXtbB2INHwO7bdxr0fFFUpVs4z978tW9Q/edit

The next PR will the controller and index page for replacing course choices

## Link to Trello card

https://trello.com/c/kUjDNNbH/1646-dev-update-course-choices-if-course-becomes-full-while-waiting-for-references

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
