### PR TITLE
Small follow up content tweaks for chaser emails  

### DIFF
--- a/app/components/candidate_interface/additional_referees_start_component.rb
+++ b/app/components/candidate_interface/additional_referees_start_component.rb
@@ -25,9 +25,9 @@ module CandidateInterface
     def reason_for_replacement(referee)
       case referee.feedback_status
       when 'email_bounced'
-        "Our email requesting a reference didn’t reach #{referee.name}"
+        "Our email requesting a reference did not reach #{referee.name}"
       when 'feedback_refused'
-        "#{referee.name} said they won’t give a reference"
+        "#{referee.name} said they will not give a reference"
       when 'cancelled'
         "We’ve cancelled the reference request for #{referee.name}"
       else

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -52,6 +52,7 @@ class RefereeMailer < ApplicationMailer
   def reference_request_chase_again_email(reference)
     @name = reference.name
     @candidate_name = reference.application_form.full_name
+    @application_form = reference.application_form
     @token = reference.refresh_feedback_token!
 
     notify_email(

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -6,7 +6,7 @@ Dear <%= @application_form.first_name %>,
 # Give details of a new referee
 <% end %>
 
-<%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name) %>
+<%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name, referee_email: @reference.email_address) %>
 
 <% if @reason == :email_bounced %>
 Give a new referee or add <%= @reference.name %>’s details again if they were not correct.

--- a/app/views/candidate_mailer/new_referee_request.text.erb
+++ b/app/views/candidate_mailer/new_referee_request.text.erb
@@ -9,7 +9,7 @@ Dear <%= @application_form.first_name %>,
 <%= t("candidate_mailer.new_referee_request.#{@reason}.explanation", referee_name: @reference.name, referee_email: @reference.email_address) %>
 
 <% if @reason == :email_bounced %>
-Give a new referee or add <%= @reference.name %>’s details again if they were not correct.
+Give a new referee or add <%= @reference.name %>’s details again if they were not correct:
 <% else %>
 Give a new referee:
 <% end %>

--- a/app/views/referee_mailer/reference_request_chase_again_email.html.erb
+++ b/app/views/referee_mailer/reference_request_chase_again_email.html.erb
@@ -10,6 +10,12 @@ Otherwise, give a reference as soon as possible:
 
 <%= referee_interface_reference_relationship_url(token: @token) %>
 
+<%= @candidate_name %> applied to:
+
+<% @application_form.application_choices.each do |application_choice| %>
+* <%= application_choice.course_option.provider.name %> - <%= application_choice.course_option.course.name %>
+<% end %>
+
 # Your data
 
 We’ll only use your data to process the candidate’s application, unless you agree to be contacted by us about your experience of giving a reference. We’ll ask about this before you submit any information.

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -26,9 +26,11 @@ en:
         explanation: |-
           %{referee_name} said they won’t give a reference.
       email_bounced:
-        subject: "Give new referee as soon as possible. Our email didn’t reach %{referee_name}"
+        subject: "Give new referee as soon as possible. Our email did not reach %{referee_name}"
         explanation: |-
-          Our email requesting a reference didn’t reach %{referee_name}.
+          Our email requesting a reference did not reach %{referee_name}.
+
+          We emailed the referee using this address: %{referee_email}
     application_rejected:
       all_rejected:
         subject: "%{provider_name} has responded: next steps"

--- a/spec/components/candidate_interface/additional_referees_start_component_spec.rb
+++ b/spec/components/candidate_interface/additional_referees_start_component_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CandidateInterface::AdditionalRefereesStartComponent do
     it 'gives a reason when email bounced' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-body').text).to include("Our email requesting a reference didn’t reach #{bounced_referee.name}.")
+      expect(result.css('.govuk-body').text).to include("Our email requesting a reference did not reach #{bounced_referee.name}.")
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe CandidateInterface::AdditionalRefereesStartComponent do
     it 'gives a reason why referee refused' do
       result = render_inline(described_class.new(application_form: application_form))
 
-      expect(result.css('.govuk-body').text).to include("#{refused_referee.name} said they won’t give a reference.")
+      expect(result.css('.govuk-body').text).to include("#{refused_referee.name} said they will not give a reference.")
     end
   end
 
@@ -86,8 +86,8 @@ RSpec.describe CandidateInterface::AdditionalRefereesStartComponent do
       result = render_inline(described_class.new(application_form: application_form))
 
       expect(result.css('.govuk-body').text).to include('Your referees have not given us a reference:')
-      expect(result.css('.govuk-body').text).to include("Our email requesting a reference didn’t reach #{first_referee.name}")
-      expect(result.css('.govuk-body').text).to include("#{second_referee.name} said they won’t give a reference")
+      expect(result.css('.govuk-body').text).to include("Our email requesting a reference did not reach #{first_referee.name}")
+      expect(result.css('.govuk-body').text).to include("#{second_referee.name} said they will not give a reference")
       expect(result.css('.govuk-body').text).not_to include(third_referee.name.to_s)
     end
   end

--- a/spec/mailers/candidate_mailer_referee_mails_spec.rb
+++ b/spec/mailers/candidate_mailer_referee_mails_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe CandidateMailer, type: :mailer do
         'a new reference request mail with subject and content', :email_bounced,
         I18n.t!('candidate_mailer.new_referee_request.email_bounced.subject', referee_name: 'Scott Knowles'),
         'heading' => 'Dear Tyrell',
-        'explanation' => 'Our email requesting a reference didn’t reach Scott Knowles.'
+        'explanation' => 'Our email requesting a reference did not reach Scott Knowles.',
+        'referee email' => 'ting@canpaint.com'
       )
     end
   end

--- a/spec/mailers/previews/referee_mailer_preview.rb
+++ b/spec/mailers/previews/referee_mailer_preview.rb
@@ -16,7 +16,7 @@ class RefereeMailerPreview < ActionMailer::Preview
   end
 
   def reference_request_chase_again_email
-    RefereeMailer.reference_request_chase_again_email(reference(application_form))
+    RefereeMailer.reference_request_chase_again_email(reference(application_form_with_application_choice))
   end
 
 private

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -134,8 +134,11 @@ RSpec.describe RefereeMailer, type: :mailer do
         :application_form,
         first_name: 'Elliot',
         last_name: 'Alderson',
+        application_choices: [build_stubbed(:application_choice, course_option: course_option)],
       )
     end
+    let(:course) { build_stubbed(:course) }
+    let(:course_option) { build_stubbed(:course_option, course: course) }
     let(:reference) { build_stubbed(:reference, application_form: application_form) }
     let(:mail) { mailer.reference_request_chase_again_email(reference) }
 
@@ -158,6 +161,10 @@ RSpec.describe RefereeMailer, type: :mailer do
 
     it 'sends an email with a link to the reference form' do
       expect(mail.body.encoded).to include(referee_interface_reference_relationship_url(token: ''))
+    end
+
+    it 'sends an email with the candidates course choice' do
+      expect(mail.body.encoded).to include(course.name)
     end
   end
 end


### PR DESCRIPTION
## Context

 Emma has gone through the previous PRs and asked for a few more tweaks to the emails

This PR adds the referee's email address to the email bounced to referee email.

It also adds the candidate's courses to the final reference chase email.

As well as removing negative contractions from some content.



## Changes proposed in this pull request


Bounced email
Before

![image](https://user-images.githubusercontent.com/42515961/84158881-4936c880-aa64-11ea-96d3-1eef9f989851.png)


After

![image](https://user-images.githubusercontent.com/42515961/84158932-5bb10200-aa64-11ea-9bb9-d0a8b3a87c75.png)


reference final chaser
Before 

![image](https://user-images.githubusercontent.com/42515961/84158841-3b814300-aa64-11ea-8ebe-148d61f41a2d.png)

After 

![image](https://user-images.githubusercontent.com/42515961/84158787-2c01fa00-aa64-11ea-9ed8-97652b9c4e07.png)


## Link to Trello card

https://trello.com/c/8LCXhKhv/1645-dev-design-tweaks-to-make-references-go-faster

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
