### PR TITLE
Rename application_reference to support_reference in the vendor api

### DIFF
--- a/app/presenters/vendor_api/single_application_presenter.rb
+++ b/app/presenters/vendor_api/single_application_presenter.rb
@@ -10,7 +10,7 @@ module VendorAPI
         id: application_choice.id.to_s,
         type: 'application',
         attributes: {
-          application_reference: application_form.support_reference,
+          support_reference: application_form.support_reference,
           status: application_choice.status,
           phase: application_form.phase,
           updated_at: application_choice.updated_at.iso8601,

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -2,7 +2,7 @@
 
 New attributes:
 
-- `ApplicationAttributes` now has an `application_reference` attribute of type string.
+- `ApplicationAttributes` now has an `support_reference` attribute of type string.
 
 ### 20th May 2020
 

--- a/config/vendor-api-v1.yml
+++ b/config/vendor-api-v1.yml
@@ -337,7 +337,7 @@ components:
       type: object
       additionalProperties: false
       required:
-      - application_reference
+      - support_reference
       - candidate
       - phase
       - contact_details
@@ -356,7 +356,7 @@ components:
       - further_information
       - work_experience
       properties:
-        application_reference:
+        support_reference:
           type: string
           description: The candidate's reference number for their application in the Apply system
           maxLength: 10

--- a/spec/system/vendor_api/vendor_receives_application_spec.rb
+++ b/spec/system/vendor_api/vendor_receives_application_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature 'Vendor receives the application' do
       id: @provider.application_choices.first.id.to_s,
       type: 'application',
       attributes: {
-        application_reference: @provider.application_forms.first.support_reference,
+        support_reference: @provider.application_forms.first.support_reference,
         personal_statement: "Why do you want to become a teacher?: I believe I would be a first-rate teacher \n What is your subject knowledge?: Everything",
         interview_preferences: 'Not on a Wednesday',
         offer: nil,


### PR DESCRIPTION
Rename application_reference to support_reference in the vendor api, so it's consistent with the field name, and to avoid confusion with the `ApplicationReference` model.

In response to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2233#discussion_r437395826