### PR TITLE
Refactor course option validation in ChangeOffer and MakeOffer

### DIFF
--- a/app/controllers/provider_interface/decisions_controller.rb
+++ b/app/controllers/provider_interface/decisions_controller.rb
@@ -18,20 +18,26 @@ module ProviderInterface
     end
 
     def new_offer
-      @course_option_id = params[:course_option_id] # from offer_changes/edit_offer
+      course_option = if params[:course_option_id]
+                        CourseOption.find(params[:course_option_id])
+                      else
+                        @application_choice.course_option
+                      end
 
       @application_offer = MakeAnOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
-        course_option_id: @course_option_id,
+        course_option: course_option,
       )
     end
 
     def confirm_offer
+      course_option = CourseOption.find(params[:course_option_id])
+
       @application_offer = MakeAnOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
-        course_option_id: params[:course_option_id],
+        course_option: course_option,
         standard_conditions: make_an_offer_params[:standard_conditions],
         further_conditions: make_an_offer_params.permit(
           :further_conditions0,
@@ -45,11 +51,12 @@ module ProviderInterface
 
     def create_offer
       offer_conditions_array = JSON.parse(params.dig(:offer_conditions))
+      course_option = CourseOption.find(params[:course_option_id])
 
       @application_offer = MakeAnOffer.new(
         actor: current_provider_user,
         application_choice: @application_choice,
-        course_option_id: params[:course_option_id],
+        course_option: course_option,
         offer_conditions: offer_conditions_array,
       )
 

--- a/app/controllers/provider_interface/offer_changes_controller.rb
+++ b/app/controllers/provider_interface/offer_changes_controller.rb
@@ -39,7 +39,7 @@ module ProviderInterface
         ::ChangeOffer.new(
           actor: current_provider_user,
           application_choice: @application_choice,
-          course_option_id: change_offer_form.course_option_id,
+          course_option: change_offer_form.selected_course_option,
         ).save
         redirect_to provider_interface_application_choice_path(@application_choice.id)
       else

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -24,7 +24,7 @@ module VendorAPI
           render_course_not_open and return
         end
       else
-        course_option = nil
+        course_option = application_choice.course_option
       end
 
       service = application_choice.offer? ? ChangeOffer : MakeAnOffer

--- a/app/controllers/vendor_api/decisions_controller.rb
+++ b/app/controllers/vendor_api/decisions_controller.rb
@@ -9,29 +9,24 @@ module VendorAPI
 
       course_data = params.dig(:data, :course)
 
-      if course_data.present?
-        course_option = GetCourseOptionFromCodes.new(
-          provider_code: course_data[:provider_code],
-          course_code: course_data[:course_code],
-          recruitment_cycle_year: course_data[:recruitment_cycle_year],
-          study_mode: course_data[:study_mode],
-          site_code: course_data[:site_code],
-        ).call
-
-        if !course_option
-          render_cannot_find_course_option and return
-        elsif course_option.course_closed_on_apply?
-          render_course_not_open and return
-        end
-      else
-        course_option = application_choice.course_option
-      end
+      course_option = if course_data.present?
+                        GetCourseOptionFromCodes.new(
+                          provider_code: course_data[:provider_code],
+                          course_code: course_data[:course_code],
+                          recruitment_cycle_year: course_data[:recruitment_cycle_year],
+                          study_mode: course_data[:study_mode],
+                          site_code: course_data[:site_code],
+                        ).call
+                      else
+                        application_choice.course_option
+                      end
 
       service = application_choice.offer? ? ChangeOffer : MakeAnOffer
+
       decision = service.new(
         actor: api_user,
         application_choice: application_choice,
-        course_option_id: course_option&.id,
+        course_option: course_option,
         offer_conditions: params.dig(:data, :conditions),
       )
 
@@ -106,28 +101,6 @@ module VendorAPI
     def render_validation_errors(errors)
       error_responses = errors.full_messages.map { |message| { error: 'ValidationError', message: message } }
       render status: :unprocessable_entity, json: { errors: error_responses }
-    end
-
-    def render_cannot_find_course_option
-      render status: :unprocessable_entity, json: {
-        errors: [
-          {
-            error: 'CourseOptionError',
-            message: 'Cannot find an appropriate course option for these codes',
-          },
-        ],
-      }
-    end
-
-    def render_course_not_open
-      render status: :unprocessable_entity, json: {
-        errors: [
-          {
-            error: 'CourseOptionError',
-            message: 'This course is not open for applications via the Apply service',
-          },
-        ],
-      }
     end
   end
 end

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -174,7 +174,12 @@ class TestApplications
   def make_offer(choice, conditions: ['Complete DBS'])
     as_provider_user(choice) do
       fast_forward(1..3)
-      MakeAnOffer.new(actor: actor, application_choice: choice, offer_conditions: conditions).save
+      MakeAnOffer.new(
+        actor: actor,
+        course_option: choice.course_option,
+        application_choice: choice,
+        offer_conditions: conditions,
+      ).save
       choice.update_columns(offered_at: time)
     end
   end

--- a/app/models/provider_interface/change_offer_form.rb
+++ b/app/models/provider_interface/change_offer_form.rb
@@ -89,5 +89,11 @@ module ProviderInterface
     def new_offer?
       application_choice.offer.blank?
     end
+
+    def selected_course_option
+      if course_option_id.present?
+        CourseOption.find(course_option_id)
+      end
+    end
   end
 end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -3,6 +3,7 @@ class ChangeOffer
 
   attr_reader :application_choice, :course_option_id
 
+  validates :course_option_id, presence: true
   validates_each :course_option_id do |record, attr, value|
     record.errors.add(attr, :no_change) if value == record.application_choice.offered_option.id
   end

--- a/app/services/change_offer.rb
+++ b/app/services/change_offer.rb
@@ -28,6 +28,10 @@ class ChangeOffer
       SetDeclineByDefault.new(application_form: @application_choice.application_form).call
       CandidateMailer.changed_offer(@application_choice).deliver_later
       StateChangeNotifier.call(:change_an_offer, application_choice: @application_choice)
+
+      true
+    else
+      false
     end
   end
 end

--- a/app/views/provider_interface/decisions/confirm_offer.html.erb
+++ b/app/views/provider_interface/decisions/confirm_offer.html.erb
@@ -26,11 +26,11 @@
       <%= f.govuk_error_summary %>
 
       <%= render SummaryListComponent.new(rows: [
-        { key: 'Provider', value: @application_choice.offered_option.provider.name_and_code },
-        { key: 'Course', value: @application_choice.offered_course.name_and_code },
-        { key: 'Full time or part time', value: @application_choice.offered_option.study_mode.humanize },
-        { key: 'Location', value: @application_choice.offered_site.name },
-        { key: 'Starting', value: @application_choice.course.recruitment_cycle_year },
+        { key: 'Provider', value: @application_offer.course_option.provider.name_and_code },
+        { key: 'Course', value: @application_offer.course_option.course.name_and_code },
+        { key: 'Full time or part time', value: @application_offer.course_option.study_mode.humanize },
+        { key: 'Location', value: @application_offer.course_option.site.name },
+        { key: 'Starting', value: @application_offer.course_option.course.recruitment_cycle_year },
         { key: 'Conditions', value: conditions },
       ]) %>
 
@@ -41,9 +41,7 @@
         Once the candidate has accepted, you can only change the conditions of this offer with their permission.
       </p>
 
-      <% if @application_offer.offered_course_option.present? %>
-        <%= hidden_field_tag :course_option_id, @application_offer.offered_course_option.id %>
-      <% end %>
+      <%= hidden_field_tag :course_option_id, @application_offer.course_option.id %>
       <%= hidden_field_tag :offer_conditions, @application_offer.offer_conditions.to_json %>
       <%= f.govuk_submit 'Make offer' %>
 

--- a/app/views/provider_interface/decisions/new_offer.html.erb
+++ b/app/views/provider_interface/decisions/new_offer.html.erb
@@ -5,7 +5,7 @@
 
 <%= form_with model: @application_offer, url: provider_interface_application_choice_confirm_offer_path(@application_choice.id), method: :post do |f| %>
   <%= f.govuk_error_summary %>
-  <%= hidden_field_tag :course_option_id, @course_option_id %>
+  <%= hidden_field_tag :course_option_id, @application_offer.course_option.id %>
 
 	<h1 class="govuk-heading-xl">
 		<span class="govuk-caption-xl"><%= @application_choice.application_form.full_name %></span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -136,7 +136,7 @@ en:
         further_conditions2: Third condition
         further_conditions3: Further condition
       change_offer:
-        course_option_id: The new course
+        course_option: The new course
     errors:
       models:
         support_interface/provider_user_form:
@@ -169,7 +169,7 @@ en:
               unsupported: Please specify a valid study mode
               unavailable_for_course: Unavailable for this course
               no_course_options: No relevant course options available
-            course_option_id:
+            course_option:
               blank: You have not chosen a new location
         provider_interface/confirm_conditions_form:
           attributes:
@@ -199,8 +199,10 @@ en:
               blank: Please specify a provider
         change_offer:
           attributes:
-            course_option_id:
+            course_option:
               no_change: is the same as the course currently offered
+              blank: could not be found
+              not_open_on_apply: is not open for applications via the Apply service
         withdraw_offer:
           attributes:
             offer_withdrawal_reason:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,8 @@ en:
         further_conditions1: Second condition
         further_conditions2: Third condition
         further_conditions3: Further condition
+      change_offer:
+        course_option_id: The new course
     errors:
       models:
         support_interface/provider_user_form:
@@ -198,7 +200,7 @@ en:
         change_offer:
           attributes:
             course_option_id:
-              no_change: You are changing the offer to the same course option
+              no_change: is the same as the course currently offered
         withdraw_offer:
           attributes:
             offer_withdrawal_reason:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,8 @@ en:
         further_conditions1: Second condition
         further_conditions2: Third condition
         further_conditions3: Further condition
+      make_an_offer:
+        course_option: The requested course
       change_offer:
         course_option: The new course
     errors:
@@ -201,6 +203,11 @@ en:
           attributes:
             course_option:
               no_change: is the same as the course currently offered
+              blank: could not be found
+              not_open_on_apply: is not open for applications via the Apply service
+        make_an_offer:
+          attributes:
+            course_option:
               blank: could not be found
               not_open_on_apply: is not open for applications via the Apply service
         withdraw_offer:

--- a/spec/requests/provider_interface/audit_trail_spec.rb
+++ b/spec/requests/provider_interface/audit_trail_spec.rb
@@ -1,12 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Provider interface - audit trail', type: :request, with_audited: true do
-  def create_application
-    create(
-      :application_choice,
-      :awaiting_provider_decision,
-    )
-  end
+  include CourseOptionHelpers
 
   def set_provider_permission(application_choice)
     allow(ProviderUser).to receive(:load_from_session)
@@ -21,11 +16,16 @@ RSpec.describe 'Provider interface - audit trail', type: :request, with_audited:
   end
 
   it 'creates audit records attributed to the authenticated provider' do
-    application_choice = create_application
+    application_choice = create(
+      :application_choice,
+      :awaiting_provider_decision,
+    )
     set_provider_permission(application_choice)
+
     expect {
       post provider_interface_application_choice_create_offer_path(
         application_choice_id: application_choice.id,
+        course_option_id: course_option_for_provider(provider: application_choice.provider).id,
       ), params: { offer_conditions: '["must be clever"]' }
     }.to(change { application_choice.audits.count })
 

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -136,15 +136,9 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       }
 
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: request_body
-
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
 
-      original_course_option = application_choice.course_option
-      new_course_option = create(
-        :course_option,
-        course: original_course_option.course,
-        study_mode: original_course_option.study_mode,
-      )
+      new_course_option = course_option_for_provider(provider: currently_authenticated_provider)
 
       request_body = {
         "data": {
@@ -153,13 +147,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
             'Completion of subject knowledge enhancement',
             'Completion of professional skills test',
           ],
-          "course": {
-            recruitment_cycle_year: original_course_option.course.recruitment_cycle_year,
-            provider_code: original_course_option.course.provider.code,
-            course_code: original_course_option.course.code,
-            study_mode: new_course_option.study_mode,
-            site_code: new_course_option.site.code,
-          },
+          "course": course_option_to_course_payload(new_course_option),
         },
       }
 
@@ -171,13 +159,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'Completion of subject knowledge enhancement',
           'Completion of professional skills test',
         ],
-        'course' => {
-          'recruitment_cycle_year' => original_course_option.course.recruitment_cycle_year,
-          'provider_code' => original_course_option.course.provider.code,
-          'course_code' => original_course_option.course.code,
-          'study_mode' => new_course_option.study_mode,
-          'site_code' => new_course_option.site.code,
-        },
+        'course' => course_option_to_course_payload(new_course_option),
       )
     end
 

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'This course is not open for applications via the Apply service'
+      expect(error_response['message']).to match 'The requested course is not open for applications via the Apply service'
     end
 
     it 'returns an error when making an offer on the same course twice' do
@@ -118,7 +118,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'This course is the same as the course currently offered'
+      expect(error_response['message']).to match 'The new course is the same as the course currently offered'
     end
 
     it 'returns an error when specifying a course that does not exist' do
@@ -141,7 +141,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
 
       expect(response).to have_http_status(422)
       expect(parsed_response).to be_valid_against_openapi_schema('UnprocessableEntityResponse')
-      expect(error_response['message']).to match 'Cannot find an appropriate course option for these codes'
+      expect(error_response['message']).to match 'The requested course could not be found'
     end
   end
 

--- a/spec/requests/vendor_api/post_make_an_offer_spec.rb
+++ b/spec/requests/vendor_api/post_make_an_offer_spec.rb
@@ -31,13 +31,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
           'Completion of subject knowledge enhancement',
           'Completion of professional skills test',
         ],
-        'course' => {
-          'recruitment_cycle_year' => course_option.course.recruitment_cycle_year,
-          'provider_code' => course_option.course.provider.code,
-          'course_code' => course_option.course.code,
-          'site_code' => course_option.site.code,
-          'study_mode' => course_option.study_mode,
-        },
+        'course' => course_option_to_course_payload(course_option),
       )
     end
   end
@@ -53,26 +47,14 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
-          'course' => {
-            'recruitment_cycle_year' => other_course_option.course.recruitment_cycle_year,
-            'provider_code' => other_course_option.course.provider.code,
-            'course_code' => other_course_option.course.code,
-            'site_code' => other_course_option.site.code,
-            'study_mode' => other_course_option.study_mode,
-          },
+          'course' => course_option_to_course_payload(other_course_option),
         },
       }
 
       expect(parsed_response).to be_valid_against_openapi_schema('SingleApplicationResponse')
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [],
-        'course' => {
-          'recruitment_cycle_year' => other_course_option.course.recruitment_cycle_year,
-          'provider_code' => other_course_option.course.provider.code,
-          'course_code' => other_course_option.course.code,
-          'site_code' => other_course_option.site.code,
-          'study_mode' => other_course_option.study_mode,
-        },
+        'course' => course_option_to_course_payload(other_course_option),
       )
     end
 
@@ -86,13 +68,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
-          'course' => {
-            'recruitment_cycle_year' => other_course_option.course.recruitment_cycle_year,
-            'provider_code' => other_course_option.course.provider.code,
-            'course_code' => other_course_option.course.code,
-            'site_code' => other_course_option.site.code,
-            'study_mode' => other_course_option.study_mode,
-          },
+          'course' => course_option_to_course_payload(other_course_option),
         },
       }
 
@@ -112,13 +88,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       post_api_request "/api/v1/applications/#{application_choice.id}/offer", params: {
         'data' => {
           'conditions' => [],
-          'course' => {
-            'recruitment_cycle_year' => other_course_option.course.recruitment_cycle_year,
-            'provider_code' => other_course_option.course.provider.code,
-            'course_code' => other_course_option.course.code,
-            'site_code' => other_course_option.site.code,
-            'study_mode' => other_course_option.study_mode,
-          },
+          'course' => course_option_to_course_payload(other_course_option),
         },
       }
 
@@ -240,13 +210,7 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
       expect(parsed_response['data']['attributes']['status']).to eq('offer')
       expect(parsed_response['data']['attributes']['offer']).to eq(
         'conditions' => [],
-        'course' => {
-          'recruitment_cycle_year' => course_option.course.recruitment_cycle_year,
-          'provider_code' => course_option.course.provider.code,
-          'course_code' => course_option.course.code,
-          'site_code' => course_option.site.code,
-          'study_mode' => course_option.study_mode,
-        },
+        'course' => course_option_to_course_payload(course_option),
       )
     end
   end
@@ -293,5 +257,15 @@ RSpec.describe 'Vendor API - POST /api/v1/applications/:application_id/offer', t
     expect(response).to have_http_status(404)
     expect(parsed_response).to be_valid_against_openapi_schema('NotFoundResponse')
     expect(error_response['message']).to eql('Could not find an application with ID non-existent-id')
+  end
+
+  def course_option_to_course_payload(course_option)
+    {
+      'recruitment_cycle_year' => course_option.course.recruitment_cycle_year,
+      'provider_code' => course_option.course.provider.code,
+      'course_code' => course_option.course.code,
+      'site_code' => course_option.site.code,
+      'study_mode' => course_option.study_mode,
+    }
   end
 end


### PR DESCRIPTION
## Context

Sorry this PR is a bit big. It does 4 things:

- Changes the interface of `ChangeOffer` and `MakeAnOffer` to accept `CourseOption` objects
- Pushes all validation of `CourseOptions` down into those objects. Previously the API controller generated errors of its own when the right `CourseOption` couldn't be found. Now the validations are available to all callers and they're unit-tested.
- Adds a validation to make sure we can't make offers on courses that aren't open on Apply, and updates specs that now have that dependency
- Updates all the call sites for those objects to use the new interface, which involves a simplification to `ProviderInterface::DecisionsController` and a couple of other places.

The first four commits fix the bug in the ticket. The rest of the them refactor so the fix isn't so horrible. Probably this should have been done the other way around.

## Guidance to review

Commit by commit. See the tests for the API are shorter, and one is added. See the tests for `ChangeOffer` and `MakeAnOffer` (and the classes themselves) becoming similar.

## Link to Trello card

https://trello.com/c/pvFqo8AX/2219-api-bugs-reported-by-ucb

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
