### PR TITLE
Send email to candidate when course fills while awaiting references

### DIFF
--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -237,9 +237,16 @@ class CandidateMailer < ApplicationMailer
 
   def course_unavailable_notification(application_choice, reason)
     @application_choice = application_choice
+    @application_form = application_choice.application_form
     email_for_candidate(
-      application_choice.application_form,
-      subject: I18n.t!("candidate_mailer.course_unavailable_notification.subject.#{reason}"),
+      @application_form,
+      subject: I18n.t!(
+        "candidate_mailer.course_unavailable_notification.subject.#{reason}",
+        course_name: application_choice.course_option.course.name_and_code,
+        provider_name: application_choice.course_option.course.provider.name,
+        study_mode: application_choice.course_option.study_mode,
+      ),
+      template_name: "course_unavailable_#{reason}",
     )
   end
 

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -235,6 +235,14 @@ class CandidateMailer < ApplicationMailer
     )
   end
 
+  def course_unavailable_notification(application_choice, reason)
+    @application_choice = application_choice
+    email_for_candidate(
+      application_choice.application_form,
+      subject: I18n.t!("candidate_mailer.course_unavailable_notification.subject.#{reason}"),
+    )
+  end
+
 private
 
   def new_offer(application_choice, template_name)

--- a/app/mailers/candidate_mailer.rb
+++ b/app/mailers/candidate_mailer.rb
@@ -244,7 +244,7 @@ class CandidateMailer < ApplicationMailer
         "candidate_mailer.course_unavailable_notification.subject.#{reason}",
         course_name: application_choice.course_option.course.name_and_code,
         provider_name: application_choice.course_option.course.provider.name,
-        study_mode: application_choice.course_option.study_mode,
+        study_mode: application_choice.course_option.study_mode.humanize.downcase,
       ),
       template_name: "course_unavailable_#{reason}",
     )

--- a/app/models/application_choice.rb
+++ b/app/models/application_choice.rb
@@ -50,6 +50,7 @@ class ApplicationChoice < ApplicationRecord
   end
 
   delegate :course_not_available?, to: :course_option
+  delegate :withdrawn?, to: :course, prefix: true
 
   def course_not_available_error
     I18n.t('errors.application_choices.course_not_available', descriptor: course.provider_and_name_code)

--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -7,5 +7,6 @@ class ChaserSent < ApplicationRecord
     follow_up_missing_references: 'follow_up_missing_references',
     provider_decision_request: 'provider_decision_request',
     candidate_decision_request: 'candidate_decision_request',
+    course_unavailable_notification: 'course_unavailable_notification',
   }
 end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -33,6 +33,7 @@ class FeatureFlag
     [:apply_again, 'Enables unsuccessful candidates to reapply, AKA Apply 2', 'Steve Hook'],
     [:mark_every_section_complete, 'Each section of the application form should have to be explicitly completed', 'David Gisbey'],
     [:replace_full_or_withdrawn_application_choices, 'Allows candidates to replace full or withdrawn application choices post-submission', 'David Gisbey'],
+    [:unavailable_course_notifications, 'Candidates with applications waiting for references receive an email notification if their course choice is withdrawn has no vacancies', 'Steve Hook'],
   ].freeze
 
   FEATURES = (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS).map { |name, description, owner|

--- a/app/services/get_application_choices_with_newly_unavailable_courses.rb
+++ b/app/services/get_application_choices_with_newly_unavailable_courses.rb
@@ -1,6 +1,7 @@
 class GetApplicationChoicesWithNewlyUnavailableCourses
   def self.call
     ApplicationChoice
+      .awaiting_references
       .joins(:course_option)
       .where(course_options: { vacancy_status: :no_vacancies })
   end

--- a/app/services/get_application_choices_with_newly_unavailable_courses.rb
+++ b/app/services/get_application_choices_with_newly_unavailable_courses.rb
@@ -1,5 +1,7 @@
 class GetApplicationChoicesWithNewlyUnavailableCourses
   def self.call
-    []
+    ApplicationChoice
+      .joins(:course_option)
+      .where(course_options: { vacancy_status: :no_vacancies })
   end
 end

--- a/app/services/get_application_choices_with_newly_unavailable_courses.rb
+++ b/app/services/get_application_choices_with_newly_unavailable_courses.rb
@@ -1,0 +1,5 @@
+class GetApplicationChoicesWithNewlyUnavailableCourses
+  def self.call
+    []
+  end
+end

--- a/app/services/get_application_choices_with_newly_unavailable_courses.rb
+++ b/app/services/get_application_choices_with_newly_unavailable_courses.rb
@@ -3,6 +3,8 @@ class GetApplicationChoicesWithNewlyUnavailableCourses
     ApplicationChoice
       .awaiting_references
       .joins(:course_option)
+      .joins("LEFT OUTER JOIN chasers_sent ON chasers_sent.chased_id = application_choices.id AND chasers_sent.chased_type = 'ApplicationChoice' AND chasers_sent.chaser_type = 'course_unavailable_notification'")
       .where(course_options: { vacancy_status: :no_vacancies })
+      .where(chasers_sent: { id: nil })
   end
 end

--- a/app/services/reason_course_not_available.rb
+++ b/app/services/reason_course_not_available.rb
@@ -1,0 +1,22 @@
+class ReasonCourseNotAvailable
+  attr_accessor :application_choice
+
+  def initialize(application_choice)
+    self.application_choice = application_choice
+  end
+
+  def call
+    return :course_withdrawn if application_choice.course_withdrawn?
+
+    # all course options for the given course are full
+    return :course_full if application_choice.course_full?
+
+    # all course options for the given course are full at the selected location
+    return :location_full if application_choice.site_full?
+
+    # all part/full-time course options are full for the given course
+    return :study_mode_full if application_choice.study_mode_full?
+
+    raise ArgumentError, 'Course is available'
+  end
+end

--- a/app/views/candidate_mailer/course_unavailable_course_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_course_full.text.erb
@@ -1,2 +1,18 @@
 Dear <%= @application_form.first_name %>,
 
+# Your course is now full
+
+There are no more places for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
+
+The places filled up while we were waiting for your references, so the provider has not got your application.
+
+# Decide what you want to do and let us know as soon as possible
+
+Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
+
+You can:
+- choose a different course (go to https://www.find-postgraduate-teacher-training.service.gov.uk to find a course)
+- remove the course from your application
+- keep the course on your application
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.

--- a/app/views/candidate_mailer/course_unavailable_course_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_course_full.text.erb
@@ -1,0 +1,2 @@
+Dear <%= @application_form.first_name %>,
+

--- a/app/views/candidate_mailer/course_unavailable_course_withdrawn.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_course_withdrawn.text.erb
@@ -1,0 +1,18 @@
+Dear <%= @application_form.first_name %>,
+
+# Your course is not running anymore
+
+<%= @application_choice.course_option.course.provider.name %> is not running <%= @application_choice.course_option.course.name_and_code %> anymore.
+
+The provider removed the course while we were waiting for your references, so they have not got your application.
+
+# Decide what you want to do and let us know as soon as possible
+
+Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
+
+You can:
+- choose a different course (go to https://www.find-postgraduate-teacher-training.service.gov.uk to find a course)
+- remove the course from your application
+- keep the course on your application
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.

--- a/app/views/candidate_mailer/course_unavailable_location_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_location_full.text.erb
@@ -1,0 +1,20 @@
+Dear <%= @application_form.first_name %>,
+
+# There are no more places at your location
+
+There are no more places at <%= @application_choice.course_option.site.name %> for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
+
+The places filled up while we were waiting for your references, so the provider has not got your application.
+
+# Decide what you want to do and let us know as soon as possible
+
+Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
+
+You can:
+
+- choose a different course: https://www.find-postgraduate-teacher-training.service.gov.uk
+- choose a different option for this course: https://www.find-postgraduate-teacher-training.service.gov.uk
+- remove the course from your application
+- keep the course on your application
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.

--- a/app/views/candidate_mailer/course_unavailable_study_mode_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_study_mode_full.text.erb
@@ -1,0 +1,20 @@
+Dear <%= @application_form.first_name %>,
+
+# There are no more <%= @application_choice.course_option.study_mode.humanize.downcase %> places
+
+There are no more <%= @application_choice.course_option.study_mode.humanize.downcase %> places for <%= @application_choice.course_option.course.name_and_code %> at <%= @application_choice.course_option.course.provider.name %>.
+
+The places filled up while we were waiting for your references, so the provider has not got your application.
+
+# Decide what you want to do and let us know as soon as possible
+
+Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
+
+You can:
+
+- choose a different course: https://www.find-postgraduate-teacher-training.service.gov.uk
+- choose a different option for this course: https://www.find-postgraduate-teacher-training.service.gov.uk
+- remove the course from your application
+- keep the course on your application
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -6,6 +6,10 @@ class SendCourseFullNotificationsWorker
 
     GetApplicationChoicesWithNewlyUnavailableCourses.call.each do |application_choice|
       reason = reason_course_is_unavailable(application_choice)
+      ChaserSent.create!(
+        chased: application_choice,
+        chaser_type: :course_unavailable_notification,
+      )
       CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
     end
   end

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -24,6 +24,9 @@ private
     # all course options for the given course are full at the selected location
     return :location_full if application_choice.site_full?
 
+    # all part/full-time course options are full for the given course
+    return :study_mode_full if application_choice.study_mode_full?
+
     # TODO: Handle other reasons...
     # :location_withdrawn # n/a?
     # :study_mode_full # all part/full-time course options are full for the given course

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -18,6 +18,9 @@ private
 
   # TODO: Refactor this logic into a separate class?
   def reason_course_is_unavailable(application_choice)
+    # the course has been withdrawn (removing all course options)
+    return :course_withdrawn if application_choice.course_withdrawn?
+
     # all course options for the given course are full
     return :course_full if application_choice.course_full?
 
@@ -33,6 +36,5 @@ private
     # :study_mode_withdrawn # n/a?
     # :study_mode_location_full # the selected study mode is full at the selected location for the given course but (another study mode is available at the given location)
     # :study_mode_location_withdrawn # n/a?
-    # :course_withdrawn # the course has been withdrawn (removing all course options)
   end
 end

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -2,13 +2,15 @@ class SendCourseFullNotificationsWorker
   include Sidekiq::Worker
 
   def perform
+    return unless FeatureFlag.active?(:unavailable_course_notifications)
+
     GetApplicationChoicesWithNewlyUnavailableCourses.call.each do |application_choice|
       reason = reason_course_is_unavailable(application_choice)
       CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
     end
   end
 
-  private
+private
 
   # TODO: Refactor this logic into a separate class?
   def reason_course_is_unavailable(application_choice)

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -1,0 +1,9 @@
+class SendCourseFullNotificationsWorker
+  include Sidekiq::Worker
+
+  def perform
+    GetApplicationChoicesWithNewlyUnavailableCourses.call.each do |application_choice|
+      CandidateMailer.course_unavailable_notification(application_choice, :course_full).deliver_later
+    end
+  end
+end

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -2,15 +2,33 @@ class SendCourseFullNotificationsWorker
   include Sidekiq::Worker
 
   def perform
-    return unless FeatureFlag.active?(:unavailable_course_notifications)
-
     GetApplicationChoicesWithNewlyUnavailableCourses.call.each do |application_choice|
       reason = ReasonCourseNotAvailable.new(application_choice).call
-      ChaserSent.create!(
-        chased: application_choice,
-        chaser_type: :course_unavailable_notification,
-      )
-      CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
+      if FeatureFlag.active?(:unavailable_course_notifications)
+        ChaserSent.create!(
+          chased: application_choice,
+          chaser_type: :course_unavailable_notification,
+        )
+        CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
+      else
+        send_slack_message(application_choice, reason)
+      end
     end
+  end
+
+private
+
+  def send_slack_message(application_choice, reason)
+    message = I18n.t!(
+      "candidate_mailer.course_unavailable_notification.slack_message.#{reason}",
+      course_name: application_choice.course_option.course.name_and_code,
+      provider_name: application_choice.course_option.course.provider.name,
+      study_mode: application_choice.course_option.study_mode.humanize.downcase,
+      location: application_choice.course_option.site.name,
+      candidate_name: application_choice.application_form.first_name,
+    )
+    url = Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form)
+
+    SlackNotificationWorker.perform_async(message, url)
   end
 end

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -3,7 +3,27 @@ class SendCourseFullNotificationsWorker
 
   def perform
     GetApplicationChoicesWithNewlyUnavailableCourses.call.each do |application_choice|
-      CandidateMailer.course_unavailable_notification(application_choice, :course_full).deliver_later
+      reason = reason_course_is_unavailable(application_choice)
+      CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
     end
+  end
+
+  private
+
+  # TODO: Refactor this logic into a separate class?
+  def reason_course_is_unavailable(application_choice)
+    # all course options for the given course are full
+    return :course_full if application_choice.course_full?
+
+    # all course options for the given course are full at the selected location
+    return :location_full if application_choice.site_full?
+
+    # TODO: Handle other reasons...
+    # :location_withdrawn # n/a?
+    # :study_mode_full # all part/full-time course options are full for the given course
+    # :study_mode_withdrawn # n/a?
+    # :study_mode_location_full # the selected study mode is full at the selected location for the given course but (another study mode is available at the given location)
+    # :study_mode_location_withdrawn # n/a?
+    # :course_withdrawn # the course has been withdrawn (removing all course options)
   end
 end

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -5,36 +5,12 @@ class SendCourseFullNotificationsWorker
     return unless FeatureFlag.active?(:unavailable_course_notifications)
 
     GetApplicationChoicesWithNewlyUnavailableCourses.call.each do |application_choice|
-      reason = reason_course_is_unavailable(application_choice)
+      reason = ReasonCourseNotAvailable.new(application_choice).call
       ChaserSent.create!(
         chased: application_choice,
         chaser_type: :course_unavailable_notification,
       )
       CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
     end
-  end
-
-private
-
-  # TODO: Refactor this logic into a separate class?
-  def reason_course_is_unavailable(application_choice)
-    # the course has been withdrawn (removing all course options)
-    return :course_withdrawn if application_choice.course_withdrawn?
-
-    # all course options for the given course are full
-    return :course_full if application_choice.course_full?
-
-    # all course options for the given course are full at the selected location
-    return :location_full if application_choice.site_full?
-
-    # all part/full-time course options are full for the given course
-    return :study_mode_full if application_choice.study_mode_full?
-
-    # TODO: Handle other reasons...
-    # :location_withdrawn # n/a?
-    # :study_mode_full # all part/full-time course options are full for the given course
-    # :study_mode_withdrawn # n/a?
-    # :study_mode_location_full # the selected study mode is full at the selected location for the given course but (another study mode is available at the given location)
-    # :study_mode_location_withdrawn # n/a?
   end
 end

--- a/config/clock.rb
+++ b/config/clock.rb
@@ -19,4 +19,5 @@ class Clock
 
   every(1.hour, 'SendChaseEmailToProviders', at: '**:35') { SendChaseEmailToProvidersWorker.perform_async }
   every(1.hour, 'SendChaseEmailToCandidates', at: '**:40') { SendChaseEmailToCandidatesWorker.perform_async }
+  every(1.hour, 'SendCourseFullNotifications', at: '**:45') { SendCourseFullNotificationsWorker.perform_async }
 end

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -70,3 +70,8 @@ en:
         study_mode_location_full: "There are no more %{study_mode} places at your choice of location for %{course_name} at %{provider_name}: update your course choice now"
         study_mode_location_withdrawn: "%{provider_name} is not running %{study_mode} places at your choice of location for %{course_name}: update your course choice now"
         course_withdrawn: '%{course_name} at %{provider_name} is not running anymore: update your course choice now'
+      slack_message:
+        course_withdrawn: '%{course_name} at %{provider_name} was withdrawn while %{candidate_name} was awaiting references'
+        course_full: "%{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"
+        location_full: "%{course_name} at %{provider_name} became full at %{location} while %{candidate_name} was awaiting references"
+        study_mode_full: "%{study_mode} places for %{course_name} at %{provider_name} became full while %{candidate_name} was awaiting references"

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -60,3 +60,13 @@ en:
       subject: "%{provider_name} changed the details of your offer"
     apply_again_call_to_action:
       subject: You can still apply for teacher training
+    course_unavailable_notification:
+      subject:
+        course_full: There are no more places for %{course_and_code} at %{provider}: update your course choice now
+        location_full: There are no more places at your choice of location for %{course_and_code} at %{provider}: update your course choice now
+        location_withdrawn: %{provider} is not running %{course_and_code} at %{location} anymore: update your course choice now
+        study_mode_full: There are no more %{study_mode} places for %{course_and_code} at %{provider}: update your course choice now
+        study_mode_withdrawn: %{provider} is not running %{study_mode} places for %{course_and_code} anymore: update your course choice now
+        study_mode_location_full: There are no more %{study_mode} places at your choice of location for %{course_and_code} at %{provider}: update your course choice now
+        study_mode_location_withdrawn: %{provider} is not running %{study_mode} places at your choice of location for %{course_and_code}: update your course choice now
+        course_withdrawn: %{course_and_code} at %{provider} is not running anymore: update your course choice now

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -62,11 +62,11 @@ en:
       subject: You can still apply for teacher training
     course_unavailable_notification:
       subject:
-        course_full: "There are no more places for %{course_and_code} at %{provider}: update your course choice now"
-        location_full: "There are no more places at your choice of location for %{course_and_code} at %{provider}: update your course choice now"
-        location_withdrawn: "%{provider} is not running %{course_and_code} at %{location} anymore: update your course choice now"
-        study_mode_full: "There are no more %{study_mode} places for %{course_and_code} at %{provider}: update your course choice now"
-        study_mode_withdrawn: "%{provider} is not running %{study_mode} places for %{course_and_code} anymore: update your course choice now"
-        study_mode_location_full: "There are no more %{study_mode} places at your choice of location for %{course_and_code} at %{provider}: update your course choice now"
-        study_mode_location_withdrawn: "%{provider} is not running %{study_mode} places at your choice of location for %{course_and_code}: update your course choice now"
-        course_withdrawn: '%{course_and_code} at %{provider} is not running anymore: update your course choice now'
+        course_full: "There are no more places for %{course_name} at %{provider_name}: update your course choice now"
+        location_full: "There are no more places at your choice of location for %{course_name} at %{provider_name}: update your course choice now"
+        location_withdrawn: "%{provider_name} is not running %{course_name} at %{location} anymore: update your course choice now"
+        study_mode_full: "There are no more %{study_mode} places for %{course_name} at %{provider_name}: update your course choice now"
+        study_mode_withdrawn: "%{provider_name} is not running %{study_mode} places for %{course_name} anymore: update your course choice now"
+        study_mode_location_full: "There are no more %{study_mode} places at your choice of location for %{course_name} at %{provider_name}: update your course choice now"
+        study_mode_location_withdrawn: "%{provider_name} is not running %{study_mode} places at your choice of location for %{course_name}: update your course choice now"
+        course_withdrawn: '%{course_name} at %{provider_name} is not running anymore: update your course choice now'

--- a/config/locales/candidate_mailer.yml
+++ b/config/locales/candidate_mailer.yml
@@ -62,11 +62,11 @@ en:
       subject: You can still apply for teacher training
     course_unavailable_notification:
       subject:
-        course_full: There are no more places for %{course_and_code} at %{provider}: update your course choice now
-        location_full: There are no more places at your choice of location for %{course_and_code} at %{provider}: update your course choice now
-        location_withdrawn: %{provider} is not running %{course_and_code} at %{location} anymore: update your course choice now
-        study_mode_full: There are no more %{study_mode} places for %{course_and_code} at %{provider}: update your course choice now
-        study_mode_withdrawn: %{provider} is not running %{study_mode} places for %{course_and_code} anymore: update your course choice now
-        study_mode_location_full: There are no more %{study_mode} places at your choice of location for %{course_and_code} at %{provider}: update your course choice now
-        study_mode_location_withdrawn: %{provider} is not running %{study_mode} places at your choice of location for %{course_and_code}: update your course choice now
-        course_withdrawn: %{course_and_code} at %{provider} is not running anymore: update your course choice now
+        course_full: "There are no more places for %{course_and_code} at %{provider}: update your course choice now"
+        location_full: "There are no more places at your choice of location for %{course_and_code} at %{provider}: update your course choice now"
+        location_withdrawn: "%{provider} is not running %{course_and_code} at %{location} anymore: update your course choice now"
+        study_mode_full: "There are no more %{study_mode} places for %{course_and_code} at %{provider}: update your course choice now"
+        study_mode_withdrawn: "%{provider} is not running %{study_mode} places for %{course_and_code} anymore: update your course choice now"
+        study_mode_location_full: "There are no more %{study_mode} places at your choice of location for %{course_and_code} at %{provider}: update your course choice now"
+        study_mode_location_withdrawn: "%{provider} is not running %{study_mode} places at your choice of location for %{course_and_code}: update your course choice now"
+        course_withdrawn: '%{course_and_code} at %{provider} is not running anymore: update your course choice now'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -343,6 +343,13 @@ FactoryBot.define do
       association :application_form, factory: %i[completed_application_form with_completed_references]
     end
 
+    factory :awaiting_references_application_choice do
+      status { 'awaiting_references' }
+      reject_by_default_at { 40.business_days.from_now }
+      reject_by_default_days { 40 }
+      association :application_form, factory: %i[completed_application_form]
+    end
+
     trait :awaiting_provider_decision do
       association :application_form, factory: %i[completed_application_form with_completed_references]
       status { :awaiting_provider_decision }

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -428,4 +428,39 @@ RSpec.describe CandidateMailer, type: :mailer do
       expect(email).to have_content "We have not had a reference from #{@referee.name} yet."
     end
   end
+
+  describe '#course_unavailable_notification' do
+    context 'when the selected course option has no vacancies and there are no other locations/study modes available' do
+      it 'has the correct subject and content' do
+        application_form = build_stubbed(
+          :application_form,
+          first_name: 'Fred',
+          candidate: @candidate,
+          application_choices: [
+            build_stubbed(
+              :application_choice,
+              status: 'awaiting_references',
+              course_option: build_stubbed(
+                :course_option,
+                vacancy_status: :no_vacancies,
+                course: build_stubbed(
+                  :course,
+                  name: 'Mathematics',
+                  code: 'M101',
+                  provider: build_stubbed(
+                    :provider,
+                    name: 'Bilberry College',
+                  ),
+                ),
+              ),
+            ),
+          ],
+        )
+        email = described_class.course_unavailable_notification(application_form.application_choices.first, :course_full)
+
+        expect(email.subject).to eq 'There are no more places for Mathematics (M101) at Bilberry College: update your course choice now'
+        expect(email.body).to include('Dear Fred,')
+      end
+    end
+  end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -476,6 +476,22 @@ RSpec.describe CandidateMailer, type: :mailer do
       end
     end
 
+    context 'when the selected course has been withdrawn' do
+      it 'has the correct subject and content' do
+        application_form = build_stubbed_application_form
+        application_choice = application_form.application_choices.first
+        email = described_class.course_unavailable_notification(
+          application_choice,
+          :course_withdrawn,
+        )
+
+        expect(email.subject).to eq('Mathematics (M101) at Bilberry College is not running anymore: update your course choice now')
+        expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('Your course is not running anymore')
+        expect(email.body).to include('Bilberry College is not running Mathematics (M101) anymore.')
+      end
+    end
+
     context 'when the selected course option has no vacancies and but there are other locations available' do
       it 'has the correct subject and content' do
         application_form = build_stubbed_application_form

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -467,5 +467,47 @@ RSpec.describe CandidateMailer, type: :mailer do
         expect(email.body).to include('There are no more places for Mathematics (M101) at Bilberry College')
       end
     end
+
+    context 'when the selected course option has no vacancies and but there are other locations available' do
+      it 'has the correct subject and content' do
+        application_form = build_stubbed(
+          :application_form,
+          first_name: 'Fred',
+          candidate: @candidate,
+          application_choices: [
+            build_stubbed(
+              :application_choice,
+              status: 'awaiting_references',
+              course_option: build_stubbed(
+                :course_option,
+                vacancy_status: :no_vacancies,
+                site: build_stubbed(
+                  :site,
+                  name: 'West Wilford School',
+                ),
+                course: build_stubbed(
+                  :course,
+                  name: 'Mathematics',
+                  code: 'M101',
+                  provider: build_stubbed(
+                    :provider,
+                    name: 'Bilberry College',
+                  ),
+                ),
+              ),
+            ),
+          ],
+        )
+        application_choice = application_form.application_choices.first
+        email = described_class.course_unavailable_notification(
+          application_choice,
+          :location_full,
+        )
+
+        expect(email.subject).to eq 'There are no more places at your choice of location for Mathematics (M101) at Bilberry College: update your course choice now'
+        expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('There are no more places at West Wilford School for Mathematics (M101) at Bilberry College')
+      end
+    end
   end
 end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -430,32 +430,40 @@ RSpec.describe CandidateMailer, type: :mailer do
   end
 
   describe '#course_unavailable_notification' do
-    context 'when the selected course option has no vacancies and there are no other locations/study modes available' do
-      it 'has the correct subject and content' do
-        application_form = build_stubbed(
-          :application_form,
-          first_name: 'Fred',
-          candidate: @candidate,
-          application_choices: [
-            build_stubbed(
-              :application_choice,
-              status: 'awaiting_references',
-              course_option: build_stubbed(
-                :course_option,
-                vacancy_status: :no_vacancies,
-                course: build_stubbed(
-                  :course,
-                  name: 'Mathematics',
-                  code: 'M101',
-                  provider: build_stubbed(
-                    :provider,
-                    name: 'Bilberry College',
-                  ),
+    def build_stubbed_application_form
+      build_stubbed(
+        :application_form,
+        first_name: 'Fred',
+        candidate: @candidate,
+        application_choices: [
+          build_stubbed(
+            :application_choice,
+            status: 'awaiting_references',
+            course_option: build_stubbed(
+              :course_option,
+              vacancy_status: :no_vacancies,
+              site: build_stubbed(
+                :site,
+                name: 'West Wilford School',
+              ),
+              course: build_stubbed(
+                :course,
+                name: 'Mathematics',
+                code: 'M101',
+                provider: build_stubbed(
+                  :provider,
+                  name: 'Bilberry College',
                 ),
               ),
             ),
-          ],
-        )
+          ),
+        ],
+      )
+    end
+
+    context 'when the selected course option has no vacancies and there are no other locations/study modes available' do
+      it 'has the correct subject and content' do
+        application_form = build_stubbed_application_form
         application_choice = application_form.application_choices.first
         email = described_class.course_unavailable_notification(
           application_choice,
@@ -470,34 +478,7 @@ RSpec.describe CandidateMailer, type: :mailer do
 
     context 'when the selected course option has no vacancies and but there are other locations available' do
       it 'has the correct subject and content' do
-        application_form = build_stubbed(
-          :application_form,
-          first_name: 'Fred',
-          candidate: @candidate,
-          application_choices: [
-            build_stubbed(
-              :application_choice,
-              status: 'awaiting_references',
-              course_option: build_stubbed(
-                :course_option,
-                vacancy_status: :no_vacancies,
-                site: build_stubbed(
-                  :site,
-                  name: 'West Wilford School',
-                ),
-                course: build_stubbed(
-                  :course,
-                  name: 'Mathematics',
-                  code: 'M101',
-                  provider: build_stubbed(
-                    :provider,
-                    name: 'Bilberry College',
-                  ),
-                ),
-              ),
-            ),
-          ],
-        )
+        application_form = build_stubbed_application_form
         application_choice = application_form.application_choices.first
         email = described_class.course_unavailable_notification(
           application_choice,
@@ -507,6 +488,21 @@ RSpec.describe CandidateMailer, type: :mailer do
         expect(email.subject).to eq 'There are no more places at your choice of location for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')
         expect(email.body).to include('There are no more places at West Wilford School for Mathematics (M101) at Bilberry College')
+      end
+    end
+
+    context 'when the selected course option has no vacancies and but there are other study modes available at the same location' do
+      it 'has the correct subject and content' do
+        application_form = build_stubbed_application_form
+        application_choice = application_form.application_choices.first
+        email = described_class.course_unavailable_notification(
+          application_choice,
+          :study_mode_full,
+        )
+
+        expect(email.subject).to eq 'There are no more full time places for Mathematics (M101) at Bilberry College: update your course choice now'
+        expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('There are no more full time places for Mathematics (M101) at Bilberry College')
       end
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -456,13 +456,15 @@ RSpec.describe CandidateMailer, type: :mailer do
             ),
           ],
         )
+        application_choice = application_form.application_choices.first
         email = described_class.course_unavailable_notification(
-          application_form.application_choices.first,
+          application_choice,
           :course_full,
         )
 
         expect(email.subject).to eq 'There are no more places for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('There are no more places for Mathematics (M101) at Bilberry College')
       end
     end
   end

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -456,7 +456,10 @@ RSpec.describe CandidateMailer, type: :mailer do
             ),
           ],
         )
-        email = described_class.course_unavailable_notification(application_form.application_choices.first, :course_full)
+        email = described_class.course_unavailable_notification(
+          application_form.application_choices.first,
+          :course_full,
+        )
 
         expect(email.subject).to eq 'There are no more places for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -283,27 +283,35 @@ class CandidateMailerPreview < ActionMailer::Preview
   end
 
   def course_unavailable_notification_course_full
-    application_choice = ApplicationChoice.awaiting_references.first
-
-    CandidateMailer.course_unavailable_notification(application_choice, :course_full)
+    application_form = application_form_with_course_choices([application_choice_awaiting_references])
+    CandidateMailer.course_unavailable_notification(
+      application_form.application_choices.first,
+      :course_full,
+    )
   end
 
   def course_unavailable_notification_course_withdrawn
-    application_choice = ApplicationChoice.awaiting_references.first
-
-    CandidateMailer.course_unavailable_notification(application_choice, :course_withdrawn)
+    application_form = application_form_with_course_choices([application_choice_awaiting_references])
+    CandidateMailer.course_unavailable_notification(
+      application_form.application_choices.first,
+      :course_withdrawn,
+    )
   end
 
   def course_unavailable_notification_location_full
-    application_choice = ApplicationChoice.awaiting_references.first
-
-    CandidateMailer.course_unavailable_notification(application_choice, :location_full)
+    application_form = application_form_with_course_choices([application_choice_awaiting_references])
+    CandidateMailer.course_unavailable_notification(
+      application_form.application_choices.first,
+      :location_full,
+    )
   end
 
   def course_unavailable_notification_study_mode_full
-    application_choice = ApplicationChoice.awaiting_references.first
-
-    CandidateMailer.course_unavailable_notification(application_choice, :study_mode_full)
+    application_form = application_form_with_course_choices([application_choice_awaiting_references])
+    CandidateMailer.course_unavailable_notification(
+      application_form.application_choices.first,
+      :study_mode_full,
+    )
   end
 
 private
@@ -358,5 +366,29 @@ private
     FactoryBot.build_stubbed(:application_choice, :with_offer,
                              course_option: course_option,
                              decline_by_default_at: Time.zone.now)
+  end
+
+  def application_choice_awaiting_references
+    FactoryBot.build_stubbed(
+      :application_choice,
+      status: 'awaiting_references',
+      course_option: FactoryBot.build_stubbed(
+        :course_option,
+        vacancy_status: :no_vacancies,
+        site: FactoryBot.build_stubbed(
+          :site,
+          name: 'West Wilford School',
+        ),
+        course: FactoryBot.build_stubbed(
+          :course,
+          name: 'Mathematics',
+          code: 'M101',
+          provider: FactoryBot.build_stubbed(
+            :provider,
+            name: 'Bilberry College',
+          ),
+        ),
+      ),
+    )
   end
 end

--- a/spec/mailers/previews/candidate_mailer_preview.rb
+++ b/spec/mailers/previews/candidate_mailer_preview.rb
@@ -282,6 +282,30 @@ class CandidateMailerPreview < ActionMailer::Preview
     CandidateMailer.apply_again_call_to_action(application_form)
   end
 
+  def course_unavailable_notification_course_full
+    application_choice = ApplicationChoice.awaiting_references.first
+
+    CandidateMailer.course_unavailable_notification(application_choice, :course_full)
+  end
+
+  def course_unavailable_notification_course_withdrawn
+    application_choice = ApplicationChoice.awaiting_references.first
+
+    CandidateMailer.course_unavailable_notification(application_choice, :course_withdrawn)
+  end
+
+  def course_unavailable_notification_location_full
+    application_choice = ApplicationChoice.awaiting_references.first
+
+    CandidateMailer.course_unavailable_notification(application_choice, :location_full)
+  end
+
+  def course_unavailable_notification_study_mode_full
+    application_choice = ApplicationChoice.awaiting_references.first
+
+    CandidateMailer.course_unavailable_notification(application_choice, :study_mode_full)
+  end
+
 private
 
   def candidate

--- a/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
+++ b/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
@@ -17,11 +17,13 @@ RSpec.describe GetApplicationChoicesWithNewlyUnavailableCourses do
   end
 
   it 'does not return application choices that have already received the notification email' do
-    pending 'need to merge with migration to add the `course_unavailable_notification_sent_at` column'
-    create(
+    application_choice = create(
       :awaiting_references_application_choice,
       course_option: create(:course_option, :no_vacancies),
-      course_unavailable_notification_sent_at: 1.day.ago,
+    )
+    ChaserSent.create!(
+      chased: application_choice,
+      chaser_type: :course_unavailable_notification,
     )
     expect(described_class.call.map(&:id)).to eq([])
   end

--- a/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
+++ b/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe GetApplicationChoicesWithNewlyUnavailableCourses do
+  include CourseOptionHelpers
+
+  it 'returns an application choice for a course that has no vacancies' do
+    application_choice_without_vacancies = create(
+      :awaiting_references_application_choice,
+      course_option: create(:course_option, :no_vacancies),
+    )
+    create :awaiting_references_application_choice
+    expect(described_class.call.map(&:id)).to eq([application_choice_without_vacancies.id])
+  end
+end

--- a/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
+++ b/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
@@ -3,9 +3,13 @@ require 'rails_helper'
 RSpec.describe GetApplicationChoicesWithNewlyUnavailableCourses do
   include CourseOptionHelpers
 
-  it 'returns an application choice for a course that has no vacancies' do
+  it 'only returns awaiting references application choices with a course that has no vacancies' do
     application_choice_without_vacancies = create(
       :awaiting_references_application_choice,
+      course_option: create(:course_option, :no_vacancies),
+    )
+    create(
+      :submitted_application_choice,
       course_option: create(:course_option, :no_vacancies),
     )
     create :awaiting_references_application_choice

--- a/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
+++ b/spec/services/get_application_choices_with_newly_unavailable_courses_spec.rb
@@ -15,4 +15,14 @@ RSpec.describe GetApplicationChoicesWithNewlyUnavailableCourses do
     create :awaiting_references_application_choice
     expect(described_class.call.map(&:id)).to eq([application_choice_without_vacancies.id])
   end
+
+  it 'does not return application choices that have already received the notification email' do
+    pending 'need to merge with migration to add the `course_unavailable_notification_sent_at` column'
+    create(
+      :awaiting_references_application_choice,
+      course_option: create(:course_option, :no_vacancies),
+      course_unavailable_notification_sent_at: 1.day.ago,
+    )
+    expect(described_class.call.map(&:id)).to eq([])
+  end
 end

--- a/spec/system/support_interface/docs_spec.rb
+++ b/spec/system/support_interface/docs_spec.rb
@@ -35,6 +35,7 @@ RSpec.feature 'Docs' do
       referee_mailer-reference_cancelled_email
       provider_mailer-fallback_sign_in_email
       candidate_mailer-apply_again_call_to_action
+      candidate_mailer-course_unavailable_notification
     ]
 
     # extract all the emails that we send into a list of strings like "referee_mailer-reference_request_chaser_email"

--- a/spec/workers/send_course_full_notifications_worker_spec.rb
+++ b/spec/workers/send_course_full_notifications_worker_spec.rb
@@ -3,14 +3,19 @@ require 'rails_helper'
 RSpec.describe SendCourseFullNotificationsWorker do
   describe '#perform', sidekiq: true do
     context 'with feature flag inactive' do
-      it 'sends no emails' do
+      it 'sends a Slack notification but no email' do
         application_choice = create :application_choice
         application_choice.course_option.update(vacancy_status: :no_vacancies)
+        allow(SlackNotificationWorker).to receive(:perform_async)
         allow(CandidateMailer).to receive(:course_unavailable_notification)
         allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
         SendCourseFullNotificationsWorker.new.perform
         expect(CandidateMailer).not_to have_received(:course_unavailable_notification)
         expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).not_to be_present
+        expect(SlackNotificationWorker).to have_received(:perform_async).with(
+          "#{application_choice.course.name_and_code} at #{application_choice.course.provider.name} became full while #{application_choice.application_form.first_name} was awaiting references",
+          Rails.application.routes.url_helpers.support_interface_application_form_url(application_choice.application_form),
+        )
       end
     end
 

--- a/spec/workers/send_course_full_notifications_worker_spec.rb
+++ b/spec/workers/send_course_full_notifications_worker_spec.rb
@@ -39,6 +39,17 @@ RSpec.describe SendCourseFullNotificationsWorker do
         expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :location_full).at_least(:once)
         expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
       end
+
+      it 'sends emails to candidates that applied to a course that is now full for the selected study mode' do
+        application_choice = create :application_choice
+        application_choice.course_option.update(vacancy_status: :no_vacancies, study_mode: :full_time)
+        create :course_option, course: application_choice.course, site: application_choice.course_option.site, study_mode: :part_time
+        allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+        SendCourseFullNotificationsWorker.new.perform
+        expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :study_mode_full).at_least(:once)
+        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
+      end
     end
   end
 end

--- a/spec/workers/send_course_full_notifications_worker_spec.rb
+++ b/spec/workers/send_course_full_notifications_worker_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe SendCourseFullNotificationsWorker do
+  describe '#perform', sidekiq: true do
+    it 'sends emails to candidates that applied to a course that is now full' do
+      application_choice = build :application_choice
+      allow(CandidateMailer).to receive(:course_unavailable_notification).and_return(double(deliver_later: true))
+      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+      SendCourseFullNotificationsWorker.new.perform
+      expect(CandidateMailer).to have_received(:course_unavailable_notification)
+    end
+  end
+end

--- a/spec/workers/send_course_full_notifications_worker_spec.rb
+++ b/spec/workers/send_course_full_notifications_worker_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe SendCourseFullNotificationsWorker do
         allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
         SendCourseFullNotificationsWorker.new.perform
         expect(CandidateMailer).not_to have_received(:course_unavailable_notification)
+        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).not_to be_present
       end
     end
 
@@ -25,6 +26,7 @@ RSpec.describe SendCourseFullNotificationsWorker do
         allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
         SendCourseFullNotificationsWorker.new.perform
         expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_full).at_least(:once)
+        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
       end
 
       it 'sends emails to candidates that applied to a course that is now full at the selected location' do
@@ -35,6 +37,7 @@ RSpec.describe SendCourseFullNotificationsWorker do
         allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
         SendCourseFullNotificationsWorker.new.perform
         expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :location_full).at_least(:once)
+        expect(ChaserSent.where(chased: application_choice, chaser_type: :course_unavailable_notification)).to be_present
       end
     end
   end

--- a/spec/workers/send_course_full_notifications_worker_spec.rb
+++ b/spec/workers/send_course_full_notifications_worker_spec.rb
@@ -2,24 +2,40 @@ require 'rails_helper'
 
 RSpec.describe SendCourseFullNotificationsWorker do
   describe '#perform', sidekiq: true do
-    it 'sends emails to candidates that applied to a course that is now full' do
-      application_choice = create :application_choice
-      application_choice.course_option.update(vacancy_status: :no_vacancies)
-      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
-      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-      SendCourseFullNotificationsWorker.new.perform
-      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_full).at_least(:once)
+    context 'with feature flag inactive' do
+      it 'sends no emails' do
+        application_choice = create :application_choice
+        application_choice.course_option.update(vacancy_status: :no_vacancies)
+        allow(CandidateMailer).to receive(:course_unavailable_notification)
+        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+        SendCourseFullNotificationsWorker.new.perform
+        expect(CandidateMailer).not_to have_received(:course_unavailable_notification)
+      end
     end
 
-    it 'sends emails to candidates that applied to a course that is now full at the selected location' do
-      pending 'need to implement the course_full template'
-      application_choice = create :application_choice
-      application_choice.course_option.update(vacancy_status: :no_vacancies)
-      create :course_option, course: application_choice.course
-      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
-      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
-      SendCourseFullNotificationsWorker.new.perform
-      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :location_full).at_least(:once)
+    context 'with feature flag active' do
+      before do
+        FeatureFlag.activate(:unavailable_course_notifications)
+      end
+
+      it 'sends emails to candidates that applied to a course that is now full' do
+        application_choice = create :application_choice
+        application_choice.course_option.update(vacancy_status: :no_vacancies)
+        allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+        SendCourseFullNotificationsWorker.new.perform
+        expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_full).at_least(:once)
+      end
+
+      it 'sends emails to candidates that applied to a course that is now full at the selected location' do
+        application_choice = create :application_choice
+        application_choice.course_option.update(vacancy_status: :no_vacancies)
+        create :course_option, course: application_choice.course
+        allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+        allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+        SendCourseFullNotificationsWorker.new.perform
+        expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :location_full).at_least(:once)
+      end
     end
   end
 end

--- a/spec/workers/send_course_full_notifications_worker_spec.rb
+++ b/spec/workers/send_course_full_notifications_worker_spec.rb
@@ -3,11 +3,23 @@ require 'rails_helper'
 RSpec.describe SendCourseFullNotificationsWorker do
   describe '#perform', sidekiq: true do
     it 'sends emails to candidates that applied to a course that is now full' do
-      application_choice = build :application_choice
-      allow(CandidateMailer).to receive(:course_unavailable_notification).and_return(double(deliver_later: true))
+      application_choice = create :application_choice
+      application_choice.course_option.update(vacancy_status: :no_vacancies)
+      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
       allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
       SendCourseFullNotificationsWorker.new.perform
-      expect(CandidateMailer).to have_received(:course_unavailable_notification)
+      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :course_full).at_least(:once)
+    end
+
+    it 'sends emails to candidates that applied to a course that is now full at the selected location' do
+      pending 'need to implement the course_full template'
+      application_choice = create :application_choice
+      application_choice.course_option.update(vacancy_status: :no_vacancies)
+      create :course_option, course: application_choice.course
+      allow(CandidateMailer).to receive(:course_unavailable_notification).and_call_original
+      allow(GetApplicationChoicesWithNewlyUnavailableCourses).to receive(:call).and_return([application_choice])
+      SendCourseFullNotificationsWorker.new.perform
+      expect(CandidateMailer).to have_received(:course_unavailable_notification).with(application_choice, :location_full).at_least(:once)
     end
   end
 end


### PR DESCRIPTION
## Context

Candidates should be notified when courses become full while they are waiting for references.

## Changes proposed in this pull request

- [x] Feature flag `unavailable_course_notifications` - the worker still runs without this flag being set but posts a message to slack rather than sending the email.
- [X] New `CandidateMailer#course_unavailable_notification` method
- [X] New `SendCourseFullNotificationsWorker` worker to poll database for application choices that are awaiting references and have become full, and invoke mailer
- [x] Configure clock to call new worker
- [x] Mail previews
- [x] Use `ChaserSent` to record whether an email has already been sent for a particular application choice.
- [x] Refactor to extract the logic for determining the 'reason' for a course being unavailable into something new.

There are several distinct reasons for a course being unavailable:
- [X] Course full
- [X] Location full (but other locations for the same course available)
- [X] Study mode full (but other study modes available for the same course/location)
- [x] Course withdrawn

## Guidance to review

- Do the reasons make sense?
- Are the tests adequate?

## Link to Trello card

https://trello.com/c/qX7OyNDH/1647-dev-notification-emails-when-a-course-becomes-full-while-waiting-for-references

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
