### PR TITLE
Allow candidate to select a course choice to replace

### DIFF
--- a/app/components/candidate_interface/new_course_choice_needed_banner_component.html.erb
+++ b/app/components/candidate_interface/new_course_choice_needed_banner_component.html.erb
@@ -7,7 +7,7 @@
         Some of your choices are not available anymore.
       <% end %>
       <br>
-    <%= govuk_link_to 'Update your course choice now', '#' %>.
+    <%= govuk_link_to 'Update your course choice now', candidate_interface_replace_course_choices_path %>.
     </h2>
   </div>
 </div>

--- a/app/controllers/candidate_interface/course_choices/replace_choice_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choice_controller.rb
@@ -28,7 +28,7 @@ module CandidateInterface
         end
       end
 
-      def show; end
+      def choose_option; end
 
     private
 

--- a/app/controllers/candidate_interface/course_choices/replace_choice_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choice_controller.rb
@@ -1,0 +1,48 @@
+module CandidateInterface
+  module CourseChoices
+    class ReplaceChoiceController < BaseController
+      skip_before_action :redirect_to_dashboard_if_submitted
+      before_action :render_404_if_flag_is_inactive
+
+      def pick_choice_to_replace
+        if only_one_course_choice_needs_replacing?
+          redirect_to candidate_interface_replace_course_choice_path(
+            current_application.course_choices_that_need_replacing.first.id,
+          ) and return
+        end
+
+        @pick_choice_to_replace = PickChoiceToReplaceForm.new
+        @choices = current_application.course_choices_that_need_replacing
+      end
+
+      def picked_choice
+        @pick_choice_to_replace = PickChoiceToReplaceForm.new(pick_choice_to_replace_params)
+
+        if @pick_choice_to_replace.valid?
+          redirect_to candidate_interface_replace_course_choice_path(@pick_choice_to_replace.id)
+        else
+          @pick_choice_to_replace = PickChoiceToReplaceForm.new
+          @choices = current_application.course_choices_that_need_replacing
+
+          render :select_choice
+        end
+      end
+
+      def show; end
+
+    private
+
+      def render_404_if_flag_is_inactive
+        render_404 and return unless FeatureFlag.active?('replace_full_or_withdrawn_application_choices')
+      end
+
+      def only_one_course_choice_needs_replacing?
+        current_application.course_choices_that_need_replacing.any? && current_application.course_choices_that_need_replacing.count == 1
+      end
+
+      def pick_choice_to_replace_params
+        params.require(:candidate_interface_pick_choice_to_replace_form).permit(:id)
+      end
+    end
+  end
+end

--- a/app/controllers/candidate_interface/course_choices/replace_choice_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choice_controller.rb
@@ -23,8 +23,9 @@ module CandidateInterface
         else
           @pick_choice_to_replace = PickChoiceToReplaceForm.new
           @choices = current_application.course_choices_that_need_replacing
+          flash[:warning] = 'Please select a course choice to update.'
 
-          render :select_choice
+          render :pick_choice_to_replace
         end
       end
 
@@ -41,6 +42,8 @@ module CandidateInterface
       end
 
       def pick_choice_to_replace_params
+        return nil unless params.key?(:candidate_interface_pick_choice_to_replace_form)
+
         params.require(:candidate_interface_pick_choice_to_replace_form).permit(:id)
       end
     end

--- a/app/models/candidate_interface/pick_choice_to_replace_form.rb
+++ b/app/models/candidate_interface/pick_choice_to_replace_form.rb
@@ -1,0 +1,9 @@
+module CandidateInterface
+  class PickChoiceToReplaceForm
+    include ActiveModel::Model
+
+    attr_accessor :id
+
+    validates :id, presence: true
+  end
+end

--- a/app/views/candidate_interface/course_choices/replace_choice/choose_option.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choice/choose_option.html.erb
@@ -1,0 +1,1 @@
+Primary

--- a/app/views/candidate_interface/course_choices/replace_choice/pick_choice_to_replace.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choice/pick_choice_to_replace.html.erb
@@ -1,0 +1,21 @@
+<% content_for :title, t('page_titles.pick_choice_to_replace') %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_application_complete_path) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @pick_choice_to_replace, url: candidate_interface_replace_course_choices_path, method: :post do |f| %>
+
+    <h1 class="govuk-heading-xl">
+      <%= t('page_titles.pick_choice_to_replace') %>
+    </h1>
+
+    <%= f.govuk_radio_buttons_fieldset :replacement_decision, legend: { text: 'Which course choice do you want to update first?' } do %>
+      <% @choices.each do |choice| %>
+        <%= f.govuk_radio_button :id, choice.id, label: { text: "#{choice.provider.name } – #{choice.course.name_and_code}" } %>
+      <% end %>
+    <% end %>
+
+    <%= f.govuk_submit 'Continue' %>
+  <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,6 +116,7 @@ en:
       confirm: Confirm offer
     covid_19_guidance: "Coronavirus (COVID-19): deadlines for processing applications extended to 31 May 2020"
     start_apply_again: Do you want to apply again?
+    pick_choice_to_replace: Some of your choices are not available anymore
   layout:
     accessibility: Accessibility
     terms_of_use: Terms of use

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,7 +202,7 @@ Rails.application.routes.draw do
 
         get '/replace' => 'course_choices/replace_choice#pick_choice_to_replace', as: :replace_course_choices
         post '/replace' => 'course_choices/replace_choice#picked_choice'
-        get '/replace/:id' => 'course_choices/replace_choice#show', as: :replace_course_choice
+        get '/replace/:id' => 'course_choices/replace_choice#choose_option', as: :replace_course_choice
 
         get '/provider' => 'course_choices/provider_selection#new', as: :course_choices_provider
         post '/provider' => 'course_choices/provider_selection#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -200,6 +200,10 @@ Rails.application.routes.draw do
         get '/find-a-course' => 'course_choices/have_you_chosen#go_to_find', as: :go_to_find
         get '/find_a_course', to: redirect('/candidate/application/courses/find-a-course')
 
+        get '/replace' => 'course_choices/replace_choice#pick_choice_to_replace', as: :replace_course_choices
+        post '/replace' => 'course_choices/replace_choice#picked_choice'
+        get '/replace/:id' => 'course_choices/replace_choice#show', as: :replace_course_choice
+
         get '/provider' => 'course_choices/provider_selection#new', as: :course_choices_provider
         post '/provider' => 'course_choices/provider_selection#create'
         get '/provider/:provider_id/courses' => 'course_choices/course_selection#new', as: :course_choices_course

--- a/spec/models/candidate_interface/pick_choice_to_replace_form_spec.rb
+++ b/spec/models/candidate_interface/pick_choice_to_replace_form_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CandidateInterface::PickChoiceToReplaceForm, type: :model do
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:id) }
+  end
+end

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     and_i_see_my_first_course_choice
     and_i_see_my_second_course_choice
 
+    when_i_click_continue_without_selecting_an_option
+    then_i_am_told_i_need_to_select_a_course_choice
+
     when_i_choose_my_first_course_choice
     and_click_continue
     then_i_arrive_at_the_replace_course_choice_page
@@ -80,12 +83,20 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     expect(page).to have_content(@application_choice.course.name)
   end
 
+  def when_i_click_continue_without_selecting_an_option
+    click_button 'Continue'
+  end
+
+  def then_i_am_told_i_need_to_select_a_course_choice
+    expect(page).to have_content 'Please select a course choice to update.'
+  end
+
   def when_i_choose_my_first_course_choice
     choose "#{@course_option.provider.name} – #{@course_option.course.name_and_code}"
   end
 
   def and_click_continue
-    click_button 'Continue'
+    when_i_click_continue_without_selecting_an_option
   end
 
   def then_i_arrive_at_the_replace_course_choice_page

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -89,6 +89,6 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   end
 
   def then_i_arrive_at_the_replace_course_choice_page
-    expect(page).to have_current_path candidate_interface_replace_course_choice_path(@course_option.application_choice.id)
+    expect(page).to have_current_path candidate_interface_replace_course_choice_path(@course_option.application_choices.first.id)
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
 
     when_i_arrive_at_my_application_dashboard
     then_i_see_that_multiple_choices_are_not_available
+
+    when_i_click_update_my_course_choice
+    then_i_see_the_replace_course_choices_page
+    and_i_see_my_first_course_choice
+    and_i_see_my_second_course_choice
+
+    when_i_choose_my_first_course_choice
+    and_click_continue
+    then_i_arrive_at_the_replace_course_choice_page
+    and_i_see_my_first_course_choice
   end
 
   def given_the_replace_full_or_withdrawn_application_choices_is_active
@@ -34,7 +44,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   end
 
   def and_another_course_exists
-    course_option_for_provider_code(provider_code: '1N1')
+    course_option_for_provider(provider: @course_option.provider)
   end
 
   def when_i_arrive_at_my_application_dashboard
@@ -46,11 +56,39 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
   end
 
   def given_i_have_two_full_course_choices
-    application_choice = create(:application_choice, application_form: @application, status: 'awaiting_references')
-    application_choice.course_option.no_vacancies!
+    @application_choice = create(:application_choice, application_form: @application, status: 'awaiting_references')
+    @application_choice.course_option.no_vacancies!
   end
 
   def then_i_see_that_multiple_choices_are_not_available
     expect(page).to have_content 'Some of your choices are not available anymore.'
+  end
+
+  def when_i_click_update_my_course_choice
+    click_link 'Update your course choice now'
+  end
+
+  def then_i_see_the_replace_course_choices_page
+    expect(page).to have_current_path candidate_interface_replace_course_choices_path
+  end
+
+  def and_i_see_my_first_course_choice
+    expect(page).to have_content(@course_option.course.name)
+  end
+
+  def and_i_see_my_second_course_choice
+    expect(page).to have_content(@application_choice.course.name)
+  end
+
+  def when_i_choose_my_first_course_choice
+    choose "#{@course_option.provider.name} – #{@course_option.course.name_and_code}"
+  end
+
+  def and_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_arrive_at_the_replace_course_choice_page
+    expect(page).to have_current_path candidate_interface_replace_course_choice_path(@course_option.application_choice.id)
   end
 end


### PR DESCRIPTION
## Context

If a user has more than 1 course choice that has become full or withdrawn, when they click on the update course choice banner, they should be able to select a course choice to replace/make a decision on.

## Changes proposed in this pull request

- Adds the ReplaceChoiceController
- Adds the pick_course_to_replace page

## Guidance to review

designs - https://docs.google.com/document/d/1FwPaGSYzSViXtbB2INHwO7bdxr0fFFUpVs4z978tW9Q/edit.

If anyone has any thoughts on the naming that would be great!

## Link to Trello card

https://trello.com/c/kUjDNNbH/1646-dev-update-course-choices-if-course-becomes-full-while-waiting-for-references

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
