### PR TITLE
Filters on small screens js

### DIFF
--- a/app/frontend/packs/application.js
+++ b/app/frontend/packs/application.js
@@ -1,9 +1,11 @@
 require.context("govuk-frontend/govuk/assets");
+
 import { initAll as govUKFrontendInitAll } from "govuk-frontend";
 import initNationalityAutocomplete from "./nationality-autocomplete";
 import initCoursesAutocomplete from "./courses-autocomplete";
 import initProvidersAutocomplete from "./providers-autocomplete";
 import initWarnOnUnsavedChanges from "./warn-on-unsaved-changes";
+import providerFilter from "./provider-filter";
 
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 import "../styles/application.scss";
@@ -13,3 +15,4 @@ initNationalityAutocomplete();
 initProvidersAutocomplete();
 initCoursesAutocomplete();
 initWarnOnUnsavedChanges();
+providerFilter();

--- a/app/frontend/packs/provider-filter.js
+++ b/app/frontend/packs/provider-filter.js
@@ -1,0 +1,23 @@
+import { FilterToggleButton } from "moj/all.js";
+
+const providerFilter = () => {
+      new FilterToggleButton({
+        bigModeMediaQuery: '(min-width: 48.063em)',
+        startHidden: false,
+        toggleButton: {
+          container: $('.filter-toggle-button'),
+          showText: 'Show filter',
+          hideText: 'Hide filter',
+          classes: 'govuk-button--secondary'
+        },
+        closeButton: {
+          container: $('.moj-filter__header-action'),
+          text: 'Close'
+        },
+        filter: {
+          container: $('.moj-filter-layout__filter')
+        }
+      });
+};
+
+export default providerFilter;

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -1,3 +1,18 @@
+.moj-action-bar__filter {
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+.filter-toggle-button {
+  float: right;
+  border-bottom: govuk-spacing(3);
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+
 .moj-action-bar__filter:after {
   background: none;
 }

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -31,8 +31,7 @@
 }
 
 .app-filter {
-  display: none;
-  @include govuk-media-query($from: large) {
-    display: block;
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(3);
   }
 }

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -1,3 +1,9 @@
+.moj-filter-layout__content {
+  .moj-action-bar {
+    height: 60px;
+  }
+}
+
 .moj-action-bar__filter {
   @include govuk-media-query($from: desktop) {
     display: none;
@@ -6,12 +12,11 @@
 
 .filter-toggle-button {
   float: right;
-  border-bottom: govuk-spacing(3);
+  margin-bottom: govuk-spacing(1);
   @include govuk-media-query($from: desktop) {
     display: none;
   }
 }
-
 
 .moj-action-bar__filter:after {
   background: none;
@@ -30,6 +35,10 @@
   border-bottom: 0;
   padding-top: govuk-spacing(3);
   padding-bottom: govuk-spacing(3);
+}
+
+.applications-sorted-by-explanation {
+  margin-top: govuk-spacing(2);
 }
 
 .moj-filter__selected {

--- a/app/frontend/styles/_provider.scss
+++ b/app/frontend/styles/_provider.scss
@@ -3,5 +3,5 @@
 }
 
 .applications-sorted-by-explanation {
-  text-align: right;
+  text-align: left;
 }

--- a/app/frontend/styles/application.scss
+++ b/app/frontend/styles/application.scss
@@ -45,10 +45,12 @@ $govuk-breakpoints: (
 @import "_work-history";
 @import "_timeline";
 @import "_notes";
+@import "~@ministryofjustice/frontend/moj/helpers/hidden";
 @import "~@ministryofjustice/frontend/moj/settings/assets";
 @import "~@ministryofjustice/frontend/moj/objects/filter-layout";
 @import "~@ministryofjustice/frontend/moj/components/filter/filter";
 @import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
+@import "~@ministryofjustice/frontend/moj/utilities/hidden";
 @import "_filter";
 @import "_provider";
 @import "_application-card";

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -24,7 +24,12 @@
     page_state: @page_state,
   ) %>
   <div class='moj-filter-layout__content'>
-    <p class='govuk-body applications-sorted-by-explanation'>Sorted by: last changed</p>
+    <div class="moj-action-bar">
+      <div class="moj-action-bar__filter">
+        <div class="filter-toggle-button"></div>
+      </div>
+      <p class='govuk-body applications-sorted-by-explanation'>Sorted by: last changed</p>
+    </div>
     <% if @application_choices.any? %>
       <div class="app-application-cards">
         <% @application_choices.each_with_index do |choice, index| %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,15 @@
 const { environment } = require('@rails/webpacker')
 
+const webpack = require('webpack')
+
+environment.plugins.prepend(
+    'Provide',
+    new webpack.ProvidePlugin({
+        $: 'jquery',
+        jQuery: 'jquery',
+        jquery: 'jquery'
+    })
+)
+
 module.exports = environment
+

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,7 @@ default: &default
   webpack_compile_output: false
 
   # Additional paths webpack should lookup modules
-  resolved_paths: ['node_modules/govuk-frontend/govuk']
+  resolved_paths: ['node_modules/govuk-frontend/govuk', 'node_modules/@ministryofjustice/frontend']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "apply-for-postgraduate-teacher-training",
   "private": true,
   "dependencies": {
-    "@ministryofjustice/frontend": "0.0.17-alpha",
+    "@ministryofjustice/frontend": "^0.0.19-alpha",
     "@rails/webpacker": "^5.1.1",
     "accessible-autocomplete": "^2.0.2",
-    "govuk-frontend": "^3.7.0"
+    "govuk-frontend": "^3.7.0",
+    "jquery": "^3.5.1"
   },
   "devDependencies": {
     "jest": "^26.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1069,12 +1069,12 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@ministryofjustice/frontend@0.0.17-alpha":
-  version "0.0.17-alpha"
-  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-0.0.17-alpha.tgz#a5e2e2d2dce58102e9245153bd6d4992e7977c5b"
-  integrity sha512-UOwqFA24kd8xJY6XrWxaQxM2xzr8BHdwb5L82xPk3rG7hgEnWRppk7vt9eszqSt3Hwdfj63pD8aaMTMsi89P4Q==
+"@ministryofjustice/frontend@^0.0.19-alpha":
+  version "0.0.19-alpha"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-0.0.19-alpha.tgz#4f00cb02cafef3f8cbfa9d4665885fa766309cdf"
+  integrity sha512-iNNJSIr+poRiBWxyoi4pxs2qcYRfFzVO9yh6ALPUeKDj9pCm1lWYReWhr02/jLgLEJ3nKdJDxIbGv0c/RxSR/w==
   dependencies:
-    moment "^2.22.2"
+    moment "^2.26.0"
 
 "@rails/webpacker@^5.1.1":
   version "5.1.1"
@@ -4565,6 +4565,11 @@ jest@^26.0.1:
     import-local "^3.0.2"
     jest-cli "^26.0.1"
 
+jquery@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
 js-base64@^2.1.8:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.5.2.tgz#313b6274dda718f714d00b3330bbae6e38e90209"
@@ -5149,10 +5154,10 @@ mkdirp@^0.5.3:
   dependencies:
     minimist "^1.2.5"
 
-moment@^2.22.2:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+moment@^2.26.0:
+  version "2.26.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.26.0.tgz#5e1f82c6bafca6e83e808b30c8705eed0dcbd39a"
+  integrity sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Context
This PR adds the filter in a progressive way to devices with small
screens.

**When JS enabled:**

- on large screens the filter is present and the 'hide/show filter' button is not present.

- on small screens the the filter collapses to a floating box on the side and can be
hidden and shown.

**When JS is not enabled:**

- on large screens the filter is present on the left.

- on small screens the filter is moved above the application cards.


## Changes proposed in this pull request

**Before:**
https://recordit.co/ZSXLmxc94b

**After:**
https://recordit.co/ZSXLmxc94b

Without JS:
https://recordit.co/UFN6vpfUqE


## Guidance to review

- checkout this branch - resize the screen. Do things look right to you (ignoring the slightly weird header on small screens there's already a ticket for that).
- As has been discussed there there are no tests for this functionality given that we can't run a headless browser that resizes the screen. 

## Link to Trello card

https://trello.com/c/uIR5I9M4/2122-title-filters-not-working-at-all-on-small-screens

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
