### PR TITLE
Remove the safeguarding question from the referee questionnaire

### DIFF
--- a/app/controllers/referee_interface/questionnaire_form.rb
+++ b/app/controllers/referee_interface/questionnaire_form.rb
@@ -6,15 +6,13 @@ module RefereeInterface
                   :experience_explanation_ok, :experience_explanation_good, :experience_explanation_very_good,
                   :guidance_rating, :guidance_explanation_very_poor,
                   :guidance_explanation_poor, :guidance_explanation_ok, :guidance_explanation_good,
-                  :guidance_explanation_very_good, :safe_to_work_with_children,
-                  :safe_to_work_with_children_explanation, :consent_to_be_contacted,
+                  :guidance_explanation_very_good, :consent_to_be_contacted,
                   :consent_to_be_contacted_details
 
     def save(reference)
       questionnaire = {
         'Please rate your experience of giving a reference' => "#{experience_rating} | #{experience_explanation}",
         'Please rate how useful our guidance was' => "#{guidance_rating} | #{guidance_explanation}",
-        'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => safe_to_work_with_children_response,
         'Can we contact you about your experience of giving a reference?' => consent_to_be_contacted_response,
       }
 
@@ -51,10 +49,6 @@ module RefereeInterface
       when 'very_good'
         guidance_explanation_very_good
       end
-    end
-
-    def safe_to_work_with_children_response
-      "#{safe_to_work_with_children} | #{(safe_to_work_with_children_explanation if safe_to_work_with_children == 'false')}"
     end
 
     def consent_to_be_contacted_response

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -173,8 +173,7 @@ module RefereeInterface
         :experience_explanation_ok, :experience_explanation_good, :experience_explanation_very_good,
         :guidance_rating, :guidance_explanation_very_poor,
         :guidance_explanation_poor, :guidance_explanation_ok, :guidance_explanation_good,
-        :guidance_explanation_very_good, :safe_to_work_with_children,
-        :safe_to_work_with_children_explanation, :consent_to_be_contacted,
+        :guidance_explanation_very_good, :consent_to_be_contacted,
         :consent_to_be_contacted_details
       )
     end

--- a/app/views/referee_interface/reference/confirmation.html.erb
+++ b/app/views/referee_interface/reference/confirmation.html.erb
@@ -69,14 +69,6 @@
           <% end %>
         <% end %>
 
-        <%= f.govuk_radio_buttons_fieldset :safe_to_work_with_children, legend: { text: t('questionnaire_form.safe_to_work_with_children'), tag: 'span' } do %>
-          <%= f.govuk_radio_button :safe_to_work_with_children, true, label: { text: t('questionnaire_form.is_safe_to_work_with_children') } %>
-
-          <%= f.govuk_radio_button :safe_to_work_with_children, false, label: { text: t('questionnaire_form.is_not_safe_to_work_with_children') } do %>
-            <%= f.govuk_text_area :safe_to_work_with_children_explanation, label: { text: t('questionnaire_form.tell_us_why') } %>
-          <% end %>
-        <% end %>
-
         <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, legend: { text: t('questionnaire_form.can_we_contact_you'), tag: 'span' }, hint_text: t('questionnaire_form.hint_text') do %>
           <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('questionnaire_form.consent_to_be_contacted') } do %>
             <%= f.govuk_text_area :consent_to_be_contacted_details, label: { text: t('questionnaire_form.availibility') } %>

--- a/spec/models/referee_interface/questionnaire_form_spec.rb
+++ b/spec/models/referee_interface/questionnaire_form_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe RefereeInterface::QuestionnaireForm do
       'guidance_explanation_ok' => 'should not be returned',
       'guidance_explanation_good' => 'definitely should be returned',
       'guidance_explanation_very_good' => 'should not be returned',
-      'safe_to_work_with_children' => 'false',
-      'safe_to_work_with_children_explanation' => 'This should show',
       'consent_to_be_contacted' => 'true',
       'consent_to_be_contacted_details' => 'anytime 012345 678900',
     }
@@ -26,7 +24,6 @@ RSpec.describe RefereeInterface::QuestionnaireForm do
     {
       'Please rate your experience of giving a reference' => 'very_good | definitely should be returned',
       'Please rate how useful our guidance was' => 'good | definitely should be returned',
-      'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => 'false | This should show',
       'Can we contact you about your experience of giving a reference?' => 'true | anytime 012345 678900',
     }
   end


### PR DESCRIPTION
## Context

Gemma was getting an error when trying to export the referee survey results.

A record was manually updated due a 500. One question's response was true when it should have been 'true'. Due to this, when calling .split triggered an error. 

While solving the above, i realised that at some point, the referee reference flow has changed. 

A question on safeguarding has been asked on a separate page.

This means that it does the additional safeguarding question on the questionnaire should be removed.


## Changes proposed in this pull request

- Remove the safeguarding question from the referee questionnaire

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
