### PR TITLE
Switch test data to more complex providers

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -22,6 +22,8 @@ class TestApplications
       create_application(states: [:rejected])
 
       candidate = Candidate.last
+      first_name = candidate.current_application.first_name
+      last_name = candidate.current_application.last_name
     else
       travel_to rand(30..60).days.ago
       raise ZeroCoursesPerApplicationError, 'You can\'t have zero courses per application' unless states.any?

--- a/lib/tasks/local_dev.rake
+++ b/lib/tasks/local_dev.rake
@@ -1,8 +1,8 @@
 desc 'Set up your local development environment with data from Find'
-task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses generate_test_applications] do
+task setup_local_dev_data: %i[environment copy_feature_flags_from_production sync_dev_providers_and_open_courses] do
   puts 'Creating a provider-only user with DfE Sign-in UID `dev-provider` and email `provider@example.com`...'
   ProviderUser.find_or_create_by!(dfe_sign_in_uid: 'dev-provider', email_address: 'provider@example.com') do |u|
-    u.providers = [ApplicationChoice.first.provider]
+    u.providers = Provider.where(code: '1JA').all
   end
 
   puts 'Creating a support & provider user with DfE Sign-in UID `dev-support` and email `support@example.com`...'
@@ -19,6 +19,8 @@ task setup_local_dev_data: %i[environment copy_feature_flags_from_production syn
     view_safeguarding_information: true,
     make_decisions: true,
   )
+
+  Rake::Task['generate_test_applications'].invoke
 end
 
 desc 'Sync some pilot-enabled providers and open all their courses'


### PR DESCRIPTION
## Context

When testing locally and on review environments, having good data makes things easier to test. This PR switches the `setup_local_dev_data` task to providers with 
 both full time and part time courses and courses accredited by other providers. These providers are actually related to each other, which will help test org relationships and permission setups.

## Changes proposed in this pull request

This PR switches the `setup_local_dev_data` task to use providers 1JA (Blackfriars Teaching School Alliance) and 24J (Keele and North Staffordshire Teacher Education) when generating applications and users.

These providers are also mentioned in real-world examples we've received from user research.

## Guidance to review

Looking at the code and the review app should probably be enough.

## Link to Trello card

No Trello card.

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
