### PR TITLE
Fix: Don't send duplicate Slack notifications for course unavailable

### DIFF
--- a/app/models/chaser_sent.rb
+++ b/app/models/chaser_sent.rb
@@ -8,5 +8,6 @@ class ChaserSent < ApplicationRecord
     provider_decision_request: 'provider_decision_request',
     candidate_decision_request: 'candidate_decision_request',
     course_unavailable_notification: 'course_unavailable_notification',
+    course_unavailable_slack_notification: 'course_unavailable_slack_notification',
   }
 end

--- a/app/workers/send_course_full_notifications_worker.rb
+++ b/app/workers/send_course_full_notifications_worker.rb
@@ -10,15 +10,23 @@ class SendCourseFullNotificationsWorker
           chaser_type: :course_unavailable_notification,
         )
         CandidateMailer.course_unavailable_notification(application_choice, reason).deliver_later
-      else
-        send_slack_message(application_choice, reason)
       end
+      send_slack_message(application_choice, reason)
     end
   end
 
 private
 
   def send_slack_message(application_choice, reason)
+    return if ChaserSent.find_by(
+      chased: application_choice,
+      chaser_type: :course_unavailable_slack_notification,
+    ).present?
+
+    ChaserSent.create!(
+      chased: application_choice,
+      chaser_type: :course_unavailable_slack_notification,
+    )
     message = I18n.t!(
       "candidate_mailer.course_unavailable_notification.slack_message.#{reason}",
       course_name: application_choice.course_option.course.name_and_code,


### PR DESCRIPTION
## Context

This is a fix for an issue introduced by https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2242 to stop sending repeated Slack notifications for all candidates with a course that filled while awaiting references.

## Changes proposed in this pull request

- Use `ChaserSent` with a new `chaser_type` to record that the slack notification was sent. Check this before posting the notification.

## Guidance to review

- I've tried to ensure that candidates are notified by email after we activate the feature flag even if a Slack notification was already sent about their case. So I left the original query alone and introduced a new `ChaserSent#chaser_type` just for Slack notifications.

## Link to Trello card

https://trello.com/c/qX7OyNDH/1647-dev-notification-emails-when-a-course-becomes-full-while-waiting-for-references

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
