### PR TITLE
Spike: Submit references before application is submitted

### DIFF
--- a/app/controllers/candidate_interface/referees_controller.rb
+++ b/app/controllers/candidate_interface/referees_controller.rb
@@ -119,9 +119,17 @@ module CandidateInterface
       @application_form = current_candidate.current_application
     end
 
+    def confirm_complete
+      @application_form = current_candidate.current_application
+    end
+
     def complete
       if current_application.application_references.count >= ApplicationForm::MINIMUM_COMPLETE_REFERENCES
-        current_application.update!(application_form_params)
+        flash[:success] = "We’ve emailed your referees."
+        current_application.update!(references_completed: true)
+        current_application.application_references.not_requested_yet.includes(:application_form).each do |reference|
+          CandidateInterface::RequestReference.call(reference)
+        end
 
         redirect_to candidate_interface_application_form_path
       else

--- a/app/views/candidate_interface/application_form/show.html.erb
+++ b/app/views/candidate_interface/application_form/show.html.erb
@@ -16,6 +16,27 @@
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-hint govuk-!-margin-bottom-8 govuk-!-margin-top-2"><%= @application_form_presenter.updated_at %></p>
 
+    <h2 class="govuk-heading-m govuk-!-font-size-27">🆕 References</h2>
+    <ul class="app-task-list govuk-!-margin-bottom-8">
+      <li class="app-task-list__item">
+        <%= render(TaskListItemComponent.new(text: 'Referees', completed: @application_form_presenter.all_referees_provided_by_candidate?, path: candidate_interface_referees_path, submitted: false)) %>
+      </li>
+      <% if @application_form_presenter.all_referees_provided_by_candidate? %>
+        <li class="app-task-list__item">
+          <span class="app-task-list__task-name"><%= @application_form.application_references.first.name %></span>
+          <strong class="govuk-tag govuk-tag--grey app-tag">
+            <%= @application_form.application_references.first.feedback_status.titleize %>
+          </strong>
+        </li>
+        <li class="app-task-list__item">
+          <span class="app-task-list__task-name"><%= @application_form.application_references.second.name %></span>
+          <strong class="govuk-tag govuk-tag--grey app-tag">
+            <%= @application_form.application_references.second.feedback_status.titleize %>
+          </strong>
+        </li>
+      <% end %>
+    </ul>
+
     <% if FeatureFlag.active?('apply_again') && @application_form.candidate_has_previously_applied? %>
       <% if @application_form.previous_application_form.application_choices.rejected.any?  %>
         <%= render(CandidateInterface::RejectionReasonsComponent.new(application_form: @application_form.previous_application_form)) %>
@@ -94,13 +115,6 @@
       </li>
       <li class="app-task-list__item govuk-hint">
         <%= render(TaskListItemComponent.new(text: t('page_titles.interview_preferences'), completed: @application_form_presenter.interview_preferences_completed?, path: @application_form_presenter.interview_preferences_completed? ? candidate_interface_interview_preferences_show_path : candidate_interface_interview_preferences_edit_path)) %>
-      </li>
-    </ul>
-
-    <h2 class="govuk-heading-m govuk-!-font-size-27">References</h2>
-    <ul class="app-task-list govuk-!-margin-bottom-8">
-      <li class="app-task-list__item">
-        <%= render(TaskListItemComponent.new(text: 'Referees', completed: @application_form_presenter.all_referees_provided_by_candidate?, path: candidate_interface_referees_path, submitted: false)) %>
       </li>
     </ul>
 

--- a/app/views/candidate_interface/referees/confirm_complete.html.erb
+++ b/app/views/candidate_interface/referees/confirm_complete.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, 'Do you want us to contact your referees now?' %>
+<% content_for :before_content, govuk_back_link_to(candidate_interface_review_referees_path, 'Back') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @application_form, url: candidate_interface_complete_referees_path, method: :patch do |f| %>
+      <h1 class="govuk-heading-xl">
+        🆕 Do you want us to contact your referees now?
+      </h1>
+
+      <p class="govuk-body">We’ll email <%= @application_form.application_references.first.name %> and <%= @application_form.application_references.second.name %> and ask them to provide a reference.</p>
+
+      <p class="govuk-body">You can fill in the rest of your application while you wait.</p>
+
+      <p class="govuk-body">If your references do not reply, you can cancel and replace them at any time.</p>
+
+      <p class='govuk-body'>You cannot submit your application without 2 complete references.</p>
+
+      <%= f.govuk_submit "Contact my referees" %>
+
+      <p class="govuk-body">
+        <%= govuk_link_to "No - I'll contact them later", candidate_interface_application_form_path %>
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/candidate_interface/referees/review.html.erb
+++ b/app/views/candidate_interface/referees/review.html.erb
@@ -28,7 +28,7 @@
 
   <% if FeatureFlag.active?('mark_every_section_complete') %>
     <%= render(CandidateInterface::CompleteSectionComponent.new(application_form: @application_form,
-                                            path: candidate_interface_complete_referees_path,
+                                            path: candidate_interface_confirm_complete_referees_path,
                                             request_method: :patch,
                                             field_name: :references_completed)) %>
   <% else %>

--- a/config/locales/application_form.yml
+++ b/config/locales/application_form.yml
@@ -317,7 +317,7 @@ en:
       confirm_chase: Are you sure you want to send emails to chase the referee?
       info:
         before_submission: You need to add 2 referees.
-        not_requested_yet:  We’ll contact your referees after you submit your application.
+        not_requested_yet:  🆕 We’ll contact your referees once you mark this section as completed.
         declined: Your referee chose not to give a reference.
         awaiting_reference_sent_less_than_5_days_ago: We’ve emailed your referee. Keep in touch with them to ensure they’re planning on giving a reference as soon as possible.
         awaiting_reference_sent_more_than_5_days_ago: Your referee has not responded yet. Ask them if they got the email - it may have gone to junk or spam.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -269,6 +269,7 @@ Rails.application.routes.draw do
         post '/(:type)' => 'referees#create'
 
         get '/review' => 'referees#review', as: :review_referees
+        patch '/confirm-complete' => 'referees#confirm_complete', as: :confirm_complete_referees
         patch '/complete' => 'referees#complete', as: :complete_referees
 
         get '/edit/:id' => 'referees#edit', as: :edit_referee


### PR DESCRIPTION
## Context

This is a spike into investigating if it is possible to ask for references before we submit an application.

## Changes proposed in this pull request

WIP.

## Guidance to review

Not meant to be merged.

<img width="685" alt="Screenshot 2020-06-11 at 17 52 41" src="https://user-images.githubusercontent.com/1650875/84416729-8047de00-ac0c-11ea-81a2-a90a6cb3e291.png">

## Link to Trello card

https://trello.com/c/2anzltcV/1562-tech-spike-decoupling-references

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
