### PR TITLE
Make pagination align with application cards

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -17,7 +17,7 @@
       <%= link_to service_name, service_url, class: 'govuk-header__link govuk-header__link--service-name' %>
       <% if navigation_items.any? %>
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-!-print-display-none" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <ul id="navigation" class="govuk-header__navigation app-!-print-display-none" aria-label="Top Level Navigation">
+        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
           <% navigation_items.each do |nav_item| %>
             <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
               <% if nav_item.href %>

--- a/app/frontend/styles/_filter.scss
+++ b/app/frontend/styles/_filter.scss
@@ -54,6 +54,10 @@
   box-shadow: none;
 }
 
+.moj-pagination__list {
+  padding-left: 3px;
+}
+
 .app-filter {
   @include govuk-media-query($from: tablet) {
     margin-bottom: govuk-spacing(3);

--- a/app/views/provider_interface/application_choices/index.html.erb
+++ b/app/views/provider_interface/application_choices/index.html.erb
@@ -41,7 +41,7 @@
     <% else %>
       <p class='govuk-body'>You haven’t received any applications from <%= t('service_name.apply') %>.</p>
     <% end %>
+    <%= render(PaginatorComponent.new(scope: @application_choices)) %>
   </div>
 </div>
 
-<%= render(PaginatorComponent.new(scope: @application_choices)) %>


### PR DESCRIPTION
## Context

Align pagination with application cards so that app matches the design.

## Changes proposed in this pull request

**Before:**
<img width="1056" alt="Screenshot 2020-06-12 at 09 29 38" src="https://user-images.githubusercontent.com/13377553/84482222-40760a80-ac8f-11ea-939f-96f311812a20.png">


**After:**
<img width="1107" alt="Screenshot 2020-06-12 at 09 27 45" src="https://user-images.githubusercontent.com/13377553/84482058-fee55f80-ac8e-11ea-8b7d-4eef04e6ec5e.png">


## Guidance to review

- is this correct from a design perspective. Note that if there are a lot of applications then the pagination will fold up into two lines:

<img width="1037" alt="Screenshot 2020-06-12 at 09 28 43" src="https://user-images.githubusercontent.com/13377553/84482152-22a8a580-ac8f-11ea-94b8-0838305c7a91.png">

## Link to Trello card

https://trello.com/c/FKkvBXXs/2117-title-pagination-should-be-aligned-with-the-list-within-the-right-hand-column

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
