### PR TITLE
Fix menu collapse on small screens

### DIFF
--- a/app/components/header_component.html.erb
+++ b/app/components/header_component.html.erb
@@ -17,7 +17,7 @@
       <%= link_to service_name, service_url, class: 'govuk-header__link govuk-header__link--service-name' %>
       <% if navigation_items.any? %>
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-!-print-display-none" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
+        <ul id="navigation" class="govuk-header__navigation app-!-print-display-none" aria-label="Top Level Navigation">
           <% navigation_items.each do |nav_item| %>
             <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
               <% if nav_item.href %>

--- a/app/components/provider_interface/header_component.html.erb
+++ b/app/components/provider_interface/header_component.html.erb
@@ -18,8 +18,8 @@
     </div>
     <div class="govuk-header__content provider-header__content">
       <% if navigation_items.any? %>
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle app-!-print-display-none" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-        <ul id="navigation" class="govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
+         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+        <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end app-!-print-display-none" aria-label="Top Level Navigation">
           <% navigation_items.each do |nav_item| %>
             <li class="govuk-header__navigation-item <%= nav_item.active ? 'govuk-header__navigation-item--active' : '' %>">
               <% if nav_item.href %>


### PR DESCRIPTION


## Context

The menu button wasn't working on small screens. It seems to be that the `govuk-header__navigation-end` class does not play well with the collapsable menu. I have replaced this with the standard `govuk-header__navigation` class and added some CSS to get the correct alignment.

## Changes proposed in this pull request

**Before:**
<img width="700" alt="Screenshot 2020-06-12 at 10 54 55" src="https://user-images.githubusercontent.com/13377553/84490496-29d5b080-ac9b-11ea-8c91-247e428fc9c5.png">

The menu button had no effect.

**After:**
Before menu is clicked:
<img width="705" alt="Screenshot 2020-06-12 at 10 56 08" src="https://user-images.githubusercontent.com/13377553/84490631-5689c800-ac9b-11ea-88d6-a01a5decdca8.png">

After menu is clicked:
<img width="579" alt="Screenshot 2020-06-12 at 11 00 32" src="https://user-images.githubusercontent.com/13377553/84491111-f3e4fc00-ac9b-11ea-99da-4f0d4486e742.png">


## Guidance to review
- Does this work? Is there a more elegant way to do the CSS for this?

## Link to Trello card

https://trello.com/c/Dr0rpyTf/2262-redundant-menu-item-in-header-on-small-screens

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
