### PR TITLE
Fix link on check your email page

### DIFF
--- a/app/views/candidate_interface/shared/_check_your_email.html.erb
+++ b/app/views/candidate_interface/shared/_check_your_email.html.erb
@@ -9,7 +9,7 @@
       We’ve sent you an email. Click on the link to confirm your address and return to this service.
     </p>
     <p class="govuk-body">
-      If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <%= govuk_link_to 'try again', candidate_interface_sign_up_path %>.
+      If our email doesn’t arrive within 5 minutes, check your spam and trash folder, or <%= govuk_link_to 'try again', candidate_interface_create_account_or_sign_in_path %>.
     </p>
   </div>
 </div>


### PR DESCRIPTION
It should link to the create account or sign in page, because users can arrive here via either route.