### PR TITLE
Small refactor for the referee survey 

### DIFF
--- a/app/controllers/referee_interface/questionnaire_form.rb
+++ b/app/controllers/referee_interface/questionnaire_form.rb
@@ -11,9 +11,9 @@ module RefereeInterface
 
     def save(reference)
       questionnaire = {
-        'Please rate your experience of giving a reference' => "#{experience_rating} | #{experience_explanation}",
-        'Please rate how useful our guidance was' => "#{guidance_rating} | #{guidance_explanation}",
-        'Can we contact you about your experience of giving a reference?' => consent_to_be_contacted_response,
+        RefereeQuestionnaire::EXPERIENCE_QUESTION => "#{experience_rating} | #{experience_explanation}",
+        RefereeQuestionnaire::GUIDANCE_QUESTION => "#{guidance_rating} | #{guidance_explanation}",
+        RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => consent_to_be_contacted_response,
       }
 
       reference.update!(questionnaire: questionnaire, consent_to_be_contacted: consent_to_be_contacted)

--- a/app/controllers/referee_interface/questionnaire_form.rb
+++ b/app/controllers/referee_interface/questionnaire_form.rb
@@ -2,12 +2,26 @@ module RefereeInterface
   class QuestionnaireForm
     include ActiveModel::Model
 
-    attr_accessor :experience_rating, :experience_explanation_very_poor, :experience_explanation_poor,
-                  :experience_explanation_ok, :experience_explanation_good, :experience_explanation_very_good,
-                  :guidance_rating, :guidance_explanation_very_poor,
-                  :guidance_explanation_poor, :guidance_explanation_ok, :guidance_explanation_good,
-                  :guidance_explanation_very_good, :consent_to_be_contacted,
-                  :consent_to_be_contacted_details
+    FORM_KEYS = %i[
+      experience_rating
+      experience_explanation_very_poor
+      experience_explanation_poor
+      experience_explanation_ok
+      experience_explanation_good
+      experience_explanation_very_good
+
+      guidance_rating
+      guidance_explanation_very_poor
+      guidance_explanation_poor
+      guidance_explanation_ok
+      guidance_explanation_good
+      guidance_explanation_very_good
+
+      consent_to_be_contacted
+      consent_to_be_contacted_details
+    ]
+
+    attr_accessor *FORM_KEYS
 
     def save(reference)
       questionnaire = {

--- a/app/controllers/referee_interface/reference_controller.rb
+++ b/app/controllers/referee_interface/reference_controller.rb
@@ -168,14 +168,7 @@ module RefereeInterface
     end
 
     def questionnaire_params
-      params.require(:referee_interface_questionnaire_form).permit(
-        :experience_rating, :experience_explanation_very_poor, :experience_explanation_poor,
-        :experience_explanation_ok, :experience_explanation_good, :experience_explanation_very_good,
-        :guidance_rating, :guidance_explanation_very_poor,
-        :guidance_explanation_poor, :guidance_explanation_ok, :guidance_explanation_good,
-        :guidance_explanation_very_good, :consent_to_be_contacted,
-        :consent_to_be_contacted_details
-      )
+      params.require(:referee_interface_questionnaire_form).permit(*QuestionnaireForm::FORM_KEYS)
     end
 
     def relationship_params

--- a/app/models/referee_interface/questionnaire_form.rb
+++ b/app/models/referee_interface/questionnaire_form.rb
@@ -19,9 +19,9 @@ module RefereeInterface
 
       consent_to_be_contacted
       consent_to_be_contacted_details
-    ]
+    ].freeze
 
-    attr_accessor *FORM_KEYS
+    attr_accessor(*FORM_KEYS)
 
     def save(reference)
       questionnaire = {

--- a/app/models/referee_questionnaire.rb
+++ b/app/models/referee_questionnaire.rb
@@ -1,0 +1,8 @@
+class RefereeQuestionnaire
+  EXPERIENCE_QUESTION = 'Please rate your experience of giving a reference'.freeze
+  GUIDANCE_QUESTION = 'Please rate how useful our guidance was'.freeze
+  CONSENT_TO_BE_CONTACTED_QUESTION = 'Can we contact you about your experience of giving a reference?'.freeze
+
+  # This question is no longer asked
+  SAFE_TO_WORK_WITH_CHILDREN_QUESTION = 'If we asked whether a candidate was safe to work with children, would you feel able to answer?'.freeze
+end

--- a/app/services/support_interface/referee_survey_export.rb
+++ b/app/services/support_interface/referee_survey_export.rb
@@ -11,14 +11,14 @@ module SupportInterface
         hash = {
           'Name' => reference.name,
           'Email_address' => reference.email_address,
-          'Guidance rating' => extract_rating(reference, 'Please rate how useful our guidance was'),
-          'Guidance explanation' => extract_explanation(reference, 'Please rate how useful our guidance was'),
-          'Experience rating' => extract_rating(reference, 'Please rate your experience of giving a reference'),
-          'Experience explanation' => extract_explanation(reference, 'Please rate your experience of giving a reference'),
-          'Consent to be contacted' => extract_rating(reference, 'Can we contact you about your experience of giving a reference?'),
-          'Contact details' => extract_explanation(reference, 'Can we contact you about your experience of giving a reference?'),
-          'Safe to work with children?' => extract_rating(reference, 'If we asked whether a candidate was safe to work with children, would you feel able to answer?'),
-          'Safe to work with children explanation' => extract_explanation(reference, 'If we asked whether a candidate was safe to work with children, would you feel able to answer?'),
+          'Guidance rating' => extract_rating(reference, RefereeQuestionnaire::GUIDANCE_QUESTION),
+          'Guidance explanation' => extract_explanation(reference, RefereeQuestionnaire::GUIDANCE_QUESTION),
+          'Experience rating' => extract_rating(reference, RefereeQuestionnaire::EXPERIENCE_QUESTION),
+          'Experience explanation' => extract_explanation(reference, RefereeQuestionnaire::EXPERIENCE_QUESTION),
+          'Consent to be contacted' => extract_rating(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
+          'Contact details' => extract_explanation(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
+          'Safe to work with children?' => extract_rating(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
+          'Safe to work with children explanation' => extract_explanation(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
         }
 
         output << hash

--- a/app/views/referee_interface/reference/confirmation.html.erb
+++ b/app/views/referee_interface/reference/confirmation.html.erb
@@ -25,7 +25,7 @@
       <p class="govuk-body">Your feedback will help us to improve our service.</p>
 
       <div class="govuk-grid-column-two-thirds">
-        <%= f.govuk_radio_buttons_fieldset :experience, legend: { text: t('questionnaire_form.experience'), tag: 'span' } do %>
+        <%= f.govuk_radio_buttons_fieldset :experience, legend: { text: RefereeQuestionnaire::EXPERIENCE_QUESTION, tag: 'span' } do %>
           <%= f.govuk_radio_button :experience_rating, 'very_poor', label: { text: t('questionnaire_form.very_poor') } do %>
             <%= f.govuk_text_area :experience_explanation_very_poor, label: { text: t('questionnaire_form.why_that_rating') } %>
           <% end %>
@@ -47,7 +47,7 @@
           <% end %>
         <% end %>
 
-        <%= f.govuk_radio_buttons_fieldset :guidance, legend: { text: 'Please rate how useful our guidance was', tag: 'span' } do %>
+        <%= f.govuk_radio_buttons_fieldset :guidance, legend: { text: RefereeQuestionnaire::GUIDANCE_QUESTION, tag: 'span' } do %>
           <%= f.govuk_radio_button :guidance_rating, 'very_poor', label: { text: t('questionnaire_form.very_poor') } do %>
             <%= f.govuk_text_area :guidance_explanation_very_poor, label: { text: t('questionnaire_form.why_that_rating') } %>
           <% end %>
@@ -69,7 +69,7 @@
           <% end %>
         <% end %>
 
-        <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, legend: { text: t('questionnaire_form.can_we_contact_you'), tag: 'span' }, hint_text: t('questionnaire_form.hint_text') do %>
+        <%= f.govuk_radio_buttons_fieldset :consent_to_be_contacted, legend: { text: RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION, tag: 'span' }, hint_text: t('questionnaire_form.hint_text') do %>
           <%= f.govuk_radio_button :consent_to_be_contacted, true, label: { text: t('questionnaire_form.consent_to_be_contacted') } do %>
             <%= f.govuk_text_area :consent_to_be_contacted_details, label: { text: t('questionnaire_form.availibility') } %>
           <% end %>

--- a/config/locales/referee.yml
+++ b/config/locales/referee.yml
@@ -9,10 +9,6 @@ en:
     ok: Ok
     good: Good
     very_good: Very Good
-    safe_to_work_with_children: If we asked whether a candidate was safe to work with children, would you feel able to answer?
-    is_safe_to_work_with_children: Yes, I could answer
-    is_not_safe_to_work_with_children: No, I wouldn’t feel able to answer
-    tell_us_why: Please tell us why
     can_we_contact_you: Can we contact you about your experience of giving a reference?
     hint_text: We’d ideally like to speak on the phone for half an hour.
     consent_to_be_contacted: Yes, you can contact me

--- a/config/locales/referee.yml
+++ b/config/locales/referee.yml
@@ -2,14 +2,12 @@ en:
   reference_form:
     confirm: Submit reference
   questionnaire_form:
-    experience: Please rate your experience of giving a reference
     why_that_rating: Tell us why you chose that rating
     very_poor: Very poor
     poor: Poor
     ok: Ok
     good: Good
     very_good: Very Good
-    can_we_contact_you: Can we contact you about your experience of giving a reference?
     hint_text: We’d ideally like to speak on the phone for half an hour.
     consent_to_be_contacted: Yes, you can contact me
     availibility: Please let us know when you’re available and give a phone number

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -477,9 +477,9 @@ FactoryBot.define do
       requested_at { Time.zone.now }
       questionnaire do
         {
-          'Please rate how useful our guidance was' => "#{%w[very_poor poor ok good very_good].sample} | #{Faker::Lorem.paragraph_by_chars(number: 300)}",
-          'Please rate your experience of giving a reference' => "#{%w[very_poor poor ok good very_good].sample} | #{Faker::Lorem.paragraph_by_chars(number: 300)}",
-          'Can we contact you about your experience of giving a reference?' => "#{%w[yes no].sample} | #{Faker::PhoneNumber.cell_phone}",
+          RefereeQuestionnaire::GUIDANCE_QUESTION => "#{%w[very_poor poor ok good very_good].sample} | #{Faker::Lorem.paragraph_by_chars(number: 300)}",
+          RefereeQuestionnaire::EXPERIENCE_QUESTION => "#{%w[very_poor poor ok good very_good].sample} | #{Faker::Lorem.paragraph_by_chars(number: 300)}",
+          RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => "#{%w[yes no].sample} | #{Faker::PhoneNumber.cell_phone}",
           'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => "#{%w[yes no].sample}| ",
         }
       end

--- a/spec/models/referee_interface/questionnaire_form_spec.rb
+++ b/spec/models/referee_interface/questionnaire_form_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe RefereeInterface::QuestionnaireForm do
 
   let(:correct_params) do
     {
-      'Please rate your experience of giving a reference' => 'very_good | definitely should be returned',
-      'Please rate how useful our guidance was' => 'good | definitely should be returned',
-      'Can we contact you about your experience of giving a reference?' => 'true | anytime 012345 678900',
+      RefereeQuestionnaire::EXPERIENCE_QUESTION => 'very_good | definitely should be returned',
+      RefereeQuestionnaire::GUIDANCE_QUESTION => 'good | definitely should be returned',
+      RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => 'true | anytime 012345 678900',
     }
   end
 

--- a/spec/services/support_interface/referee_survey_export_spec.rb
+++ b/spec/services/support_interface/referee_survey_export_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe SupportInterface::RefereeSurveyExport do
   describe '#call' do
     let(:questionnaire1) do
       {
-        'Please rate how useful our guidance was' => "very_poor | I couldn't read it.",
-        'Please rate your experience of giving a reference' => 'very_good | I could read it.',
-        'Can we contact you about your experience of giving a reference?' => 'yes | 02113131',
-        'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => 'yes | ',
+        RefereeQuestionnaire::GUIDANCE_QUESTION => "very_poor | I couldn't read it.",
+        RefereeQuestionnaire::EXPERIENCE_QUESTION => 'very_good | I could read it.',
+        RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => 'yes | 02113131',
+        RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION => 'yes | ',
       }
     end
 
     let(:questionnaire2) do
       {
-        'Please rate how useful our guidance was' => 'good | ',
-        'Please rate your experience of giving a reference' => 'poor | ',
-        'Can we contact you about your experience of giving a reference?' => ' | ',
-        'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => ' | ',
+        RefereeQuestionnaire::GUIDANCE_QUESTION => 'good | ',
+        RefereeQuestionnaire::EXPERIENCE_QUESTION => 'poor | ',
+        RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => ' | ',
+        RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION => ' | ',
       }
     end
 
     let(:questionnaire3) do
       {
-        'Please rate how useful our guidance was' => ' | ',
-        'Please rate your experience of giving a reference' => ' | ',
-        'Can we contact you about your experience of giving a reference?' => ' | ',
-        'If we asked whether a candidate was safe to work with children, would you feel able to answer?' => ' | ',
+        RefereeQuestionnaire::GUIDANCE_QUESTION => ' | ',
+        RefereeQuestionnaire::EXPERIENCE_QUESTION => ' | ',
+        RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION => ' | ',
+        RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION => ' | ',
       }
     end
 
@@ -56,14 +56,14 @@ private
     {
       'Name' => reference.name,
       'Email_address' => reference.email_address,
-      'Guidance rating' => extract_rating(reference, 'Please rate how useful our guidance was'),
-      'Guidance explanation' => extract_explanation(reference, 'Please rate how useful our guidance was'),
-      'Experience rating' => extract_rating(reference, 'Please rate your experience of giving a reference'),
-      'Experience explanation' => extract_explanation(reference, 'Please rate your experience of giving a reference'),
-      'Consent to be contacted' => extract_rating(reference, 'Can we contact you about your experience of giving a reference?'),
-      'Contact details' => extract_explanation(reference, 'Can we contact you about your experience of giving a reference?'),
-      'Safe to work with children?' => extract_rating(reference, 'If we asked whether a candidate was safe to work with children, would you feel able to answer?'),
-      'Safe to work with children explanation' => extract_explanation(reference, 'If we asked whether a candidate was safe to work with children, would you feel able to answer?'),
+      'Guidance rating' => extract_rating(reference, RefereeQuestionnaire::GUIDANCE_QUESTION),
+      'Guidance explanation' => extract_explanation(reference, RefereeQuestionnaire::GUIDANCE_QUESTION),
+      'Experience rating' => extract_rating(reference, RefereeQuestionnaire::EXPERIENCE_QUESTION),
+      'Experience explanation' => extract_explanation(reference, RefereeQuestionnaire::EXPERIENCE_QUESTION),
+      'Consent to be contacted' => extract_rating(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
+      'Contact details' => extract_explanation(reference, RefereeQuestionnaire::CONSENT_TO_BE_CONTACTED_QUESTION),
+      'Safe to work with children?' => extract_rating(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
+      'Safe to work with children explanation' => extract_explanation(reference, RefereeQuestionnaire::SAFE_TO_WORK_WITH_CHILDREN_QUESTION),
     }
   end
 end


### PR DESCRIPTION
## Context

We've recently had to jump into the referee survey (https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2253), and I noticed some duplication.

## Changes proposed in this pull request

- Use a single source of truth for the question strings
- Dedupe the keys of the survey form
- Move the form object to the correct directory

## Guidance to review

Per commit is probably best.

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
