### PR TITLE
Add 'working days' to the copy about editable days

### DIFF
--- a/app/views/candidate_interface/application_form/edit_by_support.html.erb
+++ b/app/views/candidate_interface/application_form/edit_by_support.html.erb
@@ -7,7 +7,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">You have <%= @editable_days %> to edit your application.</p>
+    <p class="govuk-body">You have <%= @editable_days %> working days to edit your application.</p>
     <p class="govuk-body">Tell us what changes you need to make by emailing us at <%= govuk_link_to 'becomingateacher@digital.education.gov.uk', 'mailto:becomingateacher@digital.education.gov.uk' %>.</p>
     <p class="govuk-body">We can only make changes once.</p>
     <h2 class="govuk-heading-m">Changing your references</h2>


### PR DESCRIPTION
## Context

We changed the copy for the 'Editing your application' page but it looks like we missed the 'working days' from the sentence _You have 5 working days to edit your application._

## Changes proposed in this pull request

- Simple copy change

![image](https://user-images.githubusercontent.com/450843/84643303-8fbd7480-aef5-11ea-896a-9e6733a6388d.png)

## Guidance to review

Nothing particularly

## Link to Trello card

https://trello.com/c/mxPrkcGN/1610-bug-content-editing-application-content

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
