### PR TITLE
Silence Redis deprecation warnings in worker logs

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,5 @@
+if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('6.1')
+  Redis.exists_returns_integer = true
+else
+  raise 'Time to remove Redis.exists_returns_integer: https://github.com/mperham/sidekiq/issues/4591'
+end


### PR DESCRIPTION
The warning:

```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?`
returns a boolean, you should use it instead. To opt-in to the new
behavior now you can set Redis.exists_returns_integer =  true. To
disable this message and keep the current (boolean) behaviour of
'exists' you can set `Redis.exists_returns_integer = false`, but this
option will be removed in 5.0.
```

The call comes from Sidekiq, which will fix this with v6.1. Until then,
silence it.

https://github.com/mperham/sidekiq/issues/4591