### PR TITLE
Add replace study mode and keep course flow 

### DIFF
--- a/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
@@ -16,6 +16,12 @@ module CandidateInterface
             replacement_course_option_id = @course_choice.course_option.get_alternative_study_mode.id
 
             redirect_to candidate_interface_confirm_replacement_course_choice_path(@course_choice.id, replacement_course_option_id)
+          elsif @pick_replacement_action.replacement_action == 'keep_choice'
+            if only_one_course_choice_needs_replacing?
+              redirect_to candidate_interface_application_complete_path
+            else
+              redirect_to candidate_interface_replace_course_choices_path
+            end
           elsif !@pick_replacement_action.valid?
             flash[:warning] = 'Please select an option to update your course choice.'
 

--- a/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
+++ b/app/controllers/candidate_interface/course_choices/replace_choices/decision_controller.rb
@@ -12,6 +12,10 @@ module CandidateInterface
 
           if @pick_replacement_action.valid? && @pick_replacement_action.replacement_action == 'replace_location'
             redirect_to candidate_interface_replace_course_choice_location_path(@course_choice.id)
+          elsif @pick_replacement_action.valid? && @pick_replacement_action.replacement_action == 'replace_study_mode'
+            replacement_course_option_id = @course_choice.course_option.get_alternative_study_mode.id
+
+            redirect_to candidate_interface_confirm_replacement_course_choice_path(@course_choice.id, replacement_course_option_id)
           elsif !@pick_replacement_action.valid?
             flash[:warning] = 'Please select an option to update your course choice.'
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -183,6 +183,6 @@ private
   end
 
   def full_course_choices
-    application_choices.map(&:course_option).select(&:no_vacancies?).map(&:application_choices)
+    application_choices.includes([:provider]).select { |choice| choice.course_option.no_vacancies? }
   end
 end

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     when_i_arrive_at_my_application_dashboard
     then_i_see_that_one_of_my_choices_in_not_available
 
+    when_i_click_update_my_course_choice
+    then_i_arrive_at_the_replace_course_choice_page
+
+    when_i_choose_submit_application_anyway
+    and_click_continue
+    then_i_arrive_at_my_dashboard
+
     given_i_have_two_full_course_choices
 
     when_i_arrive_at_my_application_dashboard
@@ -34,7 +41,13 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     when_i_click_continue_without_selecting_an_option
     then_i_am_told_i_need_to_select_an_option
 
-    when_i_choose_to_add_a_different_course
+    when_i_choose_submit_application_anyway
+    and_click_continue
+    then_i_see_the_replace_course_choices_page
+
+    when_i_choose_my_first_course_choice
+    and_click_continue
+    and_i_choose_to_add_a_different_course
     and_click_continue
     then_i_am_told_to_contact_support
 
@@ -54,7 +67,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     and_i_can_see_my_old_course_choice
 
     when_i_click_replace_course_choice
-    then_i_arrrive_at_my_dashboard
+    then_i_arrive_at_my_dashboard
     and_i_can_see_my_new_course_choice
     and_i_cannot_see_my_old_course_choice
 
@@ -68,7 +81,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     and_i_can_see_my_old_course_choices_study_mode
 
     when_i_click_replace_course_choice
-    then_i_arrrive_at_my_dashboard
+    then_i_arrive_at_my_dashboard
     and_my_new_course_choice_is_part_time
   end
 
@@ -117,6 +130,10 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     expect(page).to have_current_path candidate_interface_replace_course_choices_path
   end
 
+  def when_i_choose_submit_application_anyway
+    choose 'Submit application anyway'
+  end
+
   def and_i_see_my_first_course_choice
     expect(page).to have_content(@course_option.course.name_and_code)
   end
@@ -149,7 +166,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     expect(page).to have_content 'Please select an option to update your course choice.'
   end
 
-  def when_i_choose_to_add_a_different_course
+  def and_i_choose_to_add_a_different_course
     choose 'Choose a different course'
   end
 
@@ -189,7 +206,7 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     click_link 'Replace course choice'
   end
 
-  def then_i_arrrive_at_my_dashboard
+  def then_i_arrive_at_my_dashboard
     expect(page).to have_current_path candidate_interface_application_complete_path
   end
 

--- a/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
+++ b/spec/system/candidate_interface/course_selection/candidate_can_replace_full_or_withdrawn_course_choices_spec.rb
@@ -50,11 +50,26 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     when_i_select_a_location
     and_click_continue
     then_i_see_the_confirm_replacement_course_choice_page
+    and_i_can_see_my_new_course_choice
+    and_i_can_see_my_old_course_choice
 
     when_i_click_replace_course_choice
     then_i_arrrive_at_my_dashboard
     and_i_can_see_my_new_course_choice
     and_i_cannot_see_my_old_course_choice
+
+    given_my_course_choice_has_another_study_mode_option
+
+    when_i_click_update_my_course_choice
+    and_i_choose_to_study_part_time
+    and_click_continue
+    then_i_see_the_confirm_replacement_course_choice_page_for_my_second_course_choice
+    and_i_can_see_my_new_course_choices_study_mode
+    and_i_can_see_my_old_course_choices_study_mode
+
+    when_i_click_replace_course_choice
+    then_i_arrrive_at_my_dashboard
+    and_my_new_course_choice_is_part_time
   end
 
   def given_the_replace_full_or_withdrawn_application_choices_is_active
@@ -182,7 +197,36 @@ RSpec.describe 'A course option selected by a candidate has become full or been 
     expect(page).to have_content @course_option2.site.full_address
   end
 
+  def and_i_can_see_my_old_course_choice
+    expect(page).to have_content @course_option.site.full_address
+  end
+
   def and_i_cannot_see_my_old_course_choice
     expect(page).not_to have_content @course_option.site.full_address
+  end
+
+  def given_my_course_choice_has_another_study_mode_option
+    @part_time_course_option = create(:course_option, :part_time, site: @application_choice.course_option.site, course: @application_choice.course_option.course)
+    @application_choice.course.update!(study_mode: 'full_time_or_part_time')
+  end
+
+  def and_i_choose_to_study_part_time
+    choose 'Study part time instead'
+  end
+
+  def then_i_see_the_confirm_replacement_course_choice_page_for_my_second_course_choice
+    expect(page).to have_current_path candidate_interface_confirm_replacement_course_choice_path(@application_choice.id, @part_time_course_option.id)
+  end
+
+  def and_i_can_see_my_new_course_choices_study_mode
+    expect(page).to have_content @application_choice.course_option.study_mode.humanize
+  end
+
+  def and_i_can_see_my_old_course_choices_study_mode
+    expect(page).to have_content @part_time_course_option.study_mode.humanize
+  end
+
+  def and_my_new_course_choice_is_part_time
+    expect(page).to have_content @part_time_course_option.study_mode.humanize
   end
 end


### PR DESCRIPTION
## Context

Adds the flow for replacing study mode. 
Adds the flow for keeping a course.

## Changes proposed in this pull request

No UI changes. They just click change to x and the controller uses the existing confirmation page.

## Link to Trello card

https://trello.com/c/kUjDNNbH/1646-dev-update-course-choices-if-course-becomes-full-while-waiting-for-references

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
