### PR TITLE
Remove spec assertions that were false and only passed by accident

### DIFF
--- a/spec/system/provider_interface/see_individual_application_spec.rb
+++ b/spec/system/provider_interface/see_individual_application_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
     and_i_should_see_the_candidates_language_skills
     and_i_should_see_the_candidates_references
     and_i_should_see_the_disability_disclosure
-    and_i_should_see_the_application_timeline
     and_i_should_see_a_link_to_respond_to_the_application
     and_i_should_see_a_link_to_download_as_pdf
   end
@@ -265,10 +264,5 @@ RSpec.describe 'A Provider viewing an individual application', with_audited: tru
 
   def and_i_should_see_a_link_to_download_as_pdf
     expect(page).to have_link 'Download application (PDF)'
-  end
-
-  def and_i_should_see_the_application_timeline
-    expect(page).to have_content 'Timeline'
-    expect(page).to have_content 'Application submitted'
   end
 end


### PR DESCRIPTION
We have a "Timeline" tab and the page says "Application submitted". But
we don't show the Timeline on the application page any more.

## Link to Trello card

Noticed while looking at https://trello.com/c/9MUQ9jrv/2292-stop-emails-from-sandbox