### PR TITLE
Add new course flow link to the course full emails

### DIFF
--- a/app/views/candidate_mailer/course_unavailable_course_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_course_full.text.erb
@@ -6,6 +6,18 @@ There are no more places for <%= @application_choice.course_option.course.name_a
 
 The places filled up while we were waiting for your references, so the provider has not got your application.
 
+<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
+
+# Update course choice now
+
+Update your course choice:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
+
+<% else %>
+
 # Decide what you want to do and let us know as soon as possible
 
 Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
@@ -16,3 +28,5 @@ You can:
 - keep the course on your application
 
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
+
+<% end %>

--- a/app/views/candidate_mailer/course_unavailable_course_withdrawn.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_course_withdrawn.text.erb
@@ -6,6 +6,18 @@ Dear <%= @application_form.first_name %>,
 
 The provider removed the course while we were waiting for your references, so they have not got your application.
 
+<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
+
+# Update course choice now
+
+Update your course choice:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
+
+<% else %>
+
 # Decide what you want to do and let us know as soon as possible
 
 Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
@@ -16,3 +28,5 @@ You can:
 - keep the course on your application
 
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
+
+<% end %>

--- a/app/views/candidate_mailer/course_unavailable_location_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_location_full.text.erb
@@ -6,6 +6,18 @@ There are no more places at <%= @application_choice.course_option.site.name %> f
 
 The places filled up while we were waiting for your references, so the provider has not got your application.
 
+<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
+
+# Update your course choice now
+
+Find out about other options for <%= @application_choice.course_option.course.name_and_code %> and edit or replace the course choice:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
+
+<% else %>
+
 # Decide what you want to do and let us know as soon as possible
 
 Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
@@ -18,3 +30,5 @@ You can:
 - keep the course on your application
 
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
+
+<% end %>

--- a/app/views/candidate_mailer/course_unavailable_study_mode_full.text.erb
+++ b/app/views/candidate_mailer/course_unavailable_study_mode_full.text.erb
@@ -6,6 +6,18 @@ There are no more <%= @application_choice.course_option.study_mode.humanize.down
 
 The places filled up while we were waiting for your references, so the provider has not got your application.
 
+<% if FeatureFlag.active?(:replace_full_or_withdrawn_application_choices) %>
+
+# Update your course choice now
+
+Find out about other options for <%= @application_choice.course_option.course.name_and_code %> and edit or replace the course choice:
+
+<%= candidate_magic_link(@application_form.candidate) %>
+
+If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it. 
+
+<% else %>
+
 # Decide what you want to do and let us know as soon as possible
 
 Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do.
@@ -18,3 +30,5 @@ You can:
 - keep the course on your application
 
 If you do nothing, we’ll send your application to the provider when your references come in. There’s no guarantee they’ll consider it.
+
+<% end %>

--- a/spec/mailers/candidate_mailer_spec.rb
+++ b/spec/mailers/candidate_mailer_spec.rb
@@ -462,63 +462,124 @@ RSpec.describe CandidateMailer, type: :mailer do
     end
 
     context 'when the selected course option has no vacancies and there are no other locations/study modes available' do
-      it 'has the correct subject and content' do
+      def send_email
         application_form = build_stubbed_application_form
         application_choice = application_form.application_choices.first
-        email = described_class.course_unavailable_notification(
+        described_class.course_unavailable_notification(
           application_choice,
           :course_full,
         )
+      end
+
+      it 'has the correct subject and content' do
+        email = send_email
 
         expect(email.subject).to eq 'There are no more places for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')
         expect(email.body).to include('There are no more places for Mathematics (M101) at Bilberry College')
+        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
+      end
+
+      it 'has the correct subject and content for new course flow' do
+        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
+        email = send_email
+
+        expect(email.subject).to eq 'There are no more places for Mathematics (M101) at Bilberry College: update your course choice now'
+        expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('There are no more places for Mathematics (M101) at Bilberry College')
+        expect(email.body).to include('Update your course choice:')
       end
     end
 
     context 'when the selected course has been withdrawn' do
-      it 'has the correct subject and content' do
+      def send_email
         application_form = build_stubbed_application_form
         application_choice = application_form.application_choices.first
-        email = described_class.course_unavailable_notification(
+        described_class.course_unavailable_notification(
           application_choice,
           :course_withdrawn,
         )
+      end
+
+      it 'has the correct subject and content' do
+        email = send_email
 
         expect(email.subject).to eq('Mathematics (M101) at Bilberry College is not running anymore: update your course choice now')
         expect(email.body).to include('Dear Fred,')
         expect(email.body).to include('Your course is not running anymore')
         expect(email.body).to include('Bilberry College is not running Mathematics (M101) anymore.')
+        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
+      end
+
+      it 'has the correct subject and content for new course flow' do
+        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
+        email = send_email
+
+        expect(email.subject).to eq('Mathematics (M101) at Bilberry College is not running anymore: update your course choice now')
+        expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('Your course is not running anymore')
+        expect(email.body).to include('Bilberry College is not running Mathematics (M101) anymore.')
+        expect(email.body).to include('Update your course choice:')
       end
     end
 
     context 'when the selected course option has no vacancies and but there are other locations available' do
-      it 'has the correct subject and content' do
+      def send_email
         application_form = build_stubbed_application_form
         application_choice = application_form.application_choices.first
-        email = described_class.course_unavailable_notification(
+        described_class.course_unavailable_notification(
           application_choice,
           :location_full,
         )
+      end
+
+      it 'has the correct subject and content' do
+        email = send_email
 
         expect(email.subject).to eq 'There are no more places at your choice of location for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')
         expect(email.body).to include('There are no more places at West Wilford School for Mathematics (M101) at Bilberry College')
+        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
+      end
+
+      it 'has the correct subject and content for new course flow' do
+        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
+        email = send_email
+
+        expect(email.subject).to eq 'There are no more places at your choice of location for Mathematics (M101) at Bilberry College: update your course choice now'
+        expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('There are no more places at West Wilford School for Mathematics (M101) at Bilberry College')
+        expect(email.body).to include('Find out about other options for Mathematics (M101) and edit or replace the course choice:')
       end
     end
 
     context 'when the selected course option has no vacancies and but there are other study modes available at the same location' do
-      it 'has the correct subject and content' do
+      def send_email
         application_form = build_stubbed_application_form
         application_choice = application_form.application_choices.first
-        email = described_class.course_unavailable_notification(
+        described_class.course_unavailable_notification(
           application_choice,
           :study_mode_full,
         )
+      end
+
+      it 'has the correct subject and content' do
+        email = send_email
 
         expect(email.subject).to eq 'There are no more full time places for Mathematics (M101) at Bilberry College: update your course choice now'
         expect(email.body).to include('Dear Fred,')
         expect(email.body).to include('There are no more full time places for Mathematics (M101) at Bilberry College')
+        expect(email.body).to include('Email us at [becomingateacher@digital.education.gov.uk](mailto:becomingateacher@digital.education.gov.uk) to let us know what you want to do')
+      end
+
+      it 'has the correct subject and content for new course flow' do
+        FeatureFlag.activate(:replace_full_or_withdrawn_application_choices)
+        email = send_email
+
+        expect(email.subject).to eq 'There are no more full time places for Mathematics (M101) at Bilberry College: update your course choice now'
+        expect(email.body).to include('Dear Fred,')
+        expect(email.body).to include('There are no more full time places for Mathematics (M101) at Bilberry College')
+        expect(email.body).to include('Find out about other options for Mathematics (M101) and edit or replace the course choice:')
       end
     end
   end


### PR DESCRIPTION
## Context

Follow up to https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training/pull/2242 to integrate emails with new course edit/replace flow.

## Changes proposed in this pull request

- [x] Add content for link to new course flow under feature flag

## Guidance to review

- The link in the email is just a generic `candidate_magic_link` rather than linking straight to the course replace URL. Is it worth building a way to deep link to a particular page via the `candidate_magic_link`?

## Link to Trello card

https://trello.com/c/s3w1jLAK/1714-dev-notification-emails-for-full-applications-with-new-course-flow

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
