### PR TITLE
Do not try to delete invalid course_options which are part of offers

### DIFF
--- a/app/services/sync_provider_from_find.rb
+++ b/app/services/sync_provider_from_find.rb
@@ -168,7 +168,10 @@ private
     invalid_course_options = course_options.where.not(sites: { code: canonical_site_codes })
     return if invalid_course_options.blank?
 
-    chosen_course_option_ids = ApplicationChoice.where(course_option: invalid_course_options).pluck(:course_option_id)
+    chosen_course_option_ids = ApplicationChoice
+      .where(course_option: invalid_course_options)
+      .or(ApplicationChoice.where(offered_course_option: invalid_course_options))
+      .pluck(:course_option_id, :offered_course_option_id).flatten.uniq
 
     not_part_of_an_application = invalid_course_options.where.not(id: chosen_course_option_ids)
     not_part_of_an_application.delete_all

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -227,13 +227,18 @@ RSpec.describe SyncProviderFromFind do
 
         invalid_site_one = create(:site, provider: course.provider, code: 'B')
         invalid_site_two = create(:site, provider: course.provider, code: 'C')
+        invalid_site_three = create(:site, provider: course.provider, code: 'D')
         invalid_course_option_one = create(:course_option, course: course, site: invalid_site_one)
         invalid_course_option_two = create(:course_option, course: course, site: invalid_site_two)
+        invalid_course_option_three = create(:course_option, course: course, site: invalid_site_three)
+
         create(:application_choice, course_option: invalid_course_option_two)
+        create(:application_choice, course_option: valid_course_option, offered_course_option: invalid_course_option_three)
         SyncProviderFromFind.call(provider_name: 'ABC College', provider_code: 'ABC')
 
         expect(CourseOption.exists?(invalid_course_option_one.id)).to eq false
         expect(invalid_course_option_two.reload).not_to be_site_still_valid
+        expect(invalid_course_option_three.reload).not_to be_site_still_valid
         expect(valid_course_option.reload).to be_site_still_valid
       end
 


### PR DESCRIPTION
## Context

SyncProviderFromFind has errored out on every run(?) since 1:05pm on 15th June.
https://sentry.io/organizations/dfe-bat/issues/1727278204/?referrer=slack

## Changes proposed in this pull request

When we check for which course options are chosen, include those which are offered. Otherwise SyncProviderFromFind blows up with a foreign key error bc the course_option we're trying to delete is still referenced from the application_choices table.

## Guidance to review

Does the fix make sense?

Do we need to update any downstream code?

## Link to Trello card

N/A

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
