### PR TITLE
Stop emails from sandbox

### DIFF
--- a/app/components/provider_interface/email_log_row_component.html.erb
+++ b/app/components/provider_interface/email_log_row_component.html.erb
@@ -1,0 +1,19 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell">
+    <%= email.created_at.to_s(:govuk_date_and_time) %>
+  </td>
+  <td class="govuk-table__cell">
+    <%= render SummaryListComponent.new(rows: summary_list_rows) %>
+
+    <details class="govuk-details" data-module="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Email body
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <%= tag.pre(email.body) %>
+      </div>
+    </details>
+  </td>
+</tr>

--- a/app/components/provider_interface/email_log_row_component.rb
+++ b/app/components/provider_interface/email_log_row_component.rb
@@ -9,39 +9,10 @@ module ProviderInterface
     end
 
     def summary_list_rows
-      rows = [
-        { key: 'Status', value: status_tag },
-        { key: 'Type', value: email.humanised_email_type },
+      [
         { key: 'To', value: email.to },
         { key: 'Subject', value: email.subject.inspect },
       ]
-
-      if email.application_form
-        rows << { key: 'Application', value: application_link }
-      end
-
-      rows
-    end
-
-  private
-
-    def status_tag
-      colour_tag = {
-        not_tracked: 'govuk-tag--grey',
-        pending: 'govuk-tag--yellow',
-        unknown: 'govuk-tag--grey',
-        delivered: 'govuk-tag--green',
-        notify_error: 'govuk-tag--red',
-        permanent_failure: 'govuk-tag--red',
-        temporary_failure: 'govuk-tag--pink',
-        technical_failure: 'govuk-tag--orange',
-      }[email.delivery_status.to_sym]
-
-      tag.span(email.delivery_status.humanize, class: "govuk-tag #{colour_tag}", title: "Notify reference: `#{email.notify_reference}`")
-    end
-
-    def application_link
-      govuk_link_to("#{email.application_form.full_name} (#{email.application_form.support_reference})", support_interface_application_form_path(email.application_form))
     end
   end
 end

--- a/app/components/provider_interface/email_log_row_component.rb
+++ b/app/components/provider_interface/email_log_row_component.rb
@@ -1,0 +1,47 @@
+module ProviderInterface
+  class EmailLogRowComponent < ViewComponent::Base
+    include ViewHelper
+
+    attr_reader :email
+
+    def initialize(email:)
+      @email = email
+    end
+
+    def summary_list_rows
+      rows = [
+        { key: 'Status', value: status_tag },
+        { key: 'Type', value: email.humanised_email_type },
+        { key: 'To', value: email.to },
+        { key: 'Subject', value: email.subject.inspect },
+      ]
+
+      if email.application_form
+        rows << { key: 'Application', value: application_link }
+      end
+
+      rows
+    end
+
+  private
+
+    def status_tag
+      colour_tag = {
+        not_tracked: 'govuk-tag--grey',
+        pending: 'govuk-tag--yellow',
+        unknown: 'govuk-tag--grey',
+        delivered: 'govuk-tag--green',
+        notify_error: 'govuk-tag--red',
+        permanent_failure: 'govuk-tag--red',
+        temporary_failure: 'govuk-tag--pink',
+        technical_failure: 'govuk-tag--orange',
+      }[email.delivery_status.to_sym]
+
+      tag.span(email.delivery_status.humanize, class: "govuk-tag #{colour_tag}", title: "Notify reference: `#{email.notify_reference}`")
+    end
+
+    def application_link
+      govuk_link_to("#{email.application_form.full_name} (#{email.application_form.support_reference})", support_interface_application_form_path(email.application_form))
+    end
+  end
+end

--- a/app/components/sub_navigation_component.html.erb
+++ b/app/components/sub_navigation_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-tabs app-tabs govuk-!-display-none-print">
+<div class="govuk-tabs app-tabs govuk-!-display-none-print" data-qa="sub-navigation">
   <ul class="govuk-tabs__list">
     <% items.each do |item| %>
       <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -56,6 +56,11 @@ module ProviderInterface
 
     def timeline; end
 
+    def emails
+      @emails = Email.includes(:application_form)
+        .where(application_form_id: @application_choice.application_form)
+    end
+
   private
 
     def available_providers
@@ -85,6 +90,12 @@ module ProviderInterface
       sub_navigation_items.push(
         { name: 'Timeline', url: provider_interface_application_choice_timeline_path(@application_choice) },
       )
+
+      if HostingEnvironment.sandbox_mode?
+        sub_navigation_items.push(
+          { name: 'Emails (Sandbox only)', url: provider_interface_application_choice_emails_path(@application_choice) },
+        )
+      end
 
       sub_navigation_items
     end

--- a/app/controllers/provider_interface/application_choices_controller.rb
+++ b/app/controllers/provider_interface/application_choices_controller.rb
@@ -57,8 +57,12 @@ module ProviderInterface
     def timeline; end
 
     def emails
-      @emails = Email.includes(:application_form)
-        .where(application_form_id: @application_choice.application_form)
+      if HostingEnvironment.sandbox_mode?
+        @emails = Email.includes(:application_form)
+          .where(application_form_id: @application_choice.application_form)
+      else
+        render_403
+      end
     end
 
   private

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -1,3 +1,9 @@
+### 16th June 2020
+
+Sandbox changes:
+
+- Sandbox no longer sends emails to providers about application state changes.
+
 ### 15th June 2020
 
 New attributes:

--- a/app/views/api_docs/pages/release_notes.md
+++ b/app/views/api_docs/pages/release_notes.md
@@ -2,7 +2,7 @@
 
 Sandbox changes:
 
-- Sandbox no longer sends emails to providers about application state changes.
+- Sandbox no longer sends emails to providers about application state changes
 
 ### 15th June 2020
 

--- a/app/views/provider_interface/application_choices/emails.html.erb
+++ b/app/views/provider_interface/application_choices/emails.html.erb
@@ -27,7 +27,7 @@
   </thead>
   <tbody class="govuk-table__body">
   <% @emails.each do |email| %>
-    <%= render SupportInterface::EmailLogRowComponent.new(email: email) %>
+    <%= render ProviderInterface::EmailLogRowComponent.new(email: email) %>
   <% end %>
   </tbody>
 </table>

--- a/app/views/provider_interface/application_choices/emails.html.erb
+++ b/app/views/provider_interface/application_choices/emails.html.erb
@@ -1,0 +1,33 @@
+<% content_for :title, "#{@application_choice.application_form.full_name} – #{@application_choice.course.name_and_code} - Email log" %>
+
+<% content_for :before_content do %>
+  <div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to 'Applications', provider_interface_applications_path, class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to @application_choice.application_form.full_name, provider_interface_application_choice_path(@application_choice), class: 'govuk-breadcrumbs__link' %>
+      </li>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        Timeline
+      </li>
+    </ol>
+  </div>
+<% end %>
+
+<%= render 'application_choice_header' %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-table__header govuk-!-width-one-quarter">Time</th>
+      <th class="govuk-table__header govuk-table__header govuk-!-width-three-quarters">Email</th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% @emails.each do |email| %>
+    <%= render SupportInterface::EmailLogRowComponent.new(email: email) %>
+  <% end %>
+  </tbody>
+</table>

--- a/config/initializers/mail_interceptors.rb
+++ b/config/initializers/mail_interceptors.rb
@@ -1,10 +1,12 @@
 require 'test_email_interceptor'
 require 'environment_flag_interceptor'
 require 'email_log_interceptor'
+require 'sandbox_interceptor'
 
 if Rails.env.production?
   ActionMailer::Base.register_interceptor(TestEmailInterceptor)
 end
 
+ActionMailer::Base.register_interceptor(SandboxInterceptor)
 ActionMailer::Base.register_interceptor(EnvironmentFlagInterceptor)
 ActionMailer::Base.register_interceptor(EmailLogInterceptor)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -446,6 +446,7 @@ Rails.application.routes.draw do
     get '/applications/:application_choice_id/notes/new' => 'application_choices#new_note', as: :application_choice_new_note
     post '/applications/:application_choice_id/notes' => 'application_choices#create_note', as: :application_choice_create_note
     get '/applications/:application_choice_id/timeline' => 'application_choices#timeline', as: :application_choice_timeline
+    get '/applications/:application_choice_id/emails' => 'application_choices#emails', as: :application_choice_emails
     get '/applications/:application_choice_id/respond' => 'decisions#respond', as: :application_choice_respond
     post '/applications/:application_choice_id/respond' => 'decisions#submit_response', as: :application_choice_submit_response
     get '/applications/:application_choice_id/offer' => 'decisions#new_offer', as: :application_choice_new_offer

--- a/lib/sandbox_interceptor.rb
+++ b/lib/sandbox_interceptor.rb
@@ -1,0 +1,12 @@
+class SandboxInterceptor
+  PROVIDER_EMAIL_WHITELIST = %w[fallback_sign_in_email account_created].freeze
+
+  def self.delivering_email(message)
+    return unless HostingEnvironment.sandbox_mode?
+
+    if message.header['rails_mailer'].value == 'provider_mailer' &&
+        PROVIDER_EMAIL_WHITELIST.exclude?(message.header['rails_mail_template'].value)
+      message.perform_deliveries = false
+    end
+  end
+end

--- a/spec/lib/sandbox_interceptor_spec.rb
+++ b/spec/lib/sandbox_interceptor_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe SandboxInterceptor do
+  context 'In sandbox mode', sandbox: true do
+    context 'when rails_mailer is set to provider_mailer' do
+      it 'aborts delivery by default' do
+        message = email_with_mailer_and_template_headers('provider_mailer', 'anything')
+
+        SandboxInterceptor.delivering_email(message)
+
+        expect(message.perform_deliveries).to be false
+      end
+
+      it 'still permits fallback_sign_in_email' do
+        message = email_with_mailer_and_template_headers('provider_mailer', 'fallback_sign_in_email')
+
+        SandboxInterceptor.delivering_email(message)
+
+        expect(message.perform_deliveries).to be true
+      end
+
+      it 'still permits account_created' do
+        message = email_with_mailer_and_template_headers('provider_mailer', 'account_created')
+
+        SandboxInterceptor.delivering_email(message)
+
+        expect(message.perform_deliveries).to be true
+      end
+    end
+
+    it 'allows delivery when rails_mailer is not set to provider_mailer' do
+      message = email_with_mailer_and_template_headers('authentication_mailer', 'sign_in_email')
+
+      SandboxInterceptor.delivering_email(message)
+
+      expect(message.perform_deliveries).to be true
+    end
+  end
+
+  it 'does nothing outside sandbox mode' do
+    message = email_with_mailer_and_template_headers('provider_mailer', 'anything')
+
+    SandboxInterceptor.delivering_email(message)
+
+    expect(message.perform_deliveries).to be true
+  end
+
+  # this reflects the standard format emitted by ApplicationMailer
+  def email_with_mailer_and_template_headers(mailer, template)
+    Mail::Message.new(to: ['test@example.com'], subject: 'Foo', headers: { rails_mailer: mailer, rails_mail_template: template })
+  end
+end

--- a/spec/requests/provider_interface/email_log_spec.rb
+++ b/spec/requests/provider_interface/email_log_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe 'GET /application_choices/:id/emails' do
+  include CourseOptionHelpers
+
+  let(:provider) { create(:provider, :with_signed_agreement) }
+  let(:application_choice) do
+    create(:application_choice, :awaiting_provider_decision,
+           course_option: course_option_for_provider(provider: provider))
+  end
+
+  before do
+    provider_user = create(:provider_user, providers: [provider], dfe_sign_in_uid: 'DFE_SIGN_IN_UID')
+
+    allow(DfESignInUser).to receive(:load_from_session)
+      .and_return(
+        DfESignInUser.new(
+          email_address: provider_user.email_address,
+          dfe_sign_in_uid: provider_user.dfe_sign_in_uid,
+          first_name: provider_user.first_name,
+          last_name: provider_user.last_name,
+        ),
+      )
+  end
+
+  it 'responds with 403 if sandbox mode is disabled', sandbox: false do
+    get provider_interface_application_choice_emails_path(application_choice)
+
+    expect(response.status).to eq(403)
+  end
+
+  it 'responds with 200 if sandbox mode is enabled', sandbox: true do
+    get provider_interface_application_choice_emails_path(application_choice)
+
+    expect(response.status).to eq(200)
+  end
+end

--- a/spec/system/provider_interface/sandbox_emails_spec.rb
+++ b/spec/system/provider_interface/sandbox_emails_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature 'Emails are suppressed in Sandbox' do
+  include CourseOptionHelpers
+  include DfESignInHelpers
+
+  scenario 'when a candidate triggers a notification', sidekiq: true, sandbox: true do
+    given_i_am_a_provider_user_with_dfe_sign_in
+    and_i_am_permitted_to_see_applications_for_my_provider
+    and_an_application_choice_with_an_offer_exists_for_the_provider
+
+    when_a_user_accepts_the_offer
+    then_i_should_not_get_an_email
+
+    when_i_sign_in_to_the_provider_interface
+    and_i_visit_the_application
+    then_i_should_see_the_email_in_the_email_log
+  end
+
+  def given_i_am_a_provider_user_with_dfe_sign_in
+    provider_exists_in_dfe_sign_in
+  end
+
+  def and_i_am_permitted_to_see_applications_for_my_provider
+    provider_user_exists_in_apply_database
+  end
+
+  def and_an_application_choice_with_an_offer_exists_for_the_provider
+    course_option = course_option_for_provider_code(provider_code: 'ABC')
+    @application_choice = create(:application_choice, :with_offer, course_option: course_option)
+  end
+
+  def when_a_user_accepts_the_offer
+    # cheating as I don't want to touch the candidate UI
+    AcceptOffer.new(application_choice: @application_choice).save!
+  end
+
+  def then_i_should_not_get_an_email
+    open_email('provider@example.com')
+    expect(current_email).to be_nil
+  end
+
+  def when_i_sign_in_to_the_provider_interface
+    provider_signs_in_using_dfe_sign_in
+  end
+
+  def and_i_visit_the_application
+    visit provider_interface_application_choice_path(
+      @application_choice.id,
+    )
+  end
+
+  def then_i_should_see_the_email_in_the_email_log
+    within('[data-qa="sub-navigation"]') do
+      click_link 'Emails (Sandbox only)'
+    end
+
+    expect(page).to have_content('has accepted your offer')
+  end
+end


### PR DESCRIPTION
## Context

The sandbox sends a lot of emails, many of them related to mass-generated applications. This is noisy for providers and for us.

## Changes proposed in this pull request

- Stop delivering emails from sandbox
- Add an "Emails" tab to applications in the sandbox where providers can view the email history for an application.

![Screenshot 2020-06-16 at 15 18 19](https://user-images.githubusercontent.com/642279/84786418-a68ec480-afe4-11ea-9642-652a1ea3fac4.png)

## Guidance to review

- Are emails correctly stopped
- Does the log work?

## Link to Trello card

https://trello.com/c/9MUQ9jrv/2292-stop-emails-from-sandbox

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
