### PR TITLE
Make course queries cycle aware

### DIFF
--- a/app/components/candidate_interface/course_choices_review_component.rb
+++ b/app/components/candidate_interface/course_choices_review_component.rb
@@ -187,7 +187,7 @@ module CandidateInterface
     end
 
     def has_multiple_courses?(application_choice)
-      Course.where(provider: application_choice.provider).many?
+      Course.current_cycle.where(provider: application_choice.provider).many?
     end
   end
 end

--- a/app/forms/candidate_interface/pick_course_form.rb
+++ b/app/forms/candidate_interface/pick_course_form.rb
@@ -12,13 +12,13 @@ module CandidateInterface
 
     def radio_available_courses
       @radio_available_courses ||= begin
-        provider.courses.exposed_in_find.order(:name)
+        courses_for_current_cycle.exposed_in_find.order(:name)
       end
     end
 
     def dropdown_available_courses
       @dropdown_available_courses ||= begin
-        courses = provider.courses.exposed_in_find.includes(:accredited_provider)
+        courses = courses_for_current_cycle.exposed_in_find.includes(:accredited_provider)
 
         courses_with_names = courses.map(&:name).map(&:downcase)
         courses_with_descriptions = courses.map(&:name_and_description).map(&:downcase)
@@ -47,6 +47,10 @@ module CandidateInterface
 
     def single_site?
       CourseOption.where(course_id: course.id).one?
+    end
+
+    def courses_for_current_cycle
+      provider.courses.current_cycle
     end
 
     delegate :both_study_modes_available?, to: :course

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -8,7 +8,7 @@ class TestApplications
     1.upto(count).flat_map do
       create_application(
         states: [:awaiting_provider_decision] * courses_per_application,
-        courses_to_apply_to: Course.open_on_apply.where(provider: provider),
+        courses_to_apply_to: Course.current_cycle.open_on_apply.where(provider: provider),
       )
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,6 +11,7 @@ class Course < ApplicationRecord
 
   scope :open_on_apply, -> { exposed_in_find.where(open_on_apply: true) }
   scope :exposed_in_find, -> { where(exposed_in_find: true) }
+  scope :current_cycle, -> { where(recruitment_cycle_year: RecruitmentCycle.current_year) }
 
   CODE_LENGTH = 4
 

--- a/app/models/find_api.rb
+++ b/app/models/find_api.rb
@@ -1,3 +1,0 @@
-module FindAPI
-  RECRUITMENT_CYCLE_YEAR = ENV.fetch('RECRUITMENT_CYCLE_YEAR') { 2020 }
-end

--- a/app/models/find_api/course.rb
+++ b/app/models/find_api/course.rb
@@ -22,7 +22,7 @@ module FindAPI
     end
 
     def self.fetch(provider_code, course_code)
-      where(recruitment_cycle_year: RECRUITMENT_CYCLE_YEAR)
+      where(recruitment_cycle_year: RecruitmentCycle.current_year)
         .where(provider_code: provider_code)
         .find(course_code)
         .first

--- a/app/models/find_api/provider.rb
+++ b/app/models/find_api/provider.rb
@@ -13,7 +13,7 @@ module FindAPI
     class Subject < FindAPI::Resource; end
 
     def self.current_cycle
-      where(recruitment_cycle_year: RECRUITMENT_CYCLE_YEAR)
+      where(recruitment_cycle_year: RecruitmentCycle.current_year)
     end
   end
 end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -1,0 +1,9 @@
+module RecruitmentCycle
+  def self.current_year
+    if FeatureFlag.active?('switch_to_2021_recruitment_cycle')
+      2021
+    else
+      2020
+    end
+  end
+end

--- a/app/services/feature_flag.rb
+++ b/app/services/feature_flag.rb
@@ -18,6 +18,7 @@ class FeatureFlag
     [:dfe_sign_in_fallback, 'Use this when DfE Sign-in is down', 'Tijmen Brommet'],
     [:force_ok_computer_to_fail, 'OK Computer implements a health check endpoint, this flag forces it to fail for testing purposes', 'Michael Nacos'],
     [:pilot_open, 'Enables the Apply for Teacher Training service', 'Tijmen Brommet'],
+    [:switch_to_2021_recruitment_cycle, 'Sync and serve courses for the 2021 recruitment cycle. DO NOT ENABLE IN PRODUCTION.', 'Duncan Brown'],
   ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [

--- a/app/services/get_application_choices_for_providers.rb
+++ b/app/services/get_application_choices_for_providers.rb
@@ -17,7 +17,7 @@ class GetApplicationChoicesForProviders
     ]
 
     ApplicationChoice.includes(*includes)
-      .where('courses.provider_id' => providers)
+      .where('courses.provider_id' => providers, 'courses.recruitment_cycle_year' => RecruitmentCycle.current_year)
       .or(ApplicationChoice.includes(*includes)
         .where('courses.accredited_provider_id' => providers))
       .where('status IN (?)', ApplicationStateChange.states_visible_to_provider).includes([:accredited_provider])

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe RecruitmentCycle do
+  describe '.current_year' do
+    it 'is 2020' do
+      expect(RecruitmentCycle.current_year).to eq(2020)
+    end
+
+    it 'can be changed to 2021 using a feature flag' do
+      FeatureFlag.activate('switch_to_2021_recruitment_cycle')
+      expect(RecruitmentCycle.current_year).to eq(2021)
+    end
+  end
+end

--- a/spec/services/get_application_choices_for_providers_spec.rb
+++ b/spec/services/get_application_choices_for_providers_spec.rb
@@ -146,4 +146,30 @@ RSpec.describe GetApplicationChoicesForProviders do
     expect(returned_application_names).to include('Aaron', 'Jim', 'Harry')
     expect(returned_application_names).not_to include('Alex')
   end
+
+  it 'returns application choices for courses in this recruitment cycle only' do
+    current_provider = create(:provider)
+    course_option_for_this_cycle = course_option_for_provider(provider: current_provider)
+    course_option_for_past_cycle = course_option_for_provider(provider: current_provider).tap do |option|
+      option.course.update!(recruitment_cycle_year: 2016)
+      option.reload
+    end
+
+    choice_for_this_cycle = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option_for_this_cycle,
+    )
+
+    choice_for_past_cycle = create(
+      :application_choice,
+      :awaiting_provider_decision,
+      course_option: course_option_for_past_cycle,
+    )
+
+    returned_applications = GetApplicationChoicesForProviders.call(providers: current_provider)
+
+    expect(returned_applications.map(&:id)).to include(choice_for_this_cycle.id)
+    expect(returned_applications.map(&:id)).not_to include(choice_for_past_cycle.id)
+  end
 end

--- a/spec/services/sync_provider_from_find_spec.rb
+++ b/spec/services/sync_provider_from_find_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe SyncProviderFromFind do
         expect(course_option.course.provider.code).to eq 'ABC'
         expect(course_option.course.code).to eq '9CBA'
         expect(course_option.course.exposed_in_find).to be true
-        expect(course_option.course.recruitment_cycle_year).to be FindAPI::RECRUITMENT_CYCLE_YEAR
+        expect(course_option.course.recruitment_cycle_year).to eql RecruitmentCycle.current_year
         expect(course_option.course.description).to eq 'PGCE with QTS full time'
         expect(course_option.course.start_date).to eq Time.zone.local(2020, 10, 31)
         expect(course_option.course.course_length).to eq 'OneYear'
@@ -75,7 +75,7 @@ RSpec.describe SyncProviderFromFind do
         expect(course_option.course.provider.code).to eq 'ABC'
         expect(course_option.course.code).to eq '9CBA'
         expect(course_option.course.exposed_in_find).to be true
-        expect(course_option.course.recruitment_cycle_year).to be FindAPI::RECRUITMENT_CYCLE_YEAR
+        expect(course_option.course.recruitment_cycle_year).to eql RecruitmentCycle.current_year
         expect(course_option.site.name).to eq 'Main site'
         expect(course_option.site.address_line1).to eq 'Gorse SCITT'
         expect(course_option.site.address_line2).to be_nil


### PR DESCRIPTION
## Context

As we prepare for Rollover, we're going to start syncing courses for the next recruitment cycle.

This means that courses for 2020 and 2021 will live side by side in our database.

As a first step, we need to make sure that we don't serve up courses for the wrong recruitment cycle. We also want a way to preview the app when the next cycle has started.

## Changes proposed in this pull request

- Move the definition of the current recruitment cycle out of `FindAPI` and into a module of its own called `RecruitmentCycle`.
- Visit each place in the app where we look up courses and scope the query to the current cycle using a scope on `Course`.
- When loading applications in the provider interface, make sure we only get applications for courses in the current cycle. This might need to change in future (eg when a provider needs to retain access to courses from the previous cycle) but I think this is a reasonable place to start.
- Add a feature flag to pretend we're in the 2021 cycle so we can see what it's like and what breaks

This PR makes no changes to support, as we already display recruitment cycle information .

## Guidance to review

I'm not 100% sure I've got all the places where we look up courses — are there others?

## Link to Trello card

https://trello.com/c/yijdh9OU/2252-rollover-make-course-queries-cycle-aware

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
