### PR TITLE
publish rspec test results even if run fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,9 +38,11 @@ yarn-debug.log*
 
 # ignore code coverage reports
 coverage/*
+testArtifacts/*
 
 # dotenv
 .env
+.envrc
 
 # Mac OS thumbnail DBs
 .DS_Store
@@ -48,3 +50,6 @@ coverage/*
 # Byebug history files
 .byebug_history
 .erblint*
+
+# ignore asdf-vm file, supports running multiple ruby version
+.tool-versions

--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ group :test do
   gem 'guard-rspec'
   gem 'webmock'
   gem 'simplecov', require: false
+  gem 'simplecov-cobertura', require: false
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'clockwork-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,6 +463,8 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
+    simplecov-cobertura (1.3.1)
+      simplecov (~> 0.8)
     simplecov-html (0.12.1)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
@@ -586,6 +588,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.3)
   sidekiq
   simplecov
+  simplecov-cobertura
   timecop
   uk_postcode
   view_component

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,8 @@ variables:
   value: false
 - name: buildCancelled
   value: false
+- name: disable.coverage.autogenerate
+  value: true
 
 stages:
 - stage: build_release
@@ -71,20 +73,6 @@ stages:
         GOVUK_NOTIFY_CALLBACK_API_KEY: $(govukNotifyCallbackAPIKey)
         SANDBOX: $(sandbox)
 
-    - script: |
-        mkdir $(System.DefaultWorkingDirectory)/docker_images
-        docker save $(docker history -q $(dockerHubUsername)/$(imageName) | grep -v "<missing>") | gzip > $(System.DefaultWorkingDirectory)/docker_images/$(imageName).tar.gz
-        docker images $(dockerHubUsername)/$(imageName) | sed 1d | awk '{print $1 " " $2 " " $3}' > $(System.DefaultWorkingDirectory)/docker_images/images_manifest.txt
-      displayName: 'Export Docker image pipeline artifact'
-      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
-
-    - task: PublishPipelineArtifact@1
-      displayName: 'Publish Docker image artifact'
-      condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
-      inputs:
-        path: '$(System.DefaultWorkingDirectory)/docker_images/'
-        artifactName: 'docker_artifacts'
-    
     - task: PublishPipelineArtifact@1
       displayName: 'Publish ARM template artifacts'
       condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
@@ -203,12 +191,12 @@ stages:
         test_result=$?
         if [ "$test_result" == "0" ]
         then
-          if [ $(find results/ -type f -name TEST*.xml | wc -l) -gt 0 ]
+          if [ $(find testArtifacts/ -type f -name TEST*.xml | wc -l) -gt 0 ]
           then
             errors=0
             warnings=0
 
-            for line in $(grep "^<testsuite " results/TEST*.xml)
+            for line in $(grep "^<testsuite " testArtifacts/TEST*.xml)
             do
               if [[ $line == failure* ]]
               then
@@ -275,25 +263,29 @@ stages:
 
     - task: PublishTestResults@2
       displayName: 'Publish test results'
+      condition: succeededOrFailed()
       inputs:
         testRunner: JUnit
-        testResultsFiles: 'results/*.xml'
+        testResultsFiles: 'testArtifacts/**/TEST-*.xml'
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Cucumber Results XML'
+      condition: succeededOrFailed()
       inputs:
-        path: '$(System.DefaultWorkingDirectory)/results/'
-        artifactName: 'cucumberResults'
+        path: '$(System.DefaultWorkingDirectory)/testArtifacts/'
+        artifactName: 'cucumber-results'
 
   - template: rspec-job-template.yml
     parameters:
       testCommand: 'integration-tests'
       displayName: 'Integration Tests'
+      jobId: 'integration_tests'
         
   - template: rspec-job-template.yml
     parameters:
       testCommand: 'unit-tests'
       displayName: 'Unit Tests'
+      jobId: 'unit_tests'
 
 
 - stage: deploy_qa

--- a/rspec-job-template.yml
+++ b/rspec-job-template.yml
@@ -3,9 +3,11 @@ parameters:
     type: string
   - name: displayName
     type: string
+  - name: jobId
+    type: string    
 
 jobs:
-- job:
+- job: ${{ parameters.jobId }}
   displayName: 'RSpec - ${{ parameters.displayName }}'
   condition: and(succeeded(), eq(variables['deployOnly'], false))
   pool:
@@ -48,16 +50,18 @@ jobs:
   - template: run-rspec-test-template.yml
     parameters:
       testCommand: ${{ format('ci.{0}', parameters.testCommand) }}
-      testResultsFile: ${{ format('results/rspec-{0}-results.xml', parameters.testCommand) }}
+      testResultsFile: ${{ format('testArtifacts/rspec-{0}-results.xml', parameters.testCommand) }}
 
   - task: PublishTestResults@2
+    condition: succeededOrFailed()
     displayName: 'Publish test results'
     inputs:
-      testRunner: JUnit
-      testResultsFiles: 'results/*.xml'
+      testResultsFiles: 'testArtifacts/**/rspec-*.xml'
+      testRunTitle: ${{ parameters.testCommand }}
 
   - task: PublishPipelineArtifact@1
-    displayName: 'Publish RSpec Results'
+    condition: succeededOrFailed()
+    displayName: 'Publish Test Artifacts'
     inputs:
-      path: '$(System.DefaultWorkingDirectory)/results/'
+      path: '$(System.DefaultWorkingDirectory)/testArtifacts/'
       artifactName: ${{ format('rspec-{0}', parameters.testCommand) }}

--- a/run-rspec-test-template.yml
+++ b/run-rspec-test-template.yml
@@ -7,11 +7,17 @@ parameters:
 steps:
   - script: |
       make ${{ parameters.testCommand }}
-        test_result=$?
-        if [ "$test_result" == "0" ]
+      test_result=$?
+      if [ "$test_result" == "0" ]
+      then
+        echo $testResultFile
+        ls testArtifacts
+        if [ -f $testResultFile ]
         then
-          if [ -f $testResultFile ]
+          if [ $(grep "^<testsuite name=\"rspec\"" $testResultFile | cut -d' ' -f5 | cut -d'"' -f2) -gt 0 ]
           then
+            seedvalue=$(grep -Pio 'name="seed" value="\d+"' $testResultFile)
+            echo "##[command]$seedvalue"
             if [ $(grep "^<testsuite name=\"rspec\"" $testResultFile | cut -d' ' -f5 | cut -d'"' -f2) -gt 0 ]
             then
               echo "##vso[task.logissue type=error]One or more rspec tests failed"
@@ -23,13 +29,22 @@ steps:
             fi
           else
             echo "##vso[task.logissue type=error]rspec-results file not found."
+            echo "##vso[task.logissue type=error]One or more rspec tests failed"
             exit 1
           fi
-          exit 0
+          if [ $(grep "^<testsuite name=\"rspec\"" $testResultFile | cut -d' ' -f4 | cut -d'"' -f2) -gt 0 ]
+          then
+            echo "##vso[task.logissue type=warning]One or more rspec tests were skipped"
+          fi
         else
-          echo "##vso[task.logissue type=error]Rspec test task exited abnormally."
+          echo "##vso[task.logissue type=error]rspec-results file not found."
           exit 1
         fi
+        exit 0
+      else
+        echo "##vso[task.logissue type=error]Rspec test task exited abnormally."
+        exit 1
+      fi
     displayName: 'Execute ${{ parameters.testCommand }}'
     env:
       testResultFile: ${{ parameters.testResultsFile }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,11 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'simplecov'
+require 'simplecov-cobertura'
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::CoberturaFormatter,
+]
 SimpleCov.start 'rails'
 
 require 'sidekiq/testing'


### PR DESCRIPTION
## Context

Currently the rspec test results gets published only if the test run succeeds, this make it difficult to track tests which have failed in the pipeline.

## Changes proposed in this pull request

publish the rspec test results xml files to the build agent artifacts location 
irrespective of the test run status.

also add a simplecov-cobertura gem which produces coverage report in a html format which is compatiable with Azure DevOps.

## Guidance to review

commits.

## Link to Trello card

https://trello.com/c/ssmSZQaz/2296-log-rspec-seed-when-running-tests-on-azure-pipelines

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
