### PR TITLE
Generate TAD performance reports

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,6 +115,10 @@ Rails/NotNullColumn:
 Naming/MemoizedInstanceVariableName:
   Enabled: false
 
+# sometimes reduce is fine
+Style/EachWithObject:
+  Enabled: false
+
 # Pending cops
 # These will be enabled by default at Rubocop 1.0
 Style/HashEachMethods:

--- a/app/controllers/support_interface/performance_controller.rb
+++ b/app/controllers/support_interface/performance_controller.rb
@@ -67,6 +67,13 @@ module SupportInterface
       send_data csv, filename: "active-provider-users-#{Time.zone.today}.csv", disposition: :attachment
     end
 
+    def tad_provider_performance
+      export_rows = SupportInterface::TADProviderStatsExport.new.call
+      csv = to_csv(export_rows)
+
+      send_data csv, filename: "tad-provider-performance-#{Time.zone.today}.csv", disposition: :attachment
+    end
+
   private
 
     def to_csv(objects, header_row = nil)

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -80,6 +80,11 @@ class TestApplications
 
       return if states.include? :unsubmitted
 
+      if states.include? :cancelled
+        SupportInterface::CancelApplicationForm.new(application_form: @application_form).save!
+        return
+      end
+
       without_slack_message_sending do
         fast_forward(1..2)
         SubmitApplication.new(@application_form).call

--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -83,7 +83,12 @@ class TestApplications
       without_slack_message_sending do
         fast_forward(1..2)
         SubmitApplication.new(@application_form).call
-        @application_form.update_columns(submitted_at: time, edit_by: time + 7.days)
+
+        # To prevent immediate sending to provider, which uses the current
+        # time to decide whether edit_by has passed, temporarily set edit_by to
+        # a date in the future relative to now
+        @application_form.update_columns(submitted_at: time, edit_by: Time.zone.now + 1.day)
+
         return if states.include? :awaiting_references
 
         @application_form.application_references.each do |reference|
@@ -97,6 +102,12 @@ class TestApplications
             reference: reference,
           ).save!
         end
+
+        # Now that the application has *not* been sent to the provider as a side effect
+        # of SubmitReference, set edit_by back to a time which makes sense with the
+        # false timeline we're building for this application
+        @application_form.update_columns(edit_by: time + 7.days)
+
         return if states.include? :application_complete
 
         application_choices.map(&:reload)

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -1,0 +1,41 @@
+module SupportInterface
+  class TADProviderStatsExport
+    OFFERED_STATES = %w[offer enrolled recruited declined].freeze
+    ACCEPTED_STATES = %w[recruited enrolled].freeze
+
+    def call
+      Course.all
+        .map { |c| course_to_row(c) }
+        .sort_by { |r| r[:provider_code] }
+    end
+
+  private
+
+    def course_to_row(course)
+      statuses = ApplicationChoice
+                   .joins(:course)
+                   .where(courses: { id: course.id })
+                   .where('status IN (?)', ApplicationStateChange.states_visible_to_provider)
+                   .pluck(:status)
+
+      row_template = {
+        provider_id: nil,
+        provider_code: course.provider.code,
+        provider: course.provider.name,
+        provider_type: nil,
+        urn: nil,
+        lead_school: nil,
+        subject: course.name,
+        applications: statuses.count,
+        offers: 0,
+        acceptances: 0,
+      }
+
+      statuses.reduce(row_template) do |row, status|
+        row[:offers] += 1 if OFFERED_STATES.include?(status)
+        row[:acceptances] += 1 if ACCEPTED_STATES.include?(status)
+        row
+      end
+    end
+  end
+end

--- a/app/views/support_interface/performance/index.html.erb
+++ b/app/views/support_interface/performance/index.html.erb
@@ -83,4 +83,14 @@
 
 <p class="govuk-body">The list of provider users that have signed in to apply at least once</p>
 
-<%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path, class: 'govuk-body' %>
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download active provider users (CSV)', support_interface_active_provider_users_path %>
+</p>
+
+<h3 class="govuk-heading-m">Provider performance for TAD</h3>
+
+<p class="govuk-body">A list of all application/offered/accepted counts for all courses in Apply</p>
+
+<p class='govuk-body'>
+  <%= govuk_link_to 'Download provider performance for TAD (CSV)', support_interface_tad_provider_performance_path %>
+</p>

--- a/config/initializers/inflector.rb
+++ b/config/initializers/inflector.rb
@@ -2,6 +2,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym('DfE')
   inflect.acronym('API')
   inflect.acronym('UCAS')
+  inflect.acronym('TAD')
   inflect.irregular 'chaser_sent', 'chasers_sent'
   inflect.irregular 'provider_permissions', 'provider_permissions'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -563,6 +563,7 @@ Rails.application.routes.draw do
     get '/performance/candidate-survey', to: 'performance#candidate_survey', as: :candidate_survey
     get '/performance/applications-export-for-ucas', to: 'performance#applications_export_for_ucas', as: :applications_export_for_ucas
     get '/performance/active-provider-users', to: 'performance#active_provider_users', as: :active_provider_users
+    get '/performance/tad-provider-performance', to: 'performance#tad_provider_performance', as: :tad_provider_performance
 
     get '/tasks' => 'tasks#index', as: :tasks
     post '/tasks/:task' => 'tasks#run', as: :run_task

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe SupportInterface::TADProviderStatsExport do
+  include CourseOptionHelpers
+
+  subject(:exported_rows) { SupportInterface::TADProviderStatsExport.new.call }
+
+  describe 'calculating offers and acceptances' do
+    test_data = [
+      [%i[awaiting_provider_decision offer recruited enrolled], 4, 3, 2],
+      [%i[recruited enrolled], 2, 2, 2],
+      [[], 0, 0, 0],
+      [%i[withdrawn rejected], 2, 0, 0],
+      [ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER, 0, 0, 0],
+    ]
+
+    test_data.each do |states, applications, offers, acceptances|
+      it "correctly reports overall/offered/accepted tallies for applications in the state #{states}" do
+        provider = create(:provider)
+        course_option = course_option_for_provider(provider: provider)
+        generator = TestApplications.new
+
+        states.each do |state|
+          generator.create_application(states: [state], courses_to_apply_to: [course_option.course])
+        end
+
+        expect(exported_rows.first[:applications]).to eq applications
+        expect(exported_rows.first[:offers]).to eq offers
+        expect(exported_rows.first[:acceptances]).to eq acceptances
+      end
+    end
+
+    it 'correctly reports course metadata' do
+      provider_one = create(:provider, code: 'ABC1', name: 'Tehanu')
+      provider_two = create(:provider, code: 'DEF2', name: 'Anarres')
+
+      course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'History', provider: provider_one))
+      course_option_for_provider(provider: provider_one, course: create(:course, :open_on_apply, name: 'Biology', provider: provider_one))
+      course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'Science book', provider: provider_two))
+      course_option_for_provider(provider: provider_two, course: create(:course, :open_on_apply, name: 'French I took', provider: provider_two))
+
+      # we get a row per course
+      expect(exported_rows.count).to eq(4)
+
+      # rows are correctly divided between providers
+      expect(exported_rows.map { |r| r[:provider] }.tally['Tehanu']).to eq(2)
+      expect(exported_rows.map { |r| r[:provider] }.tally['Anarres']).to eq(2)
+
+      # rows contain metadata
+      example_row = exported_rows.find { |r| r[:subject] == 'History' }
+      expect(example_row[:provider]).to eq('Tehanu')
+      expect(example_row[:provider_code]).to eq('ABC1')
+    end
+  end
+end

--- a/spec/system/support_interface/tad_provider_performance_spec.rb
+++ b/spec/system/support_interface/tad_provider_performance_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.feature 'TAD provider performance CSV' do
+  include DfESignInHelpers
+
+  scenario 'support user can download a CSV with the TAD provider performance report' do
+    given_i_am_a_support_user
+    and_there_are_applications_in_the_system
+
+    when_i_visit_the_service_performance_page
+    and_i_click_on_download_tad_performance_report
+    then_i_should_be_able_to_download_a_csv
+  end
+
+  def given_i_am_a_support_user
+    sign_in_as_support_user
+  end
+
+  def and_there_are_applications_in_the_system
+    create(:application_choice, :awaiting_provider_decision)
+  end
+
+  def when_i_visit_the_service_performance_page
+    visit support_interface_performance_path
+  end
+
+  def and_i_click_on_download_tad_performance_report
+    click_link 'Download provider performance for TAD (CSV)'
+  end
+
+  def then_i_should_be_able_to_download_a_csv
+    c = Course.first
+    expect(page).to have_content c.name
+    expect(page).to have_content c.provider.code
+  end
+end


### PR DESCRIPTION
## Context

We need to pull some data on course application/offer/acceptance rates for TAD.

## Changes proposed in this pull request

- fix `TestApplications` so it can generate applications in `cancelled` and `application_complete` states
- export per-course data showing number of applications, offers and acceptances. Do not include applications that haven't made it to providers yet.
- available as a CSV download via support

## Guidance to review

Is the query ok?

## Link to Trello card

https://trello.com/c/4JTE9ldP/2266-pull-data-for-tad

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
