### PR TITLE
Trigger smoke tests when a successful deploy occurs

### DIFF
--- a/azure-pipelines-deploy-template.yml
+++ b/azure-pipelines-deploy-template.yml
@@ -118,13 +118,13 @@ jobs:
                   $gitApiResponse = Invoke-RestMethod -Method Get -Uri $gitContentsUri -Headers @{Authorization = $encodedAccessToken}
                   $deploymentFiles += $gitApiResponse | Where-Object {$_.name -like "*.json"} | Select-Object -ExpandProperty Name | Foreach-Object { "azure/$_" }
                   write-host ("DEBUG - Deployment files to compare changes against: {0}" -f [system.string]::Join(", ", $deploymentFiles))
-  
+
                   #Get the timestamp of the last deployment to the defined Azure environment from Azure API
                   $lastDeployment = (Get-AzResourceGroupDeployment -ResourceGroupName $resourceGroupName | Where-Object {$_.DeploymentName -Like "template-*"})[0].Timestamp
-  
+
                   #Get the commit hash for the current version deployed in the environment
                   $currentDeployedCommit = (Get-AzResourceGroup -Name $resourceGroupName).Tags.Version
-                   
+
                   #Get the timestamp of the last update to the variable groups corresponding to the environment defined
                   $variableGroupUri = "https://dev.azure.com/dfe-ssp/Become-A-Teacher/_apis/distributedtask/variablegroups"
                   $variableGroups = Invoke-RestMethod -Method Get -Uri $variableGroupUri -Headers @{Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"}
@@ -137,7 +137,7 @@ jobs:
                     -Hour ($variableGroupLastEdit | sort -descending)[0].substring(11,2) `
                     -Minute ($variableGroupLastEdit | sort -descending)[0].substring(14,2) `
                     -Second ($variableGroupLastEdit | sort -descending)[0].substring(17,2)
-  
+
                   #Get the list of files changed in the commit the build was triggered from. If this is a re-run of the same build we will just look at the files changed in that commit"
                   if ( $currentDeployedCommit -eq $env:COMMIT_HASH ) {
                     $gitCompareUri= "https://api.github.com/repos/DFE-Digital/apply-for-postgraduate-teacher-training/commits/$env:COMMIT_HASH"
@@ -150,7 +150,7 @@ jobs:
                   } else {
                     write-host ("DEBUG - No files changed in commit.")
                   }
-  
+
                   if ( $lastDeployment -lt $variableGroupLastEditTimestamp ) {
                     write-host "Full ARM deployment required - Variable group changes detected."
                     $fullDeployment = $true
@@ -294,7 +294,7 @@ jobs:
 
                   $entrypointCommand = "$($containerConfig.properties.parameters.command.value[0..1]) '$($containerConfig.properties.parameters.command.value[2..$containerConfig.properties.parameters.command.value.length])'"
                   write-host ("DEBUG - entrypoint command used for '{0}' container instance: {1}" -f $container, $entrypointCommand)
-                  
+
                   $tags = @()
                   foreach ( $tag in $containerConfig.properties.parameters.resourceTags.value | get-member -MemberType NoteProperty | select -ExpandProperty Name ) {
                     $tags += "`"$($tag)`"=`"$($containerConfig.properties.parameters.resourceTags.value.$tag)`""
@@ -354,9 +354,28 @@ jobs:
               azureSubscription: ${{ parameters.subscriptionName }}
               resourceGroup: $(resourceGroupName)
               containerName: ${{ format('{0}-{1}', variables.containerInstanceNamePrefix,'wkr') }}
-          
+
           - template: metrics-check-template.yml
             parameters:
               azureSubscription: ${{ parameters.subscriptionName }}
               resourceGroup: $(resourceGroupName)
               containerName: ${{ format('{0}-{1}', variables.containerInstanceNamePrefix,'clk') }}
+
+          - powershell: |
+              $uri = "https://api.github.com/repos/DFE-Digital/apply-for-teacher-training-tests/dispatches"
+
+              $body = @{
+               "event_type" = "Deploy ${{ parameters.environment }}"
+              } | ConvertTo-Json
+
+              $header = @{
+               "Accept" = "application/vnd.github.everest-preview+json"
+               "Authorization" = "token $($env:GITHUB_TOKEN)"
+              }
+
+              Invoke-WebRequest -Method POST -Header $header -Body $body -Uri $uri
+            displayName: 'Trigger smoke tests on GitHub'
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['buildCancelled'], false))
+            env:
+              GITHUB_TOKEN: $(smokeTestsGitHubToken)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ stages:
         echo "##vso[task.setvariable variable=docker_path;]$docker_path"
         mkdir $(pipelineDockerCachePath)
       displayName: 'Configure build environment'
-    
+
     - template: cancel-build-if-not-latest-template.yml
       parameters:
         sourceBranchName: $(Build.SourceBranchName)
@@ -84,7 +84,7 @@ stages:
       inputs:
         path: '$(System.DefaultWorkingDirectory)/docker_images/'
         artifactName: 'docker_artifacts'
-    
+
     - task: PublishPipelineArtifact@1
       displayName: 'Publish ARM template artifacts'
       condition: and(eq(variables['buildCancelled'], false), and(succeeded(), eq(variables['deployOnly'], false)))
@@ -112,7 +112,7 @@ stages:
         command: 'push'
         tags: |
           $(Build.BuildNumber)
-    
+
     - script: |
         docker tag $(dockerHubUsername)/$(imageName):$(Build.BuildNumber) $(dockerHubUsername)/$(imageName):latest
         docker rmi $(dockerHubUsername)/$(imageName):$(Build.BuildNumber)
@@ -136,7 +136,7 @@ stages:
         containerRegistry: 'DfE Docker Hub'
         command: 'logout'
 
-  
+
 - stage: test_release
   displayName: 'Test & Publish Release'
   dependsOn: build_release
@@ -289,7 +289,7 @@ stages:
     parameters:
       testCommand: 'integration-tests'
       displayName: 'Integration Tests'
-        
+
   - template: rspec-job-template.yml
     parameters:
       testCommand: 'unit-tests'


### PR DESCRIPTION
## Context

We have smoke tests at https://github.com/dfe-digital/apply-for-teacher-training-tests. We can trigger them with a POST request. We want to trigger them post-deploy.

## Changes proposed in this pull request

Call a `Invoke-WebRequest` (PowerShell `cURL`) at the end of the build. Add some env vars.

## Guidance to review

Makes sense? Going to test this in the DevOps env.

## Link to Trello card

https://trello.com/c/yHpxTA7F

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
