### PR TITLE
Add make_decisions checkboxes to provider pages for managing organisations

### DIFF
--- a/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
+++ b/app/controllers/provider_interface/provider_relationship_permissions_controller.rb
@@ -48,8 +48,9 @@ module ProviderInterface
     end
 
     def provider_relationship_permissions_form_params
-      permissions_attrs = %i[view_safeguarding_information]
-      params.fetch(:provider_interface_provider_relationship_permissions_form, {})
+      permissions_attrs = ProviderRelationshipPermissions::VALID_PERMISSIONS
+
+      params.require(:provider_interface_provider_relationship_permissions_form)
         .permit(
           accredited_body_permissions: permissions_attrs,
           training_provider_permissions: permissions_attrs,

--- a/app/views/provider_interface/organisations/_permissions_list.html.erb
+++ b/app/views/provider_interface/organisations/_permissions_list.html.erb
@@ -5,6 +5,12 @@
       access safeguarding information
     </li>
   <% end %>
+  <% if permission.make_decisions %>
+    <li>
+      <%= render 'check_icon' %>
+      make decisions
+    </li>
+  <% end %>
   <li>
     <%= render 'check_icon' %>
     view applications

--- a/app/views/provider_interface/provider_relationship_permissions/_provider_permissions.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/_provider_permissions.html.erb
@@ -8,6 +8,14 @@
       see safeguarding information
     </li>
   <% end %>
+  <% if permissions.make_decisions %>
+    <li>
+      <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
+        <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>
+      </svg>
+      make decisions
+    </li>
+  <% end %>
   <li>
     <svg class="app-icon govuk-!-margin-right-1" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 200 200" focusable="false" fill="currentColor" aria-hidden="true">
       <path d="M100 200a100 100 0 1 1 0-200 100 100 0 0 1 0 200zm-60-85l40 40 80-80-20-20-60 60-20-20-20 20z"></path>

--- a/app/views/provider_interface/provider_relationship_permissions/confirm.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/confirm.html.erb
@@ -17,11 +17,15 @@
       <%= f.fields_for :accredited_body_permissions do |abp| %>
         <%= abp.hidden_field :view_safeguarding_information,
           value: @form.accredited_body_permissions.view_safeguarding_information %>
+        <%= abp.hidden_field :make_decisions,
+          value: @form.accredited_body_permissions.make_decisions %>
       <% end %>
 
       <%= f.fields_for :training_provider_permissions do |tpp| %>
         <%= tpp.hidden_field :view_safeguarding_information,
           value: @form.training_provider_permissions.view_safeguarding_information %>
+        <%= tpp.hidden_field :make_decisions,
+          value: @form.training_provider_permissions.make_decisions %>
       <% end %>
 
       <%= render 'provider_permissions', provider: @training_provider_permissions.training_provider, permissions: @training_provider_permissions %>

--- a/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/edit.html.erb
@@ -21,6 +21,9 @@
               <li>the ‘criminal convictions and professional misconduct’ section of the application, which may include highly sensitive material about the candidate</li>
               <li>the ‘equality and diversity’ section of the application form</li>
             </ul>
+
+            <h2 class="govuk-heading-m">Permission to make decisions</h2>
+            <p>You can allow this organisation to make offers, amend offers and reject applications.</p>
           </div>
         </details>
       </div>
@@ -35,20 +38,24 @@
 
       <div class="govuk-form-group">
         <%= f.fields_for :training_provider_permissions, @form.training_provider_permissions do |tpp| %>
-          <%= tpp.govuk_check_boxes_fieldset :permissions, legend: {
+          <%= tpp.govuk_check_boxes_fieldset :permissions, classes: 'training-provider', legend: {
               text: "Select permissions for #{@form.training_provider_permissions.training_provider.name}" } do %>
             <%= tpp.govuk_check_box :view_safeguarding_information, true, multiple: false,
                                     label: { text: 'They have access to safeguarding information' } %>
+            <%= tpp.govuk_check_box :make_decisions, true, multiple: false,
+                                    label: { text: 'They can make decisions on applications' } %>
           <% end %>
         <% end %>
       </div>
 
       <div class="govuk-form-group">
         <%= f.fields_for :accredited_body_permissions, @form.accredited_body_permissions do |abp| %>
-          <%= abp.govuk_check_boxes_fieldset :permissions, legend: {
+          <%= abp.govuk_check_boxes_fieldset :permissions, classes: 'accredited-body', legend: {
               text: "Select permissions for #{@form.accredited_body_permissions.ratifying_provider.name}" } do %>
             <%= abp.govuk_check_box :view_safeguarding_information, true, multiple: false,
                                     label: { text: 'They have access to safeguarding information' } %>
+            <%= abp.govuk_check_box :make_decisions, true, multiple: false,
+                                    label: { text: 'They can make decisions on applications' } %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/provider_interface/provider_relationship_permissions/success.html.erb
+++ b/app/views/provider_interface/provider_relationship_permissions/success.html.erb
@@ -11,7 +11,7 @@
     </h2>
 
     <p class="govuk-body">
-      Select <a href="/organisations">Organisations</a> (at the top of every page) to update your permissions.
+      Select <a href="<%= provider_interface_organisations_path %>">Organisations</a> (at the top of every page) to update your permissions.
     </p>
     <h2 class="govuk-heading-m">
       Inviting users

--- a/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
+++ b/spec/system/provider_interface/manage_provider_relationship_permissions_spec.rb
@@ -104,7 +104,7 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def and_i_allow_my_training_provider_to_view_safeguarding_information
-    within(find('.govuk-checkboxes__item', match: :first)) do
+    within(find('.training-provider .govuk-checkboxes__item', match: :first)) do
       check 'They have access to safeguarding information'
     end
 
@@ -129,13 +129,13 @@ RSpec.feature 'Managing provider user permissions' do
   end
 
   def and_i_allow_the_ratifying_provider_to_view_safeguarding_information
-    within(all('.govuk-checkboxes__item').last) do
+    within(find('.accredited-body .govuk-checkboxes__item', match: :first)) do
       check 'They have access to safeguarding information'
     end
   end
 
   def and_i_deny_my_training_provider_permission_to_view_safeguarding_information
-    within(find('.govuk-checkboxes__item', match: :first)) do
+    within(find('.training-provider .govuk-checkboxes__item', match: :first)) do
       uncheck 'They have access to safeguarding information'
     end
 


### PR DESCRIPTION
## Context

It is now possible to restrict provider users from making decisions on applications either via user-level permissions or organisation-level ones. While it's possible to grant individual users `make_decisions` in the provider UI (subject to the relevant feature flag), there are no `make_decisions` checkboxes in the provider UI for managing `make_decisions` at an organisation level. This impacts interactive QA and product review.

The designs for onboarding provider users have not been finalised, but I have added the relevant checkboxes to facilitate interactive testing and demoing.

## Changes proposed in this pull request

Add `make_decisions` checkboxes to provider pages for managing organisation permissions.

## Guidance to review

Some views and partials could be dried up a little but I've decided not to do that because a redesign of these pages is pending and we can refactor as we rebuild these pages.

Please be aware multiple feature flags need to be active for reviewing this PR:
- provider_add_provider_users (currently off in prod)
- provider_change_response (currently live)
- provider_view_safeguarding (currently_live)
- provider_make_decisions_restriction (currently off)
- enforce_provider_to_provider_permissions (currently off)

## Link to Trello card

https://trello.com/c/CwAkdmkP

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
