### PR TITLE
Show logs when running under Foreman

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,5 +69,11 @@ Rails.application.configure do
 
   # Logging configuration
   config.log_level = :debug
-  LogstashLogging.enable(config) if ENV['LOGSTASH_ENABLE'] == 'true'
+  if ENV['LOGSTASH_ENABLE'] == 'true'
+    LogstashLogging.enable(config) if ENV['LOGSTASH_ENABLE'] == 'true'
+  else
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  end
 end

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,3 +1,5 @@
+require 'find_sync_check'
+
 class SimulatedFailureCheck < OkComputer::Check
   def check
     if FeatureFlag.active?('force_ok_computer_to_fail')


### PR DESCRIPTION
## Context

`rails s` gives us nice request-by-request and query-by-query logs. `foreman start` doesn't, because unlike `foreman start` `rails s` has the trick of printing out everything that goes into `logs/development.log`.

If we log straight to `STDOUT` we can get logs under `foreman` too.

## Changes proposed in this pull request

Log to `STDOUT`. Fix a noisy deprecation warning only noticed once logging to `STDOUT` begun.

#### Making a request to `/`: before

<img width="1262" alt="Screenshot 2020-06-18 at 22 25 08" src="https://user-images.githubusercontent.com/642279/85073400-9d535280-b1b2-11ea-9696-0544881b1972.png">

#### Making a request to `/`: after

<img width="1303" alt="Screenshot 2020-06-18 at 22 24 47" src="https://user-images.githubusercontent.com/642279/85073423-a47a6080-b1b2-11ea-82a0-eed9212fa755.png">

## Guidance to review

Does this break your workflow?