### PR TITLE
Fix a bug in the TAD performance report

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -147,7 +147,7 @@ class TestApplications
     when :declined
       make_offer(choice)
       decline_offer(choice)
-    when :accepted
+    when :accepted, :pending_conditions
       make_offer(choice)
       accept_offer(choice)
     when :accepted_no_conditions

--- a/app/services/application_state_change.rb
+++ b/app/services/application_state_change.rb
@@ -2,6 +2,8 @@ class ApplicationStateChange
   include Workflow
 
   STATES_NOT_VISIBLE_TO_PROVIDER = %i[unsubmitted awaiting_references application_complete cancelled].freeze
+  ACCEPTED_STATES = %i[pending_conditions conditions_not_met recruited enrolled].freeze
+  OFFERED_STATES = (ACCEPTED_STATES + %i[declined offer]).freeze
 
   attr_reader :application_choice
 

--- a/app/services/support_interface/tad_provider_stats_export.rb
+++ b/app/services/support_interface/tad_provider_stats_export.rb
@@ -1,8 +1,5 @@
 module SupportInterface
   class TADProviderStatsExport
-    OFFERED_STATES = %w[offer enrolled recruited declined].freeze
-    ACCEPTED_STATES = %w[recruited enrolled].freeze
-
     def call
       Course.all
         .map { |c| course_to_row(c) }
@@ -32,8 +29,8 @@ module SupportInterface
       }
 
       statuses.reduce(row_template) do |row, status|
-        row[:offers] += 1 if OFFERED_STATES.include?(status)
-        row[:acceptances] += 1 if ACCEPTED_STATES.include?(status)
+        row[:offers] += 1 if ApplicationStateChange::OFFERED_STATES.include?(status.to_sym)
+        row[:acceptances] += 1 if ApplicationStateChange::ACCEPTED_STATES.include?(status.to_sym)
         row
       end
     end

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -6,16 +6,23 @@ RSpec.describe SupportInterface::TADProviderStatsExport do
   subject(:exported_rows) { SupportInterface::TADProviderStatsExport.new.call }
 
   describe 'calculating offers and acceptances' do
+    accepted_states = ApplicationStateChange::ACCEPTED_STATES
+    offered_states = ApplicationStateChange::OFFERED_STATES
+
+    unless accepted_states.count < offered_states.count &&
+        (offered_states & accepted_states) == accepted_states
+      raise 'This spec assumes that ApplicationStateChange::ACCEPTED_STATES is a subset of ApplicationStateChange::OFFERED_STATES'
+    end
+
     test_data = [
-      [%i[awaiting_provider_decision offer recruited enrolled], 4, 3, 2],
-      [%i[recruited enrolled], 2, 2, 2],
-      [[], 0, 0, 0],
-      [%i[withdrawn rejected], 2, 0, 0],
+      [%i[awaiting_provider_decision], 1, 0, 0],
+      [ApplicationStateChange::OFFERED_STATES, offered_states.count, offered_states.count, accepted_states.count],
+      [ApplicationStateChange::ACCEPTED_STATES, accepted_states.count, accepted_states.count, accepted_states.count],
       [ApplicationStateChange::STATES_NOT_VISIBLE_TO_PROVIDER, 0, 0, 0],
     ]
 
     test_data.each do |states, applications, offers, acceptances|
-      it "correctly reports overall/offered/accepted tallies for applications in the state #{states}" do
+      it "correctly reports overall/offered/accepted tallies for applications in the states #{states}" do
         provider = create(:provider)
         course_option = course_option_for_provider(provider: provider)
         generator = TestApplications.new

--- a/spec/services/support_interface/tad_provider_stats_export_spec.rb
+++ b/spec/services/support_interface/tad_provider_stats_export_spec.rb
@@ -25,10 +25,9 @@ RSpec.describe SupportInterface::TADProviderStatsExport do
       it "correctly reports overall/offered/accepted tallies for applications in the states #{states}" do
         provider = create(:provider)
         course_option = course_option_for_provider(provider: provider)
-        generator = TestApplications.new
 
         states.each do |state|
-          generator.create_application(states: [state], courses_to_apply_to: [course_option.course])
+          create(:application_choice, status: state, course_option: course_option)
         end
 
         expect(exported_rows.first[:applications]).to eq applications


### PR DESCRIPTION
## Context

The TAD report in #2294 undercounted offers and acceptances because the list of possible statuses for each one was incomplete.

## Changes proposed in this pull request

Put canonical lists of the `OFFERED` and `ACCEPTED` statuses in `ApplicationStateChange` and use those.

## Guidance to review

Are the new lists correct?

## Link to Trello card

https://trello.com/c/4JTE9ldP/2266-pull-data-for-tad

## Things to check

- [X] This code doesn't rely on migrations in the same Pull Request
- [X] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [X] API release notes have been updated if necessary
- [X] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
