### PR TITLE
Add missing path helper delegation to PickCourseOption service

### DIFF
--- a/app/services/candidate_interface/pick_course_option.rb
+++ b/app/services/candidate_interface/pick_course_option.rb
@@ -15,6 +15,7 @@ module CandidateInterface
       :redirect_to,
       :candidate_interface_course_choices_add_another_course_path,
       :candidate_interface_course_choices_index_path,
+      :candidate_interface_application_form_path,
       to: :controller,
     )
 


### PR DESCRIPTION
The service object needs to be able to delegate this path helper to the
controller that gets passed in as an argument in order to correctly
handle errors on save.

https://sentry.io/organizations/dfe-bat/issues/1719517486/?project=1765973

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
