### PR TITLE
Fix permissions audit trail for programmatically created permissions

### DIFF
--- a/app/components/support_interface/audit_trail_item_component.rb
+++ b/app/components/support_interface/audit_trail_item_component.rb
@@ -61,8 +61,12 @@ module SupportInterface
           auditable_id: audit.auditable_id,
           action: 'create',
         )
+        provider = if creation_record
+                     Provider.find(creation_record.audited_changes['provider_id'])
+                   else
+                     Provider.find(audit.audited_changes['provider_id'])
+                   end
 
-        provider = Provider.find(creation_record.audited_changes['provider_id'])
         "Permissions changed for #{provider.name}"
       when 'destroy'
         provider = Provider.find(audit.audited_changes['provider_id'])


### PR DESCRIPTION
## Context

I gave all provider users `make_decisions` on QA programmatically for backwards compatibility when I switched `provider_make_decisions_restriction` on. Now I cannot see my audit trail in the support console.

This is relevant to the actual rollout, as the plan is to give all users `make_decisions` using a database migration for backwards compatibility.

## Changes proposed in this pull request

Use the `provider_id` from the audit record, if no creation_record exists.

## Guidance to review

Smol change

## Link to Trello card

https://trello.com/c/CwAkdmkP

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
