### PR TITLE
Specify explicit sort order on degree review page

### DIFF
--- a/app/components/candidate_interface/degrees_review_component.rb
+++ b/app/components/candidate_interface/degrees_review_component.rb
@@ -4,7 +4,7 @@ module CandidateInterface
 
     def initialize(application_form:, editable: true, heading_level: 2, show_incomplete: false, missing_error: false)
       @application_form = application_form
-      @degrees = application_form.application_qualifications.degrees
+      @degrees = application_form.application_qualifications.degrees.order(id: :desc)
       @editable = editable
       @heading_level = heading_level
       @show_incomplete = show_incomplete


### PR DESCRIPTION
## Context
The candidate_entering_degrees_spec is failing intermittently on Azure. The spec assumes an order when multiple degrees are present on the page. If they are out of order, the wrong degree gets deleted and subsequent assertions about the presence of the other degree fail.

<!-- Why are you making this change? What might surprise someone about it? -->


## Changes proposed in this pull request
 It may be worth investigating why implicit ordering by primary key isn't occurring on Azure test runs, but in the meantime let's specify an explicit order when we render the review page.
<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Link to Trello card

<!-- http://trello.com/123-example-card -->

## Things to check

- [ ] This code doesn't rely on migrations in the same Pull Request
- [ ] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [ ] API release notes have been updated if necessary
- [ ] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
