### PR TITLE
Remove a stray puts from configuration_spec

### DIFF
--- a/spec/azure/configuration_spec.rb
+++ b/spec/azure/configuration_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'Configuration' do
   describe 'azure-pipelines-yaml-files' do
     it 'are valid YAML' do
       Dir.glob(['azure-*.yml', '*-template.yml']).each do |template|
-        puts template
         YAML.load_file(template)
       end
     end


### PR DESCRIPTION
## Context

The spec output has some stray filenames in

## Changes proposed in this pull request

Remove a `puts`
