### PR TITLE
Set last_signed_in_at on a candidate when generating test applications

### DIFF
--- a/app/lib/test_applications.rb
+++ b/app/lib/test_applications.rb
@@ -34,6 +34,7 @@ class TestApplications
         :candidate,
         email_address: "#{first_name.downcase}.#{last_name.downcase}@example.com",
         created_at: time,
+        last_signed_in_at: time,
       )
     end
 

--- a/spec/lib/test_applications_spec.rb
+++ b/spec/lib/test_applications_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe TestApplications do
     application_form = application_choice.application_form
     candidate = application_form.candidate
 
+    expect(candidate.created_at).to eq candidate.last_signed_in_at
     expect(days_between_ignoring_time_of_day(application_choice.created_at, candidate.created_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_form.submitted_at, application_choice.created_at)).to be >= 1
     expect(days_between_ignoring_time_of_day(application_choice.sent_to_provider_at, application_form.submitted_at)).to be >= 1


### PR DESCRIPTION
## Context

When a test application is generated, the last_signed_in_at is not set. This means the account created flash shows for all applications in all states.

## Changes proposed in this pull request

- Set the last_signed_in_at to the application forms created_at

## Link to Trello card

https://trello.com/c/mW5GBEiL/1546-account-created-banner-shown-for-existing-account-qa

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
