### PR TITLE
Remove confusing line of content

### DIFF
--- a/app/views/candidate_interface/course_choices/replace_choices/decision/contact_support.html.erb
+++ b/app/views/candidate_interface/course_choices/replace_choices/decision/contact_support.html.erb
@@ -12,8 +12,5 @@
       <%= govuk_link_to 'Find postgraduate teacher training', 'https://find-postgraduate-teacher-training.education.gov.uk' %>
       and email us to let us know at: <%= bat_contact_mail_to %>.
     </p>
-
-    <p class="govuk-body">If you want to choose a new location or study mode for <%= @course_choice.course.name_and_code %> <%= govuk_link_to 'go back and edit your course choice', candidate_interface_replace_course_choice_path(@course_choice.id) %>.</p>
-
   </div>
 </div>


### PR DESCRIPTION
## Context

We were telling users they could go back to change their study mode or location. However, the radio buttons only show if they are available options. 

This may cause confusion.

## Link to Trello card

https://trello.com/b/aRIgjf0y/candidate-team-board

## Things to check

- [x] This code doesn't rely on migrations in the same Pull Request
- [x] If this code includes a migration adding or changing columns, it also backfills existing records for consistency
- [x] API release notes have been updated if necessary
- [x] New environment variables have been [added to the Azure config](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training#azure-hosting-devops-pipeline)
